### PR TITLE
feat: add JobTimeSeriesStatistics API

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -13,6 +13,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_NULL_VARIABLE_NAME;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_NULL_VARIABLE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDate;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDuration;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.gateway.mapping.http.converters.AuditLogActorTypeConverter;
@@ -53,6 +54,7 @@ import io.camunda.search.filter.GlobalListenerFilter;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.JobFilter;
+import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
 import io.camunda.search.filter.JobTypeStatisticsFilter;
 import io.camunda.search.filter.JobWorkerStatisticsFilter;
 import io.camunda.search.filter.MappingRuleFilter;
@@ -469,6 +471,36 @@ public class SearchQueryFilterMapper {
     } else {
       builder.jobType(filter.getJobType());
     }
+
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
+  }
+
+  public static Either<List<String>, JobTimeSeriesStatisticsFilter> toJobTimeSeriesStatisticsFilter(
+      final io.camunda.gateway.protocol.model.JobTimeSeriesStatisticsFilter filter) {
+    final var builder = FilterBuilders.jobTimeSeriesStatistics();
+    final List<String> validationErrors = new ArrayList<>();
+
+    if (filter == null) {
+      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter"));
+      return Either.left(validationErrors);
+    }
+
+    final var from = validateDate(filter.getFrom(), "from", validationErrors);
+    Optional.ofNullable(from).ifPresent(builder::from);
+
+    final var to = validateDate(filter.getTo(), "to", validationErrors);
+    Optional.ofNullable(to).ifPresent(builder::to);
+
+    if (filter.getJobType() == null || filter.getJobType().isBlank()) {
+      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobType"));
+    } else {
+      builder.jobType(filter.getJobType());
+    }
+
+    final var resolution = validateDuration(filter.getResolution(), "resolution", validationErrors);
+    Optional.ofNullable(resolution).ifPresent(builder::resolution);
 
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -148,6 +148,15 @@ public final class SearchQueryRequestMapper {
         filter, Either.right(null), page, SearchQueryBuilders::jobWorkerStatisticsSearchQuery);
   }
 
