### PR TITLE
ci: speed up docker checks job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1021,7 +1021,7 @@ jobs:
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >
-          ./mvnw -f dist --no-snapshot-updates -DskipChecks -Dassembly.skipAssembly=true
+          ./mvnw -pl dist/ --no-snapshot-updates -DskipChecks -Dassembly.skipAssembly=true
           -DskipUTs -Dit.test=*DockerIT -Dfailsafe.rerunFailingTestsCount=3
           -P parallel-tests,extract-flaky-tests
           -Dcamunda.docker.test.enabled=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -940,7 +940,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       security-events: write
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,6 +971,7 @@ jobs:
           sarif_file: ./hadolint.sarif
       - uses: ./.github/actions/setup-build
         with:
+          maven-cache-key-modifier: docker-checks
           dockerhub-readonly: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
This pull request introduces minor improvements to the Docker Checks CI job.

  * Sets `maven-cache-key-modifier` so that a dedicated cache is used instead of the default shared one which seems to be ineffective.
  * The Maven command for running Docker integration tests is updated to use the `-pl dist/` flag, for consistency with other jobs and to avoid potential multi-module dependency issues.