### PR TITLE
[Backport stable/8.9] Move Tasklist ClientConfig cloud and identity env bindings to TasklistProperties and clean up unused client config flags

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/CloudProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/CloudProperties.java
@@ -27,7 +27,7 @@ public class CloudProperties {
     return permissionUrl;
   }
 
-  public void setPermissionUrl(String permissionUrl) {
+  public void setPermissionUrl(final String permissionUrl) {
     this.permissionUrl = permissionUrl;
   }
 
@@ -35,7 +35,7 @@ public class CloudProperties {
     return permissionAudience;
   }
 
-  public void setPermissionAudience(String permissionAudience) {
+  public void setPermissionAudience(final String permissionAudience) {
     this.permissionAudience = permissionAudience;
   }
 

--- a/tasklist/client/e2e/fixtures/v1-visual.ts
+++ b/tasklist/client/e2e/fixtures/v1-visual.ts
@@ -91,8 +91,6 @@ const test = base.extend<PlaywrightFixtures>({
                 stage: null,
                 mixpanelToken: null,
                 mixpanelAPIHost: null,
-                isResourcePermissionsEnabled: false,
-                isUserAccessRestrictionsEnabled: true,
                 clientMode: 'v1',
               };
             `,

--- a/tasklist/client/e2e/fixtures/v2-visual.ts
+++ b/tasklist/client/e2e/fixtures/v2-visual.ts
@@ -126,8 +126,6 @@ const test = base.extend<PlaywrightFixtures>({
                 stage: null,
                 mixpanelToken: null,
                 mixpanelAPIHost: null,
-                isResourcePermissionsEnabled: false,
-                isUserAccessRestrictionsEnabled: true,
                 clientMode: 'v2',
               };
             `,

--- a/tasklist/client/src/common/config/getClientConfig.ts
+++ b/tasklist/client/src/common/config/getClientConfig.ts
@@ -18,7 +18,6 @@ const ClientConfigSchema = z.object({
   clusterId: z.string().min(1).nullable().optional().default(null),
   mixpanelToken: z.string().nullable().optional().default(null),
   mixpanelAPIHost: z.string().nullable().optional().default(null),
-  isResourcePermissionsEnabled: z.boolean().nullable().optional().default(null),
   isMultiTenancyEnabled: z.boolean().optional().default(false),
   maxRequestSize: z
     .number()

--- a/tasklist/client/src/common/global.d.ts
+++ b/tasklist/client/src/common/global.d.ts
@@ -33,7 +33,6 @@ export declare global {
       clusterId?: null | string;
       mixpanelToken?: null | string;
       mixpanelAPIHost?: null | string;
-      isResourcePermissionsEnabled?: boolean;
       isMultiTenancyEnabled?: boolean;
       maxRequestSize?: number;
       clientMode?: 'v1' | 'v2';

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/CloudProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/CloudProperties.java
@@ -11,12 +11,29 @@ import java.util.Objects;
 
 public class CloudProperties {
 
+  private String organizationId;
+
   private String permissionUrl;
   private String permissionAudience;
 
   private String clusterId;
 
   private String consoleUrl;
+
+  private String stage;
+
+  private String mixpanelToken;
+
+  private String mixpanelAPIHost;
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  public CloudProperties setOrganizationId(final String organizationId) {
+    this.organizationId = organizationId;
+    return this;
+  }
 
   public String getPermissionUrl() {
     return permissionUrl;
@@ -52,8 +69,48 @@ public class CloudProperties {
     return this;
   }
 
+  public String getStage() {
+    return stage;
+  }
+
+  public CloudProperties setStage(final String stage) {
+    this.stage = stage;
+    return this;
+  }
+
+  public String getMixpanelToken() {
+    return mixpanelToken;
+  }
+
+  public CloudProperties setMixpanelToken(final String mixpanelToken) {
+    this.mixpanelToken = mixpanelToken;
+    return this;
+  }
+
+  public String getMixpanelAPIHost() {
+    return mixpanelAPIHost;
+  }
+
+  public CloudProperties setMixpanelAPIHost(final String mixpanelAPIHost) {
+    this.mixpanelAPIHost = mixpanelAPIHost;
+    return this;
+  }
+
   @Override
-  public boolean equals(Object o) {
+  public int hashCode() {
+    return Objects.hash(
+        organizationId,
+        permissionUrl,
+        permissionAudience,
+        clusterId,
+        consoleUrl,
+        stage,
+        mixpanelToken,
+        mixpanelAPIHost);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -61,14 +118,13 @@ public class CloudProperties {
       return false;
     }
     final CloudProperties that = (CloudProperties) o;
-    return Objects.equals(permissionUrl, that.permissionUrl)
+    return Objects.equals(organizationId, that.organizationId)
+        && Objects.equals(permissionUrl, that.permissionUrl)
         && Objects.equals(permissionAudience, that.permissionAudience)
         && Objects.equals(clusterId, that.clusterId)
-        && Objects.equals(consoleUrl, that.consoleUrl);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(permissionUrl, permissionAudience, clusterId, consoleUrl);
+        && Objects.equals(consoleUrl, that.consoleUrl)
+        && Objects.equals(stage, that.stage)
+        && Objects.equals(mixpanelToken, that.mixpanelToken)
+        && Objects.equals(mixpanelAPIHost, that.mixpanelAPIHost);
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
@@ -48,11 +48,12 @@ import org.springframework.web.context.WebApplicationContext;
     properties = {
       TasklistProperties.PREFIX + ".enterprise=true",
       TasklistProperties.PREFIX + ".zeebe.compatibility.enabled = true",
-      "CAMUNDA_TASKLIST_CLOUD_ORGANIZATIONID=organizationId",
-      // CAMUNDA_TASKLIST_CLOUD_CLUSTERID=clusterId  -- leave out to test for null values
-      "CAMUNDA_TASKLIST_CLOUD_STAGE=stage",
-      "CAMUNDA_TASKLIST_CLOUD_MIXPANELTOKEN=i-am-a-token",
-      "CAMUNDA_TASKLIST_CLOUD_MIXPANELAPIHOST=https://fake.mixpanel.com",
+      TasklistProperties.PREFIX + ".cloud.organizationId=organizationId",
+      // TasklistProperties.PREFIX + ".cloud.clusterId=clusterId" -- leave out to test for null
+      // values
+      TasklistProperties.PREFIX + ".cloud.stage=stage",
+      TasklistProperties.PREFIX + ".cloud.mixpanelToken=i-am-a-token",
+      TasklistProperties.PREFIX + ".cloud.mixpanelAPIHost=https://fake.mixpanel.com",
       "management.endpoint.health.group.readiness.include=readinessState"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -95,8 +96,6 @@ public class ClientConfigRestServiceIT {
                 + "\"stage\":\"stage\","
                 + "\"mixpanelToken\":\"i-am-a-token\","
                 + "\"mixpanelAPIHost\":\"https://fake.mixpanel.com\","
-                + "\"isResourcePermissionsEnabled\":false,"
-                + "\"isUserAccessRestrictionsEnabled\":true,"
                 + "\"maxRequestSize\":10485760};");
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/rest/ClientConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/rest/ClientConfig.java
@@ -31,26 +31,11 @@ public class ClientConfig {
   public String databaseType;
 
   // Cloud related properties for mixpanel events
-  @Value("${CAMUNDA_TASKLIST_CLOUD_ORGANIZATIONID:#{null}}")
   public String organizationId;
-
-  @Value("${CAMUNDA_TASKLIST_CLOUD_CLUSTERID:#{null}}")
   public String clusterId;
-
-  @Value("${CAMUNDA_TASKLIST_CLOUD_STAGE:#{null}}")
   public String stage;
-
-  @Value("${CAMUNDA_TASKLIST_CLOUD_MIXPANELTOKEN:#{null}}")
   public String mixpanelToken;
-
-  @Value("${CAMUNDA_TASKLIST_CLOUD_MIXPANELAPIHOST:#{null}}")
   public String mixpanelAPIHost;
-
-  @Value("${CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED:#{false}}")
-  public boolean isResourcePermissionsEnabled;
-
-  @Value("${CAMUNDA_TASKLIST_IDENTITY_USER_ACCESS_RESTRICTIONS_ENABLED:#{true}}")
-  public boolean isUserAccessRestrictionsEnabled;
 
   public long maxRequestSize;
 
@@ -77,5 +62,10 @@ public class ClientConfig {
     maxRequestSize = maxRequestSizeConfigValue.toBytes();
     clientMode = isV2ModeEnabled ? "v2" : "v1";
     databaseType = environmentService.getDatabaseType();
+    organizationId = tasklistProperties.getCloud().getOrganizationId();
+    clusterId = tasklistProperties.getCloud().getClusterId();
+    stage = tasklistProperties.getCloud().getStage();
+    mixpanelToken = tasklistProperties.getCloud().getMixpanelToken();
+    mixpanelAPIHost = tasklistProperties.getCloud().getMixpanelAPIHost();
   }
 }


### PR DESCRIPTION
# Description
Backport of #46824 to `stable/8.9`.

relates to #46839