### PR TITLE
refactor: document upload should reject invalid processDefinitionId

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -117,30 +117,17 @@ test.describe.parallel('Document API Tests', () => {
     );
   });
 
-  // Regression guard for #46405 / #46407: a processDefinitionId that starts
-  // with a digit violates the BPMN identifier pattern and must be rejected.
   test('Create Document Invalid processDefinitionId 400', async ({request}) => {
-    const form = new FormData();
-    form.append(
-      'file',
-      new File(['test content'], 'test.txt', {type: 'text/plain'}),
-    );
-    form.append(
-      'metadata',
-      new Blob(
-        [
-          JSON.stringify({
-            fileName: 'test.txt',
-            processDefinitionId: '9invalid',
-          }),
-        ],
-        {type: 'application/json'},
-      ),
+    const fileName = generateUniqueId();
+    const invalidProcessDefinitionId = '123xInvalidProcessDefinitionId'; // starts with a number, not a valid BPMN ID; regression guard for #46405 / #46407
+    const payload = CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA(
+      fileName,
+      invalidProcessDefinitionId,
     );
 
     const res = await request.post(buildUrl('/documents'), {
       headers: defaultHeaders(),
-      multipart: form,
+      multipart: payload,
     });
 
     await assertBadRequest(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR refactors a test for document upload validation when an invalid `processDefinitionId` is provided. The test was a regression guard for issues #46405 / #46407, which required rejecting processDefinitionIds that start with digits (violating BPMN identifier patterns).
[Successful API test run](https://github.com/camunda/camunda/actions/runs/22443282553/job/64990976100)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46407 
