### PR TITLE
fix: add x-deprecated-enum-members to decision instance OpenAPI enums

### DIFF
--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -8,6 +8,7 @@ functions:
   - verifyEventuallyConsistent
   - verifyRequiredPropertiesExist
   - verifyArrayPropertiesRequired
+  - verifyDeprecatedEnumMembers
 functionsDir: ./spectral-functions
 rules:
   # Tag validation
@@ -128,3 +129,11 @@ rules:
     then:
       function: verifyEventuallyConsistent
     message: "Command operations are synchronous writes and must not be marked as eventually consistent. Only query operations (search, statistics, get) should use x-eventually-consistent: true."
+
+  valid-deprecated-enum-members:
+    description: "`x-deprecated-enum-members` must be a valid array of {name, deprecatedInVersion} referencing existing enum values."
+    severity: error
+    given: "$.components.schemas[*]"
+    message: "{{error}}"
+    then:
+      function: verifyDeprecatedEnumMembers

--- a/zeebe/gateway-protocol/spectral-functions/verifyDeprecatedEnumMembers.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyDeprecatedEnumMembers.js
@@ -44,7 +44,16 @@ module.exports = (input, _opts, context) => {
     return errors;
   }
 
-  const enumValues = Array.isArray(input.enum) ? new Set(input.enum) : new Set();
+  // 1b. Schema must have a non-empty `enum` array when extension is present.
+  if (!Array.isArray(input.enum) || input.enum.length === 0) {
+    errors.push({
+      message: `\`${EXTENSION_KEY}\` requires the schema to have a non-empty \`enum\` array.`,
+      path: [...context.path, 'enum'],
+    });
+    return errors;
+  }
+
+  const enumValues = new Set(input.enum);
   const seenNames = new Set();
 
   extension.forEach((entry, index) => {
@@ -77,7 +86,7 @@ module.exports = (input, _opts, context) => {
       });
     } else {
       // 3. `name` must exist in the enum values.
-      if (enumValues.size > 0 && !enumValues.has(entry.name)) {
+      if (!enumValues.has(entry.name)) {
         errors.push({
           message: `\`${EXTENSION_KEY}[${index}].name\` value "${entry.name}" is not listed in \`enum\`.`,
           path: [...entryPath, 'name'],

--- a/zeebe/gateway-protocol/spectral-functions/verifyDeprecatedEnumMembers.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyDeprecatedEnumMembers.js
@@ -1,0 +1,110 @@
+// Spectral custom function to validate the x-deprecated-enum-members vendor extension.
+//
+// Applied to schemas that have an `enum` property. When `x-deprecated-enum-members`
+// is present, it must:
+//
+// 1. Be a non-empty array.
+// 2. Each entry must be an object with exactly `name` (string) and
+//    `deprecatedInVersion` (semver string, e.g. "8.9.0").
+// 3. Every `name` must reference a value that exists in the schema's `enum` array.
+// 4. No duplicate `name` entries are allowed.
+
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+const EXTENSION_KEY = 'x-deprecated-enum-members';
+
+module.exports = (input, _opts, context) => {
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+
+  const extension = input[EXTENSION_KEY];
+
+  // Extension is optional — nothing to validate if absent.
+  if (extension === undefined) {
+    return [];
+  }
+
+  const errors = [];
+  const basePath = [...context.path, EXTENSION_KEY];
+
+  // 1. Must be a non-empty array.
+  if (!Array.isArray(extension)) {
+    errors.push({
+      message: `\`${EXTENSION_KEY}\` must be an array.`,
+      path: basePath,
+    });
+    return errors;
+  }
+
+  if (extension.length === 0) {
+    errors.push({
+      message: `\`${EXTENSION_KEY}\` must not be empty.`,
+      path: basePath,
+    });
+    return errors;
+  }
+
+  const enumValues = Array.isArray(input.enum) ? new Set(input.enum) : new Set();
+  const seenNames = new Set();
+
+  extension.forEach((entry, index) => {
+    const entryPath = [...basePath, index];
+
+    // 2a. Each entry must be an object.
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push({
+        message: `\`${EXTENSION_KEY}[${index}]\` must be an object with \`name\` and \`deprecatedInVersion\`.`,
+        path: entryPath,
+      });
+      return;
+    }
+
+    // 2b. Validate allowed keys — only `name` and `deprecatedInVersion`.
+    const allowedKeys = new Set(['name', 'deprecatedInVersion']);
+    const extraKeys = Object.keys(entry).filter((k) => !allowedKeys.has(k));
+    if (extraKeys.length > 0) {
+      errors.push({
+        message: `\`${EXTENSION_KEY}[${index}]\` contains unexpected keys: ${extraKeys.join(', ')}. Only \`name\` and \`deprecatedInVersion\` are allowed.`,
+        path: entryPath,
+      });
+    }
+
+    // 2c. `name` must be a non-empty string.
+    if (typeof entry.name !== 'string' || entry.name.length === 0) {
+      errors.push({
+        message: `\`${EXTENSION_KEY}[${index}].name\` must be a non-empty string.`,
+        path: [...entryPath, 'name'],
+      });
+    } else {
+      // 3. `name` must exist in the enum values.
+      if (enumValues.size > 0 && !enumValues.has(entry.name)) {
+        errors.push({
+          message: `\`${EXTENSION_KEY}[${index}].name\` value "${entry.name}" is not listed in \`enum\`.`,
+          path: [...entryPath, 'name'],
+        });
+      }
+
+      // 4. No duplicate names.
+      if (seenNames.has(entry.name)) {
+        errors.push({
+          message: `\`${EXTENSION_KEY}[${index}].name\` value "${entry.name}" is duplicated.`,
+          path: [...entryPath, 'name'],
+        });
+      }
+      seenNames.add(entry.name);
+    }
+
+    // 2d. `deprecatedInVersion` must be a semver string.
+    if (
+      typeof entry.deprecatedInVersion !== 'string' ||
+      !SEMVER_PATTERN.test(entry.deprecatedInVersion)
+    ) {
+      errors.push({
+        message: `\`${EXTENSION_KEY}[${index}].deprecatedInVersion\` must be a semver string (e.g. "8.9.0").`,
+        path: [...entryPath, 'deprecatedInVersion'],
+      });
+    }
+  });
+
+  return errors;
+};

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/enums.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/enums.yaml
@@ -215,6 +215,25 @@ paths:
               schema:
                 $ref: '#/components/schemas/InvalidExtraKeysResult'
 
+  /invalid-no-enum/{id}:
+    get:
+      operationId: getInvalidNoEnum
+      summary: Extension present but enum missing
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidNoEnumResult'
+
 components:
   schemas:
     # ── Valid schemas ────────────────────────────────────────
@@ -430,3 +449,19 @@ components:
         value:
           description: The value.
           $ref: '#/components/schemas/InvalidExtraKeysEnum'
+
+    InvalidNoEnumEnum:
+      description: Extension present but no enum property.
+      type: string
+      x-deprecated-enum-members:
+        - name: SOMETHING
+          deprecatedInVersion: "8.9.0"
+
+    InvalidNoEnumResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidNoEnumEnum'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/enums.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/enums.yaml
@@ -1,0 +1,432 @@
+# Domain file for deprecated-enum-members tests.
+# Contains valid and invalid enum schemas with x-deprecated-enum-members.
+
+paths:
+  # ── Valid cases ──────────────────────────────────────────────
+
+  /valid-no-extension/{id}:
+    get:
+      operationId: getValidNoExtension
+      summary: Enum without extension (valid, extension is optional)
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidNoExtensionResult'
+
+  /valid-with-extension/{id}:
+    get:
+      operationId: getValidWithExtension
+      summary: Enum with valid single deprecated member
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidWithExtensionResult'
+
+  /valid-multiple-deprecated/{id}:
+    get:
+      operationId: getValidMultipleDeprecated
+      summary: Enum with valid multiple deprecated members
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidMultipleDeprecatedResult'
+
+  # ── Invalid cases ───────────────────────────────────────────
+
+  /invalid-not-array/{id}:
+    get:
+      operationId: getInvalidNotArray
+      summary: Extension is not an array
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidNotArrayResult'
+
+  /invalid-empty-array/{id}:
+    get:
+      operationId: getInvalidEmptyArray
+      summary: Extension is an empty array
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidEmptyArrayResult'
+
+  /invalid-missing-name/{id}:
+    get:
+      operationId: getInvalidMissingName
+      summary: Entry without name
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidMissingNameResult'
+
+  /invalid-missing-version/{id}:
+    get:
+      operationId: getInvalidMissingVersion
+      summary: Entry without deprecatedInVersion
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidMissingVersionResult'
+
+  /invalid-bad-semver/{id}:
+    get:
+      operationId: getInvalidBadSemver
+      summary: deprecatedInVersion is not valid semver
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidBadSemverResult'
+
+  /invalid-name-not-in-enum/{id}:
+    get:
+      operationId: getInvalidNameNotInEnum
+      summary: Deprecated name does not exist in enum
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidNameNotInEnumResult'
+
+  /invalid-duplicate-name/{id}:
+    get:
+      operationId: getInvalidDuplicateName
+      summary: Duplicate name entries
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidDuplicateNameResult'
+
+  /invalid-extra-keys/{id}:
+    get:
+      operationId: getInvalidExtraKeys
+      summary: Entry with unexpected extra keys
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidExtraKeysResult'
+
+components:
+  schemas:
+    # ── Valid schemas ────────────────────────────────────────
+
+    ValidNoExtensionEnum:
+      description: A plain enum without x-deprecated-enum-members.
+      type: string
+      enum:
+        - ACTIVE
+        - INACTIVE
+
+    ValidNoExtensionResult:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: The status value.
+          $ref: '#/components/schemas/ValidNoExtensionEnum'
+
+    ValidWithExtensionEnum:
+      description: An enum with a properly deprecated member.
+      type: string
+      enum:
+        - ACTIVE
+        - INACTIVE
+        - LEGACY_MODE
+      x-deprecated-enum-members:
+        - name: LEGACY_MODE
+          deprecatedInVersion: "8.9.0"
+
+    ValidWithExtensionResult:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: The status value.
+          $ref: '#/components/schemas/ValidWithExtensionEnum'
+
+    ValidMultipleDeprecatedEnum:
+      description: An enum with multiple deprecated members.
+      type: string
+      enum:
+        - ACTIVE
+        - INACTIVE
+        - OLD_FORMAT
+        - LEGACY_MODE
+      x-deprecated-enum-members:
+        - name: OLD_FORMAT
+          deprecatedInVersion: "8.9.0"
+        - name: LEGACY_MODE
+          deprecatedInVersion: "8.10.0"
+
+    ValidMultipleDeprecatedResult:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: The status value.
+          $ref: '#/components/schemas/ValidMultipleDeprecatedEnum'
+
+    # ── Invalid schemas ──────────────────────────────────────
+
+    InvalidNotArrayEnum:
+      description: x-deprecated-enum-members is not an array.
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members:
+        name: A
+        deprecatedInVersion: "8.9.0"
+
+    InvalidNotArrayResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidNotArrayEnum'
+
+    InvalidEmptyArrayEnum:
+      description: x-deprecated-enum-members is empty.
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members: []
+
+    InvalidEmptyArrayResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidEmptyArrayEnum'
+
+    InvalidMissingNameEnum:
+      description: Entry is missing the name field.
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members:
+        - deprecatedInVersion: "8.9.0"
+
+    InvalidMissingNameResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidMissingNameEnum'
+
+    InvalidMissingVersionEnum:
+      description: Entry is missing deprecatedInVersion.
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members:
+        - name: A
+
+    InvalidMissingVersionResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidMissingVersionEnum'
+
+    InvalidBadSemverEnum:
+      description: deprecatedInVersion is not valid semver.
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members:
+        - name: A
+          deprecatedInVersion: "8.9"
+
+    InvalidBadSemverResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidBadSemverEnum'
+
+    InvalidNameNotInEnumEnum:
+      description: Deprecated name does not exist in enum.
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members:
+        - name: NONEXISTENT
+          deprecatedInVersion: "8.9.0"
+
+    InvalidNameNotInEnumResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidNameNotInEnumEnum'
+
+    InvalidDuplicateNameEnum:
+      description: Duplicate name entries.
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members:
+        - name: A
+          deprecatedInVersion: "8.9.0"
+        - name: A
+          deprecatedInVersion: "8.10.0"
+
+    InvalidDuplicateNameResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidDuplicateNameEnum'
+
+    InvalidExtraKeysEnum:
+      description: Entry with unexpected extra keys.
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members:
+        - name: A
+          deprecatedInVersion: "8.9.0"
+          reason: "no longer used"
+
+    InvalidExtraKeysResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidExtraKeysEnum'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/rest-api.yaml
@@ -1,0 +1,44 @@
+# Entry point for deprecated-enum-members rule tests.
+# Mirrors the real spec structure: paths $ref to domain files.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — valid-deprecated-enum-members
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid cases ──────────────────────────────────────────────
+  /valid-no-extension/{id}:
+    $ref: 'enums.yaml#/paths/~1valid-no-extension~1{id}'
+
+  /valid-with-extension/{id}:
+    $ref: 'enums.yaml#/paths/~1valid-with-extension~1{id}'
+
+  /valid-multiple-deprecated/{id}:
+    $ref: 'enums.yaml#/paths/~1valid-multiple-deprecated~1{id}'
+
+  # ── Invalid cases ───────────────────────────────────────────
+  /invalid-not-array/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-not-array~1{id}'
+
+  /invalid-empty-array/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-empty-array~1{id}'
+
+  /invalid-missing-name/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-missing-name~1{id}'
+
+  /invalid-missing-version/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-missing-version~1{id}'
+
+  /invalid-bad-semver/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-bad-semver~1{id}'
+
+  /invalid-name-not-in-enum/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-name-not-in-enum~1{id}'
+
+  /invalid-duplicate-name/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-duplicate-name~1{id}'
+
+  /invalid-extra-keys/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-extra-keys~1{id}'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/rest-api.yaml
@@ -42,3 +42,6 @@ paths:
 
   /invalid-extra-keys/{id}:
     $ref: 'enums.yaml#/paths/~1invalid-extra-keys~1{id}'
+
+  /invalid-no-enum/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-no-enum~1{id}'

--- a/zeebe/gateway-protocol/spectral-tests/helpers.js
+++ b/zeebe/gateway-protocol/spectral-tests/helpers.js
@@ -12,7 +12,19 @@ const FIXTURES_DIR = path.join(__dirname, 'fixtures');
  * Returns the parsed JSON results array.
  */
 function lintFixture(fixtureName) {
-  const specFile = path.join(FIXTURES_DIR, fixtureName, 'rest-api.yaml');
+  return lintFixtureFile(fixtureName, 'rest-api.yaml');
+}
+
+/**
+ * Runs Spectral lint on a specific file within a fixture directory using the
+ * production ruleset. Mirrors the CI *file-level pass* that lints each domain
+ * YAML independently (needed for rules whose `given` targets
+ * `$.components.schemas[*]` which only matches when linting the file that
+ * defines the schemas).
+ * Returns the parsed JSON results array.
+ */
+function lintFixtureFile(fixtureName, fileName) {
+  const specFile = path.join(FIXTURES_DIR, fixtureName, fileName);
   const cmd = `spectral lint "${specFile}" --ruleset "${RULESET_FILE}" --format json`;
 
   try {
@@ -49,4 +61,4 @@ function filterByPathSegment(violations, segment) {
   );
 }
 
-module.exports = { lintFixture, filterByRule, filterByPathSegment };
+module.exports = { lintFixture, lintFixtureFile, filterByRule, filterByPathSegment };

--- a/zeebe/gateway-protocol/spectral-tests/verifyDeprecatedEnumMembers.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyDeprecatedEnumMembers.test.js
@@ -138,4 +138,16 @@ describe('verifyDeprecatedEnumMembers', () => {
       assert.match(v[0].message, /unexpected keys.*reason/);
     });
   });
+
+  describe('invalid: extension present but enum missing', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidNoEnumEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidNoEnumEnum');
+      assert.match(v[0].message, /requires the schema to have a non-empty `enum` array/);
+    });
+  });
 });

