### PR TITLE
feat: add option to load-tests for automatic query benchmarks

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -58,6 +58,11 @@ on:
         type: string
         default: ""
         required: false
+      perform-read-benchmarks:
+        description: 'Perform continuous read benchmarks on secondary storage. This may influence the exporter performance as it puts more load on the secondary database. The metrics are available in the Data-Layer dashboard.'
+        type: boolean
+        required: false
+        default: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
         type: boolean
@@ -127,6 +132,11 @@ on:
         default: ""
         type: string
         required: false
+      perform-read-benchmarks:
+        description: 'Perform continuous read benchmarks on secondary storage. This may influence the exporter performance as it puts more load on the secondary database. The metrics are available in the Data-Layer dashboard.'
+        type: boolean
+        required: false
+        default: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
         type: boolean
@@ -384,7 +394,11 @@ jobs:
           cd load-tests/setup/${{ env.NAMESPACE }}
 
           # Build additional load test configuration
-          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set global.image.repository=${{ env.IMAGE_REPOSITORY }} --set global.image.pullSecrets[0].name=harbor-registry"
+          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
+                            --set global.image.repository=${{ env.IMAGE_REPOSITORY }} \
+                            --set global.image.pullSecrets[0].name=harbor-registry \
+                            --set global.extraEnvVars[0].name=CONFIG_FORCE_app_performReadBenchmarks \
+                            --set global.extraEnvVars[0].value=${{inputs.perform-read-benchmarks}}"
           # Append load-test-load configuration if not empty
           if [[ -n "${{ needs.calculate-scenario-config.outputs.load-test-load }}" ]]; then
             load_test_config="$load_test_config ${{ needs.calculate-scenario-config.outputs.load-test-load }}"


### PR DESCRIPTION
This pull request updates the `.github/workflows/camunda-load-test.yml` workflow to introduce a new configuration option for enabling query benchmarks during load tests. The main change is the addition of the `perform-read-benchmarks` input, which allows users to control whether read/query benchmarks are executed as part of the load test deployment. The workflow is updated to pass this new option through to the Helm deployment configuration.

**New input for query benchmarks:**

* Added a `perform-read-benchmarks` boolean input to the workflow, allowing users to toggle query benchmarks in load tests. [[1]](diffhunk://#diff-38f8fadb6cc10a82a3db16c869fcf3011395c384211d2658d0557ce2258fb4d0R56-R60) [[2]](diffhunk://#diff-38f8fadb6cc10a82a3db16c869fcf3011395c384211d2658d0557ce2258fb4d0R119-R123)

**Integration with Helm deployment:**

* Updated the Helm deployment configuration to include the `global.performReadBenchmarks` value, passing the new input to the load test setup.## Description