### PR TITLE
[Backport stable/8.9] refactor: document upload should reject invalid processDefinitionId

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -111,30 +111,17 @@ test.describe.parallel('Document API Tests', () => {
     );
   });
 
-  // Regression guard for #46405 / #46407: a processDefinitionId that starts
-  // with a digit violates the BPMN identifier pattern and must be rejected.
   test('Create Document Invalid processDefinitionId 400', async ({request}) => {
-    const form = new FormData();
-    form.append(
-      'file',
-      new File(['test content'], 'test.txt', {type: 'text/plain'}),
-    );
-    form.append(
-      'metadata',
-      new Blob(
-        [
-          JSON.stringify({
-            fileName: 'test.txt',
-            processDefinitionId: '9invalid',
-          }),
-        ],
-        {type: 'application/json'},
-      ),
+    const fileName = generateUniqueId();
+    const invalidProcessDefinitionId = '123xInvalidProcessDefinitionId'; // starts with a number, not a valid BPMN ID; regression guard for #46405 / #46407
+    const payload = CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA(
+      fileName,
+      invalidProcessDefinitionId,
     );
 
     const res = await request.post(buildUrl('/documents'), {
       headers: defaultHeaders(),
-      multipart: form,
+      multipart: payload,
     });
 
     await assertBadRequest(


### PR DESCRIPTION
# Description
Backport of #46978 to `stable/8.9`.
https://github.com/camunda/camunda/actions/runs/22444197036
relates to #46405 #46407