### PR TITLE
fix: graceful schema initialization and add readiness check

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SchemaReadinessCheck.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SchemaReadinessCheck.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.search.schema.SchemaManagerContainer;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+
+public class SchemaReadinessCheck implements HealthIndicator {
+
+  public static final String SCHEMA_READINESS_CHECK = "schemaReadinessCheck";
+  private final SchemaManagerContainer schemaManagerContainer;
+
+  public SchemaReadinessCheck(final SchemaManagerContainer schemaManagerContainer) {
+    this.schemaManagerContainer = schemaManagerContainer;
+  }
+
+  @Override
+  public Health health() {
+    return (schemaManagerContainer.isInitialized() ? Health.up() : Health.down()).build();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.beans.SearchEngineRetentionProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.search.schema.config.SchemaManagerConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.zeebe.broker.Broker;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -68,6 +70,13 @@ public class SearchEngineDatabaseConfiguration {
                 .index(searchEngineIndexProperties)
                 .retention(searchEngineRetentionProperties)
                 .schemaManager(searchEngineSchemaManagerProperties));
+  }
+
+  @Bean
+  @Qualifier(SchemaReadinessCheck.SCHEMA_READINESS_CHECK)
+  public SchemaReadinessCheck schemaReadinessCheck(
+      final SchemaManagerContainer schemaManagerContainer) {
+    return new SchemaReadinessCheck(schemaManagerContainer);
   }
 
   @ConfigurationProperties("camunda.database.schema-manager")

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -13,6 +13,7 @@ import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.search.schema.metrics.SchemaManagerMetrics;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +57,8 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     }
   }
 
-  private void synchronousSchemaInitialization(
+  @VisibleForTesting
+  void synchronousSchemaInitialization(
       final CompletableFuture<Void> future, final ExecutorService executor) throws Exception {
     try {
       future.get();
@@ -66,11 +68,15 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
           "Schema initialization task was interrupted. Shutdown signal is caught={}",
           isShutdown.get(),
           ie);
-      Thread.currentThread().interrupt();
+      if (!isShutdown.get()) {
+        // Only re-interrupt if this is not a shutdown-triggered interrupt.
+        // During shutdown, we must let Spring finish context refresh so that
+        // Broker can perform a graceful shutdown.
+        Thread.currentThread().interrupt();
+      }
     } catch (final Exception e) {
       if (isShutdown.get()) {
         LOGGER.debug("Schema initialization interrupted with shutdown.", e);
-        Thread.currentThread().interrupt();
         return;
       }
       throw e;
@@ -79,7 +85,8 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     }
   }
 
