### PR TITLE
fix: retry on other partitions for process instance creation in REST API

### DIFF
--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -30,11 +30,14 @@ import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.service.util.TreePathParser;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.broker.RequestRetryHandler;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
@@ -65,6 +68,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -75,6 +79,8 @@ public final class ProcessInstanceServices
   private final ProcessInstanceSearchClient processInstanceSearchClient;
   private final SequenceFlowSearchClient sequenceFlowSearchClient;
   private final IncidentServices incidentServices;
+  private final RequestRetryHandler requestRetryHandler;
+  private final ExecutorService executor;
 
   public ProcessInstanceServices(
       final BrokerClient brokerClient,
@@ -94,6 +100,8 @@ public final class ProcessInstanceServices
     this.processInstanceSearchClient = processInstanceSearchClient;
     this.sequenceFlowSearchClient = sequenceFlowSearchClient;
     this.incidentServices = incidentServices;
+    requestRetryHandler = new RequestRetryHandler(brokerClient, brokerClient.getTopologyManager());
+    executor = executorProvider.getExecutor();
   }
 
   @Override
@@ -229,7 +237,7 @@ public final class ProcessInstanceServices
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
     }
-    return sendBrokerRequest(brokerRequest);
+    return sendRequestWithRetryPartitions(brokerRequest);
   }
 
   public CompletableFuture<ProcessInstanceResultRecord> createProcessInstanceWithResult(
@@ -255,9 +263,10 @@ public final class ProcessInstanceServices
 
     // Use custom request timeout if provided, otherwise use default
     if (request.requestTimeout() != null && request.requestTimeout() > 0) {
-      return sendBrokerRequest(brokerRequest, Duration.ofMillis(request.requestTimeout()));
+      return sendRequestWithRetryPartitions(
+          brokerRequest, Duration.ofMillis(request.requestTimeout()));
     }
-    return sendBrokerRequest(brokerRequest);
+    return sendRequestWithRetryPartitions(brokerRequest);
   }
 
   public CompletableFuture<ProcessInstanceRecord> cancelProcessInstance(
@@ -432,6 +441,39 @@ public final class ProcessInstanceServices
                                 .build())
                         .page(query.page())
                         .sort(query.sort())));
