### PR TITLE
fix: explicitly cascade truncate for oracle

### DIFF
--- a/db/rdbms/src/main/resources/mapper/PurgeMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/PurgeMapper.xml
@@ -41,6 +41,10 @@
     TRUNCATE TABLE ${prefix}${tableName} CASCADE
   </update>
 
+  <update id="truncateTable" parameterType="java.lang.String" databaseId="oracle">
+    TRUNCATE TABLE ${prefix}${tableName} CASCADE
+  </update>
+
   <update id="truncateTable" parameterType="java.lang.String" databaseId="mssql">
     DELETE FROM ${prefix}${tableName}
   </update>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.rdbms.db;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
@@ -36,6 +37,7 @@ public class PurgerIT {
 
     ProcessInstanceFixtures.createAndSaveRandomProcessInstances(rdbmsWriters);
     ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions(rdbmsWriters);
+    DecisionInstanceFixtures.createAndSaveRandomDecisionInstances(rdbmsWriters);
 
     rdbmsWriters.getRdbmsPurger().purgeRdbms();
 


### PR DESCRIPTION
## Description

This may fix the Oracle 19c purger issue by explicitly cascading the deletion along FK constraints

## Related issues

closes #
