### PR TITLE
feat: persist business id for process instances in secondary storage

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
@@ -59,4 +59,6 @@ public interface ProcessInstance {
   String getTenantId();
 
   Set<String> getTags();
+
+  String getBusinessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
@@ -40,6 +40,7 @@ public class ProcessInstanceImpl implements ProcessInstance {
   private final Boolean hasIncident;
   private final String tenantId;
   private final Set<String> tags;
+  private final String businessId;
 
   public ProcessInstanceImpl(final ProcessInstanceResult item) {
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
@@ -57,6 +58,7 @@ public class ProcessInstanceImpl implements ProcessInstance {
     hasIncident = item.getHasIncident();
     tenantId = item.getTenantId();
     tags = item.getTags();
+    businessId = item.getBusinessId();
   }
 
   @Override
@@ -132,5 +134,10 @@ public class ProcessInstanceImpl implements ProcessInstance {
   @Override
   public Set<String> getTags() {
     return tags;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return businessId;
   }
 }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -62,6 +62,7 @@
       <column name="PARTITION_ID" type="NUMBER"/>
       <column name="TREE_PATH" type="VARCHAR(${treePathSize})"/>
       <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="BUSINESS_ID" type="VARCHAR(${userCharColumnSize})"/>
     </createTable>
 
     <createIndex tableName="${prefix}PROCESS_INSTANCE" indexName="${prefix}IDX_PROCESS_INSTANCE_HIST">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
@@ -29,7 +29,8 @@ public record ProcessInstanceDbModel(
     int partitionId,
     String treePath,
     OffsetDateTime historyCleanupDate,
-    Set<String> tags)
+    Set<String> tags,
+    String businessId)
     implements DbModel<ProcessInstanceDbModel> {
 
   @Override
@@ -54,7 +55,8 @@ public record ProcessInstanceDbModel(
                 .partitionId(partitionId)
                 .treePath(treePath)
                 .historyCleanupDate(historyCleanupDate)
-                .tags(tags))
+                .tags(tags)
+                .businessId(businessId))
         .build();
   }
 
@@ -77,6 +79,7 @@ public record ProcessInstanceDbModel(
     private String treePath;
     private OffsetDateTime historyCleanupDate;
     private Set<String> tags;
+    private String businessId;
 
     // Public constructor to initialize the builder
     public ProcessInstanceDbModelBuilder() {}
@@ -168,6 +171,11 @@ public record ProcessInstanceDbModel(
       return this;
     }
 
+    public ProcessInstanceDbModelBuilder businessId(final String businessId) {
+      this.businessId = businessId;
+      return this;
+    }
+
     @Override
     public ProcessInstanceDbModel build() {
       return new ProcessInstanceDbModel(
@@ -186,7 +194,8 @@ public record ProcessInstanceDbModel(
           partitionId,
           treePath,
           historyCleanupDate,
-          tags);
+          tags,
+          businessId);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -27,6 +27,7 @@
            pi.PARENT_ELEMENT_INSTANCE_KEY,
            pi.VERSION AS PROCESS_DEFINITION_VERSION,
            pi.TREE_PATH,
+           pi.BUSINESS_ID,
            pd.NAME        AS PROCESS_DEFINITION_NAME,
            pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG,
            pit.TAG_VALUE AS TAG_VALUE
@@ -66,6 +67,7 @@
     pif.PARENT_ELEMENT_INSTANCE_KEY,
     pif.PROCESS_DEFINITION_VERSION,
     pif.TREE_PATH,
+    pif.BUSINESS_ID,
     pif.PROCESS_DEFINITION_NAME,
     pif.PROCESS_DEFINITION_VERSION_TAG,
     pit.TAG_VALUE AS TAG_VALUE
@@ -88,6 +90,7 @@
     pi.PARENT_ELEMENT_INSTANCE_KEY,
     pi.VERSION PROCESS_DEFINITION_VERSION,
     pi.TREE_PATH,
+    pi.BUSINESS_ID,
     pd.NAME AS PROCESS_DEFINITION_NAME,
     pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
     FROM ${prefix}PROCESS_INSTANCE pi
@@ -366,6 +369,7 @@
       <arg column="HAS_INCIDENT" javaType="java.lang.Boolean"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
       <arg column="TREE_PATH" javaType="java.lang.String"/>
+      <arg column="BUSINESS_ID" javaType="java.lang.String"/>
     </constructor>
     <collection property="tags" ofType="java.lang.String" javaType="java.util.Set">
       <id column="TAG_VALUE"/>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -402,12 +402,12 @@
                                            TENANT_ID, PARENT_PROCESS_INSTANCE_KEY,
                                            PARENT_ELEMENT_INSTANCE_KEY,
                                            NUM_INCIDENTS, VERSION, PARTITION_ID, TREE_PATH,
-                                           HISTORY_CLEANUP_DATE)
+                                           HISTORY_CLEANUP_DATE, BUSINESS_ID)
     VALUES (#{processInstanceKey}, #{rootProcessInstanceKey}, #{processDefinitionId}, #{processDefinitionKey}, #{state},
             #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId},
             #{parentProcessInstanceKey},
             #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId}, #{treePath},
-            #{historyCleanupDate, jdbcType=TIMESTAMP})
+            #{historyCleanupDate, jdbcType=TIMESTAMP}, #{businessId})
   </insert>
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel">
@@ -423,7 +423,8 @@
         NUM_INCIDENTS               = #{numIncidents},
         VERSION                     = #{version},
         TREE_PATH                   = #{treePath},
-        HISTORY_CLEANUP_DATE        = #{historyCleanupDate, jdbcType=TIMESTAMP}
+        HISTORY_CLEANUP_DATE        = #{historyCleanupDate, jdbcType=TIMESTAMP},
+        BUSINESS_ID                 = #{businessId}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -747,7 +747,7 @@ public final class SearchQueryResponseMapper {
         .hasIncident(p.hasIncident())
         .tenantId(p.tenantId())
         .tags(p.tags())
-        .businessId(p.businessId());
+        .businessId(emptyToNull(p.businessId()));
   }
 
   public static List<BatchOperationResponse> toBatchOperations(
@@ -1650,6 +1650,10 @@ public final class SearchQueryResponseMapper {
       return Optional.empty();
     }
     return Optional.of(value);
+  }
+
+  private static String emptyToNull(final String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 
   private record RuleIdentifier(String ruleId, int ruleIndex) {}

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -746,7 +746,8 @@ public final class SearchQueryResponseMapper {
         .state(toProtocolState(p.state()))
         .hasIncident(p.hasIncident())
         .tenantId(p.tenantId())
-        .tags(p.tags());
+        .tags(p.tags())
+        .businessId(p.businessId());
   }
 
   public static List<BatchOperationResponse> toBatchOperations(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -119,7 +119,8 @@ class SearchQueryResponseMapperTest {
             ProcessInstanceState.ACTIVE, // state
             false, // hasIncident
             "tenant", // tenantId
-            null); // treePath
+            null, // treePath
+            null); // businessId
 
     // when
     final var response = SearchQueryResponseMapper.toProcessInstance(entity);
@@ -147,7 +148,8 @@ class SearchQueryResponseMapperTest {
             ProcessInstanceState.ACTIVE, // state
             false, // hasIncident
             "tenant", // tenantId
-            null); // treePath
+            null, // treePath
+            null); // businessId
 
     // when
     final var response = SearchQueryResponseMapper.toProcessInstance(entity);

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -86,7 +86,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
           false,
           "tenant",
           "PI_123",
-          Set.of("tag1", "tag2"));
+          Set.of("tag1", "tag2"),
+          null);
 
   static final SearchQueryResult<ProcessInstanceEntity> SEARCH_QUERY_RESULT =
       new Builder<ProcessInstanceEntity>()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
