### PR TITLE
[Backport stable/8.9] fix: exclude firstLogPosition from being serialized when unset

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupMetadata.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupMetadata.java
@@ -7,10 +7,14 @@
  */
 package io.camunda.zeebe.backup.common;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
 import java.util.List;
+import java.util.OptionalLong;
 
 /**
  * Per-partition JSON manifest containing checkpoint metadata and pre-computed backup ranges. Synced
@@ -31,7 +35,18 @@ public record BackupMetadata(
       @JsonProperty("checkpointPosition") long checkpointPosition,
       @JsonProperty("checkpointTimestamp") Instant checkpointTimestamp,
       @JsonProperty("checkpointType") CheckpointType checkpointType,
-      @JsonProperty("firstLogPosition") long firstLogPosition) {}
+      @JsonProperty("firstLogPosition") @JsonInclude(Include.NON_ABSENT)
+          OptionalLong firstLogPosition) {
+
+    /**
+     * Returns the first log position if present, or -1 if not. -1 is the value for {@link
+     * CheckpointType#MARKER} checkpoints
+     */
+    @JsonIgnore
+    public long getFirstLogPositionOrDefault() {
+      return firstLogPosition.orElse(-1L);
+    }
+  }
 
   /** A contiguous backup range [start, end]. */
   public record RangeEntry(@JsonProperty("start") long start, @JsonProperty("end") long end) {}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupMetadataSyncer.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupMetadataSyncer.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.SequencedCollection;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -73,7 +74,9 @@ public final class BackupMetadataSyncer {
                             entry.checkpointPosition(),
                             Instant.ofEpochMilli(entry.checkpointTimestamp()),
                             entry.checkpointType(),
-                            entry.firstLogPosition()))
+                            entry.firstLogPosition() > 0
+                                ? OptionalLong.of(entry.firstLogPosition())
+                                : OptionalLong.empty()))
                 .toList(),
             ranges.stream().map(range -> new RangeEntry(range.start(), range.end())).toList());
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupMetadataSyncerTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupMetadataSyncerTest.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.backup.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -18,9 +20,11 @@ import io.camunda.zeebe.backup.common.BackupMetadata.RangeEntry;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,13 +63,14 @@ final class BackupMetadataSyncerTest {
     // then - verify the content is valid JSON that deserializes correctly
     final var manifest =
         BackupMetadataSyncer.MAPPER.readValue(contentCaptor.getValue(), BackupMetadata.class);
-    assertThat(manifest.partitionId()).isEqualTo(1);
+    assertThat(manifest.partitionId()).isOne();
     assertThat(manifest.checkpoints()).hasSize(1);
     assertThat(manifest.checkpoints().getFirst().checkpointId()).isEqualTo(10L);
     assertThat(manifest.checkpoints().getFirst().checkpointPosition()).isEqualTo(100L);
     assertThat(manifest.checkpoints().getFirst().checkpointType())
         .isEqualTo(CheckpointType.SCHEDULED_BACKUP);
-    assertThat(manifest.checkpoints().getFirst().firstLogPosition()).isEqualTo(50L);
+    assertThat(manifest.checkpoints().getFirst().firstLogPosition())
+        .isEqualTo(OptionalLong.of(50L));
     assertThat(manifest.ranges()).hasSize(1);
     assertThat(manifest.ranges().getFirst().start()).isEqualTo(10L);
     assertThat(manifest.ranges().getFirst().end()).isEqualTo(20L);
@@ -90,9 +95,17 @@ final class BackupMetadataSyncerTest {
     final var checkpoints =
         List.of(
             new CheckpointEntry(
-                1L, 100L, Instant.ofEpochMilli(1000), CheckpointType.SCHEDULED_BACKUP, 50L),
+                1L,
+                100L,
+                Instant.ofEpochMilli(1000),
+                CheckpointType.SCHEDULED_BACKUP,
+                OptionalLong.of(50L)),
             new CheckpointEntry(
-                2L, 200L, Instant.ofEpochMilli(2000), CheckpointType.MANUAL_BACKUP, 150L));
+                2L,
+                200L,
+                Instant.ofEpochMilli(2000),
+                CheckpointType.MANUAL_BACKUP,
+                OptionalLong.of(150L)));
     final var ranges = List.of(new RangeEntry(1L, 2L));
     final var manifest =
         new BackupMetadata(BackupMetadata.VERSION, 1, Instant.now(), checkpoints, ranges);
