### PR TITLE
feat: add FEEL context to ExpressionRecord

### DIFF
--- a/service/src/main/java/io/camunda/service/ExpressionServices.java
+++ b/service/src/main/java/io/camunda/service/ExpressionServices.java
@@ -47,6 +47,7 @@ public final class ExpressionServices extends ApiServices<ExpressionServices> {
     return sendBrokerRequest(
         new BrokerExpressionEvaluationRequest()
             .setExpression(request.expression())
+            .setContext(request.context())
             .setTenantId(request.tenantId()));
   }
 

--- a/service/src/main/java/io/camunda/service/ExpressionServices.java
+++ b/service/src/main/java/io/camunda/service/ExpressionServices.java
@@ -47,7 +47,7 @@ public final class ExpressionServices extends ApiServices<ExpressionServices> {
     return sendBrokerRequest(
         new BrokerExpressionEvaluationRequest()
             .setExpression(request.expression())
-            .setContext(request.context())
+            .setVariables(request.context())
             .setTenantId(request.tenantId()));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
@@ -14,13 +14,11 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.Map;
-import org.agrona.concurrent.UnsafeBuffer;
 
 public class ExpressionBehavior {
 
@@ -76,8 +74,7 @@ public class ExpressionBehavior {
     return new ExpressionRecord()
         .setTenantId(expressionRecord.getTenantId())
         .setExpression(expressionRecord.getExpression())
-        .setVariables(
-            new UnsafeBuffer(MsgPackConverter.convertToMsgPack(expressionRecord.getVariables())))
+        .setVariables(expressionRecord.getVariablesBuffer())
         .setWarnings(
             evaluationResult.getWarnings().stream().map(EvaluationWarning::getMessage).toList())
         .setResultValue(evaluationResult.toBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
@@ -14,11 +14,13 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class ExpressionBehavior {
 
@@ -35,11 +37,11 @@ public class ExpressionBehavior {
 
   public Either<Rejection, ExpressionRecord> resolveExpression(
       final Expression expression, final ExpressionRecord expressionRecord) {
-    final var contextAsMap = expressionRecord.getContext();
+    final var variables = expressionRecord.getVariables();
     final var contextAsEvaluationContext =
-        contextAsMap == null
+        variables == null
             ? new InMemoryVariableEvaluationContext(Map.of())
-            : new InMemoryVariableEvaluationContext(contextAsMap);
+            : new InMemoryVariableEvaluationContext(variables);
     return evaluate(expression, contextAsEvaluationContext, expressionRecord.getTenantId())
         .map(evaluationResult -> mapSuccess(evaluationResult, expressionRecord));
   }
@@ -74,7 +76,8 @@ public class ExpressionBehavior {
     return new ExpressionRecord()
         .setTenantId(expressionRecord.getTenantId())
         .setExpression(expressionRecord.getExpression())
-        .setContext(expressionRecord.getContext())
+        .setVariables(
+            new UnsafeBuffer(MsgPackConverter.convertToMsgPack(expressionRecord.getVariables())))
         .setWarnings(
             evaluationResult.getWarnings().stream().map(EvaluationWarning::getMessage).toList())
         .setResultValue(evaluationResult.toBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
+import java.util.Map;
 
 public class ExpressionBehavior {
 
@@ -34,7 +35,12 @@ public class ExpressionBehavior {
 
   public Either<Rejection, ExpressionRecord> resolveExpression(
       final Expression expression, final ExpressionRecord expressionRecord) {
-    return evaluate(expression, expressionRecord.getTenantId())
+    final var contextAsMap = expressionRecord.getContext();
+    final var contextAsEvaluationContext =
+        contextAsMap == null
+            ? new InMemoryVariableEvaluationContext(Map.of())
+            : new InMemoryVariableEvaluationContext(contextAsMap);
+    return evaluate(expression, contextAsEvaluationContext, expressionRecord.getTenantId())
         .map(evaluationResult -> mapSuccess(evaluationResult, expressionRecord));
   }
 
@@ -51,8 +57,9 @@ public class ExpressionBehavior {
   }
 
   private Either<Rejection, EvaluationResult> evaluate(
-      final Expression expression, final String tenantId) {
+      final Expression expression, final ScopedEvaluationContext context, final String tenantId) {
     return clusterExpressionProcessor
+        .prependContext(context)
         .evaluateAnyExpression(expression, -1, tenantId)
         .mapLeft(this::mapEvaluationFailure)
         .flatMap(this::rejectIfEvaluationFailed);
@@ -67,6 +74,7 @@ public class ExpressionBehavior {
     return new ExpressionRecord()
         .setTenantId(expressionRecord.getTenantId())
         .setExpression(expressionRecord.getExpression())
+        .setContext(expressionRecord.getContext())
         .setWarnings(
             evaluationResult.getWarnings().stream().map(EvaluationWarning::getMessage).toList())
         .setResultValue(evaluationResult.toBuffer());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
+import java.util.Map;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -607,5 +608,27 @@ public class ResolveFeelExpressionTest {
             """
             Expected to evaluate expression but timed out after 300 ms: \
             'for x in 0..1000000 return for y in 0..x return x + y'""");
+  }
+
+  @Test
+  public void shouldResolveExpressionWithContext() {
+    // given
+    ENGINE_RULE.clusterVariables().withName("input").setGlobalScope().withValue("5").create();
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=camunda.vars.cluster.input * 2 + myVar")
+            .withContext(Map.of("myVar", 5))
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(15);
+    // context is passed through
+    assertThat(record.getValue().getContext()).isEqualTo(Map.of("myVar", 5));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -666,4 +666,55 @@ public class ResolveFeelExpressionTest {
         .hasRecordType(RecordType.EVENT);
     assertThat(record.getValue().getResultValue()).isEqualTo(8);
   }
+
+  @Test
+  public void shouldResolveDateTimeExpressionWithContextVariable() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("= date and time(myDateTime)")
+            .withContext(Map.of("myDateTime", "2024-01-15T10:30:00"))
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("2024-01-15T10:30:00");
+  }
+
+  @Test
+  public void shouldResolveExpressionWithListInContext() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=count(myList)")
+            .withContext(Map.of("myList", java.util.List.of(1, 2, 3, 4, 5)))
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldResolveExpressionWithNestedContext() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=person.name + \" is \" + string(person.age) + \" years old\"")
+            .withContext(Map.of("person", Map.of("name", "Alice", "age", 30)))
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("Alice is 30 years old");
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -620,7 +620,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=camunda.vars.cluster.input * 2 + myVar")
-            .withContext(Map.of("myVar", 5))
+            .withVariables(Map.of("myVar", 5))
             .resolve();
 
     // then
@@ -629,7 +629,7 @@ public class ResolveFeelExpressionTest {
         .hasRecordType(RecordType.EVENT);
     assertThat(record.getValue().getResultValue()).isEqualTo(15);
     // context is passed through
-    assertThat(record.getValue().getContext()).isEqualTo(Map.of("myVar", 5));
+    assertThat(record.getValue().getVariables()).isEqualTo(Map.of("myVar", 5));
   }
 
   @Test
@@ -639,7 +639,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=a * 2 + b")
-            .withContext(Map.of("a", "not a number"))
+            .withVariables(Map.of("a", "not a number"))
             .resolve();
 
     // then
@@ -658,7 +658,7 @@ public class ResolveFeelExpressionTest {
   public void shouldResolveExpressionWithExplicitContextAsNull() {
     // when
     final var record =
-        ENGINE_RULE.expression().withExpression("=5 + 3").withContext(null).resolve();
+        ENGINE_RULE.expression().withExpression("=5 + 3").withVariables(null).resolve();
 
     // then
     Assertions.assertThat(record)
@@ -674,7 +674,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("= date and time(myDateTime)")
-            .withContext(Map.of("myDateTime", "2024-01-15T10:30:00"))
+            .withVariables(Map.of("myDateTime", "2024-01-15T10:30:00"))
             .resolve();
 
     // then
@@ -691,7 +691,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=count(myList)")
-            .withContext(Map.of("myList", java.util.List.of(1, 2, 3, 4, 5)))
+            .withVariables(Map.of("myList", java.util.List.of(1, 2, 3, 4, 5)))
             .resolve();
 
     // then
@@ -708,7 +708,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=person.name + \" is \" + string(person.age) + \" years old\"")
-            .withContext(Map.of("person", Map.of("name", "Alice", "age", 30)))
+            .withVariables(Map.of("person", Map.of("name", "Alice", "age", 30)))
             .resolve();
 
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -631,4 +631,39 @@ public class ResolveFeelExpressionTest {
     // context is passed through
     assertThat(record.getValue().getContext()).isEqualTo(Map.of("myVar", 5));
   }
+
+  @Test
+  public void shouldResolveWithWarningIfContextVarHasAWrongTypeOrMissing() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=a * 2 + b")
+            .withContext(Map.of("a", "not a number"))
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(null);
+    assertThat(record.getValue().getWarnings())
+        .containsExactlyInAnyOrder(
+            "Can't multiply '\"not a number\"' by '2'",
+            "No variable found with name 'b'",
+            "Can't add 'null' to 'null'");
+  }
+
+  @Test
+  public void shouldResolveExpressionWithExplicitContextAsNull() {
+    // when
+    final var record =
+        ENGINE_RULE.expression().withExpression("=5 + 3").withContext(null).resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(8);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
@@ -15,6 +16,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.LongFunction;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class ExpressionClient {
 
@@ -50,8 +52,8 @@ public final class ExpressionClient {
     return this;
   }
 
-  public ExpressionClient withContext(final Map<String, Object> context) {
-    expressionRecord.setContext(context);
+  public ExpressionClient withVariables(final Map<String, Object> context) {
+    expressionRecord.setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(context)));
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
 import java.util.Random;
 import java.util.function.LongFunction;
 
@@ -46,6 +47,11 @@ public final class ExpressionClient {
 
   public ExpressionClient withExpression(final String expression) {
     expressionRecord.setExpression(expression);
+    return this;
+  }
+
+  public ExpressionClient withContext(final Map<String, Object> context) {
+    expressionRecord.setContext(context);
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExpressionEvaluationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExpressionEvaluationRequest.java
@@ -8,12 +8,14 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Map;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class BrokerExpressionEvaluationRequest extends BrokerExecuteCommand<ExpressionRecord> {
 
@@ -33,8 +35,8 @@ public class BrokerExpressionEvaluationRequest extends BrokerExecuteCommand<Expr
     return this;
   }
 
-  public BrokerExpressionEvaluationRequest setContext(final Map<String, Object> context) {
-    requestDto.setContext(context);
+  public BrokerExpressionEvaluationRequest setVariables(final Map<String, Object> context) {
+    requestDto.setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(context)));
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExpressionEvaluationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExpressionEvaluationRequest.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 
 public class BrokerExpressionEvaluationRequest extends BrokerExecuteCommand<ExpressionRecord> {
@@ -29,6 +30,11 @@ public class BrokerExpressionEvaluationRequest extends BrokerExecuteCommand<Expr
 
   public BrokerExpressionEvaluationRequest setTenantId(final String tenantId) {
     requestDto.setTenantId(tenantId);
+    return this;
+  }
+
+  public BrokerExpressionEvaluationRequest setContext(final Map<String, Object> context) {
+    requestDto.setContext(context);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -68,7 +68,8 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   }
 
   public ExpressionRecord setContext(final Map<String, Object> context) {
-    contextProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(context)));
+    final Map<String, Object> contextToEncode = context != null ? context : Map.of();
+    contextProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(contextToEncode)));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.agrona.DirectBuffer;
@@ -27,6 +28,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue RESULT_VALUE_KEY = new StringValue("resultValue");
   private static final StringValue WARNINGS_KEY = new StringValue("warnings");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue CONTEXT_KEY = new StringValue("context");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -37,12 +39,17 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
       new ArrayProperty<>(WARNINGS_KEY, StringValue::new);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
+  private final BinaryProperty contextProp =
+      new BinaryProperty(
+          CONTEXT_KEY, new UnsafeBuffer(MsgPackConverter.convertToMsgPack(Map.of())));
+
   public ExpressionRecord() {
-    super(4);
+    super(5);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(contextProp);
   }
 
   @Override
@@ -52,6 +59,16 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setExpression(final String expression) {
     expressionProp.setValue(expression);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getContext() {
+    return MsgPackConverter.convertToMap(contextProp.getValue());
+  }
+
+  public ExpressionRecord setContext(final Map<String, Object> context) {
+    contextProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(context)));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.expression;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -39,9 +40,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
       new ArrayProperty<>(WARNINGS_KEY, StringValue::new);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
-  private final BinaryProperty variablesProp =
-      new BinaryProperty(
-          VARIABLES_KEY, new UnsafeBuffer(MsgPackConverter.convertToMsgPack(Map.of())));
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
 
   public ExpressionRecord() {
     super(5);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -28,7 +28,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue RESULT_VALUE_KEY = new StringValue("resultValue");
   private static final StringValue WARNINGS_KEY = new StringValue("warnings");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
-  private static final StringValue CONTEXT_KEY = new StringValue("context");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -39,9 +39,9 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
       new ArrayProperty<>(WARNINGS_KEY, StringValue::new);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
-  private final BinaryProperty contextProp =
+  private final BinaryProperty variablesProp =
       new BinaryProperty(
-          CONTEXT_KEY, new UnsafeBuffer(MsgPackConverter.convertToMsgPack(Map.of())));
+          VARIABLES_KEY, new UnsafeBuffer(MsgPackConverter.convertToMsgPack(Map.of())));
 
   public ExpressionRecord() {
     super(5);
@@ -49,7 +49,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(contextProp);
+        .declareProperty(variablesProp);
   }
 
   @Override
@@ -59,17 +59,6 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setExpression(final String expression) {
     expressionProp.setValue(expression);
-    return this;
-  }
-
-  @Override
-  public Map<String, Object> getContext() {
-    return MsgPackConverter.convertToMap(contextProp.getValue());
-  }
-
-  public ExpressionRecord setContext(final Map<String, Object> context) {
-    final Map<String, Object> contextToEncode = context != null ? context : Map.of();
-    contextProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(contextToEncode)));
     return this;
   }
 
@@ -96,6 +85,16 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setResultValue(final DirectBuffer value) {
     resultValueProp.setValue(value);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public ExpressionRecord setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.expression;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
@@ -95,6 +96,11 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   public ExpressionRecord setVariables(final DirectBuffer variables) {
     variablesProp.setValue(variables);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -652,7 +652,8 @@ final class JsonSerializableToJsonTest {
                   .setExpression("=10 + 5")
                   .setResultValue(wrapString("15"))
                   .setTenantId("test-tenant")
-                  .setWarnings(List.of("warning1", "warning2"));
+                  .setWarnings(List.of("warning1", "warning2"))
+                  .setContext(Map.of("foo", "bar"));
               return record;
             },
         """
@@ -660,7 +661,10 @@ final class JsonSerializableToJsonTest {
                   "tenantId":"test-tenant",
                   "expression":"=10 + 5",
                   "resultValue":49,
-                  "warnings":["warning1","warning2"]
+                  "warnings":["warning1","warning2"],
+                  "context":{
+                    "foo":"bar"
+                  }
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -653,7 +653,7 @@ final class JsonSerializableToJsonTest {
                   .setResultValue(wrapString("15"))
                   .setTenantId("test-tenant")
                   .setWarnings(List.of("warning1", "warning2"))
-                  .setContext(Map.of("foo", "bar"));
+                  .setVariables(VARIABLES_MSGPACK);
               return record;
             },
         """
@@ -662,7 +662,7 @@ final class JsonSerializableToJsonTest {
                   "expression":"=10 + 5",
                   "resultValue":49,
                   "warnings":["warning1","warning2"],
-                  "context":{
+                  "variables":{
                     "foo":"bar"
                   }
                 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
@@ -7,8 +7,10 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.expression;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -16,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.agrona.DirectBuffer;
@@ -27,6 +30,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue RESULT_VALUE_KEY = new StringValue("resultValue");
   private static final StringValue WARNINGS_KEY = new StringValue("warnings");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -37,12 +41,15 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
       new ArrayProperty<>(WARNINGS_KEY, StringValue::new);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
+
   public ExpressionRecord() {
-    super(4);
+    super(5);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(variablesProp);
   }
 
   @Override
@@ -79,6 +86,21 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   public ExpressionRecord setResultValue(final DirectBuffer value) {
     resultValueProp.setValue(value);
     return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public ExpressionRecord setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
   }
 
   @Override

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
@@ -18,18 +18,21 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
+import java.util.Map;
 import org.immutables.value.Value;
 
 /**
  * Represents a record value for a FEEL expression resolution in the engine.
  *
- * <p>A FEEL expression resolution record contains the expression to evaluate and the result of the
- * evaluation.
+ * <p>A FEEL expression resolution record contains the expression to evaluate, an optional context
+ * object, and the result of the evaluation.
  *
  * <p>The value is immutable and built via {@link ImmutableExpressionRecordValue}.
  *
  * <ul>
  *   <li>{@link #getExpression()} – the FEEL expression to evaluate.
+ *   <li>{@link #getContext()} – the optional context for the expression evaluation (can be am empty
+ *       map but not {@code null}).
  *   <li>{@link #getResultValue()} – the result value (nullable).
  *   <li>{@link #getWarnings()} – the list of warnings generated during evaluation.
  * </ul>
@@ -47,6 +50,13 @@ public interface ExpressionRecordValue extends RecordValue, TenantOwned {
    * @return the FEEL expression as a String (never {@code null})
    */
   String getExpression();
+
+  /**
+   * Returns the optional FEEL context in which the expression is evaluated.
+   *
+   * @return the FEEL context as an Object (can be {@code null})
+   */
+  Map<String, Object> getContext();
 
   /**
    * Returns the result value of the expression evaluation.

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
@@ -17,8 +17,8 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import java.util.List;
-import java.util.Map;
 import org.immutables.value.Value;
 
 /**
@@ -31,8 +31,7 @@ import org.immutables.value.Value;
  *
  * <ul>
  *   <li>{@link #getExpression()} – the FEEL expression to evaluate.
- *   <li>{@link #getContext()} – the optional context for the expression evaluation (can be an empty
- *       map but not {@code null}).
+ *   <li>{@link #getVariables()} - the variables used as context for the expression evaluation.
  *   <li>{@link #getResultValue()} – the result value (nullable).
  *   <li>{@link #getWarnings()} – the list of warnings generated during evaluation.
  * </ul>
@@ -42,7 +41,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableExpressionRecordValue.Builder.class)
-public interface ExpressionRecordValue extends RecordValue, TenantOwned {
+public interface ExpressionRecordValue extends RecordValue, TenantOwned, RecordValueWithVariables {
 
   /**
    * Returns the FEEL expression to be evaluated.
@@ -50,13 +49,6 @@ public interface ExpressionRecordValue extends RecordValue, TenantOwned {
    * @return the FEEL expression as a String (never {@code null})
    */
   String getExpression();
-
-  /**
-   * Returns the optional FEEL context in which the expression is evaluated.
-   *
-   * @return the FEEL context as a {@link Map} (never {@code null}, but can be empty)
-   */
-  Map<String, Object> getContext();
 
   /**
    * Returns the result value of the expression evaluation.

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
@@ -31,7 +31,7 @@ import org.immutables.value.Value;
  *
  * <ul>
  *   <li>{@link #getExpression()} – the FEEL expression to evaluate.
- *   <li>{@link #getContext()} – the optional context for the expression evaluation (can be am empty
+ *   <li>{@link #getContext()} – the optional context for the expression evaluation (can be an empty
  *       map but not {@code null}).
  *   <li>{@link #getResultValue()} – the result value (nullable).
  *   <li>{@link #getWarnings()} – the list of warnings generated during evaluation.
@@ -54,7 +54,7 @@ public interface ExpressionRecordValue extends RecordValue, TenantOwned {
   /**
    * Returns the optional FEEL context in which the expression is evaluated.
    *
-   * @return the FEEL context as an Object (can be {@code null})
+   * @return the FEEL context as a {@link Map} (never {@code null}, but can be empty)
    */
   Map<String, Object> getContext();
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
@@ -24,8 +24,8 @@ import org.immutables.value.Value;
 /**
  * Represents a record value for a FEEL expression resolution in the engine.
  *
- * <p>A FEEL expression resolution record contains the expression to evaluate, an optional context
- * object, and the result of the evaluation.
+ * <p>A FEEL expression resolution record contains the expression to evaluate, optional variables,
+ * and the result of the evaluation.
  *
  * <p>The value is immutable and built via {@link ImmutableExpressionRecordValue}.
  *

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1060,6 +1060,7 @@ public class CompactRecordLogger {
         + StringUtils.abbreviate(value.getExpression(), "..", 50)
         + "\" = "
         + formatVariableValue(value.getResultValue())
+        + formatVariables(value.getContext())
         + formatTenant(value);
   }
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1060,7 +1060,7 @@ public class CompactRecordLogger {
         + StringUtils.abbreviate(value.getExpression(), "..", 50)
         + "\" = "
         + formatVariableValue(value.getResultValue())
-        + formatVariables(value.getContext())
+        + formatVariables(value.getVariables())
         + formatTenant(value);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR contains the main part of the implementation for #46332 

- Added a new property to `ExpressionRecord`
- Modified `ExpressionBehavior` to handle the provided context 
- Added test cases for different data types in context and some negative cases

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46334 