@@ -160,11 +160,23 @@ public class ProcessInstanceCreateIT {
     assertThat(processInstanceCreation.getTenantId()).isEqualTo(process.getTenantId());
     assertThat(processInstanceCreation.getBusinessId()).isEqualTo(BUSINESS_ID);
 
-    // we are not checking the business id in the process instance result as it is not supported in
-    // fetching the process instance result yet.
-    // FIXME add assertion for business id in the process instance result once visibility of
-    // business id in the process instance result is supported.
-    // https://github.com/camunda/product-hub/issues/3436
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceCreation.getProcessInstanceKey()),
+        f -> assertThat(f).hasSize(1));
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceGetRequest(processInstanceCreation.getProcessInstanceKey())
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessInstanceKey())
+        .isEqualTo(processInstanceCreation.getProcessInstanceKey());
+    assertThat(result.getBusinessId()).isEqualTo(BUSINESS_ID);
   }
 
   @Test
@@ -193,10 +205,22 @@ public class ProcessInstanceCreateIT {
     assertThat(processInstanceCreation.getVariablesAsMap()).isEqualTo(variables);
     assertThat(processInstanceCreation.getBusinessId()).isEqualTo(BUSINESS_ID + "-with-result");
 
-    // we are not checking the business id in the process instance result as it is not supported in
-    // fetching the process instance result yet.
-    // FIXME add assertion for business id in the process instance result once visibility of
-    // business id in the process instance result is supported.
-    // https://github.com/camunda/product-hub/issues/3436
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceCreation.getProcessInstanceKey()),
+        f -> assertThat(f).hasSize(1));
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceGetRequest(processInstanceCreation.getProcessInstanceKey())
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessInstanceKey())
+        .isEqualTo(processInstanceCreation.getProcessInstanceKey());
+    assertThat(result.getBusinessId()).isEqualTo(BUSINESS_ID + "-with-result");
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
@@ -34,7 +34,11 @@ public class ProcessInstanceEntityTransformer
         source.getTenantId(),
         source.getTreePath(),
         source.getTags(),
