### PR TITLE
feat: add authorization filter to identity audit log

### DIFF
--- a/client-components/package-lock.json
+++ b/client-components/package-lock.json
@@ -3980,7 +3980,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.46",
+			"version": "0.0.47",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.3.3",

--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.47
+
+### 🚀 Enhancements
+
+- add `relatedEntityKey` filter to Audit Log ([#45201](https://github.com/camunda/camunda/issues/45201))
+
+### ❤️ Contributors
+
+- Luca Arienti ([@arienzIT](https://github.com/arienzIT))
+
 ## v0.0.46
 
 ### 🚀 Enhancements

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
@@ -130,6 +130,7 @@ const auditLogFilterSchema = z
 		formKey: advancedStringFilterSchema.optional(),
 		resourceKey: advancedStringFilterSchema.optional(),
 		relatedEntityType: getEnumFilterSchema(auditLogEntityTypeSchema).optional(),
+		relatedEntityKey: advancedStringFilterSchema.optional(),
 		entityDescription: advancedStringFilterSchema.optional(),
 	})
 	.partial();

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.46",
+	"version": "0.0.47",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.9.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.46",
+        "@camunda/camunda-api-zod-schemas": "0.0.47",
         "@camunda/camunda-composite-components": "0.22.1",
         "@carbon/elements": "^11.57.0",
         "@carbon/react": "1.101.0",
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.46.tgz",
-      "integrity": "sha512-RvlpnMkO7kTT0MV6YqzcGieRcjEgQwuut4pGX9VBZEm839y0IOLgccbzrZSwqfmJknSqZvNAQdIv9Nk+CT7YvA==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.47.tgz",
+      "integrity": "sha512-hpWbDVgrfDMDoqYOit3F9uleYPe6AVTxnUDSYT/Qn+fXcTZ2r3lFq7WfHqWJZVwTeQD+gfbjefMMld/soJVMpw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.46",
+    "@camunda/camunda-api-zod-schemas": "0.0.47",
     "@camunda/camunda-composite-components": "0.22.1",
     "@carbon/elements": "^11.57.0",
     "@carbon/react": "1.101.0",

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -34,7 +34,10 @@ import {
   Stack,
   TextInput,
 } from "@carbon/react";
-import { auditLogResultSchema } from "@camunda/camunda-api-zod-schemas/8.9";
+import {
+  AuditLogEntityType,
+  auditLogResultSchema,
+} from "@camunda/camunda-api-zod-schemas/8.9";
 import useDebounce from "react-debounced";
 import { useForm } from "react-hook-form";
 import { CellProperty } from "src/pages/operations-log/CellProperty";
@@ -74,8 +77,10 @@ const List: FC = () => {
     setSearchParamsFilters(filters);
   }, [filters]);
 
-  const debounce = useDebounce();
+  const debounce = useDebounce(500);
   const [debouncedActor, setDebouncedActor] = useState<string>();
+  const [debouncedRelatedEntityKey, setDebouncedRelatedEntityKey] =
+    useState<string>();
 
   const [isDateRangeModalOpen, setIsDateRangeModalOpen] =
     useState<boolean>(false);
@@ -117,10 +122,11 @@ const List: FC = () => {
         filters.operationType && filters.operationType.length > 0
           ? { $in: filters.operationType }
           : undefined,
-      entityType:
-        filters.entityType && filters.entityType.length > 0
-          ? { $in: filters.entityType }
-          : undefined,
+      entityType: filters.entityType ? { $eq: filters.entityType } : undefined,
+      relatedEntityType: filters.relatedEntityType
+        ? { $eq: filters.relatedEntityType }
+        : undefined,
+      relatedEntityKey: debouncedRelatedEntityKey,
       actorId: debouncedActor,
       timestamp:
         filters.timestampFrom && filters.timestampTo
@@ -171,22 +177,67 @@ const List: FC = () => {
                 }}
                 size="sm"
               />
-              <MultiSelect
+              <Dropdown
                 id="entityType"
                 items={ALLOWED_ENTITY_TYPES}
                 titleText={t("entityType")}
-                label={t("multiSelectLabel")}
-                selectedItems={filters.entityType}
+                label={t("selectLabel")}
+                selectedItem={filters.entityType ? filters.entityType : ""}
                 itemToString={(selectedItem) =>
-                  spaceAndCapitalize(selectedItem)
+                  selectedItem ? spaceAndCapitalize(selectedItem) : ""
                 }
-                onChange={({ selectedItems }) => {
-                  if (selectedItems !== null) {
-                    setValue("entityType", selectedItems);
+                onChange={({
+                  selectedItem,
+                }: {
+                  selectedItem: AuditLogEntityType;
+                }) => {
+                  setValue("entityType", selectedItem);
+
+                  if (selectedItem !== "AUTHORIZATION") {
+                    setValue("relatedEntityType", undefined);
+                    setValue("relatedEntityKey", "");
+                    setDebouncedRelatedEntityKey(undefined);
                   }
                 }}
                 size="sm"
               />
+              {filters.entityType === "AUTHORIZATION" && (
+                <>
+                  <Dropdown
+                    id="relatedEntityType"
+                    items={ALLOWED_ENTITY_TYPES}
+                    titleText={t("ownerType")}
+                    label={t("selectLabel")}
+                    selectedItem={
+                      filters.relatedEntityType ? filters.relatedEntityType : ""
+                    }
+                    itemToString={(selectedItem) =>
+                      selectedItem ? spaceAndCapitalize(selectedItem) : ""
+                    }
+                    onChange={({
+                      selectedItem,
+                    }: {
+                      selectedItem: AuditLogEntityType;
+                    }) => {
+                      setValue("relatedEntityType", selectedItem);
+                    }}
+                  />
+                  <TextInput
+                    id="relatedEntityKey"
+                    labelText={t("ownerKey")}
+                    placeholder={t("ownerKeyPlaceholder")}
+                    value={filters.relatedEntityKey}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      const value = e.target.value.trim();
+                      setValue("relatedEntityKey", value);
+                      debounce(() =>
+                        setDebouncedRelatedEntityKey(value ? value : undefined),
+                      );
+                    }}
+                    size="sm"
+                  />
+                </>
+              )}
               <Dropdown
                 label={t("selectLabel")}
                 aria-label={t("selectLabel")}
@@ -244,7 +295,7 @@ const List: FC = () => {
                   size="sm"
                   disabled={
                     filters.operationType.length === 0 &&
-                    filters.entityType.length === 0 &&
+                    !filters.entityType &&
                     filters.result === "all" &&
                     !filters.actor &&
                     !filters.timestampFrom &&
@@ -254,13 +305,16 @@ const List: FC = () => {
                   onClick={() => {
                     reset({
                       operationType: [],
-                      entityType: [],
+                      entityType: undefined,
+                      relatedEntityType: undefined,
+                      relatedEntityKey: "",
                       result: "all",
                       actor: "",
                       timestampFrom: "",
                       timestampTo: "",
                     });
                     setDebouncedActor(undefined);
+                    setDebouncedRelatedEntityKey(undefined);
                   }}
                 >
                   {t("reset")}

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -78,9 +78,9 @@ const List: FC = () => {
   }, [filters]);
 
   const debounce = useDebounce(500);
-  const [debouncedActor, setDebouncedActor] = useState<string>();
+  const [debouncedActor, setDebouncedActor] = useState<string>(filters.actor);
   const [debouncedRelatedEntityKey, setDebouncedRelatedEntityKey] =
-    useState<string>();
+    useState<string>(filters.relatedEntityKey);
 
   const [isDateRangeModalOpen, setIsDateRangeModalOpen] =
     useState<boolean>(false);
@@ -126,8 +126,10 @@ const List: FC = () => {
       relatedEntityType: filters.relatedEntityType
         ? { $eq: filters.relatedEntityType }
         : undefined,
-      relatedEntityKey: debouncedRelatedEntityKey,
-      actorId: debouncedActor,
+      relatedEntityKey: debouncedRelatedEntityKey
+        ? debouncedRelatedEntityKey
+        : undefined,
+      actorId: debouncedActor ? debouncedActor : undefined,
       timestamp:
         filters.timestampFrom && filters.timestampTo
           ? {
@@ -196,7 +198,7 @@ const List: FC = () => {
                   if (selectedItem !== "AUTHORIZATION") {
                     setValue("relatedEntityType", undefined);
                     setValue("relatedEntityKey", "");
-                    setDebouncedRelatedEntityKey(undefined);
+                    setDebouncedRelatedEntityKey("");
                   }
                 }}
                 size="sm"
@@ -230,9 +232,7 @@ const List: FC = () => {
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                       const value = e.target.value.trim();
                       setValue("relatedEntityKey", value);
-                      debounce(() =>
-                        setDebouncedRelatedEntityKey(value ? value : undefined),
-                      );
+                      debounce(() => setDebouncedRelatedEntityKey(value ?? ""));
                     }}
                     size="sm"
                   />
@@ -270,7 +270,7 @@ const List: FC = () => {
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const value = e.target.value.trim();
                   setValue("actor", value);
-                  debounce(() => setDebouncedActor(value ? value : undefined));
+                  debounce(() => setDebouncedActor(value ?? ""));
                 }}
                 size="sm"
               />
@@ -313,8 +313,8 @@ const List: FC = () => {
                       timestampFrom: "",
                       timestampTo: "",
                     });
-                    setDebouncedActor(undefined);
-                    setDebouncedRelatedEntityKey(undefined);
+                    setDebouncedActor("");
+                    setDebouncedRelatedEntityKey("");
                   }}
                 >
                   {t("reset")}

