### PR TITLE
feat: backport user task PIM frontend warnings to stable/8.8

### DIFF
--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/index.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library.ts';
+import {EmbeddedFormWarningNotification} from './index.tsx';
+
+describe('EmbeddedFormWarningNotification', () => {
+  it('should render warning notification with correct content', () => {
+    render(<EmbeddedFormWarningNotification />);
+
+    expect(
+      screen.getByText(
+        'Embedded forms in the source user tasks will be replaced by the form defined in the target element.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render link to documentation', () => {
+    render(<EmbeddedFormWarningNotification />);
+
+    const link = screen.getByRole('link', {
+      name: 'Learn more about migration of user tasks with embedded forms',
+    });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      'https://docs.camunda.io/docs/components/concepts/process-instance-migration/#migrate-job-worker-user-tasks-to-camunda-user-tasks',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+});

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/index.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Callout, Link, Tile} from '@carbon/react';
+
+const EmbeddedFormWarningNotification: React.FC = () => {
+  return (
+    <Tile>
+      <Callout
+        kind="warning"
+        subtitle="Embedded forms in the source user tasks will be replaced by the form defined in the target element."
+        lowContrast
+      >
+        <Link
+          aria-describedby="documentation-link"
+          href="https://docs.camunda.io/docs/components/concepts/process-instance-migration/#migrate-job-worker-user-tasks-to-camunda-user-tasks"
+          target="_blank"
+        >
+          Learn more about migration of user tasks with embedded forms
+        </Link>
+      </Callout>
+    </Tile>
+  );
+};
+
+export {EmbeddedFormWarningNotification};

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/index.tsx
@@ -6,25 +6,27 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Callout, Link, Tile} from '@carbon/react';
+import {ActionableNotification, Link} from '@carbon/react';
 
 const EmbeddedFormWarningNotification: React.FC = () => {
   return (
-    <Tile>
-      <Callout
-        kind="warning"
-        subtitle="Embedded forms in the source user tasks will be replaced by the form defined in the target element."
-        lowContrast
+    <ActionableNotification
+      kind="warning"
+      title=""
+      subtitle="Embedded forms in the source user tasks will be replaced by the form defined in the target element."
+      hideCloseButton
+      hasFocus={false}
+      lowContrast={true}
+      inline
+    >
+      <Link
+        aria-describedby="documentation-link"
+        href="https://docs.camunda.io/docs/components/concepts/process-instance-migration/#migrate-job-worker-user-tasks-to-camunda-user-tasks"
+        target="_blank"
       >
-        <Link
-          aria-describedby="documentation-link"
-          href="https://docs.camunda.io/docs/components/concepts/process-instance-migration/#migrate-job-worker-user-tasks-to-camunda-user-tasks"
-          target="_blank"
-        >
-          Learn more about migration of user tasks with embedded forms
-        </Link>
-      </Callout>
-    </Tile>
+        Learn more about migration of user tasks with embedded forms
+      </Link>
+    </ActionableNotification>
   );
 };
 

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/index.tsx
@@ -6,7 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ActionableNotification, Link} from '@carbon/react';
+import {Link} from '@carbon/react';
+import {ActionableNotification} from './styled';
 
 const EmbeddedFormWarningNotification: React.FC = () => {
   return (
@@ -18,6 +19,7 @@ const EmbeddedFormWarningNotification: React.FC = () => {
       hasFocus={false}
       lowContrast={true}
       inline
+      actionButtonLabel=""
     >
       <Link
         aria-describedby="documentation-link"

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/styled.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/EmbeddedFormWarningNotification/styled.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {ActionableNotification as BaseActionableNotification} from '@carbon/react';
+
+const ActionableNotification = styled(BaseActionableNotification)`
+  margin: var(--cds-spacing-03);
+`;
+
+export {ActionableNotification};

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
@@ -8,7 +8,7 @@
 
 import {useEffect, useMemo} from 'react';
 import {observer} from 'mobx-react';
-import {SelectItem, Stack, Tag, Toggle} from '@carbon/react';
+import {SelectItem, Stack, Tag, Toggle, Tooltip} from '@carbon/react';
 
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
 import {processInstanceMigrationMappingStore} from 'modules/stores/processInstanceMigrationMapping';
@@ -24,10 +24,14 @@ import {
   SourceElementName,
   ArrowRight,
   ToggleContainer,
+  WarningFilled,
 } from './styled';
 import {useMigrationSourceXml} from 'modules/queries/processDefinitions/useMigrationSourceXml';
 import {useMigrationTargetXml} from 'modules/queries/processDefinitions/useMigrationTargetXml';
 import {processesStore} from 'modules/stores/processes/processes.migration';
+import {hasEmbeddedForm} from 'modules/bpmn-js/utils/hasEmbeddedForm';
+import {isCamundaUserTask} from 'modules/bpmn-js/utils/isCamundaUserTask';
+import {EmbeddedFormWarningNotification} from './EmbeddedFormWarningNotification';
 
 const TOGGLE_LABEL = 'Show only not mapped';
 
@@ -37,6 +41,7 @@ const BottomPanel: React.FC = observer(() => {
   const handleCheckIsRowSelected = (selectedSourceFlowNodes?: string[]) => {
     return (rowId: string) => selectedSourceFlowNodes?.includes(rowId) ?? false;
   };
+
   const {
     updateElementMapping,
     clearElementMapping,
@@ -133,6 +138,35 @@ const BottomPanel: React.FC = observer(() => {
     sourceData?.selectableSequenceFlows &&
     sourceData.selectableSequenceFlows.length > 0;
 
+  /**
+   * Returns true if sourceElement and targetElement is migration from embedded form to Camunda user task
+   */
+  const isEmbeddedFormMigration = (
+    sourceElement: string,
+    targetElement: string | undefined,
+  ) => {
+    const sourceBusinessObject = sourceData?.selectableFlowNodes.find(
+      (element) => element.id === sourceElement,
+    );
+    const targetBusinessObject = targetData?.selectableFlowNodes.find(
+      (element) => element.id === targetElement,
+    );
+    return (
+      isTargetSelected &&
+      hasEmbeddedForm(sourceBusinessObject) &&
+      isCamundaUserTask(targetBusinessObject)
+    );
+  };
+
+  /**
+   * Returns true if any of the mapped elements is migration from embedded form to Camunda user task
+   */
+  const hasAnyEmbeddedFormMigration = () => {
+    return Object.entries(elementMapping).some(([sourceId, targetId]) =>
+      isEmbeddedFormMigration(sourceId, targetId),
+    );
+  };
+
   // Automatically map elements with same id and type in source and target diagrams
   useEffect(() => {
     clearElementMapping();
@@ -199,6 +233,20 @@ const BottomPanel: React.FC = observer(() => {
                   id: sourceElement.id,
                   sourceElement: (
                     <LeftColumn>
+                      {isEmbeddedFormMigration(
+                        sourceElement.id,
+                        elementMapping[sourceElement.id] ?? '',
+                      ) && (
+                        <Tooltip
+                          label={
+                            'Embedded form in this user task will be replaced by the form defined in the target element.'
+                          }
+                          align="right-bottom"
+                          leaveDelayMs={50}
+                        >
+                          <WarningFilled />
+                        </Tooltip>
+                      )}
                       <SourceElementName>
                         {sourceElement.name ?? sourceElement.id}
                       </SourceElementName>
@@ -258,6 +306,9 @@ const BottomPanel: React.FC = observer(() => {
             )}
           />
         </>
+      )}
+      {isTargetSelected && hasAnyEmbeddedFormMigration() && (
+        <EmbeddedFormWarningNotification />
       )}
     </BottomSection>
   );

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
@@ -238,11 +238,10 @@ const BottomPanel: React.FC = observer(() => {
                         elementMapping[sourceElement.id] ?? '',
                       ) && (
                         <Tooltip
-                          label={
+                          description={
                             'Embedded form in this user task will be replaced by the form defined in the target element.'
                           }
-                          align="right-bottom"
-                          leaveDelayMs={50}
+                          align="bottom-left"
                         >
                           <WarningFilled />
                         </Tooltip>

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/styled.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/styled.tsx
@@ -7,10 +7,11 @@
  */
 
 import styled from 'styled-components';
-import {supportSuccess} from '@carbon/elements';
+import {spacing03, supportSuccess, supportWarning} from '@carbon/elements';
 import {
   CheckmarkFilled as BaseCheckmark,
   ArrowRight as BaseArrowRight,
+  WarningFilled as BaseWarningFilled,
 } from '@carbon/react/icons';
 import {DataTable as BaseDataTable} from 'modules/components/DataTable';
 import {Select as BaseSelect} from '@carbon/react';
@@ -63,6 +64,16 @@ const ErrorMessageContainer = styled.div`
   height: 100%;
 `;
 
+const WarningFilled = styled(BaseWarningFilled)`
+  fill: ${supportWarning};
+  margin-right: ${spacing03};
+
+  [data-icon-path='inner-path'] {
+    opacity: 1;
+    fill: black;
+  }
+`;
+
 const CheckmarkFilled = styled(BaseCheckmark)`
   color: ${supportSuccess};
 `;
@@ -88,4 +99,5 @@ export {
   Select,
   IconContainer,
   ToggleContainer,
+  WarningFilled,
 };

--- a/operate/client/src/modules/bpmn-js/utils/hasEmbeddedForm.test.ts
+++ b/operate/client/src/modules/bpmn-js/utils/hasEmbeddedForm.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {hasEmbeddedForm} from './hasEmbeddedForm';
+import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+describe('hasEmbeddedForm', () => {
+  it('should return false for non-user tasks', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:ServiceTask',
+      id: 'task1',
+      name: 'Task 1',
+    };
+
+    expect(hasEmbeddedForm(businessObject)).toBe(false);
+  });
+
+  it('should return false for Zeebe user tasks without formKey', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:userTask',
+          },
+        ],
+      },
+    };
+
+    expect(hasEmbeddedForm(businessObject)).toBe(false);
+  });
+
+  it('should return false for Zeebe user tasks with formKey', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:userTask',
+          },
+          {
+            $type: 'zeebe:formDefinition',
+            formKey: 'camunda-forms:bpmn:myForm',
+          },
+        ],
+      },
+    };
+
+    expect(hasEmbeddedForm(businessObject)).toBe(false);
+  });
+
+  it('should return true for job-based user tasks with embedded form', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:formDefinition',
+            formKey: 'camunda-forms:bpmn:myForm',
+          },
+        ],
+      },
+    };
+
+    expect(hasEmbeddedForm(businessObject)).toBe(true);
+  });
+
+  it('should return false for job-based user tasks without formKey', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:taskDefinition',
+            type: 'myTaskType',
+          },
+        ],
+      },
+    };
+
+    expect(hasEmbeddedForm(businessObject)).toBe(false);
+  });
+
+  it('should return false for user tasks without extension elements', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+    };
+
+    expect(hasEmbeddedForm(businessObject)).toBe(false);
+  });
+
+  it('should return false for formKey that is an external form reference', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:formDefinition',
+            formKey: 'localhost:3000/myForm',
+          },
+        ],
+      },
+    };
+
+    expect(hasEmbeddedForm(businessObject)).toBe(false);
+  });
+});