-        source.getBusinessId());
+        emptyToNull(source.getBusinessId()));
+  }
+
+  private static String emptyToNull(final String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 
   private ProcessInstanceState toState(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
@@ -33,7 +33,8 @@ public class ProcessInstanceEntityTransformer
         source.isIncident(),
         source.getTenantId(),
         source.getTreePath(),
-        source.getTags());
+        source.getTags(),
+        source.getBusinessId());
   }
 
   private ProcessInstanceState toState(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -29,7 +29,8 @@ public record ProcessInstanceEntity(
     Boolean hasIncident,
     String tenantId,
     String treePath,
-    Set<String> tags)
+    Set<String> tags,
+    String businessId)
     implements TenantOwnedEntity {
 
   public ProcessInstanceEntity {
@@ -54,7 +55,8 @@ public record ProcessInstanceEntity(
       final ProcessInstanceState state,
       final Boolean hasIncident,
       final String tenantId,
-      final String treePath) {
+      final String treePath,
+      final String businessId) {
 
     this(
         processInstanceKey,
@@ -72,7 +74,8 @@ public record ProcessInstanceEntity(
         hasIncident,
         tenantId,
         treePath,
-        null);
+        null,
+        businessId);
   }
 
   public enum ProcessInstanceState {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
@@ -40,6 +40,7 @@ public class ProcessInstanceBuilder implements ProcessInstance {
   private Boolean hasIncident;
   private String tenantId;
   private Set<String> tags;
+  private String businessId;
 
   @Override
   public Long getProcessInstanceKey() {
@@ -114,6 +115,16 @@ public class ProcessInstanceBuilder implements ProcessInstance {
   @Override
   public Set<String> getTags() {
     return tags;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  public ProcessInstanceBuilder setBusinessId(final String businessId) {
+    this.businessId = businessId;
+    return this;
   }
 
   public ProcessInstanceBuilder setTags(final Set<String> tags) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/ListViewTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/ListViewTemplate.java
@@ -58,6 +58,7 @@ public class ListViewTemplate extends AbstractTemplateDescriptor implements Prio
   public static final String VARIABLES_JOIN_RELATION = "variable";
   public static final String TAGS = "tags";
   public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
+  public static final String BUSINESS_ID = "businessId";
 
   public ListViewTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
@@ -64,6 +64,11 @@ public class ProcessInstanceForListViewEntity
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long rootProcessInstanceKey;
 
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String businessId;
+
   @JsonIgnore private Object[] sortValues;
 
   @Override
@@ -282,6 +287,15 @@ public class ProcessInstanceForListViewEntity
     return this;
   }
 
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  public ProcessInstanceForListViewEntity setBusinessId(final String businessId) {
+    this.businessId = businessId;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -305,7 +319,8 @@ public class ProcessInstanceForListViewEntity
         joinRelation,
         position,
         tags,
-        rootProcessInstanceKey);
+        rootProcessInstanceKey,
+        businessId);
   }
 
   @Override
@@ -337,6 +352,7 @@ public class ProcessInstanceForListViewEntity
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(joinRelation, that.joinRelation)
         && Objects.equals(position, that.position)
-        && Objects.equals(tags, that.tags);
+        && Objects.equals(tags, that.tags)
+        && Objects.equals(businessId, that.businessId);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -145,6 +145,9 @@
       },
       "rootProcessInstanceKey": {
         "type": "long"
+      },
+      "businessId": {
+        "type": "keyword"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
@@ -146,6 +146,9 @@
       },
       "rootProcessInstanceKey": {
         "type": "long"
+      },
+      "businessId": {
+        "type": "keyword"
       }
 		}
 	}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -339,7 +339,8 @@ abstract class AbstractBatchOperationTest {
         false,
         null,
         null,
-        Set.of());
+        Set.of(),
+        null);
   }
 
   protected IncidentEntity fakeIncidentEntity(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -1561,7 +1561,8 @@ public class ResourceDeletionTest {
         false,
         null,
         null,
-        Set.of());
+        Set.of(),
+        null);
   }
 
   private DecisionInstanceEntity createDecisionInstanceEntity(final long decisionInstanceKey) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -108,7 +108,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
         .setProcessVersion(recordValue.getVersion())
         .setProcessName(
             getProcessName(piEntity.getProcessDefinitionKey(), recordValue.getBpmnProcessId()))
