### PR TITLE
fix: allow kebab case for initializing mapping rules in default roles

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
@@ -190,7 +190,9 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             switch (assignmentsForEntityType.getKey().toLowerCase()) {
               case "users" -> EntityType.USER;
               case "clients" -> EntityType.CLIENT;
-              case "mappingrules" -> EntityType.MAPPING_RULE;
+              // when using config via env variables,
+              // spring will convert MAPPING_RULES to mapping.rules
+              case "mappingrules", "mapping-rules", "mapping.rules" -> EntityType.MAPPING_RULE;
               case "groups" -> EntityType.GROUP;
               case "roles" -> EntityType.ROLE;
               default ->

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
@@ -178,11 +178,17 @@ final class IdentitySetupInitializerIT {
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString());
+    final var mappingRules3 =
+        new ConfiguredMappingRule(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString());
     createBroker(
         true,
         1,
         cfg -> {
-          cfg.getInitialization().setMappingRules(List.of(mappingRules1, mappingRules2));
+          cfg.getInitialization()
+              .setMappingRules(List.of(mappingRules1, mappingRules2, mappingRules3));
           cfg.getInitialization()
               .getDefaultRoles()
               .put(
@@ -191,7 +197,9 @@ final class IdentitySetupInitializerIT {
                       "mappingRules",
                       List.of(mappingRules1.getMappingRuleId()),
                       "mappingrules",
-                      List.of(mappingRules2.getMappingRuleId())));
+                      List.of(mappingRules2.getMappingRuleId()),
+                      "mapping-rules",
+                      List.of(mappingRules3.getMappingRuleId())));
         });
 
     // then identity should be initialized
@@ -214,10 +222,19 @@ final class IdentitySetupInitializerIT {
         .hasClaimName(mappingRules2.getClaimName())
         .hasClaimValue(mappingRules2.getClaimValue());
 
+    final var thirdMappingRule = record.getMappingRules().get(2);
+    Assertions.assertThat(thirdMappingRule)
+        .isNotNull()
+        .hasMappingRuleId(mappingRules3.getMappingRuleId())
+        .hasClaimName(mappingRules3.getClaimName())
+        .hasClaimValue(mappingRules3.getClaimValue());
+
     final var members = record.getRoleMembers().stream().map(RoleRecordValue::getEntityId).toList();
     assertThat(members)
         .containsExactlyInAnyOrder(
-            mappingRules1.getMappingRuleId(), mappingRules2.getMappingRuleId());
+            mappingRules1.getMappingRuleId(),
+            mappingRules2.getMappingRuleId(),
+            mappingRules3.getMappingRuleId());
   }
 
   private void createBroker(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Allow kebab case for initializing mapping rules in default roles.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #36382 