@@ -113,6 +126,94 @@ final class BackupMetadataSyncerTest {
     assertThat(loaded.ranges()).hasSize(1);
     assertThat(loaded.ranges().getFirst().start()).isEqualTo(1L);
     assertThat(loaded.ranges().getFirst().end()).isEqualTo(2L);
+  }
+
+  @Test
+  void shouldSerializeMarkerWithoutFirstLogPosition() throws IOException {
+    // given
+    final var checkpointEntry =
+        new DbCheckpointMetadataState.CheckpointEntry(10L, 100L, 1000L, CheckpointType.MARKER, -1L);
+    final var range = new BackupRange(10L, 20L);
+
+    final var contentCaptor = ArgumentCaptor.forClass(byte[].class);
+    when(backupStore.storeBackupMetadata(eq(1), contentCaptor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    syncer.store(1, List.of(checkpointEntry), List.of(range)).join();
+
+    // then - verify the content is valid JSON that deserializes correctly
+    final var manifest =
+        BackupMetadataSyncer.MAPPER.readValue(contentCaptor.getValue(), BackupMetadata.class);
+    assertThat(manifest.partitionId()).isOne();
+    assertThat(manifest.checkpoints()).hasSize(1);
+    assertThat(manifest.checkpoints().getFirst().checkpointId()).isEqualTo(10L);
+    assertThat(manifest.checkpoints().getFirst().checkpointPosition()).isEqualTo(100L);
+    assertThat(manifest.checkpoints().getFirst().checkpointType()).isEqualTo(CheckpointType.MARKER);
+    assertThat(manifest.checkpoints().getFirst().firstLogPosition()).isEmpty();
+
+    assertThat(manifest.ranges()).hasSize(1);
+    assertThat(manifest.ranges().getFirst().start()).isEqualTo(10L);
+    assertThat(manifest.ranges().getFirst().end()).isEqualTo(20L);
+  }
+
+  @Test
+  void shouldParseMetadataWithoutFirstLogPositionOnMarker() {
+    // given
+    final var metadata =
+        """
+        {
+            "version": 1,
+            "partitionId": 1,
+            "lastUpdated": "2026-02-27T06:00:29.349354439Z",
+            "checkpoints": [
+                {
+                    "checkpointId": 1772172018889,
+                    "checkpointPosition": 744,
+                    "checkpointTimestamp": "2026-02-27T06:00:18.889Z",
+                    "checkpointType": "MARKER"
+                },
+                {
+                    "checkpointId": 1772172029318,
+                    "checkpointPosition": 752,
+                    "checkpointTimestamp": "2026-02-27T06:00:29.346Z",
+                    "checkpointType": "SCHEDULED_BACKUP",
+                    "firstLogPosition": 1
+                }
+            ],
+            "ranges": [
+                {
+                    "start": 1772172029318,
+                    "end": 1772172029318
+                }
+            ]
+        }
+        """;
+
+    final BackupStore store = mock(BackupStore.class);
+    final BackupMetadataSyncer syncer = new BackupMetadataSyncer(store);
+    when(store.loadBackupMetadata(anyInt()))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of(metadata.getBytes())));
+
+    // when
+    final var loadedMetadata = syncer.load(1).join();
+
+    // then
+    assertThat(loadedMetadata.isPresent());
+    assertThat(loadedMetadata.get().checkpoints().size() == 2);
+    final var cp =
+        loadedMetadata.get().checkpoints().stream()
+            .filter(f -> f.checkpointType() == CheckpointType.MARKER)
+            .findFirst();
+    assertThat(cp).isPresent();
+    assertThat(cp.get().firstLogPosition()).isEmpty();
+
+    final var marker =
+        loadedMetadata.get().checkpoints().stream()
+            .filter(f -> f.checkpointType() == CheckpointType.SCHEDULED_BACKUP)
+            .findFirst();
+    assertThat(marker).isPresent();
+    assertThat(marker.get().firstLogPosition()).isEqualTo(OptionalLong.of(1L));
   }
 
   private static byte[] serializeManifest(final BackupMetadata manifest) {

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
@@ -113,7 +113,7 @@ public class RestorePointResolver {
       return;
     }
 
-    final var firstLogPosition = checkpoint.firstLogPosition();
+    final var firstLogPosition = checkpoint.getFirstLogPositionOrDefault();
     final var previousBackup = previousBackups.getLast();
     final var previousBackupPosition = previousBackup.checkpointPosition();
     if (firstLogPosition > previousBackupPosition + 1) {
@@ -233,7 +233,7 @@ public class RestorePointResolver {
         .filter(
             checkpointEntry -> {
               final var checkpointPosition = checkpointEntry.checkpointPosition();
-              return (checkpointPosition >= restorableRange.start().firstLogPosition())
+              return (checkpointPosition >= restorableRange.start().getFirstLogPositionOrDefault())
                   && (checkpointPosition <= restorableRange.end().checkpointPosition());
             })
         .collect(Collectors.toCollection(ArrayList::new));
@@ -272,7 +272,8 @@ public class RestorePointResolver {
                         from);
                 return;
               }
-              if (exportedPosition != null && startInfo.firstLogPosition() > exportedPosition) {
+              if (exportedPosition != null
+                  && startInfo.getFirstLogPositionOrDefault() > exportedPosition) {
                 LOG.atTrace()
                     .addKeyValue("partition", metadata.partitionId())
                     .log(

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestorePointResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestorePointResolverTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -28,7 +29,7 @@ final class RestorePointResolverTest {
   void shouldResolveWithSinglePartitionSingleBackup() {
     // given – one partition, one SCHEDULED_BACKUP checkpoint, one range covering it
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
-    final var cp = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
+    final var cp = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
     final var meta = metadata(1, List.of(cp), List.of(new RangeEntry(1, 1)));
 
     // when
@@ -46,10 +47,10 @@ final class RestorePointResolverTest {
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
 
-    final var cp1p1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2p1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var cp1p2 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2p2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
+    final var cp1p1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2p1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp1p2 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2p2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
 
     final var metadataByPartition =
         List.of(
@@ -72,10 +73,10 @@ final class RestorePointResolverTest {
     final var t2 = Instant.parse("2025-06-01T00:00:00Z");
     final var to = Instant.parse("2025-01-15T00:00:00Z"); // much closer to t1
 
-    final var cp1p1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2p1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var cp1p2 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2p2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
+    final var cp1p1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2p1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp1p2 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2p2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
 
     final var metadataByPartition =
         List.of(
@@ -86,7 +87,7 @@ final class RestorePointResolverTest {
     final var result = RestorePointResolver.resolve(metadataByPartition, null, to, Map.of());
 
     // then – checkpoint 1 is closest to 'to'
-    assertThat(result.globalCheckpointId()).isEqualTo(1);
+    assertThat(result.globalCheckpointId()).isOne();
     assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp1p1);
     assertThat(result.backupsByPartitionId().get(2)).containsExactly(cp1p2);
   }
@@ -98,9 +99,9 @@ final class RestorePointResolverTest {
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
     final var t3 = Instant.parse("2025-01-03T00:00:00Z");
 
-    final var marker = entry(1, 100, t1, CheckpointType.MARKER, 50);
-    final var backup1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var backup2 = entry(3, 300, t3, CheckpointType.MANUAL_BACKUP, 201);
+    final var marker = entry(1, 100, t1, CheckpointType.MARKER, OptionalLong.empty());
+    final var backup1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var backup2 = entry(3, 300, t3, CheckpointType.MANUAL_BACKUP, OptionalLong.of(201));
 
     final var meta = metadata(1, List.of(marker, backup1, backup2), List.of(new RangeEntry(1, 3)));
 
@@ -119,9 +120,9 @@ final class RestorePointResolverTest {
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
     final var t3 = Instant.parse("2025-01-03T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
 
     final var meta = metadata(1, List.of(cp1, cp2, cp3), List.of(new RangeEntry(1, 3)));
 
@@ -141,10 +142,10 @@ final class RestorePointResolverTest {
     final var t3 = Instant.parse("2025-03-01T00:00:00Z");
     final var t4 = Instant.parse("2025-04-01T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201);
-    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
 
     final var meta =
         metadata(
@@ -168,10 +169,10 @@ final class RestorePointResolverTest {
     final var t3 = Instant.parse("2025-03-01T00:00:00Z");
     final var t4 = Instant.parse("2025-04-01T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201);
-    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
 
     final var meta =
         metadata(
@@ -192,8 +193,8 @@ final class RestorePointResolverTest {
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
 
     final var meta = metadata(1, List.of(cp1, cp2), List.of(new RangeEntry(1, 2)));
 
@@ -215,8 +216,8 @@ final class RestorePointResolverTest {
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
 
-    final var cp1p1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2p2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
+    final var cp1p1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2p2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
 
     final var metadataByPartition =
         List.of(
@@ -235,7 +236,7 @@ final class RestorePointResolverTest {
   void shouldHandleManualBackupType() {
     // given – single partition with MANUAL_BACKUP checkpoint
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
-    final var cp = entry(1, 100, t1, CheckpointType.MANUAL_BACKUP, 50);
+    final var cp = entry(1, 100, t1, CheckpointType.MANUAL_BACKUP, OptionalLong.of(50));
     final var meta = metadata(1, List.of(cp), List.of(new RangeEntry(1, 1)));
 
     // when
@@ -255,11 +256,11 @@ final class RestorePointResolverTest {
     final var t4 = Instant.parse("2025-01-04T00:00:00Z");
     final var t5 = Instant.parse("2025-01-05T00:00:00Z");
 
-    final var marker1 = entry(1, 100, t1, CheckpointType.MARKER, 50);
-    final var backup1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var marker2 = entry(3, 300, t3, CheckpointType.MARKER, 250);
-    final var backup2 = entry(4, 400, t4, CheckpointType.MANUAL_BACKUP, 201);
-    final var marker3 = entry(5, 500, t5, CheckpointType.MARKER, 450);
+    final var marker1 = entry(1, 100, t1, CheckpointType.MARKER, OptionalLong.empty());
+    final var backup1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var marker2 = entry(3, 300, t3, CheckpointType.MARKER, OptionalLong.empty());
+    final var backup2 = entry(4, 400, t4, CheckpointType.MANUAL_BACKUP, OptionalLong.of(201));
+    final var marker3 = entry(5, 500, t5, CheckpointType.MARKER, OptionalLong.empty());
 
     final var meta =
         metadata(
@@ -284,20 +285,20 @@ final class RestorePointResolverTest {
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101))),
                 List.of(new RangeEntry(1, 2))),
             metadata(
                 2,
                 List.of(
-                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, 60),
-                    entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, 111)),
+                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(60)),
+                    entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(111))),
                 List.of(new RangeEntry(1, 2))),
             metadata(
                 3,
                 List.of(
-                    entry(1, 120, t1, CheckpointType.SCHEDULED_BACKUP, 70),
-                    entry(2, 220, t2, CheckpointType.SCHEDULED_BACKUP, 121)),
+                    entry(1, 120, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(70)),
+                    entry(2, 220, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(121))),
                 List.of(new RangeEntry(1, 2))));
 
     // when
@@ -324,16 +325,16 @@ final class RestorePointResolverTest {
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101),
-                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101)),
+                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201))),
                 List.of(new RangeEntry(1, 3))),
             metadata(
                 2,
                 List.of(
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101),
-                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201),
-                    entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101)),
+                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201)),
+                    entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301))),
                 List.of(new RangeEntry(2, 4))));
 
     // when – no 'to', so picks closest to now; checkpoint 3 is common and closer to now than 2
@@ -356,16 +357,16 @@ final class RestorePointResolverTest {
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101),
-                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101)),
+                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201))),
                 List.of(new RangeEntry(1, 3))),
             metadata(
                 2,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101),