-  private void asyncSchemaInitialization(
+  @VisibleForTesting
+  void asyncSchemaInitialization(
       final CompletableFuture<Void> future, final ExecutorService executor) {
     future.whenCompleteAsync(
         (result, error) -> {

--- a/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
@@ -8,6 +8,7 @@
 package io.camunda.application.initializers;
 
 import io.camunda.application.Profile;
+import io.camunda.application.commons.search.SchemaReadinessCheck;
 import io.camunda.spring.utils.DatabaseTypeUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,7 +16,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -45,9 +45,8 @@ public class HealthConfigurationInitializer
       "management.endpoint.health.group.status.include";
   private static final String HEALTH_GROUP_LIVENESS_PROPERTY =
       "management.endpoint.health.group.liveness.include";
-
-  @Value("camunda.mode")
-  private String camundaMode;
+  private static final String BROKER_EMBEDDED_GATEWAY_ENABLED_PROPERTY =
+      "zeebe.broker.gateway.enable";
 
   @Override
   public void initialize(final ConfigurableApplicationContext context) {
@@ -56,7 +55,8 @@ public class HealthConfigurationInitializer
     final var activeProfiles =
         Stream.of(environment.getActiveProfiles()).map(String::toLowerCase).toList();
 
-    final var healthIndicators = collectHealthIndicators(activeProfiles, environment);
+    final var readinessGroupHealthIndicators =
+        collectReadinessGroupHealthIndicators(activeProfiles, environment);
     final var enableReadinessState = shouldReadinessState(activeProfiles);
     final var enableProbes = shouldEnableProbes(activeProfiles);
 
@@ -68,8 +68,8 @@ public class HealthConfigurationInitializer
     // Enables Kubernetes health groups
     propertyMap.put(SPRING_PROBES_PROPERTY, enableProbes);
 
-    if (!healthIndicators.isEmpty()) {
-      propertyMap.put(SPRING_READINESS_GROUP_PROPERTY, healthIndicators);
+    if (!readinessGroupHealthIndicators.isEmpty()) {
+      propertyMap.put(SPRING_READINESS_GROUP_PROPERTY, readinessGroupHealthIndicators);
     }
 
     // --- Gateway Properties ---
@@ -142,41 +142,45 @@ public class HealthConfigurationInitializer
   }
 
   /** Returns a list of health indicators which will be member of the readiness group */
-  protected List<String> collectHealthIndicators(
+  List<String> collectReadinessGroupHealthIndicators(
       final List<String> activeProfiles, final Environment env) {
     final var healthIndicators = new ArrayList<String>();
     final boolean secondaryStorageEnabled = DatabaseTypeUtils.isSecondaryStorageEnabled(env);
+    final boolean esOrOsEnabled = secondaryStorageEnabled && DatabaseTypeUtils.isRdbmsDisabled(env);
+    final boolean hasWebappProfile =
+        Profile.getWebappProfiles().stream().anyMatch(p -> activeProfiles.contains(p.getId()));
 
     if (activeProfiles.contains(Profile.BROKER.getId())) {
       healthIndicators.add(INDICATOR_BROKER_READY);
       healthIndicators.add(INDICATOR_NODE_ID_PROVIDER_READY);
+      healthIndicators.add(INDICATOR_BROKER_STARTUP);
     }
 
     if (activeProfiles.contains(Profile.GATEWAY.getId())) {
       healthIndicators.add(INDICATOR_GATEWAY_STARTED);
     }
 
-    if (activeProfiles.contains(Profile.BROKER.getId())) {
-      healthIndicators.add(INDICATOR_BROKER_STARTUP);
+    if (secondaryStorageEnabled && hasWebappProfile) {
+      healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
     }
 
-    if (secondaryStorageEnabled && activeProfiles.contains(Profile.OPERATE.getId())) {
-      healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
-      if (DatabaseTypeUtils.isRdbmsDisabled(env)) {
+    // Schema readiness is only relevant for ES/OS and only when serving traffic
+    // (broker with embedded gateway, standalone gateway, or webapp profiles).
+    // It must not be added for other profiles like RESTORE.
+    if (esOrOsEnabled) {
+      if (hasWebappProfile
+          || activeProfiles.contains(Profile.GATEWAY.getId())
+          || (activeProfiles.contains(Profile.BROKER.getId())
+              && env.getProperty(BROKER_EMBEDDED_GATEWAY_ENABLED_PROPERTY, Boolean.class, true))) {
+        healthIndicators.add(SchemaReadinessCheck.SCHEMA_READINESS_CHECK);
+      }
+      // legacy ES/OS health indicators for Operate and Tasklist
+      if (activeProfiles.contains(Profile.OPERATE.getId())) {
         healthIndicators.add(INDICATOR_OPERATE_INDICES_CHECK);
       }
-    }
-
-    if (secondaryStorageEnabled
-        && activeProfiles.contains(Profile.TASKLIST.getId())
-        && DatabaseTypeUtils.isRdbmsDisabled(env)) {
-      healthIndicators.add(INDICATOR_TASKLIST_SEARCH_ENGINE_CHECK);
-    }
-
-    if (secondaryStorageEnabled
-        && (activeProfiles.contains(Profile.IDENTITY.getId())
-            || activeProfiles.contains(Profile.ADMIN.getId()))) {
-      healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
+      if (activeProfiles.contains(Profile.TASKLIST.getId())) {
+        healthIndicators.add(INDICATOR_TASKLIST_SEARCH_ENGINE_CHECK);
+      }
     }
 
     return healthIndicators;

--- a/dist/src/test/java/io/camunda/application/StartCamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/StartCamundaDockerIT.java
@@ -64,6 +64,7 @@ public class StartCamundaDockerIT extends AbstractCamundaDockerIT {
                   "nodeIdProvider":{"status":"UP"},
                   "nodeIdProviderReady":{"status":"UP"},
                   "readinessState": {"status": "UP"},
+                  "schemaReadinessCheck":{"status":"UP"},
                   "searchEngineCheck": {"status": "UP"}
                 },
                 "groups": ["liveness", "readiness", "startup", "status"]

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SearchEngineSchemaInitializerTest {
+
+  private SearchEngineSchemaInitializer createInitializer() {
+    return new SearchEngineSchemaInitializer(null, new SimpleMeterRegistry(), true);
+  }
+
+  /** Sets the private {@code isShutdown} flag on the initializer via reflection. */
+  private static void setShutdown(
+      final SearchEngineSchemaInitializer initializer, final boolean value) {
+    try {
+      final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("isShutdown");
+      field.setAccessible(true);
+      ((AtomicBoolean) field.get(initializer)).set(value);
+    } catch (final ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to set isShutdown via reflection", e);
+    }
+  }
+
+  @Nested
+  class SynchronousInitialization {
+
+    private ExecutorService executor;
+
+    @AfterEach
+    void tearDown() {
+      if (executor != null && !executor.isShutdown()) {
+        executor.shutdownNow();
+      }
+      // Clear interrupt flag to avoid leaking to other tests
+      Thread.interrupted();
+    }
+
+    @Test
+    void shouldCompleteSuccessfully() throws Exception {
+      // given
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      final var future = CompletableFuture.completedFuture((Void) null);
+
+      // when
+      initializer.synchronousSchemaInitialization(future, executor);
+
+      // then — no exception thrown, executor is closed
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldNotInterruptThreadOnShutdownTriggeredInterrupt() throws Exception {
+      // given — simulate shutdown-triggered interrupt
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      setShutdown(initializer, true);
+
+      // Use an incomplete future so that future.get() blocks and sees the interrupt flag
+      final var blockingFuture = new CompletableFuture<Void>();
+
+      // when — interrupt the thread so future.get() throws InterruptedException
+      Thread.currentThread().interrupt();
+      initializer.synchronousSchemaInitialization(blockingFuture, executor);
+
+      // then — thread should NOT be interrupted (shutdown swallows the interrupt)
+      assertThat(Thread.currentThread().isInterrupted()).isFalse();
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldReInterruptThreadOnNonShutdownInterrupt() throws Exception {
+      // given — NOT a shutdown, something else interrupted
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      // isShutdown remains false (default)
+
+      final var blockingFuture = new CompletableFuture<Void>();
+
+      // when — interrupt the current thread so future.get() throws InterruptedException
+      Thread.currentThread().interrupt();
+      initializer.synchronousSchemaInitialization(blockingFuture, executor);
+
+      // then — thread should be re-interrupted
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldSuppressExceptionDuringShutdown() {
+      // given — shutdown is in progress and the future fails with a non-interrupt exception.
+      // CompletableFuture.get() wraps the cause in ExecutionException, which falls into
+      // the catch(Exception) block where isShutdown=true causes a silent return.
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      setShutdown(initializer, true);
+
+      final var future = new CompletableFuture<Void>();
+      future.completeExceptionally(new RuntimeException("ES connection failed"));
+
+      // when/then — should not throw, exception is suppressed during shutdown
+      assertThatNoException()
+          .isThrownBy(() -> initializer.synchronousSchemaInitialization(future, executor));
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldPropagateExceptionWhenNotShutdown() {
+      // given — NOT a shutdown, the future fails with a real error.
+      // CompletableFuture.get() wraps the cause in ExecutionException.
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      // isShutdown remains false
+
+      final var cause = new RuntimeException("ES connection refused");
+      final var future = new CompletableFuture<Void>();
+      future.completeExceptionally(cause);
+
+      // when/then — ExecutionException wrapping the cause should propagate
+      assertThatThrownBy(() -> initializer.synchronousSchemaInitialization(future, executor))
+          .isInstanceOf(ExecutionException.class)
+          .hasCause(cause);
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldAlwaysCloseExecutorEvenOnException() {
+      // given
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+
+      final var future = new CompletableFuture<Void>();
+      future.completeExceptionally(new RuntimeException("schema init failed"));
+
+      // when
+      try {
+        initializer.synchronousSchemaInitialization(future, executor);
+      } catch (final Exception ignored) {
+        // expected
+      }
+
+      // then — executor must be closed regardless
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldAlwaysCloseExecutorOnInterrupt() throws Exception {
+      // given
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+
+      final var blockingFuture = new CompletableFuture<Void>();
+      Thread.currentThread().interrupt();
+
+      // when
+      initializer.synchronousSchemaInitialization(blockingFuture, executor);
+
+      // then — executor must be closed regardless
+      assertThat(executor.isShutdown()).isTrue();
+    }
+  }
+
+  @Nested
+  class AsynchronousInitialization {
+
+    @Test
+    void shouldCloseExecutorOnSuccess() throws Exception {
+      // given
+      final var initializer = createInitializer();
+      final var executor = Executors.newSingleThreadExecutor();
+      final var future = CompletableFuture.completedFuture((Void) null);
+
+      // when
+      initializer.asyncSchemaInitialization(future, executor);
+
+      // then — wait a bit for the whenCompleteAsync callback to run
+      executor.awaitTermination(2, TimeUnit.SECONDS);
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldCloseExecutorOnFailure() throws Exception {
+      // given
+      final var initializer = createInitializer();
+      final var executor = Executors.newSingleThreadExecutor();
+      final var future = new CompletableFuture<Void>();
+      future.completeExceptionally(new RuntimeException("ES unavailable"));
+
+      // when
+      initializer.asyncSchemaInitialization(future, executor);
+
+      // then — wait a bit for the whenCompleteAsync callback to run
+      executor.awaitTermination(2, TimeUnit.SECONDS);
+      assertThat(executor.isShutdown()).isTrue();
+    }
+  }
+}

--- a/dist/src/test/java/io/camunda/application/initializers/HealthConfigurationInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/initializers/HealthConfigurationInitializerTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.initializers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.application.Profile;
+import io.camunda.application.commons.search.SchemaReadinessCheck;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+
+class HealthConfigurationInitializerTest {
+
+  private HealthConfigurationInitializer initializer;
+  private Environment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = mock(Environment.class);
+    initializer = new HealthConfigurationInitializer();
+  }
+
+  /** Helper to enable ES secondary storage (the default when the property is not set). */
+  private void withElasticsearchSecondaryStorage() {
+    when(environment.getProperty("camunda.data.secondary-storage.type"))
+        .thenReturn("elasticsearch");
+  }
+
+  /** Helper to enable RDBMS as secondary storage (disables ES-specific checks). */
+  private void withRdbmsSecondaryStorage() {
+    when(environment.getProperty("camunda.data.secondary-storage.type")).thenReturn("rdbms");
+  }
+
+  /** Helper to disable secondary storage entirely. */
+  private void withNoSecondaryStorage() {
+    when(environment.getProperty("camunda.data.secondary-storage.type")).thenReturn("none");
+  }
+
+  /** Helper to set the embedded gateway property. */
+  private void withEmbeddedGatewayEnabled(final boolean enabled) {
+    when(environment.getProperty("zeebe.broker.gateway.enable", Boolean.class, true))
+        .thenReturn(enabled);
+  }
+
+  @Nested
+  class BrokerProfile {
+
+    @Test
+    void shouldIncludeBrokerHealthIndicators() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.of(Profile.BROKER.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).containsExactly("brokerReady", "nodeIdProviderReady", "brokerStartup");
+    }
+
+    @Test
+    void shouldIncludeSchemaReadinessCheckWithEmbeddedGatewayAndES() {
+      // given — broker with embedded gateway (default) and ES
+      withElasticsearchSecondaryStorage();
+      withEmbeddedGatewayEnabled(true);
+      final var profiles = List.of(Profile.BROKER.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains(SchemaReadinessCheck.SCHEMA_READINESS_CHECK);
+    }
+
+    @Test
+    void shouldNotIncludeSchemaReadinessCheckWithoutEmbeddedGateway() {
+      // given — broker without embedded gateway does not serve traffic directly
+      withElasticsearchSecondaryStorage();
+      withEmbeddedGatewayEnabled(false);
+      final var profiles = List.of(Profile.BROKER.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).doesNotContain(SchemaReadinessCheck.SCHEMA_READINESS_CHECK);
+    }
+  }
+
+  @Nested
+  class GatewayProfile {
+
+    @Test
+    void shouldIncludeGatewayStartedIndicator() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.of(Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).containsExactly("gatewayStarted");
+    }
+
+    @Test
+    void shouldIncludeSchemaReadinessCheckWithES() {
+      // given — standalone gateway with ES
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains(SchemaReadinessCheck.SCHEMA_READINESS_CHECK);
+    }
+  }
+
+  @Nested
+  class BrokerAndGatewayProfiles {
+
+    @Test
+    void shouldIncludeBothBrokerAndGatewayIndicators() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.of(Profile.BROKER.getId(), Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .containsExactly("brokerReady", "nodeIdProviderReady", "brokerStartup", "gatewayStarted");
+    }
+  }
+
+  @Nested
+  class SecondaryStorageDisabled {
+
+    @Test
+    void shouldNotIncludeSearchIndicatorsWhenSecondaryStorageIsNone() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.of(Profile.OPERATE.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).isEmpty();
+    }
+  }
+
+  @Nested
+  class ElasticsearchSecondaryStorage {
+
+    @Test
+    void shouldIncludeReadinessStateAndSchemaCheckForOperate() {
+      // given
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.OPERATE.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then — Operate is a webapp profile, so it serves traffic
+      assertThat(indicators)
+          .contains("readinessState")
+          .contains(SchemaReadinessCheck.SCHEMA_READINESS_CHECK)
+          .contains("indicesCheck");
+    }
+
+    @Test
+    void shouldIncludeReadinessStateAndSchemaCheckForTasklist() {
+      // given
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.TASKLIST.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains("readinessState")
+          .contains(SchemaReadinessCheck.SCHEMA_READINESS_CHECK)
+          .contains("searchEngineCheck");
+    }
+
+    @Test
+    void shouldIncludeReadinessStateAndSchemaCheckForIdentity() {
+      // given
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.IDENTITY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains("readinessState")
+          .contains(SchemaReadinessCheck.SCHEMA_READINESS_CHECK)
+          .doesNotContain("indicesCheck")
+          .doesNotContain("searchEngineCheck");
+    }
+
+    @Test
+    void shouldIncludeReadinessStateAndSchemaCheckForAdmin() {
+      // given
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.ADMIN.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains("readinessState")
+          .contains(SchemaReadinessCheck.SCHEMA_READINESS_CHECK)
+          .doesNotContain("indicesCheck")
+          .doesNotContain("searchEngineCheck");
+    }
+
+    @Test
+    void shouldIncludeOperateAndTasklistIndicatorsWhenBothActive() {
+      // given
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.OPERATE.getId(), Profile.TASKLIST.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains("readinessState")
+          .contains(SchemaReadinessCheck.SCHEMA_READINESS_CHECK)
+          .contains("indicesCheck")
+          .contains("searchEngineCheck");
+    }
+  }
+
+  @Nested
+  class RdbmsSecondaryStorage {
+
+    @Test
+    void shouldIncludeReadinessStateButNotSearchIndicatorsForOperate() {
+      // given
+      withRdbmsSecondaryStorage();
+      final var profiles = List.of(Profile.OPERATE.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains("readinessState")
+          .doesNotContain("indicesCheck")
+          .doesNotContain("searchEngineCheck")
+          .doesNotContain(SchemaReadinessCheck.SCHEMA_READINESS_CHECK);
+    }
+
+    @Test
+    void shouldIncludeReadinessStateButNotSearchIndicatorsForTasklist() {
+      // given
+      withRdbmsSecondaryStorage();
+      final var profiles = List.of(Profile.TASKLIST.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains("readinessState")
+          .doesNotContain("searchEngineCheck")
+          .doesNotContain(SchemaReadinessCheck.SCHEMA_READINESS_CHECK);
+    }
+  }
+
+  @Nested
+  class RestoreProfile {
+
+    @Test
+    void shouldNotIncludeSchemaReadinessCheckForRestore() {
+      // given — RESTORE does not serve traffic, so schema readiness is irrelevant
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.RESTORE.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .doesNotContain(SchemaReadinessCheck.SCHEMA_READINESS_CHECK)
+          .doesNotContain("readinessState");
+    }
+  }
+
+  @Nested
+  class FullDeploymentProfile {
+
+    @Test
+    void shouldIncludeAllIndicatorsForFullDeploymentWithES() {
+      // given — typical Camunda deployment: broker + gateway + operate + tasklist
+      withElasticsearchSecondaryStorage();
+      withEmbeddedGatewayEnabled(true);
+      final var profiles =
+          List.of(
+              Profile.BROKER.getId(),
+              Profile.GATEWAY.getId(),
+              Profile.OPERATE.getId(),
+              Profile.TASKLIST.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains(
+              "brokerReady",
+              "nodeIdProviderReady",
+              "brokerStartup",
+              "gatewayStarted",
+              "readinessState",
+              SchemaReadinessCheck.SCHEMA_READINESS_CHECK,
+              "indicesCheck",
+              "searchEngineCheck");
+    }
+
+    @Test
+    void shouldNotDuplicateIndicatorsWhenMultipleProfilesServeTraffic() {
+      // given — broker + gateway + all webapps: schemaReadinessCheck should appear exactly once
+      withElasticsearchSecondaryStorage();
+      withEmbeddedGatewayEnabled(true);
+      final var profiles =
+          List.of(
+              Profile.BROKER.getId(),
+              Profile.GATEWAY.getId(),
+              Profile.OPERATE.getId(),
+              Profile.TASKLIST.getId(),
+              Profile.IDENTITY.getId(),
+              Profile.ADMIN.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then — each indicator should appear exactly once
+      assertThat(indicators.stream().filter("readinessState"::equals)).hasSize(1);
+      assertThat(indicators.stream().filter(SchemaReadinessCheck.SCHEMA_READINESS_CHECK::equals))
+          .hasSize(1);
+    }
+  }
+
+  @Nested
+  class NoProfiles {
+
+    @Test
+    void shouldReturnEmptyListWhenNoProfilesActive() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.<String>of();
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR fixes: 
**1. SearchEngineSchemaInitializer graceful shutdown on interrupt:**
When a shutdown signal arrives during schema initialization, the shutdown hook interrupts the schema init thread via `executor.shutdownNow()`. Previously, the `InterruptedException` handler would unconditionally re-interrupt the main thread, which caused Spring to abort its context refresh. This prevented the broker from executing its graceful shutdown lifecycle (partition step-down, stream processor closure...)
Now, the interrupt is only re-propagated when the interruption is not caused by shutdown. During shutdown, the interrupt flag is left clear so Spring can finish context refresh and the broker can shut down cleanly. The unnecessary Thread.currentThread().interrupt() in the catch (Exception) shutdown branch was also removed since early return already handles that case.

**2. SchemaReadinessCheck new health indicator**
A new HealthIndicator component that reports DOWN until `SchemaManagerContainer.isInitialized()` returns true. It is conditional on ES/OS secondary storage being configured. This prevents Kubernetes from routing traffic to the pod before the schema is ready. This is necessary to avoid accepting traffic on pods, typically during a rolling upgrade scenario, when a graceful shutdown is triggered for newer versions, while the schema has not yet been initialized or updated.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #43266
