### PR TITLE
refactor: rename element utility functions

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -40,7 +40,7 @@ import {
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
-import {getFlowNodeName} from 'modules/utils/elements';
+import {getElementName} from 'modules/utils/elements';
 import {getParentElement} from 'modules/bpmn-js/utils/getParentElement';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
@@ -188,9 +188,9 @@ const ModificationDropdown: React.FC<Props> = observer(
                                   scopeId: generateUniqueID(),
                                   flowNode: {
                                     id: selectedElementId,
-                                    name: getFlowNodeName({
+                                    name: getElementName({
                                       businessObjects,
-                                      flowNodeId: selectedElementId,
+                                      elementId: selectedElementId,
                                     }),
                                   },
                                   affectedTokenCount: 1,

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -54,7 +54,7 @@ import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefi
 import {isCompensationAssociation} from 'modules/bpmn-js/utils/isCompensationAssociation';
 import {useProcessSequenceFlows} from 'modules/queries/sequenceFlows/useProcessSequenceFlows';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
-import {getSubprocessOverlayFromIncidentFlowNodes} from 'modules/utils/elements';
+import {getSubprocessOverlayFromIncidentElements} from 'modules/utils/elements';
 import type {ElementState} from 'modules/types/operate';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 import {isRequestError} from 'modules/request';
@@ -151,7 +151,7 @@ const TopPanel: React.FC = observer(() => {
       (flowNodeId) => businessObjects?.[flowNodeId],
     );
 
-    const subprocessOverlays = getSubprocessOverlayFromIncidentFlowNodes(
+    const subprocessOverlays = getSubprocessOverlayFromIncidentElements(
       selectableFlowNodesWithIncidents,
     );
 

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
@@ -12,7 +12,7 @@ import pluralSuffix from 'modules/utils/pluralSuffix';
 import {Container, InlineNotification, Button} from './styled';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';
-import {getFlowNodeName} from 'modules/utils/elements';
+import {getElementName} from 'modules/utils/elements';
 import {getSelectedProcessInstancesFilter} from 'modules/queries/processInstancesStatistics/filters';
 
 type Props = {
@@ -40,14 +40,14 @@ const BatchModificationNotification: React.FC<Props> = observer(
       sourceFlowNodeId,
     );
 
-    const sourceFlowNodeName = getFlowNodeName({
+    const sourceFlowNodeName = getElementName({
       businessObjects: processDefinitionData?.diagramModel.elementsById,
-      flowNodeId: sourceFlowNodeId,
+      elementId: sourceFlowNodeId,
     });
 
-    const targetFlowNodeName = getFlowNodeName({
+    const targetFlowNodeName = getElementName({
       businessObjects: processDefinitionData?.diagramModel.elementsById,
-      flowNodeId: targetFlowNodeId,
+      elementId: targetFlowNodeId,
     });
 
     return (

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -24,8 +24,8 @@ import {useProcessInstancesOverlayData} from 'modules/queries/processInstancesSt
 import {useBatchModificationOverlayData} from 'modules/queries/processInstancesStatistics/useBatchModificationOverlayData';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';
 import {
-  getFlowNode,
-  getSubprocessOverlayFromIncidentFlowNodes,
+  getElement,
+  getSubprocessOverlayFromIncidentElements,
 } from 'modules/utils/elements';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {parseProcessInstancesFilter} from 'modules/utils/filter/v2/processInstancesSearch';
@@ -133,7 +133,7 @@ const DiagramPanel: React.FC = observer(() => {
     (flowNodeId) => businessObjects?.[flowNodeId],
   );
 
-  const subprocessOverlays = getSubprocessOverlayFromIncidentFlowNodes(
+  const subprocessOverlays = getSubprocessOverlayFromIncidentElements(
     selectableFlowNodesWithIncidents,
     'statistics-incidents',
   );
@@ -180,9 +180,9 @@ const DiagramPanel: React.FC = observer(() => {
         return false;
       }
 
-      const flowNode = getFlowNode({
+      const flowNode = getElement({
         businessObjects: processDefinitionXML?.diagramModel.elementsById,
-        flowNodeId: selectedFlowNodeId,
+        elementId: selectedFlowNodeId,
       });
 
       return isMoveModificationTarget(flowNode);

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
@@ -17,7 +17,7 @@ import {Title, DataTable} from './styled';
 import {tracking} from 'modules/tracking';
 import {useInstancesCount} from 'modules/queries/processInstancesStatistics/useInstancesCount';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';
-import {getFlowNodeName} from 'modules/utils/elements';
+import {getElementName} from 'modules/utils/elements';
 import {handleOperationError} from 'modules/utils/notifications';
 import {useModifyProcessInstancesBatchOperation} from 'modules/mutations/processes/useModifyProcessInstancesBatchOperation';
 import {useBatchOperationMutationRequestBody} from 'modules/hooks/useBatchOperationMutationRequestBody';
@@ -42,14 +42,14 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
       processDefinitionKey: process?.processDefinitionKey,
     });
 
-    const sourceFlowNodeName = getFlowNodeName({
+    const sourceFlowNodeName = getElementName({
       businessObjects: processDefinitionData?.diagramModel.elementsById,
-      flowNodeId: sourceElementId,
+      elementId: sourceElementId,
     });
 
-    const targetFlowNodeName = getFlowNodeName({
+    const targetFlowNodeName = getElementName({
       businessObjects: processDefinitionData?.diagramModel.elementsById,
-      flowNodeId: selectedTargetElementId ?? undefined,
+      elementId: selectedTargetElementId ?? undefined,
     });
 
     const {data: instancesCount} = useInstancesCount(

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/index.tsx
@@ -29,7 +29,7 @@ import {tracking} from 'modules/tracking';
 import {HelperModal} from 'modules/components/HelperModal';
 import {useProcessDefinitionKeyContext} from '../../../processDefinitionKeyContext';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';
-import {getFlowNode} from 'modules/utils/elements';
+import {getElement} from 'modules/utils/elements';
 
 const localStorageKey = 'hideMoveModificationHelperModal';
 
@@ -45,9 +45,9 @@ const MoveAction: React.FC = observer(() => {
   });
 
   const businessObject: BusinessObject | null = flowNodeId
-    ? (getFlowNode({
+    ? (getElement({
         businessObjects: processDefinitionData?.diagramModel.elementsById,
-        flowNodeId,
+        elementId: flowNodeId,
       }) ?? null)
     : null;
 

--- a/operate/client/src/modules/hooks/elementSelection.ts
+++ b/operate/client/src/modules/hooks/elementSelection.ts
@@ -15,7 +15,7 @@ import {useElementInstancesStatistics} from 'modules/queries/elementInstancesSta
 import {TOKEN_OPERATIONS} from 'modules/constants';
 import {hasPendingCancelOrMoveModification} from 'modules/utils/modifications';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
-import {getFlowNodeName} from 'modules/utils/elements';
+import {getElementName} from 'modules/utils/elements';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
 import {useEffect} from 'react';
@@ -167,9 +167,9 @@ const useSelectedElementName = () => {
     return processInstance?.processDefinitionName ?? '';
   }
 
-  return getFlowNodeName({
+  return getElementName({
     businessObjects,
-    flowNodeId: selectedElementId ?? undefined,
+    elementId: selectedElementId ?? undefined,
   });
 };
 

--- a/operate/client/src/modules/hooks/incidents.ts
+++ b/operate/client/src/modules/hooks/incidents.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {getFlowNodeName} from '../utils/elements';
+import {getElementName} from '../utils/elements';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {
   queryIncidentsRequestBodySchema,
@@ -49,9 +49,9 @@ const useEnhancedIncidents = (incidents: Incident[]): EnhancedIncident[] => {
   return incidents.map((incident) => {
     return {
       ...incident,
-      elementName: getFlowNodeName({
+      elementName: getElementName({
         businessObjects,
-        flowNodeId: incident.elementId,
+        elementId: incident.elementId,
       }),
       isSelected: isSelected({
         elementId: incident.elementId,

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -12,7 +12,7 @@ import {type ModifyProcessInstanceRequestBody} from '@camunda/camunda-api-zod-sc
 import {modifyProcessInstance} from 'modules/api/v2/processInstances/modifyProcessInstance';
 import {logger} from 'modules/logger';
 import {tracking} from 'modules/tracking';
-import {getFlowNodeName} from 'modules/utils/elements';
+import {getElementName} from 'modules/utils/elements';
 import {getFlowNodesInBetween} from 'modules/utils/processInstanceDetailsDiagram';
 import type {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {generateParentScopeIds} from 'modules/utils/modifications';
@@ -197,9 +197,9 @@ class Modifications {
           flowNode: {
             id: this.state.sourceFlowNodeIdForAddOperation,
             name:
-              getFlowNodeName({
+              getElementName({
                 businessObjects,
-                flowNodeId: this.state.sourceFlowNodeIdForAddOperation,
+                elementId: this.state.sourceFlowNodeIdForAddOperation,
               }) ?? '',
           },
           affectedTokenCount: 1,
@@ -669,7 +669,7 @@ class Modifications {
         operation: 'CANCEL_TOKEN',
         flowNode: {
           id: flowNodeId,
-          name: getFlowNodeName({businessObjects, flowNodeId}),
+          name: getElementName({businessObjects, elementId: flowNodeId}),
         },
         flowNodeInstanceKey,
         affectedTokenCount,
@@ -719,17 +719,17 @@ class Modifications {
         operation: 'MOVE_TOKEN',
         flowNode: {
           id: sourceFlowNodeId,
-          name: getFlowNodeName({
+          name: getElementName({
             businessObjects,
-            flowNodeId: sourceFlowNodeId,
+            elementId: sourceFlowNodeId,
           }),
         },
         flowNodeInstanceKey: sourceFlowNodeInstanceKey,
         targetFlowNode: {
           id: targetFlowNodeId,
-          name: getFlowNodeName({
+          name: getElementName({
             businessObjects,
-            flowNodeId: targetFlowNodeId,
+            elementId: targetFlowNodeId,
           }),
         },
         affectedTokenCount,

--- a/operate/client/src/modules/utils/elements/index.ts
+++ b/operate/client/src/modules/utils/elements/index.ts
@@ -18,26 +18,6 @@ export function isFlowNode(businessObject: BusinessObject) {
   return businessObject.$instanceOf?.('bpmn:FlowNode') ?? false;
 }
 
-export function getFlowNode({
-  businessObjects,
-  flowNodeId,
-}: {
-  businessObjects?: BusinessObjects;
-  flowNodeId?: string;
-}) {
-  return flowNodeId ? businessObjects?.[flowNodeId] : undefined;
-}
-
-export function getFlowNodeName({
-  businessObjects,
-  flowNodeId,
-}: {
-  businessObjects?: BusinessObjects;
-  flowNodeId?: string;
-}) {
-  return getFlowNode({businessObjects, flowNodeId})?.name ?? flowNodeId ?? '';
-}
-
 export function getFlowNodes(elementsById?: DiagramModel['elementsById']) {
   if (elementsById === undefined) {
     return [];
@@ -48,7 +28,27 @@ export function getFlowNodes(elementsById?: DiagramModel['elementsById']) {
   );
 }
 
-export function getSubprocessOverlayFromIncidentFlowNodes(
+export function getElement({
+  businessObjects,
+  elementId,
+}: {
+  businessObjects?: BusinessObjects;
+  elementId?: string;
+}) {
+  return elementId ? businessObjects?.[elementId] : undefined;
+}
+
+export function getElementName({
+  businessObjects,
+  elementId,
+}: {
+  businessObjects?: BusinessObjects;
+  elementId?: string;
+}) {
+  return getElement({businessObjects, elementId})?.name ?? elementId ?? '';
+}
+
+export function getSubprocessOverlayFromIncidentElements(
   flowNodes?: (BusinessObject | undefined)[],
   type: string = 'flowNodeState',
 ) {


### PR DESCRIPTION
## Description

Rename
- getFlowNodeName -> getElementName
- getSubprocessOverlayFromIncidentFlowNodes -> getSubprocessOverlayFromIncidentElements
- getFlowNode -> getElement


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46859 
