### PR TITLE
[Backport stable/8.9] test: add cluster variable UPDATE API tests with retry logic

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-search-api.spec.ts
@@ -13,6 +13,7 @@ import {
   assertUnauthorizedRequest,
   assertBadRequest,
   assertPaginatedRequest,
+  assertStatusCode,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
@@ -22,6 +23,7 @@ import {
   createTenantAndStoreResponseFields,
   assertClusterVariableUpdate,
 } from '@requestHelpers';
+import {validateResponse} from '../../../../json-body-assertions';
 
 test.describe.parallel('Search Cluster Variables API Tests', () => {
   const state: Record<string, unknown> = {};
@@ -403,43 +405,52 @@ test.describe.parallel('Search Cluster Variables API Tests', () => {
   });
 
   test('Search Finds Updated Cluster Variable Value', async ({request}) => {
-    // Create a global cluster variable
-    await createGlobalClusterVariable(request, state, 'updatedSearchVar');
+    await test.step('Create a global cluster variable', async () => {
+      await createGlobalClusterVariable(request, state, 'updatedSearchVar');
+      const variableName = state['updatedSearchVarName'] as string;
+      createdVariables.push({name: variableName});
+    });
+
     const variableName = state['updatedSearchVarName'] as string;
-    createdVariables.push({name: variableName});
-
-    // Update the variable with a new value (with retry logic)
     const updatedValue = {status: 'updated', timestamp: Date.now()};
-    await assertClusterVariableUpdate(
-      request,
-      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-      updatedValue,
-      variableName,
-      'GLOBAL',
-    );
 
-    // Search for the variable and verify updated value is returned
-    await expect(async () => {
-      const res = await request.post(buildUrl('/cluster-variables/search'), {
-        headers: jsonHeaders(),
-        data: {
-          filter: {
-            name: variableName,
-          },
-        },
-      });
-
-      expect(res.status()).toBe(200);
-      const body = await res.json();
-      expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-      expect(body.items.length).toBeGreaterThan(0);
-
-      const found = body.items.find(
-        (item: Record<string, unknown>) => item.name === variableName,
+    await test.step('Update the variable with a new value', async () => {
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        updatedValue,
+        variableName,
+        'GLOBAL',
       );
-      expect(found).toBeDefined();
-      expect(found!.scope).toBe('GLOBAL');
-      expect(JSON.parse(found!.value as string)).toEqual(updatedValue);
-    }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search for the variable and verify updated value', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl('/cluster-variables/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              name: variableName,
+            },
+          },
+        });
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {path: '/cluster-variables/search', method: 'POST', status: '200'},
+          res,
+        );
+        const body = await res.json();
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        expect(body.items.length).toBeGreaterThan(0);
+
+        const found = body.items.find(
+          (item: Record<string, unknown>) => item.name === variableName,
+        );
+        expect(found).toBeDefined();
+        expect(found!.scope).toBe('GLOBAL');
+        expect(JSON.parse(found!.value as string)).toEqual(updatedValue);
+      }).toPass(defaultAssertionOptions);
+    });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-search-api.spec.ts
@@ -20,6 +20,7 @@ import {
   createTenantClusterVariable,
   assertClusterVariableInResponse,
   createTenantAndStoreResponseFields,
+  assertClusterVariableUpdate,
 } from '@requestHelpers';
 
 test.describe.parallel('Search Cluster Variables API Tests', () => {
@@ -398,6 +399,47 @@ test.describe.parallel('Search Cluster Variables API Tests', () => {
         itemsLengthEqualTo: 0,
         totalItemsEqualTo: 0,
       });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Finds Updated Cluster Variable Value', async ({request}) => {
+    // Create a global cluster variable
+    await createGlobalClusterVariable(request, state, 'updatedSearchVar');
+    const variableName = state['updatedSearchVarName'] as string;
+    createdVariables.push({name: variableName});
+
+    // Update the variable with a new value (with retry logic)
+    const updatedValue = {status: 'updated', timestamp: Date.now()};
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      updatedValue,
+      variableName,
+      'GLOBAL',
+    );
+
+    // Search for the variable and verify updated value is returned
+    await expect(async () => {
+      const res = await request.post(buildUrl('/cluster-variables/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            name: variableName,
+          },
+        },
+      });
+
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+      expect(body.items.length).toBeGreaterThan(0);
+
+      const found = body.items.find(
+        (item: Record<string, unknown>) => item.name === variableName,
+      );
+      expect(found).toBeDefined();
+      expect(found!.scope).toBe('GLOBAL');
+      expect(JSON.parse(found!.value as string)).toEqual(updatedValue);
     }).toPass(defaultAssertionOptions);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-update-api-tests.spec.ts
