### PR TITLE
fix: support oracle 19c multiline insert syntax

### DIFF
--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -139,6 +139,15 @@
     </foreach>
   </insert>
 
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="permissionTypes" item="permissionType">
+      INTO ${prefix}AUTHORIZATIONS (AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, RESOURCE_PROPERTY_NAME, PERMISSION_TYPE)
+      VALUES (#{authorizationKey}, #{ownerId}, #{ownerType}, #{resourceType}, #{resourceMatcher}, #{resourceId}, #{resourcePropertyName}, #{permissionType})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel">
     DELETE
     FROM ${prefix}AUTHORIZATIONS

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -76,6 +76,17 @@
     </foreach>
   </insert>
 
+  <insert id="insertItems"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemsDto"
+    databaseId="oracle">
+    INSERT ALL
+    <foreach collection="items" item="item">
+      INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, STATE)
+      VALUES (#{batchOperationKey}, #{item.itemKey}, #{item.processInstanceKey}, #{item.rootProcessInstanceKey}, #{item.state})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <insert id="insertErrors"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationErrorDto">
     INSERT INTO ${prefix}BATCH_OPERATION_ERROR
@@ -84,6 +95,17 @@
     <foreach collection="errors" item="error" separator=",">
       (#{batchOperationKey}, #{error.partitionId}, #{error.type}, #{error.message})
     </foreach>
+  </insert>
+
+  <insert id="insertErrors"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationErrorDto"
+    databaseId="oracle">
+    INSERT ALL
+    <foreach collection="errors" item="error">
+      INTO ${prefix}BATCH_OPERATION_ERROR (BATCH_OPERATION_KEY, PARTITION_ID, TYPE, MESSAGE)
+      VALUES (#{batchOperationKey}, #{error.partitionId}, #{error.type}, #{error.message})
+    </foreach>
+    SELECT 1 FROM DUAL
   </insert>
 
   <update id="activate"

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -268,6 +268,15 @@
     </foreach>
   </insert>
 
+  <insert id="insertInput" parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="evaluatedInputs" item="item">
+      INTO ${prefix}DECISION_INSTANCE_INPUT (DECISION_INSTANCE_ID, INPUT_ID, INPUT_NAME, INPUT_VALUE)
+      VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <!-- create select statement for decision instance input -->
   <select id="loadInputs" parameterType="list"
     resultMap="io.camunda.db.rdbms.sql.DecisionInstanceMapper.evaluatedInputResultMap">
@@ -299,6 +308,17 @@
       (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId},
       #{item.ruleIndex})
     </foreach>
+  </insert>
+
+  <insert id="insertOutput"
+    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel"
+    databaseId="oracle">
+    INSERT ALL
+    <foreach collection="evaluatedOutputs" item="item">
+      INTO ${prefix}DECISION_INSTANCE_OUTPUT (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, OUTPUT_VALUE, RULE_ID, RULE_INDEX)
+      VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId}, #{item.ruleIndex})
+    </foreach>
+    SELECT 1 FROM DUAL
   </insert>
 
   <select id="loadOutputs" parameterType="list"

--- a/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
@@ -37,6 +37,14 @@
     </foreach>
   </insert>
 
+  <insert id="insertEventTypes" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="eventTypes" item="eventType">
+      INTO ${prefix}GLOBAL_LISTENER_EVENT_TYPE (GLOBAL_LISTENER_ID, EVENT_TYPE) VALUES (#{id}, #{eventType})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
     UPDATE ${prefix}GLOBAL_LISTENER
     SET LISTENER_ID = #{listenerId},

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -455,6 +455,14 @@
       </foreach>
   </insert>
 
+  <insert id="insertTags" parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="tags" item="tag">
+      INTO ${prefix}PROCESS_INSTANCE_TAG (PROCESS_INSTANCE_KEY, TAG_VALUE) VALUES (#{processInstanceKey}, #{tag})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}PROCESS_INSTANCE
     SET HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -35,6 +35,14 @@
     </foreach>
   </insert>
 
+  <insert id="insertCandidateUsers" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="candidateUsers" item="candidateUser">
+      INTO ${prefix}CANDIDATE_USER (USER_TASK_KEY, CANDIDATE_USER) VALUES (#{userTaskKey}, #{candidateUser})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <insert id="insertCandidateGroups" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     INSERT INTO ${prefix}CANDIDATE_GROUP (USER_TASK_KEY, CANDIDATE_GROUP)
     VALUES
@@ -43,12 +51,28 @@
     </foreach>
   </insert>
 
+  <insert id="insertCandidateGroups" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="candidateGroups" item="candidateGroup">
+      INTO ${prefix}CANDIDATE_GROUP (USER_TASK_KEY, CANDIDATE_GROUP) VALUES (#{userTaskKey}, #{candidateGroup})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <insert id="insertTags" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     INSERT INTO ${prefix}USER_TASK_TAG (USER_TASK_KEY, TAG_VALUE)
     VALUES
     <foreach collection="tags" item="tag" separator=", ">
       (#{userTaskKey}, #{tag})
     </foreach>
+  </insert>
+
+  <insert id="insertTags" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="tags" item="tag">
+      INTO ${prefix}USER_TASK_TAG (USER_TASK_KEY, TAG_VALUE) VALUES (#{userTaskKey}, #{tag})
+    </foreach>
+    SELECT 1 FROM DUAL
   </insert>
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.UserTaskDbModel">


### PR DESCRIPTION
This pull request introduces Oracle-specific bulk insert statements for several tables across the project’s MyBatis XML mappers. The main improvement is the addition of `INSERT ALL` statements, allowing multiple records to be inserted in a single operation for Oracle databases, which increases efficiency and consistency in batch insert operations. The changes are grouped by the affected domain areas.

Bulk insert support for Oracle (by domain):

**Batch Operations**
* Added `insertItems` and `insertErrors` Oracle-specific bulk insert statements in `BatchOperationMapper.xml` for batch operation items and errors, enabling efficient multi-row inserts. [[1]](diffhunk://#diff-ef88b6fd715f9aa972bd545a6e07b9fe8a436cb6c71918e20daa6c4d971725b5R79-R89) [[2]](diffhunk://#diff-ef88b6fd715f9aa972bd545a6e07b9fe8a436cb6c71918e20daa6c4d971725b5R100-R110)

**Decision Instances**
* Introduced `insertInput` and `insertOutput` Oracle bulk insert statements in `DecisionInstanceMapper.xml` for evaluated inputs and outputs, improving batch processing for decision instance data. [[1]](diffhunk://#diff-01c0d2801059c839c6d765bdbcdac735aa16de01db82ded06ee604e47c475829R271-R279) [[2]](diffhunk://#diff-01c0d2801059c839c6d765bdbcdac735aa16de01db82ded06ee604e47c475829R313-R323)

**User Tasks**
* Added Oracle bulk insert statements for candidate users, candidate groups, and tags in `UserTaskMapper.xml`, streamlining batch inserts for user task-related entities. [[1]](diffhunk://#diff-f9dea7ba54d16fe76788fca80299a8454a17e5313d4e75b4a26661dc28b48bc1R38-R45) [[2]](diffhunk://#diff-f9dea7ba54d16fe76788fca80299a8454a17e5313d4e75b4a26661dc28b48bc1R54-R61) [[3]](diffhunk://#diff-f9dea7ba54d16fe76788fca80299a8454a17e5313d4e75b4a26661dc28b48bc1R70-R77)

**Process Instances**
* Implemented `insertTags` Oracle bulk insert in `ProcessInstanceMapper.xml` for process instance tags, allowing multiple tags to be inserted efficiently.

**Authorizations and Global Listeners**
* Added Oracle bulk insert statements for authorizations and global listener event types in their respective mappers, enabling batch inserts for these entities. [[1]](diffhunk://#diff-42389b054f08dc2ad9bd50fea78c945d251763225ac182b345d942f6778c510dR142-R150) [[2]](diffhunk://#diff-7cef5b12923c3edbd76a2eedd1eae5fffb28b1dd8d8c6b710453d4349fba5d10R40-R47)

These changes collectively improve performance and maintain consistency for batch insert operations on Oracle databases throughout the application.

## Related issues

closes #