-        .setProcessVersionTag(getVersionTag(piEntity.getProcessDefinitionKey()));
+        .setProcessVersionTag(getVersionTag(piEntity.getProcessDefinitionKey()))
+        .setBusinessId(recordValue.getBusinessId());
 
     if (recordValue.getTags() != null && recordValue.getTags().size() > 0) {
       piEntity.setTags(recordValue.getTags());
@@ -179,6 +180,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     }
     if (entity.getTags() != null && !entity.getTags().isEmpty()) {
       updateFields.put(ListViewTemplate.TAGS, entity.getTags());
+    }
+    if (entity.getBusinessId() != null && !entity.getBusinessId().isEmpty()) {
+      updateFields.put(ListViewTemplate.BUSINESS_ID, entity.getBusinessId());
     }
 
     batchRequest.upsert(indexName, entity.getId(), entity, updateFields);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -109,7 +109,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
         .setProcessName(
             getProcessName(piEntity.getProcessDefinitionKey(), recordValue.getBpmnProcessId()))
         .setProcessVersionTag(getVersionTag(piEntity.getProcessDefinitionKey()))
-        .setBusinessId(recordValue.getBusinessId());
+        .setBusinessId(emptyToNull(recordValue.getBusinessId()));
 
     if (recordValue.getTags() != null && recordValue.getTags().size() > 0) {
       piEntity.setTags(recordValue.getTags());
@@ -278,5 +278,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       treePath.appendFlowNodeInstance(String.valueOf(keysWithinOnePI.getLast()));
     }
     return treePath;
