### PR TITLE
Enhance variable record with an operation source property

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.zeebe.variable;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableSourceValue;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
@@ -70,13 +71,18 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return -1L; // not used in Optimize
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return bpmnProcessId;
   }
 
   @Override
-  public long getRootProcessInstanceKey() {
-    return -1L; // not used in Optimize
+  public VariableSourceValue getSource() {
+    return null; // not used in Optimize
   }
 
   public void setBpmnProcessId(final String bpmnProcessId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -341,6 +341,61 @@ public class AuditLogProcessOperationsIT {
         "existingVar");
   }
 
+  @Test
+  void shouldNotTrackVariableCreateWhenJobCompletedWithVariables(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // given - start a process instance and wait for its jobs to be active
+    final var processInstance = createProcessInstance(client, SERVICE_TASKS_PROCESS_ID);
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+    waitForProcessInstancesToStart(
+        client, f -> f.processInstanceKey(processInstanceKey).tenantId(TENANT_A), 1);
+    final var jobs = waitForJobs(client, List.of(processInstanceKey));
+
+    // when - complete the jobs with a variable payload
+    jobs.forEach(
+        job ->
+            client
+                .newCompleteCommand(job.getJobKey())
+                .variables(Map.of("jobOutputVar", "jobOutputValue"))
+                .send()
+                .join());
+
+    // then assert that no VARIABLE audit logs were created for this process instance
+    Awaitility.await("Audit log entry is created")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () -> {
+              final var jobAuditLogs =
+                  client
+                      .newAuditLogSearchRequest()
+                      .filter(
+                          f ->
+                              f.entityType(AuditLogEntityTypeEnum.JOB)
+                                  .processInstanceKey(String.valueOf(processInstanceKey)))
+                      .send()
+                      .join()
+                      .items();
+              final var variableAuditLogs =
+                  client
+                      .newAuditLogSearchRequest()
+                      .filter(
+                          f ->
+                              f.entityType(AuditLogEntityTypeEnum.VARIABLE)
+                                  .processInstanceKey(String.valueOf(processInstanceKey)))
+                      .send()
+                      .join()
+                      .items();
+
+              assertThat(jobAuditLogs).isNotEmpty();
+              assertThat(variableAuditLogs)
+                  .as(
+                      "variables set during job completion should not produce variable audit log entries"
+                          + " because their source is not API")
+                  .isEmpty();
+            });
+  }
+
   // ========================================================================================
   // Job Tests
   // ========================================================================================

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.variable.DocumentEntry;
 import io.camunda.zeebe.engine.state.variable.IndexedDocument;
 import io.camunda.zeebe.engine.state.variable.VariableInstance;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ public final class VariableBehavior {
 
   private final IndexedDocument indexedDocument = new IndexedDocument();
   private final VariableRecord variableRecord = new VariableRecord();
+  private final VariableSourceRecord variableSourceRecord;
 
   public VariableBehavior(
       final VariableState variableState,
@@ -49,6 +51,25 @@ public final class VariableBehavior {
     this.stateWriter = stateWriter;
     this.conditionalBehavior = conditionalBehavior;
     this.keyGenerator = keyGenerator;
+    variableSourceRecord = VariableSourceRecord.none();
+  }
+
+  public VariableBehavior(
+      final VariableState variableState,
+      final StateWriter stateWriter,
+      final BpmnConditionalBehavior conditionalBehavior,
+      final KeyGenerator keyGenerator,
+      final VariableSourceRecord variableSourceRecord) {
+    this.variableState = variableState;
+    this.stateWriter = stateWriter;
+    this.conditionalBehavior = conditionalBehavior;
+    this.keyGenerator = keyGenerator;
+    this.variableSourceRecord = variableSourceRecord;
+  }
+
+  public VariableBehavior withVariableSource(final VariableSourceRecord source) {
+    return new VariableBehavior(
+        variableState, stateWriter, conditionalBehavior, keyGenerator, source);
   }
 
   /**
@@ -84,7 +105,8 @@ public final class VariableBehavior {
         .setProcessInstanceKey(processInstanceKey)
         .setRootProcessInstanceKey(rootProcessInstanceKey)
         .setBpmnProcessId(bpmnProcessId)
-        .setTenantId(tenantId);
+        .setTenantId(tenantId)
+        .setSource(variableSourceRecord);
     final List<VariableEvent> variableEvents = new ArrayList<>();
     for (final DocumentEntry entry : indexedDocument) {
       applyEntryToRecord(entry);
@@ -139,7 +161,8 @@ public final class VariableBehavior {
         .setProcessInstanceKey(processInstanceKey)
         .setRootProcessInstanceKey(rootProcessInstanceKey)
         .setBpmnProcessId(bpmnProcessId)
-        .setTenantId(tenantId);
+        .setTenantId(tenantId)
+        .setSource(variableSourceRecord);
     while ((parentScope = variableState.getParentScopeKey(currentScope)) > 0) {
       final Iterator<DocumentEntry> entryIterator = indexedDocument.iterator();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.msgpack.spec.MsgpackReaderException;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -72,7 +73,8 @@ public final class VariableDocumentUpdateProcessor
     this.userTaskState = userTaskState;
     processState = processingState.getProcessState();
     this.keyGenerator = keyGenerator;
-    variableBehavior = bpmnBehaviors.variableBehavior();
+    variableBehavior =
+        bpmnBehaviors.variableBehavior().withVariableSource(VariableSourceRecord.api());
     jobBehavior = bpmnBehaviors.jobBehavior();
     userTaskBehavior = bpmnBehaviors.userTaskBehavior();
     this.writers = writers;
@@ -133,6 +135,7 @@ public final class VariableDocumentUpdateProcessor
       writers.state().appendFollowUpEvent(variableDocKey, VariableDocumentIntent.UPDATING, value);
 
       final var userTaskRecord = userTaskState.getUserTask(userTaskKey);
+
       if (hasVariables(value)) {
         userTaskRecord.setVariables(value.getVariablesBuffer()).setVariablesChanged();
       }
@@ -200,6 +203,7 @@ public final class VariableDocumentUpdateProcessor
     final long processInstanceKey = scope.getValue().getProcessInstanceKey();
     final long rootProcessInstanceKey = scope.getValue().getRootProcessInstanceKey();
     final DirectBuffer bpmnProcessId = scope.getValue().getBpmnProcessIdBuffer();
+
     try {
       if (value.getUpdateSemantics() == VariableDocumentUpdateSemantic.LOCAL) {
         variableBehavior.mergeLocalDocument(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.engine.util.RecordingTypedEventWriter;
 import io.camunda.zeebe.engine.util.RecordingTypedEventWriter.RecordedEvent;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
@@ -38,6 +39,8 @@ import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @ExtendWith(ProcessingStateExtension.class)
 final class VariableBehaviorTest {
@@ -711,6 +714,93 @@ final class VariableBehaviorTest {
                   .hasBpmnProcessId("process")
                   .hasTenantId(tenantId);
             });
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldMergeDocumentWithVariableSource(final boolean isApiSource) {
+    // given
+    final long processDefinitionKey = 1;
+    final long rootScopeKey = 1;
+    final long parentScopeKey = 2;
+    final long childScopeKey = 3;
+    final long elementInstanceKey = 42;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
+    final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    final Map<String, Object> document = Map.of("foo", "bar");
+    state.createScope(rootScopeKey, VariableState.NO_PARENT);
+    state.createScope(parentScopeKey, rootScopeKey);
+    state.createScope(childScopeKey, parentScopeKey);
+    final var variableSource =
+        isApiSource ? VariableSourceRecord.api() : VariableSourceRecord.none();
+    final var behavior = this.behavior.withVariableSource(variableSource);
+
+    // when
+    behavior.mergeDocument(
+        childScopeKey,
+        processDefinitionKey,
+        rootScopeKey,
+        rootScopeKey,
+        bpmnProcessId,
+        tenantId,
+        MsgPackUtil.asMsgPack(document));
+
+    // then
+    final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
+    assertThat(events).hasSize(1);
+    final var event = events.getFirst();
+    assertThat(event.intent).isEqualTo(VariableIntent.CREATED);
+    VariableRecordValueAssert.assertThat(event.value)
+        .hasName("foo")
+        .hasValue("\"bar\"")
+        .hasScopeKey(rootScopeKey)
+        .hasProcessDefinitionKey(processDefinitionKey)
+        .hasProcessInstanceKey(rootScopeKey)
+        .hasBpmnProcessId("process")
+        .hasSource(variableSource);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldMergeLocalDocumentWithVariableSource(final boolean isApiSource) {
+    // given
+    final long processDefinitionKey = 1;
+    final long parentScopeKey = 1;
+    final long childScopeKey = 2;
+    final long rootKey = 3;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
+    final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    final Map<String, Object> document = Map.of("foo", "bar");
+    state.createScope(parentScopeKey, VariableState.NO_PARENT);
+    state.createScope(childScopeKey, parentScopeKey);
+    final var variableSource =
+        isApiSource ? VariableSourceRecord.api() : VariableSourceRecord.none();
+    final var behavior = this.behavior.withVariableSource(variableSource);
+
+    // when
+    behavior.mergeLocalDocument(
+        childScopeKey,
+        processDefinitionKey,
+        parentScopeKey,
+        rootKey,
+        bpmnProcessId,
+        tenantId,
+        MsgPackUtil.asMsgPack(document));
+
+    // then
+    final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
+    assertThat(events).hasSize(1);
+    final var event = events.getFirst();
+    assertThat(event.intent).isEqualTo(VariableIntent.CREATED);
+    VariableRecordValueAssert.assertThat(event.value)
+        .hasName("foo")
+        .hasValue("\"bar\"")
+        .hasScopeKey(childScopeKey)
+        .hasProcessDefinitionKey(processDefinitionKey)
+        .hasProcessInstanceKey(parentScopeKey)
+        .hasBpmnProcessId("process")
+        .hasTenantId(tenantId)
+        .hasSource(variableSource);
   }
 
   @SuppressWarnings("unchecked")

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.VariableOperationType;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 
 public class VariableAddUpdateAuditLogTransformer
@@ -23,5 +24,12 @@ public class VariableAddUpdateAuditLogTransformer
   public void transform(final Record<VariableRecordValue> record, final AuditLogEntry log) {
     final VariableRecordValue value = record.getValue();
     log.setEntityDescription(value.getName());
+  }
+
+  @Override
+  public boolean supports(final Record<?> record) {
+    final VariableRecordValue value = (VariableRecordValue) record.getValue();
+    return AuditLogTransformer.super.supports(record)
+        && VariableOperationType.API.equals(value.getSource().getType());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
@@ -11,10 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableOperationType;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import org.junit.jupiter.api.Test;
@@ -26,22 +28,32 @@ class VariableAddUpdateAuditLogTransformerTest {
       new VariableAddUpdateAuditLogTransformer();
 
   @Test
+  void shouldSupportVariableRecordWithApiSource() {
+    // given
+    final var variableSource = new VariableSourceRecord().setType(VariableOperationType.API);
+    final var record = variableRecord(VariableIntent.CREATED, variableSource);
+
+    // then
+    assertThat(transformer.supports(record)).isTrue();
+  }
+
+  @Test
+  void shouldNotSupportVariableRecordWithUnknownSource() {
+    // given
+    final var record =
+        variableRecord(
+            VariableIntent.CREATED,
+            new VariableSourceRecord().setType(VariableOperationType.UNKNOWN));
+
+    // then
+    assertThat(transformer.supports(record)).isFalse();
+  }
+
+  @Test
   void shouldTransformVariableRecord() {
     // given
-    final VariableRecordValue recordValue =
-        ImmutableVariableRecordValue.builder()
-            .from(factory.generateObject(VariableRecordValue.class))
-            .withName("variable-name")
-            .withProcessDefinitionKey(456L)
-            .withBpmnProcessId("bpmn-process-id")
-            .withTenantId("tenant-1")
-            .withProcessInstanceKey(123L)
-            .withScopeKey(789L)
-            .build();
-
     final Record<VariableRecordValue> record =
-        factory.generateRecord(
-            ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+        variableRecord(VariableIntent.CREATED, VariableSourceRecord.api());
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -58,5 +70,23 @@ class VariableAddUpdateAuditLogTransformerTest {
         .isPositive()
         .isEqualTo(record.getValue().getRootProcessInstanceKey());
     assertThat(entity.getEntityDescription()).isEqualTo("variable-name");
+  }
+
+  private Record<VariableRecordValue> variableRecord(
+      final VariableIntent intent, final VariableSourceRecord variableSource) {
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("variable-name")
+            .withProcessDefinitionKey(456L)
+            .withBpmnProcessId("bpmn-process-id")
+            .withTenantId("tenant-1")
+            .withProcessInstanceKey(123L)
+            .withScopeKey(789L)
+            .withSource(variableSource)
+            .build();
+
+    return factory.generateRecord(
+        ValueType.VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -46,6 +46,9 @@
             },
             "elementInstanceKey": {
               "type": "long"
+            },
+            "source": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -52,6 +52,9 @@
             },
             "elementInstanceKey": {
               "type": "long"
+            },
+            "source": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TemplateReaderTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TemplateReaderTest.java
@@ -230,7 +230,12 @@ final class TemplateReaderTest {
                 Property.builder().long_(LongNumberProperty.builder().build()).build()),
             Map.entry(
                 "elementInstanceKey",
-                Property.builder().long_(LongNumberProperty.builder().build()).build()));
+                Property.builder().long_(LongNumberProperty.builder().build()).build()),
+            Map.entry(
+                "source",
+                Property.builder()
+                    .object(ObjectProperty.builder().enabled(false).build())
+                    .build()));
 
     assertThat(request.template().mappings())
         .as("index template request should have mappings with properties")

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -34,6 +35,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue SOURCE_KEY = new StringValue("source");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
@@ -46,9 +48,11 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final ObjectProperty<VariableSourceRecord> sourceProp =
+      new ObjectProperty<>(SOURCE_KEY, new VariableSourceRecord());
 
   public VariableRecord() {
-    super(8);
+    super(9);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
@@ -56,7 +60,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(sourceProp);
   }
 
   @Override
@@ -95,6 +100,11 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -105,8 +115,13 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   }
 
   @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
+  public VariableSourceRecord getSource() {
+    return sourceProp.getValue();
+  }
+
+  public VariableRecord setSource(final VariableSourceRecord source) {
+    sourceProp.getValue().wrap(source);
+    return this;
   }
 
   public VariableRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableSourceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableSourceRecord.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.variable;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableOperationType;
+import io.camunda.zeebe.protocol.record.value.VariableSourceValue;
+
+public class VariableSourceRecord extends UnifiedRecordValue implements VariableSourceValue {
+
+  //  public static final VariableSourceRecord API =
+  //      new VariableSourceRecord().setType(VariableOperationType.API);
+  //  public static final VariableSourceRecord NONE =
+  //      new VariableSourceRecord().setType(VariableOperationType.UNKNOWN);
+
+  private static final StringValue TYPE_KEY = new StringValue("type");
+
+  // possible enhancements documented in https://github.com/camunda/camunda/issues/46970
+  private final EnumProperty<VariableOperationType> typeProp =
+      new EnumProperty<>(TYPE_KEY, VariableOperationType.class, VariableOperationType.UNKNOWN);
+
+  public VariableSourceRecord() {
+    super(1);
+    declareProperty(typeProp);
+  }
+
+  @Override
+  public VariableOperationType getType() {
+    return typeProp.getValue();
+  }
+
+  public VariableSourceRecord setType(final VariableOperationType variableSourceType) {
+    typeProp.setValue(variableSourceType);
+    return this;
+  }
+
+  public void wrap(final VariableSourceRecord variableSourceRecord) {
+    setType(variableSourceRecord.getType());
+  }
+
+  public static VariableSourceRecord api() {
+    return new VariableSourceRecord().setType(VariableOperationType.API);
+  }
+
+  public static VariableSourceRecord none() {
+    return new VariableSourceRecord().setType(VariableOperationType.UNKNOWN);
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -89,6 +89,7 @@ import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
 import io.camunda.zeebe.protocol.record.JsonSerializable;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -1607,6 +1608,7 @@ final class JsonSerializableToJsonTest {
               final long processDefinitionKey = 4;
               final String bpmnProcessId = "process";
               final long rootProcessInstanceKey = 5;
+              final VariableSourceRecord source = VariableSourceRecord.api();
 
               return new VariableRecord()
                   .setName(wrapString(name))
@@ -1615,6 +1617,7 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(processInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
                   .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setSource(source)
                   .setRootProcessInstanceKey(rootProcessInstanceKey);
             },
         """
@@ -1627,7 +1630,10 @@ final class JsonSerializableToJsonTest {
                   "value": "1",
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 5,
-                  "elementInstanceKey": 3
+                  "elementInstanceKey": 3,
+                  "source": {
+                    "type":"API"
+                  }
                 }
                 """
       },
@@ -1644,6 +1650,7 @@ final class JsonSerializableToJsonTest {
               final long processDefinitionKey = 4;
               final String bpmnProcessId = "process";
               final long rootProcessInstanceKey = 5;
+              final VariableSourceRecord source = VariableSourceRecord.api();
 
               return new VariableRecord()
                   .setName(wrapString(name))
@@ -1652,6 +1659,7 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(processInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
                   .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setSource(source)
                   .setTenantId("tenant-test")
                   .setRootProcessInstanceKey(rootProcessInstanceKey);
             },
@@ -1665,7 +1673,10 @@ final class JsonSerializableToJsonTest {
                   "value": "1",
                   "tenantId": "tenant-test",
                   "rootProcessInstanceKey": 5,
-                  "elementInstanceKey": 3
+                  "elementInstanceKey": 3,
+                  "source": {
+                    "type":"API"
+                  }
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -34,6 +35,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue SOURCE_KEY = new StringValue("source");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
@@ -46,9 +48,11 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final ObjectProperty<VariableSourceRecord> sourceProp =
+      new ObjectProperty<>(SOURCE_KEY, new VariableSourceRecord());
 
   public VariableRecord() {
-    super(8);
+    super(9);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
@@ -56,7 +60,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(sourceProp);
   }
 
   @Override
@@ -95,6 +100,11 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -105,8 +115,13 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   }
 
   @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
+  public VariableSourceRecord getSource() {
+    return sourceProp.getValue();
+  }
+
+  public VariableRecord setSource(final VariableSourceRecord source) {
+    sourceProp.getValue().wrap(source);
+    return this;
   }
 
   public VariableRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableSourceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableSourceRecord.golden
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.variable;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableOperationType;
+import io.camunda.zeebe.protocol.record.value.VariableSourceValue;
+
+public class VariableSourceRecord extends UnifiedRecordValue implements VariableSourceValue {
+
+  public static final VariableSourceRecord API =
+      new VariableSourceRecord().setType(VariableOperationType.API);
+  public static final VariableSourceRecord NONE =
+      new VariableSourceRecord().setType(VariableOperationType.UNKNOWN);
+
+  private static final StringValue TYPE_KEY = new StringValue("type");
+
+  // possible enhancements documented in https://github.com/camunda/camunda/issues/46970
+  private final EnumProperty<VariableOperationType> typeProp =
+      new EnumProperty<>(TYPE_KEY, VariableOperationType.class, VariableOperationType.UNKNOWN);
+
+  public VariableSourceRecord() {
+    super(1);
+    declareProperty(typeProp);
+  }
+
+  @Override
+  public VariableOperationType getType() {
+    return typeProp.getValue();
+  }
+
+  public VariableSourceRecord setType(final VariableOperationType variableSourceType) {
+    typeProp.setValue(variableSourceType);
+    return this;
+  }
+
+  public void wrap(final VariableSourceRecord variableSourceRecord) {
+    setType(variableSourceRecord.getType());
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableOperationType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableOperationType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/**
+ * Defines the type of the variable operation. This is used to distinguish between variable
+ * operations that are triggered by the API and those that are triggered by other sources (e.g.,
+ * internal operations).
+ */
+public enum VariableOperationType {
+  API,
+  UNKNOWN
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
@@ -66,12 +66,6 @@ public interface VariableRecordValue
   }
 
   /**
-   * @return the BPMN process id this process instance belongs to.
-   */
-  @Override
-  String getBpmnProcessId();
-
-  /**
    * Returns the key of the root process instance in the hierarchy. For variables in top-level
    * process instances, this is equal to {@link #getProcessInstanceKey()}. For variables in child
    * process instances (created via call activities), this is the key of the topmost parent process
@@ -79,5 +73,19 @@ public interface VariableRecordValue
    *
    * @return the key of the root process instance, or {@code -1} if not set
    */
+  @Override
   long getRootProcessInstanceKey();
+
+  /**
+   * @return the BPMN process id this process instance belongs to.
+   */
+  @Override
+  String getBpmnProcessId();
+
+  /**
+   * @return the source of the variable operation, e.g. {@code VariableOperationType.API} if the
+   *     variable was triggered through the API, or {@code VariableOperationType.UNKNOWN} if the
+   *     source is unknown.
+   */
+  VariableSourceValue getSource();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableSourceValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableSourceValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * Represents the value of a variable source record, containing information about the source of a
+ * variable operation.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableVariableSourceValue.Builder.class)
+public interface VariableSourceValue extends RecordValue {
+
+  /**
+   * @return the source of the variable operation. This is used to distinguish between variable
+   *     operations that are triggered by the API and those that are triggered by other sources
+   *     (e.g., internal operations).
+   */
+  VariableOperationType getType();
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add a new VariableRecord property to specify how a VariableRecord event was created, i.e. through a direct API request, or as a follow-up event from another command, like user task complete, or process instance modification.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46701
