### PR TITLE
perf: make AuthInfo effectively immutable and pass by reference

### DIFF
--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -124,7 +124,7 @@ public class AdHocSubProcessActivityServicesTest {
 
     // then
     assertThat(result).isEqualTo(expectedResponse);
-    assertThat(requestCaptor.getValue().getAuthorization().getClaims())
+    assertThat(requestCaptor.getValue().getAuthorization().toDecodedMap())
         .containsExactly(entry(USER_TOKEN_CLAIMS, Map.of("claim", "value")));
   }
 
@@ -147,7 +147,7 @@ public class AdHocSubProcessActivityServicesTest {
 
     // then
     assertThat(newServices).isNotSameAs(services);
-    assertThat(requestCaptor.getValue().getAuthorization().getClaims())
+    assertThat(requestCaptor.getValue().getAuthorization().toDecodedMap())
         .containsExactly(entry(USER_TOKEN_CLAIMS, Map.of("newClaim", "newValue")));
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
@@ -67,7 +67,7 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
 
   @Override
   public void setAuthorization(final Map<String, Object> claims) {
-    request.setAuthorization(new AuthInfo().setClaims(claims));
+    request.setAuthorization(AuthInfo.withClaims(claims));
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.ValueTypes;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class CommandApiRequestReader implements RequestReader {
 
@@ -70,9 +71,7 @@ public class CommandApiRequestReader implements RequestReader {
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
       final int authLength = commandRequestDecoder.authorizationLength();
       if (authLength > 0) {
-        final var authInfo = new AuthInfo();
-        authInfo.wrap(buffer, authOffset, authLength);
-        metadata.authorization(authInfo);
+        metadata.authorization(AuthInfo.of(new UnsafeBuffer(buffer, authOffset, authLength)));
       }
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -23,7 +23,6 @@ public class CommandApiRequestReader implements RequestReader {
 
   private UnifiedRecordValue value;
   private final RecordMetadata metadata = new RecordMetadata();
-  private final AuthInfo authInfo = new AuthInfo();
   private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
   private final ExecuteCommandRequestDecoder commandRequestDecoder =
       new ExecuteCommandRequestDecoder();
@@ -69,6 +68,7 @@ public class CommandApiRequestReader implements RequestReader {
     if (commandRequestDecoder.limit() < buffer.capacity()) {
       final int authOffset =
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
+      final var authInfo = new AuthInfo();
       authInfo.wrap(buffer, authOffset, commandRequestDecoder.authorizationLength());
       metadata.authorization(authInfo);
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -68,9 +68,12 @@ public class CommandApiRequestReader implements RequestReader {
     if (commandRequestDecoder.limit() < buffer.capacity()) {
       final int authOffset =
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
-      final var authInfo = new AuthInfo();
-      authInfo.wrap(buffer, authOffset, commandRequestDecoder.authorizationLength());
-      metadata.authorization(authInfo);
+      final int authLength = commandRequestDecoder.authorizationLength();
+      if (authLength > 0) {
+        final var authInfo = new AuthInfo();
+        authInfo.wrap(buffer, authOffset, authLength);
+        metadata.authorization(authInfo);
+      }
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -216,7 +216,8 @@ final class InterPartitionCommandReceiverImpl {
         return;
       }
       final var offset = messageDecoder.limit() + InterPartitionMessageDecoder.authHeaderLength();
-      recordMetadata.getAuthorization().wrap(messageDecoder.buffer(), offset, length);
+      final var authBuffer = new UnsafeBuffer(messageDecoder.buffer(), offset, length);
+      recordMetadata.authorization(authBuffer);
       messageDecoder.skipAuth();
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -232,10 +232,9 @@ final class InterPartitionCommandReceiverTest {
     final var receiverBrokerId = 1;
     final var receiverPartitionId = 7;
 
-    final var authInfo = new AuthInfo();
     final var token = "some-jwt-token";
     final var claims = Map.<String, Object>of("sub", "user-123", "scope", "test");
-    authInfo.setFormat(AuthInfo.AuthDataFormat.JWT).setAuthData(token).setClaims(claims);
+    final var authInfo = AuthInfo.withJwt(token, claims);
 
     final var sentMessage =
         sendCommand(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -294,7 +294,7 @@ final class InterPartitionCommandReceiverTest {
             assertArg(
                 (final LogAppendEntry logEntry) ->
                     assertThat(logEntry.recordMetadata().getAuthorization())
-                        .isEqualTo(new AuthInfo())));
+                        .isEqualTo(AuthInfo.empty())));
   }
 
   private byte[] sendCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -298,8 +298,7 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
       // have to copy this value for every partition.
       final var commandValue = distributionRecord.getCommandValue();
 
-      final var authInfo = new AuthInfo();
-      authInfo.copyFrom(distributionRecord.getAuthInfo());
+      final var authInfo = AuthInfo.of(distributionRecord.getAuthInfo());
 
       sideEffectWriter.appendSideEffect(
           () -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -106,8 +106,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     if (isAuthNeeded) {
       commandDistributionBehavior.withKey(eventKey).unordered().distribute(command);
     } else {
-      final var authInfo = new AuthInfo();
-      authInfo.setFormat(AuthDataFormat.PRE_AUTHORIZED);
+      final var authInfo = AuthInfo.preAuthorized();
       commandDistributionBehavior
           .withKey(eventKey)
           .unordered()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -20,10 +21,7 @@ import java.util.function.Consumer;
  * event).
  */
 public record FollowUpEventMetadata(
-    long operationReference,
-    long batchOperationReference,
-    int recordVersion,
-    Map<String, Object> claims) {
+    long operationReference, long batchOperationReference, int recordVersion, AuthInfo authInfo) {
 
   public static final int VERSION_NOT_SET = -1;
 
@@ -49,8 +47,8 @@ public record FollowUpEventMetadata(
     return recordVersion;
   }
 
-  public Map<String, Object> getClaims() {
-    return claims;
+  public AuthInfo getAuthInfo() {
+    return authInfo;
   }
 
   public static Builder builder() {
@@ -62,7 +60,7 @@ public record FollowUpEventMetadata(
     private long operationReference = RecordMetadataDecoder.operationReferenceNullValue();
     private long batchOperationReference = RecordMetadataDecoder.batchOperationReferenceNullValue();
     private int recordVersion = VERSION_NOT_SET;
-    private Map<String, Object> claims = Map.of();
+    private AuthInfo authInfo;
 
     public Builder operationReference(final long operationReference) {
       this.operationReference = operationReference;
@@ -79,14 +77,22 @@ public record FollowUpEventMetadata(
       return this;
     }
 
+    public Builder authInfo(final AuthInfo authInfo) {
+      this.authInfo = authInfo;
+      return this;
+    }
+
     public Builder claims(final Map<String, Object> claims) {
-      this.claims = claims;
+      authInfo = AuthInfo.withClaims(claims);
       return this;
     }
 
     public FollowUpEventMetadata build() {
       return new FollowUpEventMetadata(
-          operationReference, batchOperationReference, recordVersion, claims);
+          operationReference,
+          batchOperationReference,
+          recordVersion,
+          authInfo != null ? authInfo : new AuthInfo());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.EmptyAuthInfo;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
-import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -82,17 +82,12 @@ public record FollowUpEventMetadata(
       return this;
     }
 
-    public Builder claims(final Map<String, Object> claims) {
-      authInfo = AuthInfo.withClaims(claims);
-      return this;
-    }
-
     public FollowUpEventMetadata build() {
       return new FollowUpEventMetadata(
           operationReference,
           batchOperationReference,
           recordVersion,
-          authInfo != null ? authInfo : new AuthInfo());
+          authInfo != null ? authInfo : EmptyAuthInfo.getInstance());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata.Builder;
 import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -79,7 +78,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
             .recordVersion(recordVersion)
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("")
-            .authorization(new AuthInfo().setClaims(metadata.getClaims()))
+            .authorization(metadata.getAuthInfo())
             .operationReference(metadata.getOperationReference())
             .batchOperationReference(metadata.getBatchOperationReference());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
@@ -33,7 +33,7 @@ final class ResultBuilderBackedRejectionWriter extends AbstractResultBuilderBack
         new RecordMetadata()
             .recordType(RecordType.COMMAND_REJECTION)
             .intent(command.getIntent())
-            .authorization(new AuthInfo().setClaims(command.getAuthorizations()))
+            .authorization(AuthInfo.withClaims(command.getAuthorizations()))
             .rejectionType(rejectionType)
             .rejectionReason(reason)
             .operationReference(command.getOperationReference());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
@@ -30,7 +30,7 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>("commandValue", new UnifiedRecordValue(10));
   private final ObjectProperty<AuthInfo> authInfoProperty =
-      new ObjectProperty<>("authInfo", new AuthInfo());
+      new ObjectProperty<>("authInfo", AuthInfo.empty());
 
   public PersistedCommandDistribution() {
     super(5);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
@@ -30,7 +30,7 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>("commandValue", new UnifiedRecordValue(10));
   private final ObjectProperty<AuthInfo> authInfoProperty =
-      new ObjectProperty<>("authInfo", AuthInfo.empty());
+      new ObjectProperty<>("authInfo", AuthInfo.mutable());
 
   public PersistedCommandDistribution() {
     super(5);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
 import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo.AuthDataFormat;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
@@ -83,11 +82,7 @@ class CommandDistributionBehaviorTest {
 
     valueType = ValueType.DEPLOYMENT;
     intent = DeploymentIntent.CREATE;
-    authInfo =
-        new AuthInfo()
-            .setFormat(AuthDataFormat.JWT)
-            .setAuthData("some-jwt-token")
-            .setClaims(Map.of("a", "b", "c", 3));
+    authInfo = AuthInfo.withJwt("some-jwt-token", Map.of("a", "b", "c", 3));
 
     command =
         new MockTypedRecord<>(
@@ -208,11 +203,7 @@ class CommandDistributionBehaviorTest {
             mockDistributionMetrics);
 
     // given command with auth info
-    final var authInfo =
-        new AuthInfo()
-            .setFormat(AuthDataFormat.JWT)
-            .setAuthData("some-jwt-token")
-            .setClaims(Map.of("a", "b", "c", 3));
+    final var authInfo = AuthInfo.withJwt("some-jwt-token", Map.of("a", "b", "c", 3));
 
     final var key = keyGenerator.nextKey();
     final var command =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributionSchedulerTest.java
@@ -118,7 +118,7 @@ public class CommandRedistributionSchedulerTest {
     // then
     verify(mockCommandSender, times(1))
         .sendCommand(
-            1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+            1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
   }
 
   private CommandRedistributionScheduler getCommandRedistributor(
@@ -174,13 +174,13 @@ public class CommandRedistributionSchedulerTest {
       // then
       verify(mockCommandSender, times(1))
           .sendCommand(
-              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
       verify(mockCommandSender, times(1))
           .sendCommand(
-              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
       verify(mockCommandSender, never())
           .sendCommand(
-              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
     }
 
     @Test
@@ -194,13 +194,13 @@ public class CommandRedistributionSchedulerTest {
       // then
       verify(mockCommandSender, times(1))
           .sendCommand(
-              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
       verify(mockCommandSender, times(1))
           .sendCommand(
-              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
       verify(mockCommandSender, never())
           .sendCommand(
-              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
 
       // then
       // Partition 3 is now scaled up, so it should be redistributed to
@@ -211,7 +211,7 @@ public class CommandRedistributionSchedulerTest {
       commandRedistributor.runRetryCycle();
       verify(mockCommandSender, times(1))
           .sendCommand(
-              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
     }
   }
 
@@ -271,10 +271,10 @@ public class CommandRedistributionSchedulerTest {
 
       verify(mockCommandSender, times(4))
           .sendCommand(
-              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
       verify(mockCommandSender, times(4))
           .sendCommand(
-              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
+              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, AuthInfo.empty());
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
@@ -22,32 +22,25 @@ public class AuthorizationUtil {
    * @return an encoded authorization string that can be set on the record metadata
    */
   public static AuthInfo getAuthInfo(final String... authorizedTenantIds) {
-    final var auth = new AuthInfo();
-    auth.setClaims(Map.of(Authorization.AUTHORIZED_TENANTS, List.of(authorizedTenantIds)));
-    return auth;
+    return AuthInfo.withClaims(
+        Map.of(Authorization.AUTHORIZED_TENANTS, List.of(authorizedTenantIds)));
   }
 
   public static AuthInfo getUsernameAuthInfo(
       final String username, final String... authorizedTenantIds) {
-    final var auth = new AuthInfo();
-    auth.setClaims(
+    return AuthInfo.withClaims(
         Map.of(
             Authorization.AUTHORIZED_USERNAME,
             username,
             Authorization.AUTHORIZED_TENANTS,
             List.of(authorizedTenantIds)));
-    return auth;
   }
 
   public static AuthInfo getAuthInfo(final String username) {
-    final var auth = new AuthInfo();
-    auth.setClaims(Map.of(Authorization.AUTHORIZED_USERNAME, username));
-    return auth;
+    return AuthInfo.withClaims(Map.of(Authorization.AUTHORIZED_USERNAME, username));
   }
 
   public static AuthInfo getAuthInfoWithClaim(final String claim, final Object claimValue) {
-    final var auth = new AuthInfo();
-    auth.setClaims(Map.of(claim, claimValue));
-    return auth;
+    return AuthInfo.withClaims(Map.of(claim, claimValue));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -123,7 +123,8 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
 
   @Override
   public Map<String, Object> getAuthorizations() {
-    return metadata.getAuthorization().getClaims();
+    final var auth = metadata.getAuthorization();
+    return auth != null ? auth.getClaims() : Map.of();
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -124,7 +124,7 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   @Override
   public Map<String, Object> getAuthorizations() {
     final var auth = metadata.getAuthorization();
-    return auth != null ? auth.getClaims() : Map.of();
+    return auth != null ? auth.toDecodedMap() : Map.of();
   }
 
   @Override

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -267,7 +267,7 @@ final class BulkIndexRequestTest {
                       .withValue(
                           new CommandDistributionRecord()
                               .setPartitionId(1)
-                              .setAuthInfo(new AuthInfo().setAuthData("test-data"))));
+                              .setAuthInfo(AuthInfo.withJwt("test-data"))));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 
@@ -294,7 +294,7 @@ final class BulkIndexRequestTest {
                       .withValue(
                           new CommandDistributionRecord()
                               .setPartitionId(1)
-                              .setAuthInfo(new AuthInfo().setAuthData("test-data"))));
+                              .setAuthInfo(AuthInfo.withJwt("test-data"))));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -284,7 +284,7 @@ final class BulkIndexRequestTest {
                       .withValue(
                           new CommandDistributionRecord()
                               .setPartitionId(1)
-                              .setAuthInfo(new AuthInfo().setAuthData("test-data"))));
+                              .setAuthInfo(AuthInfo.withJwt("test-data"))));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 
@@ -310,7 +310,7 @@ final class BulkIndexRequestTest {
                       .withValue(
                           new CommandDistributionRecord()
                               .setPartitionId(1)
-                              .setAuthInfo(new AuthInfo().setAuthData("test-data"))));
+                              .setAuthInfo(AuthInfo.withJwt("test-data"))));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -19,7 +19,11 @@ import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-/** */
+/**
+ * AuthInfo is treated as immutable after construction. Use the static factory methods to create
+ * instances. The only mutation allowed is through {@link #wrap} and {@link #reset}, which are part
+ * of the {@link UnpackedObject} serialization contract.
+ */
 public class AuthInfo extends UnpackedObject {
 
   private final EnumProperty<AuthDataFormat> formatProp =
@@ -33,36 +37,71 @@ public class AuthInfo extends UnpackedObject {
     declareProperty(formatProp).declareProperty(authDataProp).declareProperty(claimsProp);
   }
 
-  public AuthDataFormat getFormat() {
-    return formatProp.getValue();
+  // --- Static factory methods ---
+
+  public static AuthInfo withClaims(final Map<String, Object> claims) {
+    final var auth = new AuthInfo();
+    auth.formatProp.setValue(AuthDataFormat.UNKNOWN);
+    auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
+    return auth;
   }
 
-  public AuthInfo setFormat(final AuthDataFormat format) {
-    formatProp.setValue(format);
-    return this;
+  public static AuthInfo withClaims(final DirectBuffer claimsBuffer) {
+    final var auth = new AuthInfo();
+    auth.claimsProp.setValue(claimsBuffer);
+    return auth;
+  }
+
+  public static AuthInfo withJwt(final String token) {
+    final var auth = new AuthInfo();
+    auth.formatProp.setValue(AuthDataFormat.JWT);
+    auth.authDataProp.setValue(token);
+    return auth;
+  }
+
+  public static AuthInfo withJwt(final String token, final Map<String, Object> claims) {
+    final var auth = new AuthInfo();
+    auth.formatProp.setValue(AuthDataFormat.JWT);
+    auth.authDataProp.setValue(token);
+    auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
+    return auth;
+  }
+
+  public static AuthInfo preAuthorized() {
+    final var auth = new AuthInfo();
+    auth.formatProp.setValue(AuthDataFormat.PRE_AUTHORIZED);
+    return auth;
+  }
+
+  public static AuthInfo preAuthorized(final Map<String, Object> claims) {
+    final var auth = new AuthInfo();
+    auth.formatProp.setValue(AuthDataFormat.PRE_AUTHORIZED);
+    auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
+    return auth;
+  }
+
+  public static AuthInfo of(final AuthInfo info) {
+    if (info == null) {
+      return null;
+    }
+
+    final var auth = new AuthInfo();
+    auth.copyFrom(info);
+    return auth;
+  }
+
+  // --- Getters ---
+
+  public AuthDataFormat getFormat() {
+    return formatProp.getValue();
   }
 
   public String getAuthData() {
     return BufferUtil.bufferAsString(authDataProp.getValue());
   }
 
-  public AuthInfo setAuthData(final String authData) {
-    authDataProp.setValue(authData);
-    return this;
-  }
-
   public Map<String, Object> getClaims() {
     return MsgPackConverter.convertToMap(claimsProp.getValue());
-  }
-
-  public AuthInfo setClaims(final DirectBuffer authInfo) {
-    claimsProp.setValue(authInfo);
-    return this;
-  }
-
-  public AuthInfo setClaims(final Map<String, Object> authInfo) {
-    claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(authInfo)));
-    return this;
   }
 
   @Override
@@ -104,16 +143,6 @@ public class AuthInfo extends UnpackedObject {
       return new JwtDecoder(token).decode().getClaims();
     }
     return getClaims();
-  }
-
-  public static AuthInfo of(final AuthInfo info) {
-    if (info == null) {
-      return null;
-    }
-
-    final var auth = new AuthInfo();
-    auth.copyFrom(info);
-    return auth;
   }
 
   public boolean hasAnyClaims() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -34,9 +34,18 @@ public class AuthInfo extends UnpackedObject {
   private final DocumentProperty claimsProp = new DocumentProperty("claims").sanitized();
   private transient volatile Map<String, Object> cachedDecodedMap;
 
-  public AuthInfo() {
+  protected AuthInfo() {
     super(3);
     declareProperty(formatProp).declareProperty(authDataProp).declareProperty(claimsProp);
+  }
+
+  /**
+   * Creates a new mutable, empty AuthInfo. Intended for the msgpack {@link
+   * io.camunda.zeebe.msgpack.property.ObjectProperty} framework (which requires a mutable template
+   * instance for deserialization) and for tests that need a default-valued instance.
+   */
+  public static AuthInfo empty() {
+    return new AuthInfo();
   }
 
   // --- Static factory methods ---
@@ -83,16 +92,6 @@ public class AuthInfo extends UnpackedObject {
     auth.formatProp.setValue(AuthDataFormat.PRE_AUTHORIZED);
     auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
     auth.cachedDecodedMap = Collections.unmodifiableMap(claims);
-    return auth;
-  }
-
-  public static AuthInfo of(final AuthInfo info) {
-    if (info == null) {
-      return null;
-    }
-
-    final var auth = new AuthInfo();
-    auth.copyFrom(info);
     return auth;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -32,7 +32,7 @@ public class AuthInfo extends UnpackedObject {
 
   private final StringProperty authDataProp = new StringProperty("authData", "").sanitized();
   private final DocumentProperty claimsProp = new DocumentProperty("claims").sanitized();
-  private transient volatile Map<String, Object> cachedClaims;
+  private transient volatile Map<String, Object> cachedDecodedMap;
 
   public AuthInfo() {
     super(3);
@@ -103,15 +103,11 @@ public class AuthInfo extends UnpackedObject {
   }
 
   /**
-   * Returns an unmodifiable view of the claims map, lazily deserialized from msgpack on first
-   * access. The returned map and its contents must not be mutated.
+   * Returns the raw claims from the msgpack document property. Prefer {@link #toDecodedMap()} which
+   * handles both JWT and non-JWT formats and caches the result.
    */
   public Map<String, Object> getClaims() {
-    if (cachedClaims == null) {
-      cachedClaims =
-          Collections.unmodifiableMap(MsgPackConverter.convertToMap(claimsProp.getValue()));
-    }
-    return cachedClaims;
+    return Collections.unmodifiableMap(MsgPackConverter.convertToMap(claimsProp.getValue()));
   }
 
   @Override
@@ -119,7 +115,7 @@ public class AuthInfo extends UnpackedObject {
     formatProp.setValue(AuthDataFormat.UNKNOWN);
     authDataProp.setValue("");
     claimsProp.reset();
-    cachedClaims = null;
+    cachedDecodedMap = null;
   }
 
   @Override
@@ -143,7 +139,7 @@ public class AuthInfo extends UnpackedObject {
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     super.wrap(buffer, offset, length);
-    cachedClaims = null;
+    cachedDecodedMap = null;
   }
 
   public DirectBuffer toDirectBuffer() {
@@ -154,12 +150,21 @@ public class AuthInfo extends UnpackedObject {
     return buffer;
   }
 
+  /**
+   * Returns the decoded claims map, lazily computed and cached on first access. For JWT format,
+   * decodes the token. For other formats, deserializes from msgpack. The returned map is
+   * unmodifiable.
+   */
   public Map<String, Object> toDecodedMap() {
-    if (getFormat() == AuthDataFormat.JWT) {
-      final String token = getAuthData();
-      return new JwtDecoder(token).decode().getClaims();
+    if (cachedDecodedMap == null) {
+      if (getFormat() == AuthDataFormat.JWT) {
+        final String token = getAuthData();
+        cachedDecodedMap = Collections.unmodifiableMap(new JwtDecoder(token).decode().getClaims());
+      } else {
+        cachedDecodedMap = getClaims();
+      }
     }
-    return getClaims();
+    return cachedDecodedMap;
   }
 
   public boolean hasAnyClaims() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -32,7 +32,7 @@ public class AuthInfo extends UnpackedObject {
 
   private final StringProperty authDataProp = new StringProperty("authData", "").sanitized();
   private final DocumentProperty claimsProp = new DocumentProperty("claims").sanitized();
-  private transient Map<String, Object> cachedClaims;
+  private transient volatile Map<String, Object> cachedClaims;
 
   public AuthInfo() {
     super(3);
@@ -84,7 +84,7 @@ public class AuthInfo extends UnpackedObject {
 
   public static AuthInfo of(final AuthInfo info) {
     if (info == null) {
-      return null;
+      return new AuthInfo();
     }
 
     final var auth = new AuthInfo();
@@ -138,6 +138,12 @@ public class AuthInfo extends UnpackedObject {
   @JsonIgnore
   public int getLength() {
     return super.getLength();
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    super.wrap(buffer, offset, length);
+    cachedClaims = null;
   }
 
   public DirectBuffer toDirectBuffer() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -95,6 +95,31 @@ public class AuthInfo extends UnpackedObject {
     return auth;
   }
 
+  /**
+   * Creates a new AuthInfo by deserializing from the given buffer. Returns null if the buffer
+   * represents an empty AuthInfo (identical to {@link EmptyAuthInfo}), avoiding allocation.
+   */
+  public static AuthInfo of(final DirectBuffer buffer) {
+    if (buffer.capacity() <= EmptyAuthInfo.getInstance().getLength()
+        && buffer.equals(EmptyAuthInfo.getInstance().toDirectBuffer())) {
+      return null;
+    }
+
+    final var auth = new AuthInfo();
+    auth.wrap(buffer);
+    return auth;
+  }
+
+  public static AuthInfo of(final AuthInfo info) {
+    if (info == null) {
+      return null;
+    }
+
+    final var auth = new AuthInfo();
+    auth.copyFrom(info);
+    return auth;
+  }
+
   // --- Getters ---
 
   public AuthDataFormat getFormat() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -84,7 +84,7 @@ public class AuthInfo extends UnpackedObject {
 
   public static AuthInfo of(final AuthInfo info) {
     if (info == null) {
-      return new AuthInfo();
+      return null;
     }
 
     final var auth = new AuthInfo();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collections;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -31,6 +32,7 @@ public class AuthInfo extends UnpackedObject {
 
   private final StringProperty authDataProp = new StringProperty("authData", "").sanitized();
   private final DocumentProperty claimsProp = new DocumentProperty("claims").sanitized();
+  private transient Map<String, Object> cachedClaims;
 
   public AuthInfo() {
     super(3);
@@ -100,8 +102,16 @@ public class AuthInfo extends UnpackedObject {
     return BufferUtil.bufferAsString(authDataProp.getValue());
   }
 
+  /**
+   * Returns an unmodifiable view of the claims map, lazily deserialized from msgpack on first
+   * access. The returned map and its contents must not be mutated.
+   */
   public Map<String, Object> getClaims() {
-    return MsgPackConverter.convertToMap(claimsProp.getValue());
+    if (cachedClaims == null) {
+      cachedClaims =
+          Collections.unmodifiableMap(MsgPackConverter.convertToMap(claimsProp.getValue()));
+    }
+    return cachedClaims;
   }
 
   @Override
@@ -109,6 +119,7 @@ public class AuthInfo extends UnpackedObject {
     formatProp.setValue(AuthDataFormat.UNKNOWN);
     authDataProp.setValue("");
     claimsProp.reset();
+    cachedClaims = null;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -122,17 +122,23 @@ public class AuthInfo extends UnpackedObject {
   }
 
   /**
-   * Creates a new AuthInfo by deserializing from the given buffer. Returns null if the buffer
-   * represents an empty AuthInfo (identical to {@link EmptyAuthInfo}), avoiding allocation.
+   * Creates a new AuthInfo by deserializing from the given buffer. Returns the empty singleton if
+   * the buffer matches it, avoiding allocation. The buffer contents are copied so the returned
+   * instance does not retain a reference to the caller's buffer (which may be reused, e.g. in the
+   * processing state machine).
    */
   public static AuthInfo of(final DirectBuffer buffer) {
-    if (buffer.capacity() <= EmptyAuthInfo.getInstance().getLength()
+    if (buffer.capacity() == EmptyAuthInfo.getInstance().getLength()
         && buffer.equals(EmptyAuthInfo.getInstance().toDirectBuffer())) {
-      return null;
+      return empty();
     }
 
+    // Copy the buffer so deserialized properties don't reference the caller's buffer.
+    final var copy = new byte[buffer.capacity()];
+    buffer.getBytes(0, copy);
+
     final var auth = new AuthInfo();
-    auth.wrap(buffer);
+    auth.wrap(new UnsafeBuffer(copy));
     return auth.freeze();
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -106,14 +106,6 @@ public class AuthInfo extends UnpackedObject {
     return BufferUtil.bufferAsString(authDataProp.getValue());
   }
 
-  /**
-   * Returns the raw claims from the msgpack document property. Prefer {@link #toDecodedMap()} which
-   * handles both JWT and non-JWT formats and caches the result.
-   */
-  public Map<String, Object> getClaims() {
-    return Collections.unmodifiableMap(MsgPackConverter.convertToMap(claimsProp.getValue()));
-  }
-
   @Override
   public void reset() {
     formatProp.setValue(AuthDataFormat.UNKNOWN);
@@ -135,15 +127,15 @@ public class AuthInfo extends UnpackedObject {
   }
 
   @Override
-  @JsonIgnore
-  public int getLength() {
-    return super.getLength();
-  }
-
-  @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     super.wrap(buffer, offset, length);
     cachedDecodedMap = null;
+  }
+
+  @Override
+  @JsonIgnore
+  public int getLength() {
+    return super.getLength();
   }
 
   public DirectBuffer toDirectBuffer() {
@@ -155,6 +147,13 @@ public class AuthInfo extends UnpackedObject {
   }
 
   /**
+   * Returns the stored claims from the msgpack document property. The returned map is unmodifiable.
+   */
+  public Map<String, Object> getClaims() {
+    return Collections.unmodifiableMap(MsgPackConverter.convertToMap(claimsProp.getValue()));
+  }
+
+  /**
    * Returns the decoded claims map, lazily computed and cached on first access. For JWT format,
    * decodes the token. For other formats, deserializes from msgpack. The returned map is
    * unmodifiable.
@@ -162,8 +161,8 @@ public class AuthInfo extends UnpackedObject {
   public Map<String, Object> toDecodedMap() {
     if (cachedDecodedMap == null) {
       if (getFormat() == AuthDataFormat.JWT) {
-        final String token = getAuthData();
-        cachedDecodedMap = Collections.unmodifiableMap(new JwtDecoder(token).decode().getClaims());
+        cachedDecodedMap =
+            Collections.unmodifiableMap(new JwtDecoder(getAuthData()).decode().getClaims());
       } else {
         cachedDecodedMap = getClaims();
       }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -22,8 +22,9 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * AuthInfo is treated as immutable after construction. Use the static factory methods to create
- * instances. The only mutation allowed is through {@link #wrap} and {@link #reset}, which are part
- * of the {@link UnpackedObject} serialization contract.
+ * instances. Call {@link #freeze()} to make an instance permanently immutable — after freezing,
+ * {@link #wrap} and {@link #reset} will throw {@link UnsupportedOperationException}. All factory
+ * methods except {@link #mutable()} return frozen instances.
  */
 public class AuthInfo extends UnpackedObject {
 
@@ -33,6 +34,7 @@ public class AuthInfo extends UnpackedObject {
   private final StringProperty authDataProp = new StringProperty("authData", "").sanitized();
   private final DocumentProperty claimsProp = new DocumentProperty("claims").sanitized();
   private transient volatile Map<String, Object> cachedDecodedMap;
+  private transient volatile boolean frozen;
 
   protected AuthInfo() {
     super(3);
@@ -40,12 +42,36 @@ public class AuthInfo extends UnpackedObject {
   }
 
   /**
-   * Creates a new mutable, empty AuthInfo. Intended for the msgpack {@link
-   * io.camunda.zeebe.msgpack.property.ObjectProperty} framework (which requires a mutable template
-   * instance for deserialization) and for tests that need a default-valued instance.
+   * Returns the shared immutable empty AuthInfo singleton. This is the default "no authorization"
+   * sentinel.
    */
   public static AuthInfo empty() {
+    return EmptyAuthInfo.getInstance();
+  }
+
+  /**
+   * Creates a new mutable, unfrozen AuthInfo. Intended for the msgpack {@link
+   * io.camunda.zeebe.msgpack.property.ObjectProperty} framework (which requires a mutable template
+   * instance for deserialization).
+   */
+  public static AuthInfo mutable() {
     return new AuthInfo();
+  }
+
+  /**
+   * Permanently freezes this instance. After freezing, {@link #wrap} and {@link #reset} will throw
+   * {@link UnsupportedOperationException}. This operation is idempotent and cannot be undone.
+   *
+   * @return this instance, for chaining
+   */
+  public AuthInfo freeze() {
+    frozen = true;
+    return this;
+  }
+
+  @JsonIgnore
+  public boolean isFrozen() {
+    return frozen;
   }
 
   // --- Static factory methods ---
@@ -55,20 +81,20 @@ public class AuthInfo extends UnpackedObject {
     auth.formatProp.setValue(AuthDataFormat.UNKNOWN);
     auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
     auth.cachedDecodedMap = Collections.unmodifiableMap(claims);
-    return auth;
+    return auth.freeze();
   }
 
   public static AuthInfo withClaims(final DirectBuffer claimsBuffer) {
     final var auth = new AuthInfo();
     auth.claimsProp.setValue(claimsBuffer);
-    return auth;
+    return auth.freeze();
   }
 
   public static AuthInfo withJwt(final String token) {
     final var auth = new AuthInfo();
     auth.formatProp.setValue(AuthDataFormat.JWT);
     auth.authDataProp.setValue(token);
-    return auth;
+    return auth.freeze();
   }
 
   public static AuthInfo withJwt(final String token, final Map<String, Object> claims) {
@@ -77,14 +103,14 @@ public class AuthInfo extends UnpackedObject {
     auth.authDataProp.setValue(token);
     auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
     auth.cachedDecodedMap = Collections.unmodifiableMap(claims);
-    return auth;
+    return auth.freeze();
   }
 
   public static AuthInfo preAuthorized() {
     final var auth = new AuthInfo();
     auth.formatProp.setValue(AuthDataFormat.PRE_AUTHORIZED);
     auth.cachedDecodedMap = Map.of();
-    return auth;
+    return auth.freeze();
   }
 
   public static AuthInfo preAuthorized(final Map<String, Object> claims) {
@@ -92,7 +118,7 @@ public class AuthInfo extends UnpackedObject {
     auth.formatProp.setValue(AuthDataFormat.PRE_AUTHORIZED);
     auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
     auth.cachedDecodedMap = Collections.unmodifiableMap(claims);
-    return auth;
+    return auth.freeze();
   }
 
   /**
@@ -107,7 +133,7 @@ public class AuthInfo extends UnpackedObject {
 
     final var auth = new AuthInfo();
     auth.wrap(buffer);
-    return auth;
+    return auth.freeze();
   }
 
   public static AuthInfo of(final AuthInfo info) {
@@ -117,7 +143,7 @@ public class AuthInfo extends UnpackedObject {
 
     final var auth = new AuthInfo();
     auth.copyFrom(info);
-    return auth;
+    return auth.freeze();
   }
 
   // --- Getters ---
@@ -132,6 +158,9 @@ public class AuthInfo extends UnpackedObject {
 
   @Override
   public void reset() {
+    if (frozen) {
+      throw new UnsupportedOperationException("Cannot reset a frozen AuthInfo");
+    }
     formatProp.setValue(AuthDataFormat.UNKNOWN);
     authDataProp.setValue("");
     claimsProp.reset();
@@ -152,6 +181,9 @@ public class AuthInfo extends UnpackedObject {
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    if (frozen) {
+      throw new UnsupportedOperationException("Cannot wrap a frozen AuthInfo");
+    }
     super.wrap(buffer, offset, length);
     cachedDecodedMap = null;
   }
@@ -178,20 +210,27 @@ public class AuthInfo extends UnpackedObject {
   }
 
   /**
-   * Returns the decoded claims map, lazily computed and cached on first access. For JWT format,
-   * decodes the token. For other formats, deserializes from msgpack. The returned map is
-   * unmodifiable.
+   * Returns the decoded claims map. For frozen instances the result is lazily computed and cached.
+   * For mutable instances the result is always recomputed (since the underlying data may change).
+   * For JWT format, decodes the token. For other formats, deserializes from msgpack. The returned
+   * map is unmodifiable.
    */
   public Map<String, Object> toDecodedMap() {
-    if (cachedDecodedMap == null) {
-      if (getFormat() == AuthDataFormat.JWT) {
-        cachedDecodedMap =
-            Collections.unmodifiableMap(new JwtDecoder(getAuthData()).decode().getClaims());
-      } else {
-        cachedDecodedMap = getClaims();
-      }
+    if (cachedDecodedMap != null) {
+      return cachedDecodedMap;
     }
-    return cachedDecodedMap;
+
+    final Map<String, Object> result;
+    if (getFormat() == AuthDataFormat.JWT) {
+      result = Collections.unmodifiableMap(new JwtDecoder(getAuthData()).decode().getClaims());
+    } else {
+      result = getClaims();
+    }
+
+    if (frozen) {
+      cachedDecodedMap = result;
+    }
+    return result;
   }
 
   public boolean hasAnyClaims() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -45,6 +45,7 @@ public class AuthInfo extends UnpackedObject {
     final var auth = new AuthInfo();
     auth.formatProp.setValue(AuthDataFormat.UNKNOWN);
     auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
+    auth.cachedDecodedMap = Collections.unmodifiableMap(claims);
     return auth;
   }
 
@@ -66,12 +67,14 @@ public class AuthInfo extends UnpackedObject {
     auth.formatProp.setValue(AuthDataFormat.JWT);
     auth.authDataProp.setValue(token);
     auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
+    auth.cachedDecodedMap = Collections.unmodifiableMap(claims);
     return auth;
   }
 
   public static AuthInfo preAuthorized() {
     final var auth = new AuthInfo();
     auth.formatProp.setValue(AuthDataFormat.PRE_AUTHORIZED);
+    auth.cachedDecodedMap = Map.of();
     return auth;
   }
 
@@ -79,6 +82,7 @@ public class AuthInfo extends UnpackedObject {
     final var auth = new AuthInfo();
     auth.formatProp.setValue(AuthDataFormat.PRE_AUTHORIZED);
     auth.claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(claims)));
+    auth.cachedDecodedMap = Collections.unmodifiableMap(claims);
     return auth;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
@@ -22,19 +22,18 @@ public final class EmptyAuthInfo extends AuthInfo {
 
   private static final Map<String, Object> EMPTY_MAP = Map.of();
   private final DirectBuffer cachedBuffer;
+  private final int length;
 
   private EmptyAuthInfo() {
     super();
+    // length must be set before cachedBuffer, because toDirectBuffer() calls getLength()
+    // via virtual dispatch, and our override returns this field
+    length = super.getLength();
     cachedBuffer = super.toDirectBuffer();
   }
 
   public static AuthInfo getInstance() {
     return INSTANCE;
-  }
-
-  @Override
-  public Map<String, Object> getClaims() {
-    return EMPTY_MAP;
   }
 
   @Override
@@ -48,8 +47,18 @@ public final class EmptyAuthInfo extends AuthInfo {
   }
 
   @Override
+  public int getLength() {
+    return length;
+  }
+
+  @Override
   public DirectBuffer toDirectBuffer() {
     return cachedBuffer;
+  }
+
+  @Override
+  public Map<String, Object> getClaims() {
+    return EMPTY_MAP;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
@@ -18,17 +18,23 @@ import org.agrona.DirectBuffer;
  */
 public final class EmptyAuthInfo extends AuthInfo {
 
+  private static final EmptyAuthInfo INSTANCE = new EmptyAuthInfo();
+
   private static final Map<String, Object> EMPTY_MAP = Map.of();
   private final DirectBuffer cachedBuffer;
 
-  public EmptyAuthInfo() {
+  private EmptyAuthInfo() {
     super();
     cachedBuffer = super.toDirectBuffer();
   }
 
+  public static AuthInfo getInstance() {
+    return INSTANCE;
+  }
+
   @Override
-  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
-    throw new UnsupportedOperationException("EmptyAuthInfo is immutable");
+  public Map<String, Object> getClaims() {
+    return EMPTY_MAP;
   }
 
   @Override
@@ -37,8 +43,13 @@ public final class EmptyAuthInfo extends AuthInfo {
   }
 
   @Override
-  public Map<String, Object> getClaims() {
-    return EMPTY_MAP;
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    throw new UnsupportedOperationException("EmptyAuthInfo is immutable");
+  }
+
+  @Override
+  public DirectBuffer toDirectBuffer() {
+    return cachedBuffer;
   }
 
   @Override
@@ -49,10 +60,5 @@ public final class EmptyAuthInfo extends AuthInfo {
   @Override
   public boolean hasAnyClaims() {
     return false;
-  }
-
-  @Override
-  public DirectBuffer toDirectBuffer() {
-    return cachedBuffer;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+/**
+ * An immutable, singleton-safe empty {@link AuthInfo}. This subclass guards against accidental
+ * mutation of a shared static instance by throwing {@link UnsupportedOperationException} on {@link
+ * #wrap} and {@link #reset}. All derived values (claims, decoded map, serialized buffer) are cached
+ * eagerly since they never change.
+ */
+public final class EmptyAuthInfo extends AuthInfo {
+
+  private static final Map<String, Object> EMPTY_MAP = Map.of();
+  private final DirectBuffer cachedBuffer;
+
+  public EmptyAuthInfo() {
+    super();
+    cachedBuffer = super.toDirectBuffer();
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    throw new UnsupportedOperationException("EmptyAuthInfo is immutable");
+  }
+
+  @Override
+  public void reset() {
+    throw new UnsupportedOperationException("EmptyAuthInfo is immutable");
+  }
+
+  @Override
+  public Map<String, Object> getClaims() {
+    return EMPTY_MAP;
+  }
+
+  @Override
+  public Map<String, Object> toDecodedMap() {
+    return EMPTY_MAP;
+  }
+
+  @Override
+  public boolean hasAnyClaims() {
+    return false;
+  }
+
+  @Override
+  public DirectBuffer toDirectBuffer() {
+    return cachedBuffer;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
@@ -13,10 +13,9 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 /**
- * An immutable, singleton-safe empty {@link AuthInfo}. This subclass guards against accidental
- * mutation of a shared static instance by throwing {@link UnsupportedOperationException} on {@link
- * #wrap} and {@link #reset}. All derived values (claims, decoded map, serialized buffer) are cached
- * eagerly since they never change.
+ * An immutable, singleton-safe empty {@link AuthInfo}. This subclass is frozen at construction and
+ * caches all derived values (claims, decoded map, serialized buffer) eagerly since they never
+ * change.
  */
 public final class EmptyAuthInfo extends AuthInfo {
 
@@ -35,20 +34,11 @@ public final class EmptyAuthInfo extends AuthInfo {
     final var buf = new UnsafeBuffer(bytes);
     super.write(buf, 0);
     cachedBuffer = buf;
+    freeze();
   }
 
   public static AuthInfo getInstance() {
     return INSTANCE;
-  }
-
-  @Override
-  public void reset() {
-    throw new UnsupportedOperationException("EmptyAuthInfo is immutable");
-  }
-
-  @Override
-  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
-    throw new UnsupportedOperationException("EmptyAuthInfo is immutable");
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
@@ -46,25 +46,9 @@ public final class EmptyAuthInfo extends AuthInfo {
     return length;
   }
 
-  /**
-   * Thread-safe override: copies from the pre-computed cached buffer instead of using the inherited
-   * mutable {@link io.camunda.zeebe.msgpack.MsgPackWriter} instance field, which is not safe for a
-   * shared singleton.
-   */
-  @Override
-  public int write(final MutableDirectBuffer buffer, final int offset) {
-    buffer.putBytes(offset, cachedBuffer, 0, length);
-    return length;
-  }
-
   @Override
   public DirectBuffer toDirectBuffer() {
     return cachedBuffer;
-  }
-
-  @Override
-  public Map<String, Object> getClaims() {
-    return EMPTY_MAP;
   }
 
   @Override
@@ -75,5 +59,11 @@ public final class EmptyAuthInfo extends AuthInfo {
   @Override
   public boolean hasAnyClaims() {
     return false;
+  }
+
+  @Override
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    buffer.putBytes(offset, cachedBuffer, 0, length);
+    return length;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.protocol.impl.encoding;
 
 import java.util.Map;
 import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * An immutable, singleton-safe empty {@link AuthInfo}. This subclass guards against accidental
@@ -26,10 +28,13 @@ public final class EmptyAuthInfo extends AuthInfo {
 
   private EmptyAuthInfo() {
     super();
-    // length must be set before cachedBuffer, because toDirectBuffer() calls getLength()
-    // via virtual dispatch, and our override returns this field
     length = super.getLength();
-    cachedBuffer = super.toDirectBuffer();
+    // Cannot use super.toDirectBuffer() because it calls write(buffer, 0) which dispatches
+    // to our override, but cachedBuffer is still null. Use super.write() directly instead.
+    final var bytes = new byte[length];
+    final var buf = new UnsafeBuffer(bytes);
+    super.write(buf, 0);
+    cachedBuffer = buf;
   }
 
   public static AuthInfo getInstance() {
@@ -48,6 +53,17 @@ public final class EmptyAuthInfo extends AuthInfo {
 
   @Override
   public int getLength() {
+    return length;
+  }
+
+  /**
+   * Thread-safe override: copies from the pre-computed cached buffer instead of using the inherited
+   * mutable {@link io.camunda.zeebe.msgpack.MsgPackWriter} instance field, which is not safe for a
+   * shared singleton.
+   */
+  @Override
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    buffer.putBytes(offset, cachedBuffer, 0, length);
     return length;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -37,7 +37,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   private long operationReference;
   private ValueType valueType;
   private Intent intent;
-  private AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization;
 
   public ExecuteCommandRequest() {
     reset();
@@ -50,7 +50,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     valueType = ValueType.NULL_VAL;
     intent = Intent.UNKNOWN;
     value.wrap(0, 0);
-    authorization = new AuthInfo();
+    authorization = null;
 
     return this;
   }
@@ -140,7 +140,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   public ExecuteCommandRequest setAuthorization(final DirectBuffer buffer) {
     final var auth = new AuthInfo();
     auth.wrap(buffer);
-    this.authorization = auth;
+    authorization = auth;
     return this;
   }
 
@@ -173,7 +173,11 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     final int authorizationLength = bodyDecoder.authorizationLength();
     offset += ExecuteCommandRequestDecoder.authorizationHeaderLength();
 
-    authorization.wrap(buffer, offset, authorizationLength);
+    if (authorizationLength > 0) {
+      final var auth = new AuthInfo();
+      auth.wrap(buffer, offset, authorizationLength);
+      authorization = auth;
+    }
     offset += authorizationLength;
 
     bodyDecoder.limit(offset);
@@ -193,7 +197,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         + ExecuteCommandRequestEncoder.valueHeaderLength()
         + value.capacity()
         + ExecuteCommandRequestEncoder.authorizationHeaderLength()
-        + authorization.getLength();
+        + (authorization != null ? authorization.getLength() : 0);
   }
 
   @Override
@@ -206,7 +210,10 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         .valueType(valueType)
         .intent(intent.value())
         .putValue(value, 0, value.capacity())
-        .putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
+        .putAuthorization(
+            authorization != null ? authorization.toDirectBuffer() : new UnsafeBuffer(0, 0),
+            0,
+            authorization != null ? authorization.getLength() : 0);
 
     return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -138,9 +138,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   }
 
   public ExecuteCommandRequest setAuthorization(final DirectBuffer buffer) {
-    final var auth = new AuthInfo();
-    auth.wrap(buffer);
-    authorization = auth;
+    authorization = AuthInfo.of(buffer);
     return this;
   }
 
@@ -174,9 +172,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     offset += ExecuteCommandRequestDecoder.authorizationHeaderLength();
 
     if (authorizationLength > 0) {
-      final var auth = new AuthInfo();
-      auth.wrap(buffer, offset, authorizationLength);
-      authorization = auth;
+      authorization = AuthInfo.of(new UnsafeBuffer(buffer, offset, authorizationLength));
     }
     offset += authorizationLength;
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -37,7 +37,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   private long operationReference;
   private ValueType valueType;
   private Intent intent;
-  private final AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization = new AuthInfo();
 
   public ExecuteCommandRequest() {
     reset();
@@ -50,7 +50,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     valueType = ValueType.NULL_VAL;
     intent = Intent.UNKNOWN;
     value.wrap(0, 0);
-    authorization.reset();
+    authorization = new AuthInfo();
 
     return this;
   }
@@ -133,12 +133,14 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   }
 
   public ExecuteCommandRequest setAuthorization(final AuthInfo authorization) {
-    this.authorization.copyFrom(authorization);
+    this.authorization = authorization;
     return this;
   }
 
   public ExecuteCommandRequest setAuthorization(final DirectBuffer buffer) {
-    authorization.wrap(buffer);
+    final var auth = new AuthInfo();
+    auth.wrap(buffer);
+    this.authorization = auth;
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -57,7 +57,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private long requestId;
   private short intentValue = Intent.NULL_VAL;
   private int requestStreamId;
-  private AuthInfo authorization;
+  private AuthInfo authorization = EMPTY_AUTH;
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private AgentInfo agent;
@@ -139,7 +139,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.rejectionReasonHeaderLength()
         + rejectionReason.capacity()
         + RecordMetadataEncoder.authorizationHeaderLength()
-        + authorizationOrEmpty().getLength()
+        + authorization.getLength()
         + RecordMetadataEncoder.agentHeaderLength()
         + (agent != null ? agent.getLength() : 0);
   }
@@ -171,7 +171,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
 
     BufferUtil.writeLengthPrefixed(
-        authorizationOrEmpty(),
+        authorization,
         encoder,
         RecordMetadataEncoder.authorizationHeaderLength(),
         RecordMetadataEncoder.BYTE_ORDER);
@@ -268,42 +268,35 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata authorization(final AuthInfo authorization) {
-    this.authorization = authorization;
+    this.authorization = authorization != null ? authorization : EMPTY_AUTH;
     return this;
   }
 
   public RecordMetadata authorization(final DirectBuffer buffer) {
-    authorization = AuthInfo.of(buffer);
+    final var parsed = AuthInfo.of(buffer);
+    this.authorization = parsed != null ? parsed : EMPTY_AUTH;
     return this;
   }
 
   public AuthInfo getAuthorization() {
-    return authorizationOrEmpty();
+    return authorization;
   }
 
   /**
-   * Returns the authorization if set, or the shared empty sentinel. This is used for serialization
-   * so that the wire format is preserved regardless of whether authorization is null internally.
-   */
-  private AuthInfo authorizationOrEmpty() {
-    return authorization != null ? authorization : EMPTY_AUTH;
-  }
-
-  /**
-   * Decodes the authorization field from the SBE decoder. Returns null (avoiding allocation) when
-   * the serialized bytes are identical to the empty sentinel, since {@link #authorizationOrEmpty()}
-   * will substitute the shared instance on read.
+   * Decodes the authorization field from the SBE decoder. Returns the shared empty sentinel when
+   * the serialized bytes are absent or identical to it (avoiding allocation).
    */
   private static AuthInfo decodeAuthorization(final RecordMetadataDecoder decoder) {
     final int length = decoder.authorizationLength();
     if (length <= 0) {
       decoder.skipAuthorization();
-      return null;
+      return EMPTY_AUTH;
     }
 
     final var buffer = new UnsafeBuffer();
     decoder.wrapAuthorization(buffer);
-    return AuthInfo.of(buffer);
+    final var parsed = AuthInfo.of(buffer);
+    return parsed != null ? parsed : EMPTY_AUTH;
   }
 
   public AgentInfo getAgent() {
@@ -361,7 +354,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
-    authorization = null;
+    authorization = EMPTY_AUTH;
     agent = null;
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
@@ -380,7 +373,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         requestStreamId,
         rejectionType,
         rejectionReason,
-        authorizationOrEmpty(),
+        authorization,
         protocolVersion,
         brokerVersion,
         recordVersion,
@@ -406,7 +399,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && recordType == that.recordType
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
-        && authorizationOrEmpty().equals(that.authorizationOrEmpty())
+        && authorization.equals(that.authorization)
         && Objects.equals(agent, that.agent)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
@@ -436,7 +429,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       builder.append(", rejectionReason=").append(BufferUtil.bufferAsString(rejectionReason));
     }
 
-    if (authorization != null && !authorization.isEmpty()) {
+    if (!authorization.isEmpty()) {
       builder.append(", authorization=").append(authorization);
     }
     if (operationReference != RecordMetadataEncoder.operationReferenceNullValue()) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -277,7 +277,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata authorization(final AuthInfo authorization) {
-    this.authorization = Objects.requireNonNull(authorization, "authorization can't be null");
+    this.authorization = authorization;
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -44,7 +44,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
    * authorization is serialized identically to an empty one. Mutation attempts (wrap/reset) throw
    * {@link UnsupportedOperationException}.
    */
-  private static final AuthInfo EMPTY_AUTH = new EmptyAuthInfo();
+  private static final AuthInfo EMPTY_AUTH = EmptyAuthInfo.getInstance();
 
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -113,9 +113,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     final int authorizationLength = decoder.authorizationLength();
     if (authorizationLength > 0) {
+      final var auth = new AuthInfo();
       final DirectBuffer authBuffer = new UnsafeBuffer();
       decoder.wrapAuthorization(authBuffer);
-      authorization.wrap(authBuffer);
+      auth.wrap(authBuffer);
+      authorization = auth;
     } else {
       decoder.skipAuthorization();
     }
@@ -137,7 +139,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.rejectionReasonHeaderLength()
         + rejectionReason.capacity()
         + RecordMetadataEncoder.authorizationHeaderLength()
-        + authorization.getLength()
+        + (authorization != null ? authorization.getLength() : 0)
         + RecordMetadataEncoder.agentHeaderLength()
         + (agent != null ? agent.getLength() : 0);
   }
@@ -167,11 +169,16 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
+
+    if (authorization != null) {
     BufferUtil.writeLengthPrefixed(
         authorization,
         encoder,
         RecordMetadataEncoder.authorizationHeaderLength(),
         RecordMetadataEncoder.BYTE_ORDER);
+    } else {
+      encoder.putAuthorization(new UnsafeBuffer(0, 0), 0, 0);
+    }
 
     if (agent != null) {
       BufferUtil.writeLengthPrefixed(
@@ -272,7 +279,6 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   public RecordMetadata authorization(final DirectBuffer buffer) {
     final var auth = new AuthInfo();
     auth.wrap(buffer);
-    // set the auth only if parsing succeeds
     authorization = auth;
     return this;
   }
@@ -336,7 +342,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
-    authorization = new AuthInfo();
+    authorization = null;
     agent = null;
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
@@ -381,7 +387,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && recordType == that.recordType
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
-        && authorization.equals(that.authorization)
+        && Objects.equals(authorization, that.authorization)
         && Objects.equals(agent, that.agent)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
@@ -411,7 +417,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       builder.append(", rejectionReason=").append(BufferUtil.bufferAsString(rejectionReason));
     }
 
-    if (!authorization.isEmpty()) {
+    if (authorization != null && !authorization.isEmpty()) {
       builder.append(", authorization=").append(authorization);
     }
     if (operationReference != RecordMetadataEncoder.operationReferenceNullValue()) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -120,16 +120,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       decoder.skipRejectionReason();
     }
 
-    final int authorizationLength = decoder.authorizationLength();
-    if (authorizationLength > 0) {
-      final var auth = new AuthInfo();
-      final DirectBuffer authBuffer = new UnsafeBuffer();
-      decoder.wrapAuthorization(authBuffer);
-      auth.wrap(authBuffer);
-      authorization = auth;
-    } else {
-      decoder.skipAuthorization();
-    }
+    authorization = decodeAuthorization(decoder);
 
     final int agentLength = decoder.agentLength();
     if (agentLength > 0) {
@@ -282,9 +273,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata authorization(final DirectBuffer buffer) {
-    final var auth = new AuthInfo();
-    auth.wrap(buffer);
-    authorization = auth;
+    authorization = AuthInfo.of(buffer);
     return this;
   }
 
@@ -298,6 +287,23 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
    */
   private AuthInfo authorizationOrEmpty() {
     return authorization != null ? authorization : EMPTY_AUTH;
+  }
+
+  /**
+   * Decodes the authorization field from the SBE decoder. Returns null (avoiding allocation) when
+   * the serialized bytes are identical to the empty sentinel, since {@link #authorizationOrEmpty()}
+   * will substitute the shared instance on read.
+   */
+  private static AuthInfo decodeAuthorization(final RecordMetadataDecoder decoder) {
+    final int length = decoder.authorizationLength();
+    if (length <= 0) {
+      decoder.skipAuthorization();
+      return null;
+    }
+
+    final var buffer = new UnsafeBuffer();
+    decoder.wrapAuthorization(buffer);
+    return AuthInfo.of(buffer);
   }
 
   public AgentInfo getAgent() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.EmptyAuthInfo;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
@@ -36,6 +37,14 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
   public static final VersionInfo CURRENT_BROKER_VERSION =
       VersionInfo.parse(VersionUtil.getVersion());
+
+  /**
+   * Shared immutable empty sentinel used for serialization when no authorization is set. This
+   * avoids allocating a new AuthInfo on every reset() while preserving a stable wire format: a null
+   * authorization is serialized identically to an empty one. Mutation attempts (wrap/reset) throw
+   * {@link UnsupportedOperationException}.
+   */
+  private static final AuthInfo EMPTY_AUTH = new EmptyAuthInfo();
 
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
@@ -139,7 +148,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.rejectionReasonHeaderLength()
         + rejectionReason.capacity()
         + RecordMetadataEncoder.authorizationHeaderLength()
-        + (authorization != null ? authorization.getLength() : 0)
+        + authorizationOrEmpty().getLength()
         + RecordMetadataEncoder.agentHeaderLength()
         + (agent != null ? agent.getLength() : 0);
   }
@@ -170,15 +179,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
 
-    if (authorization != null) {
     BufferUtil.writeLengthPrefixed(
-        authorization,
+        authorizationOrEmpty(),
         encoder,
         RecordMetadataEncoder.authorizationHeaderLength(),
         RecordMetadataEncoder.BYTE_ORDER);
-    } else {
-      encoder.putAuthorization(new UnsafeBuffer(0, 0), 0, 0);
-    }
 
     if (agent != null) {
       BufferUtil.writeLengthPrefixed(
@@ -284,7 +289,15 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public AuthInfo getAuthorization() {
-    return authorization;
+    return authorizationOrEmpty();
+  }
+
+  /**
+   * Returns the authorization if set, or the shared empty sentinel. This is used for serialization
+   * so that the wire format is preserved regardless of whether authorization is null internally.
+   */
+  private AuthInfo authorizationOrEmpty() {
+    return authorization != null ? authorization : EMPTY_AUTH;
   }
 
   public AgentInfo getAgent() {
@@ -361,7 +374,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         requestStreamId,
         rejectionType,
         rejectionReason,
-        authorization,
+        authorizationOrEmpty(),
         protocolVersion,
         brokerVersion,
         recordVersion,
@@ -387,7 +400,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && recordType == that.recordType
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
-        && Objects.equals(authorization, that.authorization)
+        && authorizationOrEmpty().equals(that.authorizationOrEmpty())
         && Objects.equals(agent, that.agent)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -48,7 +48,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private long requestId;
   private short intentValue = Intent.NULL_VAL;
   private int requestStreamId;
-  private final AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization;
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private AgentInfo agent;
@@ -265,12 +265,15 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata authorization(final AuthInfo authorization) {
-    this.authorization.copyFrom(authorization);
+    this.authorization = Objects.requireNonNull(authorization, "authorization can't be null");
     return this;
   }
 
   public RecordMetadata authorization(final DirectBuffer buffer) {
-    authorization.wrap(buffer);
+    final var auth = new AuthInfo();
+    auth.wrap(buffer);
+    // set the auth only if parsing succeeds
+    authorization = auth;
     return this;
   }
 
@@ -333,7 +336,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
-    authorization.reset();
+    authorization = new AuthInfo();
     agent = null;
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -98,7 +98,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
   private final ObjectProperty<AuthInfo> authInfoProperty =
-      new ObjectProperty<>(AUTH_INFO_KEY, new AuthInfo());
+      new ObjectProperty<>(AUTH_INFO_KEY, AuthInfo.empty());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -98,7 +98,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
   private final ObjectProperty<AuthInfo> authInfoProperty =
-      new ObjectProperty<>(AUTH_INFO_KEY, AuthInfo.empty());
+      new ObjectProperty<>(AUTH_INFO_KEY, AuthInfo.mutable());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -180,6 +180,43 @@ final class AuthInfoTest {
 
       assertThat(empty).isEqualTo(regular);
     }
+
+    @Test
+    void shouldWriteCorrectlyUnderConcurrentAccess() throws Exception {
+      // given — expected bytes from a single-threaded write
+      final var empty = EmptyAuthInfo.getInstance();
+      final var expected = new UnsafeBuffer(new byte[empty.getLength()]);
+      empty.write(expected, 0);
+
+      final int threads = 8;
+      final int iterations = 1_000;
+      final var errors = new java.util.concurrent.atomic.AtomicInteger(0);
+      final var latch = new java.util.concurrent.CountDownLatch(threads);
+
+      // when — write concurrently from multiple threads
+      for (int t = 0; t < threads; t++) {
+        new Thread(
+                () -> {
+                  try {
+                    for (int i = 0; i < iterations; i++) {
+                      final var buf = new UnsafeBuffer(new byte[empty.getLength()]);
+                      empty.write(buf, 0);
+                      if (!buf.equals(expected)) {
+                        errors.incrementAndGet();
+                      }
+                    }
+                  } finally {
+                    latch.countDown();
+                  }
+                })
+            .start();
+      }
+
+      latch.await();
+
+      // then — no corrupted writes
+      assertThat(errors.get()).isZero();
+    }
   }
 
   @Nested

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.protocol.impl;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.EmptyAuthInfo;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -132,6 +134,51 @@ final class AuthInfoTest {
 
       // when / then
       assertThat(authInfo.hasAnyClaims()).isTrue();
+    }
+  }
+
+  @Nested
+  class EmptyAuthInfoTests {
+    @Test
+    void shouldThrowOnWrap() {
+      final var empty = new EmptyAuthInfo();
+      final var buffer = new UnsafeBuffer(new byte[0]);
+
+      assertThatThrownBy(() -> empty.wrap(buffer, 0, 0))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldThrowOnReset() {
+      final var empty = new EmptyAuthInfo();
+
+      assertThatThrownBy(empty::reset).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldReturnEmptyClaims() {
+      final var empty = new EmptyAuthInfo();
+
+      assertThat(empty.getClaims()).isEmpty();
+      assertThat(empty.toDecodedMap()).isEmpty();
+      assertThat(empty.hasAnyClaims()).isFalse();
+    }
+
+    @Test
+    void shouldSerializeIdenticallyToNewAuthInfo() {
+      final var empty = new EmptyAuthInfo();
+      final var regular = new AuthInfo();
+
+      assertThat(empty.getLength()).isEqualTo(regular.getLength());
+      assertThat(empty.toDirectBuffer()).isEqualTo(regular.toDirectBuffer());
+    }
+
+    @Test
+    void shouldBeEqualToNewAuthInfo() {
+      final var empty = new EmptyAuthInfo();
+      final var regular = new AuthInfo();
+
+      assertThat(empty).isEqualTo(regular);
     }
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -182,4 +182,78 @@ final class AuthInfoTest {
     }
   }
 
+  @Nested
+  class OfTests {
+    @Test
+    void shouldReturnNullWhenOfCalledWithNull() {
+      // when
+      final AuthInfo result = AuthInfo.of((AuthInfo) null);
+
+      // then
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldCopyAuthInfoWhenOfCalledWithNonNull() {
+      // given
+      final AuthInfo original =
+          AuthInfo.withJwt("test-token", Map.of("claim1", "value1", "claim2", "value2"));
+
+      // when
+      final AuthInfo copy = AuthInfo.of(original);
+
+      // then
+      assertThat(copy).isNotNull();
+      assertThat(copy).isNotSameAs(original);
+      assertThat(copy.getFormat()).isEqualTo(original.getFormat());
+      assertThat(copy.getAuthData()).isEqualTo(original.getAuthData());
+      assertThat(copy.getClaims()).isEqualTo(original.getClaims());
+    }
+
+    @Test
+    void shouldReturnNullWhenOfBufferCalledWithEmptyAuthInfo() {
+      // given — serialize an empty AuthInfo
+      final var empty = AuthInfo.empty();
+      final var buffer = new UnsafeBuffer(new byte[empty.getLength()]);
+      empty.write(buffer, 0);
+
+      // when
+      final AuthInfo result = AuthInfo.of(buffer);
+
+      // then — should return null (optimization: avoids allocation)
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldDeserializePreAuthorizedFromBuffer() {
+      // given — serialize a PRE_AUTHORIZED AuthInfo
+      final var preAuth = AuthInfo.preAuthorized();
+      final var buffer = new UnsafeBuffer(new byte[preAuth.getLength()]);
+      preAuth.write(buffer, 0);
+
+      // when
+      final AuthInfo result = AuthInfo.of(buffer);
+
+      // then — must NOT return null despite same byte length as empty
+      assertThat(result).isNotNull();
+      assertThat(result.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+    }
+
+    @Test
+    void shouldDeserializePreAuthorizedWithClaimsFromBuffer() {
+      // given — serialize a PRE_AUTHORIZED AuthInfo with claims
+      final Map<String, Object> claims = Map.of("user", "admin", "role", "operator");
+      final var preAuth = AuthInfo.preAuthorized(claims);
+      final var buffer = new UnsafeBuffer(new byte[preAuth.getLength()]);
+      preAuth.write(buffer, 0);
+
+      // when
+      final AuthInfo result = AuthInfo.of(buffer);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+      assertThat(result.toDecodedMap()).isEqualTo(claims);
+    }
+  }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -73,7 +73,7 @@ final class AuthInfoTest {
       authInfo.write(buffer, 0);
 
       // decode
-      final var decoded = AuthInfo.empty();
+      final var decoded = AuthInfo.mutable();
       decoded.wrap(buffer, 0, buffer.capacity());
       return decoded;
     }
@@ -216,6 +216,60 @@ final class AuthInfoTest {
 
       // then — no corrupted writes
       assertThat(errors.get()).isZero();
+    }
+  }
+
+  @Nested
+  class FreezeTests {
+    @Test
+    void shouldThrowOnWrapAfterFreeze() {
+      final var auth = AuthInfo.mutable();
+      auth.freeze();
+      final var buffer = new UnsafeBuffer(new byte[0]);
+
+      assertThatThrownBy(() -> auth.wrap(buffer, 0, 0))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldThrowOnResetAfterFreeze() {
+      final var auth = AuthInfo.mutable();
+      auth.freeze();
+
+      assertThatThrownBy(auth::reset).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldFreezeIdempotently() {
+      final var auth = AuthInfo.mutable();
+      auth.freeze();
+      auth.freeze(); // second call should not throw
+
+      assertThat(auth.isFrozen()).isTrue();
+    }
+
+    @Test
+    void shouldMakeFactoryResultsImmutable() {
+      final var buffer = new UnsafeBuffer(new byte[0]);
+
+      assertThatThrownBy(() -> AuthInfo.withJwt("token").wrap(buffer, 0, 0))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatThrownBy(() -> AuthInfo.preAuthorized().wrap(buffer, 0, 0))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatThrownBy(() -> AuthInfo.withClaims(Map.of()).wrap(buffer, 0, 0))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldAllowMutationBeforeFreeze() {
+      final var auth = AuthInfo.mutable();
+      final var jwt = AuthInfo.withJwt("token");
+      final var buffer = new UnsafeBuffer(new byte[jwt.getLength()]);
+      jwt.write(buffer, 0);
+
+      // should not throw — mutable instance can be wrapped
+      auth.wrap(buffer, 0, jwt.getLength());
+      assertThat(auth.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.JWT);
     }
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -56,7 +56,7 @@ final class AuthInfoTest {
     @Test
     void shouldEncodeDecodeEmptyAuthInfo() {
       // given
-      final AuthInfo authInfo = new AuthInfo();
+      final AuthInfo authInfo = AuthInfo.empty();
 
       // when
       final var decoded = encodeDecode(authInfo);
@@ -73,7 +73,7 @@ final class AuthInfoTest {
       authInfo.write(buffer, 0);
 
       // decode
-      final var decoded = new AuthInfo();
+      final var decoded = AuthInfo.empty();
       decoded.wrap(buffer, 0, buffer.capacity());
       return decoded;
     }
@@ -121,7 +121,7 @@ final class AuthInfoTest {
     @Test
     void shouldReturnFalseWhenUnknownFormatHasEmptyClaims() {
       // given
-      final AuthInfo authInfo = new AuthInfo();
+      final AuthInfo authInfo = AuthInfo.empty();
 
       // when / then
       assertThat(authInfo.hasAnyClaims()).isFalse();
@@ -167,7 +167,7 @@ final class AuthInfoTest {
     @Test
     void shouldSerializeIdenticallyToNewAuthInfo() {
       final var empty = EmptyAuthInfo.getInstance();
-      final var regular = new AuthInfo();
+      final var regular = AuthInfo.empty();
 
       assertThat(empty.getLength()).isEqualTo(regular.getLength());
       assertThat(empty.toDirectBuffer()).isEqualTo(regular.toDirectBuffer());
@@ -176,38 +176,10 @@ final class AuthInfoTest {
     @Test
     void shouldBeEqualToNewAuthInfo() {
       final var empty = EmptyAuthInfo.getInstance();
-      final var regular = new AuthInfo();
+      final var regular = AuthInfo.empty();
 
       assertThat(empty).isEqualTo(regular);
     }
   }
 
-  @Nested
-  class OfTests {
-    @Test
-    void shouldReturnNullWhenOfCalledWithNull() {
-      // when
-      final AuthInfo result = AuthInfo.of(null);
-
-      // then
-      assertThat(result).isNull();
-    }
-
-    @Test
-    void shouldCopyAuthInfoWhenOfCalledWithNonNull() {
-      // given
-      final AuthInfo original =
-          AuthInfo.withJwt("test-token", Map.of("claim1", "value1", "claim2", "value2"));
-
-      // when
-      final AuthInfo copy = AuthInfo.of(original);
-
-      // then
-      assertThat(copy).isNotNull();
-      assertThat(copy).isNotSameAs(original);
-      assertThat(copy.getFormat()).isEqualTo(original.getFormat());
-      assertThat(copy.getAuthData()).isEqualTo(original.getAuthData());
-      assertThat(copy.getClaims()).isEqualTo(original.getClaims());
-    }
-  }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -141,7 +141,7 @@ final class AuthInfoTest {
   class EmptyAuthInfoTests {
     @Test
     void shouldThrowOnWrap() {
-      final var empty = new EmptyAuthInfo();
+      final var empty = EmptyAuthInfo.getInstance();
       final var buffer = new UnsafeBuffer(new byte[0]);
 
       assertThatThrownBy(() -> empty.wrap(buffer, 0, 0))
@@ -150,14 +150,14 @@ final class AuthInfoTest {
 
     @Test
     void shouldThrowOnReset() {
-      final var empty = new EmptyAuthInfo();
+      final var empty = EmptyAuthInfo.getInstance();
 
       assertThatThrownBy(empty::reset).isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
     void shouldReturnEmptyClaims() {
-      final var empty = new EmptyAuthInfo();
+      final var empty = EmptyAuthInfo.getInstance();
 
       assertThat(empty.getClaims()).isEmpty();
       assertThat(empty.toDecodedMap()).isEmpty();
@@ -166,7 +166,7 @@ final class AuthInfoTest {
 
     @Test
     void shouldSerializeIdenticallyToNewAuthInfo() {
-      final var empty = new EmptyAuthInfo();
+      final var empty = EmptyAuthInfo.getInstance();
       final var regular = new AuthInfo();
 
       assertThat(empty.getLength()).isEqualTo(regular.getLength());
@@ -175,7 +175,7 @@ final class AuthInfoTest {
 
     @Test
     void shouldBeEqualToNewAuthInfo() {
-      final var empty = new EmptyAuthInfo();
+      final var empty = EmptyAuthInfo.getInstance();
       final var regular = new AuthInfo();
 
       assertThat(empty).isEqualTo(regular);

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -64,7 +64,7 @@ final class AuthInfoTest {
       // then
       assertThat(decoded.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.UNKNOWN);
       assertThat(decoded.getAuthData()).isEqualTo("");
-      assertThat(decoded.getClaims()).isEqualTo(Map.of());
+      assertThat(decoded.toDecodedMap()).isEqualTo(Map.of());
     }
 
     private AuthInfo encodeDecode(final AuthInfo authInfo) {
@@ -159,7 +159,7 @@ final class AuthInfoTest {
     void shouldReturnEmptyClaims() {
       final var empty = EmptyAuthInfo.getInstance();
 
-      assertThat(empty.getClaims()).isEmpty();
+      assertThat(empty.toDecodedMap()).isEmpty();
       assertThat(empty.toDecodedMap()).isEmpty();
       assertThat(empty.hasAnyClaims()).isFalse();
     }
@@ -302,7 +302,7 @@ final class AuthInfoTest {
     }
 
     @Test
-    void shouldReturnNullWhenOfBufferCalledWithEmptyAuthInfo() {
+    void shouldReturnEmptySingletonWhenOfBufferCalledWithEmptyAuthInfo() {
       // given — serialize an empty AuthInfo
       final var empty = AuthInfo.empty();
       final var buffer = new UnsafeBuffer(new byte[empty.getLength()]);
@@ -311,8 +311,8 @@ final class AuthInfoTest {
       // when
       final AuthInfo result = AuthInfo.of(buffer);
 
-      // then — should return null (optimization: avoids allocation)
-      assertThat(result).isNull();
+      // then — should return the empty singleton (avoids allocation)
+      assertThat(result).isSameAs(AuthInfo.empty());
     }
 
     @Test

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -21,11 +21,7 @@ final class AuthInfoTest {
   @RegressionTest("https://github.com/camunda/camunda/issues/35177")
   void shouldSanitizeOnToString() {
     // given
-    final AuthInfo authInfo = new AuthInfo();
-    final String token = "token";
-    authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
-    authInfo.setAuthData(token);
-    authInfo.setClaims(Map.of("key", "value"));
+    final AuthInfo authInfo = AuthInfo.withJwt("token", Map.of("key", "value"));
 
     // when
     final var authInfoString = authInfo.toString();
@@ -42,20 +38,17 @@ final class AuthInfoTest {
     @Test
     void shouldEncodeDecodeAuthInfo() {
       // given
-      final AuthInfo authInfo = new AuthInfo();
       final String token = "token";
       final Map<String, Object> authInfoMap = Map.of("key", "value");
-      authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
-      authInfo.setAuthData(token);
-      authInfo.setClaims(authInfoMap);
+      final AuthInfo authInfo = AuthInfo.withJwt(token, authInfoMap);
 
       // when
-      encodeDecode(authInfo);
+      final var decoded = encodeDecode(authInfo);
 
       // then
-      assertThat(authInfo.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.JWT);
-      assertThat(authInfo.getAuthData()).isEqualTo(token);
-      assertThat(authInfo.getClaims()).isEqualTo(authInfoMap);
+      assertThat(decoded.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.JWT);
+      assertThat(decoded.getAuthData()).isEqualTo(token);
+      assertThat(decoded.getClaims()).isEqualTo(authInfoMap);
     }
 
     @Test
@@ -64,22 +57,23 @@ final class AuthInfoTest {
       final AuthInfo authInfo = new AuthInfo();
 
       // when
-      encodeDecode(authInfo);
+      final var decoded = encodeDecode(authInfo);
 
       // then
-      assertThat(authInfo.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.UNKNOWN);
-      assertThat(authInfo.getAuthData()).isEqualTo("");
-      assertThat(authInfo.getClaims()).isEqualTo(Map.of());
+      assertThat(decoded.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.UNKNOWN);
+      assertThat(decoded.getAuthData()).isEqualTo("");
+      assertThat(decoded.getClaims()).isEqualTo(Map.of());
     }
 
-    private void encodeDecode(final AuthInfo authInfo) {
+    private AuthInfo encodeDecode(final AuthInfo authInfo) {
       // encode
       final UnsafeBuffer buffer = new UnsafeBuffer(new byte[authInfo.getLength()]);
       authInfo.write(buffer, 0);
 
       // decode
-      authInfo.reset();
-      authInfo.wrap(buffer, 0, buffer.capacity());
+      final var decoded = new AuthInfo();
+      decoded.wrap(buffer, 0, buffer.capacity());
+      return decoded;
     }
   }
 
@@ -89,9 +83,7 @@ final class AuthInfoTest {
     @Test
     void shouldReturnTrueWhenJwtFormatHasAuthData() {
       // given
-      final AuthInfo authInfo = new AuthInfo();
-      authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
-      authInfo.setAuthData("valid-token");
+      final AuthInfo authInfo = AuthInfo.withJwt("valid-token");
 
       // when / then
       assertThat(authInfo.hasAnyClaims()).isTrue();
@@ -100,9 +92,7 @@ final class AuthInfoTest {
     @Test
     void shouldReturnFalseWhenJwtFormatHasEmptyAuthData() {
       // given
-      final AuthInfo authInfo = new AuthInfo();
-      authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
-      authInfo.setAuthData("");
+      final AuthInfo authInfo = AuthInfo.withJwt("");
 
       // when / then
       assertThat(authInfo.hasAnyClaims()).isFalse();
@@ -111,9 +101,7 @@ final class AuthInfoTest {
     @Test
     void shouldReturnTrueWhenPreAuthorizedFormatHasClaims() {
       // given
-      final AuthInfo authInfo = new AuthInfo();
-      authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
-      authInfo.setClaims(Map.of("key", "value"));
+      final AuthInfo authInfo = AuthInfo.preAuthorized(Map.of("key", "value"));
 
       // when / then
       assertThat(authInfo.hasAnyClaims()).isTrue();
@@ -122,9 +110,7 @@ final class AuthInfoTest {
     @Test
     void shouldReturnFalseWhenPreAuthorizedFormatHasEmptyClaims() {
       // given
-      final AuthInfo authInfo = new AuthInfo();
-      authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
-      authInfo.setClaims(Map.of());
+      final AuthInfo authInfo = AuthInfo.preAuthorized();
 
       // when / then
       assertThat(authInfo.hasAnyClaims()).isFalse();
@@ -134,8 +120,6 @@ final class AuthInfoTest {
     void shouldReturnFalseWhenUnknownFormatHasEmptyClaims() {
       // given
       final AuthInfo authInfo = new AuthInfo();
-      authInfo.setFormat(AuthInfo.AuthDataFormat.UNKNOWN);
-      authInfo.setClaims(Map.of());
 
       // when / then
       assertThat(authInfo.hasAnyClaims()).isFalse();
@@ -144,9 +128,7 @@ final class AuthInfoTest {
     @Test
     void shouldReturnTrueWhenUnknownFormatHasClaims() {
       // given
-      final AuthInfo authInfo = new AuthInfo();
-      authInfo.setFormat(AuthInfo.AuthDataFormat.UNKNOWN);
-      authInfo.setClaims(Map.of("key", "value"));
+      final AuthInfo authInfo = AuthInfo.withClaims(Map.of("key", "value"));
 
       // when / then
       assertThat(authInfo.hasAnyClaims()).isTrue();
@@ -167,10 +149,8 @@ final class AuthInfoTest {
     @Test
     void shouldCopyAuthInfoWhenOfCalledWithNonNull() {
       // given
-      final AuthInfo original = new AuthInfo();
-      original.setFormat(AuthInfo.AuthDataFormat.JWT);
-      original.setAuthData("test-token");
-      original.setClaims(Map.of("claim1", "value1", "claim2", "value2"));
+      final AuthInfo original =
+          AuthInfo.withJwt("test-token", Map.of("claim1", "value1", "claim2", "value2"));
 
       // when
       final AuthInfo copy = AuthInfo.of(original);

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -189,7 +189,7 @@ final class JsonSerializableToJsonTest {
               final int requestId = 23;
               final int requestStreamId = 1;
 
-              final AuthInfo authInfo = new AuthInfo().setClaims(Map.of("foo", "bar"));
+              final AuthInfo authInfo = AuthInfo.withClaims(Map.of("foo", "bar"));
               final AgentInfo agentInfo = new AgentInfo().setElementId("agent-element");
 
               recordMetadata
@@ -2720,7 +2720,7 @@ final class JsonSerializableToJsonTest {
                   .setValueType(ValueType.DEPLOYMENT)
                   .setIntent(DeploymentIntent.CREATE)
                   .setCommandValue(deploymentRecord)
-                  .setAuthInfo(new AuthInfo().setClaims(Map.of("claim-a", "foo")));
+                  .setAuthInfo(AuthInfo.withClaims(Map.of("claim-a", "foo")));
             },
         """
                 {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -44,12 +45,65 @@ final class RecordMetadataTest {
     assertThat(metadata.getRecordVersion()).isEqualTo(RecordMetadata.DEFAULT_RECORD_VERSION);
   }
 
+  @Test
+  void shouldEncodeDecodeMetadataWithJwtAuthorization() {
+    // given
+    final RecordMetadata metadata = new RecordMetadata();
+    final var authInfo =
+        AuthInfo.withJwt("test-token", Map.of("user", "admin", "role", "operator"));
+    metadata.authorization(authInfo);
+
+    // when
+    encodeDecode(metadata);
+
+    // then
+    final var decoded = metadata.getAuthorization();
+    assertThat(decoded.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.JWT);
+    assertThat(decoded.getAuthData()).isEqualTo("test-token");
+    assertThat(decoded.getClaims()).isEqualTo(Map.of("user", "admin", "role", "operator"));
+  }
+
+  @Test
+  void shouldEncodeDecodeMetadataWithPreAuthorizedAuthorization() {
+    // given
+    final RecordMetadata metadata = new RecordMetadata();
+    final var authInfo = AuthInfo.preAuthorized(Map.of("key", "value"));
+    metadata.authorization(authInfo);
+
+    // when
+    encodeDecode(metadata);
+
+    // then
+    final var decoded = metadata.getAuthorization();
+    assertThat(decoded.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+    assertThat(decoded.toDecodedMap()).isEqualTo(Map.of("key", "value"));
+  }
+
+  @Test
+  void shouldEncodeDecodeMetadataWithEmptyAuthorization() {
+    // given — no authorization set (null internally, uses EmptyAuthInfo for serialization)
+    final RecordMetadata metadata = new RecordMetadata();
+
+    // when
+    encodeDecode(metadata);
+
+    // then — getAuthorization() returns EmptyAuthInfo sentinel
+    final var decoded = metadata.getAuthorization();
+    assertThat(decoded).isNotNull();
+    assertThat(decoded.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.UNKNOWN);
+    assertThat(decoded.hasAnyClaims()).isFalse();
+  }
+
   private void encodeDecode(final RecordMetadata metadata) {
     // encode
     final UnsafeBuffer buffer = new UnsafeBuffer(new byte[metadata.getLength()]);
     metadata.write(buffer, 0);
 
     // decode
+    final var decoded = new RecordMetadata();
+    decoded.wrap(buffer, 0, buffer.capacity());
+
+    // copy values back for assertion (reuse the same reference pattern as original test)
     metadata.reset();
     metadata.wrap(buffer, 0, buffer.capacity());
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
@@ -38,7 +38,7 @@ final class RecordMetadataTest {
     assertThat(metadata.getIntent()).isEqualTo(Intent.UNKNOWN);
     assertThat(metadata.getRejectionType()).isEqualTo(RejectionType.NULL_VAL);
     assertThat(metadata.getRejectionReason()).isEmpty();
-    assertThat(metadata.getAuthorization()).isEqualTo(new AuthInfo());
+    assertThat(metadata.getAuthorization()).isEqualTo(AuthInfo.empty());
     assertThat(metadata.getAgent()).isNull();
     assertThat(metadata.getBrokerVersion()).isEqualTo(RecordMetadata.CURRENT_BROKER_VERSION);
     assertThat(metadata.getRecordVersion()).isEqualTo(RecordMetadata.DEFAULT_RECORD_VERSION);

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
@@ -94,7 +94,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
   private final ObjectProperty<AuthInfo> authInfoProperty =
-      new ObjectProperty<>(AUTH_INFO_KEY, new AuthInfo());
+      new ObjectProperty<>(AUTH_INFO_KEY, AuthInfo.empty());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
@@ -94,7 +94,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
   private final ObjectProperty<AuthInfo> authInfoProperty =
-      new ObjectProperty<>(AUTH_INFO_KEY, AuthInfo.empty());
+      new ObjectProperty<>(AUTH_INFO_KEY, AuthInfo.mutable());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.EmptyAuthInfo;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
@@ -37,6 +38,14 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   public static final VersionInfo CURRENT_BROKER_VERSION =
       VersionInfo.parse(VersionUtil.getVersion());
 
+  /**
+   * Shared immutable empty sentinel used for serialization when no authorization is set. This
+   * avoids allocating a new AuthInfo on every reset() while preserving a stable wire format: a null
+   * authorization is serialized identically to an empty one. Mutation attempts (wrap/reset) throw
+   * {@link UnsupportedOperationException}.
+   */
+  private static final AuthInfo EMPTY_AUTH = EmptyAuthInfo.getInstance();
+
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
   private final RecordMetadataEncoder encoder = new RecordMetadataEncoder();
@@ -48,7 +57,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private long requestId;
   private short intentValue = Intent.NULL_VAL;
   private int requestStreamId;
-  private AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization;
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private AgentInfo agent;
@@ -111,14 +120,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       decoder.skipRejectionReason();
     }
 
-    final int authorizationLength = decoder.authorizationLength();
-    if (authorizationLength > 0) {
-      final DirectBuffer authBuffer = new UnsafeBuffer();
-      decoder.wrapAuthorization(authBuffer);
-      authorization.wrap(authBuffer);
-    } else {
-      decoder.skipAuthorization();
-    }
+    authorization = decodeAuthorization(decoder);
 
     final int agentLength = decoder.agentLength();
     if (agentLength > 0) {
@@ -137,7 +139,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.rejectionReasonHeaderLength()
         + rejectionReason.capacity()
         + RecordMetadataEncoder.authorizationHeaderLength()
-        + authorization.getLength()
+        + authorizationOrEmpty().getLength()
         + RecordMetadataEncoder.agentHeaderLength()
         + (agent != null ? agent.getLength() : 0);
   }
@@ -167,12 +169,19 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
-    final var authorizationBuffer = authorization.toDirectBuffer();
-    encoder.putAuthorization(authorizationBuffer, 0, authorizationBuffer.capacity());
+
+    BufferUtil.writeLengthPrefixed(
+        authorizationOrEmpty(),
+        encoder,
+        RecordMetadataEncoder.authorizationHeaderLength(),
+        RecordMetadataEncoder.BYTE_ORDER);
 
     if (agent != null) {
-      final var bb = agent.toDirectBuffer();
-      encoder.putAgent(bb, 0, bb.capacity());
+      BufferUtil.writeLengthPrefixed(
+          agent,
+          encoder,
+          RecordMetadataEncoder.agentHeaderLength(),
+          RecordMetadataEncoder.BYTE_ORDER);
     } else {
       encoder.agent("");
     }
@@ -259,20 +268,42 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata authorization(final AuthInfo authorization) {
-    this.authorization = Objects.requireNonNull(authorization, "authorization can't be null");
+    this.authorization = authorization;
     return this;
   }
 
   public RecordMetadata authorization(final DirectBuffer buffer) {
-    final var auth = new AuthInfo();
-    auth.wrap(buffer);
-    // set the auth only if parsing succeeds
-    authorization = auth;
+    authorization = AuthInfo.of(buffer);
     return this;
   }
 
   public AuthInfo getAuthorization() {
-    return authorization;
+    return authorizationOrEmpty();
+  }
+
+  /**
+   * Returns the authorization if set, or the shared empty sentinel. This is used for serialization
+   * so that the wire format is preserved regardless of whether authorization is null internally.
+   */
+  private AuthInfo authorizationOrEmpty() {
+    return authorization != null ? authorization : EMPTY_AUTH;
+  }
+
+  /**
+   * Decodes the authorization field from the SBE decoder. Returns null (avoiding allocation) when
+   * the serialized bytes are identical to the empty sentinel, since {@link #authorizationOrEmpty()}
+   * will substitute the shared instance on read.
+   */
+  private static AuthInfo decodeAuthorization(final RecordMetadataDecoder decoder) {
+    final int length = decoder.authorizationLength();
+    if (length <= 0) {
+      decoder.skipAuthorization();
+      return null;
+    }
+
+    final var buffer = new UnsafeBuffer();
+    decoder.wrapAuthorization(buffer);
+    return AuthInfo.of(buffer);
   }
 
   public AgentInfo getAgent() {
@@ -330,7 +361,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
-    authorization = new AuthInfo();
+    authorization = null;
     agent = null;
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
@@ -349,7 +380,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         requestStreamId,
         rejectionType,
         rejectionReason,
-        authorization,
+        authorizationOrEmpty(),
         protocolVersion,
         brokerVersion,
         recordVersion,
@@ -375,7 +406,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && recordType == that.recordType
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
-        && authorization.equals(that.authorization)
+        && authorizationOrEmpty().equals(that.authorizationOrEmpty())
         && Objects.equals(agent, that.agent)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
@@ -405,7 +436,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       builder.append(", rejectionReason=").append(BufferUtil.bufferAsString(rejectionReason));
     }
 
-    if (!authorization.isEmpty()) {
+    if (authorization != null && !authorization.isEmpty()) {
       builder.append(", authorization=").append(authorization);
     }
     if (operationReference != RecordMetadataEncoder.operationReferenceNullValue()) {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
@@ -47,9 +48,10 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private long requestId;
   private short intentValue = Intent.NULL_VAL;
   private int requestStreamId;
-  private final AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization = new AuthInfo();
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
+  private AgentInfo agent;
 
   // always the current version by default
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
@@ -117,6 +119,16 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     } else {
       decoder.skipAuthorization();
     }
+
+    final int agentLength = decoder.agentLength();
+    if (agentLength > 0) {
+      agent = new AgentInfo();
+      final var agentBuffer = new UnsafeBuffer();
+      decoder.wrapAgent(agentBuffer);
+      agent.wrap(agentBuffer);
+    } else {
+      decoder.skipAgent();
+    }
   }
 
   @Override
@@ -125,21 +137,14 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.rejectionReasonHeaderLength()
         + rejectionReason.capacity()
         + RecordMetadataEncoder.authorizationHeaderLength()
-        + authorization.getLength();
+        + authorization.getLength()
+        + RecordMetadataEncoder.agentHeaderLength()
+        + (agent != null ? agent.getLength() : 0);
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
-    headerEncoder.wrap(buffer, offset);
-
-    headerEncoder
-        .blockLength(encoder.sbeBlockLength())
-        .templateId(encoder.sbeTemplateId())
-        .schemaId(encoder.sbeSchemaId())
-        .version(encoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-    encoder.wrap(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    encoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
     // working with fixed-length fields
     encoder
@@ -162,7 +167,16 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
-    encoder.putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
+    final var authorizationBuffer = authorization.toDirectBuffer();
+    encoder.putAuthorization(authorizationBuffer, 0, authorizationBuffer.capacity());
+
+    if (agent != null) {
+      final var bb = agent.toDirectBuffer();
+      encoder.putAgent(bb, 0, bb.capacity());
+    } else {
+      encoder.agent("");
+    }
+    return headerEncoder.encodedLength() + encoder.encodedLength();
   }
 
   public long getRequestId() {
@@ -245,17 +259,29 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata authorization(final AuthInfo authorization) {
-    this.authorization.copyFrom(authorization);
+    this.authorization = Objects.requireNonNull(authorization, "authorization can't be null");
     return this;
   }
 
   public RecordMetadata authorization(final DirectBuffer buffer) {
-    authorization.wrap(buffer);
+    final var auth = new AuthInfo();
+    auth.wrap(buffer);
+    // set the auth only if parsing succeeds
+    authorization = auth;
     return this;
   }
 
   public AuthInfo getAuthorization() {
     return authorization;
+  }
+
+  public AgentInfo getAgent() {
+    return agent;
+  }
+
+  public RecordMetadata agent(final AgentInfo agent) {
+    this.agent = agent;
+    return this;
   }
 
   public RecordMetadata brokerVersion(final VersionInfo brokerVersion) {
@@ -304,7 +330,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
-    authorization.reset();
+    authorization = new AuthInfo();
+    agent = null;
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
     operationReference = RecordMetadataEncoder.operationReferenceNullValue();
@@ -327,7 +354,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         brokerVersion,
         recordVersion,
         operationReference,
-        batchOperationReference);
+        batchOperationReference,
+        agent);
   }
 
   @Override
@@ -348,6 +376,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
         && authorization.equals(that.authorization)
+        && Objects.equals(agent, that.agent)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
         && operationReference == that.operationReference
@@ -384,6 +413,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     }
     if (batchOperationReference != RecordMetadataEncoder.batchOperationReferenceNullValue()) {
       builder.append(", batchOperationReference=").append(batchOperationReference);
+    }
+    if (agent != null) {
+      builder.append(", agent=").append(agent);
     }
 
     builder.append('}');

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
@@ -49,7 +49,7 @@ final class ImplRecordValuePopulator {
 
     for (final Field field : clazz.getDeclaredFields()) {
       try {
-        if (Modifier.isStatic(field.getModifiers())) {
+        if (Modifier.isStatic(field.getModifiers()) || Modifier.isTransient(field.getModifiers())) {
           continue;
         }
         field.setAccessible(true);

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -459,7 +459,9 @@ public final class ProtocolFactory {
   private Object generateProtocolImplRecord(final Class<?> implClass) {
     final Object implInstance;
     try {
-      implInstance = implClass.getDeclaredConstructor().newInstance();
+      final var constructor = implClass.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      implInstance = constructor.newInstance();
     } catch (final NoSuchMethodException e) {
       throw new IllegalArgumentException(
           "Implementation class does not have a no-arg constructor: " + implClass, e);

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
@@ -41,7 +41,7 @@ public final class ExecuteCommandRequest implements ClientRequest {
   private byte[] encodedCmd;
   private ActorFuture<DirectBuffer> responseFuture;
   private Intent intent = null;
-  private AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization = AuthInfo.empty();
 
   public ExecuteCommandRequest(
       final ClientTransport output, final String targetAddress, final MsgPackHelper msgPackHelper) {

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
@@ -41,7 +41,7 @@ public final class ExecuteCommandRequest implements ClientRequest {
   private byte[] encodedCmd;
   private ActorFuture<DirectBuffer> responseFuture;
   private Intent intent = null;
-  private AuthInfo authorization = AuthInfo.empty();
+  private AuthInfo authorization = AuthInfo.mutable();
 
   public ExecuteCommandRequest(
       final ClientTransport output, final String targetAddress, final MsgPackHelper msgPackHelper) {

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
@@ -41,7 +41,7 @@ public final class ExecuteCommandRequest implements ClientRequest {
   private byte[] encodedCmd;
   private ActorFuture<DirectBuffer> responseFuture;
   private Intent intent = null;
-  private final AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization = new AuthInfo();
 
   public ExecuteCommandRequest(
       final ClientTransport output, final String targetAddress, final MsgPackHelper msgPackHelper) {
@@ -75,7 +75,7 @@ public final class ExecuteCommandRequest implements ClientRequest {
   }
 
   public ExecuteCommandRequest setAuthorization(final AuthInfo authorization) {
-    this.authorization.copyFrom(authorization);
+    this.authorization = authorization;
     return this;
   }
 

--- a/zeebe/protocol-test-util/src/test/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactoryTest.java
+++ b/zeebe/protocol-test-util/src/test/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactoryTest.java
@@ -238,7 +238,7 @@ final class ProtocolFactoryTest {
         .isNotNull()
         .isNotEqualTo(AuthInfo.AuthDataFormat.UNKNOWN); // Should be randomized
     assertThat(authInfo.getAuthData()).isNotEmpty();
-    assertThat(authInfo.getClaims()).isNotEmpty();
+    assertThat(authInfo.toDecodedMap()).isNotEmpty();
   }
 
   @Test

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.api;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.EmptyAuthInfo;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -54,7 +55,7 @@ public record FollowUpCommandMetadata(
       return new FollowUpCommandMetadata(
           operationReference,
           batchOperationReference,
-          authInfo != null ? authInfo : new AuthInfo());
+          authInfo != null ? authInfo : EmptyAuthInfo.getInstance());
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
@@ -28,7 +28,7 @@ public record FollowUpCommandMetadata(
   public static class Builder {
     private long operationReference = RecordMetadataDecoder.operationReferenceNullValue();
     private long batchOperationReference = RecordMetadataDecoder.batchOperationReferenceNullValue();
-    private final AuthInfo authInfo = new AuthInfo();
+    private AuthInfo authInfo;
 
     public Builder operationReference(final long operationReference) {
       this.operationReference = operationReference;
@@ -41,17 +41,20 @@ public record FollowUpCommandMetadata(
     }
 
     public Builder authInfo(final AuthInfo authInfo) {
-      this.authInfo.copyFrom(authInfo);
+      this.authInfo = authInfo;
       return this;
     }
 
     public Builder claims(final Map<String, Object> claims) {
-      authInfo.setClaims(claims);
+      authInfo = AuthInfo.withClaims(claims);
       return this;
     }
 
     public FollowUpCommandMetadata build() {
-      return new FollowUpCommandMetadata(operationReference, batchOperationReference, authInfo);
+      return new FollowUpCommandMetadata(
+          operationReference,
+          batchOperationReference,
+          authInfo != null ? authInfo : new AuthInfo());
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.EmptyAuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
@@ -103,7 +103,8 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
             .valueType(valueType);
 
     metadataDecorators.forEach(m -> m.accept(metadata));
-    metadata.authorization(new AuthInfo()); // don't expose the authorization data in the response
+    // don't expose the authorization data in the response
+    metadata.authorization(EmptyAuthInfo.getInstance());
 
     final var entry = RecordBatchEntry.createEntry(key, metadata, -1, value);
     processingResponse = new ProcessingResponseImpl(entry, requestId, requestStreamId);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
@@ -102,7 +103,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
             .valueType(valueType);
 
     metadataDecorators.forEach(m -> m.accept(metadata));
-    metadata.getAuthorization().reset(); // don't expose the authorization data in the response
+    metadata.authorization(new AuthInfo()); // don't expose the authorization data in the response
 
     final var entry = RecordBatchEntry.createEntry(key, metadata, -1, value);
     processingResponse = new ProcessingResponseImpl(entry, requestId, requestStreamId);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -93,7 +93,8 @@ public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
 
   @Override
   public Map<String, Object> getAuthorizations() {
-    return metadata.getAuthorization().toDecodedMap();
+    final var auth = metadata.getAuthorization();
+    return auth != null ? auth.toDecodedMap() : Map.of();
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -83,7 +83,8 @@ public class UnwrittenRecord implements TypedRecord {
 
   @Override
   public Map<String, Object> getAuthorizations() {
-    return metadata.getAuthorization().toDecodedMap();
+    final var auth = metadata.getAuthorization();
+    return auth != null ? auth.toDecodedMap() : Map.of();
   }
 
   @Override

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilderTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilderTest.java
@@ -82,10 +82,7 @@ class BufferedProcessingResultBuilderTest {
     // given
     final Consumer<RecordMetadata> authorizationDecorator =
         metadata -> {
-          final var authInfo = new AuthInfo();
-          authInfo.setFormat(AuthDataFormat.JWT);
-          authInfo.setAuthData("secret-token");
-          metadata.authorization(authInfo);
+          metadata.authorization(AuthInfo.withJwt("secret-token"));
         };
     final var builder =
         new BufferedProcessingResultBuilder(LARGE_BATCH_PREDICATE, authorizationDecorator);


### PR DESCRIPTION
 # Description 
- Make AuthInfo effectively immutable and pass by reference instead of copying via setClaims()/copyFrom() on every event in the stream processing hot path. RecordMetadata and
  ExecuteCommandRequest now hold a nullable AuthInfo reference — no allocations on reset(), no Map→msgpack round-trips on write.
  - Cache toDecodedMap() with a single volatile field covering both JWT decoding and msgpack deserialization, so repeated calls (e.g. from exporters) don't re-decode.
    - Before caching, all maps are wrapped with `Collection.unmodifiableMap`. All map taken as arguments are mutable, but they never mutated. This can be done in a followup.
  - Introduce EmptyAuthInfo — an immutable, singleton-safe subclass that throws UnsupportedOperationException on wrap()/reset() and eagerly caches all derived values. Used as a static
  sentinel in RecordMetadata to preserve the wire format (empty msgpack envelope) without allocating on every reset().


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #46873
