### PR TITLE
[Backport stable/8.8] fix(e2e): isolate variable search tests from cross-test contamination

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
@@ -122,10 +122,17 @@ test.describe.parallel('Search Variables API Tests', () => {
   });
 
   test('Search Variables Pagination Limit 1', async ({request}) => {
+    const localState: Record<string, unknown> = {};
+    await setupVariableTest(localState, request);
+    processInstanceKeys.push(localState['processInstanceKey'] as string);
+
     await expect(async () => {
       const res = await request.post(buildUrl('/variables/search'), {
         headers: jsonHeaders(),
         data: {
+          filter: {
+            processInstanceKey: localState['processInstanceKey'],
+          },
           page: {
             limit: 1,
           },
@@ -141,10 +148,17 @@ test.describe.parallel('Search Variables API Tests', () => {
   });
 
   test('Search Variables Sort by Name ASC', async ({request}) => {
+    const localState: Record<string, unknown> = {};
+    await setupVariableTest(localState, request);
+    processInstanceKeys.push(localState['processInstanceKey'] as string);
+
     await expect(async () => {
       const res = await request.post(buildUrl('/variables/search'), {
         headers: jsonHeaders(),
         data: {
+          filter: {
+            processInstanceKey: localState['processInstanceKey'],
+          },
           sort: [
             {
               field: 'name',


### PR DESCRIPTION
# Description
Backport of #46945 to `stable/8.8`.
[API test run
](https://github.com/camunda/camunda/actions/runs/22441036203/job/64983353883)
relates to #46400