### PR TITLE
fix: convert DESCRIPTION columns to clob

### DIFF
--- a/db/rdbms-schema/pom.xml
+++ b/db/rdbms-schema/pom.xml
@@ -30,11 +30,6 @@
       <artifactId>spring-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.vertical-blank</groupId>
-      <artifactId>sql-formatter</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/LiquibaseScriptGenerator.java
+++ b/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/LiquibaseScriptGenerator.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.db.rdbms;
 
-import com.github.vertical_blank.sqlformatter.SqlFormatter;
 import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -175,22 +174,13 @@ public class LiquibaseScriptGenerator {
           }
         }
 
-        sqlScript.append(formatSql(sqlString));
+        sqlScript.append(sqlString);
         sqlScript.append(";");
         sqlScript.append("\n");
       }
 
       sqlScript.append("\n");
     }
-  }
-
-  private static String formatSql(final String sqlString) {
-    var formattedSql = SqlFormatter.format(sqlString);
-
-    // Fix spaces inside backticked identifiers (e.g., ` DESCRIPTION ` -> `DESCRIPTION`)
-    // Match backtick pairs and remove leading/trailing whitespace inside them
-    formattedSql = formattedSql.replaceAll("`\\s+([^`]+?)\\s+`", "`$1`");
-    return formattedSql;
   }
 
   private static boolean isSupported(final Change change, final Database database) {

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -1261,4 +1261,33 @@
     </createIndex>
   </changeSet>
 
+  <!-- VARCHAR->CLOB conversion via a multi-step approach to ensure compatibility across all
+       databases (e.g. Oracle does not support direct VARCHAR2->CLOB alteration: ORA-22858) -->
+  <changeSet id="alter_tenant_description_to_clob" author="camunda">
+    <addColumn tableName="${prefix}TENANT">
+      <column name="DESCRIPTION_CLOB" type="CLOB"/>
+    </addColumn>
+    <sql>UPDATE ${prefix}TENANT SET DESCRIPTION_CLOB = DESCRIPTION</sql>
+    <dropColumn tableName="${prefix}TENANT" columnName="DESCRIPTION"/>
+    <renameColumn tableName="${prefix}TENANT" oldColumnName="DESCRIPTION_CLOB" newColumnName="DESCRIPTION"/>
+  </changeSet>
+
+  <changeSet id="alter_role_description_to_clob" author="camunda">
+    <addColumn tableName="${prefix}ROLES">
+      <column name="DESCRIPTION_CLOB" type="CLOB"/>
+    </addColumn>
+    <sql>UPDATE ${prefix}ROLES SET DESCRIPTION_CLOB = DESCRIPTION</sql>
+    <dropColumn tableName="${prefix}ROLES" columnName="DESCRIPTION"/>
+    <renameColumn tableName="${prefix}ROLES" oldColumnName="DESCRIPTION_CLOB" newColumnName="DESCRIPTION"/>
+  </changeSet>
+
+  <changeSet id="alter_group_description_to_clob" author="camunda">
+    <addColumn tableName="${prefix}GROUP_">
+      <column name="DESCRIPTION_CLOB" type="CLOB"/>
+    </addColumn>
+    <sql>UPDATE ${prefix}GROUP_ SET DESCRIPTION_CLOB = DESCRIPTION</sql>
+    <dropColumn tableName="${prefix}GROUP_" columnName="DESCRIPTION"/>
+    <renameColumn tableName="${prefix}GROUP_" oldColumnName="DESCRIPTION_CLOB" newColumnName="DESCRIPTION"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/LiquibaseScriptGeneratorTest.java
+++ b/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/LiquibaseScriptGeneratorTest.java
@@ -25,7 +25,7 @@ class LiquibaseScriptGeneratorTest {
 
     // then
     final var expected = Files.readString(Paths.get("src/test/resources/test.h2.sql"));
-    assertThat(sqlScript).isEqualTo(expected);
+    assertThat(sqlScript).isEqualToIgnoringWhitespace(expected);
   }
 
   @Test
@@ -64,6 +64,6 @@ class LiquibaseScriptGeneratorTest {
 
     // then
     final var expected = Files.readString(Paths.get("src/test/resources/test_prefix.h2.sql"));
-    assertThat(sqlScript).isEqualTo(expected);
+    assertThat(sqlScript).isEqualToIgnoringWhitespace(expected);
   }
 }


### PR DESCRIPTION
## Description

This pull request updates the database schema to support longer descriptions for tenants, roles, and groups by converting their `DESCRIPTION` columns from `VARCHAR` to `CLOB`. The migration uses a multi-step process to ensure compatibility across different databases, particularly Oracle.

**Database schema changes:**

* Converted the `DESCRIPTION` column in the `${prefix}TENANT`, `${prefix}ROLES`, and `${prefix}GROUP_` tables from `VARCHAR` to `CLOB` using a process that adds a new `CLOB` column, copies data, drops the old column, and renames the new column to `DESCRIPTION` to ensure cross-database compatibility.
## Related issues

closes #47103 