+  }
+
+  private <R> CompletableFuture<R> sendRequestWithRetryPartitions(
+      final BrokerRequest<R> brokerRequest) {
+    return sendRequestWithRetryPartitions(brokerRequest, null);
+  }
+
+  private <R> CompletableFuture<R> sendRequestWithRetryPartitions(
+      final BrokerRequest<R> brokerRequest, final Duration requestTimeout) {
+    final var brokerRequestAuthorization =
+        brokerRequestAuthorizationConverter.convert(authentication);
+    brokerRequest.setAuthorization(brokerRequestAuthorization);
+    final CompletableFuture<R> responseFuture = new CompletableFuture<>();
+    if (requestTimeout != null) {
+      requestRetryHandler.sendRequest(
+          brokerRequest,
+          (key, response) -> responseFuture.complete(response),
+          responseFuture::completeExceptionally,
+          requestTimeout);
+    } else {
+      requestRetryHandler.sendRequest(
+          brokerRequest,
+          (key, response) -> responseFuture.complete(response),
+          responseFuture::completeExceptionally);
+    }
+    return responseFuture.handleAsync(
+        (response, error) -> {
+          if (error != null) {
+            throw ErrorMapper.mapError(error);
+          }
+          return response;
+        },
+        executor);
   }
 
   public record ProcessInstanceCreateRequest(

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -14,6 +14,7 @@ import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -45,24 +46,40 @@ import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.api.util.StubbedTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateBatchOperationRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteHistoryRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationMoveInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import java.net.ConnectException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Stream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 
 public final class ProcessInstanceServiceTest {
@@ -708,5 +725,261 @@ public final class ProcessInstanceServiceTest {
                     .BrokerCreateProcessInstanceWithResultRequest.class));
     verify(brokerClient, org.mockito.Mockito.never())
         .sendRequest(any(), any(java.time.Duration.class));
+  }
+
+  @Nested
+  @DisplayName("Retry on different partitions")
+  class RetryPartitionsTest {
+
+    private static Stream<Named<Throwable>> retryableErrors() {
+      return Stream.of(
+          Named.of(
+              "PARTITION_LEADER_MISMATCH",
+              new BrokerErrorException(
+                  new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "leader mismatch"))),
+          Named.of(
+              "RESOURCE_EXHAUSTED",
+              new BrokerErrorException(
+                  new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "resource exhausted"))),
+          Named.of("ConnectException", new ConnectException("connection refused")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryableErrors")
+    void shouldRetryCreateProcessInstanceOnRetryableError(final Throwable retryableError) {
+      // given
+      final var request = createProcessInstanceRequest(null);
+      final var mockResponse = new ProcessInstanceCreationRecord();
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                if (triedPartitions.size() == 1) {
+                  return CompletableFuture.failedFuture(retryableError);
+                }
+                return CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse));
+              });
+
+      // when
+      final var result = services.createProcessInstance(request).join();
+
+      // then - retried on a different partition and succeeded
+      assertThat(result).isNotNull();
+      assertThat(triedPartitions).hasSize(2);
+      assertThat(triedPartitions.get(0)).isNotEqualTo(triedPartitions.get(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryableErrors")
+    void shouldRetryCreateProcessInstanceWithResultOnRetryableError(
+        final Throwable retryableError) {
+      // given
+      final var request = createProcessInstanceWithResultRequest(null, null);
+      final var mockResponse = new ProcessInstanceResultRecord();
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceWithResultRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceWithResultRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                if (triedPartitions.size() == 1) {
+                  return CompletableFuture.failedFuture(retryableError);
+                }
+                return CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse));
+              });
+
+      // when
+      final var result = services.createProcessInstanceWithResult(request).join();
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(triedPartitions).hasSize(2);
+      assertThat(triedPartitions.get(0)).isNotEqualTo(triedPartitions.get(1));
+    }
+
+    @Test
+    void shouldExhaustRetriesForCreateProcessInstanceWhenAllPartitionsFail() {
+      // given - topology has 3 partitions, all fail with retryable errors
+      final var request = createProcessInstanceRequest(null);
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                return CompletableFuture.failedFuture(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "leader mismatch")));
+              });
+
+      // when / then - all 3 partitions tried with distinct IDs, then RESOURCE_EXHAUSTED error
+      assertThatThrownBy(() -> services.createProcessInstance(request).join())
+          .isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(ServiceException.class)
+          .extracting(Throwable::getCause)
+          .satisfies(
+              cause -> {
+                final var serviceException = (ServiceException) cause;
+                assertThat(serviceException.getStatus()).isEqualTo(Status.RESOURCE_EXHAUSTED);
+              });
+      assertThat(triedPartitions).hasSize(3);
+      assertThat(triedPartitions).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void shouldExhaustRetriesForCreateProcessInstanceWithResultWhenAllPartitionsFail() {
+      // given
+      final var request = createProcessInstanceWithResultRequest(null, null);
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceWithResultRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceWithResultRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                return CompletableFuture.failedFuture(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "resource exhausted")));
+              });
+
+      // when / then
+      assertThatThrownBy(() -> services.createProcessInstanceWithResult(request).join())
+          .isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(ServiceException.class)
+          .extracting(Throwable::getCause)
+          .satisfies(
+              cause -> {
+                final var serviceException = (ServiceException) cause;
+                assertThat(serviceException.getStatus()).isEqualTo(Status.RESOURCE_EXHAUSTED);
+              });
+      assertThat(triedPartitions).hasSize(3);
+      assertThat(triedPartitions).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void shouldNotRetryCreateProcessInstanceOnNonRetryableError() {
+      // given - a non-retryable error like PROCESS_NOT_FOUND
+      final var request = createProcessInstanceRequest(null);
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenReturn(
+              CompletableFuture.failedFuture(
+                  new BrokerErrorException(
+                      new BrokerError(ErrorCode.PROCESS_NOT_FOUND, "process not found"))));
+
+      // when / then - only tried once, no retry
+      assertThatThrownBy(() -> services.createProcessInstance(request).join())
+          .isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(ServiceException.class);
+      verify(brokerClient, times(1)).sendRequest(any(BrokerCreateProcessInstanceRequest.class));
+    }
+
+    @Test
+    void shouldNotRetryCreateProcessInstanceWhenBusinessIdIsSet() {
+      // given - businessId is set, so a fixed dispatch strategy is used (no retry across
+      // partitions)
+      final var request = createProcessInstanceRequest("my-business-id");
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenReturn(CompletableFuture.failedFuture(new ConnectException("connection refused")));
+
+      // when / then - only one attempt, error propagated directly without retrying other
+      // partitions
+      assertThatThrownBy(() -> services.createProcessInstance(request).join())
+          .isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(ServiceException.class);
+      verify(brokerClient, times(1)).sendRequest(any(BrokerCreateProcessInstanceRequest.class));
+    }
+
+    @Test
+    void shouldRetryCreateProcessInstanceWithResultUsingCustomTimeout() {
+      // given
+      final var request = createProcessInstanceWithResultRequest(600_000L, null);
+      final var mockResponse = new ProcessInstanceResultRecord();
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(
+              any(BrokerCreateProcessInstanceWithResultRequest.class),
+              eq(java.time.Duration.ofMillis(600_000L))))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceWithResultRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                if (triedPartitions.size() == 1) {
+                  return CompletableFuture.failedFuture(
+                      new BrokerErrorException(
+                          new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "leader mismatch")));
+                }
+                return CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse));
+              });
+
+      // when
+      final var result = services.createProcessInstanceWithResult(request).join();
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(triedPartitions).hasSize(2);
+      assertThat(triedPartitions.get(0)).isNotEqualTo(triedPartitions.get(1));
+      verify(brokerClient, times(2))
+          .sendRequest(
+              any(BrokerCreateProcessInstanceWithResultRequest.class),
+              eq(java.time.Duration.ofMillis(600_000L)));
+    }
+
+    @Test
+    void shouldNotRetryCreateProcessInstanceWithResultWhenBusinessIdIsSet() {
+      // given - businessId is set, so a fixed dispatch strategy is used
+      final var request = createProcessInstanceWithResultRequest(null, "my-business-id");
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceWithResultRequest.class)))
+          .thenReturn(CompletableFuture.failedFuture(new ConnectException("connection refused")));
+
+      // when / then - only one attempt
+      assertThatThrownBy(() -> services.createProcessInstanceWithResult(request).join())
+          .isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(ServiceException.class);
+      verify(brokerClient, times(1))
+          .sendRequest(any(BrokerCreateProcessInstanceWithResultRequest.class));
+    }
+
+    private ProcessInstanceServices.ProcessInstanceCreateRequest createProcessInstanceRequest(
+        final String businessId) {
+      return new ProcessInstanceServices.ProcessInstanceCreateRequest(
+          123L, // processDefinitionKey
+          "test-process", // bpmnProcessId
+          -1, // version
+          null, // variables
+          "<default>", // tenantId
+          false, // awaitCompletion
+          null, // requestTimeout
+          null, // operationReference
+          List.of(), // startInstructions
+          List.of(), // runtimeInstructions
+          List.of(), // fetchVariables
+          null, // tags
+          businessId // businessId
+          );
+    }
+
+    private ProcessInstanceServices.ProcessInstanceCreateRequest
+        createProcessInstanceWithResultRequest(final Long requestTimeout, final String businessId) {
+      return new ProcessInstanceServices.ProcessInstanceCreateRequest(
+          123L, // processDefinitionKey
+          "test-process", // bpmnProcessId
+          -1, // version
+          null, // variables
+          "<default>", // tenantId
+          true, // awaitCompletion
+          requestTimeout, // requestTimeout
+          null, // operationReference
+          List.of(), // startInstructions
+          List.of(), // runtimeInstructions
+          List.of(), // fetchVariables
+          null, // tags
+          businessId // businessId
+          );
+    }
   }
 }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -46,6 +46,7 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.gateway.api.util.StubbedTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteHistoryRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -93,6 +94,7 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(incidentServices);
     securityContextProvider = mock(SecurityContextProvider.class);
     brokerClient = mock(BrokerClient.class);
