### PR TITLE
feat: Cancel Process Instance Execution Listener

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/ListenerEventType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/ListenerEventType.java
@@ -18,6 +18,7 @@ package io.camunda.client.api.search.enums;
 public enum ListenerEventType {
   ASSIGNING,
   BEFORE_ALL,
+  CANCEL,
   CANCELING,
   COMPLETING,
   CREATING,

--- a/operate/schema/src/test/java/io/camunda/operate/entities/ListenerEventTypeTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/entities/ListenerEventTypeTest.java
@@ -23,6 +23,7 @@ public class ListenerEventTypeTest {
         // Known Execution Listener event types
         arguments("START", ListenerEventType.START),
         arguments("END", ListenerEventType.END),
+        arguments("CANCEL", ListenerEventType.CANCEL),
 
         // Known User Task Listener event types
         arguments("CREATING", ListenerEventType.CREATING),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/cache/rest-api.yaml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/cache/rest-api.yaml
@@ -10263,6 +10263,7 @@ components:
       description: The listener event type of the job.
       enum:
         - ASSIGNING
+        - CANCEL
         - CANCELING
         - COMPLETING
         - CREATING

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
@@ -57,6 +57,7 @@ public class JobEntityTransformer
       case "BEFORE_ALL" -> ListenerEventType.BEFORE_ALL;
       case "START" -> ListenerEventType.START;
       case "END" -> ListenerEventType.END;
+      case "CANCEL" -> ListenerEventType.CANCEL;
       case "CREATING" -> ListenerEventType.CREATING;
       case "ASSIGNING" -> ListenerEventType.ASSIGNING;
       case "UPDATING" -> ListenerEventType.UPDATING;

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -273,6 +273,7 @@ public record JobEntity(
   public enum ListenerEventType {
     ASSIGNING,
     BEFORE_ALL,
+    CANCEL,
     CANCELING,
     COMPLETING,
     CREATING,

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/job.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/job.ts
@@ -36,6 +36,7 @@ const listenerEventTypeSchema = z.enum([
 	'UNSPECIFIED',
 	'START',
 	'END',
+	'CANCEL',
 	'CREATING',
 	'ASSIGNING',
 	'UPDATING',

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listener/ListenerEventType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listener/ListenerEventType.java
@@ -15,6 +15,7 @@ public enum ListenerEventType {
   START,
   END,
   BEFORE_ALL,
+  CANCEL,
 
   // User Task Listener event types
   CREATING,

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractActivityBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractActivityBuilder.java
@@ -201,6 +201,16 @@ public abstract class AbstractActivityBuilder<
   }
 
   @Override
+  public B zeebeCancelExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeCancelExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeCancelExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeCancelExecutionListener(type);
+  }
+
+  @Override
   public B zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
     return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEventBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEventBuilder.java
@@ -58,6 +58,16 @@ public abstract class AbstractEventBuilder<B extends AbstractEventBuilder<B, E>,
   }
 
   @Override
+  public B zeebeCancelExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeCancelExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeCancelExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeCancelExecutionListener(type);
+  }
+
+  @Override
   public B zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
     return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEventSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEventSubProcessBuilder.java
@@ -127,6 +127,16 @@ public class AbstractEventSubProcessBuilder<B extends AbstractEventSubProcessBui
   }
 
   @Override
+  public B zeebeCancelExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeCancelExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeCancelExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeCancelExecutionListener(type);
+  }
+
+  @Override
   public B zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
     return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ExecutionListenerBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ExecutionListenerBuilder.java
@@ -43,6 +43,10 @@ public class ExecutionListenerBuilder implements BuilderWithTaskHeaders<Executio
     return eventType(ZeebeExecutionListenerEventType.end);
   }
 
+  public ExecutionListenerBuilder cancel() {
+    return eventType(ZeebeExecutionListenerEventType.cancel);
+  }
+
   public ExecutionListenerBuilder type(final String type) {
     element.setType(type);
     return this;

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -148,6 +148,16 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder>
   }
 
   @Override
+  public ProcessBuilder zeebeCancelExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeCancelExecutionListener(type, retries);
+  }
+
+  @Override
+  public ProcessBuilder zeebeCancelExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeCancelExecutionListener(type);
+  }
+
+  @Override
   public ProcessBuilder zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
     return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
@@ -36,6 +36,10 @@ public interface ZeebeExecutionListenersBuilder<B> {
 
   B zeebeEndExecutionListener(String type);
 
+  B zeebeCancelExecutionListener(String type, String retries);
+
+  B zeebeCancelExecutionListener(String type);
+
   B zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
@@ -36,9 +36,13 @@ public interface ZeebeExecutionListenersBuilder<B> {
 
   B zeebeEndExecutionListener(String type);
 
-  B zeebeCancelExecutionListener(String type, String retries);
+  default B zeebeCancelExecutionListener(final String type, final String retries) {
+    throw new UnsupportedOperationException("Please use concrete implementation");
+  }
 
-  B zeebeCancelExecutionListener(String type);
+  default B zeebeCancelExecutionListener(final String type) {
+    throw new UnsupportedOperationException("Please use concrete implementation");
+  }
 
   B zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
@@ -75,6 +75,21 @@ public class ZeebeExecutionListenersBuilderImpl<B extends AbstractBaseElementBui
   }
 
   @Override
+  public B zeebeCancelExecutionListener(final String type, final String retries) {
+    final ZeebeExecutionListener listener = createZeebeExecutionListener();
+    listener.setEventType(ZeebeExecutionListenerEventType.cancel);
+    listener.setType(type);
+    listener.setRetries(retries);
+
+    return elementBuilder;
+  }
+
+  @Override
+  public B zeebeCancelExecutionListener(final String type) {
+    return zeebeCancelExecutionListener(type, ZeebeExecutionListener.DEFAULT_RETRIES);
+  }
+
+  @Override
   public B zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
     final ZeebeExecutionListener listener = createZeebeExecutionListener();

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerEventType.java
@@ -16,11 +16,13 @@
 package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
 /**
- * Represents the type of event listener, that indicates when EL should be executed: at the start
- * (beginning) or at the end (completion) of an element's processing.
+ * Represents the type of event listener, that indicates when an execution listener should be
+ * executed: at the {@code start} (beginning), {@code end} (completion), or {@code cancel}
+ * (termination) of an element's processing.
  */
 public enum ZeebeExecutionListenerEventType {
   beforeAll,
   start,
-  end
+  end,
+  cancel
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -89,6 +89,21 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
       return;
     }
 
+    // Validate that 'cancel' event type is only used on process-level elements
+    if (!BpmnModelConstants.BPMN_ELEMENT_PROCESS.equals(parentElementTypeName)) {
+      final boolean hasCancelListener =
+          executionListeners.stream()
+              .anyMatch(
+                  listener -> ZeebeExecutionListenerEventType.cancel == listener.getEventType());
+      if (hasCancelListener) {
+        validationResultCollector.addError(
+            0,
+            "The 'cancel' execution listener event type is not supported for the '"
+                + parentElementTypeName
+                + "' element. The 'cancel' event type is only supported on the 'process' element.");
+      }
+    }
+
     validateBeforeAllListeners(executionListeners, bpmnElement, validationResultCollector);
 
     final Function<ZeebeExecutionListener, String> eventTypeAndTypeClassifier =

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -89,21 +89,7 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
       return;
     }
 
-    // Validate that 'cancel' event type is only used on process-level elements
-    if (!BpmnModelConstants.BPMN_ELEMENT_PROCESS.equals(parentElementTypeName)) {
-      final boolean hasCancelListener =
-          executionListeners.stream()
-              .anyMatch(
-                  listener -> ZeebeExecutionListenerEventType.cancel == listener.getEventType());
-      if (hasCancelListener) {
-        validationResultCollector.addError(
-            0,
-            "The 'cancel' execution listener event type is not supported for the '"
-                + parentElementTypeName
-                + "' element. The 'cancel' event type is only supported on the 'process' element.");
-      }
-    }
-
+    validateCancelListeners(executionListeners, bpmnElement, validationResultCollector);
     validateBeforeAllListeners(executionListeners, bpmnElement, validationResultCollector);
 
     final Function<ZeebeExecutionListener, String> eventTypeAndTypeClassifier =