-                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101)),
+                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201))),
                 List.of(new RangeEntry(1, 3))));
 
     // when
@@ -384,9 +385,9 @@ final class RestorePointResolverTest {
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
     final var t3 = Instant.parse("2025-01-03T00:00:00Z");
 
-    final var marker = entry(1, 100, t1, CheckpointType.MARKER, 50);
-    final var backup = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var markerAfter = entry(3, 300, t3, CheckpointType.MARKER, 250);
+    final var marker = entry(1, 100, t1, CheckpointType.MARKER, OptionalLong.empty());
+    final var backup = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var markerAfter = entry(3, 300, t3, CheckpointType.MARKER, OptionalLong.empty());
 
     final var meta =
         metadata(1, List.of(marker, backup, markerAfter), List.of(new RangeEntry(1, 3)));
@@ -407,10 +408,10 @@ final class RestorePointResolverTest {
     final var t3 = Instant.parse("2025-03-01T00:00:00Z");
     final var t4 = Instant.parse("2025-04-01T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201);
-    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
 
     // from=t2: range [1,2] start=cp1 at t1, t1.isAfter(t2)=false -> qualifies
     //          range [3,4] start=cp3 at t3, t3.isAfter(t2)=true -> filtered out
@@ -423,7 +424,7 @@ final class RestorePointResolverTest {
     final var result = RestorePointResolver.resolve(List.of(meta), t2, t1, Map.of());
 
     // then
-    assertThat(result.globalCheckpointId()).isEqualTo(1);
+    assertThat(result.globalCheckpointId()).isOne();
     assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp1);
   }
 
@@ -431,7 +432,7 @@ final class RestorePointResolverTest {
   void shouldHandleExportedPositionFilteringOutAllRanges() {
     // given – exportedPosition is too small for any range
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
 
     final var meta = metadata(1, List.of(cp1), List.of(new RangeEntry(1, 1)));
 
@@ -452,10 +453,10 @@ final class RestorePointResolverTest {
     final var t3 = Instant.parse("2025-03-01T00:00:00Z");
     final var t4 = Instant.parse("2025-04-01T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201);
-    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
 
     final var meta =
         metadata(
@@ -476,8 +477,8 @@ final class RestorePointResolverTest {
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
 
     final var meta = metadata(1, List.of(cp1, cp2), List.of(new RangeEntry(1, 2)));
 
@@ -498,10 +499,10 @@ final class RestorePointResolverTest {
     final var t3 = Instant.parse("2025-01-03T00:00:00Z");
     final var t4 = Instant.parse("2025-01-04T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
-    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201);
-    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
 
     final var meta = metadata(1, List.of(cp1, cp2, cp3, cp4), List.of(new RangeEntry(1, 4)));
 
@@ -526,14 +527,14 @@ final class RestorePointResolverTest {
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101))),
                 List.of(new RangeEntry(1, 2))),
             metadata(
                 2,
                 List.of(
-                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201),
-                    entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301)),
+                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201)),
+                    entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301))),
                 List.of(new RangeEntry(3, 4))));
 
     // when/then – from=t2 filters out P2's range (t3 > t2)
