### PR TITLE
fix: correctly declare nullable fields in batch, jobs, resource and user task API

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -325,8 +325,9 @@ components:
           format: date-time
         endDate:
           type: string
-          description: The end date of the batch operation.
+          description: The end date of the batch operation. `null` if the batch operation is still running.
           format: date-time
+          nullable: true
         actorType:
           $ref: 'audit-logs.yaml#/components/schemas/AuditLogActorTypeEnum'
         actorId:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -325,7 +325,9 @@ components:
           format: date-time
         endDate:
           type: string
-          description: The end date of the batch operation. `null` if the batch operation is still running.
+          description: |
+            The end date of the batch operation. 
+            This is `null` if the batch operation is still running.
           format: date-time
           nullable: true
         actorType:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -321,12 +321,15 @@ components:
           $ref: '#/components/schemas/BatchOperationTypeEnum'
         startDate:
           type: string
-          description: The start date of the batch operation.
+          description: |
+            The start date of the batch operation.
+            This is `null` if the batch operation has not yet started.
           format: date-time
+          nullable: true
         endDate:
           type: string
           description: |
-            The end date of the batch operation. 
+            The end date of the batch operation.
             This is `null` if the batch operation is still running.
           format: date-time
           nullable: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -201,27 +201,27 @@ components:
         processDefinition:
           nullable: true
           description: Deployed process.
-          allOf: 
+          allOf:
             - $ref: '#/components/schemas/DeploymentProcessResult'
         decisionDefinition:
           nullable: true
           description: Deployed decision.
-          allOf: 
+          allOf:
             - $ref: '#/components/schemas/DeploymentDecisionResult'
         decisionRequirements:
           nullable: true
           description: Deployed decision requirement definition.
-          allOf: 
+          allOf:
             - $ref: '#/components/schemas/DeploymentDecisionRequirementsResult'
         form:
           nullable: true
           description: Deployed form.
-          allOf: 
+          allOf:
             - $ref: '#/components/schemas/DeploymentFormResult'
         resource:
           nullable: true
           description: Deployed resource.
-          allOf: 
+          allOf:
             - $ref: '#/components/schemas/DeploymentResourceResult'
 
     DeploymentProcessResult:
@@ -405,6 +405,7 @@ components:
             - $ref: '#/components/schemas/ResourceKey'
           description: The system-assigned key for this resource, requested to be deleted.
         batchOperation:
+          nullable: true
           allOf:
             - $ref: 'batch-operations.yaml#/components/schemas/BatchOperationCreatedResult'
           description: |
@@ -412,7 +413,7 @@ components:
 
             This field is only populated when the request `deleteHistory` is set to `true` and the resource
             is a process definition. For other resource types (decisions, forms, generic resources),
-            this field will not be present in the response.
+            this field will be `null`.
 
     ResourceResult:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -415,7 +415,10 @@ components:
         listenerEventType:
           $ref: '#/components/schemas/JobListenerEventTypeEnum'
         userTask:
-          $ref: '#/components/schemas/UserTaskProperties'
+          description: User task properties, if the job is a user task. `null` if the job is not a user task.
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/UserTaskProperties'
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
         rootProcessInstanceKey:

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -415,7 +415,9 @@ components:
         listenerEventType:
           $ref: '#/components/schemas/JobListenerEventTypeEnum'
         userTask:
-          description: User task properties, if the job is a user task. `null` if the job is not a user task.
+          description: |
+            User task properties, if the job is a user task.
+            This is `null` if the job is not a user task.
           nullable: true
           allOf:
             - $ref: '#/components/schemas/UserTaskProperties'
@@ -685,7 +687,9 @@ components:
             - $ref: "keys.yaml#/components/schemas/ElementInstanceKey"
           description: The element instance key associated with the job.
         endTime:
-          description: When the job ended. `null` if the job is not in an end state yet.
+          description: |
+            End date of the job.
+            This is `null` if the job is not in an end state yet.
           type: string
           format: date-time
           nullable: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -685,9 +685,10 @@ components:
             - $ref: "keys.yaml#/components/schemas/ElementInstanceKey"
           description: The element instance key associated with the job.
         endTime:
-          description: When the job ended.
+          description: When the job ended. `null` if the job is not in an end state yet.
           type: string
           format: date-time
+          nullable: true
         errorCode:
           description: The error code provided for a failed job.
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -503,7 +503,7 @@ components:
         - rootProcessInstanceKey
         - candidateGroups
         - candidateUsers
-        - customHeaders 
+        - customHeaders
         - tags
         - assignee
         - completionDate
@@ -589,7 +589,8 @@ components:
           description: The key of the element instance.
         processName:
           type: string
-          description: The name of the process definition.
+          description: The name of the process definition. `null` if the process has no name defined.
+          nullable: true
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -589,7 +589,9 @@ components:
           description: The key of the element instance.
         processName:
           type: string
-          description: The name of the process definition. `null` if the process has no name defined.
+          description: |
+            The name of the process definition.
+            This is `null` if the process has no name defined.
           nullable: true
         processDefinitionKey:
           allOf:


### PR DESCRIPTION
## Description

`/batch-operations/search` - response.items[].endDate is declared as nullable
`/batch-operations/search` - response.items[].startDate is declared as nullable
`/batch-operations/{batchOperationKey} `- response.endDate is declared as nullable
`/batch-operations/{batchOperationKey} `- response.startDate is declared as nullable
`/jobs/activation- - response.jobs[].userTask` may be not populated if the job is not a user task, declared as nullable
`/jobs/search` - response.items[].endTime is declared as nullable
`/resources/{resourceKey}/deletion` - response.batchOperation declared as nullable
`/user-tasks/search` - response.items[].processName is declared as nullable

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46897 & #46898
