### PR TITLE
Updating the manual load test setup to prefix the current load test naming, along with minor fix on repo

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -267,7 +267,7 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         name: Build Camunda Docker Image
         with:
-          repository: '${{ env.IMAGE_REPOSITORY }}/zeebe'
+          repository: '${{ env.IMAGE_REPOSITORY }}/camunda'
           revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
@@ -352,7 +352,7 @@ jobs:
             proxy: camunda.teleport.sh:443
             token: ${{ env.TELEPORT_JOIN_TOKEN }}
             kubernetes-cluster: ${{ env.CLUSTER }}
-      
+
       - name: Create namespace if not exists
         run: |
           cd load-tests/setup
@@ -379,7 +379,7 @@ jobs:
           make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \
             secondary_storage=${{ inputs.secondary-storage-type }} \
             enable_optimize=${{ inputs.enable-optimize }} \
-            additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }} --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/zeebe' }} --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.platform-helm-values }}" \
+            additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }} --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/camunda' }} --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.platform-helm-values }}" \
             additional_load_test_configuration="$load_test_config"
       - name: Summarize platform deployment
         if: success()

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -59,8 +59,8 @@ orchestration:
   # This means we will have pods like: camunda-0, camunda-1, camunda-2
   fullnameOverride: camunda
   image:
-    registry: registry.camunda.cloud
-    repository: team-zeebe/camunda
+    registry: docker.io
+    repository: camunda/camunda
     tag: "SNAPSHOT"
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -60,7 +60,7 @@ orchestration:
   fullnameOverride: camunda
   image:
     registry: registry.camunda.cloud
-    repository: team-zeebe/zeebe
+    repository: team-zeebe/camunda
     tag: "SNAPSHOT"
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -18,6 +18,12 @@ fi
 helm_chart="camunda-platform-8.9"
 namespace="$1"
 
+# Add c8- prefix if not present
+if [[ ! "$namespace" =~ ^c8- ]]; then
+  namespace="c8-$namespace"
+  echo "Namespace prefix added: $namespace"
+fi
+
 # Validate secondaryStorage value
 secondaryStorage="${2:-elasticsearch}"
 if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "opensearch" && "$secondaryStorage" != "postgresql" ]]; then


### PR DESCRIPTION
## Description

This pull request introduces a couple of changes aimed at improving the setup process for load tests and updating the Camunda platform configuration. The most notable updates include enforcing a namespace naming convention in the load test setup script and changing the image repository reference in the Camunda platform values file.

Configuration updates:

* Changed the `image.repository` value in `load-tests/camunda-platform-values.yaml` from `team-zeebe/zeebe` to `team-zeebe/camunda` to reference the correct container image for Camunda.

Setup improvements:

* Updated `load-tests/setup/newLoadTest.sh` to automatically add a `c8-` prefix to the namespace if it is not already present, ensuring consistent naming conventions for test environments.

## Related issues
https://camunda.slack.com/archives/C08N5EPR7LP/p1772091900492199