@@ -1,0 +1,907 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertBadRequest,
+} from '../../../../utils/http';
+import {UPDATE_CLUSTER_VARIABLE_VALUE} from '../../../../utils/beans/requestBeans';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  createGlobalClusterVariable,
+  createTenantClusterVariable,
+  updateGlobalClusterVariable,
+  updateTenantClusterVariable,
+  createTenantAndStoreResponseFields,
+  assertClusterVariableUpdate,
+} from '@requestHelpers';
+import {validateResponseShape} from '../../../../json-body-assertions';
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel(
+  'Cluster Variable API Tests - Global Scope UPDATE',
+  () => {
+    const state: Record<string, unknown> = {};
+    const createdVariableNames: string[] = [];
+
+    test.afterAll(async ({request}) => {
+      for (const name of createdVariableNames) {
+        try {
+          await request.delete(
+            buildUrl('/cluster-variables/global/{name}', {name}),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    });
+
+    test('Update Global Cluster Variable With Object Value', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateObjVar');
+      const variableName = state['updateObjVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = {updatedKey: 'updatedValue', nested: {value: 123}};
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable With String Value', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateStringVar');
+      const variableName = state['updateStringVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = 'production';
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable With Number Value', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateNumberVar');
+      const variableName = state['updateNumberVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = 42;
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable With Boolean True Value', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateBoolTrueVar');
+      const variableName = state['updateBoolTrueVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = true;
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable With Boolean False Value', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateBoolFalseVar');
+      const variableName = state['updateBoolFalseVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = false;
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable With Array Value', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateArrayVar');
+      const variableName = state['updateArrayVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = [1, 2, 3, 'four'];
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable With Nested Object', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateNestedVar');
+      const variableName = state['updateNestedVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = {
+        feature_flags: {
+          new_ui: true,
+          beta_features: false,
+        },
+        config: {
+          timeout: 5000,
+        },
+      };
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable With Empty Object', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateEmptyObjVar');
+      const variableName = state['updateEmptyObjVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = {};
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable With Empty Array', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateEmptyArrVar');
+      const variableName = state['updateEmptyArrVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue: unknown[] = [];
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    test('Update Global Cluster Variable Multiple Times', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateMultipleVar');
+      const variableName = state['updateMultipleVarName'] as string;
+      createdVariableNames.push(variableName);
+
+      const firstValue = {version: 1};
+      const secondValue = {version: 2};
+
+      await test.step('First update', async () => {
+        await updateGlobalClusterVariable(request, variableName, firstValue);
+
+        await expect(async () => {
+          const res = await request.get(
+            buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          expect(res.status()).toBe(200);
+          const json = await res.json();
+          expect(JSON.parse(json.value)).toEqual(firstValue);
+        }).toPass(defaultAssertionOptions);
+      });
+
+      await test.step('Second update', async () => {
+        await updateGlobalClusterVariable(request, variableName, secondValue);
+
+        await expect(async () => {
+          const res = await request.get(
+            buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          expect(res.status()).toBe(200);
+          const json = await res.json();
+          expect(JSON.parse(json.value)).toEqual(secondValue);
+        }).toPass(defaultAssertionOptions);
+      });
+    });
+
+    test('Update Global Cluster Variable Unauthorized', async ({request}) => {
+      await createGlobalClusterVariable(request, state, 'updateUnauthorized');
+      const variableName = state['updateUnauthorizedName'] as string;
+      createdVariableNames.push(variableName);
+
+      const res = await request.put(
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        {
+          headers: {},
+          data: UPDATE_CLUSTER_VARIABLE_VALUE({updated: true}),
+        },
+      );
+      await assertUnauthorizedRequest(res);
+    });
+
+    test('Update Global Cluster Variable Not Found', async ({request}) => {
+      const res = await request.put(
+        buildUrl('/cluster-variables/global/{name}', {
+          name: 'does-not-exist',
+        }),
+        {
+          headers: jsonHeaders(),
+          data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
+        },
+      );
+      await assertNotFoundRequest(res, 'does-not-exist');
+    });
+
+    test('Update Global Cluster Variable Missing Value Field Invalid Body 400', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateMissingValue');
+      const variableName = state['updateMissingValueName'] as string;
+      createdVariableNames.push(variableName);
+
+      const res = await request.put(
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      await assertBadRequest(res, /value/i, 'INVALID_ARGUMENT');
+    });
+
+    test('Update Global Cluster Variable Verify Response Structure', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(request, state, 'updateVerifyResp');
+      const variableName = state['updateVerifyRespName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = {verified: true, timestamp: Date.now()};
+
+      // Update using helper function with built-in retry logic
+      await updateGlobalClusterVariable(request, variableName, newValue);
+
+      // Verify variable structure with retry for eventual consistency
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        expect(res.status()).toBe(200);
+        const json = await res.json();
+
+        // Verify response shape matches OpenAPI spec
+        validateResponseShape(
+          {
+            path: '/cluster-variables/global/{name}',
+            method: 'GET',
+            status: '200',
+          },
+          json,
+        );
+
+        // Verify field values
+        expect(json.name).toBe(variableName);
+        expect(json.scope).toBe('GLOBAL');
+        expect(typeof json.value).toBe('string');
+        expect(JSON.parse(json.value)).toEqual(newValue);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    test('Update Global Cluster Variable Immediately Retrievable', async ({
+      request,
+    }) => {
+      await createGlobalClusterVariable(
+        request,
+        state,
+        'updateImmediateRetrieval',
+      );
+      const variableName = state['updateImmediateRetrievalName'] as string;
+      createdVariableNames.push(variableName);
+
+      const newValue = {consistency: 'strong'};
+
+      // Update the variable with retry for eventual consistency
+      await expect(async () => {
+        const updateRes = await request.put(
+          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+          {
+            headers: jsonHeaders(),
+            data: UPDATE_CLUSTER_VARIABLE_VALUE(newValue),
+          },
+        );
+        expect(updateRes.status()).toBe(200);
+      }).toPass(defaultAssertionOptions);
+
+      // Verify variable is immediately retrievable with retry for eventual consistency
+      await expect(async () => {
+        const getRes = await request.get(
+          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        expect(getRes.status()).toBe(200);
+        const json = await getRes.json();
+        expect(JSON.parse(json.value)).toEqual(newValue);
+      }).toPass(defaultAssertionOptions);
+    });
+  },
+);
+
+test.describe.parallel(
+  'Cluster Variable API Tests - Tenant Scope UPDATE',
+  () => {
+    const state: Record<string, unknown> = {};
+    const createdVariables: {tenantId: string; name: string}[] = [];
+
+    test.beforeAll(async ({request}) => {
+      // Create tenants for testing
+      await createTenantAndStoreResponseFields(request, 2, state);
+    });
+
+    test.afterAll(async ({request}) => {
+      for (const variable of createdVariables) {
+        try {
+          await request.delete(
+            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+              tenantId: variable.tenantId,
+              name: variable.name,
+            }),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    });
+
+    test('Update Tenant Cluster Variable With Object Value', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantObjVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantObjVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = {updatedKey: 'tenantValue', nested: {value: 456}};
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        newValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    test('Update Tenant Cluster Variable With String Value', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantStringVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantStringVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = 'tenant-production';
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        newValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    test('Update Tenant Cluster Variable With Number Value', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantNumberVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantNumberVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = 1000;
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        newValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    test('Update Tenant Cluster Variable With Boolean Value', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantBoolVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantBoolVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = true;
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        newValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    test('Update Tenant Cluster Variable With Array Value', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantArrayVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantArrayVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = [10, 20, 30, 'tenant-array'];
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        newValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    test('Update Tenant Cluster Variable With Complex Nested Object', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantComplexVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantComplexVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = {
+        feature_flags: {
+          new_ui: true,
+          beta_features: false,
+        },
+        settings: {
+          theme: 'dark',
+          notifications: {
+            email: true,
+            push: false,
+          },
+        },
+      };
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        newValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    test('Update Tenant Cluster Variable With Empty Object', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantEmptyObjVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantEmptyObjVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = {};
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        newValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    test('Update Tenant Cluster Variable With Empty Array', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantEmptyArrVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantEmptyArrVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue: unknown[] = [];
+
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        newValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    test('Update Tenant Cluster Variable Multiple Times', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId2'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantMultipleVar',
+        tenantId,
+      );
+      const variableName = state['updateTenantMultipleVarName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const firstValue = {version: 1};
+      const secondValue = {version: 2};
+
+      await test.step('First update', async () => {
+        await updateTenantClusterVariable(
+          request,
+          tenantId,
+          variableName,
+          firstValue,
+        );
+
+        await expect(async () => {
+          const res = await request.get(
+            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+              tenantId,
+              name: variableName,
+            }),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          expect(res.status()).toBe(200);
+          const json = await res.json();
+          expect(JSON.parse(json.value)).toEqual(firstValue);
+        }).toPass(defaultAssertionOptions);
+      });
+
+      await test.step('Second update', async () => {
+        await updateTenantClusterVariable(
+          request,
+          tenantId,
+          variableName,
+          secondValue,
+        );
+
+        await expect(async () => {
+          const res = await request.get(
+            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+              tenantId,
+              name: variableName,
+            }),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          expect(res.status()).toBe(200);
+          const json = await res.json();
+          expect(JSON.parse(json.value)).toEqual(secondValue);
+        }).toPass(defaultAssertionOptions);
+      });
+    });
+
+    test('Update Tenant Cluster Variable Unauthorized', async ({request}) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantUnauth',
+        tenantId,
+      );
+      const variableName = state['updateTenantUnauthName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const res = await request.put(
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        {
+          headers: {},
+          data: UPDATE_CLUSTER_VARIABLE_VALUE({updated: true}),
+        },
+      );
+      await assertUnauthorizedRequest(res);
+    });
+
+    test('Update Tenant Cluster Variable Not Found', async ({request}) => {
+      const tenantId = state['tenantId1'] as string;
+      const res = await request.put(
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: 'does-not-exist',
+        }),
+        {
+          headers: jsonHeaders(),
+          data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
+        },
+      );
+      await assertNotFoundRequest(res, 'does-not-exist');
+    });
+
+    test('Update Tenant Cluster Variable Missing Value Field Invalid Body 400', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId1'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantMissingVal',
+        tenantId,
+      );
+      const variableName = state['updateTenantMissingValName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const res = await request.put(
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      await assertBadRequest(res, /value/i, 'INVALID_ARGUMENT');
+    });
+
+    test('Update Tenant Cluster Variable Invalid Tenant Not Found', async ({
+      request,
+    }) => {
+      const res = await request.put(
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId: 'invalid-tenant-id',
+          name: 'some-variable',
+        }),
+        {
+          headers: jsonHeaders(),
+          data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
+        },
+      );
+      await assertNotFoundRequest(res, 'invalid-tenant-id');
+    });
+
+    test('Update Tenant Cluster Variable Verify Response Structure', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId2'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantVerifyResp',
+        tenantId,
+      );
+      const variableName = state['updateTenantVerifyRespName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = {verified: true, timestamp: Date.now()};
+
+      // Update using helper function with built-in retry logic
+      await updateTenantClusterVariable(
+        request,
+        tenantId,
+        variableName,
+        newValue,
+      );
+
+      // Verify variable structure with retry for eventual consistency
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+            tenantId,
+            name: variableName,
+          }),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        expect(res.status()).toBe(200);
+        const json = await res.json();
+
+        // Verify response shape matches OpenAPI spec
+        validateResponseShape(
+          {
+            path: '/cluster-variables/tenants/{tenantId}/{name}',
+            method: 'GET',
+            status: '200',
+          },
+          json,
+        );
+
+        // Verify field values
+        expect(json.name).toBe(variableName);
+        expect(json.scope).toBe('TENANT');
+        expect(json.tenantId).toBe(tenantId);
+        expect(typeof json.value).toBe('string');
+        expect(JSON.parse(json.value)).toEqual(newValue);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    test('Update Tenant Cluster Variable Immediately Retrievable', async ({
+      request,
+    }) => {
+      const tenantId = state['tenantId2'] as string;
+      await createTenantClusterVariable(
+        request,
+        state,
+        'updateTenantImmediate',
+        tenantId,
+      );
+      const variableName = state['updateTenantImmediateName'] as string;
+      createdVariables.push({tenantId, name: variableName});
+
+      const newValue = {consistency: 'strong'};
+
+      // Update the variable with retry for eventual consistency
+      await expect(async () => {
+        const updateRes = await request.put(
+          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+            tenantId,
+            name: variableName,
+          }),
+          {
+            headers: jsonHeaders(),
+            data: UPDATE_CLUSTER_VARIABLE_VALUE(newValue),
+          },
+        );
+        expect(updateRes.status()).toBe(200);
+      }).toPass(defaultAssertionOptions);
+
+      // Verify variable is immediately retrievable with retry for eventual consistency
+      await expect(async () => {
+        const getRes = await request.get(
+          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+            tenantId,
+            name: variableName,
+          }),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        expect(getRes.status()).toBe(200);
+        const json = await getRes.json();
+        expect(JSON.parse(json.value)).toEqual(newValue);
+      }).toPass(defaultAssertionOptions);
+    });
+  },
+);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-update-api-tests.spec.ts
@@ -13,18 +13,24 @@ import {
   assertUnauthorizedRequest,
   assertNotFoundRequest,
   assertBadRequest,
+  assertStatusCode,
 } from '../../../../utils/http';
 import {UPDATE_CLUSTER_VARIABLE_VALUE} from '../../../../utils/beans/requestBeans';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
   createGlobalClusterVariable,
   createTenantClusterVariable,
-  updateGlobalClusterVariable,
-  updateTenantClusterVariable,
   createTenantAndStoreResponseFields,
   assertClusterVariableUpdate,
 } from '@requestHelpers';
-import {validateResponseShape} from '../../../../json-body-assertions';
+import {
+  validateResponseShape,
+  validateResponse,
+} from '../../../../json-body-assertions';
+import {
+  cleanupGlobalClusterVariables,
+  cleanupTenantClusterVariables,
+} from '../../../../utils/clusterVariablesCleanup';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel(
@@ -34,18 +40,7 @@ test.describe.parallel(
     const createdVariableNames: string[] = [];
 
     test.afterAll(async ({request}) => {
-      for (const name of createdVariableNames) {
-        try {
-          await request.delete(
-            buildUrl('/cluster-variables/global/{name}', {name}),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-        } catch {
-          // Ignore cleanup errors
-        }
-      }
+      await cleanupGlobalClusterVariables(request, createdVariableNames);
     });
 
     test('Update Global Cluster Variable With Object Value', async ({
@@ -229,35 +224,23 @@ test.describe.parallel(
       const secondValue = {version: 2};
 
       await test.step('First update', async () => {
-        await updateGlobalClusterVariable(request, variableName, firstValue);
-
-        await expect(async () => {
-          const res = await request.get(
-            buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-          expect(res.status()).toBe(200);
-          const json = await res.json();
-          expect(JSON.parse(json.value)).toEqual(firstValue);
-        }).toPass(defaultAssertionOptions);
+        await assertClusterVariableUpdate(
+          request,
+          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+          firstValue,
+          variableName,
+          'GLOBAL',
+        );
       });
 
       await test.step('Second update', async () => {
-        await updateGlobalClusterVariable(request, variableName, secondValue);
-
-        await expect(async () => {
-          const res = await request.get(
-            buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-          expect(res.status()).toBe(200);
-          const json = await res.json();
-          expect(JSON.parse(json.value)).toEqual(secondValue);
-        }).toPass(defaultAssertionOptions);
+        await assertClusterVariableUpdate(
+          request,
+          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+          secondValue,
+          variableName,
+          'GLOBAL',
+        );
       });
     });
 
@@ -315,37 +298,42 @@ test.describe.parallel(
 
       const newValue = {verified: true, timestamp: Date.now()};
 
-      // Update using helper function with built-in retry logic
-      await updateGlobalClusterVariable(request, variableName, newValue);
-
-      // Verify variable structure with retry for eventual consistency
-      await expect(async () => {
-        const res = await request.get(
+      await test.step('Update using helper function with retry logic', async () => {
+        await assertClusterVariableUpdate(
+          request,
           buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-          {
-            headers: jsonHeaders(),
-          },
+          newValue,
+          variableName,
+          'GLOBAL',
         );
+      });
 
-        expect(res.status()).toBe(200);
-        const json = await res.json();
+      await test.step('Verify variable structure with retry', async () => {
+        await expect(async () => {
+          const res = await request.get(
+            buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+            {
+              headers: jsonHeaders(),
+            },
+          );
 
-        // Verify response shape matches OpenAPI spec
-        validateResponseShape(
-          {
-            path: '/cluster-variables/global/{name}',
-            method: 'GET',
-            status: '200',
-          },
-          json,
-        );
+          await assertStatusCode(res, 200);
+          await validateResponse(
+            {
+              path: '/cluster-variables/global/{name}',
+              method: 'GET',
+              status: '200',
+            },
+            res,
+          );
+          const json = await res.json();
 
-        // Verify field values
-        expect(json.name).toBe(variableName);
-        expect(json.scope).toBe('GLOBAL');
-        expect(typeof json.value).toBe('string');
-        expect(JSON.parse(json.value)).toEqual(newValue);
-      }).toPass(defaultAssertionOptions);
+          expect(json.name).toBe(variableName);
+          expect(json.scope).toBe('GLOBAL');
+          expect(typeof json.value).toBe('string');
+          expect(JSON.parse(json.value)).toEqual(newValue);
+        }).toPass(defaultAssertionOptions);
+      });
     });
 
     test('Update Global Cluster Variable Immediately Retrievable', async ({
@@ -361,30 +349,29 @@ test.describe.parallel(
 
       const newValue = {consistency: 'strong'};
 
-      // Update the variable with retry for eventual consistency
-      await expect(async () => {
-        const updateRes = await request.put(
+      await test.step('Update the variable with retry', async () => {
+        await assertClusterVariableUpdate(
+          request,
           buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-          {
-            headers: jsonHeaders(),
-            data: UPDATE_CLUSTER_VARIABLE_VALUE(newValue),
-          },
+          newValue,
+          variableName,
+          'GLOBAL',
         );
-        expect(updateRes.status()).toBe(200);
-      }).toPass(defaultAssertionOptions);
+      });
 
-      // Verify variable is immediately retrievable with retry for eventual consistency
-      await expect(async () => {
-        const getRes = await request.get(
-          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-          {
-            headers: jsonHeaders(),
-          },
-        );
-        expect(getRes.status()).toBe(200);
-        const json = await getRes.json();
-        expect(JSON.parse(json.value)).toEqual(newValue);
-      }).toPass(defaultAssertionOptions);
+      await test.step('Verify variable is immediately retrievable', async () => {
+        await expect(async () => {
+          const getRes = await request.get(
+            buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          await assertStatusCode(getRes, 200);
+          const json = await getRes.json();
+          expect(JSON.parse(json.value)).toEqual(newValue);
+        }).toPass(defaultAssertionOptions);
+      });
     });
   },
 );
@@ -401,21 +388,7 @@ test.describe.parallel(
     });
 
     test.afterAll(async ({request}) => {
-      for (const variable of createdVariables) {
-        try {
-          await request.delete(
-            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-              tenantId: variable.tenantId,
-              name: variable.name,
-            }),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-        } catch {
-          // Ignore cleanup errors
-        }
-      }
+      await cleanupTenantClusterVariables(request, createdVariables);
     });
 
     test('Update Tenant Cluster Variable With Object Value', async ({
@@ -671,51 +644,31 @@ test.describe.parallel(
       const secondValue = {version: 2};
 
       await test.step('First update', async () => {
-        await updateTenantClusterVariable(
+        await assertClusterVariableUpdate(
           request,
-          tenantId,
-          variableName,
+          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+            tenantId,
+            name: variableName,
+          }),
           firstValue,
+          variableName,
+          'TENANT',
+          tenantId,
         );
-
-        await expect(async () => {
-          const res = await request.get(
-            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-              tenantId,
-              name: variableName,
-            }),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-          expect(res.status()).toBe(200);
-          const json = await res.json();
-          expect(JSON.parse(json.value)).toEqual(firstValue);
-        }).toPass(defaultAssertionOptions);
       });
 
       await test.step('Second update', async () => {
-        await updateTenantClusterVariable(
+        await assertClusterVariableUpdate(
           request,
-          tenantId,
-          variableName,
+          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+            tenantId,
+            name: variableName,
+          }),
           secondValue,
+          variableName,
+          'TENANT',
+          tenantId,
         );
-
-        await expect(async () => {
-          const res = await request.get(
-            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-              tenantId,
-              name: variableName,
-            }),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-          expect(res.status()).toBe(200);
-          const json = await res.json();
-          expect(JSON.parse(json.value)).toEqual(secondValue);
-        }).toPass(defaultAssertionOptions);
       });
     });
 
@@ -815,46 +768,50 @@ test.describe.parallel(
 
       const newValue = {verified: true, timestamp: Date.now()};
 
-      // Update using helper function with built-in retry logic
-      await updateTenantClusterVariable(
-        request,
-        tenantId,
-        variableName,
-        newValue,
-      );
-
-      // Verify variable structure with retry for eventual consistency
-      await expect(async () => {
-        const res = await request.get(
+      await test.step('Update using helper function with retry logic', async () => {
+        await assertClusterVariableUpdate(
+          request,
           buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
             tenantId,
             name: variableName,
           }),
-          {
-            headers: jsonHeaders(),
-          },
+          newValue,
+          variableName,
+          'TENANT',
+          tenantId,
         );
+      });
 
-        expect(res.status()).toBe(200);
-        const json = await res.json();
+      await test.step('Verify variable structure with retry', async () => {
+        await expect(async () => {
+          const res = await request.get(
+            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+              tenantId,
+              name: variableName,
+            }),
+            {
+              headers: jsonHeaders(),
+            },
+          );
 
-        // Verify response shape matches OpenAPI spec
-        validateResponseShape(
-          {
-            path: '/cluster-variables/tenants/{tenantId}/{name}',
-            method: 'GET',
-            status: '200',
-          },
-          json,
-        );
+          await assertStatusCode(res, 200);
+          await validateResponse(
+            {
+              path: '/cluster-variables/tenants/{tenantId}/{name}',
+              method: 'GET',
+              status: '200',
+            },
+            res,
+          );
+          const json = await res.json();
 
-        // Verify field values
-        expect(json.name).toBe(variableName);
-        expect(json.scope).toBe('TENANT');
-        expect(json.tenantId).toBe(tenantId);
-        expect(typeof json.value).toBe('string');
-        expect(JSON.parse(json.value)).toEqual(newValue);
-      }).toPass(defaultAssertionOptions);
+          expect(json.name).toBe(variableName);
+          expect(json.scope).toBe('TENANT');
+          expect(json.tenantId).toBe(tenantId);
+          expect(typeof json.value).toBe('string');
+          expect(JSON.parse(json.value)).toEqual(newValue);
+        }).toPass(defaultAssertionOptions);
+      });
     });
 
     test('Update Tenant Cluster Variable Immediately Retrievable', async ({
@@ -872,36 +829,36 @@ test.describe.parallel(
 
       const newValue = {consistency: 'strong'};
 
-      // Update the variable with retry for eventual consistency
-      await expect(async () => {
-        const updateRes = await request.put(
+      await test.step('Update the variable with retry', async () => {
+        await assertClusterVariableUpdate(
+          request,
           buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
             tenantId,
             name: variableName,
           }),
-          {
-            headers: jsonHeaders(),
-            data: UPDATE_CLUSTER_VARIABLE_VALUE(newValue),
-          },
+          newValue,
+          variableName,
+          'TENANT',
+          tenantId,
         );
-        expect(updateRes.status()).toBe(200);
-      }).toPass(defaultAssertionOptions);
+      });
 
-      // Verify variable is immediately retrievable with retry for eventual consistency
-      await expect(async () => {
-        const getRes = await request.get(
-          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-            tenantId,
-            name: variableName,
-          }),
-          {
-            headers: jsonHeaders(),
-          },
-        );
-        expect(getRes.status()).toBe(200);
-        const json = await getRes.json();
-        expect(JSON.parse(json.value)).toEqual(newValue);
-      }).toPass(defaultAssertionOptions);
+      await test.step('Verify variable is immediately retrievable', async () => {
+        await expect(async () => {
+          const getRes = await request.get(
+            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+              tenantId,
+              name: variableName,
+            }),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          await assertStatusCode(getRes, 200);
+          const json = await getRes.json();
+          expect(JSON.parse(json.value)).toEqual(newValue);
+        }).toPass(defaultAssertionOptions);
+      });
     });
   },
 );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -773,3 +773,9 @@ export function CREATE_CLUSTER_VARIABLE() {
     value: {testKey: `testValue-${uid}`},
   };
 }
