### PR TITLE
fix: replace RequestDispatcher.forward with HttpServletRequestWrapper

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilter.java
@@ -10,7 +10,6 @@ package io.camunda.optimize.tomcat;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
-import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -19,6 +18,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/**
+ * Servlet filter for CCSM (Camunda Cloud Self-Managed) environments that rewrites external API
+ * paths and serves static resources.
+ *
+ * <p>This filter uses {@link PathRewritingRequestWrapper} to modify the request path instead of
+ * {@link jakarta.servlet.RequestDispatcher#forward}. This is required because Spring Security 7's
+ * {@code PathPatternRequestMatcher} evaluates paths from the original request URI. Using a wrapper
+ * ensures that Spring Security (and all other downstream components) see the rewritten path.
+ */
 public class CCSMRequestAdjustmentFilter implements Filter {
 
   private ServletContext servletContext;
@@ -41,8 +49,7 @@ public class CCSMRequestAdjustmentFilter implements Filter {
     /* transform /external/api -> /api/external */
     if (requestURI.startsWith("/external/api/")) {
       final String rewrittenURI = requestURI.replaceFirst("/external/api/", "/api/external/");
-      final RequestDispatcher dispatcher = request.getRequestDispatcher(rewrittenURI);
-      dispatcher.forward(request, response);
+      chain.doFilter(new PathRewritingRequestWrapper(httpRequest, rewrittenURI), response);
       return;
     }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilter.java
@@ -48,7 +48,9 @@ public class CCSMRequestAdjustmentFilter implements Filter {
 
     /* transform /external/api -> /api/external */
     if (requestURI.startsWith("/external/api/")) {
-      final String rewrittenURI = requestURI.replaceFirst("/external/api/", "/api/external/");
+      final String rewrittenURI =
+          httpRequest.getContextPath()
+              + requestURI.replaceFirst("/external/api/", "/api/external/");
       chain.doFilter(new PathRewritingRequestWrapper(httpRequest, rewrittenURI), response);
       return;
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilter.java
@@ -10,7 +10,6 @@ package io.camunda.optimize.tomcat;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
-import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -19,6 +18,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/**
+ * Servlet filter for CCSaaS (Camunda Cloud SaaS) environments that adjusts request paths by
+ * stripping the clusterId prefix and rewriting external API paths.
+ *
+ * <p>This filter uses {@link HttpServletRequestWrapper} to modify the request path instead of
+ * {@link jakarta.servlet.RequestDispatcher#forward}. This is required because Spring Security 7's
+ * {@code PathPatternRequestMatcher} evaluates paths from the original request URI. Using a wrapper
+ * ensures that Spring Security (and all other downstream components) see the rewritten path.
+ */
 public class CCSaasRequestAdjustmentFilter implements Filter {
 
   private final String clusterId;
@@ -37,7 +45,7 @@ public class CCSaasRequestAdjustmentFilter implements Filter {
   public void doFilter(
       final ServletRequest request, final ServletResponse response, final FilterChain chain)
       throws IOException, ServletException {
-    boolean shallForward = false;
+    boolean pathModified = false;
     final HttpServletRequest httpRequest = (HttpServletRequest) request;
     final HttpServletResponse httpResponse = (HttpServletResponse) response;
     String requestURI = httpRequest.getRequestURI();
@@ -58,18 +66,20 @@ public class CCSaasRequestAdjustmentFilter implements Filter {
     /* Strip cluster ID subpath */
     if (!clusterId.isEmpty() && requestURI.startsWith(clusterIdPath())) {
       requestURI = requestURI.substring(clusterIdPath().length());
-      shallForward = true;
+      if (requestURI.isEmpty()) {
+        requestURI = "/";
+      }
+      pathModified = true;
     }
 
     /* transform /external/api -> /api/external (Optimize only) */
     if (requestURI.startsWith("/external/api/")) {
       requestURI = requestURI.replaceFirst("/external/api/", "/api/external/");
-      shallForward = true;
+      pathModified = true;
     }
 
-    if (shallForward) {
-      final RequestDispatcher dispatcher = request.getRequestDispatcher(requestURI);
-      dispatcher.forward(request, response);
+    if (pathModified) {
+      chain.doFilter(new PathRewritingRequestWrapper(httpRequest, requestURI), response);
       return;
     }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/tomcat/PathRewritingRequestWrapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/tomcat/PathRewritingRequestWrapper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.tomcat;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+/**
+ * Request wrapper that overrides path-related methods to return a rewritten URI. This ensures that
+ * all downstream components (including Spring Security 7's {@code PathPatternRequestMatcher}) see
+ * the modified path rather than the original request URI.
+ *
+ * <p>This is required because Spring Security 7's {@code PathPatternRequestMatcher} evaluates the
+ * original request URI, so using {@link RequestDispatcher#forward} to rewrite paths no longer
+ * works. See <a
+ * href="https://docs.spring.io/spring-security/reference/6.5/migration-7/web.html#use-path-pattern">Spring
+ * Security Migration Guide</a> for details on the path matching changes.
+ *
+ * <p><b>Forward dispatch handling:</b> On a {@link RequestDispatcher#forward FORWARD} dispatch,
+ * Tomcat inserts its own {@code ApplicationHttpRequest} wrapper <i>below</i> this wrapper in the
+ * chain, with {@code getRequestURI()} returning the forward target path (e.g., {@code
+ * /index.html}). This wrapper detects forward dispatches by checking for the {@link
+ * RequestDispatcher#FORWARD_REQUEST_URI} attribute and delegates to {@code super.getRequestURI()}
+ * so that Tomcat's forward target URI is visible to the {@code DispatcherServlet}. Without this
+ * delegation, the rewritten URI (e.g., {@code /}) would always be returned, causing {@code
+ * WelcomePageHandlerMapping} to match on every forward and creating an infinite forward loop
+ * ({@code StackOverflowError}).
+ *
+ * <p><b>Note:</b> {@code getServletPath()} is intentionally NOT overridden. Overriding it would
+ * break Tomcat's internal resource resolution during forward dispatches.
+ */
+public class PathRewritingRequestWrapper extends HttpServletRequestWrapper {
+
+  private final String rewrittenURI;
+
+  public PathRewritingRequestWrapper(final HttpServletRequest request, final String rewrittenURI) {
+    super(request);
+    this.rewrittenURI = rewrittenURI;
+  }
+
+  @Override
+  public String getRequestURI() {
+    // On FORWARD dispatches, Tomcat's ApplicationHttpRequest (inserted below this wrapper in the
+    // chain) sets the correct URI for the forward target. We must delegate to it rather than
+    // returning our rewritten URI, otherwise the DispatcherServlet sees "/" again and re-triggers
+    // WelcomePageHandlerMapping, causing an infinite forward loop (StackOverflowError).
+    if (getAttribute(RequestDispatcher.FORWARD_REQUEST_URI) != null) {
+      return super.getRequestURI();
+    }
+    return rewrittenURI;
+  }
+
+  @Override
+  public StringBuffer getRequestURL() {
+    // Build URL from getRequestURI() which already handles forward delegation
+    final StringBuffer url = new StringBuffer();
+    final String scheme = getScheme();
+    final int port = getServerPort();
+    url.append(scheme).append("://").append(getServerName());
+    if (("http".equals(scheme) && port != 80) || ("https".equals(scheme) && port != 443)) {
+      url.append(':').append(port);
+    }
+    url.append(getRequestURI());
+    return url;
+  }
+
+  @Override
+  public RequestDispatcher getRequestDispatcher(final String path) {
+    // ServletRequestWrapper.getRequestDispatcher() delegates to the original (wrapped) request.
+    // For relative paths (no leading '/'), the servlet container resolves them against the
+    // original request's URI. Since our wrapper rewrites the URI, we must convert relative paths
+    // to absolute ones based on the rewritten URI so the dispatch target is correct.
+    //
+    // Example: WelcomePageHandlerMapping forwards "/" to "index.html" (relative).
+    // Without this fix, "index.html" resolves against the original URI "/<clusterId>/" →
+    // "/<clusterId>/index.html" (wrong). With this fix, it resolves against "/" → "/index.html".
+    if (path != null && !path.startsWith("/")) {
+      final int lastSlash = rewrittenURI.lastIndexOf('/');
+      final String absolutePath = rewrittenURI.substring(0, lastSlash + 1) + path;
+      return super.getRequestDispatcher(absolutePath);
+    }
+    return super.getRequestDispatcher(path);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilterTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.tomcat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for {@link CCSMRequestAdjustmentFilter}.
+ *
+ * <p>These tests verify that the filter uses {@link PathRewritingRequestWrapper} to rewrite request
+ * paths (rather than {@link jakarta.servlet.RequestDispatcher#forward}), which is required for
+ * compatibility with Spring Security 7's {@code PathPatternRequestMatcher} that evaluates the
+ * original request URI.
+ */
+@ExtendWith(MockitoExtension.class)
+public class CCSMRequestAdjustmentFilterTest {
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private FilterChain filterChain;
+  @Mock private FilterConfig filterConfig;
+  @Mock private ServletContext servletContext;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    when(filterConfig.getServletContext()).thenReturn(servletContext);
+    // ExternalResourcesUtil.stripContextPath() calls getContextPath() which must not be null.
+    // Lenient because tests that short-circuit before this call would otherwise fail.
+    lenient().when(request.getContextPath()).thenReturn("");
+  }
+
+  private CCSMRequestAdjustmentFilter createFilter() throws Exception {
+    final CCSMRequestAdjustmentFilter filter = new CCSMRequestAdjustmentFilter();
+    filter.init(filterConfig);
+    return filter;
+  }
+
+  /**
+   * Regression tests for Spring Security 7 compatibility. The filter must wrap the request using
+   * PathRewritingRequestWrapper (not RequestDispatcher.forward) so that PathPatternRequestMatcher
+   * sees the rewritten path.
+   */
+  @Nested
+  class ExternalApiRewriteUsesRequestWrapper {
+
+    /**
+     * Core regression test: /external/api/... must be rewritten to /api/external/... using a
+     * request wrapper, NOT RequestDispatcher.forward().
+     */
+    @Test
+    void wrapsRequestWithRewrittenPath() throws Exception {
+      // given
+      final CCSMRequestAdjustmentFilter filter = createFilter();
+      when(request.getRequestURI()).thenReturn("/external/api/some-endpoint");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then — the filter chain must receive a wrapped request, NOT a forwarded dispatch
+      final ArgumentCaptor<ServletRequest> requestCaptor =
+          ArgumentCaptor.forClass(ServletRequest.class);
+      verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+      final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
+      assertThat(wrappedRequest).isNotSameAs(request);
+      assertThat(wrappedRequest).isInstanceOf(PathRewritingRequestWrapper.class);
+      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/api/external/some-endpoint");
+    }
+  }
+
+  @Nested
+  class NoModification {
+
+    @Test
+    void passesOriginalRequestForNonExternalApiPath() throws Exception {
+      // given
+      final CCSMRequestAdjustmentFilter filter = createFilter();
+      when(request.getRequestURI()).thenReturn("/api/some-endpoint");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then — original request is passed, not a wrapper
+      verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void passesOriginalRequestForRootPath() throws Exception {
+      // given
+      final CCSMRequestAdjustmentFilter filter = createFilter();
+      when(request.getRequestURI()).thenReturn("/");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then
+      verify(filterChain).doFilter(request, response);
+    }
+  }
+
+  @Nested
+  class ContextPathHandling {
+
+    @Test
+    void contextPathStrippedBeforeRewrite() throws Exception {
+      // given — request has a context path that should be stripped first
+      final CCSMRequestAdjustmentFilter filter = createFilter();
+      when(request.getContextPath()).thenReturn("/optimize");
+      when(request.getRequestURI()).thenReturn("/optimize/external/api/some-endpoint");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then
+      final ArgumentCaptor<ServletRequest> requestCaptor =
+          ArgumentCaptor.forClass(ServletRequest.class);
+      verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+      final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
+      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/api/external/some-endpoint");
+    }
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilterTest.java
@@ -125,8 +125,8 @@ public class CCSMRequestAdjustmentFilterTest {
   class ContextPathHandling {
 
     @Test
-    void contextPathStrippedBeforeRewrite() throws Exception {
-      // given — request has a context path that should be stripped first
+    void contextPathIsKeptOnRewrite() throws Exception {
+      // given — request has a context path that should be kept on rewrite
       final CCSMRequestAdjustmentFilter filter = createFilter();
       when(request.getContextPath()).thenReturn("/optimize");
       when(request.getRequestURI()).thenReturn("/optimize/external/api/some-endpoint");
@@ -140,7 +140,9 @@ public class CCSMRequestAdjustmentFilterTest {
       verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
 
       final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
-      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/api/external/some-endpoint");
+      assertThat(wrappedRequest.getRequestURI())
+          .describedAs("Rewritten URI must retain the context path")
+          .isEqualTo("/optimize/api/external/some-endpoint");
     }
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilterTest.java
@@ -111,7 +111,9 @@ public class CCSaasRequestAdjustmentFilterTest {
       verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
 
       final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
-      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/");
+      assertThat(wrappedRequest.getRequestURI())
+          .describedAs("Should no longer contain '/{clusterId}' prefix")
+          .isEqualTo("/");
     }
   }
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilterTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.tomcat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for {@link CCSaasRequestAdjustmentFilter}.
+ *
+ * <p>These tests verify that the filter uses {@link jakarta.servlet.http.HttpServletRequestWrapper}
+ * to rewrite request paths (rather than {@link jakarta.servlet.RequestDispatcher#forward}), which
+ * is required for compatibility with Spring Security 7's {@code PathPatternRequestMatcher} that
+ * evaluates the original request URI.
+ */
+@ExtendWith(MockitoExtension.class)
+public class CCSaasRequestAdjustmentFilterTest {
+
+  private static final String CLUSTER_ID = "abc-123";
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private FilterChain filterChain;
+  @Mock private FilterConfig filterConfig;
+  @Mock private ServletContext servletContext;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    when(filterConfig.getServletContext()).thenReturn(servletContext);
+    // ExternalResourcesUtil.stripContextPath() calls getContextPath() which must not be null.
+    // Lenient because the HomePageRedirect test short-circuits before reaching this call.
+    lenient().when(request.getContextPath()).thenReturn("");
+  }
+
+  private CCSaasRequestAdjustmentFilter createFilter(final String clusterId) throws Exception {
+    final CCSaasRequestAdjustmentFilter filter = new CCSaasRequestAdjustmentFilter(clusterId);
+    filter.init(filterConfig);
+    return filter;
+  }
+
+  /**
+   * Regression tests for Spring Security 7 compatibility. The filter must wrap the request using
+   * HttpServletRequestWrapper (not RequestDispatcher.forward) so that PathPatternRequestMatcher
+   * sees the rewritten path.
+   */
+  @Nested
+  class PathRewritingUsesRequestWrapper {
+
+    /**
+     * Core regression test: when a request arrives at /{clusterId}/some/path, the filter must pass
+     * a wrapped request to the filter chain where getRequestURI() returns /some/path. This ensures
+     * Spring Security's PathPatternRequestMatcher matches the stripped path.
+     */
+    @Test
+    void wrapsRequestWithStrippedPath() throws Exception {
+      // given
+      final CCSaasRequestAdjustmentFilter filter = createFilter(CLUSTER_ID);
+      when(request.getRequestURI()).thenReturn("/" + CLUSTER_ID + "/api/some-endpoint");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then — the filter chain must receive a wrapped request, NOT a forwarded dispatch
+      final ArgumentCaptor<ServletRequest> requestCaptor =
+          ArgumentCaptor.forClass(ServletRequest.class);
+      verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+      final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
+      assertThat(wrappedRequest).isNotSameAs(request);
+      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/api/some-endpoint");
+    }
+  }
+
+  @Nested
+  class ClusterIdStripping {
+
+    @Test
+    void rewritesToRoot() throws Exception {
+      // given — request to /<clusterId>/ (with trailing slash, so not the redirect case)
+      final CCSaasRequestAdjustmentFilter filter = createFilter(CLUSTER_ID);
+      when(request.getRequestURI()).thenReturn("/" + CLUSTER_ID + "/");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then
+      final ArgumentCaptor<ServletRequest> requestCaptor =
+          ArgumentCaptor.forClass(ServletRequest.class);
+      verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+      final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
+      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/");
+    }
+  }
+
+  @Nested
+  class ExternalApiRewrite {
+
+    @Test
+    void rewritesExternalApiToApiExternal() throws Exception {
+      // given
+      final CCSaasRequestAdjustmentFilter filter = createFilter("");
+      when(request.getRequestURI()).thenReturn("/external/api/some-endpoint");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then
+      final ArgumentCaptor<ServletRequest> requestCaptor =
+          ArgumentCaptor.forClass(ServletRequest.class);
+      verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+      final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
+      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/api/external/some-endpoint");
+    }
+
+    @Test
+    void bothClusterIdAndExternalApiRewritten() throws Exception {
+      // given — both transformations should apply in sequence
+      final CCSaasRequestAdjustmentFilter filter = createFilter(CLUSTER_ID);
+      when(request.getRequestURI()).thenReturn("/" + CLUSTER_ID + "/external/api/some-endpoint");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then
+      final ArgumentCaptor<ServletRequest> requestCaptor =
+          ArgumentCaptor.forClass(ServletRequest.class);
+      verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+      final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
+      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/api/external/some-endpoint");
+    }
+  }
+
+  @Nested
+  class NoModification {
+
+    @Test
+    void passesOriginalRequestWhenNoClusterId() throws Exception {
+      // given
+      final CCSaasRequestAdjustmentFilter filter = createFilter("");
+      when(request.getRequestURI()).thenReturn("/api/some-endpoint");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then — original request is passed, not a wrapper
+      verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void passesOriginalRequestWithoutClusterIdPrefix() throws Exception {
+      // given
+      final CCSaasRequestAdjustmentFilter filter = createFilter(CLUSTER_ID);
+      when(request.getRequestURI()).thenReturn("/api/some-endpoint");
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then — original request is passed, not a wrapper
+      verify(filterChain).doFilter(request, response);
+    }
+  }
+
+  @Nested
+  class HomePageRedirect {
+
+    @Test
+    void redirectsWithTrailingSlash() throws Exception {
+      // given
+      final CCSaasRequestAdjustmentFilter filter = createFilter(CLUSTER_ID);
+      when(request.getRequestURI()).thenReturn("/" + CLUSTER_ID);
+
+      // when
+      filter.doFilter(request, response, filterChain);
+
+      // then
+      verify(response).sendRedirect("/" + CLUSTER_ID + "/");
+    }
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/PathRewritingRequestWrapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/PathRewritingRequestWrapperTest.java
@@ -32,7 +32,7 @@ class PathRewritingRequestWrapperTest {
     void returnsRewrittenURI() {
       // given — no forward attribute set (normal REQUEST dispatch)
       final HttpServletRequest original = mock(HttpServletRequest.class);
-      final PathRewritingRequestWrapper wrapper =
+      final HttpServletRequest wrapper =
           new PathRewritingRequestWrapper(original, "/api/some-endpoint");
 
       // when / then
@@ -47,7 +47,7 @@ class PathRewritingRequestWrapperTest {
       when(original.getServerName()).thenReturn("example.com");
       when(original.getServerPort()).thenReturn(443);
 
-      final PathRewritingRequestWrapper wrapper =
+      final HttpServletRequest wrapper =
           new PathRewritingRequestWrapper(original, "/api/some-endpoint");
 
       // when / then
@@ -61,8 +61,7 @@ class PathRewritingRequestWrapperTest {
       final HttpServletRequest original = mock(HttpServletRequest.class);
       when(original.getServletPath()).thenReturn("/original/servlet/path");
 
-      final PathRewritingRequestWrapper wrapper =
-          new PathRewritingRequestWrapper(original, "/rewritten");
+      final HttpServletRequest wrapper = new PathRewritingRequestWrapper(original, "/rewritten");
 
       // when / then — getServletPath must NOT be overridden
       assertThat(wrapper.getServletPath()).isEqualTo("/original/servlet/path");
@@ -123,7 +122,7 @@ class PathRewritingRequestWrapperTest {
       final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
       when(original.getRequestDispatcher("/index.html")).thenReturn(expectedDispatcher);
 
-      final PathRewritingRequestWrapper wrapper = new PathRewritingRequestWrapper(original, "/");
+      final HttpServletRequest wrapper = new PathRewritingRequestWrapper(original, "/");
 
       // when
       final RequestDispatcher result = wrapper.getRequestDispatcher("index.html");
@@ -140,8 +139,7 @@ class PathRewritingRequestWrapperTest {
       final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
       when(original.getRequestDispatcher("/api/resource.html")).thenReturn(expectedDispatcher);
 
-      final PathRewritingRequestWrapper wrapper =
-          new PathRewritingRequestWrapper(original, "/api/endpoint");
+      final HttpServletRequest wrapper = new PathRewritingRequestWrapper(original, "/api/endpoint");
 
       // when
       final RequestDispatcher result = wrapper.getRequestDispatcher("resource.html");
@@ -158,7 +156,7 @@ class PathRewritingRequestWrapperTest {
       final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
       when(original.getRequestDispatcher("/absolute/path")).thenReturn(expectedDispatcher);
 
-      final PathRewritingRequestWrapper wrapper = new PathRewritingRequestWrapper(original, "/");
+      final HttpServletRequest wrapper = new PathRewritingRequestWrapper(original, "/");
 
       // when
       final RequestDispatcher result = wrapper.getRequestDispatcher("/absolute/path");

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/PathRewritingRequestWrapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/PathRewritingRequestWrapperTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.tomcat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PathRewritingRequestWrapper}.
+ *
+ * <p>These tests verify the wrapper's behavior in both REQUEST and FORWARD dispatch scenarios,
+ * ensuring Spring Security 7 compatibility without causing infinite forward loops.
+ */
+class PathRewritingRequestWrapperTest {
+
+  @Nested
+  class OnRequestDispatch {
+
+    @Test
+    void returnsRewrittenURI() {
+      // given — no forward attribute set (normal REQUEST dispatch)
+      final HttpServletRequest original = mock(HttpServletRequest.class);
+      final PathRewritingRequestWrapper wrapper =
+          new PathRewritingRequestWrapper(original, "/api/some-endpoint");
+
+      // when / then
+      assertThat(wrapper.getRequestURI()).isEqualTo("/api/some-endpoint");
+    }
+
+    @Test
+    void requestURLReflectsRewrittenURI() {
+      // given
+      final HttpServletRequest original = mock(HttpServletRequest.class);
+      when(original.getScheme()).thenReturn("https");
+      when(original.getServerName()).thenReturn("example.com");
+      when(original.getServerPort()).thenReturn(443);
+
+      final PathRewritingRequestWrapper wrapper =
+          new PathRewritingRequestWrapper(original, "/api/some-endpoint");
+
+      // when / then
+      assertThat(wrapper.getRequestURL().toString())
+          .isEqualTo("https://example.com/api/some-endpoint");
+    }
+
+    @Test
+    void servletPathDelegatesToOriginalRequest() {
+      // given
+      final HttpServletRequest original = mock(HttpServletRequest.class);
+      when(original.getServletPath()).thenReturn("/original/servlet/path");
+
+      final PathRewritingRequestWrapper wrapper =
+          new PathRewritingRequestWrapper(original, "/rewritten");
+
+      // when / then — getServletPath must NOT be overridden
+      assertThat(wrapper.getServletPath()).isEqualTo("/original/servlet/path");
+    }
+  }
+
+  /**
+   * Regression tests for the forward dispatch loop issue. When Spring Boot's
+   * WelcomePageHandlerMapping forwards "/" to "/index.html", Tomcat inserts an
+   * ApplicationHttpRequest wrapper below our PathRewritingRequestWrapper. Our wrapper must detect
+   * the forward dispatch and delegate getRequestURI() to the underlying request, or the
+   * DispatcherServlet will see "/" again and re-trigger the forward infinitely
+   * (StackOverflowError).
+   */
+  @Nested
+  class OnForwardDispatch {
+
+    @Test
+    void delegatesToUnderlyingRequestWhenForwardAttributePresent() {
+      // given — initial REQUEST dispatch
+      final HttpServletRequest original = mock(HttpServletRequest.class);
+      final PathRewritingRequestWrapper wrapper = new PathRewritingRequestWrapper(original, "/");
+
+      // Verify initial behavior
+      assertThat(wrapper.getRequestURI()).isEqualTo("/");
+
+      // Simulate what Tomcat does on a FORWARD dispatch:
+      // 1. ApplicationDispatcher inserts ApplicationHttpRequest below our wrapper
+      // 2. ApplicationHttpRequest.getRequestURI() returns the forward target
+      // 3. The FORWARD_REQUEST_URI attribute is set on the request
+      final HttpServletRequest tomcatForwardWrapper = mock(HttpServletRequest.class);
+      when(tomcatForwardWrapper.getRequestURI()).thenReturn("/index.html");
+      when(tomcatForwardWrapper.getAttribute(RequestDispatcher.FORWARD_REQUEST_URI))
+          .thenReturn("/");
+      wrapper.setRequest(tomcatForwardWrapper);
+
+      // when / then — must delegate to Tomcat's wrapper, returning /index.html
+      assertThat(wrapper.getRequestURI()).isEqualTo("/index.html");
+    }
+  }
+
+  /**
+   * Regression tests for relative-path request dispatcher resolution. When Spring Boot's
+   * WelcomePageHandlerMapping forwards "/" to "index.html" (relative path, no leading '/'), {@link
+   * jakarta.servlet.ServletRequestWrapper#getRequestDispatcher(String)} delegates to the original
+   * (wrapped) request. The servlet container resolves the relative path against the original
+   * request's URI (e.g., "/clusterId/"), producing "/clusterId/index.html" instead of
+   * "/index.html". The wrapper must convert relative paths to absolute ones based on the rewritten
+   * URI.
+   */
+  @Nested
+  class OnRelativePathDispatch {
+
+    @Test
+    void convertsRelativePathToAbsolute() {
+      // given — rewritten URI is "/", relative path is "index.html"
+      final HttpServletRequest original = mock(HttpServletRequest.class);
+      final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
+      when(original.getRequestDispatcher("/index.html")).thenReturn(expectedDispatcher);
+
+      final PathRewritingRequestWrapper wrapper = new PathRewritingRequestWrapper(original, "/");
+
+      // when
+      final RequestDispatcher result = wrapper.getRequestDispatcher("index.html");
+
+      // then — resolves "index.html" relative to "/" → "/index.html"
+      assertThat(result).isSameAs(expectedDispatcher);
+      verify(original).getRequestDispatcher("/index.html");
+    }
+
+    @Test
+    void convertsRelativePathUnderSubPath() {
+      // given — rewritten URI has a nested path
+      final HttpServletRequest original = mock(HttpServletRequest.class);
+      final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
+      when(original.getRequestDispatcher("/api/resource.html")).thenReturn(expectedDispatcher);
+
+      final PathRewritingRequestWrapper wrapper =
+          new PathRewritingRequestWrapper(original, "/api/endpoint");
+
+      // when
+      final RequestDispatcher result = wrapper.getRequestDispatcher("resource.html");
+
+      // then — resolves "resource.html" relative to "/api/endpoint" → "/api/resource.html"
+      assertThat(result).isSameAs(expectedDispatcher);
+      verify(original).getRequestDispatcher("/api/resource.html");
+    }
+
+    @Test
+    void passesAbsolutePathUnchanged() {
+      // given — path already starts with '/'
+      final HttpServletRequest original = mock(HttpServletRequest.class);
+      final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
+      when(original.getRequestDispatcher("/absolute/path")).thenReturn(expectedDispatcher);
+
+      final PathRewritingRequestWrapper wrapper = new PathRewritingRequestWrapper(original, "/");
+
+      // when
+      final RequestDispatcher result = wrapper.getRequestDispatcher("/absolute/path");
+
+      // then — absolute path passed through unchanged
+      assertThat(result).isSameAs(expectedDispatcher);
+      verify(original).getRequestDispatcher("/absolute/path");
+    }
+  }
+}


### PR DESCRIPTION
## Description

## Summary

Replace `RequestDispatcher.forward()` with `HttpServletRequestWrapper` in Optimize's CCSaaS and CCSM request adjustment filters for compatibility with Spring Security 7.

Ideally I'd liked to get rid of this custom filter setup and use just plain contextPath config from spring, but that seems to be a rabbit hole as this would break access to custom health endpoints like `/api/readyz` and require controller changes 😬 

I did not find any existing suitable integration test setup to add regression tests for, thus I only went with unit tests and manual verification in SaaS. This is a problem we should follow-up on, as this is why the regression was not caught in CI.

## Problem

After upgrading to Spring Boot 4.0 / Spring Framework 7 / Spring Security 7 with https://github.com/camunda/camunda/pull/44602, **all security-matched endpoints behind `/<clusterId>/` paths stopped working**, including OAuth2 login at `/<clusterId>/sso/auth0`.

### Root Cause

Spring Security 7 replaced `AntPathRequestMatcher` with `PathPatternRequestMatcher`, which evaluates paths from `HttpServletRequest.getRequestURI()` — the **original** request URI — rather than the forwarded path. Previously, our filters used `RequestDispatcher.forward()` to strip the clusterId prefix and rewrite `/external/api/` → `/api/external/`. After the upgrade, Spring Security never sees the rewritten path, so no security patterns match.

```
Request: GET /<clusterId>/sso/auth0
  ↓
CCSaasRequestAdjustmentFilter: forward to /sso/auth0
  ↓
PathPatternRequestMatcher: checks getRequestURI() → still /<clusterId>/sso/auth0 ❌
```

## Solution

Replace `RequestDispatcher.forward()` with a `PathRewritingRequestWrapper` (`HttpServletRequestWrapper`) that overrides `getRequestURI()` and `getRequestURL()` to return the rewritten path. Since the wrapper modifies the request object itself, `PathPatternRequestMatcher` sees the rewritten URI.

```
Request: GET /<clusterId>/sso/auth0
  ↓
CCSaasRequestAdjustmentFilter: wrap request → getRequestURI() returns /sso/auth0
  ↓
PathPatternRequestMatcher: checks getRequestURI() → /sso/auth0 ✅
```

### Forward Dispatch Delegation

On `FORWARD` dispatches (e.g., Spring Boot's `WelcomePageHandlerMapping` forwarding `"/"` to `"/index.html"`), Tomcat inserts its own `ApplicationHttpRequest` wrapper below ours. The `PathRewritingRequestWrapper` detects forward dispatches by checking for the `jakarta.servlet.RequestDispatcher.FORWARD_REQUEST_URI` attribute and delegates `getRequestURI()` to the underlying request, allowing Tomcat's forward target URI to be visible to the `DispatcherServlet`.

Without this delegation, the wrapper always returns `"/"` on every forward, causing `WelcomePageHandlerMapping` to re-match infinitely → `StackOverflowError`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #46344
