### PR TITLE
[Backport stable/8.6] fix: retry on other partitions for process instance creation in REST API

### DIFF
--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -17,6 +17,8 @@ import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.broker.RequestRetryHandler;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
@@ -31,6 +33,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -39,6 +42,8 @@ import java.util.function.Function;
 public final class ProcessInstanceServices
     extends SearchQueryService<
         ProcessInstanceServices, ProcessInstanceQuery, ProcessInstanceEntity> {
+
+  private final RequestRetryHandler requestRetryHandler;
 
   public ProcessInstanceServices(
       final BrokerClient brokerClient, final CamundaSearchClient dataStoreClient) {
@@ -51,6 +56,7 @@ public final class ProcessInstanceServices
       final ServiceTransformers transformers,
       final Authentication authentication) {
     super(brokerClient, searchClient, transformers, authentication);
+    requestRetryHandler = new RequestRetryHandler(brokerClient, brokerClient.getTopologyManager());
   }
 
   @Override
@@ -82,7 +88,7 @@ public final class ProcessInstanceServices
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
     }
-    return sendBrokerRequest(brokerRequest);
+    return sendRequestWithRetryPartitions(brokerRequest);
   }
 
   public CompletableFuture<ProcessInstanceResultRecord> createProcessInstanceWithResult(
@@ -100,7 +106,13 @@ public final class ProcessInstanceServices
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
     }
-    return sendBrokerRequest(brokerRequest);
+
+    // Use custom request timeout if provided, otherwise use default
+    if (request.requestTimeout() != null && request.requestTimeout() > 0) {
+      return sendRequestWithRetryPartitions(
+          brokerRequest, Duration.ofMillis(request.requestTimeout()));
+    }
+    return sendRequestWithRetryPartitions(brokerRequest);
   }
 
   public CompletableFuture<ProcessInstanceRecord> cancelProcessInstance(
@@ -141,6 +153,36 @@ public final class ProcessInstanceServices
       brokerRequest.setOperationReference(request.operationReference());
     }
     return sendBrokerRequest(brokerRequest);