+
+export function UPDATE_CLUSTER_VARIABLE_VALUE(value: unknown) {
+  return {
+    value,
+  };
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/clusterVariablesCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/clusterVariablesCleanup.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext} from '@playwright/test';
+import {jsonHeaders, buildUrl} from './http';
+
+export async function cleanupGlobalClusterVariables(
+  request: APIRequestContext,
+  variableNames: string[],
+): Promise<void> {
+  if (variableNames.length === 0) return;
+
+  console.log(
+    `Cleaning up ${variableNames.length} global cluster variables via API...`,
+  );
+
+  await Promise.allSettled(
+    variableNames.map(async (name) => {
+      try {
+        const response = await request.delete(
+          buildUrl('/cluster-variables/global/{name}', {name}),
+          {headers: jsonHeaders()},
+        );
+        if (response.status() === 204) {
+          console.log(`Successfully deleted global cluster variable: ${name}`);
+        } else if (response.status() === 404) {
+          console.log(
+            `Global cluster variable already deleted or doesn't exist: ${name}`,
+          );
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for global cluster variable ${name}`,
+          );
+        }
+      } catch {}
+    }),
+  );
+}
+
+export async function cleanupTenantClusterVariables(
+  request: APIRequestContext,
+  variables: {tenantId: string; name: string}[],
+): Promise<void> {
+  if (variables.length === 0) return;
+
+  console.log(
+    `Cleaning up ${variables.length} tenant cluster variables via API...`,
+  );
+
+  await Promise.allSettled(
+    variables.map(async ({tenantId, name}) => {
+      try {
+        const response = await request.delete(
+          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+            tenantId,
+            name,
+          }),
+          {headers: jsonHeaders()},
+        );
+        if (response.status() === 204) {
+          console.log(
+            `Successfully deleted tenant cluster variable: ${tenantId}/${name}`,
+          );
+        } else if (response.status() === 404) {
+          console.log(
+            `Tenant cluster variable already deleted or doesn't exist: ${tenantId}/${name}`,
+          );
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for tenant cluster variable ${tenantId}/${name}`,
+          );
+        }
+      } catch {}
+    }),
+  );
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/cluster-variable-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/cluster-variable-requestHelpers.ts
@@ -131,6 +131,50 @@ export async function deleteTenantClusterVariable(
 }
 
 /**
+ * Updates a global cluster variable
+ */
+export async function updateGlobalClusterVariable(
+  request: APIRequestContext,
+  name: string,
+  value: unknown,
+): Promise<void> {
+  await expect(async () => {
+    const res = await request.put(
+      buildUrl('/cluster-variables/global/{name}', {name}),
+      {
+        headers: jsonHeaders(),
+        data: {value},
+      },
+    );
+    await assertStatusCode(res, 200);
+  }).toPass(defaultAssertionOptions);
+}
+
+/**
+ * Updates a tenant-scoped cluster variable
+ */
+export async function updateTenantClusterVariable(
+  request: APIRequestContext,
+  tenantId: string,
+  name: string,
+  value: unknown,
+): Promise<void> {
+  await expect(async () => {
+    const res = await request.put(
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name,
+      }),
+      {
+        headers: jsonHeaders(),
+        data: {value},
+      },
+    );
+    await assertStatusCode(res, 200);
+  }).toPass(defaultAssertionOptions);
+}
+
+/**
  * Asserts that a cluster variable exists in a search response
  */
 export function assertClusterVariableInResponse(
@@ -145,4 +189,34 @@ export function assertClusterVariableInResponse(
   for (const key of Object.keys(expectedBody)) {
     expect(found![key]).toEqual(expectedBody[key]);
   }
+}
+
+/**
+ * Performs a cluster variable update with retry and full validation.
+ * Consolidates the repeated PUT + status/shape check pattern used across multiple tests.
+ */
+export async function assertClusterVariableUpdate(
+  request: APIRequestContext,
+  url: string,
+  value: unknown,
+  expectedName: string,
+  expectedScope: 'GLOBAL' | 'TENANT',
+  expectedTenantId?: string,
+): Promise<void> {
+  await expect(async () => {
+    const res = await request.put(url, {
+      headers: jsonHeaders(),
+      data: {value},
+    });
+
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    expect(json.name).toBe(expectedName);
+    expect(json.scope).toBe(expectedScope);
+    if (expectedTenantId) {
+      expect(json.tenantId).toBe(expectedTenantId);
+    }
+    // Value is returned as JSON string
+    expect(JSON.parse(json.value)).toEqual(value);
+  }).toPass(defaultAssertionOptions);
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/cluster-variable-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/cluster-variable-requestHelpers.ts
@@ -15,6 +15,7 @@ import {
 } from '../http';
 import {defaultAssertionOptions} from '../constants';
 import {CREATE_CLUSTER_VARIABLE} from '../beans/requestBeans';
+import {validateResponse} from '../../json-body-assertions';
 
 /**
  * Creates a global cluster variable and stores the response fields in state
@@ -33,6 +34,10 @@ export async function createGlobalClusterVariable(
       data,
     });
     await assertStatusCode(res, 200);
+    await validateResponse(
+      {path: '/cluster-variables/global', method: 'POST', status: '200'},
+      res,
+    );
     await extractAndStoreIds(res, state);
     const json = await res.json();
     state[`${stateKey}Name`] = json.name;
@@ -62,6 +67,10 @@ export async function createTenantClusterVariable(
       },
     );
     await assertStatusCode(res, 200);
+    await validateResponse(
+      {path: '/cluster-variables/tenants/{tenantId}', method: 'POST', status: '200'},
+      res,
+    );
     await extractAndStoreIds(res, state);
     const json = await res.json();
     state[`${stateKey}Name`] = json.name;
@@ -131,50 +140,6 @@ export async function deleteTenantClusterVariable(
 }
 
 /**
- * Updates a global cluster variable
- */
-export async function updateGlobalClusterVariable(
-  request: APIRequestContext,
-  name: string,
-  value: unknown,
-): Promise<void> {
-  await expect(async () => {
-    const res = await request.put(
-      buildUrl('/cluster-variables/global/{name}', {name}),
-      {
-        headers: jsonHeaders(),
-        data: {value},
-      },
-    );
-    await assertStatusCode(res, 200);
-  }).toPass(defaultAssertionOptions);
-}
-
-/**
- * Updates a tenant-scoped cluster variable
- */
-export async function updateTenantClusterVariable(
-  request: APIRequestContext,
-  tenantId: string,
-  name: string,
-  value: unknown,
-): Promise<void> {
-  await expect(async () => {
-    const res = await request.put(
-      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-        tenantId,
-        name,
-      }),
-      {
-        headers: jsonHeaders(),
-        data: {value},
-      },
-    );
-    await assertStatusCode(res, 200);
-  }).toPass(defaultAssertionOptions);
-}
-
-/**
  * Asserts that a cluster variable exists in a search response
  */
 export function assertClusterVariableInResponse(
@@ -209,7 +174,18 @@ export async function assertClusterVariableUpdate(
       data: {value},
     });
 
-    expect(res.status()).toBe(200);
+    await assertStatusCode(res, 200);
+    
+    // Determine the correct path for validation based on scope
+    const path = expectedScope === 'GLOBAL' 
+      ? '/cluster-variables/global/{name}' as const
+      : '/cluster-variables/tenants/{tenantId}/{name}' as const;
+    
+    await validateResponse(
+      {path, method: 'PUT', status: '200'},
+      res,
+    );
+    
     const json = await res.json();
     expect(json.name).toBe(expectedName);
     expect(json.scope).toBe(expectedScope);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -58,8 +58,6 @@ export {
   createGlobalClusterVariablesAndStoreResponseFields,
   deleteGlobalClusterVariable,
   deleteTenantClusterVariable,
-  updateGlobalClusterVariable,
-  updateTenantClusterVariable,
   assertClusterVariableInResponse,
   assertClusterVariableUpdate,
 } from './cluster-variable-requestHelpers';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -58,7 +58,10 @@ export {
   createGlobalClusterVariablesAndStoreResponseFields,
   deleteGlobalClusterVariable,
   deleteTenantClusterVariable,
+  updateGlobalClusterVariable,
+  updateTenantClusterVariable,
   assertClusterVariableInResponse,
+  assertClusterVariableUpdate,
 } from './cluster-variable-requestHelpers';
 export {
   createProcessInstanceWithAJob,


### PR DESCRIPTION
## Description
Backport of #46896 to `stable/8.9`.

## On demand workflow
[API tests are all green](https://github.com/camunda/camunda/actions/runs/22446088414/job/65001018747), UI failure is a flaky test