--- a/operate/client/src/modules/bpmn-js/utils/hasEmbeddedForm.ts
+++ b/operate/client/src/modules/bpmn-js/utils/hasEmbeddedForm.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+/**
+ * Checks if a user task has an embedded form.
+ *
+ * @param businessObject - The BPMN business object to check
+ * @returns true if the element is a job-based user task with an embedded form
+ */
+const hasEmbeddedForm = (businessObject?: BusinessObject): boolean => {
+  if (businessObject?.$type !== 'bpmn:UserTask') {
+    return false;
+  }
+
+  const hasZeebeUserTask =
+    businessObject.extensionElements?.values?.some(
+      (element) => element.$type === 'zeebe:userTask',
+    ) ?? false;
+
+  if (hasZeebeUserTask) {
+    return false;
+  }
+
+  const formDefinition = businessObject.extensionElements?.values?.find(
+    (element) => element.$type === 'zeebe:formDefinition',
+  );
+  return (
+    formDefinition?.formKey !== undefined &&
+    formDefinition?.formKey.toLowerCase().startsWith('camunda-forms:bpmn:')
+  );
+};
+
+export {hasEmbeddedForm};

--- a/operate/client/src/modules/bpmn-js/utils/isCamundaUserTask.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isCamundaUserTask.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+/**
+ * Checks if a user task is a Camunda user task.
+ *
+ * @param businessObject - The BPMN business object to check
+ * @returns true if the element is a Camunda user task
+ */
+const isCamundaUserTask = (businessObject?: BusinessObject): boolean => {
+  if (businessObject?.$type !== 'bpmn:UserTask') {
+    return false;
+  }
+
+  return (
+    businessObject.extensionElements?.values?.some(
+      (element) => element.$type === 'zeebe:userTask',
+    ) ?? false
+  );
+};
+
+export {isCamundaUserTask};

--- a/operate/client/src/modules/types/bpmn-js.d.ts
+++ b/operate/client/src/modules/types/bpmn-js.d.ts
@@ -79,6 +79,8 @@ declare module 'bpmn-js/lib/NavigatedViewer' {
     extensionElements?: {
       values: {
         $type: string;
+        type?: string;
+        formKey?: string;
         $children?: {
           $type: string;
           source: string;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backport of the frontend warnings of the user task PIM feature.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/44181 and https://github.com/camunda/camunda/issues/40374
