### PR TITLE
Improve assertion error message when limiting is done in the wong spot

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -836,6 +836,11 @@ public final class RecordingExporter implements Exporter {
                     temporarily reduce the wait time of the exporter and prevent the short-circuiting failure.
                     Please be aware that doing this will set the maximum wait time to 200ms. It cannot guarantee
                     the record won't be exported after this.
+
+                  If you did add a limit and the test still fails please consider:
+                  - Do you limit at the right place? If you added filters before the limit, maybe the
+                    record you are limiting on is filtered out of the stream. In this case simply move
+                     the limit before the filters.
                   """);
             }
           } catch (final InterruptedException ignored) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -837,10 +837,10 @@ public final class RecordingExporter implements Exporter {
                     Please be aware that doing this will set the maximum wait time to 200ms. It cannot guarantee
                     the record won't be exported after this.
 
-                  If you did add a limit and the test still fails please consider:
-                  - Do you limit at the right place? If you added filters before the limit, maybe the
+                  If you did add a limit and the test still fails, please consider:
+                  - Do you limit in the right place? If you added filters before the limit, maybe the
                     record you are limiting on is filtered out of the stream. In this case simply move
-                     the limit before the filters.
+                    the limit before the filters.
                   """);
             }
           } catch (final InterruptedException ignored) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
It can happen that you do include a limit on a record that exists. However, filters that are applied before the limit
 could filter out the record that the limit applies to. In this case there is a limit, but it doesn't work. This
 short section explains that this could be a problem, and that the limit should be moved above the filters in this case.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to #36489 
