### PR TITLE
[Backport stable/8.8] fix: only update the batch operation list view field if the id is not already present

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
@@ -266,7 +266,7 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
       final String script =
           "if (ctx._source.batchOperationIds == null){"
               + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
-              + "} else {"
+              + "} else if (!ctx._source.batchOperationIds.contains(params.batchOperationId)) {"
               + "ctx._source.batchOperationIds.add(params.batchOperationId);"
               + "}";
       batchRequest.updateWithScript(
@@ -331,7 +331,7 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
       final var script =
           "if (ctx._source.batchOperationIds == null){"
               + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
-              + "} else {"
+              + "} else if (!ctx._source.batchOperationIds.contains(params.batchOperationId)) {"
               + "ctx._source.batchOperationIds.add(params.batchOperationId);"
               + "}";
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
@@ -260,7 +260,7 @@ public class OpensearchBatchOperationWriter
       final String script =
           "if (ctx._source.batchOperationIds == null){"
               + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
-              + "} else {"
+              + "} else if (!ctx._source.batchOperationIds.contains(params.batchOperationId)) {"
               + "ctx._source.batchOperationIds.add(params.batchOperationId);"
               + "}";
       batchRequest.updateWithScript(
@@ -320,7 +320,7 @@ public class OpensearchBatchOperationWriter
       final var script =
           "if (ctx._source.batchOperationIds == null){"
               + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
-              + "} else {"
+              + "} else if (!ctx._source.batchOperationIds.contains(params.batchOperationId)) {"
               + "ctx._source.batchOperationIds.add(params.batchOperationId);"
               + "}";
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
@@ -66,7 +66,7 @@ public class ListViewFromChunkItemHandler
     final String script =
         "if (ctx._source.batchOperationIds == null){"
             + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
-            + "} else {"
+            + "} else if (!ctx._source.batchOperationIds.contains(params.batchOperationId)) {"
             + "ctx._source.batchOperationIds.add(params.batchOperationId);"
             + "}";
     batchRequest.updateWithScript(


### PR DESCRIPTION
# Description
Backport of #46033 to `stable/8.8`.

relates to #44423