### PR TITLE
Change to a get + put pattern to avoid deadlock.

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
@@ -39,7 +39,17 @@ final class StatefulMeterRegistry extends CompositeMeterRegistry {
   }
 
   StatefulGauge registerIfNecessary(final Id id, final Builder builder) {
-    return gauges.computeIfAbsent(id, metricId -> registerStatefulGauge(metricId, builder));
+    // NOTE: We intentionally use get() + putIfAbsent() instead of computeIfAbsent() here.
+    // Using computeIfAbsent() could cause a deadlock, see issue
+    // https://github.com/camunda/camunda/issues/33941#issuecomment-3965969887
+    final var existing = gauges.get(id);
+    if (existing != null) {
+      return existing;
+    }
+
+    final StatefulGauge statefulGauge = registerStatefulGauge(id, builder);
+    final StatefulGauge previousValue = gauges.putIfAbsent(id, statefulGauge);
+    return previousValue != null ? previousValue : statefulGauge;
   }
 
   StatefulGauge registerStatefulGauge(final Id id, final Builder builder) {

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
@@ -61,7 +61,7 @@ final class StatefulMeterRegistryTest {
 
   /** See issue: <a href="https://github.com/camunda/camunda/issues/33941">...</a> */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
   void shouldNotDeadlockWithManyThreadsRegisteringAndRemoving() {
     final int numThreads = 10;
     final int numGauges = 50;

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
@@ -11,10 +11,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class StatefulMeterRegistryTest {
+  private static final Logger LOG = LoggerFactory.getLogger(StatefulMeterRegistryTest.class);
+
   @AutoClose private MeterRegistry wrapped = new SimpleMeterRegistry();
   @AutoClose private final StatefulMeterRegistry registry = new StatefulMeterRegistry(wrapped);
 
@@ -44,5 +57,121 @@ final class StatefulMeterRegistryTest {
     // then
     assertThat(second).isSameAs(first);
     assertThat(second.value()).isOne();
+  }
+
+  /** See issue: <a href="https://github.com/camunda/camunda/issues/33941">...</a> */
+  @Test
+  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  void shouldNotDeadlockWithManyThreadsRegisteringAndRemoving() {
+    final int numThreads = 10;
+    final int numGauges = 50;
+    final int numIterations = 30;
+    final var simpleMeterRegistry = new SimpleMeterRegistry();
+    final var meterRegistry = new StatefulMeterRegistry(simpleMeterRegistry);
+    final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+
+    try {
+      final List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+      // Create registering tasks
+      for (int threadId = 0; threadId < numThreads / 2; threadId++) {
+        final int id = threadId;
+        futures.add(
+            CompletableFuture.runAsync(
+                () -> {
+                  for (int iter = 0; iter < numIterations; iter++) {
+                    for (int gaugeIndex = 0; gaugeIndex < numGauges; gaugeIndex++) {
+                      registerGauge(gaugeIndex, id, iter, meterRegistry);
+                    }
+                  }
+                },
+                executor));
+      }
+
+      // Create removing tasks
+      for (int threadId = 0; threadId < numThreads / 2; threadId++) {
+        final int id = threadId;
+        futures.add(
+            CompletableFuture.runAsync(
+                () -> {
+                  for (int iter = 0; iter < numIterations; iter++) {
+                    for (int gaugeIndex = 0; gaugeIndex < numGauges; gaugeIndex++) {
+                      removeGauge(gaugeIndex, id, iter, meterRegistry);
+                    }
+                  }
+                },
+                executor));
+      }
+
+      try {
+        // Wait for all futures to complete
+        final var allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        allFutures.get();
+      } catch (final Exception e) {
+        throw new AssertionError("Test failed due to exception: " + e.getMessage(), e);
+      }
+    } finally {
+      // Check for deadlocked threads using JVM's ThreadMXBean
+      checkForDeadlock();
+
+      executor.shutdownNow();
+      meterRegistry.close();
+      simpleMeterRegistry.close();
+    }
+  }
+
+  private void checkForDeadlock() {
+    final ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+    final long[] deadlockedThreads = bean.findDeadlockedThreads();
+
+    if (deadlockedThreads != null) {
+      final StringBuilder sb = new StringBuilder("Deadlock detected by JVM ThreadMXBean:\n");
+      for (final long id : deadlockedThreads) {
+        sb.append("Deadlocked Thread ID: ").append(id).append("\n");
+        sb.append(bean.getThreadInfo(id)).append("\n");
+      }
+      LOG.error(sb.toString());
+      throw new AssertionError(sb.toString());
+    }
+  }
+
+  private void registerGauge(
+      final int gaugeIndex,
+      final int threadId,
+      final int iteration,
+      final StatefulMeterRegistry testRegistry) {
+    final String gaugeName = "mt-gauge-" + gaugeIndex;
+    LOG.debug(
+        "Attempting to register gauge: {} (threadId={}, iteration={})",
+        gaugeName,
+        threadId,
+        iteration);
+    final var gauge = StatefulGauge.builder(gaugeName).register(testRegistry);
+    gauge.set((long) threadId * 1000 + iteration);
+    LOG.debug("Registered gauge: {} (threadId={}, iteration={})", gaugeName, threadId, iteration);
+  }
+
+  private void removeGauge(
+      final int gaugeIndex,
+      final int threadId,
+      final int iteration,
+      final StatefulMeterRegistry testRegistry) {
+    final String gaugeName = "mt-gauge-" + gaugeIndex;
+    LOG.debug(
+        "Attempting to remove gauge: {} (threadId={}, iteration={})",
+        gaugeName,
+        threadId,
+        iteration);
+    final var search = testRegistry.find(gaugeName).gauge();
+    if (search != null) {
+      testRegistry.remove(search);
+      LOG.debug("Removed gauge: {} (threadId={}, iteration={})", gaugeName, threadId, iteration);
+    } else {
+      LOG.debug(
+          "Gauge not found for removal: {} (threadId={}, iteration={})",
+          gaugeName,
+          threadId,
+          iteration);
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR changes to a get() + put() pattern in StatefulGauge.registerIfNecessary() instead of a computIfAbsent() to avoid a deadlock.

See explanation in comment https://github.com/camunda/camunda/issues/33941#issuecomment-3965969887

This issue was also observed in the following support case: [#inc-support-31666-zeebe-partitions-unhealthy](https://camunda.slack.com/archives/C0AGR3G0PUM).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/33941
