### PR TITLE
refactor: use unified types

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.49",
+        "@camunda/camunda-api-zod-schemas": "0.0.50",
         "@camunda/camunda-composite-components": "0.22.1",
         "@carbon/elements": "^11.57.0",
         "@carbon/react": "1.101.0",
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.49",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.49.tgz",
-      "integrity": "sha512-Ok17q54j8WtnMk55t7VqhKCfwY8nylkKxP/dM3m6aF1NiwlU/D7+IkUYwh+iT/WLZXly5sptmMa3yv1M2mitww==",
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.50.tgz",
+      "integrity": "sha512-KcvgDL3sX2imEgC1aOfwXaCpQQjZdKHfRSPCjswkrPCxKQn9ZgoT9WZ5m5H2I7zQk+yoJJtB+AMlvv5PGixKMA==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -88,6 +88,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -572,6 +573,7 @@
       "integrity": "sha512-BY241uKsNyR37z4BS1/Boce16iqFU4EUrbES4z8n5u2kc1VDef3v3ljPbNEKWwq1Z9U9SHriNrwDKoKMYPMSFQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.3",
         "@carbon/feature-flags": "1.0.0",
@@ -2558,6 +2560,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2761,6 +2764,7 @@
       "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2770,6 +2774,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2848,6 +2853,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3086,6 +3092,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3226,6 +3233,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3800,6 +3808,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3860,6 +3869,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4136,7 +4146,8 @@
       "version": "1.0.31",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
       "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4496,6 +4507,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -5746,6 +5758,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -6123,6 +6136,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6182,6 +6196,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6204,6 +6219,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6274,7 +6290,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6547,6 +6564,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6685,6 +6703,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -6982,6 +7001,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.11.tgz",
       "integrity": "sha512-opzgceGlQ5rdZdGwf9ddLW7EM2F4L7tgsgLn6fFzQ2JgE5EVQ4HZwNkcgB1p8WfOBx1GEZP3fa66ajJmtXhSrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -7112,6 +7132,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7206,6 +7227,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7421,6 +7443,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7529,6 +7552,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7632,6 +7656,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -88,7 +88,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -573,7 +572,6 @@
       "integrity": "sha512-BY241uKsNyR37z4BS1/Boce16iqFU4EUrbES4z8n5u2kc1VDef3v3ljPbNEKWwq1Z9U9SHriNrwDKoKMYPMSFQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.3",
         "@carbon/feature-flags": "1.0.0",
@@ -2560,7 +2558,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2764,7 +2761,6 @@
       "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2774,7 +2770,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2853,7 +2848,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3092,7 +3086,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3233,7 +3226,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3808,7 +3800,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3869,7 +3860,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4146,8 +4136,7 @@
       "version": "1.0.31",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
       "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4507,7 +4496,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -5758,7 +5746,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -6136,7 +6123,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6196,7 +6182,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6219,7 +6204,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6290,8 +6274,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6564,7 +6547,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6703,7 +6685,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -7001,7 +6982,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.11.tgz",
       "integrity": "sha512-opzgceGlQ5rdZdGwf9ddLW7EM2F4L7tgsgLn6fFzQ2JgE5EVQ4HZwNkcgB1p8WfOBx1GEZP3fa66ajJmtXhSrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -7132,7 +7112,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7227,7 +7206,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7443,7 +7421,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7552,7 +7529,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7656,7 +7632,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-frontend",
