### PR TITLE
test: increase monorepo SaaS tests timeout

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -343,7 +343,7 @@ jobs:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
     needs: [build-and-push, format-identifier]
-    timeout-minutes: 30
+    timeout-minutes: 35
     permissions: { }
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

The Trigger SaaS step on [monorepo PR](https://github.com/camunda/camunda/pull/46918/checks?check_run_id=65015076339) duration was 30 minutes.

The [triggered run](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/22449921655)on our side took approximately 32 minutes.

We could not get the result of the run due to  30 min window so I increased to 35 min. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