+  public static Either<ProblemDetail, io.camunda.search.query.JobTimeSeriesStatisticsQuery>
+      toJobTimeSeriesStatisticsQuery(
+          final io.camunda.gateway.protocol.model.JobTimeSeriesStatisticsQuery request) {
+    final Either<List<String>, SearchQueryPage> page = toSearchQueryPage(request.getPage());
+    final var filter = SearchQueryFilterMapper.toJobTimeSeriesStatisticsFilter(request.getFilter());
+    return buildSearchQuery(
+        filter, Either.right(null), page, SearchQueryBuilders::jobTimeSeriesStatisticsSearchQuery);
+  }
+
   public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(
       final io.camunda.gateway.protocol.model.simple.ProcessDefinitionSearchQuery query) {
     return toProcessDefinitionQuery(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -77,6 +77,8 @@ import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
 import io.camunda.gateway.protocol.model.JobSearchResult;
 import io.camunda.gateway.protocol.model.JobStateEnum;
+import io.camunda.gateway.protocol.model.JobTimeSeriesStatisticsItem;
+import io.camunda.gateway.protocol.model.JobTimeSeriesStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobTypeStatisticsItem;
 import io.camunda.gateway.protocol.model.JobTypeStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobWorkerStatisticsItem;
@@ -159,6 +161,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.entities.MappingRuleEntity;
@@ -1598,6 +1601,30 @@ public final class SearchQueryResponseMapper {
 
     return new JobWorkerStatisticsItem()
         .worker(entity.worker())
+        .created(toStatusMetric(entity.created()))
+        .completed(toStatusMetric(entity.completed()))
+        .failed(toStatusMetric(entity.failed()));
+  }
+
+  public static JobTimeSeriesStatisticsQueryResult toJobTimeSeriesStatisticsQueryResult(
+      final SearchQueryResult<JobTimeSeriesStatisticsEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new JobTimeSeriesStatisticsQueryResult()
+        .page(page)
+        .items(
+            result.items().stream()
+                .map(SearchQueryResponseMapper::toJobTimeSeriesStatisticsItem)
+                .toList());
+  }
+
+  private static JobTimeSeriesStatisticsItem toJobTimeSeriesStatisticsItem(
+      final JobTimeSeriesStatisticsEntity entity) {
+    if (entity == null) {
+      return new JobTimeSeriesStatisticsItem();
+    }
+
+    return new JobTimeSeriesStatisticsItem()
+        .time(formatDate(entity.time()))
         .created(toStatusMetric(entity.created()))
         .completed(toStatusMetric(entity.completed()))
         .failed(toStatusMetric(entity.failed()));

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
@@ -11,6 +11,8 @@ public final class ErrorMessages {
 
   public static final String ERROR_MESSAGE_DATE_PARSING =
       "The provided %s '%s' cannot be parsed as a date according to RFC 3339, section 5.6";
+  public static final String ERROR_MESSAGE_DURATION_PARSING =
+      "The provided %s '%s' cannot be parsed as a duration according to ISO 8601 (e.g. PT1M, PT1H)";
   public static final String ERROR_MESSAGE_EMPTY_UPDATE_CHANGESET =
       """
       No update data provided. Provide at least an "action" or a non-null value \

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mapping.http.validator;
 
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_DATE_PARSING;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_DURATION_PARSING;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_KEY_FORMAT;
@@ -16,6 +17,7 @@ import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import io.camunda.gateway.mapping.http.util.KeyUtil;
 import io.camunda.gateway.protocol.model.Changeset;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -52,6 +54,18 @@ public final class RequestValidator {
         return OffsetDateTime.parse(dateString);
       } catch (final DateTimeParseException ex) {
         violations.add(ERROR_MESSAGE_DATE_PARSING.formatted(attributeName, dateString));
+      }
+    }
+    return null;
+  }
+
+  public static Duration validateDuration(
+      final String durationString, final String attributeName, final List<String> violations) {
+    if (durationString != null && !durationString.isEmpty()) {
+      try {
+        return Duration.parse(durationString);
+      } catch (final DateTimeParseException ex) {
+        violations.add(ERROR_MESSAGE_DURATION_PARSING.formatted(attributeName, durationString));
       }
     }
     return null;

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -34,6 +34,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.entities.MappingRuleEntity;
@@ -80,6 +81,7 @@ import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuer
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.MappingRuleQuery;
@@ -402,6 +404,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final JobWorkerStatisticsQuery query) {
     return doReadWithResourceAccessController(
         access -> readers.jobMetricsBatchReader().getJobWorkerStatistics(query, access));
+  }
+
+  @Override
+  public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
+      final JobTimeSeriesStatisticsQuery query) {
+    throw new UnsupportedOperationException("Job time-series statistics is not yet implemented");
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
@@ -9,10 +9,12 @@ package io.camunda.search.clients;
 
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -28,6 +30,9 @@ public interface JobSearchClient {
 
   SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
       JobWorkerStatisticsQuery query);
+
+  SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
+      JobTimeSeriesStatisticsQuery query);
 
   JobSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -28,6 +28,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.entities.MappingRuleEntity;
@@ -69,6 +70,7 @@ import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuer
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.MappingRuleQuery;
@@ -418,6 +420,12 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
       final JobWorkerStatisticsQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
+      final JobTimeSeriesStatisticsQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -30,6 +30,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.entities.MappingRuleEntity;
@@ -70,6 +71,7 @@ import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuer
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.MappingRuleQuery;
@@ -421,6 +423,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
       final JobWorkerStatisticsQuery query) {
     return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
+      final JobTimeSeriesStatisticsQuery query) {
+    throw new UnsupportedOperationException("Job time-series statistics is not yet implemented");
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobTimeSeriesStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobTimeSeriesStatisticsEntity.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import java.time.OffsetDateTime;
+
+/**
+ * Represents aggregated job metrics for a single time bucket.
+ *
+ * @param time the start timestamp of the time bucket
+ * @param created metrics for jobs created within this bucket
+ * @param completed metrics for jobs completed within this bucket
+ * @param failed metrics for jobs failed within this bucket
+ */
+public record JobTimeSeriesStatisticsEntity(
+    OffsetDateTime time, StatusMetric created, StatusMetric completed, StatusMetric failed) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -367,6 +367,17 @@ public final class FilterBuilders {
     return fn.apply(jobWorkerStatistics()).build();
   }
 
+  public static JobTimeSeriesStatisticsFilter.Builder jobTimeSeriesStatistics() {
+    return new JobTimeSeriesStatisticsFilter.Builder();
+  }
+
+  public static JobTimeSeriesStatisticsFilter jobTimeSeriesStatistics(
+      final Function<
+              JobTimeSeriesStatisticsFilter.Builder, ObjectBuilder<JobTimeSeriesStatisticsFilter>>
+          fn) {
+    return fn.apply(jobTimeSeriesStatistics()).build();
+  }
+
   public static GlobalListenerFilter.Builder globalListener() {
     return new GlobalListenerFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/JobTimeSeriesStatisticsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/JobTimeSeriesStatisticsFilter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import io.camunda.util.DurationUtil;
+import io.camunda.util.ObjectBuilder;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Filter for job time-series statistics queries.
+ *
+ * @param from start of the time window to filter metrics
+ * @param to end of the time window to filter metrics
+ * @param jobType the job type to return time-series metrics for
+ * @param resolution time bucket resolution (e.g. PT1M for 1 minute); automatically computed from
+ *     {@code (to - from) / DEFAULT_DESIRED_DATA_POINTS} when not provided explicitly
+ */
+public record JobTimeSeriesStatisticsFilter(
+    OffsetDateTime from, OffsetDateTime to, String jobType, Duration resolution)
+    implements FilterBase {
+
+  /** Desired number of data points when resolution is not explicitly provided. */
+  public static final int DEFAULT_DESIRED_DATA_POINTS = 1000;
+
+  /** Minimum allowed resolution. */
+  public static final Duration MIN_RESOLUTION = Duration.ofMinutes(1);
+
+  public static JobTimeSeriesStatisticsFilter of(
+      final Function<Builder, ObjectBuilder<JobTimeSeriesStatisticsFilter>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<JobTimeSeriesStatisticsFilter> {
+    private OffsetDateTime from;
+    private OffsetDateTime to;
+    private String jobType;
+    private Duration resolution;
+
+    public Builder from(final OffsetDateTime from) {
+      this.from = from;
+      return this;
+    }
+
+    public Builder to(final OffsetDateTime to) {
+      this.to = to;
+      return this;
+    }
+
+    public Builder jobType(final String jobType) {
+      this.jobType = jobType;
+      return this;
+    }
+
+    public Builder resolution(final Duration resolution) {
+      this.resolution = resolution;
+      return this;
+    }
+
+    private static Duration computeResolution(
+        final OffsetDateTime from, final OffsetDateTime to, final Duration explicitResolution) {
+      final var computed =
+          explicitResolution != null
+              ? explicitResolution
+              : Duration.between(from, to).dividedBy(DEFAULT_DESIRED_DATA_POINTS);
+      return DurationUtil.max(computed, MIN_RESOLUTION);
+    }
+
+    @Override
+    public JobTimeSeriesStatisticsFilter build() {
+      final var validFrom = Objects.requireNonNull(from, "from must not be null");
+      final var validTo = Objects.requireNonNull(to, "to must not be null");
+      return new JobTimeSeriesStatisticsFilter(
+          validFrom,
+          validTo,
+          Objects.requireNonNull(jobType, "jobType must not be null"),
+          computeResolution(validFrom, validTo, resolution));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/JobTimeSeriesStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/JobTimeSeriesStatisticsQuery.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Query for retrieving time-bucketed job statistics for a given job type.
+ *
+ * @param filter the filter criteria for the time-series statistics
+ * @param page pagination parameters
+ */
+public record JobTimeSeriesStatisticsQuery(
+    JobTimeSeriesStatisticsFilter filter, SearchQueryPage page)
+    implements TypedSearchQuery<JobTimeSeriesStatisticsFilter, NoSort> {
+
+  public static JobTimeSeriesStatisticsQuery of(
+      final Function<Builder, ObjectBuilder<JobTimeSeriesStatisticsQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public NoSort sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
+  public io.camunda.search.aggregation.AggregationBase aggregation() {
+    return null;
+  }
+
+  @Override
+  public SearchQueryPage page() {
+    return page;
+  }
+
+  public static final class Builder
+      extends SearchQueryBase.AbstractQueryBuilder<JobTimeSeriesStatisticsQuery.Builder>
+      implements TypedSearchQueryBuilder<
+          JobTimeSeriesStatisticsQuery,
+          JobTimeSeriesStatisticsQuery.Builder,
+          JobTimeSeriesStatisticsFilter,
+          NoSort> {
+
+    private JobTimeSeriesStatisticsFilter filter;
+    private SearchQueryPage page;
+
+    @Override
+    public Builder filter(final JobTimeSeriesStatisticsFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final NoSort value) {
+      return this;
+    }
+
+    public Builder filter(
+        final Function<
+                JobTimeSeriesStatisticsFilter.Builder, ObjectBuilder<JobTimeSeriesStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.jobTimeSeriesStatistics(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public Builder page(final SearchQueryPage page) {
+      this.page = page;
+      return this;
+    }
+
+    @Override
+    public Builder page(
+        final Function<SearchQueryPage.Builder, ObjectBuilder<SearchQueryPage>> fn) {
+      return page(SearchQueryPage.of(fn));
+    }
+
+    @Override
+    public JobTimeSeriesStatisticsQuery build() {
+      return new JobTimeSeriesStatisticsQuery(
+          Objects.requireNonNull(filter, "filter must not be null"), page);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -48,6 +48,10 @@ public final class SearchQueryBuilders {
     return new JobWorkerStatisticsQuery.Builder();
   }
 
+  public static JobTimeSeriesStatisticsQuery.Builder jobTimeSeriesStatisticsSearchQuery() {
+    return new JobTimeSeriesStatisticsQuery.Builder();
+  }
+
   public static ProcessInstanceQuery processInstanceSearchQuery(
       final Function<ProcessInstanceQuery.Builder, ObjectBuilder<ProcessInstanceQuery>> fn) {
     return fn.apply(processInstanceSearchQuery()).build();

--- a/search/search-domain/src/main/java/io/camunda/util/DurationUtil.java
+++ b/search/search-domain/src/main/java/io/camunda/util/DurationUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.util;
+
+import java.time.Duration;
+
+public final class DurationUtil {
+
+  private DurationUtil() {}
+
+  /** Returns the larger of two durations. */
+  public static Duration max(final Duration a, final Duration b) {
+    return a.compareTo(b) >= 0 ? a : b;
+  }
+
+  /** Returns the smaller of two durations. */
+  public static Duration min(final Duration a, final Duration b) {
+    return a.compareTo(b) <= 0 ? a : b;
+  }
+}

--- a/search/search-domain/src/test/java/io/camunda/util/DurationUtilTest.java
+++ b/search/search-domain/src/test/java/io/camunda/util/DurationUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class DurationUtilTest {
+
+  @Test
+  void minReturnsFirstWhenSmaller() {
+    assertThat(DurationUtil.min(Duration.ofSeconds(30), Duration.ofMinutes(1)))
+        .isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void minReturnsSecondWhenSmaller() {
+    assertThat(DurationUtil.min(Duration.ofMinutes(2), Duration.ofMinutes(1)))
+        .isEqualTo(Duration.ofMinutes(1));
+  }
+
+  @Test
+  void minReturnsEitherWhenEqual() {
+    final var duration = Duration.ofMinutes(1);
+    assertThat(DurationUtil.min(duration, duration)).isEqualTo(duration);
+  }
+
+  @Test
+  void maxReturnsFirstWhenLarger() {
+    assertThat(DurationUtil.max(Duration.ofMinutes(2), Duration.ofMinutes(1)))
+        .isEqualTo(Duration.ofMinutes(2));
+  }
+
+  @Test
+  void maxReturnsSecondWhenLarger() {
+    assertThat(DurationUtil.max(Duration.ofSeconds(30), Duration.ofMinutes(1)))
+        .isEqualTo(Duration.ofMinutes(1));
+  }
+
+  @Test
+  void maxReturnsEitherWhenEqual() {
+    final var duration = Duration.ofMinutes(1);
+    assertThat(DurationUtil.max(duration, duration)).isEqualTo(duration);
+  }
+}

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -12,10 +12,12 @@ import static io.camunda.service.authorization.Authorizations.JOB_READ_AUTHORIZA
 import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -176,6 +178,17 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
                     securityContextProvider.provideSecurityContext(
                         authentication, Authorization.of(a -> a.system().readJobMetric())))
                 .getJobWorkerStatistics(query));
+  }
+
+  public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
+      final JobTimeSeriesStatisticsQuery query) {
+    return executeSearchRequest(
+        () ->
+            jobSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, Authorization.of(a -> a.system().readJobMetric())))
+                .getJobTimeSeriesStatistics(query));
   }
 
   public record ActivateJobsRequest(

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -114,6 +114,39 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 
+  /jobs/statistics/time-series:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Job
+      operationId: getJobTimeSeriesStatistics
+      summary: Get time-series metrics for a job type
+      description: |
+        Returns a list of time-bucketed metrics ordered ascending by time.
+        The `from` and `to` fields select the time window of interest.
+        Each item in the response corresponds to one time bucket of the requested resolution.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobTimeSeriesStatisticsQuery'
+      responses:
+        "200":
+          description: The job time-series statistics result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobTimeSeriesStatisticsQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+
 ## Schema definitions
 
 components:
@@ -308,3 +341,84 @@ components:
           $ref: '#/components/schemas/StatusMetric'
         failed:
           $ref: '#/components/schemas/StatusMetric'
+
+    JobTimeSeriesStatisticsQuery:
+      description: Job time-series statistics query.
+      type: object
+      required:
+        - filter
+      properties:
+        filter:
+          $ref: '#/components/schemas/JobTimeSeriesStatisticsFilter'
+        page:
+          description: Search cursor pagination.
+          allOf:
+            - $ref: 'search-models.yaml#/components/schemas/CursorForwardPagination'
+
+    JobTimeSeriesStatisticsFilter:
+      description: Job time-series statistics search filter.
+      type: object
+      required:
+        - from
+        - to
+        - jobType
+      properties:
+        from:
+          description: |
+            Start of the time window to filter metrics. ISO 8601 date-time format.
+          type: string
+          format: date-time
+          example: "2024-07-28T15:51:28.071Z"
+        to:
+          description: |
+            End of the time window to filter metrics. ISO 8601 date-time format.
+          type: string
+          format: date-time
+          example: "2024-07-29T15:51:28.071Z"
+        jobType:
+          description: Job type to return time-series metrics for.
+          type: string
+          example: "fetch-customer-data"
+        resolution:
+          description: |
+            Time bucket resolution as an ISO 8601 duration (for example `PT1M` for 1 minute,
+            `PT1H` for 1 hour). If omitted, the server chooses a sensible default.
+          type: string
+          example: "PT1M"
+
+    JobTimeSeriesStatisticsQueryResult:
+      description: Job time-series statistics query result.
+      type: object
+      required:
+        - items
+        - page
+      allOf:
+        - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The list of time-bucketed statistics items, ordered ascending by time.
+          type: array
+          items:
+            $ref: '#/components/schemas/JobTimeSeriesStatisticsItem'
+
+    JobTimeSeriesStatisticsItem:
+      description: Aggregated job metrics for a single time bucket.
+      type: object
+      required:
+        - time
+        - created
+        - completed
+        - failed
+      properties:
+        time:
+          description: ISO 8601 timestamp representing the start of this time bucket.
+          type: string
+          format: date-time
+          example: "2024-07-29T15:51:00.000Z"
+        created:
+          $ref: '#/components/schemas/StatusMetric'
+        completed:
+          $ref: '#/components/schemas/StatusMetric'
+        failed:
+          $ref: '#/components/schemas/StatusMetric'
+

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -241,6 +241,8 @@ paths:
     $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1by-types'
   /jobs/statistics/by-workers:
     $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1by-workers'
+  /jobs/statistics/time-series:
+    $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1time-series'
 
   # License endpoints
   /license:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -24,6 +24,8 @@ import io.camunda.gateway.protocol.model.JobErrorRequest;
 import io.camunda.gateway.protocol.model.JobFailRequest;
 import io.camunda.gateway.protocol.model.JobSearchQuery;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
+import io.camunda.gateway.protocol.model.JobTimeSeriesStatisticsQuery;
+import io.camunda.gateway.protocol.model.JobTimeSeriesStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobTypeStatisticsQuery;
 import io.camunda.gateway.protocol.model.JobTypeStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobUpdateRequest;
@@ -138,6 +140,14 @@ public class JobController {
         .fold(RestErrorMapper::mapProblemToResponse, this::getWorkerStatistics);
   }
 
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/statistics/time-series")
+  public ResponseEntity<JobTimeSeriesStatisticsQueryResult> getJobTimeSeriesStatistics(
+      @RequestBody final JobTimeSeriesStatisticsQuery request) {
+    return SearchQueryRequestMapper.toJobTimeSeriesStatisticsQuery(request)
+        .fold(RestErrorMapper::mapProblemToResponse, this::getTimeSeriesStatistics);
+  }
+
   private CompletableFuture<ResponseEntity<Object>> activateJobs(
       final ActivateJobsRequest activationRequest) {
     final var result = new CompletableFuture<ResponseEntity<Object>>();
@@ -248,6 +258,20 @@ public class JobController {
               .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .getJobWorkerStatistics(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toJobWorkerStatisticsQueryResult(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private ResponseEntity<JobTimeSeriesStatisticsQueryResult> getTimeSeriesStatistics(
+      final io.camunda.search.query.JobTimeSeriesStatisticsQuery query) {
+    try {
+      final var result =
+          jobServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .getJobTimeSeriesStatistics(query);
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toJobTimeSeriesStatisticsQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.SearchQueryResult;
@@ -1012,8 +1013,9 @@ public class JobControllerTest extends RestControllerTest {
 
     final var searchResult =
         new SearchQueryResult.Builder<JobTypeStatisticsEntity>()
-            .total(2L)
+            .total(2L, true)
             .items(List.of(statisticsEntity1, statisticsEntity2))
+            .endCursor("endCursor")
             .build();
 
     when(jobServices.getJobTypeStatistics(any())).thenReturn(searchResult);
@@ -1065,7 +1067,10 @@ public class JobControllerTest extends RestControllerTest {
                 }
               ],
               "page": {
-                "totalItems": 2
+                "totalItems": 2,
+                "startCursor": null,
+                "endCursor": "endCursor",
+                "hasMoreTotalItems": true
               }
             }""";
 
@@ -1082,7 +1087,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse, JsonCompareMode.LENIENT);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1099,7 +1104,8 @@ public class JobControllerTest extends RestControllerTest {
 
     final var searchResult =
         new SearchQueryResult.Builder<JobTypeStatisticsEntity>()
-            .total(1L)
+            .total(1L, false)
+            .endCursor("endCursor")
             .items(List.of(statisticsEntity))
             .build();
 
@@ -1139,7 +1145,10 @@ public class JobControllerTest extends RestControllerTest {
                 }
               ],
               "page": {
-                "totalItems": 1
+                "totalItems": 1,
+                "startCursor": null,
+                "endCursor": "endCursor",
+                "hasMoreTotalItems": false
               }
             }""";
 
@@ -1156,7 +1165,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse, JsonCompareMode.LENIENT);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1173,7 +1182,8 @@ public class JobControllerTest extends RestControllerTest {
 
     final var searchResult =
         new SearchQueryResult.Builder<JobTypeStatisticsEntity>()
-            .total(1L)
+            .total(1L, false)
+            .endCursor("endCursor")
             .items(List.of(statisticsEntity))
             .build();
 
@@ -1213,7 +1223,10 @@ public class JobControllerTest extends RestControllerTest {
                 }
               ],
               "page": {
-                "totalItems": 1
+                "totalItems": 1,
+                "startCursor": null,
+                "endCursor": "endCursor",
+                "hasMoreTotalItems": false
               }
             }""";
 
@@ -1230,7 +1243,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse, JsonCompareMode.LENIENT);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1524,7 +1537,8 @@ public class JobControllerTest extends RestControllerTest {
 
     final var searchResult =
         new SearchQueryResult.Builder<JobWorkerStatisticsEntity>()
-            .total(2L)
+            .total(2L, true)
+            .endCursor("endCursor")
             .items(List.of(workerEntity1, workerEntity2))
             .build();
 
@@ -1576,7 +1590,10 @@ public class JobControllerTest extends RestControllerTest {
                 }
               ],
               "page": {
-                "totalItems": 2
+                "totalItems": 2,
+                "startCursor": null,
+                "endCursor": "endCursor",
+                "hasMoreTotalItems": true
               }
             }""";
 
@@ -1593,7 +1610,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse, JsonCompareMode.LENIENT);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1609,7 +1626,8 @@ public class JobControllerTest extends RestControllerTest {
 
     final var searchResult =
         new SearchQueryResult.Builder<JobWorkerStatisticsEntity>()
-            .total(1L)
+            .total(1L, false)
+            .endCursor("endCursor")
             .items(List.of(workerEntity))
             .build();
 
@@ -1649,7 +1667,10 @@ public class JobControllerTest extends RestControllerTest {
                 }
               ],
               "page": {
-                "totalItems": 1
+                "totalItems": 1,
+                "startCursor": null,
+                "endCursor": "endCursor",
+                "hasMoreTotalItems": false
               }
             }""";
 