+  }
+
+  private static String emptyToNull(final String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -306,6 +306,30 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
   }
 
   @Test
+  void shouldMapEmptyBusinessIdToNull() {
+    // given
+    final ProcessInstanceRecordValue processInstanceRecordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.PROCESS)
+            .withElementInstancePath(List.of(List.of(111L)))
+            .withProcessDefinitionPath(List.of(222L))
+            .withBusinessId("")
+            .build();
+    final Record<ProcessInstanceRecordValue> processInstanceRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r -> r.withIntent(ELEMENT_ACTIVATING).withValue(processInstanceRecordValue));
+
+    // when
+    final ProcessInstanceForListViewEntity entity = new ProcessInstanceForListViewEntity();
+    underTest.updateEntity(processInstanceRecord, entity);
+
+    // then
+    assertThat(entity.getBusinessId()).isNull();
+  }
+
+  @Test
   public void shouldUpdateTreePathFromRecordWithCallActivity() {
     // given
     final long processDefinitionKey1 = 999L;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -168,7 +168,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setEndDate(OffsetDateTime.now())
             .setState(ProcessInstanceState.ACTIVE)
             .setTreePath("PI_111")
-            .setTags(Set.of("businessKey:123", "priority:high"));
+            .setTags(Set.of("businessKey:123", "priority:high"))
+            .setBusinessId("my-business-id");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
@@ -182,6 +183,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(ListViewTemplate.START_DATE, inputEntity.getStartDate());
     expectedUpdateFields.put(ListViewTemplate.END_DATE, inputEntity.getEndDate());
     expectedUpdateFields.put(ListViewTemplate.TAGS, inputEntity.getTags());
+    expectedUpdateFields.put(ListViewTemplate.BUSINESS_ID, "my-business-id");
     expectedUpdateFields.put(PARTITION_ID, 12);
     expectedUpdateFields.put(POSITION, 123L);
 
@@ -294,6 +296,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     assertThat(processInstanceForListViewEntity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(processInstanceRecordValue.getRootProcessInstanceKey());
+    assertThat(processInstanceForListViewEntity.getBusinessId())
+        .isEqualTo(processInstanceRecordValue.getBusinessId());
 
     // process name and version tag is read from the cache
     assertThat(processInstanceForListViewEntity.getProcessName()).isEqualTo("test-process-name");

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -108,6 +108,7 @@ public class ProcessInstanceExportHandler
         .partitionId(record.getPartitionId())
         .treePath(createTreePath(record).toTruncatedString())
         .tags(value.getTags())
+        .businessId(value.getBusinessId())
         .build();
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -108,7 +108,7 @@ public class ProcessInstanceExportHandler
         .partitionId(record.getPartitionId())
         .treePath(createTreePath(record).toTruncatedString())
         .tags(value.getTags())
-        .businessId(value.getBusinessId())
+        .businessId(emptyToNull(value.getBusinessId()))
         .build();
   }
 
@@ -155,5 +155,9 @@ public class ProcessInstanceExportHandler
       treePath.appendFlowNodeInstance(String.valueOf(keysWithinOnePI.getLast()));
     }
     return treePath;
+  }
+
+  private static String emptyToNull(final String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandlerTest.java
@@ -193,6 +193,24 @@ class ProcessInstanceExportHandlerTest {
     }
   }
 
