### PR TITLE
ci: allow Unified CI jobs to take up to 30min runtime

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -21,9 +21,9 @@ warn[msg] {
     # only enforced on workflows that opted-in
     input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
-    count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
+    count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 30)) > 0
 
-    msg := sprintf("There are GitHub Actions jobs with too high (>15) timeout-minutes! Affected job IDs: %s",
+    msg := sprintf("There are GitHub Actions jobs with too high (>30) timeout-minutes! Affected job IDs: %s",
         [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 15))])
 }
 

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -24,7 +24,7 @@ warn[msg] {
     count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 30)) > 0
 
     msg := sprintf("There are GitHub Actions jobs with too high (>30) timeout-minutes! Affected job IDs: %s",
-        [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 15))])
+        [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 30))])
 }
 
 deny[msg] {

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -63,7 +63,7 @@ jobs:
     name: "Unit - Front End"
     if: inputs.runFeTests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     defaults:
       run:

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -295,7 +295,7 @@ jobs:
   run-backup-restore-tests:
     if: inputs.runBeTests
     name: "Integration / Backup Restore ITs"
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
@@ -371,7 +371,7 @@ jobs:
     # Currently only runs Tasklist Docker tests but should be extended in future to also include backend tests
     name: "Integration / Docker ITs"
     runs-on: gcp-core-4-default
-    timeout-minutes: 25
+    timeout-minutes: 30
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Integration

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -181,7 +181,7 @@ jobs:
   performance-tests:
     name: "Performance"
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"
@@ -252,7 +252,7 @@ jobs:
     # Zeebe tests requiring strace
     name: "Unit - Strace Tests"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       TEST_OWNER: Core Features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     name: "Lint / Commitlint"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - name: Determine fetch depth for checkout
@@ -143,7 +143,7 @@ jobs:
     name: "Lint / Maven Spotless"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v6
@@ -168,7 +168,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "Java Checks"
     needs: [ detect-changes ]
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
     steps:
@@ -195,7 +195,7 @@ jobs:
     if: needs.detect-changes.outputs.frontend-changes == 'true'
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v6
@@ -256,7 +256,7 @@ jobs:
       # IT Engine = ZEEBE_CORE_FEATURES_MODULES + ZEEBE_PROTOCOL_MODULES + ZEEBE_GATEWAY_MODULES + ZEEBE_CLIENT_MODULES (explicit list)
       ZEEBE_IT_ENGINE_MODULES: ${{ steps.set-constants.outputs.it_engine }}
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     permissions: { }
     steps:
       - name: Set all test constants
@@ -323,7 +323,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "General / Unit - Back End"
     needs: [ detect-changes, setup-tests ]
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     outputs:
@@ -389,7 +389,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "Zeebe / Unit - ${{matrix.component}}"
     needs: [ detect-changes, setup-tests ]
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     outputs:
@@ -561,7 +561,7 @@ jobs:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS ITs"
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: gcp-perf-core-8-default
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
@@ -870,7 +870,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "General / Unit - ArchUnit"
     needs: [ detect-changes ]
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     env:
@@ -1129,7 +1129,7 @@ jobs:
     name: "Identity / Unit - Front End"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -1272,7 +1272,7 @@ jobs:
     if: needs.detect-changes.outputs.openapi-changes == 'true'
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       # renovate: datasource=npm depName=@stoplight/spectral-cli
@@ -1321,7 +1321,7 @@ jobs:
     name: "Lint / Renovate Config Validator"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Reliability is favored over speed, to avoid near-misses. We track runtime SLOs independently. See exact background in https://github.com/camunda/camunda/issues/46679

Utility jobs are set to 5-10mins in this PR, since runtime growth is unlikely.

Unit test jobs are set to 10-20mins in this PR, since runtime growth is expected.

Integration test jobs are set to 20-30mins in this PR, since their runtime fluctuates the most and "near misses" are very likely.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Closes #46679
