### PR TITLE
[Backport stable/8.9] fix: return a fallback from structuredContent to TextContent in MCP gateway responses

### DIFF
--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -111,6 +111,10 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/mapper/CallToolResultMapper.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/mapper/CallToolResultMapper.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.gateway.mcp.mapper;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
+import io.camunda.gateway.mcp.config.McpObjectMapperUtilities;
 import io.camunda.zeebe.util.Either;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import java.util.concurrent.CompletableFuture;
@@ -17,7 +19,10 @@ import org.springframework.http.ProblemDetail;
 public class CallToolResultMapper {
 
   public static CallToolResult from(final Object content) {
-    return CallToolResult.builder().structuredContent(content).build();
+    return CallToolResult.builder()
+        .structuredContent(content)
+        .addTextContent(structuredContentAsJson(content))
+        .build();
   }
 
   public static <T> CallToolResult from(
@@ -62,10 +67,22 @@ public class CallToolResultMapper {
   }
 
   public static CallToolResult mapProblemToResult(final ProblemDetail problemDetail) {
-    return CallToolResult.builder().structuredContent(problemDetail).isError(true).build();
+    return CallToolResult.builder()
+        .structuredContent(problemDetail)
+        .addTextContent(structuredContentAsJson(problemDetail))
+        .isError(true)
+        .build();
   }
 
   public static CallToolResult mapErrorToResult(final Throwable error) {
     return mapProblemToResult(GatewayErrorMapper.mapErrorToProblem(error));
+  }
+
+  private static String structuredContentAsJson(final Object object) {
+    try {
+      return McpObjectMapperUtilities.getObjectMapper().writeValueAsString(object);
+    } catch (final JsonProcessingException ex) {
+      throw new RuntimeException("Failed to convert structuredContent to JSON representation", ex);
+    }
   }
 }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/CallToolResultAssertions.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/CallToolResultAssertions.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.gateway.mcp.config.McpObjectMapperUtilities;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public final class CallToolResultAssertions {
+
+  private static final ObjectMapper NON_NULL_MAPPER =
+      McpObjectMapperUtilities.getObjectMapper()
+          .copy()
+          .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+
+  private CallToolResultAssertions() {}
+
+  /**
+   * Asserts that the structured content and the text content fallback of a {@link CallToolResult}
+   * are equivalent JSON, ignoring null fields. This is necessary because the MCP transport
+   * round-trip drops null values from the structured content map.
+   */
+  public static void assertTextContentFallback(final CallToolResult result) {
+    assertThat(result.structuredContent()).isNotNull();
+    assertThat(result.content()).isNotNull().hasSize(1).first().isInstanceOf(TextContent.class);
+
+    final var textContent = ((TextContent) result.content().getFirst()).text();
+
+    try {
+      JSONAssert.assertEquals(
+          NON_NULL_MAPPER.writeValueAsString(NON_NULL_MAPPER.readValue(textContent, Object.class)),
+          NON_NULL_MAPPER.writeValueAsString(result.structuredContent()),
+          true);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to compare structuredContent to text content fallback", e);
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.gateway.mcp.tool.cluster;
 
+import static io.camunda.gateway.mcp.tool.CallToolResultAssertions.assertTextContentFallback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -90,7 +91,6 @@ class ClusterToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -98,6 +98,8 @@ class ClusterToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_STATE");
+
+      assertTextContentFallback(result);
     }
   }
 
@@ -207,7 +209,6 @@ class ClusterToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -215,6 +216,8 @@ class ClusterToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_STATE");
+
+      assertTextContentFallback(result);
     }
   }
 }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.gateway.mcp.tool.incident;
 
+import static io.camunda.gateway.mcp.tool.CallToolResultAssertions.assertTextContentFallback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
@@ -142,6 +143,8 @@ class IncidentToolsTest extends ToolsTest {
       assertExampleIncident(incident);
 
       verify(incidentServices).getByKey(5L);
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -160,7 +163,6 @@ class IncidentToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -168,6 +170,8 @@ class IncidentToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -285,6 +289,8 @@ class IncidentToolsTest extends ToolsTest {
 
       assertThat(capturedQuery.page().size()).isEqualTo(25);
       assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -300,7 +306,6 @@ class IncidentToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -308,6 +313,8 @@ class IncidentToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
   }
 
@@ -406,7 +413,6 @@ class IncidentToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -418,6 +424,8 @@ class IncidentToolsTest extends ToolsTest {
       verify(incidentServices).resolveIncident(5L, null);
       verify(incidentServices).getByKey(5L);
       verify(jobServices).updateJob(4L, null, new UpdateJobChangeset(1, null));
+
+      assertTextContentFallback(result);
     }
 
     @Test

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.gateway.mcp.tool.process.definition;
 
+import static io.camunda.gateway.mcp.tool.CallToolResultAssertions.assertTextContentFallback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
@@ -117,6 +118,8 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       final var processDefinition =
           objectMapper.convertValue(result.structuredContent(), ProcessDefinitionResult.class);
       assertExampleProcessDefinitionResult(processDefinition);
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -198,6 +201,8 @@ class ProcessDefinitionToolsTest extends ToolsTest {
 
       assertThat(capturedQuery.page().size()).isEqualTo(25);
       assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -216,7 +221,6 @@ class ProcessDefinitionToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -224,6 +228,8 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -295,6 +301,8 @@ class ProcessDefinitionToolsTest extends ToolsTest {
           .isEqualTo("The BPMN XML for this process definition is not available.");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
   }
 }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.gateway.mcp.tool.process.instance;
 
+import static io.camunda.gateway.mcp.tool.CallToolResultAssertions.assertTextContentFallback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
@@ -150,6 +151,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertExampleProcessInstance(processInstance);
 
       verify(processInstanceServices).getByKey(123L);
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -168,7 +171,6 @@ class ProcessInstanceToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -176,6 +178,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -292,6 +296,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
 
       assertThat(capturedQuery.page().size()).isEqualTo(25);
       assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -326,13 +332,14 @@ class ProcessInstanceToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
 
       final var problemDetail =
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
   }
 