@@ -555,14 +556,14 @@ final class RestorePointResolverTest {
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101))),
                 List.of(new RangeEntry(1, 2))),
             metadata(
                 2,
                 List.of(
-                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, 60),
-                    entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, 111)),
+                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(60)),
+                    entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(111))),
                 List.of(new RangeEntry(1, 2))));
 
     // when – P2 exportedPosition=200 means cp1 on P2 (checkpointPosition=110) < 200 -> skip cp1
@@ -582,11 +583,11 @@ final class RestorePointResolverTest {
         List.of(
             metadata(
                 1,
-                List.of(entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50)),
+                List.of(entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50))),
                 List.of(new RangeEntry(1, 1))),
             metadata(
                 2,
-                List.of(entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, 60)),
+                List.of(entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(60))),
                 List.of(new RangeEntry(1, 1))));
 
     // when – P1 exportedPosition=500 > cp1.checkpointPosition=100 -> range filtered out
@@ -610,18 +611,18 @@ final class RestorePointResolverTest {
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101),
-                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201),
-                    entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101)),
+                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201)),
+                    entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301))),
                 List.of(new RangeEntry(1, 2), new RangeEntry(3, 4))),
             metadata(
                 2,
                 List.of(
-                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, 60),
-                    entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, 111),
-                    entry(3, 310, t3, CheckpointType.SCHEDULED_BACKUP, 211),
-                    entry(4, 410, t4, CheckpointType.SCHEDULED_BACKUP, 311)),
+                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(60)),
+                    entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(111)),
+                    entry(3, 310, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(211)),
+                    entry(4, 410, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(311))),
                 List.of(new RangeEntry(1, 2), new RangeEntry(3, 4))));
 
     // when – P1 exportedPosition=250 filters out range [1,2] (end cp2.pos=200 < 250)
