### PR TITLE
fix: update Teleport setup and authentication in load test workflows

### DIFF
--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -16,6 +16,10 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+
 jobs:
   sanitize-branch-name:
     name: Sanitize Branch Name
@@ -171,14 +175,18 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: google-github-actions/auth@v3
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v3.0.0
+          version: 17.2.2
+
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+
       - name: Delete benchmarks
         run: |
           kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}"

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -175,6 +175,8 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Set up Teleport
         uses: teleport-actions/setup@v1
         with:

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -39,6 +39,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 
 jobs:
   profile-all-pods:
@@ -61,14 +64,18 @@ jobs:
             event: alloc
     steps:
       - uses: actions/checkout@v6
-      - uses: google-github-actions/auth@v3
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v3.0.0
+          version: 17.2.2
+
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: 'zeebe-cluster'
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+
       - name: Set right namespace
         run: |
           kubectl config set-context --current --namespace=${{ inputs.name }}
@@ -107,14 +114,17 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@v6
-      - uses: google-github-actions/auth@v3
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v3.0.0
+          version: 17.2.2
+
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: 'zeebe-cluster'
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Set right namespace
         run: |
           kubectl config set-context --current --namespace=${{ inputs.name }}


### PR DESCRIPTION
## Description
This pull request updates the GitHub Actions workflows for load testing by switching cluster authentication from Google Cloud (GKE) to Teleport. The main goal is to standardize and simplify Kubernetes cluster access using Teleport, improving security and maintainability.

closes https://camunda.slack.com/archives/C08N5EPR7LP/p1772091900492199