-  "version": "8.9.0-SNAPSHOT",
+  "version": "8.10.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-frontend",
-      "version": "8.9.0-SNAPSHOT",
+      "version": "8.10.0-SNAPSHOT",
       "dependencies": {
         "@camunda/camunda-api-zod-schemas": "0.0.49",
         "@camunda/camunda-composite-components": "0.22.1",

--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.50",
+        "@camunda/camunda-api-zod-schemas": "0.0.51",
         "@camunda/camunda-composite-components": "0.22.1",
         "@carbon/elements": "^11.57.0",
         "@carbon/react": "1.101.0",
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.50.tgz",
-      "integrity": "sha512-KcvgDL3sX2imEgC1aOfwXaCpQQjZdKHfRSPCjswkrPCxKQn9ZgoT9WZ5m5H2I7zQk+yoJJtB+AMlvv5PGixKMA==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.51.tgz",
+      "integrity": "sha512-cVVd1b0SeoN5Wif4nFvqrgWh+YHCiKZQY038mRYE185Bcvm6p5T1orOZXoZL0EmpSP1QwIeLeWvDqAzKggPLzA==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.49",
+    "@camunda/camunda-api-zod-schemas": "0.0.50",
     "@camunda/camunda-composite-components": "0.22.1",
     "@carbon/elements": "^11.57.0",
     "@carbon/react": "1.101.0",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.50",
+    "@camunda/camunda-api-zod-schemas": "0.0.51",
     "@camunda/camunda-composite-components": "0.22.1",
     "@carbon/elements": "^11.57.0",
     "@carbon/react": "1.101.0",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "identity-frontend",
   "private": true,
-  "version": "8.9.0-SNAPSHOT",
+  "version": "8.10.0-SNAPSHOT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -53,7 +53,7 @@ const StyledToolTip = styled(Tooltip)`
 `;
 
 export type EntityData = {
-  [key: string]: string | object | boolean | number;
+  [key: string]: string | object | boolean | number | null | undefined;
 } & {
   id?: string;
 };

--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -53,7 +53,7 @@ const StyledToolTip = styled(Tooltip)`
 `;
 
 export type EntityData = {
-  [key: string]: string | object | boolean | number | null | undefined;
+  [key: string]: string | object | boolean | number | null;
 } & {
   id?: string;
 };

--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -8,11 +8,13 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { isCamundaGroupsEnabled } from "src/configuration";
-import { SearchResponse } from "src/utility/api";
 import { useApiCall, usePaginatedApiCall } from "src/utility/api";
-import { MemberGroup } from "src/utility/api/groups";
 import { ApiDefinition } from "src/utility/api/request";
 import { searchGroups, Group } from "src/utility/api/groups";
+import type {
+  QueryGroupsResponseBody,
+  QueryGroupsByRoleResponseBody,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 
 type UseEnrichedGroupsResult = {
   groups: Group[];
@@ -23,7 +25,10 @@ type UseEnrichedGroupsResult = {
 };
 
 export function useEnrichedGroups<P>(
-  apiDefinition: ApiDefinition<SearchResponse<MemberGroup>, P>,
+  apiDefinition: ApiDefinition<
+    QueryGroupsResponseBody | QueryGroupsByRoleResponseBody,
+    P
+  >,
   params: P,
 ): UseEnrichedGroupsResult {
   const [callSearchMembers, paginationProps] =

--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -72,6 +72,7 @@ export function useEnrichedGroups<P>(
         return {
           groupId: member.groupId,
           name: group?.name || "",
+          description: group?.description || "",
         };
       });
 

--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -10,10 +10,11 @@ import { useCallback, useEffect, useState } from "react";
 import { isCamundaGroupsEnabled } from "src/configuration";
 import { useApiCall, usePaginatedApiCall } from "src/utility/api";
 import { ApiDefinition } from "src/utility/api/request";
-import { searchGroups, Group } from "src/utility/api/groups";
+import { searchGroups } from "src/utility/api/groups";
 import type {
   QueryGroupsResponseBody,
   QueryGroupsByRoleResponseBody,
+  Group,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type UseEnrichedGroupsResult = {

--- a/identity/client/src/components/global/useEnrichUsers.tsx
+++ b/identity/client/src/components/global/useEnrichUsers.tsx
@@ -8,11 +8,14 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { isOIDC } from "src/configuration";
-import { SearchResponse } from "src/utility/api";
 import { useApiCall, usePaginatedApiCall } from "src/utility/api";
-import { MemberUser } from "src/utility/api/membership";
+import type {
+  User,
+  QueryUsersResponseBody,
+  QueryUsersByGroupResponseBody,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition } from "src/utility/api/request";
-import { searchUser, User } from "src/utility/api/users";
+import { searchUser } from "src/utility/api/users";
 
 type UseEnrichedUsersResult = {
   users: User[];
@@ -23,7 +26,10 @@ type UseEnrichedUsersResult = {
 };
 
 export function useEnrichedUsers<P>(
-  apiDefinition: ApiDefinition<SearchResponse<MemberUser>, P>,
+  apiDefinition: ApiDefinition<
+    QueryUsersResponseBody | QueryUsersByGroupResponseBody,
+    P
+  >,
   params: P,
 ): UseEnrichedUsersResult {
   const [callSearchMembers, paginationProps] =

--- a/identity/client/src/components/layout/AppHeader.tsx
+++ b/identity/client/src/components/layout/AppHeader.tsx
@@ -10,7 +10,7 @@ import { C3Navigation } from "@camunda/camunda-composite-components";
 import { useGlobalRoutes } from "src/components/global/useGlobalRoutes";
 import { Link } from "react-router-dom";
 import { useApi } from "src/utility/api";
-import { checkLicense, License } from "src/utility/api/headers";
+import { checkLicense } from "src/utility/api/headers";
 import { getAuthentication } from "src/utility/api/authentication";
 import { ArrowRight } from "@carbon/react/icons";
 import { logout } from "src/utility/auth";
@@ -18,6 +18,7 @@ import { useState } from "react";
 import { isSaaS } from "src/configuration";
 import { useNotifications } from "src/components/notifications";
 import useTranslate from "src/utility/localization";
+import type { License } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const LOGOUT_DELAY = 1000;
 

--- a/identity/client/src/pages/authorizations/AuthorizationsList.tsx
+++ b/identity/client/src/pages/authorizations/AuthorizationsList.tsx
@@ -51,7 +51,6 @@ const AuthorizationList: FC<AuthorizationListProps> = ({
 
   const propertyNameHeader: DataTableHeader<Authorization> = {
     header: t("resourcePropertyName"),
-    // @ts-expect-error todo fix
     key: "resourcePropertyName",
     isSortable: true,
   };

--- a/identity/client/src/pages/authorizations/AuthorizationsList.tsx
+++ b/identity/client/src/pages/authorizations/AuthorizationsList.tsx
@@ -9,7 +9,6 @@
 import { FC } from "react";
 import { Add, TrashCan } from "@carbon/react/icons";
 import { C3EmptyState } from "@camunda/camunda-composite-components";
-import { Authorization } from "src/utility/api/authorizations";
 import { SearchResponse, usePagination } from "src/utility/api";
 import useTranslate from "src/utility/localization";
 import EntityList from "src/components/entityList";
@@ -17,7 +16,10 @@ import { useEntityModal } from "src/components/modal/useModal";
 import { AddModal } from "./modals/add-modal";
 import DeleteModal from "./modals/DeleteModal";
 import { DataTableHeader } from "src/components/entityList/EntityList";
-import type { ResourceType } from "@camunda/camunda-api-zod-schemas/8.9";
+import type {
+  Authorization,
+  ResourceType,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 
 type AuthorizationListProps = {
   tab: ResourceType;
@@ -49,6 +51,7 @@ const AuthorizationList: FC<AuthorizationListProps> = ({
 
   const propertyNameHeader: DataTableHeader<Authorization> = {
     header: t("resourcePropertyName"),
+    // @ts-expect-error todo fix
     key: "resourcePropertyName",
     isSortable: true,
   };

--- a/identity/client/src/pages/authorizations/AuthorizationsList.tsx
+++ b/identity/client/src/pages/authorizations/AuthorizationsList.tsx
@@ -61,7 +61,7 @@ const AuthorizationList: FC<AuthorizationListProps> = ({
   const headers: DataTableHeader<Authorization>[] = [
     { header: t("ownerType"), key: "ownerType", isSortable: true },
     { header: t("ownerId"), key: "ownerId", isSortable: true },
-    tab === ResourceType.USER_TASK ? propertyNameHeader : resourceIdHeader,
+    tab === "USER_TASK" ? propertyNameHeader : resourceIdHeader,
     { header: t("permissionTypes"), key: "permissionTypes" },
   ];
 

--- a/identity/client/src/pages/authorizations/AuthorizationsList.tsx
+++ b/identity/client/src/pages/authorizations/AuthorizationsList.tsx
@@ -9,12 +9,7 @@
 import { FC } from "react";
 import { Add, TrashCan } from "@carbon/react/icons";
 import { C3EmptyState } from "@camunda/camunda-composite-components";
-import {
-  Authorization,
-  GeneralAuthorization,
-  ResourceType,
-  TaskAuthorization,
-} from "src/utility/api/authorizations";
+import { Authorization, ResourceType } from "src/utility/api/authorizations";
 import { SearchResponse, usePagination } from "src/utility/api";
 import useTranslate from "src/utility/localization";
 import EntityList from "src/components/entityList";
@@ -51,13 +46,13 @@ const AuthorizationList: FC<AuthorizationListProps> = ({
     reload,
   );
 
-  const propertyNameHeader: DataTableHeader<TaskAuthorization> = {
+  const propertyNameHeader: DataTableHeader<Authorization> = {
     header: t("resourcePropertyName"),
     key: "resourcePropertyName",
     isSortable: true,
   };
 
-  const resourceIdHeader: DataTableHeader<GeneralAuthorization> = {
+  const resourceIdHeader: DataTableHeader<Authorization> = {
     header: t("resourceId"),
     key: "resourceId",
     isSortable: true,

--- a/identity/client/src/pages/authorizations/AuthorizationsList.tsx
+++ b/identity/client/src/pages/authorizations/AuthorizationsList.tsx
@@ -9,7 +9,7 @@
 import { FC } from "react";
 import { Add, TrashCan } from "@carbon/react/icons";
 import { C3EmptyState } from "@camunda/camunda-composite-components";
-import { Authorization, ResourceType } from "src/utility/api/authorizations";
+import { Authorization } from "src/utility/api/authorizations";
 import { SearchResponse, usePagination } from "src/utility/api";
 import useTranslate from "src/utility/localization";
 import EntityList from "src/components/entityList";
@@ -17,6 +17,7 @@ import { useEntityModal } from "src/components/modal/useModal";
 import { AddModal } from "./modals/add-modal";
 import DeleteModal from "./modals/DeleteModal";
 import { DataTableHeader } from "src/components/entityList/EntityList";
+import type { ResourceType } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type AuthorizationListProps = {
   tab: ResourceType;

--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -93,6 +93,7 @@ const List: FC = () => {
               <CustomTabPanel key={tab}>
                 <AuthorizationList
                   tab={tab}
+                  // @ts-expect-error todo fix
                   data={transformedData}
                   loading={loading}
                   reload={reload}

--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -12,7 +12,9 @@ import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
 import Page, { PageHeader } from "src/components/layout/Page";
 import {
-  ResourceType,
+  type ResourceType,
+  ALL_RESOURCE_TYPES,
+  RESOURCE_TYPES_WITHOUT_TENANT,
   searchAuthorization,
 } from "src/utility/api/authorizations";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
@@ -27,17 +29,13 @@ import { isTenantsApiEnabled } from "src/configuration";
 
 const List: FC = () => {
   const { t } = useTranslate("authorizations");
+  const authorizationTabs = isTenantsApiEnabled
+    ? ALL_RESOURCE_TYPES
+    : RESOURCE_TYPES_WITHOUT_TENANT;
 
-  const allResourceTypes = Object.values(ResourceType);
-  let authorizationTabs = allResourceTypes;
-
-  if (!isTenantsApiEnabled) {
-    authorizationTabs = authorizationTabs.filter(
-      (type) => type !== ResourceType.TENANT,
-    );
-  }
-
-  const [activeTab, setActiveTab] = useState<string>(authorizationTabs[0]);
+  const [activeTab, setActiveTab] = useState<ResourceType>(
+    authorizationTabs[0],
+  );
 
   const {
     data,

--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -93,7 +93,6 @@ const List: FC = () => {
               <CustomTabPanel key={tab}>
                 <AuthorizationList
                   tab={tab}
-                  // @ts-expect-error todo fix
                   data={transformedData}
                   loading={loading}
                   reload={reload}

--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -12,7 +12,6 @@ import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
 import Page, { PageHeader } from "src/components/layout/Page";
 import {
-  type ResourceType,
   ALL_RESOURCE_TYPES,
   RESOURCE_TYPES_WITHOUT_TENANT,
   searchAuthorization,
@@ -26,6 +25,7 @@ import {
 } from "./components";
 import AuthorizationList from "./AuthorizationsList";
 import { isTenantsApiEnabled } from "src/configuration";
+import type { ResourceType } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const List: FC = () => {
   const { t } = useTranslate("authorizations");

--- a/identity/client/src/pages/authorizations/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/DeleteModal.tsx
@@ -15,11 +15,9 @@ import {
   DeleteModal as Modal,
   UseEntityModalProps,
 } from "src/components/modal";
-import {
-  Authorization,
-  deleteAuthorization,
-} from "src/utility/api/authorizations";
+import { deleteAuthorization } from "src/utility/api/authorizations";
 import { useNotifications } from "src/components/notifications";
+import type { Authorization } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const DeleteAuthorizationModal: FC<UseEntityModalProps<Authorization>> = ({
   open,
@@ -71,6 +69,7 @@ const DeleteAuthorizationModal: FC<UseEntityModalProps<Authorization>> = ({
           {resourceData.resourceType === "USER_TASK" ? (
             <ListItem>
               <strong>{t("resourcePropertyName")}</strong>:{" "}
+              {/* @ts-expect-error todo fix */}
               {resourceData.resourcePropertyName}
             </ListItem>
           ) : (

--- a/identity/client/src/pages/authorizations/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/DeleteModal.tsx
@@ -18,7 +18,6 @@ import {
 import {
   Authorization,
   deleteAuthorization,
-  ResourceType,
 } from "src/utility/api/authorizations";
 import { useNotifications } from "src/components/notifications";
 
@@ -69,7 +68,7 @@ const DeleteAuthorizationModal: FC<UseEntityModalProps<Authorization>> = ({
           <ListItem>
             <strong>{t("ownerType")}</strong>: {ownerType}
           </ListItem>
-          {resourceData.resourceType === ResourceType.USER_TASK ? (
+          {resourceData.resourceType === "USER_TASK" ? (
             <ListItem>
               <strong>{t("resourcePropertyName")}</strong>:{" "}
               {resourceData.resourcePropertyName}

--- a/identity/client/src/pages/authorizations/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/DeleteModal.tsx
@@ -69,7 +69,6 @@ const DeleteAuthorizationModal: FC<UseEntityModalProps<Authorization>> = ({
           {resourceData.resourceType === "USER_TASK" ? (
             <ListItem>
               <strong>{t("resourcePropertyName")}</strong>:{" "}
-              {/* @ts-expect-error todo fix */}
               {resourceData.resourcePropertyName}
             </ListItem>
           ) : (

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -17,12 +17,9 @@ import {
   ALL_RESOURCE_TYPES,
   createAuthorization,
   NewAuthorization,
-  OwnerType,
-  PermissionType,
   RESOURCE_TYPES_WITHOUT_TENANT,
   OWNER_TYPES,
   RESOURCE_PROPERTY_NAMES,
-  ResourceType,
   type ResourcePropertyName,
 } from "src/utility/api/authorizations";
 import { useNotifications } from "src/components/notifications";
@@ -37,6 +34,11 @@ import {
   isValidResourceId,
   getIdPattern,
 } from "src/utility/validate";
+import type {
+  OwnerType,
+  PermissionType,
+  ResourceType,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 
 const resourcePermissions: Record<ResourceType, PermissionType[]> = {
   AUDIT_LOG: ["READ"],

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -354,7 +354,6 @@ function createEmptyAuthorization(
       ownerType: "USER",
       ownerId: "",
       resourceType: "USER_TASK",
-      // @ts-expect-error todo fix
       resourceId: null,
       resourcePropertyName: "assignee",
       permissionTypes: [],

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -78,6 +78,8 @@ const resourcePermissions: Record<ResourceType, PermissionType[]> = {
   MESSAGE: ["CREATE", "READ"],
   PROCESS_DEFINITION: [
     "CANCEL_PROCESS_INSTANCE",
+    "CLAIM_USER_TASK",
+    "COMPLETE_USER_TASK",
     "CREATE_PROCESS_INSTANCE",
     "DELETE_PROCESS_INSTANCE",
     "MODIFY_PROCESS_INSTANCE",
@@ -86,7 +88,6 @@ const resourcePermissions: Record<ResourceType, PermissionType[]> = {
     "READ_USER_TASK",
     "UPDATE_PROCESS_INSTANCE",
     "UPDATE_USER_TASK",
-    "CLAIM_USER_TASK",
   ],
   USER_TASK: ["READ", "UPDATE", "CLAIM", "COMPLETE"],
   ROLE: ["CREATE", "DELETE", "READ", "UPDATE"],

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -187,7 +187,9 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
                 label={t("selectOwnerType")}
                 titleText={t("ownerType")}
                 items={OWNER_TYPES.filter((ownerType) => {
-                  const excludedType = isOIDC ? [] : ["MAPPING_RULE", "CLIENT"];
+                  const excludedType = isOIDC
+                    ? ["UNSPECIFIED"]
+                    : ["MAPPING_RULE", "CLIENT", "UNSPECIFIED"];
 
                   return !excludedType.includes(ownerType);
                 })}

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -14,13 +14,16 @@ import useTranslate from "src/utility/localization";
 import { isOIDC, isTenantsApiEnabled } from "src/configuration";
 import { FormModal, UseEntityModalProps } from "src/components/modal";
 import {
-  Authorization,
+  ALL_RESOURCE_TYPES,
   createAuthorization,
   NewAuthorization,
   OwnerType,
   PermissionType,
-  ResourcePropertyName,
+  RESOURCE_TYPES_WITHOUT_TENANT,
+  OWNER_TYPES,
+  RESOURCE_PROPERTY_NAMES,
   ResourceType,
+  type ResourcePropertyName,
 } from "src/utility/api/authorizations";
 import { useNotifications } from "src/components/notifications";
 import TextField from "src/components/form/TextField";
@@ -35,114 +38,65 @@ import {
   getIdPattern,
 } from "src/utility/validate";
 
-type ResourcePermissionsType = {
-  [key in keyof typeof ResourceType]: Authorization["permissionTypes"];
-};
-
-const resourcePermissions: ResourcePermissionsType = {
-  AUDIT_LOG: [PermissionType.READ],
-  AUTHORIZATION: [
-    PermissionType.CREATE,
-    PermissionType.DELETE,
-    PermissionType.READ,
-    PermissionType.UPDATE,
-  ],
+const resourcePermissions: Record<ResourceType, PermissionType[]> = {
+  AUDIT_LOG: ["READ"],
+  AUTHORIZATION: ["CREATE", "DELETE", "READ", "UPDATE"],
   BATCH: [
-    PermissionType.CREATE,
-    PermissionType.CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE,
-    PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION,
-    PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE,
-    PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION,
-    PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE,
-    PermissionType.CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE,
-    PermissionType.CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE,
-    PermissionType.CREATE_BATCH_OPERATION_RESOLVE_INCIDENT,
-    PermissionType.READ,
-    PermissionType.UPDATE,
+    "CREATE",
+    "CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE",
+    "CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION",
+    "CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE",
+    "CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION",
+    "CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE",
+    "CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE",
+    "CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE",
+    "CREATE_BATCH_OPERATION_RESOLVE_INCIDENT",
+    "READ",
+    "UPDATE",
   ],
-  COMPONENT: [PermissionType.ACCESS],
+  COMPONENT: ["ACCESS"],
   DECISION_DEFINITION: [
-    PermissionType.CREATE_DECISION_INSTANCE,
-    PermissionType.DELETE_DECISION_INSTANCE,
-    PermissionType.READ_DECISION_DEFINITION,
-    PermissionType.READ_DECISION_INSTANCE,
+    "CREATE_DECISION_INSTANCE",
+    "DELETE_DECISION_INSTANCE",
+    "READ_DECISION_DEFINITION",
+    "READ_DECISION_INSTANCE",
   ],
-  DECISION_REQUIREMENTS_DEFINITION: [PermissionType.READ],
-  EXPRESSION: [PermissionType.EVALUATE],
+  DECISION_REQUIREMENTS_DEFINITION: ["READ"],
+  EXPRESSION: ["EVALUATE"],
   RESOURCE: [
-    PermissionType.CREATE,
-    PermissionType.READ,
-    PermissionType.DELETE_DRD,
-    PermissionType.DELETE_FORM,
-    PermissionType.DELETE_PROCESS,
-    PermissionType.DELETE_RESOURCE,
+    "CREATE",
+    "READ",
+    "DELETE_DRD",
+    "DELETE_FORM",
+    "DELETE_PROCESS",
+    "DELETE_RESOURCE",
   ],
-  GROUP: [
-    PermissionType.CREATE,
-    PermissionType.DELETE,
-    PermissionType.READ,
-    PermissionType.UPDATE,
-  ],
-  MAPPING_RULE: [
-    PermissionType.CREATE,
-    PermissionType.DELETE,
-    PermissionType.READ,
-    PermissionType.UPDATE,
-  ],
-  MESSAGE: [PermissionType.CREATE, PermissionType.READ],
+  GROUP: ["CREATE", "DELETE", "READ", "UPDATE"],
+  MAPPING_RULE: ["CREATE", "DELETE", "READ", "UPDATE"],
+  MESSAGE: ["CREATE", "READ"],
   PROCESS_DEFINITION: [
-    PermissionType.CANCEL_PROCESS_INSTANCE,
-    PermissionType.CREATE_PROCESS_INSTANCE,
-    PermissionType.DELETE_PROCESS_INSTANCE,
-    PermissionType.MODIFY_PROCESS_INSTANCE,
-    PermissionType.READ_PROCESS_DEFINITION,
-    PermissionType.READ_PROCESS_INSTANCE,
-    PermissionType.READ_USER_TASK,
-    PermissionType.UPDATE_PROCESS_INSTANCE,
-    PermissionType.UPDATE_USER_TASK,
+    "CANCEL_PROCESS_INSTANCE",
+    "CREATE_PROCESS_INSTANCE",
+    "DELETE_PROCESS_INSTANCE",
+    "MODIFY_PROCESS_INSTANCE",
+    "READ_PROCESS_DEFINITION",
+    "READ_PROCESS_INSTANCE",
+    "READ_USER_TASK",
+    "UPDATE_PROCESS_INSTANCE",
+    "UPDATE_USER_TASK",
   ],
-  USER_TASK: [
-    PermissionType.READ,
-    PermissionType.UPDATE,
-    PermissionType.CLAIM,
-    PermissionType.COMPLETE,
-  ],
-  ROLE: [
-    PermissionType.CREATE,
-    PermissionType.DELETE,
-    PermissionType.READ,
-    PermissionType.UPDATE,
-  ],
-  SYSTEM: [
-    PermissionType.READ,
-    PermissionType.READ_JOB_METRIC,
-    PermissionType.READ_USAGE_METRIC,
-    PermissionType.UPDATE,
-  ],
-  TENANT: [
-    PermissionType.CREATE,
-    PermissionType.DELETE,
-    PermissionType.READ,
-    PermissionType.UPDATE,
-  ],
-  USER: [
-    PermissionType.CREATE,
-    PermissionType.DELETE,
-    PermissionType.READ,
-    PermissionType.UPDATE,
-  ],
-  CLUSTER_VARIABLE: [
-    PermissionType.CREATE,
-    PermissionType.UPDATE,
-    PermissionType.DELETE,
-    PermissionType.READ,
-  ],
-  DOCUMENT: [PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE],
+  USER_TASK: ["READ", "UPDATE", "CLAIM", "COMPLETE"],
+  ROLE: ["CREATE", "DELETE", "READ", "UPDATE"],
+  SYSTEM: ["READ", "READ_JOB_METRIC", "READ_USAGE_METRIC", "UPDATE"],
+  TENANT: ["CREATE", "DELETE", "READ", "UPDATE"],
+  USER: ["CREATE", "DELETE", "READ", "UPDATE"],
+  CLUSTER_VARIABLE: ["CREATE", "UPDATE", "DELETE", "READ"],
+  DOCUMENT: ["CREATE", "READ", "DELETE"],
   GLOBAL_LISTENER: [
-    PermissionType.CREATE_TASK_LISTENER,
-    PermissionType.DELETE_TASK_LISTENER,
-    PermissionType.READ_TASK_LISTENER,
-    PermissionType.UPDATE_TASK_LISTENER,
+    "CREATE_TASK_LISTENER",
+    "DELETE_TASK_LISTENER",
+    "READ_TASK_LISTENER",
+    "UPDATE_TASK_LISTENER",
   ],
 };
 
@@ -163,17 +117,9 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
 
   const { DropdownAutoFocus } = useDropdownAutoFocus(open);
 
-  const ownerTypeItems = Object.values(OwnerType);
-  const allResourceTypes = Object.values(ResourceType);
-  const userTaskResourcePropertyNames = Object.values(ResourcePropertyName);
-
-  let resourceTypeItems = allResourceTypes;
-
-  if (!isTenantsApiEnabled) {
-    resourceTypeItems = resourceTypeItems.filter(
-      (type) => type !== ResourceType.TENANT,
-    );
-  }
+  const resourceTypeItems: ResourceType[] = isTenantsApiEnabled
+    ? ALL_RESOURCE_TYPES
+    : RESOURCE_TYPES_WITHOUT_TENANT;
 
   const { control, handleSubmit, watch, setValue } = useForm<NewAuthorization>({
     defaultValues: createEmptyAuthorization(defaultResourceType),
@@ -200,10 +146,10 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
 
   useEffect(() => {
     setValue("permissionTypes", []);
-    if (watchedResourceType !== ResourceType.USER_TASK) {
+    if (watchedResourceType !== "USER_TASK") {
       setValue("resourceId", "");
     } else {
-      setValue("resourcePropertyName", ResourcePropertyName.assignee);
+      setValue("resourcePropertyName", "assignee");
     }
   }, [watchedResourceType, setValue]);
 
@@ -236,24 +182,20 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
             name="ownerType"
             control={control}
             render={({ field }) => (
-              <Dropdown
+              <Dropdown<OwnerType>
                 id="owner-type-dropdown"
                 label={t("selectOwnerType")}
                 titleText={t("ownerType")}
-                items={ownerTypeItems.filter((ownerType) => {
-                  const excludedType = isOIDC
-                    ? []
-                    : [OwnerType.MAPPING_RULE, OwnerType.CLIENT];
+                items={OWNER_TYPES.filter((ownerType) => {
+                  const excludedType = isOIDC ? [] : ["MAPPING_RULE", "CLIENT"];
 
                   return !excludedType.includes(ownerType);
                 })}
-                onChange={(item: { selectedItem: OwnerType }) => {
+                onChange={(item) => {
                   setValue("ownerId", "");
                   field.onChange(item.selectedItem);
                 }}
-                itemToString={(item: Authorization["ownerType"]) =>
-                  item ? t(item) : ""
-                }
+                itemToString={(item) => (item ? t(item) : "")}
                 selectedItem={field.value}
               />
             )}
@@ -284,37 +226,38 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
           name="resourceType"
           control={control}
           render={({ field }) => (
-            <Dropdown
+            <Dropdown<ResourceType>
               id="resource-type-dropdown"
               label={t("selectResourceType")}
               titleText={t("resourceType")}
               items={resourceTypeItems}
-              onChange={(item: { selectedItem: ResourceType }) => {
+              onChange={(item) => {
                 field.onChange(item.selectedItem);
               }}
-              itemToString={(item: string) => (item ? t(item) : "")}
+              itemToString={(item) => (item ? t(item) : "")}
               selectedItem={
-                resourceTypeItems.find((item) => item === field.value) || ""
+                resourceTypeItems.find((item) => item === field.value) ||
+                resourceTypeItems[0]
               }
             />
           )}
         />
         <TextFieldContainer>
-          {watchedResourceType === ResourceType.USER_TASK ? (
+          {watchedResourceType === "USER_TASK" ? (
             <Controller
               name="resourcePropertyName"
               control={control}
               render={({ field, fieldState }) => {
                 return (
-                  <Dropdown
+                  <Dropdown<ResourcePropertyName>
                     id="property-name-dropdown"
                     label={t("selectResourcePropertyName")}
                     titleText={t("resourcePropertyName")}
-                    items={userTaskResourcePropertyNames}
-                    onChange={(item: { selectedItem: string }) => {
+                    items={RESOURCE_PROPERTY_NAMES}
+                    onChange={(item) => {
                       field.onChange(item.selectedItem);
                     }}
-                    itemToString={(item: string) => item || ""}
+                    itemToString={(item) => item || ""}
                     selectedItem={field.value}
                     invalid={!!fieldState.error}
                     invalidText={fieldState.error?.message}
@@ -377,7 +320,7 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
             {resourcePermissions[watchedResourceType].map((permission) => (
               <Checkbox
                 key={permission}
-                labelText={PermissionType[permission]}
+                labelText={permission}
                 id={permission}
                 checked={field.value.includes(permission)}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -400,20 +343,20 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
 function createEmptyAuthorization(
   resourceType: ResourceType,
 ): NewAuthorization {
-  if (resourceType === ResourceType.USER_TASK) {
+  if (resourceType === "USER_TASK") {
     return {
-      ownerType: OwnerType.USER,
+      ownerType: "USER",
       ownerId: "",
-      resourceType: ResourceType.USER_TASK,
+      resourceType: "USER_TASK",
       resourceId: null,
-      resourcePropertyName: ResourcePropertyName.assignee,
+      resourcePropertyName: "assignee",
       permissionTypes: [],
     };
   } else {
     return {
-      ownerType: OwnerType.USER,
+      ownerType: "USER",
       ownerId: "",
-      resourceType: ResourceType.USER,
+      resourceType: "USER",
       resourceId: "",
       resourcePropertyName: null,
       permissionTypes: [],

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -353,6 +353,7 @@ function createEmptyAuthorization(
       ownerType: "USER",
       ownerId: "",
       resourceType: "USER_TASK",
+      // @ts-expect-error todo fix
       resourceId: null,
       resourcePropertyName: "assignee",
       permissionTypes: [],

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -92,8 +92,6 @@ const resourcePermissions: ResourcePermissionsType = {
   MESSAGE: [PermissionType.CREATE, PermissionType.READ],
   PROCESS_DEFINITION: [
     PermissionType.CANCEL_PROCESS_INSTANCE,
-    PermissionType.CLAIM_USER_TASK,
-    PermissionType.COMPLETE_USER_TASK,
     PermissionType.CREATE_PROCESS_INSTANCE,
     PermissionType.DELETE_PROCESS_INSTANCE,
     PermissionType.MODIFY_PROCESS_INSTANCE,
@@ -254,7 +252,7 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
                   field.onChange(item.selectedItem);
                 }}
                 itemToString={(item: Authorization["ownerType"]) =>
-                  item ? t(OwnerType[item]) : ""
+                  item ? t(item) : ""
                 }
                 selectedItem={field.value}
               />
@@ -331,7 +329,7 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
               rules={{
                 required: t("resourceIdRequired"),
                 validate: (value) =>
-                  isValidResourceId(value) ||
+                  isValidResourceId(value ?? "") ||
                   t("pleaseEnterValidResourceId", {
                     pattern: getIdPattern(),
                   }),
@@ -339,6 +337,7 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
               render={({ field, fieldState }) => (
                 <TextField
                   {...field}
+                  value={field.value ?? ""}
                   label={t("resourceId")}
                   placeholder={t("enterId")}
                   errors={fieldState.error?.message}
@@ -406,6 +405,7 @@ function createEmptyAuthorization(
       ownerType: OwnerType.USER,
       ownerId: "",
       resourceType: ResourceType.USER_TASK,
+      resourceId: null,
       resourcePropertyName: ResourcePropertyName.assignee,
       permissionTypes: [],
     };
@@ -415,6 +415,7 @@ function createEmptyAuthorization(
       ownerId: "",
       resourceType: ResourceType.USER,
       resourceId: "",
+      resourcePropertyName: null,
       permissionTypes: [],
     };
   }

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -86,6 +86,7 @@ const resourcePermissions: Record<ResourceType, PermissionType[]> = {
     "READ_USER_TASK",
     "UPDATE_PROCESS_INSTANCE",
     "UPDATE_USER_TASK",
+    "CLAIM_USER_TASK",
   ],
   USER_TASK: ["READ", "UPDATE", "CLAIM", "COMPLETE"],
   ROLE: ["CREATE", "DELETE", "READ", "UPDATE"],

--- a/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelection.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelection.tsx
@@ -54,7 +54,7 @@ const OwnerSelection = <T,>({
         itemToString={(item) => (item ? itemToString(item) : "")}
         shouldFilterItem={({ inputValue, item }) => {
           if (item && inputValue) {
-            const value = (itemToString(item) ?? "").toLowerCase();
+            const value = itemToString(item).toLowerCase();
             return value.includes(inputValue.toLowerCase());
           }
           return true;

--- a/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelection.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelection.tsx
@@ -54,7 +54,7 @@ const OwnerSelection = <T,>({
         itemToString={(item) => (item ? itemToString(item) : "")}
         shouldFilterItem={({ inputValue, item }) => {
           if (item && inputValue) {
-            const value = itemToString(item).toLowerCase();
+            const value = (itemToString(item) ?? "").toLowerCase();
             return value.includes(inputValue.toLowerCase());
           }
           return true;

--- a/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Authorization, OwnerType } from "src/utility/api/authorizations";
+import { Authorization } from "src/utility/api/authorizations";
 import { searchUser } from "src/utility/api/users";
 import { searchGroups } from "src/utility/api/groups";
 import { searchMappingRule } from "src/utility/api/mapping-rules";
@@ -40,7 +40,7 @@ const Selection: FC<SelectionProps> = ({
   const { t, Translate } = useTranslate("authorizations");
 
   switch (type) {
-    case OwnerType.USER:
+    case "USER":
       if (isOIDC) {
         return (
           <TextField
@@ -87,7 +87,7 @@ const Selection: FC<SelectionProps> = ({
           isEmpty={isEmpty}
         />
       );
-    case OwnerType.GROUP:
+    case "GROUP":
       if (isCamundaGroupsEnabled) {
         return (
           <OwnerSelection
@@ -120,7 +120,7 @@ const Selection: FC<SelectionProps> = ({
           }
         />
       );
-    case OwnerType.MAPPING_RULE:
+    case "MAPPING_RULE":
       return (
         <OwnerSelection
           id="mappingRuleSelection"
@@ -134,7 +134,7 @@ const Selection: FC<SelectionProps> = ({
           isEmpty={isEmpty}
         />
       );
-    case OwnerType.ROLE:
+    case "ROLE":
       return (
         <OwnerSelection
           id="roleSelection"
@@ -146,7 +146,7 @@ const Selection: FC<SelectionProps> = ({
           isEmpty={isEmpty}
         />
       );
-    case OwnerType.CLIENT:
+    case "CLIENT":
       return (
         <TextField
           value={ownerId}

--- a/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
@@ -166,6 +166,7 @@ const Selection: FC<SelectionProps> = ({
           }
         />
       );
+    case "UNSPECIFIED":
     default:
       return null;
   }

--- a/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { OwnerType } from "src/utility/api/authorizations";
+import { Authorization, OwnerType } from "src/utility/api/authorizations";
 import { searchUser } from "src/utility/api/users";
 import { searchGroups } from "src/utility/api/groups";
 import { searchMappingRule } from "src/utility/api/mapping-rules";
@@ -21,7 +21,7 @@ import { DocumentationLink } from "src/components/documentation";
 import { getIdPattern } from "src/utility/validate";
 
 type SelectionProps = {
-  type: OwnerType;
+  type: Authorization["ownerType"];
   ownerId: string;
   onChange: (newOwner: string) => void;
   onBlur: () => void;

--- a/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import { FC } from "react";
-import { Authorization } from "src/utility/api/authorizations";
 import { searchUser } from "src/utility/api/users";
 import { searchGroups } from "src/utility/api/groups";
 import { searchMappingRule } from "src/utility/api/mapping-rules";
@@ -19,6 +18,7 @@ import { isCamundaGroupsEnabled, isOIDC } from "src/configuration";
 import { Caption } from "src/pages/authorizations/modals/components.tsx";
 import { DocumentationLink } from "src/components/documentation";
 import { getIdPattern } from "src/utility/validate";
+import type { Authorization } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type SelectionProps = {
   type: Authorization["ownerType"];

--- a/identity/client/src/pages/cluster-variables/List.tsx
+++ b/identity/client/src/pages/cluster-variables/List.tsx
@@ -12,10 +12,7 @@ import EntityList from "src/components/entityList";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
 import { usePaginatedApi } from "src/utility/api";
-import {
-  ScopeType,
-  searchClusterVariables,
-} from "src/utility/api/cluster-variables";
+import { searchClusterVariables } from "src/utility/api/cluster-variables";
 import PageEmptyState from "src/components/layout/PageEmptyState";
 import { AddModal } from "./modals/add-modal";
 import DeleteModal from "./modals/DeleteModal";
@@ -86,7 +83,7 @@ export default function List() {
               ...clusterVar,
               value: clusterVar.value,
               scopeValue:
-                clusterVar.scope === ScopeType.GLOBAL
+                clusterVar.scope === "GLOBAL"
                   ? t("clusterVariableScopeTypeGlobal")
                   : `${t("clusterVariableScopeTypeTenant")}: ${clusterVar.tenantId}`,
             };

--- a/identity/client/src/pages/cluster-variables/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modals/DeleteModal.tsx
@@ -14,17 +14,12 @@ import {
 } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import {
-  deleteClusterVariable,
-  DeleteClusterVariableParams,
-} from "src/utility/api/cluster-variables";
+import { deleteClusterVariable } from "src/utility/api/cluster-variables";
+import type { ClusterVariable } from "@camunda/camunda-api-zod-schemas/8.9";
 
-const DeleteModal: FC<UseEntityModalProps<DeleteClusterVariableParams>> = ({
-  open,
-  onClose,
-  onSuccess,
-  entity: deleteClusterVariableParams,
-}) => {
+const DeleteModal: FC<
+  UseEntityModalProps<Pick<ClusterVariable, "scope" | "tenantId" | "name">>
+> = ({ open, onClose, onSuccess, entity: deleteClusterVariableParams }) => {
   const { t, Translate } = useTranslate("clusterVariables");
   const { enqueueNotification } = useNotifications();
   const [apiCall, { loading }] = useApiCall(deleteClusterVariable);

--- a/identity/client/src/pages/cluster-variables/modals/EditModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modals/EditModal.tsx
@@ -13,22 +13,15 @@ import useTranslate from "src/utility/localization";
 import { beautify, isValid } from "src/utility/components/editor/jsonUtils.ts";
 import JSONEditor from "src/components/form/JSONEditor.tsx";
 import { useApiCall } from "src/utility/api";
-import {
-  ClusterVariable,
-  updateClusterVariable,
-} from "src/utility/api/cluster-variables";
+import { updateClusterVariable } from "src/utility/api/cluster-variables";
 import { useNotifications } from "src/components/notifications";
-
-type ClusterVariableEntity = Pick<
-  ClusterVariable,
-  "name" | "value" | "scope" | "tenantId"
->;
+import type { ClusterVariable } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type FormData = {
   value: string;
 };
 
-const EditModal: FC<UseEntityModalProps<ClusterVariableEntity>> = ({
+const EditModal: FC<UseEntityModalProps<ClusterVariable>> = ({
   open,
   onClose,
   onSuccess,

--- a/identity/client/src/pages/cluster-variables/modals/EditModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modals/EditModal.tsx
@@ -14,17 +14,15 @@ import { beautify, isValid } from "src/utility/components/editor/jsonUtils.ts";
 import JSONEditor from "src/components/form/JSONEditor.tsx";
 import { useApiCall } from "src/utility/api";
 import {
-  ScopeType,
+  ClusterVariable,
   updateClusterVariable,
 } from "src/utility/api/cluster-variables";
 import { useNotifications } from "src/components/notifications";
 
-type ClusterVariableEntity = {
-  name: string;
-  value: string;
-  scope: ScopeType;
-  tenantId?: string;
-};
+type ClusterVariableEntity = Pick<
+  ClusterVariable,
+  "name" | "value" | "scope" | "tenantId"
+>;
 
 type FormData = {
   value: string;

--- a/identity/client/src/pages/cluster-variables/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modals/add-modal/AddModal.tsx
@@ -9,7 +9,7 @@
 import { FC } from "react";
 import {
   createClusterVariable,
-  ScopeType,
+  type ClusterVariableScope,
 } from "src/utility/api/cluster-variables";
 import { RadioButton, RadioButtonGroup, Stack } from "@carbon/react";
 import { Controller, useForm } from "react-hook-form";
@@ -27,7 +27,7 @@ import ClusterVariableTenantDropdown from "./ClusterVariableTenantDropdown.tsx";
 type FormData = {
   name: string;
   value: string;
-  scope: ScopeType;
+  scope: ClusterVariableScope;
   tenantId?: string;
 };
 
@@ -45,14 +45,14 @@ export const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
     defaultValues: {
       name: "",
       value: "",
-      scope: ScopeType.GLOBAL,
+      scope: "GLOBAL",
       tenantId: "",
     },
     mode: "all",
   });
 
   const watchedScope = watch("scope");
-  const isTenantScoped = watchedScope === ScopeType.TENANT;
+  const isTenantScoped = watchedScope === "TENANT";
 
   const onSubmit = async (data: FormData) => {
     const { success } = await callAddClusterVariable({
@@ -112,16 +112,16 @@ export const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
               orientation="horizontal"
             >
               <RadioButton
-                value={ScopeType.GLOBAL as string}
-                checked={field.value === ScopeType.GLOBAL}
-                onClick={() => field.onChange(ScopeType.GLOBAL)}
+                value={"GLOBAL"}
+                checked={field.value === "GLOBAL"}
+                onClick={() => field.onChange("GLOBAL")}
                 labelText={<span>{t("clusterVariableScopeTypeGlobal")}</span>}
                 type="radio"
               />
               <RadioButton
-                value={ScopeType.TENANT as string}
-                checked={field.value === ScopeType.TENANT}
-                onClick={() => field.onChange(ScopeType.TENANT)}
+                value={"TENANT"}
+                checked={field.value === "TENANT"}
+                onClick={() => field.onChange("TENANT")}
                 labelText={<span>{t("clusterVariableScopeTypeTenant")}</span>}
                 disabled={isSaaS}
                 type="radio"

--- a/identity/client/src/pages/cluster-variables/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modals/add-modal/AddModal.tsx
@@ -7,10 +7,8 @@
  */
 
 import { FC } from "react";
-import {
-  createClusterVariable,
-  type ClusterVariableScope,
-} from "src/utility/api/cluster-variables";
+import type { ClusterVariableScope } from "@camunda/camunda-api-zod-schemas/8.9";
+import { createClusterVariable } from "src/utility/api/cluster-variables";
 import { RadioButton, RadioButtonGroup, Stack } from "@carbon/react";
 import { Controller, useForm } from "react-hook-form";
 import { useNotifications } from "src/components/notifications";

--- a/identity/client/src/pages/cluster-variables/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modals/add-modal/AddModal.tsx
@@ -59,7 +59,7 @@ export const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
       name: data.name.trim(),
       value: JSON.parse(data.value.trim()),
       scope: data.scope,
-      tenantId: isTenantScoped ? data.tenantId : "",
+      tenantId: isTenantScoped ? (data.tenantId ?? null) : "",
     });
 
     if (success) {

--- a/identity/client/src/pages/cluster-variables/modals/add-modal/ClusterVariableTenantDropdown.tsx
+++ b/identity/client/src/pages/cluster-variables/modals/add-modal/ClusterVariableTenantDropdown.tsx
@@ -8,9 +8,10 @@
 
 import { FC, useEffect } from "react";
 import { usePaginatedApi } from "src/utility/api";
-import { searchTenant, Tenant } from "src/utility/api/tenants";
+import { searchTenant } from "src/utility/api/tenants";
 import { Dropdown } from "@carbon/react";
 import useTranslate from "src/utility/localization";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 export type TenantDropdownProps = {
   tenantId: string | undefined;

--- a/identity/client/src/pages/global-task-listeners/List.tsx
+++ b/identity/client/src/pages/global-task-listeners/List.tsx
@@ -12,10 +12,7 @@ import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
 import Page, { PageHeader } from "src/components/layout/Page";
 import EntityList from "src/components/entityList";
-import {
-  GlobalTaskListener,
-  searchGlobalTaskListeners,
-} from "src/utility/api/global-task-listeners";
+import { searchGlobalTaskListeners } from "src/utility/api/global-task-listeners";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
 import AddModal from "src/pages/global-task-listeners/modals/AddModal";
@@ -114,15 +111,13 @@ const List: FC = () => {
           {
             label: t("editGlobalTaskListener"),
             icon: Edit,
-            onClick: (entity) =>
-              editGlobalTaskListener(entity as unknown as GlobalTaskListener),
+            onClick: (entity) => editGlobalTaskListener(entity),
           },
           {
             label: t("delete"),
             icon: TrashCan,
             isDangerous: true,
-            onClick: (entity) =>
-              deleteGlobalTaskListener(entity as unknown as GlobalTaskListener),
+            onClick: (entity) => deleteGlobalTaskListener(entity),
           },
         ]}
         searchPlaceholder={t("searchById")}

--- a/identity/client/src/pages/global-task-listeners/List.tsx
+++ b/identity/client/src/pages/global-task-listeners/List.tsx
@@ -14,7 +14,6 @@ import Page, { PageHeader } from "src/components/layout/Page";
 import EntityList from "src/components/entityList";
 import {
   GlobalTaskListener,
-  ListenerEventType,
   searchGlobalTaskListeners,
 } from "src/utility/api/global-task-listeners";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
@@ -78,7 +77,7 @@ const List: FC = () => {
     executionOrderDisplay: listener.afterNonGlobal
       ? t("executionOrderAfter")
       : t("executionOrderBefore"),
-    eventTypesDisplay: listener.eventTypes.includes(ListenerEventType.ALL)
+    eventTypesDisplay: listener.eventTypes.includes("all")
       ? t("eventTypeAll")
       : listener.eventTypes.join(", "),
   }));

--- a/identity/client/src/pages/global-task-listeners/modals/AddModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modals/AddModal.tsx
@@ -15,13 +15,15 @@ import { useApiCall } from "src/utility/api";
 import TextField from "src/components/form/TextField";
 import {
   createGlobalTaskListener,
-  CreateGlobalTaskListenerParams,
-  GlobalTaskListener,
-  GlobalTaskListenerEventType,
   LISTENER_EVENT_TYPES,
 } from "src/utility/api/global-task-listeners";
 import { useNotifications } from "src/components/notifications";
 import { LISTENER_TYPE_PATTERN } from "src/pages/global-task-listeners";
+import type {
+  CreateGlobalTaskListenerRequestBody,
+  GlobalTaskListener,
+  GlobalTaskListenerEventType,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
   const { t } = useTranslate("globalTaskListeners");
@@ -34,7 +36,7 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
   );
 
   const { control, handleSubmit, watch, setValue } =
-    useForm<CreateGlobalTaskListenerParams>({
+    useForm<CreateGlobalTaskListenerRequestBody>({
       defaultValues: {
         id: "",
         type: "",
@@ -103,7 +105,7 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
     return labels[eventType];
   };
 
-  const onSubmit = async (data: CreateGlobalTaskListenerParams) => {
+  const onSubmit = async (data: CreateGlobalTaskListenerRequestBody) => {
     const eventTypes = data.eventTypes.includes("all")
       ? ["all" as const]
       : data.eventTypes.filter((type) => type !== "all");

--- a/identity/client/src/pages/global-task-listeners/modals/AddModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modals/AddModal.tsx
@@ -16,8 +16,9 @@ import TextField from "src/components/form/TextField";
 import {
   createGlobalTaskListener,
   CreateGlobalTaskListenerParams,
+  GlobalTaskListener,
+  GlobalTaskListenerEventType,
   LISTENER_EVENT_TYPES,
-  ListenerEventType,
 } from "src/utility/api/global-task-listeners";
 import { useNotifications } from "src/components/notifications";
 import { LISTENER_TYPE_PATTERN } from "src/pages/global-task-listeners";
@@ -47,37 +48,31 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
 
   const eventTypes = watch("eventTypes");
 
-  const handleEventTypeChange = (selectedItems: ListenerEventType[]) => {
-    const individualTypes = LISTENER_EVENT_TYPES.filter(
-      (opt) => opt !== ListenerEventType.ALL,
-    );
+  const handleEventTypeChange = (
+    selectedItems: GlobalTaskListenerEventType[],
+  ) => {
+    const individualTypes = LISTENER_EVENT_TYPES.filter((opt) => opt !== "all");
 
     // If "all" was just checked, select all individual types too
-    if (
-      selectedItems.includes(ListenerEventType.ALL) &&
-      !eventTypes.includes(ListenerEventType.ALL)
-    ) {
+    if (selectedItems.includes("all") && !eventTypes.includes("all")) {
       setValue("eventTypes", [...LISTENER_EVENT_TYPES]); // includes "all" and all individuals
       return;
     }
 
     // If "all" was just unchecked, uncheck all individual types too
-    if (
-      !selectedItems.includes(ListenerEventType.ALL) &&
-      eventTypes.includes(ListenerEventType.ALL)
-    ) {
+    if (!selectedItems.includes("all") && eventTypes.includes("all")) {
       setValue("eventTypes", []);
       return;
     }
 
     // If an individual type was unchecked while "all" is checked, uncheck "all" too
     if (
-      eventTypes.includes(ListenerEventType.ALL) &&
+      eventTypes.includes("all") &&
       selectedItems.length < LISTENER_EVENT_TYPES.length
     ) {
       setValue(
         "eventTypes",
-        selectedItems.filter((item) => item !== ListenerEventType.ALL),
+        selectedItems.filter((item) => item !== "all"),
       );
       return;
     }
@@ -86,10 +81,7 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
     const allIndividualSelected = individualTypes.every((type) =>
       selectedItems.includes(type),
     );
-    if (
-      allIndividualSelected &&
-      !selectedItems.includes(ListenerEventType.ALL)
-    ) {
+    if (allIndividualSelected && !selectedItems.includes("all")) {
       setValue("eventTypes", [...LISTENER_EVENT_TYPES]); // includes "all" and all individuals
       return;
     }
@@ -97,8 +89,10 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
     setValue("eventTypes", selectedItems);
   };
 
-  const getEventTypeLabel = (eventType: ListenerEventType): string => {
-    const labels: Record<ListenerEventType, string> = {
+  const getEventTypeLabel = (
+    eventType: GlobalTaskListener["eventTypes"][number],
+  ): string => {
+    const labels: Record<GlobalTaskListener["eventTypes"][number], string> = {
       all: t("eventTypeAll"),
       creating: t("eventTypeCreating"),
       updating: t("eventTypeUpdating"),
@@ -110,9 +104,9 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
   };
 
   const onSubmit = async (data: CreateGlobalTaskListenerParams) => {
-    const eventTypes = data.eventTypes.includes(ListenerEventType.ALL)
-      ? [ListenerEventType.ALL]
-      : data.eventTypes.filter((type) => type !== ListenerEventType.ALL);
+    const eventTypes = data.eventTypes.includes("all")
+      ? ["all" as const]
+      : data.eventTypes.filter((type) => type !== "all");
 
     const { success } = await callCreateGlobalTaskListener({
       id: data.id,
@@ -202,7 +196,7 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
             titleText={t("eventType")}
             label={
               field.value.length > 0
-                ? field.value.includes(ListenerEventType.ALL)
+                ? field.value.includes("all")
                   ? t("eventTypeAll")
                   : field.value.map(getEventTypeLabel).join(", ")
                 : t("selectEventTypes")
@@ -212,11 +206,13 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
             onChange={({
               selectedItems,
             }: {
-              selectedItems: ListenerEventType[];
+              selectedItems: GlobalTaskListenerEventType[];
             }) => {
               handleEventTypeChange(selectedItems);
             }}
-            itemToString={(item: ListenerEventType) => getEventTypeLabel(item)}
+            itemToString={(item: GlobalTaskListenerEventType) =>
+              getEventTypeLabel(item)
+            }
             invalid={!!fieldState.error}
             invalidText={fieldState.error?.message}
           />

--- a/identity/client/src/pages/global-task-listeners/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modals/DeleteModal.tsx
@@ -13,11 +13,9 @@ import {
   DeleteModal as Modal,
   UseEntityModalProps,
 } from "src/components/modal";
-import {
-  deleteGlobalTaskListener,
-  GlobalTaskListener,
-} from "src/utility/api/global-task-listeners";
+import { deleteGlobalTaskListener } from "src/utility/api/global-task-listeners";
 import { useNotifications } from "src/components/notifications";
+import type { GlobalTaskListener } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const DeleteModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
   open,

--- a/identity/client/src/pages/global-task-listeners/modals/EditModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modals/EditModal.tsx
@@ -15,13 +15,15 @@ import { useApiCall } from "src/utility/api";
 import TextField from "src/components/form/TextField";
 import {
   updateGlobalTaskListener,
-  GlobalTaskListener,
-  GlobalTaskListenerEventType,
   LISTENER_EVENT_TYPES,
-  CreateGlobalTaskListenerParams,
 } from "src/utility/api/global-task-listeners";
 import { useNotifications } from "src/components/notifications";
 import { LISTENER_TYPE_PATTERN } from "src/pages/global-task-listeners";
+import type {
+  CreateGlobalTaskListenerRequestBody,
+  GlobalTaskListener,
+  GlobalTaskListenerEventType,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 
 const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
   open,
@@ -39,7 +41,7 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
   );
 
   const { control, handleSubmit, watch, setValue, reset } =
-    useForm<CreateGlobalTaskListenerParams>({
+    useForm<CreateGlobalTaskListenerRequestBody>({
       defaultValues: {
         id: entity.id,
         type: entity.type,
@@ -120,7 +122,7 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
     return labels[eventType];
   };
 
-  const onSubmit = async (data: CreateGlobalTaskListenerParams) => {
+  const onSubmit = async (data: CreateGlobalTaskListenerRequestBody) => {
     const eventTypes = data.eventTypes.includes("all")
       ? ["all" as const]
       : data.eventTypes.filter((type) => type !== "all");

--- a/identity/client/src/pages/global-task-listeners/modals/EditModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modals/EditModal.tsx
@@ -16,7 +16,7 @@ import TextField from "src/components/form/TextField";
 import {
   updateGlobalTaskListener,
   GlobalTaskListener,
-  ListenerEventType,
+  GlobalTaskListenerEventType,
   LISTENER_EVENT_TYPES,
   CreateGlobalTaskListenerParams,
 } from "src/utility/api/global-task-listeners";
@@ -38,20 +38,15 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
     },
   );
 
-  // Parse eventTypes array to form format
-  const parseEventTypes = (eventTypes: string[]): ListenerEventType[] => {
-    return eventTypes as ListenerEventType[];
-  };
-
   const { control, handleSubmit, watch, setValue, reset } =
     useForm<CreateGlobalTaskListenerParams>({
       defaultValues: {
         id: entity.id,
         type: entity.type,
-        eventTypes: parseEventTypes(entity.eventTypes),
-        retries: entity.retries,
-        afterNonGlobal: entity.afterNonGlobal,
-        priority: entity.priority,
+        eventTypes: entity.eventTypes,
+        retries: entity.retries ?? undefined,
+        afterNonGlobal: entity.afterNonGlobal ?? undefined,
+        priority: entity.priority ?? undefined,
       },
       mode: "all",
     });
@@ -61,46 +56,40 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
     reset({
       id: entity.id,
       type: entity.type,
-      eventTypes: parseEventTypes(entity.eventTypes),
-      retries: entity.retries,
-      afterNonGlobal: entity.afterNonGlobal,
-      priority: entity.priority,
+      eventTypes: entity.eventTypes,
+      retries: entity.retries ?? undefined,
+      afterNonGlobal: entity.afterNonGlobal ?? undefined,
+      priority: entity.priority ?? undefined,
     });
   }, [entity, reset]);
 
   const eventTypes = watch("eventTypes");
 
-  const handleEventTypeChange = (selectedItems: ListenerEventType[]) => {
-    const individualTypes = LISTENER_EVENT_TYPES.filter(
-      (opt) => opt !== ListenerEventType.ALL,
-    );
+  const handleEventTypeChange = (
+    selectedItems: GlobalTaskListenerEventType[],
+  ) => {
+    const individualTypes = LISTENER_EVENT_TYPES.filter((opt) => opt !== "all");
 
     // If "all" was just checked, select all individual types too
-    if (
-      selectedItems.includes(ListenerEventType.ALL) &&
-      !eventTypes.includes(ListenerEventType.ALL)
-    ) {
+    if (selectedItems.includes("all") && !eventTypes.includes("all")) {
       setValue("eventTypes", [...LISTENER_EVENT_TYPES]); // includes "all" and all individuals
       return;
     }
 
     // If "all" was just unchecked, uncheck all individual types too
-    if (
-      !selectedItems.includes(ListenerEventType.ALL) &&
-      eventTypes.includes(ListenerEventType.ALL)
-    ) {
+    if (!selectedItems.includes("all") && eventTypes.includes("all")) {
       setValue("eventTypes", []);
       return;
     }
 
     // If an individual type was unchecked while "all" is checked, uncheck "all" too
     if (
-      eventTypes.includes(ListenerEventType.ALL) &&
+      eventTypes.includes("all") &&
       selectedItems.length < LISTENER_EVENT_TYPES.length
     ) {
       setValue(
         "eventTypes",
-        selectedItems.filter((item) => item !== ListenerEventType.ALL),
+        selectedItems.filter((item) => item !== "all"),
       );
       return;
     }
@@ -109,10 +98,7 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
     const allIndividualSelected = individualTypes.every((type) =>
       selectedItems.includes(type),
     );
-    if (
-      allIndividualSelected &&
-      !selectedItems.includes(ListenerEventType.ALL)
-    ) {
+    if (allIndividualSelected && !selectedItems.includes("all")) {
       setValue("eventTypes", [...LISTENER_EVENT_TYPES]); // includes "all" and all individuals
       return;
     }
@@ -120,8 +106,10 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
     setValue("eventTypes", selectedItems);
   };
 
-  const getEventTypeLabel = (eventType: ListenerEventType): string => {
-    const labels: Record<ListenerEventType, string> = {
+  const getEventTypeLabel = (
+    eventType: GlobalTaskListener["eventTypes"][number],
+  ): string => {
+    const labels: Record<GlobalTaskListener["eventTypes"][number], string> = {
       all: t("eventTypeAll"),
       creating: t("eventTypeCreating"),
       updating: t("eventTypeUpdating"),
@@ -133,9 +121,9 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
   };
 
   const onSubmit = async (data: CreateGlobalTaskListenerParams) => {
-    const eventTypes = data.eventTypes.includes(ListenerEventType.ALL)
-      ? [ListenerEventType.ALL]
-      : data.eventTypes.filter((type) => type !== ListenerEventType.ALL);
+    const eventTypes = data.eventTypes.includes("all")
+      ? ["all" as const]
+      : data.eventTypes.filter((type) => type !== "all");
 
     const { success } = await callUpdateGlobalTaskListener({
       id: entity.id,
@@ -216,7 +204,7 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
             titleText={t("eventType")}
             label={
               field.value.length > 0
-                ? field.value.includes(ListenerEventType.ALL)
+                ? field.value.includes("all")
                   ? t("eventTypeAll")
                   : field.value.map(getEventTypeLabel).join(", ")
                 : t("selectEventTypes")
@@ -226,11 +214,13 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
             onChange={({
               selectedItems,
             }: {
-              selectedItems: ListenerEventType[];
+              selectedItems: GlobalTaskListenerEventType[];
             }) => {
               handleEventTypeChange(selectedItems);
             }}
-            itemToString={(item: ListenerEventType) => getEventTypeLabel(item)}
+            itemToString={(item: GlobalTaskListenerEventType) =>
+              getEventTypeLabel(item)
+            }
             invalid={!!fieldState.error}
             invalidText={fieldState.error?.message}
           />

--- a/identity/client/src/pages/groups/List.tsx
+++ b/identity/client/src/pages/groups/List.tsx
@@ -12,7 +12,7 @@ import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
 import Page, { PageHeader } from "src/components/layout/Page";
 import EntityList from "src/components/entityList";
-import { Group, searchGroups } from "src/utility/api/groups";
+import { searchGroups } from "src/utility/api/groups";
 import { useNavigate } from "react-router-dom";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
@@ -20,6 +20,7 @@ import EditModal from "src/pages/groups/modals/EditModal";
 import DeleteModal from "src/pages/groups/modals/DeleteModal";
 import AddModal from "src/pages/groups/modals/AddModal";
 import PageEmptyState from "src/components/layout/PageEmptyState";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const List: FC = () => {
   const { t } = useTranslate("groups");

--- a/identity/client/src/pages/groups/detail/clients/AssignClientsModal.tsx
+++ b/identity/client/src/pages/groups/detail/clients/AssignClientsModal.tsx
@@ -9,19 +9,19 @@
 import { FC, useEffect, useState } from "react";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import { Client } from "src/utility/api/groups";
 import FormModal from "src/components/modal/FormModal";
-import { assignGroupClient, Group } from "src/utility/api/groups";
+import { assignGroupClient } from "src/utility/api/groups";
 import TextField from "src/components/form/TextField";
 import { UseEntityModalProps } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
+import type { Group, TenantClient } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignClientsModal: FC<
   UseEntityModalProps<{ groupId: Group["groupId"] }>
 > = ({ entity: { groupId }, onSuccess, open, onClose }) => {
   const { t } = useTranslate("groups");
   const { enqueueNotification } = useNotifications();
-  const [clientId, setClientId] = useState<Client["clientId"]>("");
+  const [clientId, setClientId] = useState<TenantClient["clientId"]>("");
   const [loadingAssignClient, setLoadingAssignClient] = useState(false);
 
   const [callAssignClient] = useApiCall(assignGroupClient);

--- a/identity/client/src/pages/groups/detail/clients/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detail/clients/DeleteModal.tsx
@@ -15,7 +15,7 @@ import {
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
 import { unassignGroupClient } from "src/utility/api/groups";
-import type { Group, TenantClient } from "@camunda/camunda-api-zod-schemas/8.8";
+import type { Group, TenantClient } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveGroupClientModalProps = UseEntityModalCustomProps<
   TenantClient,

--- a/identity/client/src/pages/groups/detail/clients/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detail/clients/DeleteModal.tsx
@@ -14,11 +14,11 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { Client, Group } from "src/utility/api/groups";
 import { unassignGroupClient } from "src/utility/api/groups";
+import type { Group, TenantClient } from "@camunda/camunda-api-zod-schemas/8.8";
 
 type RemoveGroupClientModalProps = UseEntityModalCustomProps<
-  Client,
+  TenantClient,
   {
     groupId: Group["groupId"];
   }

--- a/identity/client/src/pages/groups/detail/clients/index.tsx
+++ b/identity/client/src/pages/groups/detail/clients/index.tsx
@@ -11,12 +11,13 @@ import { C3EmptyState } from "@camunda/camunda-composite-components";
 import { TrashCan } from "@carbon/react/icons";
 import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
-import { getClientsByGroupId, Group } from "src/utility/api/groups";
+import { getClientsByGroupId } from "src/utility/api/groups";
 import EntityList from "src/components/entityList";
 import { useEntityModal } from "src/components/modal";
 import DeleteModal from "src/pages/groups/detail/clients/DeleteModal";
 import AssignClientsModal from "src/pages/groups/detail/clients/AssignClientsModal";
 import TabEmptyState from "src/components/layout/TabEmptyState";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type ClientsProps = {
   groupId: Group["groupId"];

--- a/identity/client/src/pages/groups/detail/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/groups/detail/mapping-rules/AssignMappingRulesModal.tsx
@@ -11,13 +11,14 @@ import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchMappingRule, MappingRule } from "src/utility/api/mapping-rules";
+import { searchMappingRule } from "src/utility/api/mapping-rules";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { assignGroupMappingRule, Group } from "src/utility/api/groups";
+import { assignGroupMappingRule } from "src/utility/api/groups";
 import { useNotifications } from "src/components/notifications";
+import type { Group, MappingRule } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedMappingRules = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/groups/detail/mapping-rules/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detail/mapping-rules/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { MappingRule } from "src/utility/api/mapping-rules";
 import { unassignGroupMappingRule } from "src/utility/api/groups";
+import type { MappingRule } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveGroupMappingRuleModalProps = UseEntityModalCustomProps<
   MappingRule,

--- a/identity/client/src/pages/groups/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/AssignMemberModal.tsx
@@ -11,13 +11,12 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignGroupMember } from "src/utility/api/membership";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import { User } from "src/utility/api/users";
 import FormModal from "src/components/modal/FormModal";
-import { Group } from "src/utility/api/groups";
 import TextField from "src/components/form/TextField";
 import { useNotifications } from "src/components/notifications";
 import { DocumentationLink } from "src/components/documentation";
 import { Caption } from "src/pages/authorizations/modals/components.tsx";
+import type { Group, User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignMemberModal: FC<
   UseEntityModalCustomProps<

--- a/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
@@ -12,13 +12,13 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignGroupMember } from "src/utility/api/membership";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchUser, User } from "src/utility/api/users";
+import { searchUser } from "src/utility/api/users";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { Group } from "src/utility/api/groups";
 import { useNotifications } from "src/components/notifications";
+import type { Group, User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedUsers = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/groups/detail/members/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { User } from "src/utility/api/users";
 import { unassignGroupMember } from "src/utility/api/membership";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveGroupMemberModalProps = UseEntityModalCustomProps<
   User,

--- a/identity/client/src/pages/groups/detail/roles/AssignRolesModal.tsx
+++ b/identity/client/src/pages/groups/detail/roles/AssignRolesModal.tsx
@@ -11,13 +11,14 @@ import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchRoles, Role } from "src/utility/api/roles";
+import { searchRoles } from "src/utility/api/roles";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { assignGroupRole, Group } from "src/utility/api/groups";
+import { assignGroupRole } from "src/utility/api/groups";
 import { useNotifications } from "src/components/notifications";
+import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedRoles = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/groups/detail/roles/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detail/roles/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { Role } from "src/utility/api/roles";
 import { unassignGroupRole } from "src/utility/api/groups";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveGroupRoleModalProps = UseEntityModalCustomProps<
   Role,

--- a/identity/client/src/pages/groups/detail/roles/index.tsx
+++ b/identity/client/src/pages/groups/detail/roles/index.tsx
@@ -38,7 +38,6 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
   const isRolesListEmpty = !roles || roles.items?.length === 0;
 
   const [assignRoles, assignRolesModal] = useEntityModal(
-    // @ts-expect-error todo fix
     AssignRolesModal,
     reload,
     {
@@ -81,7 +80,6 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
   return (
     <>
       <EntityList
-        // @ts-expect-error todo fix
         data={roles?.items}
         headers={[
           { header: t("roleId"), key: "roleId", isSortable: true },

--- a/identity/client/src/pages/groups/detail/roles/index.tsx
+++ b/identity/client/src/pages/groups/detail/roles/index.tsx
@@ -38,6 +38,7 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
   const isRolesListEmpty = !roles || roles.items?.length === 0;
 
   const [assignRoles, assignRolesModal] = useEntityModal(
+    // @ts-expect-error todo fix
     AssignRolesModal,
     reload,
     {
@@ -80,6 +81,7 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
   return (
     <>
       <EntityList
+        // @ts-expect-error todo fix
         data={roles?.items}
         headers={[
           { header: t("roleId"), key: "roleId", isSortable: true },

--- a/identity/client/src/pages/groups/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/modals/DeleteModal.tsx
@@ -14,7 +14,8 @@ import {
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
 import { useNotifications } from "src/components/notifications";
-import { deleteGroup, Group } from "src/utility/api/groups";
+import { deleteGroup } from "src/utility/api/groups";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const DeleteModal: FC<UseEntityModalProps<Group>> = ({
   entity: { groupId },

--- a/identity/client/src/pages/groups/modals/EditModal.tsx
+++ b/identity/client/src/pages/groups/modals/EditModal.tsx
@@ -11,9 +11,10 @@ import { FormModal, UseEntityModalProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
 import { useNotifications } from "src/components/notifications";
-import { Group, updateGroup } from "src/utility/api/groups";
+import { updateGroup } from "src/utility/api/groups";
 import TextField from "src/components/form/TextField";
 import { isValidId } from "src/utility/validate.ts";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const EditModal: FC<UseEntityModalProps<Group>> = ({
   entity: group,

--- a/identity/client/src/pages/mapping-rules/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/mapping-rules/modals/DeleteModal.tsx
@@ -10,7 +10,7 @@ import { FC } from "react";
 import { useApiCall } from "src/utility/api";
 import {
   deleteMappingRule,
-  DeleteMappingRuleParams,
+  type MappingRule,
 } from "src/utility/api/mapping-rules";
 import useTranslate from "src/utility/localization";
 import {
@@ -19,9 +19,12 @@ import {
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
 
-const DeleteMappingRulesModal: FC<
-  UseEntityModalProps<DeleteMappingRuleParams>
-> = ({ open, onClose, onSuccess, entity: { mappingRuleId, name } }) => {
+const DeleteMappingRulesModal: FC<UseEntityModalProps<MappingRule>> = ({
+  open,
+  onClose,
+  onSuccess,
+  entity: { mappingRuleId, name },
+}) => {
   const { t, Translate } = useTranslate("mappingRules");
   const { enqueueNotification } = useNotifications();
   const [apiCall, { loading }] = useApiCall(deleteMappingRule);

--- a/identity/client/src/pages/mapping-rules/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/mapping-rules/modals/DeleteModal.tsx
@@ -8,16 +8,14 @@
 
 import { FC } from "react";
 import { useApiCall } from "src/utility/api";
-import {
-  deleteMappingRule,
-  type MappingRule,
-} from "src/utility/api/mapping-rules";
+import { deleteMappingRule } from "src/utility/api/mapping-rules";
 import useTranslate from "src/utility/localization";
 import {
   DeleteModal as Modal,
   UseEntityModalProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
+import type { MappingRule } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const DeleteMappingRulesModal: FC<UseEntityModalProps<MappingRule>> = ({
   open,

--- a/identity/client/src/pages/mapping-rules/modals/EditModal.tsx
+++ b/identity/client/src/pages/mapping-rules/modals/EditModal.tsx
@@ -14,13 +14,14 @@ import TextField from "src/components/form/TextField";
 import { useApiCall } from "src/utility/api";
 import useTranslate from "src/utility/localization";
 import { FormModal, UseEntityModalProps } from "src/components/modal";
-import { updateMappingRule, MappingRule } from "src/utility/api/mapping-rules";
+import { updateMappingRule } from "src/utility/api/mapping-rules";
 import {
   CustomStack,
   EqualSignContainer,
   MappingRuleContainer,
 } from "./components";
 import { useNotifications } from "src/components/notifications";
+import type { MappingRule } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const EditModal: FC<UseEntityModalProps<MappingRule>> = ({
   open,

--- a/identity/client/src/pages/operations-log/CellProperty.tsx
+++ b/identity/client/src/pages/operations-log/CellProperty.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { AuditLog } from "@camunda/camunda-api-zod-schemas/8.9/audit-log";
+import type { AuditLog } from "@camunda/camunda-api-zod-schemas/8.9";
 import { OwnerInfo, PropertyText } from "./components/styled";
 import { CodeSnippet } from "@carbon/react";
 import { spaceAndCapitalize } from "src/utility/format/spaceAndCapitalize";

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -35,7 +35,7 @@ import {
   TextInput,
 } from "@carbon/react";
 import {
-  AuditLogEntityType,
+  type AuditLogEntityType,
   auditLogResultSchema,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import useDebounce from "react-debounced";
@@ -165,7 +165,7 @@ const List: FC = () => {
               <Heading>{t("filter")}</Heading>
               <MultiSelect
                 id="operationType"
-                items={ALLOWED_OPERATION_TYPES}
+                items={[...ALLOWED_OPERATION_TYPES]}
                 titleText={t("operationType")}
                 label={t("multiSelectLabel")}
                 selectedItems={filters.operationType}
@@ -181,7 +181,7 @@ const List: FC = () => {
               />
               <Dropdown
                 id="entityType"
-                items={ALLOWED_ENTITY_TYPES}
+                items={[...ALLOWED_ENTITY_TYPES]}
                 titleText={t("entityType")}
                 label={t("selectLabel")}
                 selectedItem={filters.entityType ? filters.entityType : ""}
@@ -207,7 +207,7 @@ const List: FC = () => {
                 <>
                   <Dropdown
                     id="relatedEntityType"
-                    items={ALLOWED_ENTITY_TYPES}
+                    items={[...ALLOWED_ENTITY_TYPES]}
                     titleText={t("ownerType")}
                     label={t("selectLabel")}
                     selectedItem={

--- a/identity/client/src/pages/operations-log/filters.ts
+++ b/identity/client/src/pages/operations-log/filters.ts
@@ -30,22 +30,22 @@ export type AuditLogFilters = {
   timestampTo: string;
 };
 
-export const ALLOWED_OPERATION_TYPES: AuditLogOperationType[] = [
+export const ALLOWED_OPERATION_TYPES = [
   "CREATE",
   "ASSIGN",
   "UNASSIGN",
   "DELETE",
   "UPDATE",
-] as const;
+] as const satisfies readonly AuditLogOperationType[];
 
-export const ALLOWED_ENTITY_TYPES: AuditLogEntityType[] = [
+export const ALLOWED_ENTITY_TYPES = [
   "AUTHORIZATION",
   "ROLE",
   "USER",
   "GROUP",
   "MAPPING_RULE",
   "TENANT",
-] as const;
+] as const satisfies readonly AuditLogEntityType[];
 
 export const ALLOWED_RESULT_TYPES = [
   "all",
@@ -57,7 +57,9 @@ const auditLogSearchParamsSync = createSearchParamsSync<AuditLogFilters>({
     parse: (params) => {
       return parseArrayParam<AuditLogOperationType>(
         params.get("operationType"),
-      ).filter((item) => ALLOWED_OPERATION_TYPES.includes(item));
+      ).filter((item): item is (typeof ALLOWED_OPERATION_TYPES)[number] =>
+        ALLOWED_OPERATION_TYPES.some((t) => t === item),
+      );
     },
     serialize: (value, params) => {
       const v = buildArrayParam(value);
@@ -67,9 +69,8 @@ const auditLogSearchParamsSync = createSearchParamsSync<AuditLogFilters>({
 
   entityType: {
     parse: (params) => {
-      const entityType = params.get("entityType") as AuditLogEntityType;
-
-      return ALLOWED_ENTITY_TYPES.includes(entityType) ? entityType : undefined;
+      const entityType = params.get("entityType");
+      return ALLOWED_ENTITY_TYPES.find((t) => t === entityType);
     },
     serialize: (value, params) => {
       if (value) params.set("entityType", value);
@@ -78,13 +79,8 @@ const auditLogSearchParamsSync = createSearchParamsSync<AuditLogFilters>({
 
   relatedEntityType: {
     parse: (params) => {
-      const relatedEntityType = params.get(
-        "relatedEntityType",
-      ) as AuditLogEntityType;
-
-      return ALLOWED_ENTITY_TYPES.includes(relatedEntityType)
-        ? relatedEntityType
-        : undefined;
+      const relatedEntityType = params.get("relatedEntityType");
+      return ALLOWED_ENTITY_TYPES.find((t) => t === relatedEntityType);
     },
     serialize: (value, params) => {
       if (value) params.set("relatedEntityType", value);
@@ -100,13 +96,8 @@ const auditLogSearchParamsSync = createSearchParamsSync<AuditLogFilters>({
 
   result: {
     parse: (params) => {
-      const result = params.get("result") as AuditLogResult;
-
-      if (result && ALLOWED_RESULT_TYPES.includes(result)) {
-        return result;
-      }
-
-      return "all";
+      const result = params.get("result");
+      return ALLOWED_RESULT_TYPES.find((t) => t === result) ?? "all";
     },
     serialize: (value, params) => {
       if (value !== "all") {

--- a/identity/client/src/pages/roles/List.tsx
+++ b/identity/client/src/pages/roles/List.tsx
@@ -13,12 +13,13 @@ import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
 import Page, { PageHeader } from "src/components/layout/Page";
 import EntityList from "src/components/entityList";
-import { searchRoles, Role } from "src/utility/api/roles";
+import { searchRoles } from "src/utility/api/roles";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
 import AddModal from "src/pages/roles/modals/AddModal";
 import DeleteModal from "src/pages/roles/modals/DeleteModal";
 import PageEmptyState from "src/components/layout/PageEmptyState";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const List: FC = () => {
   const { t } = useTranslate("roles");

--- a/identity/client/src/pages/roles/detail/clients/AssignClientsModal.tsx
+++ b/identity/client/src/pages/roles/detail/clients/AssignClientsModal.tsx
@@ -9,11 +9,11 @@
 import { FC, useEffect, useState } from "react";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import { Client } from "src/utility/api/roles";
 import FormModal from "src/components/modal/FormModal";
-import { assignRoleClient, Role } from "src/utility/api/roles";
+import { assignRoleClient } from "src/utility/api/roles";
 import TextField from "src/components/form/TextField";
 import { UseEntityModalProps } from "src/components/modal";
+import type { Role, TenantClient } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignClientsModal: FC<UseEntityModalProps<Role["roleId"]>> = ({
   entity: roleId,
@@ -22,7 +22,7 @@ const AssignClientsModal: FC<UseEntityModalProps<Role["roleId"]>> = ({
   onClose,
 }) => {
   const { t, Translate } = useTranslate("roles");
-  const [clientId, setClientId] = useState<Client["clientId"]>("");
+  const [clientId, setClientId] = useState<TenantClient["clientId"]>("");
   const [loadingAssignClient, setLoadingAssignClient] = useState(false);
 
   const [callAssignClient] = useApiCall(assignRoleClient);

--- a/identity/client/src/pages/roles/detail/clients/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detail/clients/DeleteModal.tsx
@@ -14,11 +14,11 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { Client, Role } from "src/utility/api/roles";
 import { unassignRoleClient } from "src/utility/api/roles";
+import type { Role, TenantClient } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveRoleClientModalProps = UseEntityModalCustomProps<
-  Client,
+  TenantClient,
   {
     roleId: Role["roleId"];
   }

--- a/identity/client/src/pages/roles/detail/clients/index.tsx
+++ b/identity/client/src/pages/roles/detail/clients/index.tsx
@@ -11,12 +11,13 @@ import { C3EmptyState } from "@camunda/camunda-composite-components";
 import { TrashCan } from "@carbon/react/icons";
 import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
-import { getClientsByRoleId, Role } from "src/utility/api/roles";
+import { getClientsByRoleId } from "src/utility/api/roles";
 import EntityList from "src/components/entityList";
 import { useEntityModal } from "src/components/modal";
 import DeleteModal from "src/pages/roles/detail/clients/DeleteModal";
 import AssignClientsModal from "src/pages/roles/detail/clients/AssignClientsModal";
 import TabEmptyState from "src/components/layout/TabEmptyState";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type ClientsProps = {
   roleId: Role["roleId"];

--- a/identity/client/src/pages/roles/detail/groups/AssignGroupModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/AssignGroupModal.tsx
@@ -8,12 +8,12 @@
 
 import { FC, useEffect, useState } from "react";
 import { UseEntityModalCustomProps } from "src/components/modal";
-import { assignRoleGroup, Role } from "src/utility/api/roles";
+import { assignRoleGroup } from "src/utility/api/roles";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import { Group } from "src/utility/api/groups";
 import FormModal from "src/components/modal/FormModal";
 import TextField from "src/components/form/TextField";
+import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignGroupModal: FC<
   UseEntityModalCustomProps<

--- a/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
@@ -12,11 +12,12 @@ import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchGroups, Group } from "src/utility/api/groups";
+import { searchGroups } from "src/utility/api/groups";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { assignRoleGroup, Role } from "src/utility/api/roles";
+import { assignRoleGroup } from "src/utility/api/roles";
+import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedGroups = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/roles/detail/groups/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { Group } from "src/utility/api/groups";
 import { unassignRoleGroup } from "src/utility/api/roles";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveRoleGroupModalProps = UseEntityModalCustomProps<
   Group,

--- a/identity/client/src/pages/roles/detail/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/roles/detail/mapping-rules/AssignMappingRulesModal.tsx
@@ -12,11 +12,12 @@ import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchMappingRule, MappingRule } from "src/utility/api/mapping-rules";
+import { searchMappingRule } from "src/utility/api/mapping-rules";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { assignRoleMappingRule, Role } from "src/utility/api/roles";
+import { assignRoleMappingRule } from "src/utility/api/roles";
+import type { MappingRule, Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedMappingRules = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/roles/detail/mapping-rules/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detail/mapping-rules/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { MappingRule } from "src/utility/api/mapping-rules";
 import { unassignRoleMappingRule } from "src/utility/api/roles";
+import type { MappingRule } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveRoleMappingRuleModalProps = UseEntityModalCustomProps<
   MappingRule,

--- a/identity/client/src/pages/roles/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/AssignMemberModal.tsx
@@ -11,12 +11,11 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignRoleMember } from "src/utility/api/membership";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import { User } from "src/utility/api/users";
 import FormModal from "src/components/modal/FormModal";
-import { Role } from "src/utility/api/roles";
 import TextField from "src/components/form/TextField";
 import { Caption } from "src/pages/authorizations/modals/components.tsx";
 import { DocumentationLink } from "src/components/documentation";
+import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignMemberModal: FC<
   UseEntityModalCustomProps<

--- a/identity/client/src/pages/roles/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/AssignMembersModal.tsx
@@ -12,12 +12,12 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignRoleMember } from "src/utility/api/membership";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchUser, User } from "src/utility/api/users";
+import { searchUser } from "src/utility/api/users";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { Role } from "src/utility/api/roles";
+import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedUsers = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/roles/detail/members/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { User } from "src/utility/api/users";
 import { unassignRoleMember } from "src/utility/api/membership";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveRoleMemberModalProps = UseEntityModalCustomProps<
   User,

--- a/identity/client/src/pages/roles/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/modals/DeleteModal.tsx
@@ -13,10 +13,11 @@ import {
   DeleteModal as Modal,
   UseEntityModalProps,
 } from "src/components/modal";
-import { deleteRole, DeleteRoleParams } from "src/utility/api/roles";
+import { deleteRole } from "src/utility/api/roles";
 import { useNotifications } from "src/components/notifications";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.8";
 
-const DeleteModal: FC<UseEntityModalProps<DeleteRoleParams>> = ({
+const DeleteModal: FC<UseEntityModalProps<Role>> = ({
   open,
   onClose,
   onSuccess,

--- a/identity/client/src/pages/roles/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/modals/DeleteModal.tsx
@@ -15,7 +15,7 @@ import {
 } from "src/components/modal";
 import { deleteRole } from "src/utility/api/roles";
 import { useNotifications } from "src/components/notifications";
-import type { Role } from "@camunda/camunda-api-zod-schemas/8.8";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const DeleteModal: FC<UseEntityModalProps<Role>> = ({
   open,

--- a/identity/client/src/pages/tenants/List.tsx
+++ b/identity/client/src/pages/tenants/List.tsx
@@ -13,12 +13,13 @@ import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
 import Page, { PageHeader } from "src/components/layout/Page";
 import EntityList from "src/components/entityList";
-import { searchTenant, Tenant } from "src/utility/api/tenants";
+import { searchTenant } from "src/utility/api/tenants";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
 import AddModal from "src/pages/tenants/modals/AddModal";
 import DeleteModal from "src/pages/tenants/modals/DeleteModal";
 import PageEmptyState from "src/components/layout/PageEmptyState";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const List: FC = () => {
   const { t } = useTranslate("tenants");

--- a/identity/client/src/pages/tenants/detail/clients/AssignClientsModal.tsx
+++ b/identity/client/src/pages/tenants/detail/clients/AssignClientsModal.tsx
@@ -9,11 +9,11 @@
 import { FC, useEffect, useState } from "react";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import { Client } from "src/utility/api/tenants";
 import FormModal from "src/components/modal/FormModal";
-import { assignTenantClient, Tenant } from "src/utility/api/tenants";
+import { assignTenantClient } from "src/utility/api/tenants";
 import TextField from "src/components/form/TextField";
 import { UseEntityModalProps } from "src/components/modal";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignClientsModal: FC<UseEntityModalProps<Tenant["tenantId"]>> = ({
   entity: tenantId,
@@ -22,7 +22,7 @@ const AssignClientsModal: FC<UseEntityModalProps<Tenant["tenantId"]>> = ({
   onClose,
 }) => {
   const { t } = useTranslate("tenants");
-  const [clientId, setClientId] = useState<Client["clientId"]>("");
+  const [clientId, setClientId] = useState<string>("");
   const [loadingAssignClient, setLoadingAssignClient] = useState(false);
 
   const [callAssignClient] = useApiCall(assignTenantClient);

--- a/identity/client/src/pages/tenants/detail/clients/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/clients/DeleteModal.tsx
@@ -15,11 +15,13 @@ import {
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
 import { unassignTenantClient } from "src/utility/api/tenants";
-import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
-import type { Client } from "src/utility/api/tenants";
+import type {
+  Tenant,
+  TenantClient,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveTenantClientModalProps = UseEntityModalCustomProps<
-  Client,
+  TenantClient,
   {
     tenantId: Tenant["tenantId"];
   }

--- a/identity/client/src/pages/tenants/detail/clients/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/clients/DeleteModal.tsx
@@ -14,8 +14,9 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { Client, Tenant } from "src/utility/api/tenants";
 import { unassignTenantClient } from "src/utility/api/tenants";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
+import type { Client } from "src/utility/api/tenants";
 
 type RemoveTenantClientModalProps = UseEntityModalCustomProps<
   Client,

--- a/identity/client/src/pages/tenants/detail/clients/index.tsx
+++ b/identity/client/src/pages/tenants/detail/clients/index.tsx
@@ -11,12 +11,13 @@ import { C3EmptyState } from "@camunda/camunda-composite-components";
 import { TrashCan } from "@carbon/react/icons";
 import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
-import { getClientsByTenantId, Tenant } from "src/utility/api/tenants";
+import { getClientsByTenantId } from "src/utility/api/tenants";
 import EntityList from "src/components/entityList";
 import { useEntityModal } from "src/components/modal";
 import DeleteModal from "src/pages/tenants/detail/clients/DeleteModal";
 import AssignClientsModal from "src/pages/tenants/detail/clients/AssignClientsModal";
 import TabEmptyState from "src/components/layout/TabEmptyState";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type ClientsProps = {
   tenantId: Tenant["tenantId"];

--- a/identity/client/src/pages/tenants/detail/groups/AssignGroupModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/AssignGroupModal.tsx
@@ -8,12 +8,13 @@
 
 import { FC, useEffect, useState } from "react";
 import { UseEntityModalCustomProps } from "src/components/modal";
-import { assignTenantGroup, Tenant } from "src/utility/api/tenants";
+import { assignTenantGroup } from "src/utility/api/tenants";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
 import { Group } from "src/utility/api/groups";
 import FormModal from "src/components/modal/FormModal";
 import TextField from "src/components/form/TextField";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignGroupModal: FC<
   UseEntityModalCustomProps<

--- a/identity/client/src/pages/tenants/detail/groups/AssignGroupModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/AssignGroupModal.tsx
@@ -11,10 +11,9 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignTenantGroup } from "src/utility/api/tenants";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import { Group } from "src/utility/api/groups";
 import FormModal from "src/components/modal/FormModal";
 import TextField from "src/components/form/TextField";
-import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
+import type { Group, Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignGroupModal: FC<
   UseEntityModalCustomProps<

--- a/identity/client/src/pages/tenants/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/AssignGroupsModal.tsx
@@ -16,7 +16,8 @@ import { searchGroups, Group } from "src/utility/api/groups";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { assignTenantGroup, Tenant } from "src/utility/api/tenants";
+import { assignTenantGroup } from "src/utility/api/tenants";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedGroups = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/tenants/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/AssignGroupsModal.tsx
@@ -12,12 +12,12 @@ import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchGroups, Group } from "src/utility/api/groups";
+import { searchGroups } from "src/utility/api/groups";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
 import { assignTenantGroup } from "src/utility/api/tenants";
-import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
+import type { Group, Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedGroups = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/tenants/detail/groups/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { Group } from "src/utility/api/groups";
 import { unassignTenantGroup } from "src/utility/api/tenants";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveTenantGroupModalProps = UseEntityModalCustomProps<
   Group,

--- a/identity/client/src/pages/tenants/detail/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mapping-rules/AssignMappingRulesModal.tsx
@@ -11,13 +11,13 @@ import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchMappingRule, MappingRule } from "src/utility/api/mapping-rules";
+import { searchMappingRule } from "src/utility/api/mapping-rules";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
 import { assignTenantMappingRule } from "src/utility/api/tenants";
-import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
+import type { MappingRule, Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedMappingRules = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/tenants/detail/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mapping-rules/AssignMappingRulesModal.tsx
@@ -16,7 +16,8 @@ import { TranslatedErrorInlineNotification } from "src/components/notifications/
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { assignTenantMappingRule, Tenant } from "src/utility/api/tenants";
+import { assignTenantMappingRule } from "src/utility/api/tenants";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedMappingRules = styled.div`
   margin-top: 0;
@@ -24,7 +25,7 @@ const SelectedMappingRules = styled.div`
 
 const AssignMappingRulesModal: FC<
   UseEntityModalCustomProps<
-    { id: Tenant["tenantKey"] },
+    { id: Tenant["tenantId"] },
     { assignedMappingRules: MappingRule[] }
   >
 > = ({ entity: tenant, assignedMappingRules, onSuccess, open, onClose }) => {

--- a/identity/client/src/pages/tenants/detail/mapping-rules/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mapping-rules/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { MappingRule } from "src/utility/api/mapping-rules";
 import { unassignTenantMappingRule } from "src/utility/api/tenants";
+import type { MappingRule } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveTenantMappingRuleModalProps = UseEntityModalCustomProps<
   MappingRule,

--- a/identity/client/src/pages/tenants/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/tenants/detail/members/AssignMemberModal.tsx
@@ -11,12 +11,11 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignTenantMember } from "src/utility/api/membership";
 import useTranslate from "src/utility/localization";
 import { useApiCall } from "src/utility/api";
-import { User } from "src/utility/api/users";
 import FormModal from "src/components/modal/FormModal";
-import { Tenant } from "src/utility/api/tenants";
 import TextField from "src/components/form/TextField";
 import { Caption } from "src/pages/authorizations/modals/components.tsx";
 import { DocumentationLink } from "src/components/documentation";
+import type { Tenant, User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const AssignMemberModal: FC<
   UseEntityModalCustomProps<

--- a/identity/client/src/pages/tenants/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/tenants/detail/members/AssignMembersModal.tsx
@@ -12,12 +12,12 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignTenantMember } from "src/utility/api/membership";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchUser, User } from "src/utility/api/users";
+import { searchUser } from "src/utility/api/users";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { Tenant } from "src/utility/api/tenants";
+import type { Tenant, User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedUsers = styled.div`
   margin-top: 0;

--- a/identity/client/src/pages/tenants/detail/members/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/members/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { User } from "src/utility/api/users";
 import { unassignTenantMember } from "src/utility/api/membership";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveTenantMemberModalProps = UseEntityModalCustomProps<
   User,

--- a/identity/client/src/pages/tenants/detail/roles/AssignRolesModal.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/AssignRolesModal.tsx
@@ -11,12 +11,13 @@ import { Tag } from "@carbon/react";
 import { UseEntityModalCustomProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api";
-import { searchRoles, Role } from "src/utility/api/roles";
+import { searchRoles } from "src/utility/api/roles";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
 import FormModal from "src/components/modal/FormModal";
-import { assignTenantRole, Tenant } from "src/utility/api/tenants";
+import { assignTenantRole } from "src/utility/api/tenants";
+import type { Role, Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const SelectedRoles = styled.div`
   margin-top: 0;
@@ -24,7 +25,7 @@ const SelectedRoles = styled.div`
 
 const AssignRolesModal: FC<
   UseEntityModalCustomProps<
-    { id: Tenant["tenantKey"] },
+    { id: Tenant["tenantId"] },
     { assignedRoles: Role[] }
   >
 > = ({ entity: tenant, assignedRoles, onSuccess, open, onClose }) => {

--- a/identity/client/src/pages/tenants/detail/roles/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/DeleteModal.tsx
@@ -14,8 +14,8 @@ import {
   UseEntityModalCustomProps,
 } from "src/components/modal";
 import { useNotifications } from "src/components/notifications";
-import { Role } from "src/utility/api/roles";
 import { unassignTenantRole } from "src/utility/api/tenants";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type RemoveTenantRoleModalProps = UseEntityModalCustomProps<
   Role,

--- a/identity/client/src/pages/tenants/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/modals/DeleteModal.tsx
@@ -13,10 +13,11 @@ import {
   DeleteModal as Modal,
   UseEntityModalProps,
 } from "src/components/modal";
-import { deleteTenant, DeleteTenantParams } from "src/utility/api/tenants";
+import { deleteTenant } from "src/utility/api/tenants";
 import { useNotifications } from "src/components/notifications";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.9";
 
-const DeleteTenantModal: FC<UseEntityModalProps<DeleteTenantParams>> = ({
+const DeleteTenantModal: FC<UseEntityModalProps<Tenant>> = ({
   open,
   onClose,
   onSuccess,

--- a/identity/client/src/pages/users/List.tsx
+++ b/identity/client/src/pages/users/List.tsx
@@ -13,13 +13,14 @@ import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
 import Page, { PageHeader } from "src/components/layout/Page";
 import EntityList from "src/components/entityList";
-import { searchUser, User } from "src/utility/api/users";
+import { searchUser } from "src/utility/api/users";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
 import AddModal from "src/pages/users/modals/AddModal";
 import EditModal from "src/pages/users/modals/EditModal";
 import DeleteModal from "src/pages/users/modals/DeleteModal";
 import PageEmptyState from "src/components/layout/PageEmptyState";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const List: FC = () => {
   const { t } = useTranslate("users");

--- a/identity/client/src/pages/users/detail/UserDetailsTab.tsx
+++ b/identity/client/src/pages/users/detail/UserDetailsTab.tsx
@@ -6,10 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
 import { FC } from "react";
 import EntityDetail from "src/components/entityDetail";
 import useTranslate from "src/utility/localization";
-import { User } from "src/utility/api/users";
 
 type UserDetailsProps = {
   user: User;

--- a/identity/client/src/pages/users/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/users/modals/DeleteModal.tsx
@@ -13,8 +13,9 @@ import {
   DeleteModal as Modal,
   UseEntityModalProps,
 } from "src/components/modal";
-import { deleteUser, User } from "src/utility/api/users";
+import { deleteUser } from "src/utility/api/users";
 import { useNotifications } from "src/components/notifications";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 const DeleteModal: FC<UseEntityModalProps<User>> = ({
   open,

--- a/identity/client/src/pages/users/modals/EditModal.tsx
+++ b/identity/client/src/pages/users/modals/EditModal.tsx
@@ -13,8 +13,9 @@ import { useApiCall } from "src/utility/api";
 import useTranslate from "src/utility/localization";
 import Divider from "src/components/form/Divider";
 import { FormModal, UseEntityModalProps } from "src/components/modal";
-import { updateUser, User } from "src/utility/api/users";
+import { updateUser } from "src/utility/api/users";
 import { isValidEmail } from "src/utility/validate";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
 
 type FormData = Pick<User, "name" | "email"> & {
   password: string;

--- a/identity/client/src/utility/api/audit-logs/index.ts
+++ b/identity/client/src/utility/api/audit-logs/index.ts
@@ -6,15 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { AuditLog } from "@camunda/camunda-api-zod-schemas/8.9";
+import type {
+  QueryAuditLogsResponseBody,
+  QueryAuditLogsRequestBody,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiPost } from "src/utility/api/request";
-import { SearchResponse } from "src/utility/api";
-
-export type { AuditLog };
 
 export const AUDIT_LOGS_ENDPOINT = "/audit-logs";
 
 export const searchAuditLogs: ApiDefinition<
-  SearchResponse<AuditLog>,
-  Record<string, unknown> | undefined
+  QueryAuditLogsResponseBody,
+  QueryAuditLogsRequestBody | undefined
 > = (params) => apiPost(`${AUDIT_LOGS_ENDPOINT}/search`, params);

--- a/identity/client/src/utility/api/audit-logs/index.ts
+++ b/identity/client/src/utility/api/audit-logs/index.ts
@@ -10,7 +10,7 @@ import { ApiDefinition, apiPost } from "src/utility/api/request";
 import type {
   QueryAuditLogsRequestBody,
   QueryAuditLogsResponseBody,
-} from "@camunda/camunda-api-zod-schemas/8.9/audit-log";
+} from "@camunda/camunda-api-zod-schemas/8.9";
 
 export const AUDIT_LOGS_ENDPOINT = "/audit-logs";
 

--- a/identity/client/src/utility/api/audit-logs/index.ts
+++ b/identity/client/src/utility/api/audit-logs/index.ts
@@ -6,15 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { AuditLog } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiPost } from "src/utility/api/request";
-import type {
-  QueryAuditLogsRequestBody,
-  QueryAuditLogsResponseBody,
-} from "@camunda/camunda-api-zod-schemas/8.9";
+import { SearchResponse } from "src/utility/api";
+
+export type { AuditLog };
 
 export const AUDIT_LOGS_ENDPOINT = "/audit-logs";
 
 export const searchAuditLogs: ApiDefinition<
-  QueryAuditLogsResponseBody,
-  QueryAuditLogsRequestBody | undefined
+  SearchResponse<AuditLog>,
+  Record<string, unknown> | undefined
 > = (params) => apiPost(`${AUDIT_LOGS_ENDPOINT}/search`, params);

--- a/identity/client/src/utility/api/authentication/index.ts
+++ b/identity/client/src/utility/api/authentication/index.ts
@@ -27,7 +27,7 @@ export interface CamundaUser {
   tenants: readonly TenantInfo[];
   groups: readonly string[];
   roles: readonly string[];
-  salesPlanType: string;
+  salesPlanType: string | null;
   c8Links: readonly C8Link[];
   canLogout: boolean;
   apiUser: boolean;

--- a/identity/client/src/utility/api/authentication/index.ts
+++ b/identity/client/src/utility/api/authentication/index.ts
@@ -6,34 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { CurrentUser } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiGet } from "src/utility/api/request.ts";
 
-export interface TenantInfo {
-  tenantId: string;
-  name: string;
-}
-
-export interface C8Link {
-  name: string;
-  link: string;
-}
-
-export interface CamundaUser {
-  userId: string;
-  userKey: number;
-  displayName: string;
-  email: string;
-  authorizedComponents: readonly string[];
-  tenants: readonly TenantInfo[];
-  groups: readonly string[];
-  roles: readonly string[];
-  salesPlanType: string | null;
-  c8Links: readonly C8Link[];
-  canLogout: boolean;
-  apiUser: boolean;
-}
-
-export const getAuthentication: ApiDefinition<CamundaUser> = () =>
+export const getAuthentication: ApiDefinition<CurrentUser> = () =>
   apiGet("/authentication/me");
 
 export const getSaasUserToken: ApiDefinition<string> = () =>

--- a/identity/client/src/utility/api/authorizations/index.ts
+++ b/identity/client/src/utility/api/authorizations/index.ts
@@ -7,7 +7,7 @@
  */
 
 import type {
-  AuthorizationResult,
+  Authorization,
   OwnerType,
   ResourceType,
   QueryAuthorizationsRequestBody,
@@ -41,8 +41,6 @@ export const RESOURCE_PROPERTY_NAMES: ResourcePropertyName[] = [
   "candidateGroups",
   "candidateUsers",
 ];
-
-export type Authorization = AuthorizationResult;
 
 export type NewAuthorization = Omit<
   Authorization,

--- a/identity/client/src/utility/api/authorizations/index.ts
+++ b/identity/client/src/utility/api/authorizations/index.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { AuthorizationResult } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiDelete, apiPost } from "src/utility/api/request";
 import { SearchResponse } from "src/utility/api";
 
@@ -50,14 +51,13 @@ export enum PermissionType {
   READ_USAGE_METRIC = "READ_USAGE_METRIC",
   READ_JOB_METRIC = "READ_JOB_METRIC",
   COMPLETE = "COMPLETE",
-  COMPLETE_USER_TASK = "COMPLETE_USER_TASK",
   CLAIM = "CLAIM",
-  CLAIM_USER_TASK = "CLAIM_USER_TASK",
 }
 
 export type PermissionTypes = keyof typeof PermissionType;
 
 export enum OwnerType {
+  "UNSPECIFIED" = "UNSPECIFIED",
   "USER" = "USER",
   "ROLE" = "ROLE",
   "GROUP" = "GROUP",
@@ -88,34 +88,15 @@ export enum ResourceType {
   USER = "USER",
 }
 
-type BaseAuthorization = {
-  authorizationKey: string;
-  ownerId: string;
-  ownerType: OwnerType;
-  permissionTypes: readonly PermissionTypes[];
-};
-
 export enum ResourcePropertyName {
   assignee = "assignee",
   candidateGroups = "candidateGroups",
   candidateUsers = "candidateUsers",
 }
 
-export type TaskAuthorization = BaseAuthorization & {
-  resourceType: ResourceType.USER_TASK;
-  resourcePropertyName: ResourcePropertyName;
-};
+export type Authorization = AuthorizationResult;
 
-export type GeneralAuthorization = BaseAuthorization & {
-  resourceType: Exclude<ResourceType, ResourceType.USER_TASK>;
-  resourceId: string;
-};
-
-export type Authorization = TaskAuthorization | GeneralAuthorization;
-
-export type NewAuthorization =
-  | Omit<TaskAuthorization, "authorizationKey">
-  | Omit<GeneralAuthorization, "authorizationKey">;
+export type NewAuthorization = Omit<Authorization, "authorizationKey">;
 
 export enum PatchAuthorizationAction {
   ADD = "ADD",

--- a/identity/client/src/utility/api/authorizations/index.ts
+++ b/identity/client/src/utility/api/authorizations/index.ts
@@ -6,97 +6,52 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { AuthorizationResult } from "@camunda/camunda-api-zod-schemas/8.9";
+import type {
+  AuthorizationResult,
+  PermissionType,
+  OwnerType,
+  ResourceType,
+} from "@camunda/camunda-api-zod-schemas/8.9";
+import {
+  resourceTypeSchema,
+  ownerTypeSchema,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiDelete, apiPost } from "src/utility/api/request";
 import { SearchResponse } from "src/utility/api";
 
 export const AUTHORIZATIONS_ENDPOINT = "/authorizations";
 
-export enum PermissionType {
-  ACCESS = "ACCESS",
-  CREATE = "CREATE",
-  CREATE_PROCESS_INSTANCE = "CREATE_PROCESS_INSTANCE",
-  CREATE_DECISION_INSTANCE = "CREATE_DECISION_INSTANCE",
-  CREATE_TASK_LISTENER = "CREATE_TASK_LISTENER",
-  EVALUATE = "EVALUATE",
-  READ = "READ",
-  READ_PROCESS_INSTANCE = "READ_PROCESS_INSTANCE",
-  READ_USER_TASK = "READ_USER_TASK",
-  READ_DECISION_INSTANCE = "READ_DECISION_INSTANCE",
-  READ_PROCESS_DEFINITION = "READ_PROCESS_DEFINITION",
-  READ_DECISION_DEFINITION = "READ_DECISION_DEFINITION",
-  READ_TASK_LISTENER = "READ_TASK_LISTENER",
-  UPDATE = "UPDATE",
-  UPDATE_PROCESS_INSTANCE = "UPDATE_PROCESS_INSTANCE",
-  UPDATE_USER_TASK = "UPDATE_USER_TASK",
-  UPDATE_TASK_LISTENER = "UPDATE_TASK_LISTENER",
-  DELETE = "DELETE",
-  DELETE_PROCESS = "DELETE_PROCESS",
-  DELETE_DRD = "DELETE_DRD",
-  DELETE_FORM = "DELETE_FORM",
-  DELETE_RESOURCE = "DELETE_RESOURCE",
-  DELETE_PROCESS_INSTANCE = "DELETE_PROCESS_INSTANCE",
-  DELETE_DECISION_INSTANCE = "DELETE_DECISION_INSTANCE",
-  DELETE_TASK_LISTENER = "DELETE_TASK_LISTENER",
-  CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE = "CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE",
-  CREATE_BATCH_OPERATION_RESOLVE_INCIDENT = "CREATE_BATCH_OPERATION_RESOLVE_INCIDENT",
-  CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE = "CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE",
-  CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE = "CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE",
-  CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE = "CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE",
-  CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE = "CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE",
-  CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION = "CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION",
-  CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION = "CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION",
-  CANCEL_PROCESS_INSTANCE = "CANCEL_PROCESS_INSTANCE",
-  MODIFY_PROCESS_INSTANCE = "MODIFY_PROCESS_INSTANCE",
-  READ_USAGE_METRIC = "READ_USAGE_METRIC",
-  READ_JOB_METRIC = "READ_JOB_METRIC",
-  COMPLETE = "COMPLETE",
-  CLAIM = "CLAIM",
-}
+export { PermissionType, OwnerType, ResourceType };
 
-export type PermissionTypes = keyof typeof PermissionType;
+export const ALL_RESOURCE_TYPES: ResourceType[] = [
+  ...resourceTypeSchema.options,
+];
 
-export enum OwnerType {
-  "UNSPECIFIED" = "UNSPECIFIED",
-  "USER" = "USER",
-  "ROLE" = "ROLE",
-  "GROUP" = "GROUP",
-  "MAPPING_RULE" = "MAPPING_RULE",
-  "CLIENT" = "CLIENT",
-}
+export const RESOURCE_TYPES_WITHOUT_TENANT: ResourceType[] =
+  ALL_RESOURCE_TYPES.filter((type) => type !== "TENANT");
 
-export enum ResourceType {
-  AUDIT_LOG = "AUDIT_LOG",
-  AUTHORIZATION = "AUTHORIZATION",
-  BATCH = "BATCH",
-  CLUSTER_VARIABLE = "CLUSTER_VARIABLE",
-  COMPONENT = "COMPONENT",
-  DECISION_DEFINITION = "DECISION_DEFINITION",
-  DECISION_REQUIREMENTS_DEFINITION = "DECISION_REQUIREMENTS_DEFINITION",
-  DOCUMENT = "DOCUMENT",
-  EXPRESSION = "EXPRESSION",
-  GLOBAL_LISTENER = "GLOBAL_LISTENER",
-  GROUP = "GROUP",
-  MAPPING_RULE = "MAPPING_RULE",
-  MESSAGE = "MESSAGE",
-  USER_TASK = "USER_TASK",
-  PROCESS_DEFINITION = "PROCESS_DEFINITION",
-  RESOURCE = "RESOURCE",
-  ROLE = "ROLE",
-  SYSTEM = "SYSTEM",
-  TENANT = "TENANT",
-  USER = "USER",
-}
+export const OWNER_TYPES: OwnerType[] = [...ownerTypeSchema.options];
 
-export enum ResourcePropertyName {
-  assignee = "assignee",
-  candidateGroups = "candidateGroups",
-  candidateUsers = "candidateUsers",
-}
+export type ResourcePropertyName =
+  | "assignee"
+  | "candidateGroups"
+  | "candidateUsers"
+  | null;
+
+export const RESOURCE_PROPERTY_NAMES: ResourcePropertyName[] = [
+  "assignee",
+  "candidateGroups",
+  "candidateUsers",
+];
 
 export type Authorization = AuthorizationResult;
 
-export type NewAuthorization = Omit<Authorization, "authorizationKey">;
+export type NewAuthorization = Omit<
+  Authorization,
+  "authorizationKey" | "resourcePropertyName"
+> & {
+  resourcePropertyName: ResourcePropertyName | null;
+};
 
 export enum PatchAuthorizationAction {
   ADD = "ADD",
@@ -105,7 +60,7 @@ export enum PatchAuthorizationAction {
 
 export type searchAuthorizationsParams = {
   filter: {
-    resourceType: string;
+    resourceType: ResourceType;
   };
 };
 

--- a/identity/client/src/utility/api/authorizations/index.ts
+++ b/identity/client/src/utility/api/authorizations/index.ts
@@ -49,12 +49,6 @@ export type NewAuthorization = Omit<
   resourcePropertyName: ResourcePropertyName | null;
 };
 
-export type searchAuthorizationsParams = {
-  filter: {
-    resourceType: ResourceType;
-  };
-};
-
 export const searchAuthorization: ApiDefinition<
   QueryAuthorizationsResponseBody,
   QueryAuthorizationsRequestBody

--- a/identity/client/src/utility/api/authorizations/index.ts
+++ b/identity/client/src/utility/api/authorizations/index.ts
@@ -8,20 +8,18 @@
 
 import type {
   AuthorizationResult,
-  PermissionType,
   OwnerType,
   ResourceType,
+  QueryAuthorizationsRequestBody,
+  QueryAuthorizationsResponseBody,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   resourceTypeSchema,
   ownerTypeSchema,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiDelete, apiPost } from "src/utility/api/request";
-import { SearchResponse } from "src/utility/api";
 
 export const AUTHORIZATIONS_ENDPOINT = "/authorizations";
-
-export { PermissionType, OwnerType, ResourceType };
 
 export const ALL_RESOURCE_TYPES: ResourceType[] = [
   ...resourceTypeSchema.options,
@@ -53,11 +51,6 @@ export type NewAuthorization = Omit<
   resourcePropertyName: ResourcePropertyName | null;
 };
 
-export enum PatchAuthorizationAction {
-  ADD = "ADD",
-  REMOVE = "REMOVE",
-}
-
 export type searchAuthorizationsParams = {
   filter: {
     resourceType: ResourceType;
@@ -65,20 +58,16 @@ export type searchAuthorizationsParams = {
 };
 
 export const searchAuthorization: ApiDefinition<
-  SearchResponse<Authorization>,
-  searchAuthorizationsParams
+  QueryAuthorizationsResponseBody,
+  QueryAuthorizationsRequestBody
 > = (param) => apiPost(`${AUTHORIZATIONS_ENDPOINT}/search`, param);
 
 export const createAuthorization: ApiDefinition<undefined, NewAuthorization> = (
   authorization,
 ) => apiPost(AUTHORIZATIONS_ENDPOINT, authorization);
 
-export type DeleteAuthorizationParams = {
-  authorizationKey: string;
-};
-
 export const deleteAuthorization: ApiDefinition<
   undefined,
-  DeleteAuthorizationParams
+  Pick<Authorization, "authorizationKey">
 > = ({ authorizationKey }) =>
   apiDelete(`${AUTHORIZATIONS_ENDPOINT}/${authorizationKey}`);

--- a/identity/client/src/utility/api/cluster-variables/index.ts
+++ b/identity/client/src/utility/api/cluster-variables/index.ts
@@ -6,35 +6,36 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {
+  ClusterVariable as BaseClusterVariable,
+  ClusterVariableScope,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiDelete,
   apiGet,
   apiPost,
   apiPut,
-} from "src/utility/api/request.ts";
+} from "src/utility/api/request";
 import { PageSearchParams, SearchResponse } from "src/utility/api";
-import { EntityData } from "src/components/entityList/EntityList.tsx";
 
 export const CLUSTER_VARIABLES_ENDPOINT = "/cluster-variables";
 
-export enum ScopeType {
-  GLOBAL = "GLOBAL",
-  TENANT = "TENANT",
-}
+export type { ClusterVariableScope };
 
-export type ClusterVariable = EntityData & {
-  name: string;
-  scope: ScopeType;
-  tenantId?: string;
-  value: string;
-};
+export type ClusterVariable = BaseClusterVariable;
 
-function buildEndpoint(scopeType: ScopeType, tenantId?: string): string {
+function buildEndpoint(
+  scopeType: ClusterVariableScope,
+  tenantId?: string | null,
+): string {
   switch (scopeType) {
-    case ScopeType.GLOBAL:
+    case "GLOBAL":
       return `${CLUSTER_VARIABLES_ENDPOINT}/global`;
-    case ScopeType.TENANT:
+    case "TENANT":
+      if (!tenantId) {
+        throw new Error("tenantId is required for TENANT scope");
+      }
       return `${CLUSTER_VARIABLES_ENDPOINT}/tenants/${tenantId}`;
     default:
       throw new Error(`Unknown scope type: ${scopeType}`);
@@ -62,8 +63,8 @@ export const searchClusterVariables: ApiDefinition<
 };
 
 type GetClusterVariableParams = {
-  scope: ScopeType;
-  tenantId?: string;
+  scope: ClusterVariableScope;
+  tenantId?: string | null;
   name: string;
 };
 
@@ -92,8 +93,8 @@ export const deleteClusterVariable: ApiDefinition<
   apiDelete(`${buildEndpoint(scope, tenantId)}/${name}`);
 
 type UpdateClusterVariableParams = {
-  scope: ScopeType;
-  tenantId?: string;
+  scope: ClusterVariableScope;
+  tenantId?: string | null;
   name: string;
   value: string;
 };

--- a/identity/client/src/utility/api/cluster-variables/index.ts
+++ b/identity/client/src/utility/api/cluster-variables/index.ts
@@ -7,8 +7,11 @@
  */
 
 import type {
-  ClusterVariable as BaseClusterVariable,
+  ClusterVariable,
   ClusterVariableScope,
+  QueryClusterVariablesRequestBody,
+  QueryClusterVariablesResponseBody,
+  CreateClusterVariableRequestBody,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
@@ -17,13 +20,10 @@ import {
   apiPost,
   apiPut,
 } from "src/utility/api/request";
-import { PageSearchParams, SearchResponse } from "src/utility/api";
 
 export const CLUSTER_VARIABLES_ENDPOINT = "/cluster-variables";
 
 export type { ClusterVariableScope };
-
-export type ClusterVariable = BaseClusterVariable;
 
 function buildEndpoint(
   scopeType: ClusterVariableScope,
@@ -42,19 +42,17 @@ function buildEndpoint(
   }
 }
 
-type SearchClusterVariableParams = {
-  clusterVariableNames: string[];
-};
-
 export const searchClusterVariables: ApiDefinition<
-  SearchResponse<ClusterVariable>,
-  Partial<SearchClusterVariableParams & PageSearchParams> | undefined
+  QueryClusterVariablesResponseBody,
+  | (QueryClusterVariablesRequestBody & { clusterVariableNames?: string[] })
+  | undefined
 > = (params = {}) => {
   const { clusterVariableNames, ...restParams } = params;
 
-  const filters = clusterVariableNames
-    ? { filter: { name: { $in: clusterVariableNames } } }
-    : undefined;
+  const filters: QueryClusterVariablesRequestBody | undefined =
+    clusterVariableNames
+      ? { filter: { name: { $in: clusterVariableNames } } }
+      : undefined;
 
   return apiPost(`${CLUSTER_VARIABLES_ENDPOINT}/search`, {
     ...restParams,
@@ -62,45 +60,26 @@ export const searchClusterVariables: ApiDefinition<
   });
 };
 
-type GetClusterVariableParams = {
-  scope: ClusterVariableScope;
-  tenantId?: string | null;
-  name: string;
-};
-
 export const getClusterVariableDetails: ApiDefinition<
-  SearchResponse<ClusterVariable>,
-  GetClusterVariableParams
+  QueryClusterVariablesResponseBody,
+  Pick<ClusterVariable, "scope" | "tenantId" | "name">
 > = ({ scope, tenantId, name }) =>
   apiGet(`${buildEndpoint(scope, tenantId)}/${name}`);
 
-type CreateClusterVariableParams = GetClusterVariableParams & {
-  value: string;
-};
-
 export const createClusterVariable: ApiDefinition<
   undefined,
-  CreateClusterVariableParams
+  CreateClusterVariableRequestBody & Pick<ClusterVariable, "scope" | "tenantId">
 > = ({ scope, tenantId, ...params }) =>
   apiPost(buildEndpoint(scope, tenantId), params);
 
-export type DeleteClusterVariableParams = GetClusterVariableParams;
-
 export const deleteClusterVariable: ApiDefinition<
   undefined,
-  DeleteClusterVariableParams
+  Pick<ClusterVariable, "scope" | "tenantId" | "name">
 > = ({ scope, tenantId, name }) =>
   apiDelete(`${buildEndpoint(scope, tenantId)}/${name}`);
 
-type UpdateClusterVariableParams = {
-  scope: ClusterVariableScope;
-  tenantId?: string | null;
-  name: string;
-  value: string;
-};
-
 export const updateClusterVariable: ApiDefinition<
   ClusterVariable,
-  UpdateClusterVariableParams
+  ClusterVariable
 > = ({ scope, tenantId, name, value }) =>
   apiPut(`${buildEndpoint(scope, tenantId)}/${name}`, { value });

--- a/identity/client/src/utility/api/cluster-variables/index.ts
+++ b/identity/client/src/utility/api/cluster-variables/index.ts
@@ -23,8 +23,6 @@ import {
 
 export const CLUSTER_VARIABLES_ENDPOINT = "/cluster-variables";
 
-export type { ClusterVariableScope };
-
 function buildEndpoint(
   scopeType: ClusterVariableScope,
   tenantId?: string | null,

--- a/identity/client/src/utility/api/global-task-listeners/index.ts
+++ b/identity/client/src/utility/api/global-task-listeners/index.ts
@@ -6,6 +6,13 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {
+  GlobalTaskListener as BaseGlobalTaskListener,
+  GlobalTaskListenerEventType,
+  GlobalListenerSource,
+  CreateGlobalTaskListenerRequestBody,
+} from "@camunda/camunda-api-zod-schemas/8.9";
+import { globalTaskListenerEventTypeSchema } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiDelete,
@@ -16,31 +23,13 @@ import { SearchResponse, PageSearchParams } from "src/utility/api";
 
 export const GLOBAL_TASK_LISTENERS_ENDPOINT = "/global-task-listeners";
 
-export enum ListenerSource {
-  CONFIGURATION = "CONFIGURATION",
-  API = "API",
-}
+export type { GlobalTaskListenerEventType, GlobalListenerSource };
 
-export enum ListenerEventType {
-  ALL = "all",
-  CREATING = "creating",
-  UPDATING = "updating",
-  ASSIGNING = "assigning",
-  COMPLETING = "completing",
-  CANCELING = "canceling",
-}
+export const LISTENER_EVENT_TYPES: GlobalTaskListenerEventType[] = [
+  ...globalTaskListenerEventTypeSchema.options,
+];
 
-export const LISTENER_EVENT_TYPES = Object.values(ListenerEventType);
-
-export type GlobalTaskListener = {
-  id: string;
-  type: string;
-  eventTypes: ListenerEventType[];
-  retries?: number;
-  afterNonGlobal?: boolean;
-  priority?: number;
-  source?: ListenerSource;
-};
+export type GlobalTaskListener = BaseGlobalTaskListener;
 
 export const searchGlobalTaskListeners: ApiDefinition<
   SearchResponse<GlobalTaskListener>,
@@ -49,14 +38,16 @@ export const searchGlobalTaskListeners: ApiDefinition<
   return apiPost(`${GLOBAL_TASK_LISTENERS_ENDPOINT}/search`, params);
 };
 
-export type CreateGlobalTaskListenerParams = Omit<GlobalTaskListener, "source">;
+export type CreateGlobalTaskListenerParams =
+  CreateGlobalTaskListenerRequestBody;
 
 export const createGlobalTaskListener: ApiDefinition<
   undefined,
   CreateGlobalTaskListenerParams
 > = (params) => apiPost(GLOBAL_TASK_LISTENERS_ENDPOINT, params);
 
-export type UpdateGlobalTaskListenerParams = Omit<GlobalTaskListener, "source">;
+export type UpdateGlobalTaskListenerParams =
+  CreateGlobalTaskListenerRequestBody;
 
 export const updateGlobalTaskListener: ApiDefinition<
   undefined,

--- a/identity/client/src/utility/api/global-task-listeners/index.ts
+++ b/identity/client/src/utility/api/global-task-listeners/index.ts
@@ -7,9 +7,10 @@
  */
 
 import type {
-  GlobalTaskListener as BaseGlobalTaskListener,
+  GlobalTaskListener,
   GlobalTaskListenerEventType,
-  GlobalListenerSource,
+  QueryGlobalTaskListenersRequestBody,
+  QueryGlobalTaskListenersResponseBody,
   CreateGlobalTaskListenerRequestBody,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import { globalTaskListenerEventTypeSchema } from "@camunda/camunda-api-zod-schemas/8.9";
@@ -19,49 +20,34 @@ import {
   apiPost,
   apiPut,
 } from "src/utility/api/request";
-import { SearchResponse, PageSearchParams } from "src/utility/api";
 
 export const GLOBAL_TASK_LISTENERS_ENDPOINT = "/global-task-listeners";
-
-export type { GlobalTaskListenerEventType, GlobalListenerSource };
 
 export const LISTENER_EVENT_TYPES: GlobalTaskListenerEventType[] = [
   ...globalTaskListenerEventTypeSchema.options,
 ];
 
-export type GlobalTaskListener = BaseGlobalTaskListener;
-
 export const searchGlobalTaskListeners: ApiDefinition<
-  SearchResponse<GlobalTaskListener>,
-  PageSearchParams | Record<string, unknown> | undefined
+  QueryGlobalTaskListenersResponseBody,
+  QueryGlobalTaskListenersRequestBody | undefined
 > = (params = {}) => {
   return apiPost(`${GLOBAL_TASK_LISTENERS_ENDPOINT}/search`, params);
 };
 
-export type CreateGlobalTaskListenerParams =
-  CreateGlobalTaskListenerRequestBody;
-
 export const createGlobalTaskListener: ApiDefinition<
   undefined,
-  CreateGlobalTaskListenerParams
+  CreateGlobalTaskListenerRequestBody
 > = (params) => apiPost(GLOBAL_TASK_LISTENERS_ENDPOINT, params);
-
-export type UpdateGlobalTaskListenerParams =
-  CreateGlobalTaskListenerRequestBody;
 
 export const updateGlobalTaskListener: ApiDefinition<
   undefined,
-  UpdateGlobalTaskListenerParams
+  CreateGlobalTaskListenerRequestBody
 > = (params) => {
   const { id, ...listener } = params;
   return apiPut(`${GLOBAL_TASK_LISTENERS_ENDPOINT}/${id}`, listener);
 };
 
-export type DeleteGlobalTaskListenerParams = {
-  id: string;
-};
-
 export const deleteGlobalTaskListener: ApiDefinition<
   undefined,
-  DeleteGlobalTaskListenerParams
+  Pick<GlobalTaskListener, "id">
 > = ({ id }) => apiDelete(`${GLOBAL_TASK_LISTENERS_ENDPOINT}/${id}`);

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -23,8 +23,6 @@ import type {
 import { ApiDefinition, apiDelete, apiGet, apiPost, apiPut } from "../request";
 import { ROLES_ENDPOINT } from "src/utility/api/roles";
 
-export type { Group };
-
 export type GroupKeys = keyof Group;
 
 export const GROUPS_ENDPOINT = "/groups";
@@ -63,9 +61,6 @@ export const deleteGroup: ApiDefinition<undefined, Pick<Group, "groupId">> = ({
 
 // ----------------- Roles within a Group -----------------
 
-export type GetGroupRolesParams = {
-  groupId: string;
-};
 export const searchRolesByGroupId: ApiDefinition<
   QueryRolesByGroupResponseBody,
   QueryRolesByGroupRequestBody & Pick<Group, "groupId">

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -6,21 +6,18 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiDelete, apiGet, apiPost, apiPut } from "../request";
 import { SearchResponse } from "src/utility/api";
 import { Role, ROLES_ENDPOINT } from "src/utility/api/roles";
 import { MappingRule } from "src/utility/api/mapping-rules";
 import { PageSearchParams } from "../hooks/usePagination";
 
+export type { Group };
+
+export type GroupKeys = keyof Group;
+
 export const GROUPS_ENDPOINT = "/groups";
-
-export type GroupKeys = "groupId" | "name" | "description";
-
-export type Group = {
-  groupId: string;
-  name: string;
-  description?: string;
-};
 
 export type MemberGroup = Pick<Group, "groupId">;
 

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -6,7 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { Group } from "@camunda/camunda-api-zod-schemas/8.9";
+import type {
+  Group,
+  TenantClient as Client,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiDelete, apiGet, apiPost, apiPut } from "../request";
 import { SearchResponse } from "src/utility/api";
 import { Role, ROLES_ENDPOINT } from "src/utility/api/roles";
@@ -123,9 +126,7 @@ type GetGroupClientsParams = {
   groupId: string;
 };
 
-export type Client = {
-  clientId: string;
-};
+export type { Client };
 
 export const getClientsByGroupId: ApiDefinition<
   SearchResponse<Client>,

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -7,14 +7,21 @@
  */
 
 import type {
+  MappingRule,
+  Role,
   Group,
-  TenantClient as Client,
+  TenantClient,
+  QueryGroupsRequestBody,
+  QueryGroupsResponseBody,
+  QueryRolesByGroupRequestBody,
+  QueryRolesByGroupResponseBody,
+  QueryMappingRulesByGroupRequestBody,
+  QueryMappingRulesByGroupResponseBody,
+  QueryClientsByGroupRequestBody,
+  QueryClientsByGroupResponseBody,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiDelete, apiGet, apiPost, apiPut } from "../request";
-import { SearchResponse } from "src/utility/api";
-import { Role, ROLES_ENDPOINT } from "src/utility/api/roles";
-import { MappingRule } from "src/utility/api/mapping-rules";
-import { PageSearchParams } from "../hooks/usePagination";
+import { ROLES_ENDPOINT } from "src/utility/api/roles";
 
 export type { Group };
 
@@ -22,15 +29,9 @@ export type GroupKeys = keyof Group;
 
 export const GROUPS_ENDPOINT = "/groups";
 
-export type MemberGroup = Pick<Group, "groupId">;
-
-type SearchGroupsParams = {
-  groupIds: string[];
-};
-
 export const searchGroups: ApiDefinition<
-  SearchResponse<Group>,
-  Partial<SearchGroupsParams & PageSearchParams> | undefined
+  QueryGroupsResponseBody,
+  (QueryGroupsRequestBody & { groupIds?: string[] }) | undefined
 > = (filterParams = {}) => {
   const { groupIds, ...pageParams } = filterParams;
 
@@ -41,11 +42,7 @@ export const searchGroups: ApiDefinition<
   return apiPost(`${GROUPS_ENDPOINT}/search`, { ...params, ...pageParams });
 };
 
-export type GetGroupParams = {
-  groupId: string;
-};
-
-export const getGroupDetails: ApiDefinition<Group, GetGroupParams> = ({
+export const getGroupDetails: ApiDefinition<Group, Pick<Group, "groupId">> = ({
   groupId,
 }) => apiGet(`${GROUPS_ENDPOINT}/${groupId}`);
 
@@ -60,9 +57,7 @@ export const updateGroup: ApiDefinition<undefined, Group> = (group) => {
   });
 };
 
-type DeleteGroupParams = GetGroupParams;
-
-export const deleteGroup: ApiDefinition<undefined, DeleteGroupParams> = ({
+export const deleteGroup: ApiDefinition<undefined, Pick<Group, "groupId">> = ({
   groupId,
 }) => apiDelete(`${GROUPS_ENDPOINT}/${groupId}`);
 
@@ -72,81 +67,64 @@ export type GetGroupRolesParams = {
   groupId: string;
 };
 export const searchRolesByGroupId: ApiDefinition<
-  SearchResponse<Role>,
-  GetGroupRolesParams
+  QueryRolesByGroupResponseBody,
+  QueryRolesByGroupRequestBody & Pick<Group, "groupId">
 > = ({ groupId, ...body }) =>
   apiPost(`${GROUPS_ENDPOINT}/${groupId}/roles/search`, body);
 
-type AssignGroupRoleParams = GetGroupRolesParams & { roleId: string };
 export const assignGroupRole: ApiDefinition<
   undefined,
-  AssignGroupRoleParams
+  Pick<Group, "groupId"> & Pick<Role, "roleId">
 > = ({ groupId, roleId }) => {
   return apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
 };
 
-type UnassignGroupRoleParams = AssignGroupRoleParams;
 export const unassignGroupRole: ApiDefinition<
   undefined,
-  UnassignGroupRoleParams
+  Pick<Group, "groupId"> & Pick<Role, "roleId">
 > = ({ groupId, roleId }) =>
   apiDelete(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
 
 // ----------------- Mapping rules within a Group -----------------
 
-export type GetGroupMappingRulesParams = {
-  groupId: string;
-};
 export const getMappingRulesByGroupId: ApiDefinition<
-  SearchResponse<MappingRule>,
-  GetGroupMappingRulesParams
+  QueryMappingRulesByGroupResponseBody,
+  QueryMappingRulesByGroupRequestBody & Pick<Group, "groupId">
 > = (params) => {
   const { groupId, ...body } = params;
   return apiPost(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/search`, body);
 };
 
-type AssignGroupMappingRuleParams = GetGroupMappingRulesParams & {
-  mappingRuleId: string;
-};
 export const assignGroupMappingRule: ApiDefinition<
   undefined,
-  AssignGroupMappingRuleParams
+  Pick<Group, "groupId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ groupId, mappingRuleId }) => {
   return apiPut(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${mappingRuleId}`);
 };
 
-type UnassignGroupMappingRuleParams = AssignGroupMappingRuleParams;
 export const unassignGroupMappingRule: ApiDefinition<
   undefined,
-  UnassignGroupMappingRuleParams
+  Pick<Group, "groupId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ groupId, mappingRuleId }) =>
   apiDelete(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${mappingRuleId}`);
 
-type GetGroupClientsParams = {
-  groupId: string;
-};
-
-export type { Client };
-
 export const getClientsByGroupId: ApiDefinition<
-  SearchResponse<Client>,
-  GetGroupClientsParams
+  QueryClientsByGroupResponseBody,
+  QueryClientsByGroupRequestBody & Pick<Group, "groupId">
 > = (args) => {
   const { groupId, ...body } = args;
   return apiPost(`${GROUPS_ENDPOINT}/${groupId}/clients/search`, body);
 };
 
-type AssignGroupClientParams = GetGroupClientsParams & Client;
 export const assignGroupClient: ApiDefinition<
   undefined,
-  AssignGroupClientParams
+  Pick<Group, "groupId"> & Pick<TenantClient, "clientId">
 > = ({ groupId, clientId }) => {
   return apiPut(`${GROUPS_ENDPOINT}/${groupId}/clients/${clientId}`);
 };
 
-type UnassignGroupClientParams = AssignGroupClientParams;
 export const unassignGroupClient: ApiDefinition<
   undefined,
-  UnassignGroupClientParams
+  Pick<Group, "groupId"> & Pick<TenantClient, "clientId">
 > = ({ groupId, clientId }) =>
   apiDelete(`${GROUPS_ENDPOINT}/${groupId}/clients/${clientId}`);

--- a/identity/client/src/utility/api/headers/index.ts
+++ b/identity/client/src/utility/api/headers/index.ts
@@ -9,8 +9,6 @@
 import type { License } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiGet } from "../request";
 
-export type { License };
-
 export const LICENSE_ENDPOINT = "/license";
 
 export const checkLicense: ApiDefinition<License> = () =>

--- a/identity/client/src/utility/api/headers/index.ts
+++ b/identity/client/src/utility/api/headers/index.ts
@@ -6,15 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { License } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiGet } from "../request";
-export const LICENSE_ENDPOINT = "/license";
 
-export type License = {
-  validLicense: boolean;
-  licenseType: string;
-  isCommercial: boolean;
-  expiresAt: string | null;
-};
+export type { License };
+
+export const LICENSE_ENDPOINT = "/license";
 
 export const checkLicense: ApiDefinition<License> = () =>
   apiGet(`${LICENSE_ENDPOINT}`);

--- a/identity/client/src/utility/api/hooks/usePagination.ts
+++ b/identity/client/src/utility/api/hooks/usePagination.ts
@@ -7,14 +7,10 @@
  */
 
 import { useCallback, useMemo, useState } from "react";
+import type { QueryPage } from "@camunda/camunda-api-zod-schemas/8.9";
 
 export type PageSearchParams = {
-  page: {
-    from?: number;
-    limit?: number;
-    after?: string;
-    before?: string;
-  };
+  page: QueryPage;
 };
 
 export type PageResult = {

--- a/identity/client/src/utility/api/mapping-rules/index.ts
+++ b/identity/client/src/utility/api/mapping-rules/index.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { QueryMappingRulesResponseBody } from "@camunda/camunda-api-zod-schemas/8.9";
+import type { MappingRuleResult } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiDelete,
@@ -15,7 +15,7 @@ import {
 } from "src/utility/api/request";
 import { SearchResponse } from "src/utility/api";
 
-export type MappingRule = QueryMappingRulesResponseBody["items"][number];
+export type MappingRule = MappingRuleResult;
 
 export const MAPPING_RULES_ENDPOINT = "/mapping-rules";
 

--- a/identity/client/src/utility/api/mapping-rules/index.ts
+++ b/identity/client/src/utility/api/mapping-rules/index.ts
@@ -7,7 +7,7 @@
  */
 
 import type {
-  MappingRuleResult,
+  MappingRule,
   QueryMappingRulesRequestBody,
   QueryMappingRulesResponseBody,
   UpdateMappingRuleRequestBody,
@@ -20,8 +20,6 @@ import {
 } from "src/utility/api/request";
 
 export const MAPPING_RULES_ENDPOINT = "/mapping-rules";
-
-export type MappingRule = MappingRuleResult;
 
 export const searchMappingRule: ApiDefinition<
   QueryMappingRulesResponseBody,

--- a/identity/client/src/utility/api/mapping-rules/index.ts
+++ b/identity/client/src/utility/api/mapping-rules/index.ts
@@ -6,47 +6,35 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { MappingRuleResult } from "@camunda/camunda-api-zod-schemas/8.9";
+import type {
+  MappingRuleResult,
+  QueryMappingRulesRequestBody,
+  QueryMappingRulesResponseBody,
+  UpdateMappingRuleRequestBody,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiDelete,
   apiPut,
   apiPost,
 } from "src/utility/api/request";
-import { SearchResponse } from "src/utility/api";
-
-export type MappingRule = MappingRuleResult;
 
 export const MAPPING_RULES_ENDPOINT = "/mapping-rules";
 
-type MappingRuleSearchParams = {
-  filter?: {
-    name?: string;
-    claimName?: string;
-    claimValue?: string;
-    mappingRuleId?: string;
-  };
-};
+export type MappingRule = MappingRuleResult;
 
 export const searchMappingRule: ApiDefinition<
-  SearchResponse<MappingRule>,
-  MappingRuleSearchParams | undefined
+  QueryMappingRulesResponseBody,
+  QueryMappingRulesRequestBody | undefined
 > = (params) => apiPost(`${MAPPING_RULES_ENDPOINT}/search`, params);
 
 export const createMappingRule: ApiDefinition<undefined, MappingRule> = (
   mappingRule,
 ) => apiPost(MAPPING_RULES_ENDPOINT, mappingRule);
 
-export type UpdateMappingRuleParams = {
-  mappingRuleId: string;
-  name: string;
-  claimName: string;
-  claimValue: string;
-};
-
 export const updateMappingRule: ApiDefinition<
   undefined,
-  UpdateMappingRuleParams
+  UpdateMappingRuleRequestBody & Pick<MappingRule, "mappingRuleId">
 > = ({ mappingRuleId, claimName, claimValue, name }) =>
   apiPut(`${MAPPING_RULES_ENDPOINT}/${mappingRuleId}`, {
     name,
@@ -54,9 +42,8 @@ export const updateMappingRule: ApiDefinition<
     claimValue,
   });
 
-export type DeleteMappingRuleParams = UpdateMappingRuleParams;
 export const deleteMappingRule: ApiDefinition<
   undefined,
-  { mappingRuleId: string }
+  Pick<MappingRule, "mappingRuleId">
 > = ({ mappingRuleId }) =>
   apiDelete(`${MAPPING_RULES_ENDPOINT}/${mappingRuleId}`);

--- a/identity/client/src/utility/api/mapping-rules/index.ts
+++ b/identity/client/src/utility/api/mapping-rules/index.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { QueryMappingRulesResponseBody } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiDelete,
@@ -14,14 +15,9 @@ import {
 } from "src/utility/api/request";
 import { SearchResponse } from "src/utility/api";
 
-export const MAPPING_RULES_ENDPOINT = "/mapping-rules";
+export type MappingRule = QueryMappingRulesResponseBody["items"][number];
 
-export type MappingRule = {
-  mappingRuleId: string;
-  name: string;
-  claimName: string;
-  claimValue: string;
-};
+export const MAPPING_RULES_ENDPOINT = "/mapping-rules";
 
 type MappingRuleSearchParams = {
   filter?: {

--- a/identity/client/src/utility/api/membership/index.ts
+++ b/identity/client/src/utility/api/membership/index.ts
@@ -6,82 +6,75 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {
+  Group,
+  QueryUsersByGroupResponseBody,
+  QueryUsersByTenantRequestBody,
+  QueryUsersByTenantResponseBody,
+  QueryUsersByGroupRequestBody,
+  QueryUsersByRoleRequestBody,
+  QueryUsersByRoleResponseBody,
+  Role,
+  Tenant,
+  User,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiDelete, apiPost, apiPut } from "../request";
-import { User } from "src/utility/api/users";
 import { GROUPS_ENDPOINT } from "src/utility/api/groups";
-import { SearchResponse } from "src/utility/api";
 import { TENANTS_ENDPOINT } from "src/utility/api/tenants";
 import { ROLES_ENDPOINT } from "src/utility/api/roles";
 
-export type MemberUser = Pick<User, "username">;
-
-export type GetGroupMembersParams = {
-  groupId: string;
-};
 export const searchMembersByGroup: ApiDefinition<
-  SearchResponse<MemberUser>,
-  GetGroupMembersParams
+  QueryUsersByGroupResponseBody,
+  QueryUsersByGroupRequestBody & Pick<Group, "groupId">
 > = ({ groupId, ...body }) =>
   apiPost(`${GROUPS_ENDPOINT}/${groupId}/users/search`, body);
 
-export type GetTenantMembersParams = {
-  tenantId: string;
-};
 export const getMembersByTenantId: ApiDefinition<
-  SearchResponse<MemberUser>,
-  GetTenantMembersParams
+  QueryUsersByTenantResponseBody,
+  QueryUsersByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
   apiPost(`${TENANTS_ENDPOINT}/${tenantId}/users/search`, body);
 
-export type GetRoleMembersParams = {
-  roleId: string;
-};
 export const getMembersByRole: ApiDefinition<
-  SearchResponse<MemberUser>,
-  GetRoleMembersParams
+  QueryUsersByRoleResponseBody,
+  QueryUsersByRoleRequestBody & Pick<Role, "roleId">
 > = ({ roleId, ...body }) =>
   apiPost(`${ROLES_ENDPOINT}/${roleId}/users/search`, body);
 
-type AssignGroupMemberParams = GetGroupMembersParams & { username: string };
 export const assignGroupMember: ApiDefinition<
   undefined,
-  AssignGroupMemberParams
+  Pick<Group, "groupId"> & Pick<User, "username">
 > = ({ groupId, username }) =>
   apiPut(`${GROUPS_ENDPOINT}/${groupId}/users/${username}`);
 
-type UnassignGroupMemberParams = AssignGroupMemberParams;
 export const unassignGroupMember: ApiDefinition<
   undefined,
-  UnassignGroupMemberParams
+  Pick<Group, "groupId"> & Pick<User, "username">
 > = ({ groupId, username }) =>
   apiDelete(`${GROUPS_ENDPOINT}/${groupId}/users/${username}`);
 
-type AssignTenantMemberParams = GetTenantMembersParams & { username: string };
 export const assignTenantMember: ApiDefinition<
   undefined,
-  AssignTenantMemberParams
+  Pick<Tenant, "tenantId"> & Pick<User, "username">
 > = ({ tenantId, username }) => {
   return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/users/${username}`);
 };
 
-type UnassignTenantMemberParams = AssignTenantMemberParams;
 export const unassignTenantMember: ApiDefinition<
   undefined,
-  UnassignTenantMemberParams
+  Pick<Tenant, "tenantId"> & Pick<User, "username">
 > = ({ tenantId, username }) =>
   apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/users/${username}`);
 
-type AssignRoleMemberParams = GetRoleMembersParams & { username: string };
 export const assignRoleMember: ApiDefinition<
   undefined,
-  AssignRoleMemberParams
+  Pick<Role, "roleId"> & Pick<User, "username">
 > = ({ roleId, username }) => {
   return apiPut(`${ROLES_ENDPOINT}/${roleId}/users/${username}`);
 };
 
-type UnassignRoleMemberParams = AssignRoleMemberParams;
 export const unassignRoleMember: ApiDefinition<
   undefined,
-  UnassignRoleMemberParams
+  Pick<Role, "roleId"> & Pick<User, "username">
 > = ({ roleId, username }) =>
   apiDelete(`${ROLES_ENDPOINT}/${roleId}/users/${username}`);

--- a/identity/client/src/utility/api/request.ts
+++ b/identity/client/src/utility/api/request.ts
@@ -6,15 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { ProblemDetails } from "@camunda/camunda-api-zod-schemas/8.9";
+
 export type ErrorResponse<Type = "generic" | "detailed"> =
   Type extends "detailed"
-    ? {
-        detail: string;
-        instance: string;
-        status: number;
-        title: string;
-        type: string;
-      }
+    ? ProblemDetails
     : {
         error: string;
         path: string;

--- a/identity/client/src/utility/api/roles/index.ts
+++ b/identity/client/src/utility/api/roles/index.ts
@@ -8,7 +8,7 @@
 
 import type {
   Group,
-  MappingRuleResult,
+  MappingRule,
   QueryClientsByRoleRequestBody,
   QueryClientsByRoleResponseBody,
   QueryGroupsByRoleRequestBody,
@@ -18,7 +18,7 @@ import type {
   QueryRolesRequestBody,
   QueryRolesResponseBody,
   Role,
-  TenantClient as Client,
+  TenantClient,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
@@ -27,8 +27,6 @@ import {
   apiPost,
   apiPut,
 } from "src/utility/api/request";
-
-export type { Role };
 
 export const ROLES_ENDPOINT = "/roles";
 
@@ -60,14 +58,14 @@ export const getMappingRulesByRoleId: ApiDefinition<
 
 export const assignRoleMappingRule: ApiDefinition<
   undefined,
-  Pick<Role, "roleId"> & Pick<MappingRuleResult, "mappingRuleId">
+  Pick<Role, "roleId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ roleId, mappingRuleId }) => {
   return apiPut(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingRuleId}`);
 };
 
 export const unassignRoleMappingRule: ApiDefinition<
   undefined,
-  Pick<Role, "roleId"> & Pick<MappingRuleResult, "mappingRuleId">
+  Pick<Role, "roleId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ roleId, mappingRuleId }) =>
   apiDelete(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingRuleId}`);
 
@@ -94,8 +92,6 @@ export const unassignRoleGroup: ApiDefinition<
 
 // ----------------- Clients within a Role -----------------
 
-export type { Client };
-
 export const getClientsByRoleId: ApiDefinition<
   QueryClientsByRoleResponseBody,
   QueryClientsByRoleRequestBody & Pick<Role, "roleId">
@@ -106,13 +102,13 @@ export const getClientsByRoleId: ApiDefinition<
 
 export const assignRoleClient: ApiDefinition<
   undefined,
-  Pick<Role, "roleId"> & Pick<Client, "clientId">
+  Pick<Role, "roleId"> & Pick<TenantClient, "clientId">
 > = ({ roleId, clientId }) => {
   return apiPut(`${ROLES_ENDPOINT}/${roleId}/clients/${clientId}`);
 };
 
 export const unassignRoleClient: ApiDefinition<
   undefined,
-  Pick<Role, "roleId"> & Pick<Client, "clientId">
+  Pick<Role, "roleId"> & Pick<TenantClient, "clientId">
 > = ({ roleId, clientId }) =>
   apiDelete(`${ROLES_ENDPOINT}/${roleId}/clients/${clientId}`);

--- a/identity/client/src/utility/api/roles/index.ts
+++ b/identity/client/src/utility/api/roles/index.ts
@@ -6,7 +6,20 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { Role } from "@camunda/camunda-api-zod-schemas/8.9";
+import type {
+  Group,
+  MappingRuleResult,
+  QueryClientsByRoleRequestBody,
+  QueryClientsByRoleResponseBody,
+  QueryGroupsByRoleRequestBody,
+  QueryGroupsByRoleResponseBody,
+  QueryMappingRulesByRoleRequestBody,
+  QueryMappingRulesResponseBody,
+  QueryRolesRequestBody,
+  QueryRolesResponseBody,
+  Role,
+  TenantClient as Client,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiDelete,
@@ -14,124 +27,92 @@ import {
   apiPost,
   apiPut,
 } from "src/utility/api/request";
-import { SearchResponse } from "src/utility/api";
-import { Group } from "src/utility/api/groups";
-import { MappingRule } from "src/utility/api/mapping-rules";
-import { PageSearchParams } from "../hooks/usePagination";
 
 export type { Role };
 
 export const ROLES_ENDPOINT = "/roles";
 
 export const searchRoles: ApiDefinition<
-  SearchResponse<Role>,
-  PageSearchParams | Record<string, unknown> | undefined
+  QueryRolesResponseBody,
+  QueryRolesRequestBody | undefined
 > = (params) => apiPost(`${ROLES_ENDPOINT}/search`, params);
 
-type GetRoleParams = {
-  roleId: string;
-};
-export const getRoleDetails: ApiDefinition<Role, GetRoleParams> = ({
+export const getRoleDetails: ApiDefinition<Role, Pick<Role, "roleId">> = ({
   roleId,
 }) => apiGet(`${ROLES_ENDPOINT}/${roleId}`);
 
 export const createRole: ApiDefinition<undefined, Role> = (role) =>
   apiPost(ROLES_ENDPOINT, role);
 
-export type DeleteRoleParams = {
-  roleId: string;
-  name: string;
-};
-export const deleteRole: ApiDefinition<undefined, { roleId: string }> = ({
+export const deleteRole: ApiDefinition<undefined, Pick<Role, "roleId">> = ({
   roleId,
 }) => apiDelete(`${ROLES_ENDPOINT}/${roleId}`);
 
 // ----------------- Mapping rules within a Role -----------------
 
-export type GetRoleMappingRulesParams = {
-  roleId: string;
-};
 export const getMappingRulesByRoleId: ApiDefinition<
-  SearchResponse<MappingRule>,
-  GetRoleMappingRulesParams
+  QueryMappingRulesResponseBody,
+  QueryMappingRulesByRoleRequestBody & Pick<Role, "roleId">
 > = (params) => {
   const { roleId, ...body } = params;
   return apiPost(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/search`, body);
 };
 
-type AssignRoleMappingParams = GetRoleMappingRulesParams & {
-  mappingRuleId: string;
-};
 export const assignRoleMappingRule: ApiDefinition<
   undefined,
-  AssignRoleMappingParams
+  Pick<Role, "roleId"> & Pick<MappingRuleResult, "mappingRuleId">
 > = ({ roleId, mappingRuleId }) => {
   return apiPut(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingRuleId}`);
 };
 
-type UnassignRoleMappingParams = AssignRoleMappingParams;
 export const unassignRoleMappingRule: ApiDefinition<
   undefined,
-  UnassignRoleMappingParams
+  Pick<Role, "roleId"> & Pick<MappingRuleResult, "mappingRuleId">
 > = ({ roleId, mappingRuleId }) =>
   apiDelete(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingRuleId}`);
 
 // ----------------- Groups within a Role -----------------
 
-type GetRoleGroupsParams = {
-  roleId: string;
-};
-
 export const getGroupsByRoleId: ApiDefinition<
-  SearchResponse<Group>,
-  GetRoleGroupsParams
+  QueryGroupsByRoleResponseBody,
+  Pick<Role, "roleId"> & QueryGroupsByRoleRequestBody
 > = ({ roleId, ...body }) =>
   apiPost(`${ROLES_ENDPOINT}/${roleId}/groups/search`, body);
 
-type AssignRoleGroupParams = GetRoleGroupsParams & Pick<Group, "groupId">;
 export const assignRoleGroup: ApiDefinition<
   undefined,
-  AssignRoleGroupParams
+  Pick<Role, "roleId"> & Pick<Group, "groupId">
 > = ({ roleId, groupId }) => {
   return apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
 };
 
-type UnassignRoleGroupParams = AssignRoleGroupParams;
 export const unassignRoleGroup: ApiDefinition<
   undefined,
-  UnassignRoleGroupParams
+  Pick<Role, "roleId"> & Pick<Group, "groupId">
 > = ({ roleId, groupId }) =>
   apiDelete(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
 
 // ----------------- Clients within a Role -----------------
 
-type GetRoleClientsParams = {
-  roleId: string;
-};
-
-export type Client = {
-  clientId: string;
-};
+export type { Client };
 
 export const getClientsByRoleId: ApiDefinition<
-  SearchResponse<Client>,
-  GetRoleClientsParams
+  QueryClientsByRoleResponseBody,
+  QueryClientsByRoleRequestBody & Pick<Role, "roleId">
 > = (args) => {
   const { roleId, ...body } = args;
   return apiPost(`${ROLES_ENDPOINT}/${roleId}/clients/search`, body);
 };
 
-type AssignRoleClientParams = GetRoleClientsParams & Client;
 export const assignRoleClient: ApiDefinition<
   undefined,
-  AssignRoleClientParams
+  Pick<Role, "roleId"> & Pick<Client, "clientId">
 > = ({ roleId, clientId }) => {
   return apiPut(`${ROLES_ENDPOINT}/${roleId}/clients/${clientId}`);
 };
 
-type UnassignRoleClientParams = AssignRoleClientParams;
 export const unassignRoleClient: ApiDefinition<
   undefined,
-  UnassignRoleClientParams
+  Pick<Role, "roleId"> & Pick<Client, "clientId">
 > = ({ roleId, clientId }) =>
   apiDelete(`${ROLES_ENDPOINT}/${roleId}/clients/${clientId}`);

--- a/identity/client/src/utility/api/roles/index.ts
+++ b/identity/client/src/utility/api/roles/index.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiDelete,
@@ -18,13 +19,9 @@ import { Group } from "src/utility/api/groups";
 import { MappingRule } from "src/utility/api/mapping-rules";
 import { PageSearchParams } from "../hooks/usePagination";
 
-export const ROLES_ENDPOINT = "/roles";
+export type { Role };
 
-export type Role = {
-  roleId: string;
-  name: string;
-  description: string;
-};
+export const ROLES_ENDPOINT = "/roles";
 
 export const searchRoles: ApiDefinition<
   SearchResponse<Role>,

--- a/identity/client/src/utility/api/setup/index.ts
+++ b/identity/client/src/utility/api/setup/index.ts
@@ -6,16 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { CreateUserRequestBody } from "@camunda/camunda-api-zod-schemas/8.8";
 import { ApiDefinition, apiPost } from "src/utility/api/request";
 
 export const SETUP_ENDPOINT = "/setup/user";
 
-export type AdminUser = {
-  username: string;
-  name: string;
-  email: string;
-  password: string;
-};
-
-export const createAdminUser: ApiDefinition<undefined, AdminUser> = (user) =>
-  apiPost(SETUP_ENDPOINT, user);
+export const createAdminUser: ApiDefinition<
+  undefined,
+  CreateUserRequestBody
+> = (user) => apiPost(SETUP_ENDPOINT, user);

--- a/identity/client/src/utility/api/setup/index.ts
+++ b/identity/client/src/utility/api/setup/index.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { CreateUserRequestBody } from "@camunda/camunda-api-zod-schemas/8.8";
+import type { CreateUserRequestBody } from "@camunda/camunda-api-zod-schemas/8.9";
 import { ApiDefinition, apiPost } from "src/utility/api/request";
 
 export const SETUP_ENDPOINT = "/setup/user";

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -6,7 +6,24 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { Tenant as BaseTenant } from "@camunda/camunda-api-zod-schemas/8.9";
+import type {
+  Tenant,
+  Group,
+  Role,
+  QueryTenantsRequestBody,
+  QueryTenantsResponseBody,
+  CreateTenantRequestBody,
+  UpdateTenantRequestBody,
+  QueryGroupsByTenantRequestBody,
+  QueryGroupsByTenantResponseBody,
+  QueryRolesByTenantRequestBody,
+  QueryRolesByTenantResponseBody,
+  QueryMappingRulesByTenantRequestBody,
+  QueryMappingRulesByTenantResponseBody,
+  QueryClientsByTenantRequestBody,
+  QueryClientsByTenantResponseBody,
+  MappingRuleResult,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiPost,
@@ -14,164 +31,127 @@ import {
   apiDelete,
   apiPut,
 } from "src/utility/api/request";
-import { SearchResponse } from "src/utility/api";
-import { Group } from "src/utility/api/groups";
-import { Role } from "src/utility/api/roles";
-import { MappingRule } from "src/utility/api/mapping-rules";
-import { PageSearchParams } from "../hooks/usePagination";
+
+// TODO fix
+type MappingRule = MappingRuleResult;
+
+export type Client = QueryClientsByTenantResponseBody["items"][number];
 
 export const TENANTS_ENDPOINT = "/tenants";
 
-export type Tenant = BaseTenant & { tenantKey: string };
-
 export const searchTenant: ApiDefinition<
-  SearchResponse<Tenant>,
-  PageSearchParams
+  QueryTenantsResponseBody,
+  QueryTenantsRequestBody
 > = (params) => apiPost(`${TENANTS_ENDPOINT}/search`, params);
 
-type GetTenantParams = {
-  tenantId?: string;
-  name?: string;
-  description?: string;
-};
 export const getTenantDetails: ApiDefinition<
-  SearchResponse<Tenant>,
-  GetTenantParams
+  QueryTenantsResponseBody,
+  Partial<Pick<Tenant, "tenantId" | "name">>
 > = ({ tenantId, name }) =>
   apiPost(`${TENANTS_ENDPOINT}/search`, {
     filter: { ...(tenantId && { tenantId }), ...(name && { name }) },
   });
 
-type CreateTenantParams = Omit<Tenant, "tenantKey">;
-export const createTenant: ApiDefinition<undefined, CreateTenantParams> = (
+export const createTenant: ApiDefinition<undefined, CreateTenantRequestBody> = (
   tenant,
 ) => apiPost(TENANTS_ENDPOINT, tenant);
 
-export type UpdateTenantParams = {
-  tenantId: string;
-  name: string;
-  description: string | null;
-};
-export const updateTenant: ApiDefinition<undefined, UpdateTenantParams> = ({
-  tenantId,
-  name,
-  description,
-}) => apiPatch(`${TENANTS_ENDPOINT}/${tenantId}`, { name, description });
+export const updateTenant: ApiDefinition<
+  undefined,
+  UpdateTenantRequestBody & Pick<Tenant, "tenantId">
+> = ({ tenantId, name, description }) =>
+  apiPatch(`${TENANTS_ENDPOINT}/${tenantId}`, { name, description });
 
-export type DeleteTenantParams = UpdateTenantParams;
-export const deleteTenant: ApiDefinition<undefined, { tenantId: string }> = ({
-  tenantId,
-}) => apiDelete(`${TENANTS_ENDPOINT}/${tenantId}`);
+export const deleteTenant: ApiDefinition<
+  undefined,
+  Pick<Tenant, "tenantId">
+> = ({ tenantId }) => apiDelete(`${TENANTS_ENDPOINT}/${tenantId}`);
 
 // ----------------- Groups within a Tenant -----------------
 
-export type GetTenantGroupsParams = {
-  tenantId: string;
-};
 export const getGroupsByTenantId: ApiDefinition<
-  SearchResponse<Group>,
-  GetTenantGroupsParams
+  QueryGroupsByTenantResponseBody,
+  QueryGroupsByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
   apiPost(`${TENANTS_ENDPOINT}/${tenantId}/groups/search`, body);
 
-type AssignTenantGroupParams = GetTenantGroupsParams & { groupId: string };
 export const assignTenantGroup: ApiDefinition<
   undefined,
-  AssignTenantGroupParams
+  Pick<Tenant, "tenantId"> & Pick<Group, "groupId">
 > = ({ tenantId, groupId }) => {
   return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupId}`);
 };
 
-type UnassignTenantGroupParams = AssignTenantGroupParams;
 export const unassignTenantGroup: ApiDefinition<
   undefined,
-  UnassignTenantGroupParams
+  Pick<Tenant, "tenantId"> & Pick<Group, "groupId">
 > = ({ tenantId, groupId }) =>
   apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupId}`);
 
 // ----------------- Roles within a Tenant -----------------
 
-export type GetTenantRolesParams = {
-  tenantId: string;
-};
 export const getRolesByTenantId: ApiDefinition<
-  SearchResponse<Role>,
-  GetTenantRolesParams
+  // TODO fix response type
+  Omit<QueryRolesByTenantResponseBody, "items"> & { items: Role[] },
+  QueryRolesByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
   apiPost(`${TENANTS_ENDPOINT}/${tenantId}/roles/search`, body);
 
-type AssignTenantRoleParams = GetTenantRolesParams & { roleId: string };
 export const assignTenantRole: ApiDefinition<
   undefined,
-  AssignTenantRoleParams
+  Pick<Tenant, "tenantId"> & Pick<Role, "roleId">
 > = ({ tenantId, roleId }) => {
   return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/roles/${roleId}`);
 };
 
-type UnassignTenantRoleParams = AssignTenantRoleParams;
 export const unassignTenantRole: ApiDefinition<
   undefined,
-  UnassignTenantRoleParams
+  Pick<Tenant, "tenantId"> & Pick<Role, "roleId">
 > = ({ tenantId, roleId }) =>
   apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/roles/${roleId}`);
 
 // ----------------- Mapping rules within a Tenant -----------------
 
-export type GetTenantMappingRulesParams = {
-  tenantId: string;
-};
 export const getMappingRulesByTenantId: ApiDefinition<
-  SearchResponse<MappingRule>,
-  GetTenantMappingRulesParams
+  Omit<QueryMappingRulesByTenantResponseBody, "items"> & {
+    items: MappingRule[];
+  },
+  QueryMappingRulesByTenantRequestBody & Pick<Tenant, "tenantId">
 > = (params) => {
   const { tenantId, ...body } = params;
   return apiPost(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/search`, body);
 };
 
-type AssignTenantMappingRuleParams = GetTenantMappingRulesParams & {
-  mappingRuleId: string;
-};
 export const assignTenantMappingRule: ApiDefinition<
   undefined,
-  AssignTenantMappingRuleParams
+  Pick<Tenant, "tenantId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ tenantId, mappingRuleId }) => {
   return apiPut(
     `${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${mappingRuleId}`,
   );
 };
 
-type UnassignTenantMappingParams = AssignTenantMappingRuleParams;
 export const unassignTenantMappingRule: ApiDefinition<
   undefined,
-  UnassignTenantMappingParams
+  Pick<Tenant, "tenantId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ tenantId, mappingRuleId }) =>
   apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${mappingRuleId}`);
 
-type GetTenantClientsParams = {
-  tenantId: string;
-};
-
-export type Client = {
-  clientId: string;
-};
-
 export const getClientsByTenantId: ApiDefinition<
-  SearchResponse<Client>,
-  GetTenantClientsParams
+  QueryClientsByTenantResponseBody,
+  QueryClientsByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
   apiPost(`${TENANTS_ENDPOINT}/${tenantId}/clients/search`, body);
 
-type AssignTenantClientParams = GetTenantClientsParams & Client;
 export const assignTenantClient: ApiDefinition<
   undefined,
-  AssignTenantClientParams
+  Pick<Tenant, "tenantId"> & { clientId: string }
 > = ({ tenantId, clientId, ...body }) => {
   return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/clients/${clientId}`, body);
 };
 
-type UnassignTenantClientParams = AssignTenantClientParams;
 export const unassignTenantClient: ApiDefinition<
   undefined,
-  UnassignTenantClientParams
+  Pick<Tenant, "tenantId"> & { clientId: string }
 > = ({ tenantId, clientId }) =>
   apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/clients/${clientId}`);

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  MappingRule,
   Tenant,
   Group,
   Role,
@@ -22,7 +23,6 @@ import type {
   QueryMappingRulesByTenantResponseBody,
   QueryClientsByTenantRequestBody,
   QueryClientsByTenantResponseBody,
-  MappingRuleResult,
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
@@ -31,11 +31,6 @@ import {
   apiDelete,
   apiPut,
 } from "src/utility/api/request";
-
-// TODO fix
-type MappingRule = MappingRuleResult;
-
-export type Client = QueryClientsByTenantResponseBody["items"][number];
 
 export const TENANTS_ENDPOINT = "/tenants";
 
@@ -92,7 +87,7 @@ export const unassignTenantGroup: ApiDefinition<
 
 export const getRolesByTenantId: ApiDefinition<
   // TODO fix response type
-  Omit<QueryRolesByTenantResponseBody, "items"> & { items: Role[] },
+  QueryRolesByTenantResponseBody,
   QueryRolesByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
   apiPost(`${TENANTS_ENDPOINT}/${tenantId}/roles/search`, body);
@@ -113,9 +108,7 @@ export const unassignTenantRole: ApiDefinition<
 // ----------------- Mapping rules within a Tenant -----------------
 
 export const getMappingRulesByTenantId: ApiDefinition<
-  Omit<QueryMappingRulesByTenantResponseBody, "items"> & {
-    items: MappingRule[];
-  },
+  QueryMappingRulesByTenantResponseBody,
   QueryMappingRulesByTenantRequestBody & Pick<Tenant, "tenantId">
 > = (params) => {
   const { tenantId, ...body } = params;

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -86,7 +86,6 @@ export const unassignTenantGroup: ApiDefinition<
 // ----------------- Roles within a Tenant -----------------
 
 export const getRolesByTenantId: ApiDefinition<
-  // TODO fix response type
   QueryRolesByTenantResponseBody,
   QueryRolesByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { Tenant as BaseTenant } from "@camunda/camunda-api-zod-schemas/8.9";
 import {
   ApiDefinition,
   apiPost,
@@ -14,7 +15,6 @@ import {
   apiPut,
 } from "src/utility/api/request";
 import { SearchResponse } from "src/utility/api";
-import { EntityData } from "src/components/entityList/EntityList";
 import { Group } from "src/utility/api/groups";
 import { Role } from "src/utility/api/roles";
 import { MappingRule } from "src/utility/api/mapping-rules";
@@ -22,12 +22,7 @@ import { PageSearchParams } from "../hooks/usePagination";
 
 export const TENANTS_ENDPOINT = "/tenants";
 
-export type Tenant = EntityData & {
-  tenantKey: string;
-  tenantId: string;
-  name: string;
-  description: string;
-};
+export type Tenant = BaseTenant & { tenantKey: string };
 
 export const searchTenant: ApiDefinition<
   SearchResponse<Tenant>,
@@ -55,7 +50,7 @@ export const createTenant: ApiDefinition<undefined, CreateTenantParams> = (
 export type UpdateTenantParams = {
   tenantId: string;
   name: string;
-  description: string;
+  description: string | null;
 };
 export const updateTenant: ApiDefinition<undefined, UpdateTenantParams> = ({
   tenantId,

--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -6,66 +6,55 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
-import { PageSearchParams } from "../hooks/usePagination";
-import { ApiDefinition, apiDelete, apiPost, apiPut } from "../request";
-import { SearchResponse } from "src/utility/api";
+import type {
+  User,
+  QueryUsersRequestBody,
+  QueryUsersResponseBody,
+  CreateUserRequestBody,
+  UpdateUserRequestBody,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 
-export type { User };
+import { ApiDefinition, apiDelete, apiPost, apiPut } from "../request";
 
 export type UserKeys = keyof User;
 
 export const USERS_ENDPOINT = "/users";
 
-type SearchUserParams = {
-  usernames: string[];
-};
-
 export const searchUser: ApiDefinition<
-  SearchResponse<User>,
-  Partial<SearchUserParams & PageSearchParams> | undefined
+  QueryUsersResponseBody,
+  (QueryUsersRequestBody & { usernames?: string[] }) | undefined
 > = (params = {}) => {
   const { usernames, ...restParams } = params;
 
-  const filters = usernames
+  const filters: QueryUsersRequestBody | undefined = usernames
     ? { filter: { username: { $in: usernames } } }
     : undefined;
 
   return apiPost(`${USERS_ENDPOINT}/search`, { ...restParams, ...filters });
 };
 
-type GetUserParams = {
-  username: string;
-};
-
 export const getUserDetails: ApiDefinition<
-  SearchResponse<User>,
-  GetUserParams
+  QueryUsersResponseBody,
+  Pick<User, "username">
 > = ({ username }) =>
   apiPost(`${USERS_ENDPOINT}/search`, { filter: { username } });
 
-type CreateUserParams = { password: string } & User;
-
-export const createUser: ApiDefinition<undefined, CreateUserParams> = (user) =>
-  apiPost(USERS_ENDPOINT, { ...user });
-
-type UpdateUserParams = { password?: string } & User;
-
-export const updateUser: ApiDefinition<undefined, UpdateUserParams> = (
+export const createUser: ApiDefinition<undefined, CreateUserRequestBody> = (
   user,
-) => {
+) => apiPost(USERS_ENDPOINT, { ...user });
+
+export const updateUser: ApiDefinition<
+  undefined,
+  UpdateUserRequestBody & Pick<User, "username">
+> = (user) => {
   const { name, email, username, password } = user;
   return apiPut(`${USERS_ENDPOINT}/${username}`, {
     name,
     email,
-    password: password ?? "",
+    password,
   });
 };
 
-type DeleteUserParams = {
-  username: string;
-};
-
-export const deleteUser: ApiDefinition<undefined, DeleteUserParams> = ({
+export const deleteUser: ApiDefinition<undefined, Pick<User, "username">> = ({
   username,
 }) => apiDelete(`${USERS_ENDPOINT}/${username}`);

--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -6,19 +6,16 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type { User } from "@camunda/camunda-api-zod-schemas/8.9";
 import { PageSearchParams } from "../hooks/usePagination";
 import { ApiDefinition, apiDelete, apiPost, apiPut } from "../request";
 import { SearchResponse } from "src/utility/api";
 
+export type { User };
+
+export type UserKeys = keyof User;
+
 export const USERS_ENDPOINT = "/users";
-
-export type UserKeys = "name" | "username" | "email";
-
-export type User = {
-  name: string;
-  username: string;
-  email: string;
-};
 
 type SearchUserParams = {
   usernames: string[];

--- a/identity/client/src/utility/format/spaceAndCapitalize.ts
+++ b/identity/client/src/utility/format/spaceAndCapitalize.ts
@@ -6,7 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const spaceAndCapitalize = (str: string): string => {
+const spaceAndCapitalize = (str: string | null | undefined): string => {
+  if (!str) return "";
   const spaced = str.replace(/[-_]/gi, " ");
   return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
 };

--- a/identity/client/src/utility/license.ts
+++ b/identity/client/src/utility/license.ts
@@ -6,8 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { checkLicense, License } from "src/utility/api/headers";
+import { checkLicense } from "src/utility/api/headers";
 import { useApi } from "src/utility/api";
+import type { License } from "@camunda/camunda-api-zod-schemas/8.9";
 
 export function useLicense(): License | null {
   const { data } = useApi(checkLicense);


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/pull/46183 made all optional fields return as null. With that change we want to align Identity types with the schemas that we use and fix any issues with nullable fields.

> [!NOTE]
ClusterVariable and GlobalTaskListener seem to be custom types that are absent from the unified schema, so we will extend the schema and update types in a separate PR

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