@@ -647,14 +648,14 @@ final class RestorePointResolverTest {
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101))),
                 List.of(new RangeEntry(1, 2))),
             metadata(
                 2,
                 List.of(
-                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, 201),
-                    entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, 301)),
+                    entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201)),
+                    entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301))),
                 List.of(new RangeEntry(3, 4))));
 
     // when/then
@@ -672,9 +673,9 @@ final class RestorePointResolverTest {
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
     // firstLogPosition=300 creates a gap with cp1.checkpointPosition=100
-    final var cp2 = entry(2, 400, t2, CheckpointType.SCHEDULED_BACKUP, 300);
+    final var cp2 = entry(2, 400, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(300));
 
     final var meta = metadata(1, List.of(cp1, cp2), List.of(new RangeEntry(1, 2)));
 
@@ -692,8 +693,8 @@ final class RestorePointResolverTest {
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
 
     final var meta = metadata(1, List.of(cp1, cp2), List.of(new RangeEntry(1, 2)));
 
@@ -711,8 +712,8 @@ final class RestorePointResolverTest {
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
 
-    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 10);
-    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 50);
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(10));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
 
     final var meta = metadata(1, List.of(cp1, cp2), List.of(new RangeEntry(1, 2)));
 
@@ -731,10 +732,10 @@ final class RestorePointResolverTest {
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
     final var t3 = Instant.parse("2025-01-03T00:00:00Z");
 
-    final var backup1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50);
-    final var marker = entry(2, 200, t2, CheckpointType.MARKER, 101);
+    final var backup1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var marker = entry(2, 200, t2, CheckpointType.MARKER, OptionalLong.empty());
     // firstLogPosition=300 creates a gap with backup1.checkpointPosition=100
