### PR TITLE
Feat/identity length validation

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/UserRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/UserRequestValidator.java
@@ -27,10 +27,14 @@ public class UserRequestValidator {
     return validate(
         () ->
             userValidator.validateCreateRequest(
-                request.getUsername(), request.getPassword(), request.getEmail()));
+                request.getUsername(),
+                request.getPassword(),
+                request.getName(),
+                request.getEmail()));
   }
 
   public Optional<ProblemDetail> validateUpdateRequest(final UserUpdateRequest request) {
-    return validate(() -> userValidator.validateUpdateRequest(request.getEmail()));
+    return validate(
+        () -> userValidator.validateUpdateRequest(request.getName(), request.getEmail()));
   }
 }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/GroupValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/GroupValidator.java
@@ -50,7 +50,7 @@ public final class GroupValidator {
     } else if (name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
       violations.add(
           ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-              name, ValidationConstants.MAX_FIELD_LENGTH));
+              "name", ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/GroupValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/GroupValidator.java
@@ -47,6 +47,10 @@ public final class GroupValidator {
   private static void validateGroupName(final String name, final List<String> violations) {
     if (name == null || name.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+    } else if (name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
+      violations.add(
+          ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              name, ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/IdentifierValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/IdentifierValidator.java
@@ -25,7 +25,6 @@ public class IdentifierValidator {
 
   private static final String DEFAULT_TENANT_ID = "<default>";
 
-  private static final int MAX_LENGTH = 256;
   private static final int TENANT_ID_MAX_LENGTH = 31;
 
   private final Pattern idPattern;
@@ -74,7 +73,13 @@ public class IdentifierValidator {
       final String propertyName,
       final List<String> violations,
       final Function<String, Boolean> alternativeCheck) {
-    validateIdInternal(id, propertyName, violations, idPattern, alternativeCheck, MAX_LENGTH);
+    validateIdInternal(
+        id,
+        propertyName,
+        violations,
+        idPattern,
+        alternativeCheck,
+        ValidationConstants.MAX_FIELD_LENGTH);
   }
 
   public void validateTenantId(final String id, final List<String> violations) {
@@ -88,7 +93,13 @@ public class IdentifierValidator {
   }
 
   public void validateGroupId(final String id, final List<String> violations) {
-    validateIdInternal(id, "groupId", violations, groupIdPattern, s -> false, MAX_LENGTH);
+    validateIdInternal(
+        id,
+        "groupId",
+        violations,
+        groupIdPattern,
+        s -> false,
+        ValidationConstants.MAX_FIELD_LENGTH);
   }
 
   private static void validateIdInternal(

--- a/security/security-validation/src/main/java/io/camunda/security/validation/MappingRuleValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/MappingRuleValidator.java
@@ -49,6 +49,10 @@ public final class MappingRuleValidator {
   private static List<String> validateName(final String name) {
     if (name == null || name.isBlank()) {
       return List.of(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+    } else if (name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
+      return List.of(
+          ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              name, ValidationConstants.MAX_FIELD_LENGTH));
     }
     return new ArrayList<>();
   }
@@ -57,9 +61,18 @@ public final class MappingRuleValidator {
     final List<String> violations = new ArrayList<>();
     if (claimName == null || claimName.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimName"));
+    } else if (claimName.length() > ValidationConstants.MAX_FIELD_LENGTH) {
+      return List.of(
+          ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              claimName, ValidationConstants.MAX_FIELD_LENGTH));
     }
+
     if (claimValue == null || claimValue.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimValue"));
+    } else if (claimValue.length() > ValidationConstants.MAX_FIELD_LENGTH) {
+      return List.of(
+          ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              claimValue, ValidationConstants.MAX_FIELD_LENGTH));
     }
     return violations;
   }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/MappingRuleValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/MappingRuleValidator.java
@@ -52,7 +52,7 @@ public final class MappingRuleValidator {
     } else if (name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
       return List.of(
           ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-              name, ValidationConstants.MAX_FIELD_LENGTH));
+              "name", ValidationConstants.MAX_FIELD_LENGTH));
     }
     return new ArrayList<>();
   }
@@ -62,17 +62,17 @@ public final class MappingRuleValidator {
     if (claimName == null || claimName.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimName"));
     } else if (claimName.length() > ValidationConstants.MAX_FIELD_LENGTH) {
-      return List.of(
+      violations.add(
           ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-              claimName, ValidationConstants.MAX_FIELD_LENGTH));
+              "claimName", ValidationConstants.MAX_FIELD_LENGTH));
     }
 
     if (claimValue == null || claimValue.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimValue"));
     } else if (claimValue.length() > ValidationConstants.MAX_FIELD_LENGTH) {
-      return List.of(
+      violations.add(
           ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-              claimValue, ValidationConstants.MAX_FIELD_LENGTH));
+              "claimValue", ValidationConstants.MAX_FIELD_LENGTH));
     }
     return violations;
   }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/RoleValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/RoleValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.security.validation;
 
 import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static java.util.Collections.emptyList;
 
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -50,6 +51,10 @@ public final class RoleValidator {
   private static void validateRoleName(final String name, final List<String> violations) {
     if (name == null || name.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+    }
+    if (name != null && name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
+      violations.add(
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(name, ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 

--- a/security/security-validation/src/main/java/io/camunda/security/validation/RoleValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/RoleValidator.java
@@ -54,7 +54,8 @@ public final class RoleValidator {
     }
     if (name != null && name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
       violations.add(
-          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(name, ValidationConstants.MAX_FIELD_LENGTH));
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              "name", ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 

--- a/security/security-validation/src/main/java/io/camunda/security/validation/TenantValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/TenantValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.security.validation;
 
 import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.ArrayList;
@@ -54,6 +55,10 @@ public class TenantValidator {
   private static void validateTenantName(final String name, final List<String> violations) {
     if (name == null || name.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+    }
+    if (name != null && name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
+      violations.add(
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(name, ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/TenantValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/TenantValidator.java
@@ -58,7 +58,8 @@ public class TenantValidator {
     }
     if (name != null && name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
       violations.add(
-          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(name, ValidationConstants.MAX_FIELD_LENGTH));
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              "name", ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/UserValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/UserValidator.java
@@ -9,6 +9,7 @@ package io.camunda.security.validation;
 
 import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_INVALID_EMAIL;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,25 +24,40 @@ public class UserValidator {
   }
 
   public List<String> validateCreateRequest(
-      final String username, final String password, final String email) {
+      final String username, final String password, final String name, final String email) {
     final List<String> violations = new ArrayList<>();
     identifierValidator.validateId(username, "username", violations);
     if (password == null || password.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("password"));
     }
+    validateName(name, violations);
     validateUserEmail(email, violations);
     return violations;
   }
 
-  public List<String> validateUpdateRequest(final String email) {
+  public List<String> validateUpdateRequest(final String name, final String email) {
     final List<String> violations = new ArrayList<>();
+    validateName(name, violations);
     validateUserEmail(email, violations);
     return violations;
   }
 
   private static void validateUserEmail(final String email, final List<String> violations) {
-    if (email != null && !email.isBlank() && !EmailValidator.getInstance().isValid(email)) {
-      violations.add(ERROR_MESSAGE_INVALID_EMAIL.formatted(email));
+    if (email != null && !email.isBlank()) {
+      if (!EmailValidator.getInstance().isValid(email)) {
+        violations.add(ERROR_MESSAGE_INVALID_EMAIL.formatted(email));
+      }
+    }
+    if (email != null && email.length() > ValidationConstants.MAX_FIELD_LENGTH) {
+      violations.add(
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(email, ValidationConstants.MAX_FIELD_LENGTH));
+    }
+  }
+
+  private static void validateName(final String name, final List<String> violations) {
+    if (name != null && !name.isBlank() && name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
+      violations.add(
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(name, ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/UserValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/UserValidator.java
@@ -50,14 +50,16 @@ public class UserValidator {
     }
     if (email != null && email.length() > ValidationConstants.MAX_FIELD_LENGTH) {
       violations.add(
-          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(email, ValidationConstants.MAX_FIELD_LENGTH));
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              "email", ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 
   private static void validateName(final String name, final List<String> violations) {
     if (name != null && !name.isBlank() && name.length() > ValidationConstants.MAX_FIELD_LENGTH) {
       violations.add(
-          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(name, ValidationConstants.MAX_FIELD_LENGTH));
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              "name", ValidationConstants.MAX_FIELD_LENGTH));
     }
   }
 }

--- a/security/security-validation/src/main/java/io/camunda/security/validation/ValidationConstants.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/ValidationConstants.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.validation;
+
+public final class ValidationConstants {
+  public static final int MAX_FIELD_LENGTH = 256;
+
+  private ValidationConstants() {
+    // prevent instantiation
+  }
+}

--- a/security/security-validation/src/test/java/io/camunda/security/validation/GroupValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/GroupValidatorTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.validation;
+
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class GroupValidatorTest {
+
+  private static final Pattern ID_PATTERN = Pattern.compile("^[a-zA-Z0-9_~@.+-]+$");
+
+  private static final GroupValidator VALIDATOR =
+      new GroupValidator(new IdentifierValidator(ID_PATTERN, ID_PATTERN));
+
+  // ---- validate ----
+
+  @Test
+  void shouldReturnNoViolationsForValidGroup() {
+    // when:
+    final List<String> violations = VALIDATOR.validate("my-group", "My Group");
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingGroupId(final String groupId) {
+    // when:
+    final List<String> violations = VALIDATOR.validate(groupId, "My Group");
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("groupId"));
+  }
+
+  @Test
+  void shouldRejectGroupIdWithIllegalCharacters() {
+    // when:
+    final List<String> violations = VALIDATOR.validate("invalid id!", "My Group");
+
+    // then:
+    assertThat(violations)
+        .contains(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("groupId", ID_PATTERN));
+  }
+
+  @Test
+  void shouldRejectGroupIdExceedingMaxLength() {
+    // given:
+    final String longId = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations = VALIDATOR.validate(longId, "My Group");
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                "groupId", ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptGroupIdAtMaxLength() {
+    // given:
+    final String maxId = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations = VALIDATOR.validate(maxId, "My Group");
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingName(final String name) {
+    // when:
+    final List<String> violations = VALIDATOR.validate("my-group", name);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+  }
+
+  @Test
+  void shouldRejectNameExceedingMaxLength() {
+    // given:
+    final String longName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations = VALIDATOR.validate("my-group", longName);
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptNameAtMaxLength() {
+    // given:
+    final String maxName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations = VALIDATOR.validate("my-group", maxName);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldReturnAllViolationsWhenBothFieldsInvalid() {
+    // when:
+    final List<String> violations = VALIDATOR.validate(null, null);
+
+    // then:
+    assertThat(violations)
+        .containsExactlyInAnyOrder(
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("groupId"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+  }
+
+  // ---- validateMembers ----
+
+  @Test
+  void shouldReturnNoViolationsForNullMemberList() {
+    // when:
+    final List<String> violations = VALIDATOR.validateMembers(null, EntityType.USER);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNoViolationsForValidUserMembers() {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateMembers(List.of("alice", "bob"), EntityType.USER);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldRejectMemberIdWithIllegalCharacters() {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateMembers(List.of("valid", "invalid id!"), EntityType.USER);
+
+    // then:
+    assertThat(violations)
+        .contains(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("username", ID_PATTERN));
+  }
+
+  @Test
+  void shouldRejectBlankMemberIds() {
+    // when:
+    final List<String> violations = VALIDATOR.validateMembers(List.of(""), EntityType.USER);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+  }
+
+  // ---- validateMember ----
+
+  @Test
+  void shouldReturnNoViolationsForValidMember() {
+    // when:
+    final List<String> violations = VALIDATOR.validateMember("my-group", "alice", EntityType.USER);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingGroupIdInValidateMember(final String groupId) {
+    // when:
+    final List<String> violations = VALIDATOR.validateMember(groupId, "alice", EntityType.USER);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("groupId"));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingMemberIdInValidateMember(final String memberId) {
+    // when:
+    final List<String> violations = VALIDATOR.validateMember("my-group", memberId, EntityType.USER);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+  }
+
+  @Test
+  void shouldReturnAllViolationsWhenBothMemberFieldsInvalid() {
+    // when:
+    final List<String> violations = VALIDATOR.validateMember(null, null, EntityType.USER);
+
+    // then:
+    assertThat(violations)
+        .containsExactlyInAnyOrder(
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("groupId"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+  }
+}

--- a/security/security-validation/src/test/java/io/camunda/security/validation/GroupValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/GroupValidatorTest.java
@@ -109,7 +109,7 @@ class GroupValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longName, ValidationConstants.MAX_FIELD_LENGTH));
+                "name", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test

--- a/security/security-validation/src/test/java/io/camunda/security/validation/MappingRuleValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/MappingRuleValidatorTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.validation;
+
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MappingRuleValidatorTest {
+
+  private static final Pattern ID_PATTERN = Pattern.compile("^[a-zA-Z0-9_~@.+-]+$");
+
+  private static final MappingRuleValidator VALIDATOR =
+      new MappingRuleValidator(new IdentifierValidator(ID_PATTERN, ID_PATTERN));
+
+  // ---- validateCreateRequest ----
+
+  @Test
+  void shouldReturnNoViolationsForValidCreateRequest() {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("rule-1", "email", "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingMappingRuleIdOnCreate(final String mappingRuleId) {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest(mappingRuleId, "email", "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("mappingRuleId"));
+  }
+
+  @Test
+  void shouldRejectMappingRuleIdWithIllegalCharacters() {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("invalid id!", "email", "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations)
+        .contains(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("mappingRuleId", ID_PATTERN));
+  }
+
+  @Test
+  void shouldRejectMappingRuleIdExceedingMaxLength() {
+    // given:
+    final String longId = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest(longId, "email", "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                "mappingRuleId", ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptMappingRuleIdAtMaxLength() {
+    // given:
+    final String maxId = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest(maxId, "email", "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingClaimNameOnCreate(final String claimName) {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("rule-1", claimName, "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimName"));
+  }
+
+  @Test
+  void shouldRejectClaimNameExceedingMaxLength() {
+    // given:
+    final String longClaimName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("rule-1", longClaimName, "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longClaimName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingClaimValueOnCreate(final String claimValue) {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("rule-1", "email", claimValue, "My Rule");
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimValue"));
+  }
+
+  @Test
+  void shouldRejectClaimValueExceedingMaxLength() {
+    // given:
+    final String longClaimValue = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("rule-1", "email", longClaimValue, "My Rule");
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longClaimValue, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingNameOnCreate(final String name) {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("rule-1", "email", "user@example.com", name);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+  }
+
+  @Test
+  void shouldRejectNameExceedingMaxLengthOnCreate() {
+    // given:
+    final String longName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("rule-1", "email", "user@example.com", longName);
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptNameAtMaxLengthOnCreate() {
+    // given:
+    final String maxName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("rule-1", "email", "user@example.com", maxName);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldReturnAllViolationsWhenAllFieldsMissingOnCreate() {
+    // when:
+    final List<String> violations = VALIDATOR.validateCreateRequest(null, null, null, null);
+
+    // then:
+    assertThat(violations)
+        .containsExactlyInAnyOrder(
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimName"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimValue"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("mappingRuleId"));
+  }
+
+  // ---- validateUpdateRequest ----
+
+  @Test
+  void shouldReturnNoViolationsForValidUpdateRequest() {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateUpdateRequest("email", "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingClaimNameOnUpdate(final String claimName) {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateUpdateRequest(claimName, "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimName"));
+  }
+
+  @Test
+  void shouldRejectClaimNameExceedingMaxLengthOnUpdate() {
+    // given:
+    final String longClaimName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateUpdateRequest(longClaimName, "user@example.com", "My Rule");
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longClaimName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingClaimValueOnUpdate(final String claimValue) {
+    // when:
+    final List<String> violations = VALIDATOR.validateUpdateRequest("email", claimValue, "My Rule");
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimValue"));
+  }
+
+  @Test
+  void shouldRejectClaimValueExceedingMaxLengthOnUpdate() {
+    // given:
+    final String longClaimValue = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateUpdateRequest("email", longClaimValue, "My Rule");
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longClaimValue, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingNameOnUpdate(final String name) {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateUpdateRequest("email", "user@example.com", name);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+  }
+
+  @Test
+  void shouldRejectNameExceedingMaxLengthOnUpdate() {
+    // given:
+    final String longName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateUpdateRequest("email", "user@example.com", longName);
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptNameAtMaxLengthOnUpdate() {
+    // given:
+    final String maxName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateUpdateRequest("email", "user@example.com", maxName);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldReturnAllViolationsWhenAllFieldsMissingOnUpdate() {
+    // when:
+    final List<String> violations = VALIDATOR.validateUpdateRequest(null, null, null);
+
+    // then:
+    assertThat(violations)
+        .containsExactlyInAnyOrder(
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimName"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("claimValue"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+  }
+}

--- a/security/security-validation/src/test/java/io/camunda/security/validation/MappingRuleValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/MappingRuleValidatorTest.java
@@ -115,7 +115,7 @@ class MappingRuleValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longClaimName, ValidationConstants.MAX_FIELD_LENGTH));
+                "claimName", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @ParameterizedTest
@@ -143,7 +143,7 @@ class MappingRuleValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longClaimValue, ValidationConstants.MAX_FIELD_LENGTH));
+                "claimValue", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @ParameterizedTest
@@ -171,7 +171,7 @@ class MappingRuleValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longName, ValidationConstants.MAX_FIELD_LENGTH));
+                "name", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test
@@ -238,7 +238,7 @@ class MappingRuleValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longClaimName, ValidationConstants.MAX_FIELD_LENGTH));
+                "claimName", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @ParameterizedTest
@@ -265,7 +265,7 @@ class MappingRuleValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longClaimValue, ValidationConstants.MAX_FIELD_LENGTH));
+                "claimValue", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @ParameterizedTest
@@ -293,7 +293,7 @@ class MappingRuleValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longName, ValidationConstants.MAX_FIELD_LENGTH));
+                "name", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test

--- a/security/security-validation/src/test/java/io/camunda/security/validation/RoleValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/RoleValidatorTest.java
@@ -109,7 +109,7 @@ class RoleValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longName, ValidationConstants.MAX_FIELD_LENGTH));
+                "name", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test

--- a/security/security-validation/src/test/java/io/camunda/security/validation/RoleValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/RoleValidatorTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.validation;
+
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RoleValidatorTest {
+
+  private static final Pattern ID_PATTERN = Pattern.compile("^[a-zA-Z0-9_~@.+-]+$");
+
+  private static final RoleValidator VALIDATOR =
+      new RoleValidator(new IdentifierValidator(ID_PATTERN, ID_PATTERN));
+
+  // ---- validate ----
+
+  @Test
+  void shouldReturnNoViolationsForValidRole() {
+    // when:
+    final List<String> violations = VALIDATOR.validate("my-role", "My Role");
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingRoleId(final String roleId) {
+    // when:
+    final List<String> violations = VALIDATOR.validate(roleId, "My Role");
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("roleId"));
+  }
+
+  @Test
+  void shouldRejectRoleIdWithIllegalCharacters() {
+    // when:
+    final List<String> violations = VALIDATOR.validate("invalid role id!", "My Role");
+
+    // then:
+    assertThat(violations)
+        .contains(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("roleId", ID_PATTERN));
+  }
+
+  @Test
+  void shouldRejectRoleIdExceedingMaxLength() {
+    // given:
+    final String longId = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations = VALIDATOR.validate(longId, "My Role");
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                "roleId", ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptRoleIdAtMaxLength() {
+    // given:
+    final String maxId = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations = VALIDATOR.validate(maxId, "My Role");
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingName(final String name) {
+    // when:
+    final List<String> violations = VALIDATOR.validate("my-role", name);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+  }
+
+  @Test
+  void shouldRejectNameExceedingMaxLength() {
+    // given:
+    final String longName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations = VALIDATOR.validate("my-role", longName);
+
+    // then:
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptNameAtMaxLength() {
+    // given:
+    final String maxName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations = VALIDATOR.validate("my-role", maxName);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldReturnAllViolationsWhenBothFieldsInvalid() {
+    // when:
+    final List<String> violations = VALIDATOR.validate(null, null);
+
+    // then:
+    assertThat(violations)
+        .containsExactlyInAnyOrder(
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("roleId"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+  }
+
+  // ---- validateMembers ----
+
+  @Test
+  void shouldReturnNoViolationsForNullMemberList() {
+    // when:
+    final List<String> violations = VALIDATOR.validateMembers(null, EntityType.USER);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNoViolationsForValidUserMembers() {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateMembers(List.of("alice", "bob"), EntityType.USER);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldRejectInvalidMemberIds() {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateMembers(List.of("valid", "invalid id!"), EntityType.USER);
+
+    // then:
+    assertThat(violations)
+        .contains(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("username", ID_PATTERN));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldRejectBlankMemberIds(final String memberId) {
+    // when:
+    final List<String> violations =
+        VALIDATOR.validateMembers(List.of(memberId == null ? "" : memberId), EntityType.USER);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+  }
+
+  // ---- validateMember ----
+
+  @Test
+  void shouldReturnNoViolationsForValidMember() {
+    // when:
+    final List<String> violations = VALIDATOR.validateMember("my-role", "alice", EntityType.USER);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingRoleIdInValidateMember(final String roleId) {
+    // when:
+    final List<String> violations = VALIDATOR.validateMember(roleId, "alice", EntityType.USER);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("roleId"));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingMemberIdInValidateMember(final String memberId) {
+    // when:
+    final List<String> violations = VALIDATOR.validateMember("my-role", memberId, EntityType.USER);
+
+    // then:
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+  }
+
+  @Test
+  void shouldReturnAllViolationsWhenBothMemberFieldsInvalid() {
+    // when:
+    final List<String> violations = VALIDATOR.validateMember(null, null, EntityType.USER);
+
+    // then:
+    assertThat(violations)
+        .containsExactlyInAnyOrder(
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("roleId"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+  }
+}

--- a/security/security-validation/src/test/java/io/camunda/security/validation/TenantValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/TenantValidatorTest.java
@@ -51,7 +51,7 @@ class TenantValidatorTest {
     assertThat(violations)
         .containsExactly(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longName, ValidationConstants.MAX_FIELD_LENGTH));
+                "name", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test
@@ -78,7 +78,7 @@ class TenantValidatorTest {
     assertThat(violations)
         .containsExactly(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longName, ValidationConstants.MAX_FIELD_LENGTH));
+                "name", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test

--- a/security/security-validation/src/test/java/io/camunda/security/validation/TenantValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/TenantValidatorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.security.validation;
 
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -33,6 +34,60 @@ class TenantValidatorTest {
   public void shouldSuccessfullyConfigure() {
     // when:
     final List<String> violations = VALIDATOR.validateCreate("foo", "Foo");
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldRejectNameExceedingMaxLengthOnCreate() {
+    // given:
+    final String longName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations = VALIDATOR.validateCreate("foo", longName);
+
+    // then:
+    assertThat(violations)
+        .containsExactly(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptNameAtMaxLengthOnCreate() {
+    // given:
+    final String maxName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations = VALIDATOR.validateCreate("foo", maxName);
+
+    // then:
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldRejectNameExceedingMaxLengthOnUpdate() {
+    // given:
+    final String longName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+
+    // when:
+    final List<String> violations = VALIDATOR.validateUpdate(longName);
+
+    // then:
+    assertThat(violations)
+        .containsExactly(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptNameAtMaxLengthOnUpdate() {
+    // given:
+    final String maxName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+
+    // when:
+    final List<String> violations = VALIDATOR.validateUpdate(maxName);
 
     // then:
     assertThat(violations).isEmpty();

--- a/security/security-validation/src/test/java/io/camunda/security/validation/UserValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/UserValidatorTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.validation;
+
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_INVALID_EMAIL;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UserValidatorTest {
+
+  private static final UserValidator VALIDATOR =
+      new UserValidator(
+          new IdentifierValidator(
+              Pattern.compile("^[a-zA-Z0-9_~@.+-]+$"), Pattern.compile("^[a-zA-Z0-9_~@.+-]+$")));
+
+  // ---- validateCreateRequest ----
+
+  @Test
+  void shouldReturnNoViolationsForValidCreateRequest() {
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("alice", "s3cr3t", "Alice Smith", "alice@example.com");
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNoViolationsForCreateRequestWithoutOptionalFields() {
+    final List<String> violations = VALIDATOR.validateCreateRequest("alice", "s3cr3t", null, null);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingUsername(final String username) {
+    final List<String> violations = VALIDATOR.validateCreateRequest(username, "s3cr3t", null, null);
+
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldRejectMissingPassword(final String password) {
+    final List<String> violations = VALIDATOR.validateCreateRequest("alice", password, null, null);
+
+    assertThat(violations).contains(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("password"));
+  }
+
+  @Test
+  void shouldRejectAllMissingMandatoryFieldsOnCreate() {
+    final List<String> violations = VALIDATOR.validateCreateRequest(null, null, null, null);
+
+    assertThat(violations)
+        .containsExactlyInAnyOrder(
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"),
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("password"));
+  }
+
+  @Test
+  void shouldRejectInvalidEmailOnCreate() {
+    final String invalidEmail = "not-an-email";
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("alice", "s3cr3t", null, invalidEmail);
+
+    assertThat(violations).contains(ERROR_MESSAGE_INVALID_EMAIL.formatted(invalidEmail));
+  }
+
+  @Test
+  void shouldAcceptBlankEmailOnCreate() {
+    final List<String> violations = VALIDATOR.validateCreateRequest("alice", "s3cr3t", null, "   ");
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldRejectEmailExceedingMaxLengthOnCreate() {
+    final String longEmail = "a".repeat(250) + "@example.com";
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("alice", "s3cr3t", null, longEmail);
+
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longEmail, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldRejectNameExceedingMaxLengthOnCreate() {
+    final String longName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("alice", "s3cr3t", longName, null);
+
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptNameAtMaxLengthOnCreate() {
+    final String maxName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+    final List<String> violations =
+        VALIDATOR.validateCreateRequest("alice", "s3cr3t", maxName, null);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldAcceptBlankNameOnCreate() {
+    final List<String> violations = VALIDATOR.validateCreateRequest("alice", "s3cr3t", "   ", null);
+
+    assertThat(violations).isEmpty();
+  }
+
+  // ---- validateUpdateRequest ----
+
+  @Test
+  void shouldReturnNoViolationsForValidUpdateRequest() {
+    final List<String> violations =
+        VALIDATOR.validateUpdateRequest("Alice Smith", "alice@example.com");
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNoViolationsForUpdateRequestWithNullFields() {
+    final List<String> violations = VALIDATOR.validateUpdateRequest(null, null);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldRejectInvalidEmailOnUpdate() {
+    final String invalidEmail = "not-an-email";
+    final List<String> violations = VALIDATOR.validateUpdateRequest(null, invalidEmail);
+
+    assertThat(violations).contains(ERROR_MESSAGE_INVALID_EMAIL.formatted(invalidEmail));
+  }
+
+  @Test
+  void shouldAcceptBlankEmailOnUpdate() {
+    final List<String> violations = VALIDATOR.validateUpdateRequest(null, "   ");
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldRejectEmailExceedingMaxLengthOnUpdate() {
+    final String longEmail = "a".repeat(250) + "@example.com";
+    final List<String> violations = VALIDATOR.validateUpdateRequest(null, longEmail);
+
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longEmail, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldRejectNameExceedingMaxLengthOnUpdate() {
+    final String longName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH + 1);
+    final List<String> violations = VALIDATOR.validateUpdateRequest(longName, null);
+
+    assertThat(violations)
+        .contains(
+            ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+                longName, ValidationConstants.MAX_FIELD_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptNameAtMaxLengthOnUpdate() {
+    final String maxName = "a".repeat(ValidationConstants.MAX_FIELD_LENGTH);
+    final List<String> violations = VALIDATOR.validateUpdateRequest(maxName, null);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldAcceptBlankNameOnUpdate() {
+    final List<String> violations = VALIDATOR.validateUpdateRequest("   ", null);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"user@example.com", "user+tag@sub.domain.org", "first.last@company.co.uk"})
+  void shouldAcceptValidEmailFormats(final String email) {
+    final List<String> violations = VALIDATOR.validateUpdateRequest(null, email);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"plainaddress", "@missinglocal.com", "missing@domain"})
+  void shouldRejectInvalidEmailFormats(final String email) {
+    final List<String> violations = VALIDATOR.validateUpdateRequest(null, email);
+
+    assertThat(violations).contains(ERROR_MESSAGE_INVALID_EMAIL.formatted(email));
+  }
+}

--- a/security/security-validation/src/test/java/io/camunda/security/validation/UserValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/UserValidatorTest.java
@@ -96,7 +96,7 @@ class UserValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longEmail, ValidationConstants.MAX_FIELD_LENGTH));
+                "email", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test
@@ -108,7 +108,7 @@ class UserValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longName, ValidationConstants.MAX_FIELD_LENGTH));
+                "name", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test
@@ -167,7 +167,7 @@ class UserValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longEmail, ValidationConstants.MAX_FIELD_LENGTH));
+                "email", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test
@@ -178,7 +178,7 @@ class UserValidatorTest {
     assertThat(violations)
         .contains(
             ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
-                longName, ValidationConstants.MAX_FIELD_LENGTH));
+                "name", ValidationConstants.MAX_FIELD_LENGTH));
   }
 
   @Test


### PR DESCRIPTION
## Description

To be able to store all properties of identity entities in the relational database, we need to verify the properties agains the same limit as the ID length is verified.

I also added several missing unit-tests.

## Related issues

closes #45682
