### PR TITLE
CI: fix health metrics submission for alwaysgreen jobs

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -167,6 +167,9 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         job_id != "setup-tests"
         job_id != "utils-flaky-tests-summary"
         job_id != "fe-unit-tests-merge"
+        # temporary for docker-build-helm-integration.yml workflow from alwaysgreen
+        job_id != "format-identifier"
+        job_id != "should-run"
 
         # not enforced on jobs that invoke other reusable workflows (instead enforced there)
         not job.uses

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -69,16 +69,6 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
     steps:
       - run: echo "Workflow conditions met, proceeding with build"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          job_name: docker-build-helm-integration-should-run
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   # Parallel frontend builds
   build-operate-frontend:
@@ -292,16 +282,6 @@ jobs:
           # Truncate to max 40 chars if needed (k8s namespace limit)
           IDENTIFIER="${IDENTIFIER:0:40}"
           echo "identifier=${IDENTIFIER}" >> "$GITHUB_OUTPUT"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          job_name: docker-build-helm-integration-format-identifier
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   helm-deploy:
     name: Helm chart Integration Tests

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -316,6 +316,29 @@ jobs:
         secret/data/github.com/organizations/camunda NEXUS_USR | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
         secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
 
+  helm-deploy-status:
+    name: Observe Helm chart Integration Tests status
+    needs: helm-deploy
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions: { }
+    steps:
+      - uses: actions/checkout@v6
+      - run: |
+          # shellcheck disable=SC2242
+          exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ needs.helm-deploy.result }}
+          job_name: docker-build-helm-integration-helm-deploy
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   trigger-saas-e2e:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -365,17 +365,6 @@ jobs:
                   }
                 }'
 
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          job_name: trigger-saas-e2e
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
       - name: Wait for downstream workflow to finish
         id: wait-downstream
         env:
@@ -481,3 +470,14 @@ jobs:
           else
             echo "No downstream workflow run URL found." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: docker-build-helm-integration-trigger-saas-e2e
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

Fixes for the issues [described here](https://camunda.slack.com/archives/C071KP5BTHB/p1772024856532709?thread_ts=1772019971.557389&cid=C071KP5BTHB):

* the trigger-saas-e2e job sends CI health metrics BEFORE actually receiving the downstream results
    * demo with intentional cancellation: https://github.com/camunda/camunda/actions/runs/22442773952/job/64990220920?pr=46977#step:7:106
* the helm-deploy jobs does NOT send any health metrics at all
    * demo with intentional cancellation: https://github.com/camunda/camunda/actions/runs/22442773952/job/64990381209?pr=46977
* two jobs try to send metrics but never run `git checkout` → their metrics are not useful anyways since the jobs are super fast & easy so we drop it

We need accurate and working CI health metrics submission for alwaysgreen jobs in order to assess reliability at scale, before making it a required status check.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None