### PR TITLE
ci: do not fetch entire git history + tags

### DIFF
--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -37,7 +37,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
       - name: Authenticate for saas image registry
         id: auth-saas
         uses: google-github-actions/auth@v3


### PR DESCRIPTION
## Description
For building the image at `ref` it's not necessary to download the entire git repo w/ history.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
