### PR TITLE
[Backport stable/8.9] refactor: set correct entity keys for PI creation and decision evaluation

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
@@ -11,9 +11,6 @@ import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
-import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
-import java.util.List;
-import java.util.Optional;
 
 public class DecisionEvaluationAuditLogTransformer
     implements AuditLogTransformer<DecisionEvaluationRecordValue> {
@@ -30,13 +27,21 @@ public class DecisionEvaluationAuditLogTransformer
     log.setDecisionDefinitionId(value.getDecisionId())
         .setDecisionDefinitionKey(value.getDecisionKey())
         .setDecisionRequirementsId(value.getDecisionRequirementsId())
-        .setDecisionRequirementsKey(value.getDecisionRequirementsKey())
-        .setDecisionEvaluationKey(
-            Optional.ofNullable(value.getEvaluatedDecisions())
-                .filter(list -> !list.isEmpty())
-                .map(List::getFirst)
-                .map(EvaluatedDecisionValue::getDecisionKey)
-                .orElse(null));
+        .setDecisionRequirementsKey(value.getDecisionRequirementsKey());
+
+    if (value.getEvaluatedDecisions() != null) {
+      value.getEvaluatedDecisions().stream()
+          .filter(
+              ed ->
+                  ed.getDecisionEvaluationInstanceKey() != null
+                      && !ed.getDecisionEvaluationInstanceKey().isEmpty())
+          .findFirst()
+          .ifPresent(
+              ed ->
+                  log.setEntityKey(ed.getDecisionEvaluationInstanceKey())
+                      .setDecisionEvaluationKey(ed.getDecisionKey()));
+    }
+
     if (record.getIntent() == DecisionEvaluationIntent.FAILED) {
       log.setEntityDescription(record.getRejectionType().name());
       log.setResult(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
@@ -22,7 +22,9 @@ public class ProcessInstanceCreationAuditLogTransformer
   @Override
   public void transform(
       final Record<ProcessInstanceCreationRecordValue> record, final AuditLogEntry log) {
-    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    final var value = record.getValue();
+    log.setEntityKey(String.valueOf(value.getProcessInstanceKey()));
+    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);
     }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
@@ -82,6 +82,7 @@ class DecisionEvaluationAuditLogTransformerTest {
 
     // then
     assertThat(entity.getDecisionEvaluationKey()).isNull();
+    assertThat(entity.getEntityKey()).isEqualTo(String.valueOf(record.getKey()));
   }
 
   @Test
@@ -106,6 +107,7 @@ class DecisionEvaluationAuditLogTransformerTest {
 
     // then
     assertThat(entity.getDecisionEvaluationKey()).isNull();
+    assertThat(entity.getEntityKey()).isEqualTo(String.valueOf(record.getKey()));
   }
 
   @Test
@@ -115,6 +117,7 @@ class DecisionEvaluationAuditLogTransformerTest {
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
             .withDecisionKey(999L)
+            .withDecisionEvaluationInstanceKey("999-1")
             .build();
 
     final DecisionEvaluationRecordValue recordValue =
@@ -136,6 +139,7 @@ class DecisionEvaluationAuditLogTransformerTest {
 
     // then
     assertThat(entity.getDecisionEvaluationKey()).isEqualTo(999L);
+    assertThat(entity.getEntityKey()).isEqualTo("999-1");
   }
 
   @Test
@@ -145,18 +149,21 @@ class DecisionEvaluationAuditLogTransformerTest {
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
             .withDecisionKey(111L)
+            .withDecisionEvaluationInstanceKey("111-1")
             .build();
 
     final ImmutableEvaluatedDecisionValue secondDecision =
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
             .withDecisionKey(222L)
+            .withDecisionEvaluationInstanceKey("222-1")
             .build();
 
     final ImmutableEvaluatedDecisionValue thirdDecision =
         ImmutableEvaluatedDecisionValue.builder()
             .from(factory.generateObject(EvaluatedDecisionValue.class))
             .withDecisionKey(333L)
+            .withDecisionEvaluationInstanceKey("333-1")
             .build();
 
     final DecisionEvaluationRecordValue recordValue =
@@ -178,6 +185,78 @@ class DecisionEvaluationAuditLogTransformerTest {
 
     // then
     assertThat(entity.getDecisionEvaluationKey()).isEqualTo(111L);
+    assertThat(entity.getEntityKey()).isEqualTo("111-1");
+  }
+
+  @Test
+  void shouldHandleEmptyDecisionEvaluationInstanceKey() {
+    // given
+    final ImmutableEvaluatedDecisionValue evaluatedDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(999L)
+            .withDecisionEvaluationInstanceKey("")
+            .build();
+
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withEvaluatedDecisions(List.of(evaluatedDecision))
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final var entity = AuditLogEntry.of(record);
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionEvaluationKey()).isNull();
+    assertThat(entity.getEntityKey()).isEqualTo(String.valueOf(record.getKey()));
+  }
+
+  @Test
+  void shouldTakeFirstDecisionEvaluationWithNonEmptyInstanceKey() {
+    // given
+    final ImmutableEvaluatedDecisionValue firstEvaluatedDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(777L)
+            .withDecisionEvaluationInstanceKey("")
+            .build();
+
+    final ImmutableEvaluatedDecisionValue secondEvaluatedDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(888L)
+            .withDecisionEvaluationInstanceKey("111-2")
+            .build();
+
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withEvaluatedDecisions(List.of(firstEvaluatedDecision, secondEvaluatedDecision))
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final var entity = AuditLogEntry.of(record);
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionEvaluationKey()).isEqualTo(888L);
+    assertThat(entity.getEntityKey()).isEqualTo("111-2");
   }
 
   @Test

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreatedAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreatedAuditLogTransformerTest.java
@@ -50,6 +50,7 @@ class ProcessInstanceCreatedAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(456L);
     assertThat(entity.getProcessDefinitionId()).isEqualTo("test-process");
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
+    assertThat(entity.getEntityKey()).isEqualTo("123");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()


### PR DESCRIPTION
# Description
Backport of #46935 to `stable/8.9`.

relates to camunda/camunda#46934