### PR TITLE
ci: support daily qa against 8.9-snapshot

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -55,7 +55,7 @@ jobs:
                   map(
                     if .branch == "stable/8.8" then
                       .generation_template = "Camunda 8.8-SNAPSHOT"
-                    else if .branch == "stable/8.9" then
+                    elif .branch == "stable/8.9" then
                       .generation_template = "Camunda 8.9-SNAPSHOT"
                     else
                       .

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -55,6 +55,8 @@ jobs:
                   map(
                     if .branch == "stable/8.8" then
                       .generation_template = "Camunda 8.8-SNAPSHOT"
+                    else if .branch == "stable/8.9" then
+                      .generation_template = "Camunda 8.9-SNAPSHOT"
                     else
                       .
                     end


### PR DESCRIPTION
## Description

Adds support for running the daily QA workflow against the `8.9-snapshot` generation. The `zeebe-daily-qa.yml` workflow uses a `jq` conditional to map branches to their corresponding generation templates. This change extends the existing branch handling by adding an `elif` clause for `stable/8.9`, mapping it to the `Camunda 8.9-SNAPSHOT` generation template — similar to the existing mapping for `stable/8.8`.

This generation is available as [`643523b1-2f5c-4a60-bec1-e5472d45d25c`](https://accounts.ultrawombat.com/consoleadmin/generations/643523b1-2f5c-4a60-bec1-e5472d45d25c)

### Changes

- Modified `.github/workflows/zeebe-daily-qa.yml` to add a `jq` conditional branch for `stable/8.9` → `Camunda 8.9-SNAPSHOT`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

discussion in https://camunda.slack.com/archives/C013MEVQ4M9/p1772091975966399
closes https://github.com/camunda/camunda/issues/46989