### PR TITLE
Optimize Opt-in JWT bearer authentication

### DIFF
--- a/optimize/backend/BACKEND_AUTH.md
+++ b/optimize/backend/BACKEND_AUTH.md
@@ -1,0 +1,262 @@
+# Optimize — JWT Bearer Token Authentication for `/api/**`
+
+By default, Optimize's non-public REST API (`/api/**`) only accepts requests authenticated
+via an Identity session cookie (browser login flow). This guide explains how to enable
+**JWT bearer token authentication** so that any HTTP client can call those endpoints directly
+using a standard `Authorization: Bearer <token>` header.
+
+---
+
+## How it works
+
+When `jwtAuthForApiEnabled` is `true`, Optimize enables Spring Security's built-in
+`oauth2ResourceServer` support, which adds `BearerTokenAuthenticationFilter` to the security
+chain. The cookie filter runs before it (at a lower order). On every request that carries an
+`Authorization: Bearer` header the bearer filter:
+
+1. Validates the JWT signature, expiry, and audience against the configured Keycloak JWK Set URI.
+2. On success — places a `JwtAuthenticationToken` in the `SecurityContextHolder`; `SessionService`
+   resolves the authenticated user directly from that token, skipping cookie extraction.
+3. On failure — immediately returns `401 Unauthorized`; the request does not fall back to
+   cookie-based authentication, even though the cookie filter runs earlier in the chain (a bad
+   bearer header is never silently ignored, per RFC 6750 §3.1).
+
+Requests without a `Bearer` header are unaffected and continue to use the cookie flow.
+
+---
+
+## Prerequisites
+
+|         Requirement         |                                     Details                                      |
+|-----------------------------|----------------------------------------------------------------------------------|
+| Keycloak running            | Default local URL: `http://localhost:18080`                                      |
+| Optimize running            | Default local URL: `http://localhost:8090`                                       |
+| `jq` installed              | Used to parse JSON responses in the shell examples                               |
+| Optimize client in Keycloak | Pre-configured by Identity (`client_id=optimize`, `secret=demo-optimize-secret`) |
+
+---
+
+## Step 1 — Enable Direct Access Grants on the Optimize Keycloak client
+
+The Optimize Keycloak client has Direct Access Grants (Resource Owner Password Credentials)
+disabled by default. Enable it via the Keycloak Admin API:
+
+```bash
+# 1. Obtain a Keycloak admin token
+ADMIN_TOKEN=$(curl -s -X POST \
+  "http://localhost:18080/auth/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password" \
+  -d "client_id=admin-cli" \
+  -d "username=admin" \
+  -d "password=admin" \
+  | jq -r '.access_token')
+
+# 2. Resolve the internal UUID of the 'optimize' client
+CLIENT_UUID=$(curl -s \
+  "http://localhost:18080/auth/admin/realms/camunda-platform/clients?clientId=optimize" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  | jq -r '.[0].id')
+
+# 3. Patch the client to enable Direct Access Grants
+curl -s -X PUT \
+  "http://localhost:18080/auth/admin/realms/camunda-platform/clients/$CLIENT_UUID" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"directAccessGrantsEnabled": true}'
+```
+
+> **Note:** This change persists in Keycloak until reverted. It is safe for local development
+> but should be evaluated carefully before enabling in a shared or production environment.
+
+---
+
+## Step 2 — Configure Optimize
+
+Two properties must be set. Both can be provided as environment variables, YAML overrides,
+or Java system properties.
+
+### Required properties
+
+|                        Property                         |                                           Description                                           |
+|---------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED`                 | Enables JWT bearer auth for `/api/**`. Default: `false`                                         |
+| `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI` | Keycloak JWK Set URI used to validate token signatures                                          |
+| `CAMUNDA_OPTIMIZE_API_AUDIENCE`                         | Must match the `aud` claim in the token. Default: `optimize`. For this setup use `optimize-api` |
+
+### Option A — Environment variables (recommended for containers / local run)
+
+```bash
+export CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED=true
+export SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
+export CAMUNDA_OPTIMIZE_API_AUDIENCE=optimize-api
+```
+
+### Option B — `environment-config.yaml` override file
+
+Place this file alongside the Optimize distribution or in the working directory:
+
+```yaml
+api:
+  jwtAuthForApiEnabled: true
+  jwtSetUri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+  audience: "optimize-api"
+```
+
+### Option C — Java system properties (IDE / `java -jar`)
+
+```bash
+java \
+  -DCAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED=true \
+  -DSPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/certs \
+  -DCAMUNDA_OPTIMIZE_API_AUDIENCE=optimize-api \
+  -jar optimize.jar
+```
+
+### Option D — Docker / Docker Compose
+
+```yaml
+services:
+  optimize:
+    image: camunda/optimize:latest
+    environment:
+      CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED: "true"
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+      CAMUNDA_OPTIMIZE_API_AUDIENCE: "optimize-api"
+```
+
+> **Note:** When Optimize and Keycloak run in the same Docker network, replace `localhost`
+> with the Keycloak service name (e.g. `keycloak`).
+
+---
+
+## Step 3 — Obtain a JWT token
+
+After enabling Direct Access Grants (Step 1) and restarting Optimize with the new config
+(Step 2), obtain a token for a Keycloak user:
+
+```bash
+TOKEN=$(curl -s -X POST \
+  "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password" \
+  -d "client_id=optimize" \
+  -d "client_secret=demo-optimize-secret" \
+  -d "username=demo" \
+  -d "password=demo" \
+  | jq -r '.access_token')
+
+echo $TOKEN
+```
+
+The `demo` user and `demo-optimize-secret` are the defaults from the local Identity preset.
+Adjust if your environment uses different credentials.
+
+---
+
+## Step 4 — Call the Optimize API
+
+Pass the token as a standard Bearer header:
+
+```bash
+# Health check (always public, useful to verify connectivity)
+curl -s "http://localhost:8090/api/readyz"
+
+# Management dashboard (requires auth)
+curl -s \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8090/api/dashboard/management" | jq .
+
+# Specific dashboard by ID
+curl -s \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8090/api/dashboard/<dashboard-id>" | jq .
+
+# List reports (public API — requires separate M2M token, see /api/public docs)
+curl -s \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8090/api/report" | jq .
+```
+
+---
+
+## Step 5 — Disable when done (optional)
+
+Set the flag back to `false` and restart Optimize. All `/api/**` endpoints will revert to
+cookie-only authentication. No `BearerTokenAuthenticationFilter` is registered, so requests
+without a cookie are rejected at the authorization layer as before.
+
+```bash
+export CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED=false
+```
+
+To also revoke Direct Access Grants in Keycloak:
+
+```bash
+ADMIN_TOKEN=$(curl -s -X POST \
+  "http://localhost:18080/auth/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password" \
+  -d "client_id=admin-cli" \
+  -d "username=admin" \
+  -d "password=admin" \
+  | jq -r '.access_token')
+
+CLIENT_UUID=$(curl -s \
+  "http://localhost:18080/auth/admin/realms/camunda-platform/clients?clientId=optimize" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  | jq -r '.[0].id')
+
+curl -s -X PUT \
+  "http://localhost:18080/auth/admin/realms/camunda-platform/clients/$CLIENT_UUID" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"directAccessGrantsEnabled": false}'
+```
+
+---
+
+## Reference
+
+### Configuration properties summary
+
+|          YAML key          |                  Environment variable                   |  Default   |                               Description                                |
+|----------------------------|---------------------------------------------------------|------------|--------------------------------------------------------------------------|
+| `api.jwtAuthForApiEnabled` | `CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED`                 | `false`    | Enable JWT bearer auth for `/api/**`                                     |
+| `api.jwtSetUri`            | `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI` | `null`     | Keycloak JWK Set URI. **Required** when flag is `true`                   |
+| `api.audience`             | `CAMUNDA_OPTIMIZE_API_AUDIENCE`                         | `optimize` | Expected `aud` claim in the token. Must be `optimize-api` for this setup |
+
+### Default local Keycloak endpoints
+
+|     Purpose     |                                         URL                                         |
+|-----------------|-------------------------------------------------------------------------------------|
+| Token endpoint  | `http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token` |
+| JWK Set (certs) | `http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/certs` |
+| Admin API       | `http://localhost:18080/auth/admin/realms/camunda-platform`                         |
+
+### Endpoints that remain public (no auth required)
+
+These endpoints are always accessible regardless of the flag:
+
+|              Endpoint              |                       Description                       |
+|------------------------------------|---------------------------------------------------------|
+| `GET /api/readyz`                  | Health / readiness probe                                |
+| `GET /api/authentication/callback` | Identity OIDC redirect callback                         |
+| `GET /api/authentication/logout`   | Session logout (must work with expired tokens)          |
+| `GET /api/ui-configuration`        | UI bootstrap configuration                              |
+| `GET /api/localization`            | Locale files                                            |
+| `/api/external/**`                 | Public share API (dashboards / reports shared publicly) |
+| `/external/**`                     | Public share UI resources                               |
+| `/actuator/**`                     | Spring Boot Actuator (management port `8092`)           |
+
+### Troubleshooting
+
+|                          Symptom                           |                     Likely cause                      |                             Fix                              |
+|------------------------------------------------------------|-------------------------------------------------------|--------------------------------------------------------------|
+| `401` with a valid token                                   | `audience` mismatch                                   | Set `CAMUNDA_OPTIMIZE_API_AUDIENCE=optimize-api`             |
+| `401` with `"Client not allowed for direct access grants"` | Direct Access Grants disabled                         | Run Step 1                                                   |
+| `401` with no error body                                   | Flag is `false`                                       | Set `CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED=true` and restart |
+| `500 IllegalStateException` on startup                     | `jwtSetUri` not set while flag is `true`              | Set `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI`  |
+| Token obtained but still `401`                             | Token expired                                         | Re-run Step 3 to get a fresh token                           |
+| `NoResourceFoundException`                                 | Wrong port — hitting actuator (`8092`) instead of app | Use port `8090` (HTTP) or `8091` (HTTPS)                     |
+

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.rest.security.ccsm;
 import static io.camunda.optimize.OptimizeTomcatConfig.EXTERNAL_SUB_PATH;
 import static io.camunda.optimize.rest.AuthenticationRestService.AUTHENTICATION_PATH;
 import static io.camunda.optimize.rest.AuthenticationRestService.CALLBACK;
+import static io.camunda.optimize.rest.AuthenticationRestService.LOGOUT;
 import static io.camunda.optimize.rest.HealthRestService.READYZ_PATH;
 import static io.camunda.optimize.rest.IngestionRestService.INGESTION_PATH;
 import static io.camunda.optimize.rest.IngestionRestService.VARIABLE_SUB_PATH;
@@ -27,6 +28,7 @@ import io.camunda.optimize.service.security.AuthCookieService;
 import io.camunda.optimize.service.security.CCSMTokenService;
 import io.camunda.optimize.service.security.SessionService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.OptimizeApiConfiguration;
 import io.camunda.optimize.service.util.configuration.condition.CCSMCondition;
 import io.camunda.optimize.tomcat.CCSMRequestAdjustmentFilter;
 import jakarta.servlet.http.HttpServletRequest;
@@ -50,9 +52,9 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
-import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 @Configuration
@@ -124,73 +126,100 @@ public class CCSMSecurityConfigurerAdapter extends AbstractSecurityConfigurerAda
   @Order(2)
   protected SecurityFilterChain configureWebSecurity(final HttpSecurity http) {
     try {
-      return super.configureGenericSecurityOptions(http)
-          // Then we configure the specific web security for CCSM
-          .authorizeHttpRequests(
-              requests ->
-                  requests
-                      // ready endpoint is public
-                      .requestMatchers(
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(createApiPath(READYZ_PATH)))
-                      .permitAll()
-                      // Identity callback request handling is public
-                      .requestMatchers(
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(createApiPath(AUTHENTICATION_PATH + CALLBACK)))
-                      .permitAll()
-                      // Static resources
-                      .requestMatchers(
-                          PathPatternRequestMatcher.withDefaults().matcher("/*.ico"),
-                          PathPatternRequestMatcher.withDefaults().matcher("/*.html"),
-                          PathPatternRequestMatcher.withDefaults().matcher("/static/*.js"),
-                          PathPatternRequestMatcher.withDefaults().matcher("/static/*.css"),
-                          PathPatternRequestMatcher.withDefaults().matcher("/static/*.html"))
-                      .permitAll()
-                      // public share resources
-                      .requestMatchers(
-                          PathPatternRequestMatcher.withDefaults().matcher(EXTERNAL_SUB_PATH + "/"),
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(EXTERNAL_SUB_PATH + "/index*"),
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(EXTERNAL_SUB_PATH + STATIC_RESOURCE_PATH + "/**"),
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(EXTERNAL_SUB_PATH + "/*.js"),
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(EXTERNAL_SUB_PATH + "/*.ico"))
-                      .permitAll()
-                      // public share related resources (API)
-                      .requestMatchers(
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(createApiPath(EXTERNAL_SUB_PATH + DEEP_SUB_PATH_ANY)),
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(EXTERNAL_SUB_PATH + "/api/**"))
-                      .permitAll()
-                      // common public api resources
-                      .requestMatchers(
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(createApiPath(UI_CONFIGURATION_PATH)),
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(createApiPath(LOCALIZATION_PATH)))
-                      .permitAll()
-                      .requestMatchers(
-                          PathPatternRequestMatcher.withDefaults()
-                              .matcher(ACTUATOR_ENDPOINT + "/**"))
-                      .permitAll()
-                      .anyRequest()
-                      .authenticated())
-          .addFilterBefore(
-              ccsmAuthenticationCookieFilter(http), AbstractPreAuthenticatedProcessingFilter.class)
-          .exceptionHandling(
-              exceptionHandling ->
-                  exceptionHandling
-                      .defaultAuthenticationEntryPointFor(
-                          new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
-                          PathPatternRequestMatcher.withDefaults().matcher(REST_API_PATH + "/**"))
-                      .defaultAuthenticationEntryPointFor(
-                          this::redirectToIdentity,
-                          PathPatternRequestMatcher.withDefaults().matcher("/**")))
-          .build();
+      final var httpSecurity =
+          super.configureGenericSecurityOptions(http)
+              // Then we configure the specific web security for CCSM
+              .authorizeHttpRequests(
+                  requests ->
+                      requests
+                          // ready endpoint is public
+                          .requestMatchers(
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(createApiPath(READYZ_PATH)))
+                          .permitAll()
+                          // Identity callback and logout are public — logout must work even
+                          // when the session token has already expired
+                          .requestMatchers(
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(createApiPath(AUTHENTICATION_PATH + CALLBACK)),
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(createApiPath(AUTHENTICATION_PATH + LOGOUT)))
+                          .permitAll()
+                          // Static resources
+                          .requestMatchers(
+                              PathPatternRequestMatcher.withDefaults().matcher("/*.ico"),
+                              PathPatternRequestMatcher.withDefaults().matcher("/*.html"),
+                              PathPatternRequestMatcher.withDefaults().matcher("/static/*.js"),
+                              PathPatternRequestMatcher.withDefaults().matcher("/static/*.css"),
+                              PathPatternRequestMatcher.withDefaults().matcher("/static/*.html"))
+                          .permitAll()
+                          // public share resources
+                          .requestMatchers(
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(EXTERNAL_SUB_PATH + "/"),
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(EXTERNAL_SUB_PATH + "/index*"),
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(EXTERNAL_SUB_PATH + STATIC_RESOURCE_PATH + "/**"),
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(EXTERNAL_SUB_PATH + "/*.js"),
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(EXTERNAL_SUB_PATH + "/*.ico"))
+                          .permitAll()
+                          // public share related resources (API)
+                          .requestMatchers(
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(createApiPath(EXTERNAL_SUB_PATH + DEEP_SUB_PATH_ANY)),
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(EXTERNAL_SUB_PATH + "/api/**"))
+                          .permitAll()
+                          // common public api resources
+                          .requestMatchers(
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(createApiPath(UI_CONFIGURATION_PATH)),
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(createApiPath(LOCALIZATION_PATH)))
+                          .permitAll()
+                          .requestMatchers(
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(ACTUATOR_ENDPOINT + "/**"))
+                          .permitAll()
+                          .anyRequest()
+                          .authenticated())
+              // Register cookie filter before BearerTokenAuthenticationFilter (position 1100).
+              // When jwtAuthForApiEnabled=true, oauth2ResourceServer adds
+              // BearerTokenAuthenticationFilter at 1100 and the cookie filter sits just before it.
+              // When jwtAuthForApiEnabled=false, no BearerTokenAuthenticationFilter instance is
+              // registered, but Spring still uses BearerTokenAuthenticationFilter.class as the
+              // anchor for ordering, so the cookie filter keeps this relative position.
+              .addFilterBefore(
+                  ccsmAuthenticationCookieFilter(http), BearerTokenAuthenticationFilter.class)
+              .exceptionHandling(
+                  exceptionHandling ->
+                      exceptionHandling
+                          .defaultAuthenticationEntryPointFor(
+                              new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
+                              PathPatternRequestMatcher.withDefaults()
+                                  .matcher(REST_API_PATH + "/**"))
+                          .defaultAuthenticationEntryPointFor(
+                              this::redirectToIdentity,
+                              PathPatternRequestMatcher.withDefaults().matcher("/**")));
+
+      // When the flag is on, enable Spring's native bearer-token support. This adds
+      // BearerTokenAuthenticationFilter (order 1100) to the chain. The cookie filter registered
+      // above still runs first at 1099, so it only acts as a no-op when no relevant auth cookies
+      // are present (which is typical for M2M bearer-token clients). Spring's bearer-token filter
+      // then handles auth and populates the SecurityContext before
+      // AbstractPreAuthenticatedProcessingFilter (1500) can interfere.
+      if (configurationService.getOptimizeApiConfiguration().isJwtAuthForApiEnabled()) {
+        LOG.info(
+            "JWT bearer-token authentication for /api/** is ENABLED "
+                + "(api.jwtAuthForApiEnabled=true)");
+        httpSecurity.oauth2ResourceServer(
+            oauth2 -> oauth2.jwt(jwt -> jwt.decoder(publicApiJwtDecoder())));
+      }
+
+      return httpSecurity.build();
     } catch (final Exception e) {
       throw new OptimizeRuntimeException(e);
     }
@@ -200,9 +229,19 @@ public class CCSMSecurityConfigurerAdapter extends AbstractSecurityConfigurerAda
     return configurationService.getOptimizeApiConfiguration().getAudience();
   }
 
+  @Bean
   @Override
   protected JwtDecoder publicApiJwtDecoder() {
-    return Optional.ofNullable(configurationService.getOptimizeApiConfiguration().getJwtSetUri())
+    final OptimizeApiConfiguration apiConfig = configurationService.getOptimizeApiConfiguration();
+    if (apiConfig.isJwtAuthForApiEnabled()) {
+      final String jwtSetUri = apiConfig.getJwtSetUri();
+      if (jwtSetUri == null || jwtSetUri.isEmpty()) {
+        throw new IllegalStateException(
+            "api.jwtAuthForApiEnabled is true but api.jwtSetUri is not configured");
+      }
+      return createJwtDecoderWithAudience(jwtSetUri);
+    }
+    return Optional.ofNullable(apiConfig.getJwtSetUri())
         .map(this::createJwtDecoderWithAudience)
         .orElseGet(() -> new OptimizeStaticTokenDecoder(configurationService));
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.springframework.context.ApplicationContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -80,10 +82,55 @@ public class SessionService implements ConfigurationReloadable {
     return isValid;
   }
 
+  /**
+   * Resolves the authenticated user ID from the current request, regardless of whether the request
+   * was authenticated via an Identity session cookie or a bearer JWT token.
+   *
+   * <p>Resolution order:
+   *
+   * <ol>
+   *   <li>If the {@link SecurityContextHolder} already holds a {@link JwtAuthenticationToken} (set
+   *       by Spring Security's OAuth2 resource server bearer-token authentication when {@code
+   *       api.jwtAuthForApiEnabled=true}), the subject is taken directly from that token. This
+   *       avoids any cookie look-up for bearer-authenticated requests.
+   *   <li>Otherwise, the token is extracted from the Optimize auth cookie (or request attributes
+   *       set during cookie renewal) and the subject is decoded from it.
+   * </ol>
+   *
+   * @throws NotAuthorizedException if no authenticated identity can be resolved.
+   */
   public String getRequestUserOrFailNotAuthorized(final HttpServletRequest request) {
-    return AuthCookieService.getAuthCookieToken(request)
-        .flatMap(AuthCookieService::getTokenSubject)
+    return subjectFromSecurityContext()
+        .or(
+            () ->
+                AuthCookieService.getAuthCookieToken(request)
+                    .flatMap(AuthCookieService::getTokenSubject))
         .orElseThrow(() -> new NotAuthorizedException("Could not extract request user!"));
+  }
+
+  /**
+   * Extracts the JWT subject from the {@link SecurityContextHolder} when the request was
+   * authenticated via a bearer token ({@code ApiBearerTokenAuthenticationFilter}).
+   *
+   * <p>Only consulted when {@code api.jwtAuthForApiEnabled=true}. When the flag is {@code false},
+   * this always returns {@link Optional#empty()} so that a stale or injected {@link
+   * JwtAuthenticationToken} in the context can never bypass cookie-based auth.
+   *
+   * <p><strong>Note:</strong> the filter chain is wired once at startup based on the flag value at
+   * that time, while this method re-reads the flag on every call via {@code configurationService}.
+   * A hot configuration reload that flips the flag while a request is in-flight can cause a
+   * mismatch: the bearer filter authenticates the request, but this method returns empty and the
+   * request falls through to cookie auth, resulting in a spurious 401. This is an inherent
+   * limitation of combining immutable filter chains with a reloadable configuration.
+   */
+  private Optional<String> subjectFromSecurityContext() {
+    if (!configurationService.getOptimizeApiConfiguration().isJwtAuthForApiEnabled()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+        .filter(JwtAuthenticationToken.class::isInstance)
+        .map(JwtAuthenticationToken.class::cast)
+        .map(jwtAuth -> jwtAuth.getToken().getSubject());
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/SessionServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/SessionServiceTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.rest.exceptions.NotAuthorizedException;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.OptimizeApiConfiguration;
+import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+@ExtendWith(MockitoExtension.class)
+class SessionServiceTest {
+
+  private static final String USER_SUBJECT = "user123";
+
+  @Mock private TerminatedSessionService terminatedSessionService;
+  @Mock private ConfigurationService configurationService;
+  @Mock private AuthConfiguration authConfiguration;
+  @Mock private OptimizeApiConfiguration apiConfiguration;
+
+  private SessionService sessionService;
+
+  @BeforeEach
+  void setUp() {
+    when(authConfiguration.getTokenSecret()).thenReturn(Optional.empty());
+    when(configurationService.getAuthConfiguration()).thenReturn(authConfiguration);
+    when(configurationService.getOptimizeApiConfiguration()).thenReturn(apiConfiguration);
+    sessionService = new SessionService(terminatedSessionService, configurationService);
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void shouldReturnSubjectFromBearerTokenWhenFlagEnabledAndJwtPresentInSecurityContext() {
+    // given
+    when(apiConfiguration.isJwtAuthForApiEnabled()).thenReturn(true);
+    SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(buildJwt()));
+
+    // when — bearer path is taken before the cookie path so no cookie stub is needed
+    final String user =
+        sessionService.getRequestUserOrFailNotAuthorized(mock(HttpServletRequest.class));
+
+    // then
+    assertThat(user).isEqualTo(USER_SUBJECT);
+  }
+
+  @Test
+  void shouldIgnoreJwtInContextAndFallThroughToCookieWhenFlagDisabled() {
+    // given — flag off: a JWT in the context must be ignored and the request must fall through to
+    // cookie extraction; with no cookie present the call must ultimately throw
+    when(apiConfiguration.isJwtAuthForApiEnabled()).thenReturn(false);
+    SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(buildJwt()));
+
+    // when - then
+    assertThatThrownBy(() -> sessionService.getRequestUserOrFailNotAuthorized(emptyRequest()))
+        .isInstanceOf(NotAuthorizedException.class);
+  }
+
+  @Test
+  void shouldThrowNotAuthorizedWhenNeitherBearerTokenNorCookieIsPresent() {
+    // given — flag enabled but SecurityContextHolder is empty and the request carries no cookie
+    when(apiConfiguration.isJwtAuthForApiEnabled()).thenReturn(true);
+
+    // when - then
+    assertThatThrownBy(() -> sessionService.getRequestUserOrFailNotAuthorized(emptyRequest()))
+        .isInstanceOf(NotAuthorizedException.class);
+  }
+
+  /** Returns a mock request that has no auth cookie and won't NPE inside AuthCookieService. */
+  private static HttpServletRequest emptyRequest() {
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getAttributeNames()).thenReturn(Collections.emptyEnumeration());
+    return request;
+  }
+
+  private static Jwt buildJwt() {
+    return Jwt.withTokenValue("test-token")
+        .header("alg", "none")
+        .claim("sub", USER_SUBJECT)
+        .build();
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OptimizeApiConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OptimizeApiConfiguration.java
@@ -21,6 +21,14 @@ public class OptimizeApiConfiguration {
   @JsonProperty("audience")
   private String audience;
 
+  /**
+   * When {@code true}, non-public {@code /api/**} endpoints also accept a standard {@code
+   * Authorization: Bearer <jwt>} header in addition to the existing Identity session cookie. Only
+   * meaningful in self-managed (CCSM) mode. Defaults to {@code false}.
+   */
+  @JsonProperty("jwtAuthForApiEnabled")
+  private boolean jwtAuthForApiEnabled = false;
+
   public OptimizeApiConfiguration() {}
 
   public String getAccessToken() {
@@ -50,8 +58,18 @@ public class OptimizeApiConfiguration {
     this.audience = audience;
   }
 
-  protected boolean canEqual(final Object other) {
-    return other instanceof OptimizeApiConfiguration;
+  public boolean isJwtAuthForApiEnabled() {
+    return jwtAuthForApiEnabled;
+  }
+
+  @JsonProperty("jwtAuthForApiEnabled")
+  public void setJwtAuthForApiEnabled(final boolean jwtAuthForApiEnabled) {
+    this.jwtAuthForApiEnabled = jwtAuthForApiEnabled;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(accessToken, jwtSetUri, audience, jwtAuthForApiEnabled);
   }
 
   @Override
@@ -60,14 +78,10 @@ public class OptimizeApiConfiguration {
       return false;
     }
     final OptimizeApiConfiguration that = (OptimizeApiConfiguration) o;
-    return Objects.equals(accessToken, that.accessToken)
+    return jwtAuthForApiEnabled == that.jwtAuthForApiEnabled
+        && Objects.equals(accessToken, that.accessToken)
         && Objects.equals(jwtSetUri, that.jwtSetUri)
         && Objects.equals(audience, that.audience);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(accessToken, jwtSetUri, audience);
   }
 
   @Override
@@ -78,6 +92,8 @@ public class OptimizeApiConfiguration {
         + getJwtSetUri()
         + ", audience="
         + getAudience()
+        + ", jwtAuthForApiEnabled="
+        + isJwtAuthForApiEnabled()
         + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -92,6 +92,11 @@ api:
   accessToken: ${OPTIMIZE_API_ACCESS_TOKEN:null}
   jwtSetUri: ${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI:null}
   audience: ${CAMUNDA_OPTIMIZE_API_AUDIENCE:optimize}
+  # Self-managed (CCSM) only. When true, non-public /api/** endpoints also accept an
+  # 'Authorization: Bearer <jwt>' header in addition to the existing Identity session cookie.
+  # The bearer token is validated with the same jwtSetUri / audience configured above.
+  # Requires jwtSetUri to be set. Defaults to false.
+  jwtAuthForApiEnabled: ${CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED:false}
 
 container:
   # A host name or IP address, to identify a specific network interface on


### PR DESCRIPTION
## Description
 ---                                                                                                                                                       
  Problem                                                                                                                                                   

  Optimize's non-public /api/** endpoints (used by machine-to-machine clients) can only be authenticated via an Identity session cookie. There is no way for a service or automation tool to call these endpoints using a standard Authorization: Bearer <jwt> header, which is the expected pattern in self-managed (CCSM) environments.                                                                                                                                    
 
  Changes                                                                                                                                                   

  Opt-in JWT bearer authentication for /api/** (CCSMSecurityConfigurerAdapter, SessionService): when api.jwtAuthForApiEnabled=true, Spring Security's oauth2ResourceServer is conditionally added to the CCSM filter chain, enabling BearerTokenAuthenticationFilter alongside the existing Identity session cookie filter. The bearer token is validated using the same jwtSetUri and audience already configured for the public API. The cookie filter is anchored before BearerTokenAuthenticationFilter so filter ordering is governed by Spring's own constants rather than custom code.

  Shared NimbusJwtDecoder (CCSMSecurityConfigurerAdapter): publicApiJwtDecoder is promoted to a @Bean so a single decoder instance is shared between the public-API chain and the bearer filter. When jwtAuthForApiEnabled=true, the method validates that jwtSetUri is set and fails fast at startup rather than at request time.

  User resolution from bearer token (SessionService): getRequestUserOrFailNotAuthorized now first checks the SecurityContextHolder for a JwtAuthenticationToken (set by the bearer filter) and extracts the subject from it, falling back to cookie extraction for non-bearer requests. The bearer path is guarded by the flag so a stale context token can never bypass cookie auth when the feature is off. 

  Configuration (OptimizeApiConfiguration, service-config.yaml): new jwtAuthForApiEnabled flag (default false) exposed via env var CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED.

  Logout endpoint made public (CCSMSecurityConfigurerAdapter): the logout endpoint is now permitted without authentication so it remains reachable when the session token has already expired.

  Configuration                                                                                                                                           

  api:
    jwtSetUri: <issuer-jwks-url>   # already required for public API
    audience: optimize              # already required for public API                                                                                       
    jwtAuthForApiEnabled: true      # opt-in; default false                                                                                                 

  Or via environment variable: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED=true.                                                                                  

  jwtSetUri must be set when the flag is enabled; the application will refuse to start otherwise.                                                           