@@ -391,6 +398,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(actualResult.getTenantId()).isEqualTo("<default>");
       assertThat(actualResult.getVariables()).isEmpty();
       assertThat(actualResult.getTags()).isEmpty();
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -448,6 +457,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(actualResult.getTenantId()).isEqualTo("<default>");
       assertThat(actualResult.getVariables()).isEmpty();
       assertThat(actualResult.getTags()).containsExactly("mcp-tool:abc");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -510,6 +521,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(actualResult.getVariables())
           .containsExactly(entry("foo", "bar"), entry("nested", Map.of("x", 1)));
       assertThat(actualResult.getTags()).containsExactly("mcp-tool:abc");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -572,6 +585,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(actualResult.getVariables())
           .containsExactly(entry("foo", "bar"), entry("nested", Map.of("x", 1)));
       assertThat(actualResult.getTags()).containsExactly("mcp-tool:abc");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -592,13 +607,14 @@ class ProcessInstanceToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
 
       final var problemDetail =
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -617,6 +633,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
       assertThat(problemDetail.getDetail())
           .contains("At least one of [processDefinitionId, processDefinitionKey] is required");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -639,6 +657,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
       assertThat(problemDetail.getDetail())
           .contains("Only one of [processDefinitionId, processDefinitionKey] is allowed");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -695,6 +715,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(actualResult.getTenantId()).isEqualTo("tenant-a");
       assertThat(actualResult.getVariables()).isEmpty();
       assertThat(actualResult.getTags()).isEmpty();
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -754,6 +776,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(actualResult.getTenantId()).isEqualTo("tenant-a");
       assertThat(actualResult.getVariables()).isEmpty();
       assertThat(actualResult.getTags()).containsExactly("mcp-tool:abc");
+
+      assertTextContentFallback(result);
     }
 
     @ParameterizedTest
@@ -785,7 +809,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailCreateProcessInstanceWhenMultiTenancyEnabledButNoTenantProvided() {
+    void shouldFailCreateProcessInstanceWhenMultiTenancyEnabledButNoTenantProvided()
+        throws Exception {
       // given
       when(multiTenancyConfiguration.isChecksEnabled()).thenReturn(true);
 
@@ -807,6 +832,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail())
           .contains(
               "Expected to handle request Create Process Instance with multi-tenancy enabled, but no tenant identifier was provided.");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -849,6 +876,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), CreateProcessInstanceResult.class);
       assertThat(actualResult.getProcessInstanceKey()).isEqualTo("456");
       assertThat(actualResult.getBusinessId()).isEqualTo(businessId);
+
+      assertTextContentFallback(result);
     }
   }
 }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.gateway.mcp.tool.usertask;
 
+import static io.camunda.gateway.mcp.tool.CallToolResultAssertions.assertTextContentFallback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
@@ -196,6 +197,8 @@ class UserTaskToolsTest extends ToolsTest {
       assertExampleUserTask(userTask);
 
       verify(userTaskServices).getByKey(5L);
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -214,7 +217,6 @@ class UserTaskToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -222,6 +224,8 @@ class UserTaskToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -309,6 +313,8 @@ class UserTaskToolsTest extends ToolsTest {
 
       assertThat(capturedQuery.page().size()).isEqualTo(25);
       assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -515,7 +521,6 @@ class UserTaskToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -523,6 +528,8 @@ class UserTaskToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
   }
 
@@ -666,7 +673,6 @@ class UserTaskToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -674,6 +680,8 @@ class UserTaskToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -745,6 +753,8 @@ class UserTaskToolsTest extends ToolsTest {
               });
 
       verify(userTaskServices).searchUserTaskVariables(eq(5L), variableQueryCaptor.capture());
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -778,6 +788,8 @@ class UserTaskToolsTest extends ToolsTest {
               });
 
       verify(userTaskServices).searchUserTaskVariables(eq(5L), variableQueryCaptor.capture());
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -837,7 +849,6 @@ class UserTaskToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -845,6 +856,8 @@ class UserTaskToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
 
     @Test

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.gateway.mcp.tool.variable;
 
+import static io.camunda.gateway.mcp.tool.CallToolResultAssertions.assertTextContentFallback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
@@ -130,6 +131,8 @@ class VariableToolsTest extends ToolsTest {
       assertExampleVariable(variable);
 
       verify(variableServices).getByKey(123L);
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -148,7 +151,6 @@ class VariableToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
       assertThat(result.structuredContent()).isNotNull();
 
       final var problemDetail =
@@ -156,6 +158,8 @@ class VariableToolsTest extends ToolsTest {
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -227,6 +231,8 @@ class VariableToolsTest extends ToolsTest {
                 assertThat(variable.getIsTruncated()).isFalse();
                 assertThat(variable.getValue()).isEqualTo(FULL_VALUE);
               });
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -292,6 +298,8 @@ class VariableToolsTest extends ToolsTest {
 
       assertThat(capturedQuery.page().size()).isEqualTo(25);
       assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+
+      assertTextContentFallback(result);
     }
 
     @Test
@@ -307,13 +315,14 @@ class VariableToolsTest extends ToolsTest {
 
       // then
       assertThat(result.isError()).isTrue();
-      assertThat(result.content()).isEmpty();
 
       final var problemDetail =
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #46950 to `stable/8.9`.

relates to #46949