@@ -1666,7 +1687,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse, JsonCompareMode.LENIENT);
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @Test
@@ -1816,6 +1837,316 @@ public class JobControllerTest extends RestControllerTest {
     webClient
         .post()
         .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  // -------------------------------------------------------------------------
+  // /statistics/time-series tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldGetJobTimeSeriesStatistics() {
+    // given
+    final var time1 = OffsetDateTime.parse("2024-07-29T15:50:00.000Z");
+    final var time2 = OffsetDateTime.parse("2024-07-29T15:51:00.000Z");
+    final var lastUpdatedAt = OffsetDateTime.parse("2024-07-29T15:51:28.071Z");
+
+    final var entity1 =
+        new JobTimeSeriesStatisticsEntity(
+            time1,
+            new StatusMetric(12, lastUpdatedAt),
+            new StatusMetric(10, lastUpdatedAt),
+            new StatusMetric(0, null));
+    final var entity2 =
+        new JobTimeSeriesStatisticsEntity(
+            time2,
+            new StatusMetric(7, lastUpdatedAt),
+            new StatusMetric(6, lastUpdatedAt),
+            new StatusMetric(1, lastUpdatedAt));
+
+    final var searchResult =
+        new SearchQueryResult.Builder<JobTimeSeriesStatisticsEntity>()
+            .total(2L, true)
+            .items(List.of(entity1, entity2))
+            .endCursor("endCursor")
+            .build();
+
+    when(jobServices.getJobTimeSeriesStatistics(any())).thenReturn(searchResult);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    final var expectedResponse =
+        """
+            {
+              "items": [
+                {
+                  "time": "2024-07-29T15:50:00.000Z",
+                  "created":   { "count": 12, "lastUpdatedAt": "2024-07-29T15:51:28.071Z" },
+                  "completed": { "count": 10, "lastUpdatedAt": "2024-07-29T15:51:28.071Z" },
+                  "failed":    { "count": 0,  "lastUpdatedAt": null }
+                },
+                {
+                  "time": "2024-07-29T15:51:00.000Z",
+                  "created":   { "count": 7, "lastUpdatedAt": "2024-07-29T15:51:28.071Z" },
+                  "completed": { "count": 6, "lastUpdatedAt": "2024-07-29T15:51:28.071Z" },
+                  "failed":    { "count": 1, "lastUpdatedAt": "2024-07-29T15:51:28.071Z" }
+                }
+              ],
+              "page": {
+                "totalItems": 2,
+                "startCursor": null,
+                "endCursor": "endCursor",
+                "hasMoreTotalItems": true
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldGetJobTimeSeriesStatisticsWithResolution() {
+    // given
+    final var time1 = OffsetDateTime.parse("2024-07-29T15:00:00.000Z");
+    final var lastUpdatedAt = OffsetDateTime.parse("2024-07-29T15:51:28.071Z");
+    final var entity =
+        new JobTimeSeriesStatisticsEntity(
+            time1,
+            new StatusMetric(100, lastUpdatedAt),
+            new StatusMetric(95, lastUpdatedAt),
+            new StatusMetric(2, lastUpdatedAt));
+    final var searchResult =
+        new SearchQueryResult.Builder<JobTimeSeriesStatisticsEntity>()
+            .total(1L)
+            .items(List.of(entity))
+            .build();
+
+    when(jobServices.getJobTimeSeriesStatistics(any())).thenReturn(searchResult);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:00:00.000Z",
+                "to":   "2024-07-29T15:00:00.000Z",
+                "jobType": "fetch-customer-data",
+                "resolution": "PT1H"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("$.items[0].time")
+        .isEqualTo("2024-07-29T15:00:00.000Z")
+        .jsonPath("$.items[0].created.count")
+        .isEqualTo(100);
+  }
+
+  @Test
+  void shouldRejectJobTimeSeriesStatisticsWithMissingBody() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "Bad Request",
+              "detail": "Required request body is missing",
+              "instance": "%s"
+            }"""
+            .formatted(JOBS_BASE_URL + "/statistics/time-series");
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobTimeSeriesStatisticsWithMissingFilter() {
+    // given
+    final var request = "{}";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobTimeSeriesStatisticsWithEmptyFilter() {
+    // given
+    final var request =
+        """
+        { "filter": {} }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobTimeSeriesStatisticsWithMissingFrom() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobTimeSeriesStatisticsWithMissingTo() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobTimeSeriesStatisticsWithMissingJobType() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobTimeSeriesStatisticsWithInvalidResolution() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to":   "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data",
+                "resolution": "not-a-duration"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)


### PR DESCRIPTION
## Description

This pull request introduces support for job time-series statistics queries and responses across the gateway and search client layers. The main changes include new mapping logic, validation for ISO 8601 durations, and the addition of entity and filter classes to represent time-series job statistics. The client interfaces have been updated to expose the new query, though implementations are currently placeholders.

**Job Time-Series Statistics Support**

* Added `JobTimeSeriesStatisticsEntity` record to represent aggregated job metrics per time bucket.
* Introduced `JobTimeSeriesStatisticsFilter` and builder methods in `FilterBuilders` for constructing filters for time-series statistics.

**Gateway Mapping and Validation**

* Implemented `toJobTimeSeriesStatisticsFilter` in `SearchQueryFilterMapper` to map and validate request filters, including date and ISO 8601 duration parsing. [[1]](diffhunk://#diff-e1f65762c93bb5ef2c37f4c053b3bf3bd244485263d62e64276b97772981027fR480-R509) [[2]](diffhunk://#diff-00db7f47fb8038440839720c6807573b495f7bc005a920e0f485b7b3249c9611R62-R73) [[3]](diffhunk://#diff-ffba816addbfba510d1f45c3d8a2a179ab341b9c9ec569025e6f413d5ba81eefR14-R15)
* Added mapping logic in `SearchQueryRequestMapper` and `SearchQueryResponseMapper` for job time-series statistics queries and results. [[1]](diffhunk://#diff-2f50a632e9f67fa9422b16bdf13afef8966a85408cea148428ab2b763c86fefaR151-R159) [[2]](diffhunk://#diff-06c4e31c99d1aca6e942471bbb0c7dfdb715a4cc9535d3cbd34a982dcb3714f2R1608-R1629)

**Search Client Interface Updates**

* Extended `JobSearchClient` and `CamundaSearchClients` to include `getJobTimeSeriesStatistics`, with placeholder implementations in `NoDBSearchClientsProxy` and `NoopSearchClientsProxy`. [[1]](diffhunk://#diff-cb11a4b24fb6e9c25f887e4b2b02055b11b559dca7d87fdd650da35a5184df9eR34-R36) [[2]](diffhunk://#diff-99616651437db17eb866f9a3b4a3ef9d0e6d75bea00465643f7204920966fa93R409-R414) [[3]](diffhunk://#diff-38418fdd9bb6a019d3630943518b33259023fb83352657e76a9d862394278b80R426-R431) [[4]](diffhunk://#diff-c79d6b60e20a1f39b125755908386489c3f033508a294e45ef84feed9a285b1eR428-R433)

**Dependency and Import Adjustments**

* Added necessary imports for new entity, filter, and query types in gateway and search client files. [[1]](diffhunk://#diff-e1f65762c93bb5ef2c37f4c053b3bf3bd244485263d62e64276b97772981027fR57) [[2]](diffhunk://#diff-06c4e31c99d1aca6e942471bbb0c7dfdb715a4cc9535d3cbd34a982dcb3714f2R164) [[3]](diffhunk://#diff-99616651437db17eb866f9a3b4a3ef9d0e6d75bea00465643f7204920966fa93R84) [[4]](diffhunk://#diff-cb11a4b24fb6e9c25f887e4b2b02055b11b559dca7d87fdd650da35a5184df9eR12-R17) [[5]](diffhunk://#diff-38418fdd9bb6a019d3630943518b33259023fb83352657e76a9d862394278b80R73) [[6]](diffhunk://#diff-c79d6b60e20a1f39b125755908386489c3f033508a294e45ef84feed9a285b1eR74) [[7]](diffhunk://#diff-00db7f47fb8038440839720c6807573b495f7bc005a920e0f485b7b3249c9611R20)

**Error Handling Improvements**

* Introduced a specific error message for invalid ISO 8601 durations in `ErrorMessages`.

These changes lay the groundwork for supporting time-series job statistics queries, with validation and mapping logic in place and client interfaces ready for future implementation.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43058
