### PR TITLE
Revert "build: module do not read files from other modules"

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -113,13 +113,6 @@
       <artifactId>zeebe-gateway-grpc</artifactId>
     </dependency>
 
-    <!-- required to unpack OpenAPI specs at build time -->
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-gateway-protocol</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-restore</artifactId>
@@ -990,7 +983,7 @@
               <outputDirectory>${project.build.directory}/camunda-zeebe/config/openapi/v2</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/v2</directory>
+                  <directory>${project.basedir}/../zeebe/gateway-protocol/src/main/proto/v2</directory>
                   <includes>
                     <include>**/*.yaml</include>
                   </includes>
@@ -1075,25 +1068,6 @@
             <dep>io.camunda.optimize:optimize-webjar</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
-        <executions>
-          <execution>
-            <id>unpack-openapi-yaml</id>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <phase>initialize</phase>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>io.camunda</groupId>
-                  <artifactId>zeebe-gateway-protocol</artifactId>
-                  <includes>v2/**</includes>
-                  <outputDirectory>${project.build.directory}</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -19,13 +19,11 @@
   <packaging>jar</packaging>
   <name>Camunda Gateway Model</name>
 
+  <properties>
+    <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto/v2</openapi.dir>
+  </properties>
+
   <dependencies>
-    <!-- required to unpack OpenAPI specs at build time -->
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-gateway-protocol</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <!-- required for OpenAPI model generation -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -84,7 +82,7 @@
               <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
               <generatorName>spring</generatorName>
               <templateDirectory>${project.basedir}/src/main/resources/templates/java-spring/advanced</templateDirectory>
-              <inputSpec>${project.build.directory}/v2/rest-api.yaml</inputSpec>
+              <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
               <modelPackage>io.camunda.gateway.protocol.model</modelPackage>
               <typeMappings>
                 <!-- map OffsetDateTime to String to avoid timezone issues and do validation manually -->
@@ -137,7 +135,7 @@
               <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
               <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
               <generatorName>spring</generatorName>
-              <inputSpec>${project.build.directory}/v2/rest-api.yaml</inputSpec>
+              <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
               <modelPackage>io.camunda.gateway.protocol.model.simple</modelPackage>
               <templateDirectory>${project.basedir}/src/main/resources/templates/java-spring/simple</templateDirectory>
               <typeMappings>
@@ -273,25 +271,6 @@
             <dependency>jakarta.annotation:jakarta.annotation-api</dependency>
           </usedDependencies>
         </configuration>
-        <executions>
-          <execution>
-            <id>unpack-openapi-specs</id>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <phase>initialize</phase>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>io.camunda</groupId>
-                  <artifactId>zeebe-gateway-protocol</artifactId>
-                  <includes>v2/**</includes>
-                  <outputDirectory>${project.build.directory}</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/zeebe/gateway-protocol-impl/pom.xml
+++ b/zeebe/gateway-protocol-impl/pom.xml
@@ -23,6 +23,7 @@
   <properties>
     <version.java>8</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
+    <proto.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto</proto.dir>
   </properties>
 
   <dependencies>
@@ -85,35 +86,12 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>unpack-proto-sources</id>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <phase>initialize</phase>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>io.camunda</groupId>
-                  <artifactId>zeebe-gateway-protocol</artifactId>
-                  <includes>**/*.proto</includes>
-                  <outputDirectory>${project.build.directory}/proto</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <!-- generate Java protobuf code -->
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <configuration>
-          <protoSourceRoot>${project.build.directory}/proto</protoSourceRoot>
+          <protoSourceRoot>${proto.dir}</protoSourceRoot>
         </configuration>
       </plugin>
     </plugins>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -19,6 +19,10 @@
   <packaging>jar</packaging>
   <name>Zeebe Gateway REST API server</name>
 
+  <properties>
+    <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto/v2</openapi.dir>
+  </properties>
+
   <dependencies>
 
     <!-- required to guarantee the protocol is processed earlier during the build -->


### PR DESCRIPTION
Reverts camunda/camunda#46522

It's not possible anymore to just run `mvn compile` because the `package` goal is necessary for unpacking the sources from the jars. 