+  }
+
+  private <R> CompletableFuture<R> sendRequestWithRetryPartitions(
+      final BrokerRequest<R> brokerRequest) {
+    return sendRequestWithRetryPartitions(brokerRequest, null);
+  }
+
+  private <R> CompletableFuture<R> sendRequestWithRetryPartitions(
+      final BrokerRequest<R> brokerRequest, final Duration requestTimeout) {
+    brokerRequest.setAuthorization(authentication.token());
+    final CompletableFuture<R> responseFuture = new CompletableFuture<>();
+    if (requestTimeout != null) {
+      requestRetryHandler.sendRequest(
+          brokerRequest,
+          (key, response) -> responseFuture.complete(response),
+          responseFuture::completeExceptionally,
+          requestTimeout);
+    } else {
+      requestRetryHandler.sendRequest(
+          brokerRequest,
+          (key, response) -> responseFuture.complete(response),
+          responseFuture::completeExceptionally);
+    }
+    return responseFuture.handleAsync(
+        (response, error) -> {
+          if (error != null) {
+            throw new CamundaServiceException(error);
+          }
+          return response;
+        });
   }
 
   public record ProcessInstanceCreateRequest(

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.util.StubbedCamundaSearchClient;
+import io.camunda.service.util.StubbedTopologyManager;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import java.net.ConnectException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public final class ProcessInstanceServiceTest {
+
+  private ProcessInstanceServices services;
+  private BrokerClient brokerClient;
+
+  @BeforeEach
+  public void before() {
+
+    brokerClient = mock(BrokerClient.class);
+    when(brokerClient.getTopologyManager()).thenReturn(new StubbedTopologyManager(3));
+
+    services =
+        new ProcessInstanceServices(
+            brokerClient,
+            new StubbedCamundaSearchClient(),
+            null,
+            new Authentication.Builder().token("token").build());
+  }
+
+  @Nested
+  @DisplayName("Retry on different partitions")
+  class RetryPartitionsTest {
+
+    public static final String RETRY_EXHAUSTED_ERROR =
+        "Expected to execute the command on one of the partitions, but all failed; there are no more partitions available to retry. Please try again. If the error persists contact your zeebe operator";
+
+    private static Stream<Named<Throwable>> retryableErrors() {
+      return Stream.of(
+          Named.of(
+              "PARTITION_LEADER_MISMATCH",
+              new BrokerErrorException(
+                  new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "leader mismatch"))),
+          Named.of(
+              "RESOURCE_EXHAUSTED",
+              new BrokerErrorException(
+                  new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "resource exhausted"))),
+          Named.of("ConnectException", new ConnectException("connection refused")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryableErrors")
+    void shouldRetryCreateProcessInstanceOnRetryableError(final Throwable retryableError) {
+      // given
+      final var request = createProcessInstanceRequest();
+      final var mockResponse = new ProcessInstanceCreationRecord();
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                if (triedPartitions.size() == 1) {
+                  return CompletableFuture.failedFuture(retryableError);
+                }
+                return CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse));
+              });
+
+      // when
+      final var result = services.createProcessInstance(request).join();
+
+      // then - retried on a different partition and succeeded
+      assertThat(result).isNotNull();
+      assertThat(triedPartitions).hasSize(2);
+      assertThat(triedPartitions.get(0)).isNotEqualTo(triedPartitions.get(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryableErrors")
+    void shouldRetryCreateProcessInstanceWithResultOnRetryableError(
+        final Throwable retryableError) {
+      // given
+      final var request = createProcessInstanceWithResultRequest(null);
+      final var mockResponse = new ProcessInstanceResultRecord();
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceWithResultRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceWithResultRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                if (triedPartitions.size() == 1) {
+                  return CompletableFuture.failedFuture(retryableError);
+                }
+                return CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse));
+              });
+
+      // when
+      final var result = services.createProcessInstanceWithResult(request).join();
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(triedPartitions).hasSize(2);
+      assertThat(triedPartitions.get(0)).isNotEqualTo(triedPartitions.get(1));
+    }
+
+    @Test
+    void shouldExhaustRetriesForCreateProcessInstanceWhenAllPartitionsFail() {
+      // given - topology has 3 partitions, all fail with retryable errors
+      final var request = createProcessInstanceRequest();
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                return CompletableFuture.failedFuture(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "leader mismatch")));
+              });
+
+      // when / then - all 3 partitions tried with distinct IDs, then RESOURCE_EXHAUSTED error
+      assertThatThrownBy(() -> services.createProcessInstance(request).join())
+          .isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(CamundaServiceException.class)
+          .extracting(Throwable::getCause)
+          .satisfies(
+              cause -> {
+                final var serviceException = (RequestRetriesExhaustedException) cause.getCause();
+                assertThat(serviceException.getMessage()).isEqualTo(RETRY_EXHAUSTED_ERROR);
+              });
+      assertThat(triedPartitions).hasSize(3);
+      assertThat(triedPartitions).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void shouldExhaustRetriesForCreateProcessInstanceWithResultWhenAllPartitionsFail() {
+      // given
+      final var request = createProcessInstanceWithResultRequest(null);
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceWithResultRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceWithResultRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                return CompletableFuture.failedFuture(
+                    new BrokerErrorException(
+                        new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "resource exhausted")));
+              });
+
+      // when / then
+      assertThatThrownBy(() -> services.createProcessInstanceWithResult(request).join())
+          .isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(CamundaServiceException.class)
+          .extracting(Throwable::getCause)
+          .satisfies(
+              cause -> {
+                final var serviceException = (RequestRetriesExhaustedException) cause.getCause();
+                assertThat(serviceException.getMessage()).isEqualTo(RETRY_EXHAUSTED_ERROR);
+              });
+      assertThat(triedPartitions).hasSize(3);
+      assertThat(triedPartitions).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void shouldNotRetryCreateProcessInstanceOnNonRetryableError() {
+      // given - a non-retryable error like PROCESS_NOT_FOUND
+      final var request = createProcessInstanceRequest();
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenReturn(
+              CompletableFuture.failedFuture(
+                  new BrokerErrorException(
+                      new BrokerError(ErrorCode.PROCESS_NOT_FOUND, "process not found"))));
+
+      // when / then - only tried once, no retry
+      assertThatThrownBy(() -> services.createProcessInstance(request).join())
+          .isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(CamundaServiceException.class);
+      verify(brokerClient, times(1)).sendRequest(any(BrokerCreateProcessInstanceRequest.class));
+    }
+
+    @Test
+    void shouldRetryCreateProcessInstanceWithResultUsingCustomTimeout() {
+      // given
+      final var request = createProcessInstanceWithResultRequest(600_000L);
+      final var mockResponse = new ProcessInstanceResultRecord();
+      final var triedPartitions = new ArrayList<Integer>();
+      when(brokerClient.sendRequest(
+              any(BrokerCreateProcessInstanceWithResultRequest.class),
+              eq(java.time.Duration.ofMillis(600_000L))))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceWithResultRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                if (triedPartitions.size() == 1) {
+                  return CompletableFuture.failedFuture(
+                      new BrokerErrorException(
+                          new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "leader mismatch")));
+                }
+                return CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse));
+              });
+
+      // when
+      final var result = services.createProcessInstanceWithResult(request).join();
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(triedPartitions).hasSize(2);
+      assertThat(triedPartitions.get(0)).isNotEqualTo(triedPartitions.get(1));
+      verify(brokerClient, times(2))
+          .sendRequest(
+              any(BrokerCreateProcessInstanceWithResultRequest.class),
+              eq(java.time.Duration.ofMillis(600_000L)));
+    }
+
+    private ProcessInstanceServices.ProcessInstanceCreateRequest createProcessInstanceRequest() {
+      return new ProcessInstanceServices.ProcessInstanceCreateRequest(
+          123L, // processDefinitionKey
+          "test-process", // bpmnProcessId
+          -1, // version
+          null, // variables
+          "<default>", // tenantId
+          false, // awaitCompletion
+          null, // requestTimeout
+          null, // operationReference
+          List.of(), // startInstructions
+          List.of() // fetchVariables
+          );
+    }
+
+    private ProcessInstanceServices.ProcessInstanceCreateRequest
+        createProcessInstanceWithResultRequest(final Long requestTimeout) {
+      return new ProcessInstanceServices.ProcessInstanceCreateRequest(
+          123L, // processDefinitionKey
+          "test-process", // bpmnProcessId
+          -1, // version
+          null, // variables
+          "<default>", // tenantId
+          true, // awaitCompletion
+          requestTimeout, // requestTimeout
+          null, // operationReference
+          List.of(), // startInstructions
+          List.of() // fetchVariables
+          );
+    }
+  }
+}

