### PR TITLE
perf: do not allocate a Either.right(null) everytime

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -115,7 +115,7 @@ public final class AuthorizationCheckBehavior {
   @Deprecated(forRemoval = true, since = "8.8.0")
   public Either<Rejection, Void> isAuthorized(final AuthorizationRequest requestBuilder) {
     if (shouldSkipAllChecks()) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
     return isAuthorized(requestBuilder.build());
   }
@@ -134,7 +134,7 @@ public final class AuthorizationCheckBehavior {
    */
   public Either<Rejection, Void> isAuthorized(final AuthorizationRequestMetadata request) {
     if (shouldSkipAllChecks()) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
     try {
       return authorizationsCache.get(request);
@@ -148,11 +148,11 @@ public final class AuthorizationCheckBehavior {
 
   public Either<Rejection, Void> isAuthorizedOrInternalCommand(final AuthorizationRequest request) {
     if (shouldSkipAllChecks()) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
     final var command = request.command;
     if (isInternalCommand(command.hasRequestMetadata(), command.getBatchOperationReference())) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
     return isAuthorized(request);
   }
@@ -160,7 +160,7 @@ public final class AuthorizationCheckBehavior {
   private Either<Rejection, Void> checkAuthorized(final AuthorizationRequestMetadata request) {
 
     if (shouldSkipAuthorization(request)) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
 
     final List<AuthorizationRejection> aggregatedRejections = new ArrayList<>();
@@ -169,14 +169,14 @@ public final class AuthorizationCheckBehavior {
         checkPrimaryAuthorization(request, aggregatedRejections);
 
     if (primaryResult.hasBothAccess()) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
 
     final AuthorizationResult mappingRuleResult =
         checkMappingRuleAuthorization(request, primaryResult, aggregatedRejections);
 
     if (mappingRuleResult.hasBothAccess()) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
 
     return getRejection(aggregatedRejections);
@@ -288,7 +288,7 @@ public final class AuthorizationCheckBehavior {
                 AuthorizationRejectionType.TENANT));
       }
     }
-    return Either.right(null);
+    return Either.rightVoid();
   }
 
   /**
@@ -306,7 +306,7 @@ public final class AuthorizationCheckBehavior {
       final Collection<String> entityIds) {
 
     if (!authorizationsEnabled) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
 
     final var isAuthorizedForResource =
@@ -322,7 +322,7 @@ public final class AuthorizationCheckBehavior {
             .anyMatch(
                 authorizationScope -> request.authorizationScopes().contains(authorizationScope));
     if (isAuthorizedForResource) {
-      return Either.right(null);
+      return Either.rightVoid();
     }
 
     return Either.left(

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatch.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatch.java
@@ -54,7 +54,7 @@ public final class RecordBatch implements MutableRecordBatch {
 
     recordBatchEntries.add(recordBatchEntry);
     batchSize += entryLength;
-    return Either.right(null);
+    return Either.rightVoid();
   }
 
   @Override

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Either.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Either.java
@@ -70,6 +70,11 @@ public sealed interface Either<L, R> {
    */
   static <L, R> Either<L, R> right(final R right) {
     return new Right<>(right);
+  }  Either<Void, Void> RIGHT_VOID = Either.rightVoid();
+
+  @SuppressWarnings("unchecked")
+  static <L> Either<L, Void> rightVoid() {
+    return (Either<L, Void>) RIGHT_VOID;
   }
 
   /**
@@ -530,4 +535,6 @@ public sealed interface Either<L, R> {
       return right.<Either<L, R>>map(Either::right).orElse(Either.left(left));
     }
   }
+
+
 }


### PR DESCRIPTION
## Description
Small optimization, stacked on #46939

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
