### PR TITLE
Add RDBMS To Nightly, On-Demand & Release OC WFs

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -270,6 +270,7 @@ jobs:
             if curl -sf -u demo:demo http://localhost:8080/v2/topology >/dev/null 2>&1; then
               exit 0
             fi
+            echo "Attempt $i: Camunda not ready yet"
             sleep 5
           done
           tail -100 dev-dist/camunda.log

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -215,7 +215,101 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  api-tests-rdbms:
+    name: API Tests (H2/RDBMS) (${{ matrix.branch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [stable/8.9, main]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions: {}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.branch }}
 
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: e2e-h2-api-tests
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Build Camunda distribution
+        run: ./mvnw install -Dquickly -T1C
+
+      - name: Extract distribution
+        run: |
+          mkdir -p dev-dist
+          exploded="dist/target/camunda-zeebe"
+          if [ -d "$exploded/bin" ]; then
+            cp -a "$exploded"/. dev-dist/
+          else
+            tarball=$(find dist/target -maxdepth 1 -name 'camunda-zeebe-*.tar.gz' | head -1)
+            if [ -z "$tarball" ]; then
+              echo "ERROR: No dist build output found."
+              exit 1
+            fi
+            tar xzf "$tarball" --strip-components=1 -C dev-dist
+          fi
+
+      - name: Start Camunda with H2/RDBMS
+        run: |
+          chmod +x dev-dist/bin/camunda
+          export SPRING_PROFILES_ACTIVE="broker,consolidated-auth,admin"
+          export ZEEBE_CLOCK_CONTROLLED="true"
+          # (keep your existing env exports here)
+          dev-dist/bin/camunda > dev-dist/camunda.log 2>&1 &
+          echo $! > dev-dist/camunda.pid
+
+      - name: Wait for Camunda to be ready
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sf -u demo:demo http://localhost:8080/v2/topology >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 5
+          done
+          tail -100 dev-dist/camunda.log
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Run API tests
+        env:
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: "http://localhost:8080"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
+        run: npm run test -- --project=api-tests
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Stop Camunda
+        if: always()
+        run: |
+          if [ -f dev-dist/camunda.pid ]; then
+            kill "$(cat dev-dist/camunda.pid)" 2>/dev/null || true
+          fi
   nightly-tests:
     name: nightly-tests (${{ matrix.branch }} - Tasklist ${{ matrix.tasklist_mode }} mode)
     strategy:

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -236,6 +236,173 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  c8-orchestration-cluster-api-tests-rdbms:
+    if: ${{ needs.validate-branch.outputs.base == 'stable/8.9' || needs.validate-branch.outputs.base == 'main' }}
+    name: C8 Orchestration Cluster API Tests (H2/RDBMS)
+    needs: validate-branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions: {}
+    steps:
+      - name: Print input and base branch
+        run: |
+          echo "Input branch: ${{ github.event.inputs.branch }}"
+          echo "Base branch: ${{ needs.validate-branch.outputs.base }}"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: e2e-h2-api-tests
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Build Camunda distribution
+        run: ./mvnw install -Dquickly -T1C
+
+      - name: Extract distribution
+        run: |
+          mkdir -p dev-dist
+          exploded="dist/target/camunda-zeebe"
+          if [ -d "$exploded/bin" ]; then
+            cp -a "$exploded"/. dev-dist/
+          else
+            tarball=$(find dist/target -maxdepth 1 -name 'camunda-zeebe-*.tar.gz' | head -1)
+            if [ -z "$tarball" ]; then
+              echo "ERROR: No dist build output found."
+              exit 1
+            fi
+            tar xzf "$tarball" --strip-components=1 -C dev-dist
+          fi
+
+      - name: Start Camunda with H2/RDBMS
+        run: |
+          chmod +x dev-dist/bin/camunda
+
+          export SPRING_PROFILES_ACTIVE="broker,consolidated-auth,admin"
+          export ZEEBE_CLOCK_CONTROLLED="true"
+
+          # Auth configuration
+          export CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI="false"
+          export CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED="true"
+          export CAMUNDA_SECURITY_AUTHENTICATION_METHOD="BASIC"
+          export CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED="false"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME="demo"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD="demo"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME="Demo"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL="demo@example.com"
+          export CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0="demo"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_1_USERNAME="lisa"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_1_PASSWORD="lisa"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_1_NAME="lisa"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_1_EMAIL="lisa@example.com"
+          export CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_1="lisa"
+
+          # H2 in-memory database with RDBMS secondary storage
+          export CAMUNDA_DATA_SECONDARY_STORAGE_TYPE="rdbms"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL="jdbc:h2:mem:cpt;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_USERNAME="sa"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_PASSWORD=""
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_AUTO_DDL="true"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_FLUSH_INTERVAL="PT0S"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_HISTORY_DEFAULT_HISTORY_TTL="PT60S"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_HISTORY_MIN_HISTORY_CLEANUP_INTERVAL="PT10S"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_HISTORY_MAX_HISTORY_CLEANUP_INTERVAL="PT60S"
+
+          # Audit log
+          export CAMUNDA_DATA_AUDITLOG_ENABLED="true"
+          export CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_0="ADMIN"
+          export CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_1="DEPLOYED_RESOURCES"
+          export CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_2="USER_TASKS"
+          export CAMUNDA_DATA_AUDITLOG_USER_EXCLUDES_0="VARIABLE"
+          export CAMUNDA_DATA_AUDITLOG_USER_EXCLUDES_1="BATCH"
+          export CAMUNDA_DATA_AUDITLOG_CLIENT_CATEGORIES_0="ADMIN"
+          export CAMUNDA_DATA_AUDITLOG_CLIENT_EXCLUDES_0="PROCESS_INSTANCE"
+
+          dev-dist/bin/camunda > dev-dist/camunda.log 2>&1 &
+          echo $! > dev-dist/camunda.pid
+          echo "Camunda starting (PID $(cat dev-dist/camunda.pid))..."
+
+      - name: Wait for Camunda to be ready
+        run: |
+          echo "Waiting for Camunda to be ready..."
+          for i in $(seq 1 90); do
+            if curl -sf -u demo:demo http://localhost:8080/v2/topology >/dev/null 2>&1; then
+              echo "Camunda is ready!"
+              exit 0
+            fi
+            echo "Waiting... ($i/90)"
+            sleep 5
+          done
+          echo "Camunda failed to start in time."
+          echo "=== Last 100 lines of log ==="
+          tail -100 dev-dist/camunda.log
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Run API tests
+        env:
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: "http://localhost:8080"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
+        run: |
+          echo "Running API tests against H2/RDBMS backend"
+          npm run test -- --project=api-tests
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Print Camunda logs on failure
+        if: failure()
+        run: |
+          echo "=== Camunda logs ==="
+          cat dev-dist/camunda.log
+
+      - uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: C8 Orchestration Cluster API Test Result (H2-RDBMS)
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 10
+
+      - name: Stop Camunda
+        if: always()
+        run: |
+          if [ -f dev-dist/camunda.pid ]; then
+            kill "$(cat dev-dist/camunda.pid)" 2>/dev/null || true
+          fi
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   c8-orchestration-cluster-e2e-tests:
     name: C8 Orchestration Cluster E2E Tests (Tasklist ${{ matrix.tasklist_mode }} mode)
     strategy:

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -383,6 +383,7 @@ jobs:
             if curl -sf -u demo:demo http://localhost:8080/v2/topology >/dev/null 2>&1; then
               exit 0
             fi
+            echo "Attempt $i: Camunda not ready yet"
             sleep 5
           done
           tail -100 dev-dist/camunda.log

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -304,6 +304,125 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  c8-orchestration-cluster-api-tests-rdbms:
+    name: C8 Orchestration Cluster API Tests (H2/RDBMS)
+    needs: validate-release
+    if: ${{ needs.validate-release.outputs.base == 'stable/8.9' || needs.validate-release.outputs.base == 'main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions: {}
+    steps:
+      - name: Print release info
+        shell: bash
+        run: |
+          echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
+          echo "Base branch: ${{ needs.validate-release.outputs.base }}"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-release.outputs.base }}
+
+      # If this job needs the docker-compose image tag changed too, keep this step
+      - name: Update docker-compose with release version
+        shell: bash
+        run: |
+          release_version="${{ needs.validate-release.outputs.release_version }}"
+          base="${{ needs.validate-release.outputs.base }}"
+          compose_file="qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml"
+
+          echo "Updating docker images to version: $release_version for base: $base"
+
+          if [[ "$base" == "stable/8.6" || "$base" == "stable/8.7" ]]; then
+            sed -i.bak "s|image: camunda/zeebe:.*|image: camunda/zeebe:$release_version|g" "$compose_file"
+            sed -i.bak2 "s|image: camunda/tasklist:.*|image: camunda/tasklist:$release_version|g" "$compose_file"
+            sed -i.bak3 "s|image: camunda/operate:.*|image: camunda/operate:$release_version|g" "$compose_file"
+          else
+            sed -i.bak "s|image: camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
+          fi
+
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: e2e-h2-api-tests
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Build Camunda distribution
+        run: ./mvnw install -Dquickly -T1C
+
+      - name: Extract distribution
+        run: |
+          mkdir -p dev-dist
+          exploded="dist/target/camunda-zeebe"
+          if [ -d "$exploded/bin" ]; then
+            cp -a "$exploded"/. dev-dist/
+          else
+            tarball=$(find dist/target -maxdepth 1 -name 'camunda-zeebe-*.tar.gz' | head -1)
+            if [ -z "$tarball" ]; then
+              echo "ERROR: No dist build output found."
+              exit 1
+            fi
+            tar xzf "$tarball" --strip-components=1 -C dev-dist
+          fi
+
+      - name: Start Camunda with H2/RDBMS
+        run: |
+          chmod +x dev-dist/bin/camunda
+
+          export SPRING_PROFILES_ACTIVE="broker,consolidated-auth,admin"
+          export ZEEBE_CLOCK_CONTROLLED="true"
+
+          # (copy your existing env exports here)
+
+          dev-dist/bin/camunda > dev-dist/camunda.log 2>&1 &
+          echo $! > dev-dist/camunda.pid
+
+      - name: Wait for Camunda to be ready
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sf -u demo:demo http://localhost:8080/v2/topology >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 5
+          done
+          tail -100 dev-dist/camunda.log
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Run API tests
+        env:
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: "http://localhost:8080"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
+        run: npm run test -- --project=api-tests
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Stop Camunda
+        if: always()
+        run: |
+          if [ -f dev-dist/camunda.pid ]; then
+            kill "$(cat dev-dist/camunda.pid)" 2>/dev/null || true
+          fi
   c8-orchestration-cluster-e2e-tests:
     name: C8 Orchestration Cluster E2E Tests Release (Tasklist ${{ matrix.tasklist_mode }} mode)
     strategy:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds the c8-orchestration-cluster-api-tests-rdbms (H2/RDBMS) API test job to:

- the on-demand branch workflow,
- the nightly scheduled workflow, and
- the monorepo release workflow

The RDBMS job is gated to run only for main and stable/8.9 (via base-branch detection for on-demand/release, and via matrix restriction for nightly) to avoid running unsupported configurations on older branches.

Successfully spun up test environment [here](https://github.com/camunda/camunda/actions/runs/22444578026). Failing tests need to be addressed via a pairing session as discussed in the linked Slack thread below. They will not be skipped as it is currently unclear if these are due to a bug or not.

Related Slack thread [here](https://camunda.slack.com/archives/C08F5RD5X8B/p1772104552462409?thread_ts=1771713588.921589&cid=C08F5RD5X8B). 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46937 