-    final var backup2 = entry(3, 400, t3, CheckpointType.SCHEDULED_BACKUP, 300);
+    final var backup2 = entry(3, 400, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(300));
 
     final var meta = metadata(1, List.of(backup1, marker, backup2), List.of(new RangeEntry(1, 3)));
 
@@ -755,15 +756,15 @@ final class RestorePointResolverTest {
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, 50),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, 101)),
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101))),
                 List.of(new RangeEntry(1, 2))),
             metadata(
                 2,
                 List.of(
-                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, 60),
+                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(60)),
                     // firstLogPosition=500 creates a gap with cp1.checkpointPosition=110
-                    entry(2, 600, t2, CheckpointType.SCHEDULED_BACKUP, 500)),
+                    entry(2, 600, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(500))),
                 List.of(new RangeEntry(1, 2))));
 
     // when/then – gap detected on partition 2
@@ -778,7 +779,7 @@ final class RestorePointResolverTest {
       final long position,
       final Instant timestamp,
       final CheckpointType type,
-      final long firstLogPosition) {
+      final OptionalLong firstLogPosition) {
     return new CheckpointEntry(id, position, timestamp, type, firstLogPosition);
   }
 


### PR DESCRIPTION
# Description
Backport of #47070 to `stable/8.9`.

relates to 