### PR TITLE
Switch from xolstice to ascopes protobuf-maven-plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -232,7 +232,7 @@
     <plugin.version.flaky-tests>2.1.1</plugin.version.flaky-tests>
     <plugin.version.jacoco>0.8.14</plugin.version.jacoco>
     <plugin.version.maven-jar>3.5.0</plugin.version.maven-jar>
-    <plugin.version.protobuf-maven-plugin>0.6.1</plugin.version.protobuf-maven-plugin>
+    <plugin.version.protobuf-maven-plugin>5.0.0</plugin.version.protobuf-maven-plugin>
     <plugin.version.replacer>1.5.3</plugin.version.replacer>
     <plugin.version.resources>3.4.0</plugin.version.resources>
     <plugin.version.revapi>0.15.1</plugin.version.revapi>
@@ -2737,20 +2737,23 @@
 
         <!-- protobuf generation -->
         <plugin>
-          <groupId>org.xolstice.maven.plugins</groupId>
+          <groupId>io.github.ascopes</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
           <version>${plugin.version.protobuf-maven-plugin}</version>
           <configuration>
-            <checkStaleness>true</checkStaleness>
-            <protocArtifact>com.google.protobuf:protoc:${version.protobuf}:exe:${os.detected.classifier}</protocArtifact>
-            <pluginId>grpc-java</pluginId>
-            <pluginArtifact>io.grpc:protoc-gen-grpc-java:${version.grpc}:exe:${os.detected.classifier}</pluginArtifact>
+            <protoc>${version.protobuf}</protoc>
+            <plugins>
+              <plugin kind="binary-maven">
+                <groupId>io.grpc</groupId>
+                <artifactId>protoc-gen-grpc-java</artifactId>
+                <version>${version.grpc}</version>
+              </plugin>
+            </plugins>
           </configuration>
           <executions>
             <execution>
               <goals>
-                <goal>compile</goal>
-                <goal>compile-custom</goal>
+                <goal>generate</goal>
               </goals>
             </execution>
           </executions>

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -145,10 +145,12 @@
     <plugins>
       <!-- generate Java protobuf code -->
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
+        <groupId>io.github.ascopes</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <configuration>
-          <protoSourceRoot>${proto.dir}</protoSourceRoot>
+          <sourceDirectories>
+            <sourceDirectory>${proto.dir}</sourceDirectory>
+          </sourceDirectories>
         </configuration>
       </plugin>
 

--- a/zeebe/gateway-protocol-impl/pom.xml
+++ b/zeebe/gateway-protocol-impl/pom.xml
@@ -88,10 +88,12 @@
     <plugins>
       <!-- generate Java protobuf code -->
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
+        <groupId>io.github.ascopes</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <configuration>
-          <protoSourceRoot>${proto.dir}</protoSourceRoot>
+          <sourceDirectories>
+            <sourceDirectory>${proto.dir}</sourceDirectory>
+          </sourceDirectories>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Description

Replace the unmaintained [xolstice `protobuf-maven-plugin`](https://github.com/xolstice/protobuf-maven-plugin) (`0.6.1`) with the actively maintained [ascopes `protobuf-maven-plugin`](https://github.com/ascopes/protobuf-maven-plugin) (`5.0.0`).

The xolstice plugin has not been updated since 2019 and lacks native support for Apple Silicon, requiring Rosetta as a workaround. The ascopes plugin is its actively maintained successor with native Apple Silicon support and automatic `protoc` binary resolution.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #43016