### PR TITLE
fix: Show ellipsis for large titles on Optimize

### DIFF
--- a/optimize/client/src/components/Home/Collection.js
+++ b/optimize/client/src/components/Home/Collection.js
@@ -140,8 +140,11 @@ export class Collection extends Component {
             }}
             header={{
               title: (
-                <Stack gap={4} orientation="horizontal">
-                  <Folder size="24" /> {collection?.name}
+                <Stack gap={4} orientation="horizontal" className="titleContainer">
+                  <Folder size="24" />
+                  <span className="collectionName" title={collection?.name}>
+                    {collection?.name}
+                  </span>
                 </Stack>
               ),
               tag: collection && formatRole(collection?.currentUserRole),

--- a/optimize/client/src/components/Home/Collection.scss
+++ b/optimize/client/src/components/Home/Collection.scss
@@ -4,6 +4,19 @@
   height: 100%;
   padding-block: spacing.$spacing-06;
 
+  .titleContainer {
+    max-width: 100vh;
+  }
+
+  .collectionName {
+    display: inline-block;
+    max-width: calc(100% - 40px);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+  }
+
   .layoutContainer {
     .cds--tab-content {
       padding: 0;

--- a/optimize/client/src/components/Home/Collection.scss
+++ b/optimize/client/src/components/Home/Collection.scss
@@ -5,7 +5,7 @@
   padding-block: spacing.$spacing-06;
 
   .titleContainer {
-    max-width: 100vh;
+    max-width: 100vw;
   }
 
   .collectionName {

--- a/optimize/client/src/components/Home/Collection.scss
+++ b/optimize/client/src/components/Home/Collection.scss
@@ -5,7 +5,7 @@
   padding-block: spacing.$spacing-06;
 
   .titleContainer {
-    max-width: 100vw;
+    max-width: 60vw;
   }
 
   .collectionName {

--- a/optimize/client/src/modules/components/Breadcrumbs/Breadcrumbs.scss
+++ b/optimize/client/src/modules/components/Breadcrumbs/Breadcrumbs.scss
@@ -1,3 +1,12 @@
 .Breadcrumbs {
   margin: 0 40px;
+
+  .breadcrumbEntityName {
+    display: inline-block;
+    max-width: 300px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+  }
 }

--- a/optimize/client/src/modules/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/optimize/client/src/modules/components/Breadcrumbs/Breadcrumbs.tsx
@@ -56,13 +56,16 @@ export default function Breadcrumbs() {
             <Link to="/collections">{t('navigation.collections')}</Link>
           </BreadcrumbItem>
           {collection && (
-            <BreadcrumbItem>
-              <Link to={`/collection/${collection}/`}>{entityNames.collectionName}</Link>
+            <BreadcrumbItem title={entityNames.collectionName ?? undefined}>
+              <Link className="breadcrumbEntityName" to={`/collection/${collection}/`}>
+                {entityNames.collectionName}
+              </Link>
             </BreadcrumbItem>
           )}
           {report && dashboard && (
-            <BreadcrumbItem>
+            <BreadcrumbItem title={entityNames.dashboardName ?? undefined}>
               <Link
+                className="breadcrumbEntityName"
                 to={
                   collection
                     ? `/collection/${collection}/dashboard/${dashboard}/`

--- a/optimize/client/src/modules/components/EntityList/EntityList.scss
+++ b/optimize/client/src/modules/components/EntityList/EntityList.scss
@@ -15,6 +15,14 @@
     font-weight: 500;
   }
 
+  .entityName,
+  .rowName {
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
   thead th.tableHeader {
     white-space: nowrap;
 

--- a/optimize/client/src/modules/components/EntityList/EntityList.tsx
+++ b/optimize/client/src/modules/components/EntityList/EntityList.tsx
@@ -126,11 +126,13 @@ export default function EntityList({
           <div className="entityIcon">{row.icon}</div>
           <Stack gap={2} orientation="vertical">
             {row.link ? (
-              <Link title={row.name} className="cds--link" to={row.link}>
+              <Link title={row.name} className="cds--link entityName" to={row.link}>
                 {row.name}
               </Link>
             ) : (
-              <span className="rowName">{row.name}</span>
+              <span className="rowName" title={row.name}>
+                {row.name}
+              </span>
             )}
             <span>{row.type}</span>
           </Stack>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->


Optimize's backend accepts very long titles for things like collections, dashboards, etc but the UI is completely broken and unusable.

This was initially reported in this [support ticket](https://jira.camunda.com/browse/SUPPORT-31457)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46546
