### PR TITLE
build: remove formatting of generated code

### DIFF
--- a/clients/java-deprecated/pom.xml
+++ b/clients/java-deprecated/pom.xml
@@ -331,28 +331,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>cleanupModels</id>
-            <goals>
-              <goal>apply</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <applySkip>false</applySkip>
-              <java>
-                <includes>
-                  <include>**/io/camunda/zeebe/client/protocol/rest/*.java</include>
-                </includes>
-              </java>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -362,30 +362,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>cleanupModels</id>
-            <goals>
-              <goal>apply</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <applySkip>false</applySkip>
-              <java>
-                <includes>
-                  <include>**/io/camunda/client/protocol/rest/*.java</include>
-                </includes>
-                <removeUnusedImports/>
-              </java>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -90,6 +90,7 @@
                 <!-- map complex String schemas to String -->
                 <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
                 <typeMapping>ResourceKey=String</typeMapping>
+                <typeMapping>ElementInstanceKey=String</typeMapping>
                 <!-- map specific filter properties to basic filter types -->
                 <typeMapping>AuditLogEntityKeyFilterProperty=BasicStringFilterProperty</typeMapping>
                 <typeMapping>AuditLogKeyFilterProperty=BasicStringFilterProperty</typeMapping>
@@ -144,6 +145,7 @@
                 <!-- map complex String schemas to String -->
                 <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
                 <typeMapping>ResourceKey=String</typeMapping>
+                <typeMapping>ElementInstanceKey=String</typeMapping>
                 <!-- map specific filter properties to String for equality behavior -->
                 <typeMapping>AuditLogEntityKeyFilterProperty=String</typeMapping>
                 <typeMapping>AuditLogKeyFilterProperty=String</typeMapping>

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -242,28 +242,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>cleanupModels</id>
-            <goals>
-              <goal>apply</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <applySkip>false</applySkip>
-              <java>
-                <includes>
-                  <include>**/io/camunda/gateway/protocol/model/**/*.java</include>
-                </includes>
-                <removeUnusedImports/>
-              </java>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1447,9 +1447,7 @@ components:
             Set to -1 to create the new element instance within an existing element instance of the
             flow scope. If multiple instances of the target element's flow scope exist, choose one
             specifically with this property by providing its key.
-          oneOf:
-            - type: string
-              default: "-1"
+          allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
       required:
         - elementId
@@ -1581,8 +1579,6 @@ components:
             flow scope. If multiple instances of the target element's flow scope exist, choose one
             specifically with this property by providing its key.
           oneOf:
-            - type: string
-              default: "-1"
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
       required:
         - ancestorElementInstanceKey


### PR DESCRIPTION
Formatting is relatively expensive and, as far as I can tell, only used because generated code failed to compile before the fixes in 994beac542a695daa4cf423e9d95acaf2524993d.