--- a/zeebe/gateway-protocol/spectral-tests/verifyDeprecatedEnumMembers.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyDeprecatedEnumMembers.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixtureFile, filterByRule, filterByPathSegment } = require('./helpers');
+
+const RULE = 'valid-deprecated-enum-members';
+const FIXTURE = 'deprecated-enum-members';
+
+describe('verifyDeprecatedEnumMembers', () => {
+  let violations;
+
+  before(() => {
+    // Lint the domain file directly (mirrors the CI file-level pass that lints
+    // each *.yaml independently — required because `$.components.schemas[*]`
+    // only matches schemas defined in the file being linted).
+    const allResults = lintFixtureFile(FIXTURE, 'enums.yaml');
+    violations = filterByRule(allResults, RULE);
+  });
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid: enum without x-deprecated-enum-members', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'ValidNoExtensionEnum');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: enum with single deprecated member', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'ValidWithExtensionEnum');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: enum with multiple deprecated members', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'ValidMultipleDeprecatedEnum');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid: x-deprecated-enum-members is not an array', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidNotArrayEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidNotArrayEnum');
+      assert.match(v[0].message, /must be an array/);
+    });
+  });
+
+  describe('invalid: x-deprecated-enum-members is an empty array', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidEmptyArrayEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidEmptyArrayEnum');
+      assert.match(v[0].message, /must not be empty/);
+    });
+  });
+
+  describe('invalid: entry missing name', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidMissingNameEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidMissingNameEnum');
+      assert.match(v[0].message, /\.name.*must be a non-empty string/);
+    });
+  });
+
+  describe('invalid: entry missing deprecatedInVersion', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidMissingVersionEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidMissingVersionEnum');
+      assert.match(v[0].message, /deprecatedInVersion.*must be a semver string/);
+    });
+  });
+
+  describe('invalid: deprecatedInVersion is not valid semver', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidBadSemverEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidBadSemverEnum');
+      assert.match(v[0].message, /deprecatedInVersion.*must be a semver string/);
+    });
+  });
+
+  describe('invalid: deprecated name does not exist in enum', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidNameNotInEnumEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidNameNotInEnumEnum');
+      assert.match(v[0].message, /NONEXISTENT.*is not listed in `enum`/);
+    });
+  });
+
+  describe('invalid: duplicate name entries', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidDuplicateNameEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidDuplicateNameEnum');
+      assert.match(v[0].message, /"A".*is duplicated/);
+    });
+  });
+
+  describe('invalid: entry with unexpected extra keys', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidExtraKeysEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidExtraKeysEnum');
+      assert.match(v[0].message, /unexpected keys.*reason/);
+    });
+  });
+});

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -445,6 +445,9 @@ components:
         - LITERAL_EXPRESSION
         - UNSPECIFIED
         - UNKNOWN
+      x-deprecated-enum-members:
+        - name: UNSPECIFIED
+          deprecatedInVersion: "8.9.0"
 
     DecisionInstanceStateEnum:
       description: The state of the decision instance. UNSPECIFIED and UNKNOWN are deprecated and should not be used anymore, for removal in 8.10
@@ -454,6 +457,11 @@ components:
         - FAILED
         - UNSPECIFIED
         - UNKNOWN
+      x-deprecated-enum-members:
+        - name: UNSPECIFIED
+          deprecatedInVersion: "8.9.0"
+        - name: UNKNOWN
+          deprecatedInVersion: "8.9.0"
 
     ## Filters
 


### PR DESCRIPTION
## Description

Adds the deprecation vendor key `x-deprecated-enum-members` for the enum values deprecated with https://github.com/camunda/camunda/issues/46285

Adds a spectral rule that ensures correct usage of the vendor key.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46398