+  @Test
+  void shouldMapEmptyBusinessIdToNullOnCreate() {
+    // given
+    final var record =
+        TestRecordFactory.rootProcessWithBusinessId(ProcessInstanceIntent.ELEMENT_ACTIVATING, "");
+    try (final var mocked = Mockito.mockStatic(ProcessCacheUtil.class)) {
+      mocked
+          .when(() -> ProcessCacheUtil.getCallActivityIds(any(), any()))
+          .thenReturn(List.of(List.of(100L)));
+      // when
+      handler.export(record);
+      // then
+      final var captor = ArgumentCaptor.forClass(ProcessInstanceDbModel.class);
+      verify(processInstanceWriter).create(captor.capture());
+      assertThat(captor.getValue().businessId()).isNull();
+    }
+  }
+
   // Helper factory for test records
   static class TestRecordFactory {
     static Record<ProcessInstanceRecordValue> simpleProcess() {

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandlerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
 import io.camunda.exporter.rdbms.utils.TreePath;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class ProcessInstanceExportHandlerTest {
@@ -154,6 +156,43 @@ class ProcessInstanceExportHandlerTest {
     verifyNoInteractions(historyCleanupService);
   }
 
+  @Test
+  void shouldMapBusinessIdOnCreate() {
+    // given
+    final var record =
+        TestRecordFactory.rootProcessWithBusinessId(
+            ProcessInstanceIntent.ELEMENT_ACTIVATING, "my-business-id");
+    try (final var mocked = Mockito.mockStatic(ProcessCacheUtil.class)) {
+      mocked
+          .when(() -> ProcessCacheUtil.getCallActivityIds(any(), any()))
+          .thenReturn(List.of(List.of(100L)));
+      // when
+      handler.export(record);
+      // then
+      final var captor = ArgumentCaptor.forClass(ProcessInstanceDbModel.class);
+      verify(processInstanceWriter).create(captor.capture());
+      assertThat(captor.getValue().businessId()).isEqualTo("my-business-id");
+    }
+  }
+
+  @Test
+  void shouldMapNullBusinessIdOnCreate() {
+    // given
+    final var record =
+        TestRecordFactory.rootProcessWithBusinessId(ProcessInstanceIntent.ELEMENT_ACTIVATING, null);
+    try (final var mocked = Mockito.mockStatic(ProcessCacheUtil.class)) {
+      mocked
+          .when(() -> ProcessCacheUtil.getCallActivityIds(any(), any()))
+          .thenReturn(List.of(List.of(100L)));
+      // when
+      handler.export(record);
+      // then
+      final var captor = ArgumentCaptor.forClass(ProcessInstanceDbModel.class);
+      verify(processInstanceWriter).create(captor.capture());
+      assertThat(captor.getValue().businessId()).isNull();
+    }
+  }
+
   // Helper factory for test records
   static class TestRecordFactory {
     static Record<ProcessInstanceRecordValue> simpleProcess() {
@@ -161,12 +200,18 @@ class ProcessInstanceExportHandlerTest {
     }
 
     static Record<ProcessInstanceRecordValue> rootProcess(final ProcessInstanceIntent intent) {
+      return rootProcessWithBusinessId(intent, null);
+    }
+
+    static Record<ProcessInstanceRecordValue> rootProcessWithBusinessId(
+        final ProcessInstanceIntent intent, final String businessId) {
       final var value = mock(ProcessInstanceRecordValue.class);
       when(value.getElementInstancePath()).thenReturn(List.of(List.of(1L)));
       when(value.getProcessDefinitionPath()).thenReturn(List.of(10L));
       when(value.getCallingElementPath()).thenReturn(List.of(0));
       when(value.getProcessInstanceKey()).thenReturn(ROOT_PROCESS_INSTANCE_KEY);
       when(value.getRootProcessInstanceKey()).thenReturn(ROOT_PROCESS_INSTANCE_KEY);
+      when(value.getBusinessId()).thenReturn(businessId);
       return mockRecord(value, intent);
     }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1213,6 +1213,7 @@ components:
         - parentElementInstanceKey
         - rootProcessInstanceKey
         - tags
+        - businessId
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
@@ -1272,6 +1273,11 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+        businessId:
+          description: The business id associated with this process instance.
+          nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
 
     CancelProcessInstanceRequest:
       type: object

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -89,7 +89,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           false,
           "tenant",
           "PI_123",
-          Set.of("tag1", "tag2"));
+          Set.of("tag1", "tag2"),
+          "biz-id");
   private static final String PROCESS_INSTANCE_ENTITY_JSON =
       """
             {
@@ -107,7 +108,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             "state": "ACTIVE",
             "hasIncident": false,
             "tenantId": "tenant",
-            "tags": ["tag1", "tag2"]
+            "tags": ["tag1", "tag2"],
+            "businessId": "biz-id"
           }
           """;
   private static final String EXPECTED_SEARCH_RESPONSE =
@@ -129,7 +131,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                   "state": "ACTIVE",
                   "hasIncident": false,
                   "tenantId": "tenant",
-                  "tags": ["tag1", "tag2"]
+                  "tags": ["tag1", "tag2"],
+                  "businessId": "biz-id"
                 }
               ],
               "page": {
@@ -654,6 +657,67 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
 
     // Verify that the service was called with the valid key
     verify(processInstanceServices).getByKey(validProcesInstanceKey);
+  }
+
+  @Test
+  public void shouldReturnProcessInstanceWithNullBusinessId() {
+    // given
+    final var processInstanceKey = 456L;
+    final var entityWithNullBusinessId =
+        new ProcessInstanceEntity(
+            processInstanceKey,
+            processInstanceKey,
+            "demoProcess",
+            "Demo Process",
+            1,
+            null,
+            789L,
+            null,
+            null,
+            OffsetDateTime.parse("2024-01-01T00:00:00Z"),
+            null,
+            ProcessInstanceState.ACTIVE,
+            false,
+            "tenant",
+            "PI_456",
+            null,
+            null);
+    when(processInstanceServices.getByKey(processInstanceKey)).thenReturn(entityWithNullBusinessId);
+
+    final var expectedJson =
+        """
+            {
+              "processInstanceKey": "456",
+              "rootProcessInstanceKey": "456",
+              "processDefinitionId": "demoProcess",
+              "processDefinitionName": "Demo Process",
+              "processDefinitionVersion": 1,
+              "processDefinitionVersionTag": null,
+              "processDefinitionKey": "789",
+              "parentProcessInstanceKey": null,
+              "parentElementInstanceKey": null,
+              "startDate": "2024-01-01T00:00:00.000Z",
+              "endDate": null,
+              "state": "ACTIVE",
+              "hasIncident": false,
+              "tenantId": "tenant",
+              "tags": [],
+              "businessId": null
+            }
+            """;
+
+    // when / then
+    webClient
+        .get()
+        .uri(PROCESS_INSTANCES_BY_KEY_URL, processInstanceKey)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .consumeWith(result -> assertJsonNonExtensible(expectedJson, result.getResponseBody()));
+
+    verify(processInstanceServices).getByKey(processInstanceKey);
   }
 
   @Test


### PR DESCRIPTION
## Description

Persist the `businessId` associated with process instances into secondary storage, enabling the C8 API to return it in `get` and `search` process instance responses.

### What was done

1. **Schema & index changes** – Added `businessId` as a `keyword` field to the process instance list-view entity and index templates for both Elasticsearch and OpenSearch.
2. **Camunda Exporter** – Wired `businessId` from `ProcessInstanceRecordValue` into the list-view entity during export.
3. **RDBMS Exporter** – Added `businessId` to the RDBMS schema, model, and exporter mapping.
4. **API response mapping** – `businessId` is now returned in `get` and `search` process instance responses.
5. **Empty-to-null conversion** – The engine produces an empty string when no business id is set, but the API schema requires `minLength=1`. Empty strings are converted to `null` at write time in both exporters and defensively at read time in the entity transformer and response mapper to handle pre-existing data.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45298
