### PR TITLE
ci: increase Copilot timeout

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 50
 
     permissions:
       contents: read


### PR DESCRIPTION
## Description

Increases the agent timeout for Copilot to see if this resolves agent sessions timing out after 5 minutes regularly.

## Related issues

n/a
