### PR TITLE
fix: prevent process details popover text from overflowing

### DIFF
--- a/optimize/client/src/modules/components/Popover/Popover.scss
+++ b/optimize/client/src/modules/components/Popover/Popover.scss
@@ -17,7 +17,7 @@
   > .cds--popover > .popoverContent {
     @include theme.theme(themes.$g10);
     padding: spacing.$spacing-05;
-
+    overflow-wrap: break-word;
     &.scrollable {
       @include scrollable;
     }


### PR DESCRIPTION
## Description

When a report’s process name is a very long string with no spaces, the process details popover overflows its container on the shared report page.

This PR includes :-
- Updated .popoverContent styles to allow long, space-less strings to wrap
  instead of overflowing.

## Screenshots

Before:
  
<img width="1566" height="942" alt="image" src="https://github.com/user-attachments/assets/691c161f-2d42-49d9-a839-e4df7e5bf98d" />

After:

<img width="481" height="506" alt="Screenshot 2026-02-25 at 3 48 26 PM" src="https://github.com/user-attachments/assets/69f12418-a366-4fec-93dd-2b788c8e8c3f" />

- Verified shared report popover with:
  - Short name with spaces.
  - Long name with spaces.
  - Long name without spaces (original failing case).
  - Different window widths and browser zoom levels.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #29613