--- a/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceFilterTest.java
@@ -8,6 +8,7 @@
 package io.camunda.service.query.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.camunda.search.clients.query.*;
 import io.camunda.service.ProcessInstanceServices;
@@ -19,6 +20,7 @@ import io.camunda.service.search.query.ProcessInstanceQuery;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.util.StubbedCamundaSearchClient;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +35,7 @@ public final class ProcessInstanceFilterTest {
   public void before() {
     client = new StubbedCamundaSearchClient();
     new ProcessInstanceSearchQueryStub().registerWith(client);
-    services = new ProcessInstanceServices(null, client);
+    services = new ProcessInstanceServices(mock(BrokerClient.class), client);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/query/result/ProcessInstanceResultConfigTest.java
+++ b/service/src/test/java/io/camunda/service/query/result/ProcessInstanceResultConfigTest.java
@@ -8,12 +8,14 @@
 package io.camunda.service.query.result;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.query.filter.ProcessInstanceSearchQueryStub;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.util.StubbedCamundaSearchClient;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +27,7 @@ public class ProcessInstanceResultConfigTest {
   public void before() {
     client = new StubbedCamundaSearchClient();
     new ProcessInstanceSearchQueryStub().registerWith(client);
-    services = new ProcessInstanceServices(null, client);
+    services = new ProcessInstanceServices(mock(BrokerClient.class), client);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/query/sort/ProcessInstanceSortTest.java
+++ b/service/src/test/java/io/camunda/service/query/sort/ProcessInstanceSortTest.java
@@ -8,6 +8,7 @@
 package io.camunda.service.query.sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.sort.SearchSortOptions;
@@ -18,6 +19,7 @@ import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.util.StubbedCamundaSearchClient;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +35,7 @@ public class ProcessInstanceSortTest {
   public void before() {
     client = new StubbedCamundaSearchClient();
     new ProcessInstanceSearchQueryStub().registerWith(client);
-    services = new ProcessInstanceServices(null, client);
+    services = new ProcessInstanceServices(mock(BrokerClient.class), client);
   }
 
   private static Stream<Arguments> provideSortParameters() {

--- a/service/src/test/java/io/camunda/service/util/StubbedTopologyManager.java
+++ b/service/src/test/java/io/camunda/service/util/StubbedTopologyManager.java
@@ -18,12 +18,14 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 public final class StubbedTopologyManager implements BrokerTopologyManager {
 
   private final BrokerClusterStateImpl clusterState;
+  private final ClusterConfiguration clusterConfiguration;
 
-  StubbedTopologyManager() {
+  public StubbedTopologyManager() {
     this(8);
   }
 
-  StubbedTopologyManager(final int partitionsCount) {
+  public StubbedTopologyManager(final int partitionsCount) {
+    clusterConfiguration = ClusterConfiguration.uninitialized();
     clusterState = new BrokerClusterStateImpl();
     clusterState.setClusterSize(1);
     clusterState.addBrokerIfAbsent(0);
@@ -42,7 +44,7 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
 
   @Override
   public ClusterConfiguration getClusterConfiguration() {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return clusterConfiguration;
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #46854 to `stable/8.6`.

relates to #46756