### PR TITLE
[Backport stable/8.9] Track job completed operations in the audit log

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
@@ -23,6 +23,7 @@ const auditLogEntityTypeSchema = z.enum([
 	'DECISION',
 	'GROUP',
 	'INCIDENT',
+	'JOB',
 	'MAPPING_RULE',
 	'PROCESS_INSTANCE',
 	'ROLE',

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AuditLogEntityTypeEnum.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AuditLogEntityTypeEnum.java
@@ -21,6 +21,7 @@ public enum AuditLogEntityTypeEnum {
   DECISION,
   GROUP,
   INCIDENT,
+  JOB,
   MAPPING_RULE,
   PROCESS_INSTANCE,
   ROLE,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAgentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAgentIT.java
@@ -71,7 +71,7 @@ public class AuditLogAgentIT {
         .join();
 
     // Wait for audit logs to be available
-    Awaitility.await("process instance to be completed")
+    Awaitility.await("job to be completed")
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -80,13 +80,12 @@ public class AuditLogAgentIT {
                       .newAuditLogSearchRequest()
                       .filter(
                           f ->
-                              f.operationType(AuditLogOperationTypeEnum.CREATE)
-                                  .entityType(AuditLogEntityTypeEnum.VARIABLE))
+                              f.operationType(AuditLogOperationTypeEnum.COMPLETE)
+                                  .entityType(AuditLogEntityTypeEnum.JOB))
                       .send()
                       .join();
 
-              // first is the internal adhoc subprocess variable, second is the job variable
-              assertThat(result.items()).hasSizeGreaterThan(1);
+              assertThat(result.items()).hasSize(1);
             });
   }
 
@@ -97,7 +96,7 @@ public class AuditLogAgentIT {
     final var result =
         client
             .newAuditLogSearchRequest()
-            .filter(f -> f.entityType(AuditLogEntityTypeEnum.VARIABLE))
+            .filter(f -> f.entityType(AuditLogEntityTypeEnum.JOB))
             .send()
             .join();
 
@@ -108,7 +107,8 @@ public class AuditLogAgentIT {
             auditLog -> {
               assertThat(auditLog.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
               assertThat(auditLog.getActorId()).isEqualTo(DEFAULT_USERNAME);
-              assertThat(auditLog.getEntityDescription()).isEqualTo("testVar");
+              assertThat(auditLog.getEntityDescription())
+                  .isEqualTo(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX);
               assertThat(auditLog.getAgentElementId()).isEqualTo(AGENT_ELEMENT_ID);
             });
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -12,6 +12,7 @@ import static io.camunda.it.auditlog.AuditLogUtils.TENANT_A;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForDecisionsToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitForJobs;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
@@ -23,6 +24,7 @@ import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.AuditLogActorTypeEnum;
+import io.camunda.client.api.search.enums.AuditLogCategoryEnum;
 import io.camunda.client.api.search.enums.AuditLogEntityTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogResultEnum;
@@ -30,6 +32,7 @@ import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.filter.AuditLogFilter;
 import io.camunda.client.api.search.response.AuditLogResult;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.Job;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
@@ -336,6 +339,41 @@ public class AuditLogProcessOperationsIT {
         processInstance.getProcessDefinitionKey(),
         SERVICE_TASKS_PROCESS_ID,
         "existingVar");
+  }
+
+  // ========================================================================================
+  // Job Tests
+  // ========================================================================================
+
+  @Test
+  void shouldTrackJobCompleted(@Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // given - start a process that creates a job
+    final var processInstance = createProcessInstance(client, SERVICE_TASKS_PROCESS_ID);
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+
+    waitForProcessInstancesToStart(
+        client, f -> f.processInstanceKey(processInstanceKey).tenantId(TENANT_A), 1);
+
+    // Get the job key
+    final var jobs = waitForJobs(client, List.of(processInstanceKey));
+
+    // when - complete the job
+    jobs.forEach(
+        job -> {
+          client.newCompleteCommand(job.getJobKey()).send().join();
+
+          // then - wait for audit log entry and verify
+          final var auditLogItems =
+              awaitAuditLogEntry(
+                  client,
+                  AuditLogEntityTypeEnum.JOB,
+                  AuditLogOperationTypeEnum.COMPLETE,
+                  String.valueOf(job.getJobKey()));
+          assertThat(auditLogItems)
+              .isNotEmpty()
+              .allMatch(
+                  auditLog -> assertJobAuditLog(auditLog, AuditLogOperationTypeEnum.COMPLETE, job));
+        });
   }
 
   // ========================================================================================
@@ -722,6 +760,36 @@ public class AuditLogProcessOperationsIT {
     assertThat(auditLog.getProcessDefinitionKey()).isEqualTo(String.valueOf(processDefinitionKey));
     assertThat(auditLog.getTenantId()).isEqualTo(TENANT_A);
     assertThat(auditLog.getProcessDefinitionId()).isEqualTo(processDefinitionId);
+  }
+
+  /**
+   * Asserts common audit log fields for job operations.
+   *
+   * @param auditLog the audit log to verify
+   * @param operationType the expected operation type
+   * @param job the expected job
+   */
+  private boolean assertJobAuditLog(
+      final AuditLogResult auditLog, final AuditLogOperationTypeEnum operationType, final Job job) {
+    final var jobKey = job.getJobKey();
+    assertCommonAuditLogFields(auditLog, AuditLogEntityTypeEnum.JOB, operationType);
+    assertThat(auditLog.getCategory()).isEqualTo(AuditLogCategoryEnum.DEPLOYED_RESOURCES);
+    assertThat(auditLog.getEntityKey()).isEqualTo(String.valueOf(jobKey));
+    assertThat(auditLog.getEntityDescription()).isEqualTo(job.getType());
+    assertThat(auditLog.getJobKey()).isEqualTo(String.valueOf(jobKey));
+    assertThat(auditLog.getElementInstanceKey())
+        .isEqualTo(String.valueOf(job.getElementInstanceKey()));
+    assertThat(auditLog.getProcessInstanceKey())
+        .isEqualTo(String.valueOf(job.getProcessInstanceKey()));
+    assertThat(auditLog.getProcessDefinitionKey())
+        .isEqualTo(String.valueOf(job.getProcessDefinitionKey()));
+    assertThat(auditLog.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(job.getProcessDefinitionId()));
+    assertThat(auditLog.getRootProcessInstanceKey())
+        .isEqualTo(String.valueOf(job.getRootProcessInstanceKey()));
+    assertThat(auditLog.getTenantId()).isEqualTo(TENANT_A);
+
+    return true;
   }
 
   /**

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
@@ -317,6 +317,7 @@ public record AuditLogEntity(
     PROCESS_INSTANCE,
     VARIABLE,
     INCIDENT,
+    JOB,
     USER_TASK,
     DECISION,
     BATCH,

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntityType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntityType.java
@@ -12,6 +12,7 @@ public enum AuditLogEntityType {
   PROCESS_INSTANCE,
   VARIABLE,
   INCIDENT,
+  JOB,
   USER_TASK,
   DECISION,
   BATCH,

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
@@ -426,6 +426,7 @@ public class AuditLogEntry {
             .setProcessDefinitionKey(getProcessDefinitionKey(record))
             .setElementInstanceKey(getElementInstanceKey(record))
             .setProcessDefinitionId(getProcessDefinitionId(record))
+            .setRootProcessInstanceKey(getRootProcessInstanceKey(record))
             .setEntityVersion(record.getRecordVersion())
             .setEntityValueType(record.getValueType().value())
             .setEntityOperationIntent(record.getIntent().value())
@@ -462,6 +463,15 @@ public class AuditLogEntry {
     final var value = record.getValue();
     if (value instanceof AuditLogProcessInstanceRelated) {
       return ((AuditLogProcessInstanceRelated) value).getElementInstanceKey();
+    }
+    return null;
+  }
+
+  private static <R extends RecordValue> Long getRootProcessInstanceKey(final Record<R> record) {
+    final var value = record.getValue();
+    if (value instanceof AuditLogProcessInstanceRelated
+        && ((AuditLogProcessInstanceRelated) value).getRootProcessInstanceKey() > 0) {
+      return ((AuditLogProcessInstanceRelated) value).getRootProcessInstanceKey();
     }
     return null;
   }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -91,6 +92,9 @@ public record AuditLogInfo(
           // Incident
           Map.entry(IncidentIntent.RESOLVED, AuditLogOperationType.RESOLVE),
           Map.entry(IncidentIntent.RESOLVE, AuditLogOperationType.RESOLVE),
+
+          // Job
+          Map.entry(JobIntent.COMPLETED, AuditLogOperationType.COMPLETE),
 
           // MappingRule
           Map.entry(MappingRuleIntent.CREATED, AuditLogOperationType.CREATE),
@@ -162,6 +166,7 @@ public record AuditLogInfo(
           Map.entry(ValueType.DECISION, AuditLogOperationCategory.DEPLOYED_RESOURCES),
           Map.entry(ValueType.FORM, AuditLogOperationCategory.DEPLOYED_RESOURCES),
           Map.entry(ValueType.INCIDENT, AuditLogOperationCategory.DEPLOYED_RESOURCES),
+          Map.entry(ValueType.JOB, AuditLogOperationCategory.DEPLOYED_RESOURCES),
           Map.entry(
               ValueType.PROCESS_INSTANCE_CREATION, AuditLogOperationCategory.DEPLOYED_RESOURCES),
           Map.entry(
@@ -193,6 +198,7 @@ public record AuditLogInfo(
           Map.entry(ValueType.DECISION, AuditLogEntityType.DECISION),
           Map.entry(ValueType.DECISION_EVALUATION, AuditLogEntityType.DECISION),
           Map.entry(ValueType.DECISION_REQUIREMENTS, AuditLogEntityType.RESOURCE),
+          Map.entry(ValueType.JOB, AuditLogEntityType.JOB),
           Map.entry(ValueType.BATCH_OPERATION_CREATION, AuditLogEntityType.BATCH),
           Map.entry(ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, AuditLogEntityType.BATCH),
           Map.entry(ValueType.USER, AuditLogEntityType.USER),

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -105,6 +106,9 @@ public class AuditLogTransformerConfigs {
       TransformerConfig.with(ValueType.INCIDENT)
           .withIntents(IncidentIntent.RESOLVED)
           .withRejections(IncidentIntent.RESOLVE, RejectionType.INVALID_STATE);
+
+  public static final TransformerConfig JOB_CONFIG =
+      TransformerConfig.with(ValueType.JOB).withIntents(JobIntent.COMPLETED);
 
   public static final TransformerConfig MAPPING_RULE_CONFIG =
       TransformerConfig.with(MAPPING_RULE)

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerRegistry.java
@@ -105,6 +105,7 @@ public final class AuditLogTransformerRegistry {
         BatchOperationLifecycleManagementAuditLogTransformer::new,
         DecisionEvaluationAuditLogTransformer::new,
         IncidentResolutionAuditLogTransformer::new,
+        JobAuditLogTransformer::new,
         ProcessInstanceCancelAuditLogTransformer::new,
         ProcessInstanceCreationAuditLogTransformer::new,
         ProcessInstanceMigrationAuditLogTransformer::new,

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformer.java
@@ -23,9 +23,5 @@ public class IncidentResolutionAuditLogTransformer
   public void transform(final Record<IncidentRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setJobKey(value.getJobKey());
-    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/JobAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/JobAuditLogTransformer.java
@@ -21,12 +21,7 @@ public class JobAuditLogTransformer implements AuditLogTransformer<JobRecordValu
   @Override
   public void transform(final Record<JobRecordValue> record, final AuditLogEntry log) {
     log.setJobKey(record.getKey());
-
     final var value = record.getValue();
     log.setEntityDescription(value.getType());
-    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/JobAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/JobAuditLogTransformer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.auditlog.transformers;
+
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+
+public class JobAuditLogTransformer implements AuditLogTransformer<JobRecordValue> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.JOB_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<JobRecordValue> record, final AuditLogEntry log) {
+    log.setJobKey(record.getKey());
+
+    final var value = record.getValue();
+    log.setEntityDescription(value.getType());
+    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs.PROCESS_INSTANCE_CANCEL_CONFIG;
 
-import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 
 public class ProcessInstanceCancelAuditLogTransformer
@@ -19,13 +17,5 @@ public class ProcessInstanceCancelAuditLogTransformer
   @Override
   public TransformerConfig config() {
     return PROCESS_INSTANCE_CANCEL_CONFIG;
-  }
-
-  @Override
-  public void transform(final Record<ProcessInstanceRecordValue> record, final AuditLogEntry log) {
-    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
@@ -24,9 +24,5 @@ public class ProcessInstanceCreationAuditLogTransformer
       final Record<ProcessInstanceCreationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(String.valueOf(value.getProcessInstanceKey()));
-    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformer.java
@@ -26,9 +26,5 @@ public class ProcessInstanceMigrationAuditLogTransformer
       final Record<ProcessInstanceMigrationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setProcessDefinitionKey(value.getTargetProcessDefinitionKey());
-    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformer.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs.PROCESS_INSTANCE_MODIFICATION_CONFIG;
 
-import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 
 public class ProcessInstanceModificationAuditLogTransformer
@@ -19,14 +17,5 @@ public class ProcessInstanceModificationAuditLogTransformer
   @Override
   public TransformerConfig config() {
     return PROCESS_INSTANCE_MODIFICATION_CONFIG;
-  }
-
-  @Override
-  public void transform(
-      final Record<ProcessInstanceModificationRecordValue> record, final AuditLogEntry log) {
-    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
@@ -24,10 +24,6 @@ public class UserTaskAuditLogTransformer implements AuditLogTransformer<UserTask
   public void transform(final Record<UserTaskRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setUserTaskKey(value.getUserTaskKey()).setEntityKey(String.valueOf(value.getUserTaskKey()));
-    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
     if (record.getIntent() == UserTaskIntent.ASSIGNED) {
       log.setRelatedEntityKey(value.getAssignee());
       log.setRelatedEntityType(AuditLogEntityType.USER);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
@@ -22,10 +22,6 @@ public class VariableAddUpdateAuditLogTransformer
   @Override
   public void transform(final Record<VariableRecordValue> record, final AuditLogEntry log) {
     final VariableRecordValue value = record.getValue();
-    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
     log.setEntityDescription(value.getName());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntryTest.java
@@ -69,6 +69,7 @@ class AuditLogEntryTest {
     assertThat(entry.getProcessInstanceKey()).isEqualTo(value.getProcessInstanceKey());
     assertThat(entry.getProcessDefinitionId()).isEqualTo(value.getBpmnProcessId());
     assertThat(entry.getProcessDefinitionKey()).isEqualTo(value.getProcessDefinitionKey());
+    assertThat(entry.getRootProcessInstanceKey()).isEqualTo(value.getRootProcessInstanceKey());
     assertThat(entry.getEntityVersion()).isEqualTo(record.getRecordVersion());
     assertThat(entry.getEntityValueType())
         .isEqualTo(ValueType.PROCESS_INSTANCE_MODIFICATION.value());
@@ -93,7 +94,6 @@ class AuditLogEntryTest {
     assertThat(entry.getDeploymentKey()).isNull();
     assertThat(entry.getFormKey()).isNull();
     assertThat(entry.getResourceKey()).isNull();
-    assertThat(entry.getRootProcessInstanceKey()).isNull();
   }
 
   @Test

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/JobAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/JobAuditLogTransformerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.auditlog.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class JobAuditLogTransformerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final JobAuditLogTransformer transformer = new JobAuditLogTransformer();
+
+  @Test
+  void shouldTransformIncidentResolutionRecord() {
+    // given
+    final JobRecordValue recordValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("test-job")
+            .withBpmnProcessId("proc-1")
+            .withProcessDefinitionKey(456L)
+            .withProcessInstanceKey(123L)
+            .withElementInstanceKey(789L)
+            .withTenantId("tenant-1")
+            .build();
+
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r -> r.withKey(222L).withIntent(JobIntent.COMPLETED).withValue(recordValue));
+
+    // when
+    final var entity = AuditLogEntry.of(record);
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getEntityDescription()).isEqualTo("test-job");
+    assertThat(entity.getProcessDefinitionId()).isEqualTo("proc-1");
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(456L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
+    assertThat(entity.getElementInstanceKey()).isEqualTo(789L);
+    assertThat(entity.getJobKey()).isEqualTo(222L);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.COMPLETE);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.exporter.common.auditlog.transformers.FormAuditLogTransf
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupEntityAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.IncidentResolutionAuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.JobAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.MappingRuleAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.ProcessAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.ProcessInstanceCancelAuditLogTransformer;
@@ -134,6 +135,7 @@ class RdbmsExporterWrapperTest {
             Map.entry(TenantEntityAuditLogTransformer.class, ValueType.TENANT),
             Map.entry(UserAuditLogTransformer.class, ValueType.USER),
             Map.entry(UserTaskAuditLogTransformer.class, ValueType.USER_TASK),
+            Map.entry(JobAuditLogTransformer.class, ValueType.JOB),
             Map.entry(VariableAddUpdateAuditLogTransformer.class, ValueType.VARIABLE));
 
     // Check that all expected AuditLogExportHandlers are registered

--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -403,6 +403,7 @@ components:
         - DECISION
         - GROUP
         - INCIDENT
+        - JOB
         - MAPPING_RULE
         - PROCESS_INSTANCE
         - RESOURCE

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuditLogProcessInstanceRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuditLogProcessInstanceRelated.java
@@ -25,6 +25,11 @@ public interface AuditLogProcessInstanceRelated {
   }
 
   /**
+   * @return the key of the related root process instance, or -1 if not applicable
+   */
+  long getRootProcessInstanceKey();
+
+  /**
    * @return the BPMN process id of the corresponding process definition
    */
   String getBpmnProcessId();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -31,7 +31,10 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableJobRecordValue.Builder.class)
 public interface JobRecordValue
-    extends RecordValueWithVariables, ProcessInstanceRelated, TenantOwned {
+    extends RecordValueWithVariables,
+        ProcessInstanceRelated,
+        AuditLogProcessInstanceRelated,
+        TenantOwned {
 
   /**
    * @return the type of the job
@@ -99,11 +102,13 @@ public interface JobRecordValue
   /**
    * @return the element instance key of the corresponding service task
    */
+  @Override
   long getElementInstanceKey();
 
   /**
    * @return the bpmn process id of the corresponding process definition
    */
+  @Override
   String getBpmnProcessId();
 
   /**
@@ -114,6 +119,7 @@ public interface JobRecordValue
   /**
    * @return the process key of the corresponding process definition
    */
+  @Override
   long getProcessDefinitionKey();
 
   /**


### PR DESCRIPTION
# Description
Backport of #46658 to `stable/8.9`.

relates to #46657