--- a/identity/client/src/pages/operations-log/filters.ts
+++ b/identity/client/src/pages/operations-log/filters.ts
@@ -21,7 +21,9 @@ import { isValidDate } from "src/utility/validate";
 
 export type AuditLogFilters = {
   operationType: AuditLogOperationType[];
-  entityType: AuditLogEntityType[];
+  entityType?: AuditLogEntityType;
+  relatedEntityType?: AuditLogEntityType;
+  relatedEntityKey: string;
   result: AuditLogResult | "all";
   actor: string;
   timestampFrom: string;
@@ -65,13 +67,34 @@ const auditLogSearchParamsSync = createSearchParamsSync<AuditLogFilters>({
 
   entityType: {
     parse: (params) => {
-      return parseArrayParam<AuditLogEntityType>(
-        params.get("entityType"),
-      ).filter((item) => ALLOWED_ENTITY_TYPES.includes(item));
+      const entityType = params.get("entityType") as AuditLogEntityType;
+
+      return ALLOWED_ENTITY_TYPES.includes(entityType) ? entityType : undefined;
     },
     serialize: (value, params) => {
-      const v = buildArrayParam(value);
-      if (v) params.set("entityType", v);
+      if (value) params.set("entityType", value);
+    },
+  },
+
+  relatedEntityType: {
+    parse: (params) => {
+      const relatedEntityType = params.get(
+        "relatedEntityType",
+      ) as AuditLogEntityType;
+
+      return ALLOWED_ENTITY_TYPES.includes(relatedEntityType)
+        ? relatedEntityType
+        : undefined;
+    },
+    serialize: (value, params) => {
+      if (value) params.set("relatedEntityType", value);
+    },
+  },
+
+  relatedEntityKey: {
+    parse: (params) => params.get("relatedEntityKey") ?? "",
+    serialize: (value, params) => {
+      if (value) params.set("relatedEntityKey", value);
     },
   },
 

--- a/identity/client/src/utility/localization/en/operationsLog.json
+++ b/identity/client/src/utility/localization/en/operationsLog.json
@@ -16,5 +16,8 @@
   "reset": "Reset filters",
   "errorCode": "Error code",
   "owner": "Owner",
-  "assignee": "Assignee"
+  "assignee": "Assignee",
+  "ownerType": "Owner type",
+  "ownerKey": "Owner ID",
+  "ownerKeyPlaceholder": "Enter owner ID"
 }


### PR DESCRIPTION
## Description

- Make the `entityType` filter single
- Add authorisation specific filters for `referenceEntityKey`, `referenceEntityType` when `entityType` is `AUTHORIZATION`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45201