+    when(brokerClient.getTopologyManager()).thenReturn(new StubbedTopologyManager(3));
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);


### PR DESCRIPTION
## Description

Fixes a partition retry inconsistency between the gRPC and REST gateways for process instance creation.

### Problem

The REST gateway (`ProcessInstanceServices`) used `ApiServices.sendBrokerRequest()` to handle `createProcessInstance` and `createProcessInstanceWithResult` requests. This method calls `brokerClient.sendRequest()` directly and does **not** perform any partition-level retry logic — if the request fails due to a transient partition error, the failure is immediately propagated to the caller.

In contrast, the gRPC gateway (`EndpointManager`) uses `sendRequestWithRetryPartitions` via `RequestRetryHandler`, which automatically retries requests on different partitions when certain transient errors occur:
- **`ConnectException`** — partition leader unreachable
- **`PARTITION_LEADER_MISMATCH`** — targeted broker is no longer the leader
- **`RESOURCE_EXHAUSTED`** — partition under backpressure

This inconsistency was identified as an oversight during the original REST gateway implementation (see [discussion](https://github.com/camunda/camunda/pull/46554#discussion_r2845914481)).

### Solution

This PR introduces `sendRequestWithRetryPartitions` to the `ProcessInstanceServices` base class, reusing the existing `RequestRetryHandler` from the gateway module. The method is provided in two overloads (with and without a custom request timeout), matching the existing `sendBrokerRequest` signatures.

`ProcessInstanceServices.createProcessInstance` and `createProcessInstanceWithResult` are updated to use `sendRequestWithRetryPartitions` instead of `sendBrokerRequest`, making the REST API path consistent with the gRPC gateway behavior.

## Related issues

closes #46756
