### PR TITLE
Ensure missing index templates are created after restore

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -54,8 +55,10 @@ import org.agrona.CloseHelper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -115,6 +118,17 @@ public class BackupRestoreIT {
   private HistoryBackupClient historyBackupClient;
   private MultiDbConfigurator configurator;
   private WorkingDirectory workingDirectory;
+
+  @BeforeAll
+  public static void beforeAll() {
+    // Non-snapshot version
+    VersionUtil.overrideVersionForTesting("8.10.0");
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    VersionUtil.resetVersionForTesting();
+  }
 
   @AfterEach
   public void tearDown() {
@@ -217,8 +231,15 @@ public class BackupRestoreIT {
     // Zeebe's folder is deleted by ZeebeIntegration automatically when the application is stop()
 
     webappsDBClient.deleteAllIndices(INDEX_PREFIX);
+    // also delete index templates, to test the case restore is done in an empty ES/OS cluster
+    webappsDBClient.deleteAllIndexTemplates(INDEX_PREFIX);
 
-    Awaitility.await().untilAsserted(() -> assertThat(webappsDBClient.cat(INDEX_PREFIX)).isEmpty());
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              assertThat(webappsDBClient.cat(INDEX_PREFIX)).isEmpty();
+              assertThat(webappsDBClient.getIndexTemplates(INDEX_PREFIX)).isEmpty();
+            });
 
     // RESTORE PROCEDURE
     webappsDBClient.restore(REPOSITORY_NAME, snapshots);
@@ -237,6 +258,7 @@ public class BackupRestoreIT {
 
     // then
     generator.verifyAllExported(ProcessInstanceState.COMPLETED);
+    assertThat(webappsDBClient.getIndexTemplates(INDEX_PREFIX)).isNotEmpty();
   }
 
   private void configureZeebeBackupStore(final Camunda cfg, final DatabaseType databaseType) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
@@ -39,6 +39,10 @@ public interface DocumentClient extends AutoCloseable {
   // TODO remove this when purge functionality is available
   void deleteAllIndices(final String indexPrefix) throws IOException;
 
+  void deleteAllIndexTemplates(final String indexPrefix) throws IOException;
+
+  List<String> getIndexTemplates(String indexPrefix) throws IOException;
+
   BackupRepository zeebeBackupRepository(
       String repositoryName, SnapshotNameProvider snapshotNameProvider);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
@@ -78,6 +78,22 @@ public class ESClient implements DocumentClient {
   }
 
   @Override
+  public void deleteAllIndexTemplates(final String indexPrefix) throws IOException {
+    esClient.indices().deleteIndexTemplate(b -> b.name(indexPrefix + "*"));
+  }
+
+  @Override
+  public List<String> getIndexTemplates(final String indexPrefix) throws IOException {
+    return esClient
+        .indices()
+        .getIndexTemplate(b -> b.name(indexPrefix + "*"))
+        .indexTemplates()
+        .stream()
+        .map(t -> t.name())
+        .toList();
+  }
+
+  @Override
   public BackupRepository zeebeBackupRepository(
       final String repositoryName, final SnapshotNameProvider snapshotNameProvider) {
     return new ElasticsearchBackupRepository(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
@@ -89,6 +89,22 @@ public class OSClient implements DocumentClient {
   }
 
   @Override
+  public void deleteAllIndexTemplates(final String indexPrefix) throws IOException {
+    opensearchClient.indices().deleteIndexTemplate(b -> b.name(indexPrefix + "*"));
+  }
+
+  @Override
+  public List<String> getIndexTemplates(final String indexPrefix) throws IOException {
+    return opensearchClient
+        .indices()
+        .getIndexTemplate(b -> b.name(indexPrefix + "*"))
+        .indexTemplates()
+        .stream()
+        .map(t -> t.name())
+        .toList();
+  }
+
+  @Override
   public BackupRepository zeebeBackupRepository(
       final String repositoryName, final SnapshotNameProvider snapshotNameProvider) {
     return new OpensearchBackupRepository(

--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -192,6 +192,12 @@
   </dependencies>
 
   <build>
+    <testResources>
+      <testResource>
+        <filtering>true</filtering>
+        <directory>src/test/resources</directory>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -159,10 +159,13 @@ public class SchemaManager implements CloseableSilently {
         upgradeSchema = true;
         break;
     }
+    // create any missing index templates, it is done even outside an upgrade scenario, to create
+    // missing index templates after a backup restore
+    initialiseIndexTemplates();
     if (upgradeSchema) {
       final var newIndexProperties = validateIndices(allIndexDescriptors);
-      //  used to create any indices/templates which don't exist
-      initialiseResources();
+      // create any missing indices
+      initialiseIndices();
 
       //  used to update existing indices/templates
       if (!newIndexProperties.isEmpty()) {
@@ -275,12 +278,8 @@ public class SchemaManager implements CloseableSilently {
             String.valueOf(indexSettingsFromConfig.getNumberOfReplicas())));
   }
 
-  public void initialiseResources() {
-    initialiseIndexTemplates();
-    initialiseIndices();
-  }
-
-  private void initialiseIndices() {
+  @VisibleForTesting
+  void initialiseIndices() {
     if (allIndexDescriptors.isEmpty()) {
       LOG.info("Do not create any indices, as descriptors are missing");
       return;
@@ -319,7 +318,8 @@ public class SchemaManager implements CloseableSilently {
         .toList();
   }
 
-  private void initialiseIndexTemplates() {
+  @VisibleForTesting
+  void initialiseIndexTemplates() {
     if (indexTemplateDescriptors.isEmpty()) {
       LOG.info("Do not create any index templates, as descriptors are missing");
       return;

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -98,7 +98,7 @@ public class SchemaManagerIT {
             config,
             objectMapper);
 
-    schemaManager.initialiseResources();
+    initialiseResources(schemaManager);
 
     // when
     final var newProperties = new HashSet<IndexMappingProperty>();
@@ -134,7 +134,7 @@ public class SchemaManagerIT {
             objectMapper);
 
     // when
-    schemaManager.initialiseResources();
+    initialiseResources(schemaManager);
 
     // then
     final var retrievedIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
@@ -162,7 +162,7 @@ public class SchemaManagerIT {
             objectMapper);
 
     // when
-    schemaManager.initialiseResources();
+    initialiseResources(schemaManager);
 
     // then
     final var retrievedIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
@@ -184,7 +184,7 @@ public class SchemaManagerIT {
             config,
             objectMapper);
 
-    schemaManager.initialiseResources();
+    initialiseResources(schemaManager);
 
     // when
     indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
@@ -1422,7 +1422,7 @@ public class SchemaManagerIT {
         new SchemaManager(
             searchEngineClient, Set.of(metadataIndex), Set.of(indexTemplate), config, objectMapper);
 
-    firstSchemaManager.initialiseResources();
+    initialiseResources(firstSchemaManager);
 
     // verify the first template was created
     verify(searchEngineClient, times(1)).createIndexTemplate(eq(indexTemplate), any(), eq(true));
@@ -1445,7 +1445,7 @@ public class SchemaManagerIT {
             config,
             objectMapper);
 
-    secondSchemaManager.initialiseResources();
+    initialiseResources(secondSchemaManager);
 
     // then - verify existing template was not recreated but new template was created
     verify(searchEngineClient, never()).createIndexTemplate(eq(indexTemplate), any(), eq(true));
@@ -1609,5 +1609,10 @@ public class SchemaManagerIT {
                 () -> new IllegalStateException("Could not find transition to 'deleted' state"));
 
     return deletedTransition.at("/conditions/min_index_age").asText();
+  }
+
+  private void initialiseResources(final SchemaManager schemaManager) {
+    schemaManager.initialiseIndexTemplates();
+    schemaManager.initialiseIndices();
   }
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
@@ -12,7 +12,6 @@ import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.VALUE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -201,14 +200,14 @@ class SchemaManagerTest {
           .forEach(
               indexDescriptor ->
                   verify(searchEngineClient).createIndex(indexDescriptor, config.index()));
-      verify(searchEngineClient).createIndexTemplate(testTemplateDescriptor, config.index(), true);
     } else {
       // Verify schema upgrade was skipped - no upsert should happen for same version
       verify(searchEngineClient, never()).upsertDocument(anyString(), anyString(), any());
       verify(searchEngineClient, never()).createIndex(any(), any());
-      verify(searchEngineClient, never()).createIndexTemplate(any(), any(), anyBoolean());
     }
 
+    // Creating missing index templates is always invoked
+    verify(searchEngineClient).createIndexTemplate(testTemplateDescriptor, config.index(), true);
     // Settings and lifecycle policies should always be updated unless returning early
     Stream.of(metadataIndex, testIndexDescriptor, testTemplateDescriptor)
         .forEach(

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -83,15 +83,12 @@ class SchemaUpdateIT {
             .withEnv("SPRING_PROFILES_ACTIVE", "broker,standalone")
             .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", databaseType.toString())
             .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_%s_URL".formatted(databaseType.name()), url)
-            .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", indexPrefix)
-            .withEnv("CAMUNDA_DATABASE_INDEX_NUMBEROFREPLICAS", "1")
-            .withEnv("CAMUNDA_DATABASE_RETENTION_ENABLED", "true")
-            .withEnv("CAMUNDA_DATABASE_RETENTION_ENABLED", "true")
             .withEnv(
-                "CAMUNDA_DATA_SECONDARY_STORAGE_%s_INDEX_PREFIX".formatted(databaseType.name()),
-                indexPrefix)
+                "CAMUNDA_DATA_SECONDARYSTORAGE_%s_NUMBEROFREPLICAS".formatted(databaseType.name()),
+                "1")
+            .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_RETENTION_ENABLED", "true")
             .withEnv(
-                "CAMUNDA_DATA_SECONDARY_STORAGE_%s_INDEX_PREFIX".formatted(databaseType.name()),
+                "CAMUNDA_DATA_SECONDARYSTORAGE_%s_INDEXPREFIX".formatted(databaseType.name()),
                 indexPrefix)) {
       previousVersionContainer.start();
       previousVersionContainer.followOutput(new Slf4jLogConsumer(LOG));

--- a/schema-manager/src/test/resources/zeebe-util.properties
+++ b/schema-manager/src/test/resources/zeebe-util.properties
@@ -1,1 +1,1 @@
-zeebe.version=8.9.0-SNAPSHOT
+zeebe.version=${project.version}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java
@@ -82,6 +82,29 @@ public final class VersionUtil {
     return SemanticVersion.parse(getPreviousVersion());
   }
 
+  /**
+   * Overrides the cached version with the given value. This is intended for testing only, to allow
+   * setting a specific version without relying on environment variables or properties files.
+   *
+   * <p>Call {@link #resetVersionForTesting()} to clear the override and allow the version to be
+   * re-read from the normal sources.
+   */
+  @VisibleForTesting("Allow tests to override the version without setting env vars")
+  public static void overrideVersionForTesting(final String versionOverride) {
+    version = versionOverride;
+    versionLowerCase = null;
+  }
+
+  /**
+   * Resets the cached version so that the next call to {@link #getVersion()} will re-read it from
+   * the normal sources (env var, properties file, or package). This is intended for testing only.
+   */
+  @VisibleForTesting("Allow tests to reset the version after overriding it")
+  public static void resetVersionForTesting() {
+    version = null;
+    versionLowerCase = null;
+  }
+
   private static String readProperty(final String property) {
     try (final InputStream lastVersionFileStream =
         VersionUtil.class.getResourceAsStream(VERSION_PROPERTIES_PATH)) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Updated `SchemaManager` to separately initialize index templates and indices, ensuring missing templates are always created after restore in an empty Elasticsearch/OpenSearch cluster, outside upgrade scenarios.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #40675
