### PR TITLE
fix: handle deleted state on listing

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -325,6 +325,7 @@ public final class BackupEndpoint {
       case FAILED -> StateCode.FAILED;
       case DOES_NOT_EXIST -> StateCode.DOES_NOT_EXIST;
       case INCOMPLETE -> StateCode.INCOMPLETE;
+      case DELETED -> StateCode.DELETED;
     };
   }
 
@@ -334,6 +335,7 @@ public final class BackupEndpoint {
       case COMPLETED -> StateCode.COMPLETED;
       case FAILED -> StateCode.FAILED;
       case DOES_NOT_EXIST -> StateCode.DOES_NOT_EXIST;
+      case DELETED -> StateCode.DELETED;
       default -> throw new IllegalStateException("Unknown BackupState %s".formatted(status));
     };
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -353,7 +353,8 @@ public final class BackupRequestHandler implements BackupApi {
     }
     if ((statuses.contains(BackupStatusCode.IN_PROGRESS)
             || statuses.contains(BackupStatusCode.COMPLETED))
-        && statuses.contains(BackupStatusCode.DOES_NOT_EXIST)) {
+        && (statuses.contains(BackupStatusCode.DOES_NOT_EXIST)
+            || statuses.contains(BackupStatusCode.DELETED))) {
       return State.INCOMPLETE;
     }
     if (statuses.contains(BackupStatusCode.IN_PROGRESS)) {
@@ -362,6 +363,10 @@ public final class BackupRequestHandler implements BackupApi {
 
     if (statuses.contains(BackupStatusCode.DOES_NOT_EXIST)) {
       return State.DOES_NOT_EXIST;
+    }
+
+    if (statuses.contains(BackupStatusCode.DELETED)) {
+      return State.DELETED;
     }
 
     if (statuses.size() == 1 && statuses.contains(BackupStatusCode.COMPLETED)) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -353,16 +353,17 @@ public final class BackupRequestHandler implements BackupApi {
     }
     if ((statuses.contains(BackupStatusCode.IN_PROGRESS)
             || statuses.contains(BackupStatusCode.COMPLETED))
-        && (statuses.contains(BackupStatusCode.DOES_NOT_EXIST)
-            || statuses.contains(BackupStatusCode.DELETED))) {
+        && statuses.contains(BackupStatusCode.DOES_NOT_EXIST)
+        && !statuses.contains(BackupStatusCode.DELETED)) {
       return State.INCOMPLETE;
-    }
-    if (statuses.contains(BackupStatusCode.IN_PROGRESS)) {
-      return State.IN_PROGRESS;
     }
 
     if (statuses.contains(BackupStatusCode.DELETED)) {
       return State.DELETED;
+    }
+
+    if (statuses.contains(BackupStatusCode.IN_PROGRESS)) {
+      return State.IN_PROGRESS;
     }
 
     if (statuses.contains(BackupStatusCode.DOES_NOT_EXIST)) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -361,12 +361,12 @@ public final class BackupRequestHandler implements BackupApi {
       return State.IN_PROGRESS;
     }
 
-    if (statuses.contains(BackupStatusCode.DOES_NOT_EXIST)) {
-      return State.DOES_NOT_EXIST;
-    }
-
     if (statuses.contains(BackupStatusCode.DELETED)) {
       return State.DELETED;
+    }
+
+    if (statuses.contains(BackupStatusCode.DOES_NOT_EXIST)) {
+      return State.DOES_NOT_EXIST;
     }
 
     if (statuses.size() == 1 && statuses.contains(BackupStatusCode.COMPLETED)) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/PartitionBackupStatus.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/PartitionBackupStatus.java
@@ -31,7 +31,7 @@ public record PartitionBackupStatus(
     return switch (status) {
       case FAILED -> failedStatus(response);
       case DOES_NOT_EXIST -> notExistingStatus(response.getPartitionId());
-      case IN_PROGRESS, COMPLETED -> validStatus(response);
+      case IN_PROGRESS, COMPLETED, DELETED -> validStatus(response);
       default -> throw new IllegalArgumentException("Unknown backup status %s".formatted(status));
     };
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/State.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/State.java
@@ -11,6 +11,7 @@ public enum State {
   DOES_NOT_EXIST,
   INCOMPLETE,
   FAILED,
+  DELETED,
   IN_PROGRESS,
   COMPLETED
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupQueryStub.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupQueryStub.java
@@ -83,6 +83,20 @@ public class BackupQueryStub
         .setFailureReason("");
   }
 
+  private BackupStatusResponse getDeletedStatus(final BackupStatusRequest request) {
+    return new BackupStatusResponse()
+        .setBackupId(request.getBackupId())
+        .setStatus(BackupStatusCode.DELETED)
+        .setSnapshotId("sid")
+        .setFailureReason("")
+        .setCheckpointPosition(100)
+        .setBrokerId(1)
+        .setPartitionId(request.getPartitionId())
+        .setBrokerVersion("test")
+        .setCreatedAt(Instant.now().toString())
+        .setLastUpdated(Instant.now().toString());
+  }
+
   public BackupQueryStub withErrorResponseFor(final int partitionId) {
     responses.put(
         partitionId,
@@ -102,6 +116,11 @@ public class BackupQueryStub
 
   public BackupQueryStub withDoesNotExistFor(final int partitionId) {
     responses.put(partitionId, request -> new BrokerResponse<>(getDoesNotExistStatus(request)));
+    return this;
+  }
+
+  public BackupQueryStub withDeletedResponseFor(final int partitionId) {
+    responses.put(partitionId, request -> new BrokerResponse<>(getDeletedStatus(request)));
     return this;
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
@@ -219,6 +219,66 @@ public class BackupRequestHandlerTest extends GatewayTest {
   }
 
   @Test
+  public void shouldReturnIncompleteStatusWhenOnePartitionBackupIsDeleted() {
+    // given
+    final BackupQueryStub stub = new BackupQueryStub();
+    stub.withDeletedResponseFor(2);
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.getStatus(1);
+
+    // then
+    assertThat(future)
+        .succeedsWithin(Duration.ofMillis(500))
+        .returns(State.DELETED, BackupStatus::status);
+
+    final var status = future.toCompletableFuture().join();
+    assertThat(status.partitions())
+        .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
+  }
+
+  @Test
+  public void shouldReturnDeletedStatusWhenBackupIsDeleted() {
+    // given
+    final BackupQueryStub stub = new BackupQueryStub();
+    stub.withDeletedResponseFor(1);
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.getStatus(1);
+
+    // then
+    assertThat(future)
+        .succeedsWithin(Duration.ofMillis(500))
+        .returns(State.DELETED, BackupStatus::status);
+
+    final var status = future.toCompletableFuture().join();
+    assertThat(status.partitions())
+        .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
+  }
+
+  @Test
+  public void shouldReturnDeletedStatusOnAtLeastOneDeleted() {
+    // given
+    final BackupQueryStub stub = new BackupQueryStub();
+    stub.withDeletedResponseFor(2).withDoesNotExistFor(3);
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.getStatus(1);
+
+    // then
+    assertThat(future)
+        .succeedsWithin(Duration.ofMillis(500))
+        .returns(State.DELETED, BackupStatus::status);
+
+    final var status = future.toCompletableFuture().join();
+    assertThat(status.partitions())
+        .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
+  }
+
+  @Test
   public void shouldFailWhenQueryToOnePartitionFails() {
     // given
     final BackupQueryStub stub = new BackupQueryStub();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Handle `DELETED` status on backup listing request. There is a chance to have `DELETED` manifests during listing even without failures on the actual deletion, if requesting a `list` during the deletion.

It's also more visible now that deletions go through the processor.

Removes the flakiness for [BackupCompatibilityAcceptance](https://github.com/camunda/camunda/actions/runs/22402242436/job/64851924099?pr=46845) in multiple runs

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