@@ -117,6 +103,27 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
     listenersGroupedByType.values().stream()
         .filter(duplicates -> duplicates.size() > 1)
         .forEach(duplicates -> reportDuplicateListeners(duplicates, validationResultCollector));
+  }
+
+  /** Validate that 'cancel' event type is only used on process-level elements */
+  private void validateCancelListeners(
+      final Collection<ZeebeExecutionListener> executionListeners,
+      final ModelElementInstance bpmnElement,
+      final ValidationResultCollector validationResultCollector) {
+    final String parentElementTypeName = bpmnElement.getElementType().getTypeName();
+    if (!BpmnModelConstants.BPMN_ELEMENT_PROCESS.equals(parentElementTypeName)) {
+      final boolean hasCancelListener =
+          executionListeners.stream()
+              .anyMatch(
+                  listener -> ZeebeExecutionListenerEventType.cancel == listener.getEventType());
+      if (hasCancelListener) {
+        validationResultCollector.addError(
+            0,
+            "The 'cancel' execution listener event type is not supported for the '"
+                + parentElementTypeName
+                + "' element. The 'cancel' event type is only supported on the 'process' element.");
+      }
+    }
   }
 
   /**

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
@@ -40,6 +40,7 @@ public class ZeebeExecutionListenersValidationTest {
   private static final String BEFORE_ALL_EL_TYPE = "before_all_execution_listener_job";
   private static final String START_EL_TYPE = "start_execution_listener_job";
   private static final String END_EL_TYPE = "end_execution_listener_job";
+  private static final String CANCEL_EL_TYPE = "cancel_execution_listener_job";
 
   @Test
   @DisplayName("element with ExecutionListeners defined without job `type`")
@@ -311,5 +312,146 @@ public class ZeebeExecutionListenersValidationTest {
             ZeebeExecutionListeners.class,
             "Execution listeners with event type 'beforeAll' are only supported on multi-instance "
                 + "activities and are not valid on 'process'"));
+  }
+
+  @Test
+  @DisplayName("cancel execution listener on process element should pass validation")
+  void testCancelExecutionListenerOnProcessElement() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName("cancel execution listener on service task should fail validation")
+  void testCancelExecutionListenerOnServiceTaskElement() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeCancelExecutionListener(CANCEL_EL_TYPE))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeExecutionListeners.class,
+            "The 'cancel' execution listener event type is not supported for the 'serviceTask'"
+                + " element. The 'cancel' event type is only supported on the 'process' element."));
+  }
+
+  private static Stream<Arguments> nonProcessElementsForCancelListener() {
+    return Stream.of(
+        Arguments.of(
+            "userTask",
+            (Function<Void, BpmnModelInstance>)
+                v ->
+                    Bpmn.createExecutableProcess(PROCESS_ID)
+                        .startEvent()
+                        .userTask("task", t -> t.zeebeCancelExecutionListener(CANCEL_EL_TYPE))
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            "subProcess",
+            (Function<Void, BpmnModelInstance>)
+                v ->
+                    Bpmn.createExecutableProcess(PROCESS_ID)
+                        .startEvent()
+                        .subProcess(
+                            "sub",
+                            s ->
+                                s.zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                                    .embeddedSubProcess()
+                                    .startEvent()
+                                    .endEvent())
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            "callActivity",
+            (Function<Void, BpmnModelInstance>)
+                v ->
+                    Bpmn.createExecutableProcess(PROCESS_ID)
+                        .startEvent()
+                        .callActivity(
+                            "call",
+                            c ->
+                                c.zeebeProcessId("child")
+                                    .zeebeCancelExecutionListener(CANCEL_EL_TYPE))
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            "intermediateCatchEvent",
+            (Function<Void, BpmnModelInstance>)
+                v ->
+                    Bpmn.createExecutableProcess(PROCESS_ID)
+                        .startEvent()
+                        .intermediateCatchEvent(
+                            "catch",
+                            i ->
+                                i.timerWithDuration("PT1S")
+                                    .zeebeCancelExecutionListener(CANCEL_EL_TYPE))
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            "boundaryEvent",
+            (Function<Void, BpmnModelInstance>)
+                v ->
+                    Bpmn.createExecutableProcess(PROCESS_ID)
+                        .startEvent()
+                        .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                        .boundaryEvent(
+                            "boundary",
+                            b ->
+                                b.timerWithDuration("PT1S")
+                                    .zeebeCancelExecutionListener(CANCEL_EL_TYPE))
+                        .endEvent()
+                        .moveToActivity("task")
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            "startEvent",
+            (Function<Void, BpmnModelInstance>)
+                v ->
+                    Bpmn.createExecutableProcess(PROCESS_ID)
+                        .eventSubProcess(
+                            "esp",
+                            sub ->
+                                sub.startEvent("esp-start")
+                                    .timerWithDuration("PT1S")
+                                    .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                                    .endEvent())
+                        .startEvent()
+                        .endEvent()
+                        .done()));
+  }
+
+  @ParameterizedTest(name = "cancel execution listener on {0} should fail validation")
+  @MethodSource("nonProcessElementsForCancelListener")
+  void testCancelExecutionListenerOnNonProcessElement(
+      final String elementTypeName, final Function<Void, BpmnModelInstance> builder) {
+    // given
+    final BpmnModelInstance process = builder.apply(null);
+
+    // when/then: validator must reject the cancel listener on the non-process element
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeExecutionListeners.class,
+            "The 'cancel' execution listener event type is not supported for the '"
+                + elementTypeName
+                + "' element. The 'cancel' event type is only supported on the 'process' element."));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -242,6 +242,7 @@ public class Engine implements RecordProcessor {
     final boolean isAllowedOnBannedInstance =
         intent == ProcessInstanceIntent.CANCEL
             || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
+            || intent == ProcessInstanceIntent.CONTINUE_TERMINATING_ELEMENT
             || intent == ProcessInstanceBatchIntent.TERMINATE;
 
     return isAllowedOnBannedInstance;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -184,7 +184,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         final var terminatingContext = stateTransitionBehavior.transitionToTerminating(context);
         final var transitionOutcome = processor.onTerminate(element, terminatingContext);
         if (transitionOutcome == TransitionOutcome.CONTINUE) {
-          processor.finalizeTermination(element, terminatingContext);
+          afterTerminating(element, processor, terminatingContext)
+              .ifLeft(failure -> incidentBehavior.createIncident(failure, terminatingContext));
         }
         break;
       case COMPLETE_EXECUTION_LISTENER:
@@ -200,13 +201,17 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
           case ELEMENT_COMPLETING ->
               onEndExecutionListenerComplete((ExecutableFlowNode) element, processor, context)
                   .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
+          case ELEMENT_TERMINATING ->
+              onCancelExecutionListenerComplete((ExecutableFlowNode) element, processor, context)
+                  .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
           default ->
               throw new BpmnProcessingException(
                   context, String.format("Unexpected element state: '%s'", elementState));
         }
         break;
       case CONTINUE_TERMINATING_ELEMENT:
-        processor.finalizeTermination(element, context);
+        afterTerminating(element, processor, context)
+            .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
         break;
       default:
         throw new BpmnProcessingException(
@@ -268,6 +273,17 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         context,
         ExecutableFlowNode::getEndExecutionListeners,
         processor::finalizeCompletion);
+  }
+
+  private Either<Failure, ?> afterTerminating(
+      final ExecutableFlowElement element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    return processElementWithListeners(
+        element,
+        context,
+        ExecutableFlowNode::getCancelExecutionListeners,
+        (e, c) -> doFinalizeTermination(processor, e, c));
   }
 
   private Either<Failure, ?> processElementWithListeners(
@@ -342,6 +358,18 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         processor::finalizeCompletion);
   }
 
+  public Either<Failure, ?> onCancelExecutionListenerComplete(
+      final ExecutableFlowNode element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    mergeVariablesOfExecutionListener(context, false);
+    return onExecutionListenerComplete(
+        element,
+        context,
+        ExecutableFlowNode::getCancelExecutionListeners,
+        (e, c) -> doFinalizeTermination(processor, e, c));
+  }
+
   private Either<Failure, ?> onExecutionListenerComplete(
       final ExecutableFlowNode element,
       final BpmnElementContext context,
@@ -403,5 +431,13 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         recordValue.getTenantId(),
         recordValue.getElementIdBuffer(),
         processor.getType());
+  }
+
+  private Either<Failure, ?> doFinalizeTermination(
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final ExecutableFlowElement element,
+      final BpmnElementContext context) {
+    processor.finalizeTermination(element, context);
+    return BpmnElementProcessor.SUCCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -77,14 +77,16 @@ public final class ProcessInstanceStateTransitionGuard {
               context,
               ProcessInstanceIntent.ELEMENT_ACTIVATING,
               ProcessInstanceIntent.ELEMENT_ACTIVATED,
-              ProcessInstanceIntent.ELEMENT_COMPLETING);
+              ProcessInstanceIntent.ELEMENT_COMPLETING,
+              ProcessInstanceIntent.ELEMENT_TERMINATING);
       case CONTINUE_TERMINATING_ELEMENT ->
           hasElementInstanceWithState(context, ProcessInstanceIntent.ELEMENT_TERMINATING);
       case COMPLETE_EXECUTION_LISTENER ->
           hasElementInstanceWithState(
               context,
               ProcessInstanceIntent.ELEMENT_ACTIVATING,
-              ProcessInstanceIntent.ELEMENT_COMPLETING);
+              ProcessInstanceIntent.ELEMENT_COMPLETING,
+              ProcessInstanceIntent.ELEMENT_TERMINATING);
       default -> Either.left(UNSUPPORTED_INTENT_MESSAGE.formatted(context.getIntent()));
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -481,6 +481,7 @@ public final class BpmnJobBehavior {
       case beforeAll -> JobListenerEventType.BEFORE_ALL;
       case start -> JobListenerEventType.START;
       case end -> JobListenerEventType.END;
+      case cancel -> JobListenerEventType.CANCEL;
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -86,6 +86,14 @@ public final class BpmnStateTransitionBehavior {
     this.incidentBehavior = incidentBehavior;
   }
 
+  public void continueTerminating(final BpmnElementContext context) {
+    resetTreePathProperties(context);
+    commandWriter.appendFollowUpCommand(
+        context.getElementInstanceKey(),
+        ProcessInstanceIntent.CONTINUE_TERMINATING_ELEMENT,
+        context.getRecordValue());
+  }
+
   /**
    * @return context with updated intent
    */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -213,10 +213,20 @@ public final class BpmnStateTransitionBehavior {
     final var illegalStateException =
         new IllegalStateException(
             String.format(ALREADY_MIGRATED_ERROR_MSG, context.getBpmnElementType(), methodName));
-    if (Arrays.stream(illegalStateException.getStackTrace())
-        .noneMatch(ele -> ele.getMethodName().equals("attemptToContinueProcessProcessing"))) {
+    if (!isIncidentResolving(illegalStateException)) {
       throw illegalStateException;
     }
+  }
+
+  /** see {{@link #verifyIncidentResolving(BpmnElementContext, String)} */
+  private boolean isIncidentResolving() {
+    final var illegalStateException = new IllegalStateException();
+    return isIncidentResolving(illegalStateException);
+  }
+
+  private boolean isIncidentResolving(final Exception exception) {
+    return Arrays.stream(exception.getStackTrace())
+        .anyMatch(ele -> ele.getMethodName().equals("attemptToContinueProcessProcessing"));
   }
 
   /**
@@ -273,6 +283,19 @@ public final class BpmnStateTransitionBehavior {
               context.getBpmnElementType(),
               "#transitionToTerminating"));
     }
+
+    final var elementInstance = stateBehavior.getElementInstance(context);
+    if (elementInstance.getState() == ProcessInstanceIntent.ELEMENT_TERMINATING
+        && isIncidentResolving()) {
+      // if the element is already terminating, then the Terminate_Element command is processed as a
+      // result of resolving an incident. We don't have to transition again. Just update the
+      // context
+      return context.copy(
+          context.getElementInstanceKey(),
+          context.getRecordValue(),
+          ProcessInstanceIntent.ELEMENT_TERMINATING);
+    }
+
     return transitionTo(context, ProcessInstanceIntent.ELEMENT_TERMINATING);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -108,17 +108,19 @@ public final class ProcessProcessor
     compensationSubscriptionBehaviour.deleteSubscriptionsOfProcessInstance(context);
 
     final var noActiveChildInstances = stateTransitionBehavior.terminateChildInstances(context);
+    return noActiveChildInstances ? TransitionOutcome.CONTINUE : TransitionOutcome.AWAIT;
+  }
 
-    if (noActiveChildInstances) {
-      transitionTo(
-          element,
-          context,
-          terminating ->
-              Either.right(
-                  stateTransitionBehavior.transitionToTerminated(
-                      terminating, element.getEventType(), getAsyncRequest(context))));
-    }
-    return TransitionOutcome.CONTINUE;
+  @Override
+  public void finalizeTermination(
+      final ExecutableFlowElementContainer element, final BpmnElementContext terminationContext) {
+    transitionTo(
+        element,
+        terminationContext,
+        context ->
+            Either.right(
+                stateTransitionBehavior.transitionToTerminated(
+                    context, element.getEventType(), getAsyncRequest(context))));
   }
 
   private AsyncRequest getAsyncRequest(final BpmnElementContext context) {
@@ -197,16 +199,17 @@ public final class ProcessProcessor
                         eventTrigger,
                         flowScopeContext));
       }
-    } else if (stateBehavior.canBeTerminated(childContext)) {
-      if (flowScopeInstance.isTerminating()) {
-        // the process instance was canceled, or interrupted by a parent process instance
-        transitionTo(
-            element,
-            flowScopeContext,
-            context ->
-                Either.right(
-                    stateTransitionBehavior.transitionToTerminated(
-                        context, element.getEventType(), getAsyncRequest(context))));
+    } else if (stateBehavior.canBeTerminated(childContext) && flowScopeInstance.isTerminating()) {
+      // the process instance was canceled or interrupted by a parent process instance
+      if (!element.hasCancelExecutionListeners()) {
+        // Stay backwards compatible during a rolling upgrade: only emit the
+        // CONTINUE_TERMINATING_ELEMENT command when the process actually defines
+        // cancel listeners. Processes without cancel listeners must produce the
+        // same record stream as previous broker versions, so a leader change from
+        // a newer to an older broker mid-upgrade does terminate a process instance correctly.
+        finalizeTermination(element, flowScopeContext);
+      } else {
+        stateTransitionBehavior.continueTerminating(flowScopeContext);
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -78,6 +78,17 @@ public class ExecutableFlowNode extends AbstractFlowElement {
         .toList();
   }
 
+  public List<ExecutionListener> getCancelExecutionListeners() {
+    return executionListeners.stream()
+        .filter(el -> el.getEventType() == ZeebeExecutionListenerEventType.cancel)
+        .toList();
+  }
+
+  public boolean hasCancelExecutionListeners() {
+    return executionListeners.stream()
+        .anyMatch(el -> el.getEventType() == ZeebeExecutionListenerEventType.cancel);
+  }
+
   public boolean hasExecutionListeners() {
     return !executionListeners.isEmpty();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -47,7 +47,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   public static final String NO_INCIDENT_FOUND_MSG =
       "Expected to resolve incident with key '%d', but no such incident was found";
   private static final String ELEMENT_NOT_IN_SUPPORTED_STATE_MSG =
-      "Expected incident to refer to element in state ELEMENT_ACTIVATING or ELEMENT_COMPLETING, but element is in state %s";
+      "Expected incident to refer to element in state ELEMENT_ACTIVATING, ELEMENT_COMPLETING, or ELEMENT_TERMINATING, but element is in state %s";
   private static final String UNEXPECTED_LIFECYCLE_STATE_CONVERSION_MSG =
       "Unexpected user task lifecycle state: '%s' encountered during conversion to failed user task command.";
 
@@ -281,6 +281,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
     return switch (instanceState) {
       case ELEMENT_ACTIVATING -> Either.right(ProcessInstanceIntent.ACTIVATE_ELEMENT);
       case ELEMENT_COMPLETING -> Either.right(ProcessInstanceIntent.COMPLETE_ELEMENT);
+      case ELEMENT_TERMINATING -> Either.right(ProcessInstanceIntent.TERMINATE_ELEMENT);
       default -> Either.left(String.format(ELEMENT_NOT_IN_SUPPORTED_STATE_MSG, instanceState));
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -386,7 +386,7 @@ public final class ProcessInstanceModificationModifyProcessor
           final var flowScopeKey = elementInstance.getValue().getFlowScopeKey();
 
           terminateElement(elementInstance);
-          terminateFlowScopes(flowScopeKey, requiredKeysForActivation);
+          terminateFlowScopes(flowScopeKey, requiredKeysForActivation, process);
         });
 
     stateWriter.appendFollowUpEvent(
@@ -1432,7 +1432,9 @@ public final class ProcessInstanceModificationModifyProcessor
   }
 
   private void terminateFlowScopes(
-      final long elementInstanceKey, final Set<Long> requiredKeysForActivation) {
+      final long elementInstanceKey,
+      final Set<Long> requiredKeysForActivation,
+      final DeployedProcess process) {
     var currentElementInstance = elementInstanceState.getInstance(elementInstanceKey);
 
     while (canTerminateElementInstance(currentElementInstance, requiredKeysForActivation)) {
@@ -1447,11 +1449,12 @@ public final class ProcessInstanceModificationModifyProcessor
                 currentElementInstanceRecord.getBpmnProcessId()));
       }
 
-      // Delegate process-level termination to the BPMN stream processor by writing a
-      // TERMINATE_ELEMENT command, so that the cancel execution listener chain runs before
-      // the process reaches ELEMENT_TERMINATED. Inner flow scopes have no cancel listeners
-      // (forbidden by the validator) and continue to be terminated directly.
-      if (currentElementInstanceRecord.getBpmnElementType() == BpmnElementType.PROCESS) {
+      // Delegate process-level termination to the BPMN stream processor only when the process
+      // declares at least one cancel execution listener, so that the cancel listener chain runs
+      // before the process reaches ELEMENT_TERMINATED. Otherwise the process is terminated
+      // directly to keep the record stream byte-identical to previous broker versions.
+      if (currentElementInstanceRecord.getBpmnElementType() == BpmnElementType.PROCESS
+          && process.getProcess().hasCancelExecutionListeners()) {
         commandWriter.appendFollowUpCommand(
             currentElementInstance.getKey(),
             ProcessInstanceIntent.TERMINATE_ELEMENT,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -188,6 +189,7 @@ public final class ProcessInstanceModificationModifyProcessor
   private static final Either<Rejection, Object> VALID = Either.right(null);
 
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedResponseWriter responseWriter;
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
@@ -207,6 +209,7 @@ public final class ProcessInstanceModificationModifyProcessor
       final BpmnBehaviors bpmnBehaviors,
       final AuthorizationCheckBehavior authCheckBehavior) {
     stateWriter = writers.state();
+    commandWriter = writers.command();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.elementInstanceState = elementInstanceState;
@@ -1442,6 +1445,18 @@ public final class ProcessInstanceModificationModifyProcessor
         throw new TerminatedChildProcessException(
             ERROR_MESSAGE_CHILD_PROCESS_INSTANCE_TERMINATED.formatted(
                 currentElementInstanceRecord.getBpmnProcessId()));
+      }
+
+      // Delegate process-level termination to the BPMN stream processor by writing a
+      // TERMINATE_ELEMENT command, so that the cancel execution listener chain runs before
+      // the process reaches ELEMENT_TERMINATED. Inner flow scopes have no cancel listeners
+      // (forbidden by the validator) and continue to be terminated directly.
+      if (currentElementInstanceRecord.getBpmnElementType() == BpmnElementType.PROCESS) {
+        commandWriter.appendFollowUpCommand(
+            currentElementInstance.getKey(),
+            ProcessInstanceIntent.TERMINATE_ELEMENT,
+            currentElementInstanceRecord);
+        return;
       }
 
       final var flowScopeKey = currentElementInstance.getValue().getFlowScopeKey();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerCancelTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerCancelTest.java
@@ -1,0 +1,1642 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution;
+
+import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.END_EL_TYPE;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.PROCESS_ID;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.SERVICE_TASK_TYPE;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.START_EL_TYPE;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.assertExecutionListenerJobsCompletedForElement;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.createProcessInstance;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.records;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ExecutionListenerCancelTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  static final String CANCEL_EL_TYPE = "cancel_execution_listener_job";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateCancelElJobWhenProcessInstanceIsCanceled() {
+    // given: process with a cancel execution listener
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    // wait for the service task to be activated
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // then: cancel EL job should be created
+    assertThat(
+            jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withType(CANCEL_EL_TYPE)
+                .getFirst()
+                .getValue())
+        .satisfies(
+            job -> {
+              assertThat(job.getJobKind()).isEqualTo(JobKind.EXECUTION_LISTENER);
+              assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.CANCEL);
+            });
+
+    // complete the cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: process instance should be terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteMultipleCancelElsInOrder() {
+    // given: process with multiple cancel execution listeners
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE + "_1")
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE + "_2")
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE + "_3")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    // wait for the service task
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // complete cancel EL jobs in order
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE + "_1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE + "_2").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE + "_3").complete();
+
+    // then: all cancel EL jobs should be completed in order
+    assertExecutionListenerJobsCompletedForElement(
+        processInstanceKey,
+        PROCESS_ID,
+        CANCEL_EL_TYPE + "_1",
+        CANCEL_EL_TYPE + "_2",
+        CANCEL_EL_TYPE + "_3");
+
+    // and: process instance should be terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldHaveCorrectJobPropertiesForCancelElJob() {
+    // given: process with cancel EL
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // then: verify all job properties
+    final var cancelElJob =
+        jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withJobKind(JobKind.EXECUTION_LISTENER)
+            .withType(CANCEL_EL_TYPE)
+            .getFirst();
+
+    assertThat(cancelElJob.getValue().getJobKind()).isEqualTo(JobKind.EXECUTION_LISTENER);
+    assertThat(cancelElJob.getValue().getJobListenerEventType())
+        .isEqualTo(JobListenerEventType.CANCEL);
+    assertThat(cancelElJob.getValue().getType()).isEqualTo(CANCEL_EL_TYPE);
+    assertThat(cancelElJob.getValue().getElementId()).isEqualTo(PROCESS_ID);
+  }
+
+  @Test
+  public void shouldRetryCancelElJobAfterFailure() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process and fail the cancel EL job
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).withRetries(1).fail();
+
+    // complete the retried cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: assert the cancel EL job was completed after the failure
+    assertThat(records().betweenProcessInstance(processInstanceKey))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSubsequence(
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(ValueType.JOB, JobIntent.CREATED),
+            tuple(ValueType.JOB, JobIntent.FAILED),
+            tuple(ValueType.JOB, JobIntent.COMPLETE),
+            tuple(ValueType.JOB, JobIntent.COMPLETED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldRecreateCancelElJobsAndProceedAfterIncidentResolution() {
+    // given: process with expression-based cancel EL type that will fail
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeExecutionListener(el -> el.cancel().type(CANCEL_EL_TYPE + "_1"))
+                .zeebeExecutionListener(el -> el.cancel().typeExpression("cancel_el_2_name_var"))
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // complete the first cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE + "_1").complete();
+
+    // then: incident should be raised for missing variable
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+                Expected result of the expression 'cancel_el_2_name_var' to be 'STRING', but was 'NULL'. \
+                The evaluation reported the following warnings:
+                [NO_VARIABLE_FOUND] No variable found with name 'cancel_el_2_name_var'""");
+
+    // fix by resolving the incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // complete re-created first cancel EL job, providing the needed variable via job output
+    final long recreatedJobKey =
+        jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(CANCEL_EL_TYPE + "_1")
+            .skip(1)
+            .getFirst()
+            .getKey();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withKey(recreatedJobKey)
+        .withVariable("cancel_el_2_name_var", CANCEL_EL_TYPE + "_evaluated_2")
+        .complete();
+    // complete the second cancel EL job
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(CANCEL_EL_TYPE + "_evaluated_2")
+        .complete();
+
+    // then: assert cancel EL jobs were processed correctly
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .filter(r -> r.getValue().getJobListenerEventType() == JobListenerEventType.CANCEL)
+                .limit(3))
+        .extracting(r -> r.getValue().getType())
+        .containsExactly(
+            CANCEL_EL_TYPE + "_1", CANCEL_EL_TYPE + "_1", CANCEL_EL_TYPE + "_evaluated_2");
+
+    // and: process instance should be terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElWithStartAndEndEls() {
+    // given: process with start, end, and cancel execution listeners
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeStartExecutionListener(START_EL_TYPE)
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    // complete the start EL
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+
+    // wait for service task
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance (should trigger cancel EL, not end EL)
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // complete the cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: start EL was completed, cancel EL was created and completed,
+    // end EL was NOT triggered
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .limit(2))
+        .extracting(r -> r.getValue().getType(), r -> r.getValue().getJobListenerEventType())
+        .containsExactly(
+            tuple(START_EL_TYPE, JobListenerEventType.START),
+            tuple(CANCEL_EL_TYPE, JobListenerEventType.CANCEL));
+
+    // and: process instance should be terminated (not completed)
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldBlockTerminationUntilCancelElIsCompleted() {
+    // given: process with cancel EL
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // wait for the cancel EL job to be created
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(CANCEL_EL_TYPE)
+        .await();
+
+    // then: process should be in ELEMENT_TERMINATING state (blocked by cancel EL)
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processInstanceRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withElementType(BpmnElementType.PROCESS)
+                        .withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                        .exists()))
+        .isFalse();
+
+    // when: complete the cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: process should now be terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .findAny())
+        .isPresent();
+  }
+
+  @Test
+  public void shouldEvaluateExpressionsForCancelExecutionListeners() {
+    // given: process with expression-based cancel EL
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeExecutionListener(
+                    el ->
+                        el.cancel()
+                            .typeExpression("cancelListenerTypeVar")
+                            .retriesExpression("cancelRetries"))
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done(),
+            Map.of("cancelListenerTypeVar", CANCEL_EL_TYPE, "cancelRetries", 5));
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // complete the cancel EL
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: cancel EL job should have evaluated expression values
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .getFirst())
+        .satisfies(
+            record -> {
+              assertThat(record.getValue().getType()).isEqualTo(CANCEL_EL_TYPE);
+              assertThat(record.getValue().getRetries()).isEqualTo(5);
+              assertThat(record.getValue().getJobListenerEventType())
+                  .isEqualTo(JobListenerEventType.CANCEL);
+            });
+  }
+
+  @Test
+  public void shouldNotTriggerCancelElWhenProcessCompletesNormally() {
+    // given: process with cancel EL (and end EL for contrast)
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .manualTask()
+                .endEvent()
+                .done());
+
+    // complete the end EL
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // then: only end EL should be executed, not cancel EL
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .limit(1))
+        .extracting(r -> r.getValue().getType(), r -> r.getValue().getJobListenerEventType())
+        .containsExactly(tuple(END_EL_TYPE, JobListenerEventType.END));
+
+    // and: process instance should be completed (not terminated)
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    // and: no cancel EL job should have been created
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .jobRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withJobKind(JobKind.EXECUTION_LISTENER)
+                        .withType(CANCEL_EL_TYPE)
+                        .exists()))
+        .describedAs("Cancel EL job should not be created when process completes normally")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldCancelActiveServiceTaskBeforeCancelElExecution() {
+    // given: process with cancel EL and a service task
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // then: the service task job should be canceled
+    assertThat(
+            jobRecords(JobIntent.CANCELED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType(SERVICE_TASK_TYPE)
+                .getFirst())
+        .isNotNull();
+
+    // complete the cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: verify order: service task canceled before cancel EL completes
+    assertThat(records().betweenProcessInstance(processInstanceKey).onlyEvents())
+        .filteredOn(
+            r ->
+                r.getValueType() == ValueType.JOB || r.getValueType() == ValueType.PROCESS_INSTANCE)
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSubsequence(
+            tuple(ValueType.JOB, JobIntent.CANCELED), // service task canceled
+            tuple(ValueType.JOB, JobIntent.CREATED), // cancel EL created
+            tuple(ValueType.JOB, JobIntent.COMPLETED), // cancel EL completed
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElWhenProcessWithEmbeddedSubprocessIsCanceled() {
+    // given: process with cancel EL and an embedded subprocess containing a service task
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    s ->
+                        s.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("sub_task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                            .endEvent())
+                .endEvent()
+                .done());
+
+    // wait for the service task inside the subprocess to be activated
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // then: the subprocess service task job should be canceled
+    assertThat(
+            jobRecords(JobIntent.CANCELED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType(SERVICE_TASK_TYPE)
+                .getFirst())
+        .isNotNull();
+
+    // complete the cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: cancel EL should have correct properties
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .getFirst()
+                .getValue())
+        .satisfies(
+            job -> {
+              assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.CANCEL);
+              assertThat(job.getElementId()).isEqualTo(PROCESS_ID);
+            });
+
+    // and: process instance should be terminated with correct sequence:
+    // process enters TERMINATING, children terminate, cancel EL fires, process terminates
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldEmitContinueTerminatingElementWhenProcessWithCancelElHasActiveChildren() {
+    // given: process with cancel EL and an active service task as a direct child
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the process instance and complete the cancel EL job
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: CONTINUE_TERMINATING_ELEMENT is emitted between the child's ELEMENT_TERMINATED
+    // and the process's COMPLETE_EXECUTION_LISTENER, so the cancel listener chain runs
+    // after children are gone but before the process reaches ELEMENT_TERMINATED
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.CONTINUE_TERMINATING_ELEMENT),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElWhenProcessWithParallelGatewayIsCanceled() {
+    // given: process with cancel EL and a parallel gateway with two active tasks
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .parallelGateway("fork")
+                .serviceTask("task_a", t -> t.zeebeJobType(SERVICE_TASK_TYPE + "_a"))
+                .endEvent("end_a")
+                .moveToNode("fork")
+                .serviceTask("task_b", t -> t.zeebeJobType(SERVICE_TASK_TYPE + "_b"))
+                .endEvent("end_b")
+                .done());
+
+    // wait for both tasks to be activated
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE + "_a")
+        .await();
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE + "_b")
+        .await();
+
+    // when: cancel the process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // complete the cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: both task jobs should be canceled
+    assertThat(jobRecords(JobIntent.CANCELED).withProcessInstanceKey(processInstanceKey).limit(2))
+        .extracting(r -> r.getValue().getType())
+        .containsExactlyInAnyOrder(SERVICE_TASK_TYPE + "_a", SERVICE_TASK_TYPE + "_b");
+
+    // and: cancel EL should have been completed
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .getFirst()
+                .getValue())
+        .satisfies(
+            job -> {
+              assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.CANCEL);
+              assertThat(job.getElementId()).isEqualTo(PROCESS_ID);
+            });
+
+    // and: process instance should be terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElWhenProcessWithCallActivityIsCanceled() {
+    // given: a child process and a parent process with cancel EL + call activity
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess("child_process")
+            .startEvent()
+            .serviceTask("child_task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+            .endEvent()
+            .done();
+    final BpmnModelInstance parentProcess =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+            .startEvent()
+            .callActivity("call_activity", c -> c.zeebeProcessId("child_process"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource("child.bpmn", childProcess).deploy();
+    ENGINE.deployment().withXmlResource("parent.bpmn", parentProcess).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // wait for the child process task to be activated
+    jobRecords(JobIntent.CREATED).withType(SERVICE_TASK_TYPE).await();
+
+    // when: cancel the parent process instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // complete the cancel EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: cancel EL should have been completed with correct properties
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .getFirst()
+                .getValue())
+        .satisfies(
+            job -> {
+              assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.CANCEL);
+              assertThat(job.getElementId()).isEqualTo(PROCESS_ID);
+            });
+
+    // and: parent process instance should be terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldNotTriggerCancelElWhenInterruptingEventSubprocessActivates() {
+    // given: process with cancel EL and an interrupting message event subprocess
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .eventSubProcess(
+                    "event_subprocess",
+                    sub ->
+                        sub.startEvent("event_start")
+                            .interrupting(true)
+                            .message(
+                                m -> m.name("interruptMsg").zeebeCorrelationKeyExpression("key"))
+                            .endEvent("event_end"))
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done(),
+            Map.of("key", "correlationKey"));
+
+    // wait for the service task
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: trigger the interrupting event subprocess
+    ENGINE.message().withName("interruptMsg").withCorrelationKey("correlationKey").publish();
+
+    // complete the end EL (event subprocess completion triggers process end EL)
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // then: the process should complete (via event subprocess), not terminate
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    // and: no cancel EL job should have been created
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .jobRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withJobKind(JobKind.EXECUTION_LISTENER)
+                        .withType(CANCEL_EL_TYPE)
+                        .exists()))
+        .describedAs(
+            "Cancel EL job should not be created when process is interrupted by event subprocess")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldCompleteCancelElWithVariables() {
+    // given: process with cancel EL
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel and complete the cancel EL with variables
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(CANCEL_EL_TYPE)
+        .withVariable("cancelReason", "user_requested")
+        .complete();
+
+    // then: process instance should be terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldRejectDoubleCancelWhileTerminatingWithActiveChildrenAndNoCancelEl() {
+    // given: child process with cancel-EL (keeps it in TERMINATING state)
+    // and parent process with cancel-EL and a call activity
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess("child_process")
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE + "_child")
+            .startEvent()
+            .serviceTask("child_task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+            .endEvent()
+            .done();
+    final BpmnModelInstance parentProcess =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+            .startEvent()
+            .callActivity("call_activity", c -> c.zeebeProcessId("child_process"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource("child.bpmn", childProcess).deploy();
+    ENGINE.deployment().withXmlResource("parent.bpmn", parentProcess).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // wait for child process service task
+    jobRecords(JobIntent.CREATED).withType(SERVICE_TASK_TYPE).await();
+
+    // when: cancel the parent process instance
+    // The parent enters TERMINATING → call activity enters TERMINATING
+    // → child process enters TERMINATING → child cancel-EL job is created
+    // Parent is still TERMINATING with active children and NO active cancel-EL job
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // wait for child cancel-EL job to confirm parent is in correct state:
+    // parent is TERMINATING, call activity is still active, parent has NO cancel-EL job
+    final var childCancelElJob =
+        jobRecords(JobIntent.CREATED)
+            .withType(CANCEL_EL_TYPE + "_child")
+            .withJobKind(JobKind.EXECUTION_LISTENER)
+            .getFirst();
+
+    // when: send a second cancel while parent is terminating with no cancel-EL job active
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectRejection().cancel();
+
+    // then: the second cancel should be rejected (no active cancel-EL job on parent)
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .onlyCommandRejections()
+                .withProcessInstanceKey(processInstanceKey)
+                .withIntent(ProcessInstanceIntent.CANCEL)
+                .findAny())
+        .describedAs(
+            "Second cancel should be rejected when process is terminating with active children "
+                + "and no active cancel-EL job")
+        .isPresent();
+
+    // complete the child cancel-EL job so the process can finish normally
+    ENGINE.job().withKey(childCancelElJob.getKey()).complete();
+
+    // complete the parent cancel-EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // and: process instance should eventually be terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldRaiseAndResolveIncidentWhenCancelElJobExhaustsRetries() {
+    // given: process with cancel EL
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel and exhaust the cancel-EL job's retries
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(CANCEL_EL_TYPE)
+        .withRetries(0)
+        .withErrorMessage("worker giving up")
+        .fail();
+
+    // then: a job-no-retries incident is raised for the cancel EL
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    Assertions.assertThat(incident.getValue())
+        .hasErrorType(ErrorType.EXECUTION_LISTENER_NO_RETRIES)
+        .hasErrorMessage("worker giving up")
+        .hasElementId(PROCESS_ID);
+
+    // when: update retries on the job and resolve the incident; cancel EL completes
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(CANCEL_EL_TYPE)
+        .withRetries(1)
+        .updateRetries();
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: process instance terminates after the incident is resolved
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElForProcessInstanceWithUnresolvedIncident() {
+    // The banned-instance allow-list change in Engine.java is exercised here through the
+    // realistic operational path: an instance carrying an unresolved incident on a child element
+    // should still be cancelable end-to-end via the cancel-EL chain.
+    // given: process with cancel EL whose service task fails terminally before cancellation
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .withRetries(0)
+        .withErrorMessage("service task error")
+        .fail();
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withErrorType(ErrorType.JOB_NO_RETRIES)
+        .await();
+
+    // when: cancel the instance while it is in incident state
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: cancel EL ran and the process terminated despite the unresolved service-task incident
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withType(CANCEL_EL_TYPE)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .getFirst()
+                .getValue())
+        .satisfies(
+            job ->
+                assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.CANCEL));
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldIgnoreDeniedFlagOnCancelElCompletion() {
+    // The Javadoc on JobListenerEventType.CANCEL says termination cannot be denied. The deny
+    // logic in JobCompleteProcessor only enforces task listeners; for execution listeners the
+    // denied flag is silently ignored, so the cancel-EL still drives the process to TERMINATED.
+    // given: process with cancel EL
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel and complete the cancel-EL with denied=true
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(CANCEL_EL_TYPE)
+        .withResult(new JobResult().setDenied(true))
+        .complete();
+
+    // then: the denied flag is ignored and the process still terminates
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldNotTriggerCancelElWhenProcessIsInterruptedByTerminateEndEvent() {
+    // given: process with cancel EL where one branch reaches a terminate end event
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .startEvent()
+                .parallelGateway("fork")
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .moveToNode("fork")
+                .endEvent("terminate-end", EndEventBuilder::terminate)
+                .done());
+
+    // wait for the parallel branch to become active, then complete the end EL
+    // (the terminate end event ends the process as a normal completion)
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // then: the process completes (not terminates), and no cancel-EL job is created
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .jobRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withJobKind(JobKind.EXECUTION_LISTENER)
+                        .withType(CANCEL_EL_TYPE)
+                        .exists()))
+        .describedAs(
+            "Cancel EL job must not be created when the process completes via a terminate end event")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldExecuteCancelElWhenProcessIsCanceledWhileStartElIsPending() {
+    // given: process with start + cancel ELs and a service task; start EL job is pending
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeStartExecutionListener(START_EL_TYPE)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    // wait for the start EL job to be created and leave it pending
+    final long startElJobKey =
+        jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withJobKind(JobKind.EXECUTION_LISTENER)
+            .withType(START_EL_TYPE)
+            .getFirst()
+            .getKey();
+
+    // when: cancel the process while the start EL is still in flight
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: the pending start EL job was canceled, the cancel EL fired, and the process terminated
+    assertThat(jobRecords(JobIntent.CANCELED).withRecordKey(startElJobKey).getFirst().getValue())
+        .satisfies(
+            job -> {
+              assertThat(job.getJobKind()).isEqualTo(JobKind.EXECUTION_LISTENER);
+              assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.START);
+            });
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElWhenProcessIsCanceledWhileEndElIsPending() {
+    // given: process with end + cancel ELs and a manual task; end EL job is pending after
+    // completion
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .manualTask()
+                .endEvent()
+                .done());
+
+    final long endElJobKey =
+        jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withJobKind(JobKind.EXECUTION_LISTENER)
+            .withType(END_EL_TYPE)
+            .getFirst()
+            .getKey();
+
+    // when: cancel the process while the end EL is still in flight
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: the pending end EL job was canceled, the cancel EL fired, and the process terminated
+    assertThat(jobRecords(JobIntent.CANCELED).withRecordKey(endElJobKey).getFirst().getValue())
+        .satisfies(
+            job -> {
+              assertThat(job.getJobKind()).isEqualTo(JobKind.EXECUTION_LISTENER);
+              assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.END);
+            });
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteChildCancelElWhenParentWithoutCancelElIsCanceled() {
+    // given: parent without cancel EL calling a child process that has a cancel EL
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess("child_process")
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE + "_child")
+            .startEvent()
+            .serviceTask("child_task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+            .endEvent()
+            .done();
+    final BpmnModelInstance parentProcess =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .callActivity(
+                "call_activity",
+                c ->
+                    c.zeebeProcessId("child_process")
+                        .zeebeOutputExpression("childCancelOutput", "parentVar"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource("child.bpmn", childProcess).deploy();
+    ENGINE.deployment().withXmlResource("parent.bpmn", parentProcess).deploy();
+    final long parentInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long childInstanceKey =
+        RecordingExporter.processInstanceRecords()
+            .withParentProcessInstanceKey(parentInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    jobRecords(JobIntent.CREATED).withType(SERVICE_TASK_TYPE).await();
+
+    // when: cancel the parent — the child's cancel EL must fire before the child terminates
+    ENGINE.processInstance().withInstanceKey(parentInstanceKey).expectTerminating().cancel();
+    ENGINE
+        .job()
+        .ofInstance(childInstanceKey)
+        .withType(CANCEL_EL_TYPE + "_child")
+        .withVariable("childCancelOutput", "leaked")
+        .complete();
+
+    // then: child cancel EL completed and both processes terminated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(parentInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(childInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .getFirst()
+                .getValue())
+        .satisfies(
+            job ->
+                assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.CANCEL));
+
+    // and: child cancel-EL output variables must NOT be propagated to the parent via call-activity
+    // output mappings (the call activity is being terminated, not completed)
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .variableRecords()
+                        .withProcessInstanceKey(parentInstanceKey)
+                        .withName("parentVar")
+                        .exists()))
+        .describedAs("Child cancel-EL output variables must not propagate up via the call activity")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldScopeCancelElOutputVariableToProcessInstance() {
+    // given: process with cancel EL and a service task
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel and complete the cancel-EL with a variable
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(CANCEL_EL_TYPE)
+        .withVariable("cancelOutput", "value")
+        .complete();
+
+    // then: the variable is scoped to the process instance, not a child element scope
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("cancelOutput")
+                .getFirst()
+                .getValue())
+        .satisfies(
+            (VariableRecordValue v) -> {
+              assertThat(v.getScopeKey()).isEqualTo(processInstanceKey);
+              assertThat(v.getValue()).isEqualTo("\"value\"");
+            });
+  }
+
+  @Test
+  public void shouldExecuteCancelElForProcessStartedByMessageStartEvent() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+            .startEvent("msg-start")
+            .message(m -> m.name("startMsg"))
+            .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    ENGINE.message().withName("startMsg").withCorrelationKey("start").publish();
+    final long processInstanceKey =
+        RecordingExporter.processInstanceRecords()
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+    jobRecords(JobIntent.CREATED).withType(SERVICE_TASK_TYPE).await();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElForProcessStartedByTimerStartEvent() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+            .startEvent("timer-start")
+            .timerWithCycle("R1/PT1S")
+            .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    ENGINE.increaseTime(Duration.ofSeconds(2));
+    final long processInstanceKey =
+        RecordingExporter.processInstanceRecords()
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+    jobRecords(JobIntent.CREATED).withType(SERVICE_TASK_TYPE).await();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElForProcessStartedBySignalStartEvent() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+            .startEvent("signal-start")
+            .signal("startSignal")
+            .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    ENGINE.signal().withSignalName("startSignal").broadcast();
+    final long processInstanceKey =
+        RecordingExporter.processInstanceRecords()
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+    jobRecords(JobIntent.CREATED).withType(SERVICE_TASK_TYPE).await();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldNotRunCompensationDuringProcessCancellationWithCancelEl() {
+    // given: process with cancel EL and a service task that has a compensation handler
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    t ->
+                        t.zeebeJobType(SERVICE_TASK_TYPE)
+                            .boundaryEvent()
+                            .compensation(
+                                c ->
+                                    c.serviceTask("compensation-handler")
+                                        .zeebeJobType("compensation")))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    // when: cancel the instance and complete the cancel EL
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: the process terminates and no compensation handler job was ever created
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .jobRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withType("compensation")
+                        .exists()))
+        .describedAs("Compensation handler must not run when the process is canceled")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldRejectSecondCancelWhileCancelElJobIsActive() {
+    // given: process with cancel EL and a service task; cancel terminates the task and creates the
+    // cancel-EL job with no remaining children
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withJobKind(JobKind.EXECUTION_LISTENER)
+        .withType(CANCEL_EL_TYPE)
+        .await();
+
+    // when: a second cancel arrives while the cancel-EL job is still active
+    final var rejectedCancel =
+        ENGINE.processInstance().withInstanceKey(processInstanceKey).expectRejection().cancel();
+
+    // then: the second cancel is rejected (the process is already terminating)
+    assertThat(rejectedCancel.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+
+    // cleanup: complete the cancel-EL job so the process terminates
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .filter(r -> r.getValue().getBpmnElementType() == BpmnElementType.PROCESS)
+                .map(Record::getIntent))
+        .contains(ProcessInstanceIntent.ELEMENT_TERMINATED);
+  }
+
+  @Test
+  public void shouldRecoverPendingCancelElJobAfterStreamProcessorRestart() {
+    // given: process with cancel EL; cancel-EL job is created and left pending
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withJobKind(JobKind.EXECUTION_LISTENER)
+        .withType(CANCEL_EL_TYPE)
+        .await();
+
+    // when: take a snapshot and reprocess (simulates a leader restart with snapshot recovery)
+    ENGINE.snapshot();
+    ENGINE.reprocess();
+
+    // then: completing the cancel-EL job after reprocess still drives the process to TERMINATED
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerCancelTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerCancelTest.java
@@ -1639,4 +1639,101 @@ public class ExecutionListenerCancelTest {
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
+
+  @Test
+  public void shouldExecuteCancelElWhenProcessIsTerminatedByModification() {
+    // given: process with cancel EL and a service task; modification will empty the process
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    final long serviceTaskInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getKey();
+
+    // when: modification terminates the only active element
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .terminateElement(serviceTaskInstanceKey)
+        .modify();
+
+    // then: the cancel-EL job is created; complete it
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    // then: the process terminates after the cancel listener runs
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.TERMINATE_ELEMENT),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldExecuteCancelElWhenProcessIsTerminatedByModificationOfNestedSubprocess() {
+    // given: process with cancel EL and an embedded subprocess containing the only active task
+    final long processInstanceKey =
+        createProcessInstance(
+            ENGINE,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeCancelExecutionListener(CANCEL_EL_TYPE)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    s ->
+                        s.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("sub_task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                            .endEvent())
+                .endEvent()
+                .done());
+
+    final long subTaskInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("sub_task")
+            .getFirst()
+            .getKey();
+
+    // when: modification terminates the only active leaf — terminateFlowScopes walks up
+    // through the subprocess and delegates to the stream processor at the process
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .terminateElement(subTaskInstanceKey)
+        .modify();
+
+    // then: cancel-EL job fires after the subprocess is gone but before the process terminates
+    ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.TERMINATE_ELEMENT),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerCancelTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerCancelTest.java
@@ -1356,6 +1356,79 @@ public class ExecutionListenerCancelTest {
   }
 
   @Test
+  public void shouldExecuteChildCancelElWhenCallActivityIsInterruptedByBoundaryEvent() {
+    // given: parent (no cancel-EL) with a call activity carrying an interrupting boundary timer;
+    // child (with cancel-EL) running a waiting service task
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess("child_process")
+            .zeebeCancelExecutionListener(CANCEL_EL_TYPE + "_child")
+            .startEvent()
+            .serviceTask("child_task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+            .endEvent()
+            .done();
+    final BpmnModelInstance parentProcess =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .callActivity("call_activity", c -> c.zeebeProcessId("child_process"))
+            .boundaryEvent("timeout", b -> b.cancelActivity(true).timerWithDuration("PT1S"))
+            .endEvent("after_boundary")
+            .done();
+
+    ENGINE.deployment().withXmlResource("child.bpmn", childProcess).deploy();
+    ENGINE.deployment().withXmlResource("parent.bpmn", parentProcess).deploy();
+    final long parentInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long childInstanceKey =
+        RecordingExporter.processInstanceRecords()
+            .withParentProcessInstanceKey(parentInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+    jobRecords(JobIntent.CREATED).withType(SERVICE_TASK_TYPE).await();
+
+    // when: the boundary timer interrupts the call activity, terminating the child process
+    ENGINE.increaseTime(Duration.ofSeconds(2));
+    ENGINE.job().ofInstance(childInstanceKey).withType(CANCEL_EL_TYPE + "_child").complete();
+
+    // then: child cancel-EL ran before the child terminated
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(childInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .getFirst()
+                .getValue())
+        .satisfies(
+            job ->
+                assertThat(job.getJobListenerEventType()).isEqualTo(JobListenerEventType.CANCEL));
+
+    // and: child process reached ELEMENT_TERMINATED after the cancel-EL completed
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(childInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+
+    // and: parent continued out of the boundary event and completed normally
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(parentInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
   public void shouldScopeCancelElOutputVariableToProcessInstance() {
     // given: process with cancel EL and a service task
     final long processInstanceKey =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -740,4 +740,34 @@ public class DeploymentRejectionTest {
         .contains(
             "The BPMN 2.0 schema requires flow element references to appear before event definitions");
   }
+
+  @Test
+  public void shouldRejectDeploymentIfCancelExecutionListenerIsDefinedOnNonProcessElement() {
+    // given: a service task carrying a cancel execution listener (only valid on the process)
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("service")
+                        .zeebeCancelExecutionListener("cancel_execution_listener_job"))
+            .endEvent()
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "The 'cancel' execution listener event type is not supported for the 'serviceTask' element. "
+                + "The 'cancel' event type is only supported on the 'process' element.");
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
@@ -636,6 +636,7 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.SUB_PROCESS,
                 "subprocess",
                 ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATED))
         .describedAs("Expect the flow scope not to be completed")
@@ -805,6 +806,7 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.EVENT_SUB_PROCESS,
                 "event-subprocess",
                 ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
@@ -899,6 +901,7 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.SUB_PROCESS,
                 "subprocess",
                 ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
@@ -969,6 +972,7 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.CALL_ACTIVITY,
                 "callActivity",
                 ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
@@ -636,7 +636,6 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.SUB_PROCESS,
                 "subprocess",
                 ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATED))
         .describedAs("Expect the flow scope not to be completed")
@@ -806,7 +805,6 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.EVENT_SUB_PROCESS,
                 "event-subprocess",
                 ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
@@ -901,7 +899,6 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.SUB_PROCESS,
                 "subprocess",
                 ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
@@ -972,7 +969,6 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.CALL_ACTIVITY,
                 "callActivity",
                 ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -83,6 +83,7 @@ message ActivatedJob {
     UNSPECIFIED = 6;
     UPDATING = 7;
     BEFORE_ALL = 8;
+    CANCEL = 9;
   }
 
   // the key, a unique identifier for the job

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1074,6 +1074,7 @@ components:
       enum:
         - ASSIGNING
         - BEFORE_ALL
+        - CANCEL
         - CANCELING
         - COMPLETING
         - CREATING

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -231,6 +231,113 @@ public class JobQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldSearchExecutionListenerJobWithCancelEventType() {
+    // given
+    final var cancelElResult =
+        new SearchQueryResult.Builder<JobEntity>()
+            .total(1L)
+            .items(
+                List.of(
+                    new JobEntity.Builder()
+                        .jobKey(10L)
+                        .type("cancelCleanup")
+                        .worker("elWorker")
+                        .state(JobState.CREATED)
+                        .kind(JobKind.EXECUTION_LISTENER)
+                        .listenerEventType(ListenerEventType.CANCEL)
+                        .retries(3)
+                        .isDenied(false)
+                        .hasFailedWithRetriesLeft(false)
+                        .customHeaders(Map.of())
+                        .processDefinitionId("myProcess")
+                        .processDefinitionKey(5L)
+                        .processInstanceKey(6L)
+                        .rootProcessInstanceKey(6L)
+                        .elementId("myProcess")
+                        .elementInstanceKey(7L)
+                        .tenantId("<default>")
+                        .creationTime(OffsetDateTime.parse("2025-06-05T09:00:00.000Z"))
+                        .lastUpdateTime(OffsetDateTime.parse("2025-06-05T10:04:00.000Z"))
+                        .build()))
+            .startCursor("abc")
+            .endCursor("def")
+            .build();
+    when(jobServices.search(any(JobQuery.class), any())).thenReturn(cancelElResult);
+
+    final var request =
+        """
+      {
+        "filter": {
+          "kind": "EXECUTION_LISTENER",
+          "listenerEventType": "CANCEL"
+        }
+      }
+      """;
+
+    final var expectedResponse =
+        """
+      {
+        "items": [
+          {
+            "jobKey": "10",
+            "type": "cancelCleanup",
+            "worker": "elWorker",
+            "state": "CREATED",
+            "kind": "EXECUTION_LISTENER",
+            "listenerEventType": "CANCEL",
+            "retries": 3,
+            "isDenied": false,
+            "hasFailedWithRetriesLeft": false,
+            "customHeaders": {},
+            "processDefinitionId": "myProcess",
+            "processDefinitionKey": "5",
+            "processInstanceKey": "6",
+            "rootProcessInstanceKey": "6",
+            "elementId": "myProcess",
+            "elementInstanceKey": "7",
+            "tenantId": "<default>",
+            "creationTime": "2025-06-05T09:00:00.000Z",
+            "lastUpdateTime": "2025-06-05T10:04:00.000Z"
+          }
+        ],
+        "page": {
+          "totalItems": 1,
+          "startCursor": "abc",
+          "endCursor": "def",
+          "hasMoreTotalItems": false
+        }
+      }
+      """;
+
+    // when / then
+    webClient
+        .post()
+        .uri(JOB_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.LENIENT);
+
+    verify(jobServices)
+        .search(
+            eq(
+                new JobQuery.Builder()
+                    .filter(
+                        new JobFilter.Builder()
+                            .kinds(JobKind.EXECUTION_LISTENER.name())
+                            .listenerEventTypes(ListenerEventType.CANCEL.name())
+                            .build())
+                    .build()),
+            any());
+  }
+
+  @Test
   void shouldSearchJobWithFullSorting() {
     // given
     when(jobServices.search(any(JobQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
@@ -33,6 +33,14 @@ public enum JobListenerEventType {
   BEFORE_ALL,
 
   /**
+   * Represents the `cancel` event for an execution listener. This event type is used to indicate
+   * that the listener should be triggered when the process element reaches {@code
+   * ELEMENT_TERMINATING} state (e.g. explicit process instance cancellation). The element
+   * termination can't be denied by a listener of this type.
+   */
+  CANCEL,
+
+  /**
    * Represents the `start` event for an execution listener. This event type is used to indicate
    * that the listener should be triggered at the start of an execution, such as the beginning of a
    * process instance, sub-process or element (task, event, gateway).


### PR DESCRIPTION
## Description

 Implements the `cancel` event type for execution listeners on the `<process>` element. When a process instance is terminated, declared cancel listeners run as job-worker jobs in declaration order, after all children have terminated and before the process reaches its final terminated state. They use the same job infrastructure as `start` and `end` listeners and surface as `JobKind.EXECUTION_LISTENER` with `listenerEventType: CANCEL`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #52616
