### PR TITLE
[Backport stable/8.9] feat: add sticky header to filters in identity operations log

### DIFF
--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -21,6 +21,7 @@ import {
   Grid,
   ColumnRightPadding,
   CenteredRow,
+  StickySection,
 } from "./components/styled";
 import {
   Button,
@@ -29,7 +30,6 @@ import {
   Dropdown,
   Heading,
   MultiSelect,
-  Section,
   Stack,
   TextInput,
 } from "@carbon/react";
@@ -180,7 +180,7 @@ const List: FC = () => {
       />
       <Grid condensed fullWidth>
         <ColumnRightPadding sm={4} md={3} lg={4} xlg={3}>
-          <Section level={4}>
+          <StickySection level={4}>
             <Stack gap={5}>
               <Heading>{t("filter")}</Heading>
               <MultiSelect
@@ -296,7 +296,7 @@ const List: FC = () => {
                 </Button>
               </CenteredRow>
             </Stack>
-          </Section>
+          </StickySection>
         </ColumnRightPadding>
         <Column sm={4} md={5} lg={12} xlg={13}>
           <EntityList

--- a/identity/client/src/pages/operations-log/components/styled.tsx
+++ b/identity/client/src/pages/operations-log/components/styled.tsx
@@ -11,7 +11,7 @@ import {
   CheckmarkOutline as BaseCheckmarkOutline,
   ErrorOutline as BaseErrorOutline,
 } from "@carbon/react/icons";
-import { Column, Grid as CarbonGrid } from "@carbon/react";
+import { Column, Grid as CarbonGrid, Section } from "@carbon/react";
 import { styles } from "@carbon/elements";
 
 const OperationLogName = styled.div`
@@ -50,6 +50,11 @@ const OwnerInfo = styled.div`
   white-space: nowrap;
 `;
 
+const StickySection = styled(Section)`
+  position: sticky;
+  top: 0;
+`;
+
 export {
   OperationLogName,
   SuccessIcon,
@@ -59,4 +64,5 @@ export {
   CenteredRow,
   PropertyText,
   OwnerInfo,
+  StickySection,
 };


### PR DESCRIPTION
# Description
Backport of #46794 to `stable/8.9`.

relates to #45199