### PR TITLE
[Backport stable/8.9] feat: adjust message for an empty state in the operations log

### DIFF
--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -99,7 +99,27 @@ describe('OperationsLog InstancesTable', () => {
     expect(screen.getByTestId('data-table-loader')).toBeInTheDocument();
   });
 
-  it('should render empty state when no operations are found', async () => {
+  it('should render empty state when no operations are found without filters', async () => {
+    mockQueryAuditLogs().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
+    render(<InstancesTable />, {
+      wrapper: Wrapper,
+    });
+
+    expect(
+      await screen.findByText('No operation log items yet'),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'Operations that you perform in UI or via the API will appear here.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render empty state when no operations are found with filters', async () => {
     mockQueryAuditLogs().withSuccess({
       items: [],
       page: {
@@ -110,8 +130,22 @@ describe('OperationsLog InstancesTable', () => {
       },
     });
 
+    const WrapperWithFilter: React.FC<{children: React.ReactNode}> = ({
+      children,
+    }) => {
+      return (
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={['/operations-log?operationType=CREATE']}>
+            <Routes>
+              <Route path="/operations-log" element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+    };
+
     render(<InstancesTable />, {
-      wrapper: Wrapper,
+      wrapper: WrapperWithFilter,
     });
 
     expect(

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -102,7 +102,12 @@ describe('OperationsLog InstancesTable', () => {
   it('should render empty state when no operations are found without filters', async () => {
     mockQueryAuditLogs().withSuccess({
       items: [],
-      page: {totalItems: 0},
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
     });
 
     render(<InstancesTable />, {
@@ -135,7 +140,9 @@ describe('OperationsLog InstancesTable', () => {
     }) => {
       return (
         <QueryClientProvider client={getMockQueryClient()}>
-          <MemoryRouter initialEntries={['/operations-log?operationType=CREATE']}>
+          <MemoryRouter
+            initialEntries={['/operations-log?operationType=CREATE']}
+          >
             <Routes>
               <Route path="/operations-log" element={children} />
             </Routes>

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -242,16 +242,27 @@ const InstancesTable: React.FC = observer(() => {
     return 'content';
   };
 
+  const getEmptyMessage = () => {
+    if (Object.keys(filterValues).length === 0) {
+      return {
+        message: 'No operation log items yet',
+        additionalInfo:
+          'Operations that you perform in UI or via the API will appear here.',
+      };
+    }
+    return {
+      message: 'No operations log found',
+      additionalInfo: 'Try adjusting your filters or check back later.',
+    };
+  };
+
   return (
     <Container>
       <BasePanelHeader title="Operations Log" count={data?.totalCount} />
       <PaginatedSortableTable
         state={getTableState()}
         rows={rows}
-        emptyMessage={{
-          message: 'No operations log found',
-          additionalInfo: 'Try adjusting your filters or check back later.',
-        }}
+        emptyMessage={getEmptyMessage()}
         headerColumns={headerColumns}
         pagination={{
           hasPreviousPage,

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -242,7 +242,7 @@ const InstancesTable: React.FC = observer(() => {
     return 'content';
   };
 
-  const getEmptyMessage = () => {
+  const emptyMessage = useMemo(() => {
     if (Object.keys(filterValues).length === 0) {
       return {
         message: 'No operation log items yet',
@@ -254,7 +254,7 @@ const InstancesTable: React.FC = observer(() => {
       message: 'No operations log found',
       additionalInfo: 'Try adjusting your filters or check back later.',
     };
-  };
+  }, [filterValues]);
 
   return (
     <Container>
@@ -262,7 +262,7 @@ const InstancesTable: React.FC = observer(() => {
       <PaginatedSortableTable
         state={getTableState()}
         rows={rows}
-        emptyMessage={getEmptyMessage()}
+        emptyMessage={emptyMessage}
         headerColumns={headerColumns}
         pagination={{
           hasPreviousPage,


### PR DESCRIPTION
# Description
Backport of #46757 to `stable/8.9`.

relates to #45203