### PR TITLE
fix: complete search API response definitions for groups, roles, and tenants

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -538,7 +538,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/GroupMappingRuleSearchResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -828,3 +828,17 @@ components:
           type: array
           items:
             $ref: 'roles.yaml#/components/schemas/RoleResult'
+
+    GroupMappingRuleSearchResult:
+      description: Group mapping rule search response.
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching mapping rules.
+          type: array
+          items:
+            $ref: 'mapping-rules.yaml#/components/schemas/MappingRuleResult'

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -581,7 +581,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/GroupRoleSearchResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -814,3 +814,17 @@ components:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
         - field
+
+    GroupRoleSearchResult:
+      description: Group role search response.
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching roles.
+          type: array
+          items:
+            $ref: 'roles.yaml#/components/schemas/RoleResult'

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -657,7 +657,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/RoleMappingRuleSearchResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -932,3 +932,17 @@ components:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
         - field
+
+    RoleMappingRuleSearchResult:
+      description: Role mapping rule search response.
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching mapping rules.
+          type: array
+          items:
+            $ref: 'mapping-rules.yaml#/components/schemas/MappingRuleResult'

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -541,7 +541,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/TenantRoleSearchResult'
 
   /tenants/{tenantId}/roles/{roleId}:
     put:
@@ -1016,3 +1016,17 @@ components:
           type: array
           items:
             $ref: 'mapping-rules.yaml#/components/schemas/MappingRuleResult'
+
+    TenantRoleSearchResult:
+      description: Tenant role search response.
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching roles.
+          type: array
+          items:
+            $ref: 'roles.yaml#/components/schemas/RoleResult'

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -729,7 +729,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/TenantMappingRuleSearchResult'
 
 ## Schema definitions
 
@@ -1002,3 +1002,17 @@ components:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
         - field
+
+    TenantMappingRuleSearchResult:
+      description: Tenant mapping rule search response.
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching mapping rules.
+          type: array
+          items:
+            $ref: 'mapping-rules.yaml#/components/schemas/MappingRuleResult'


### PR DESCRIPTION
## Summary
- Fixes 5 search endpoints that were using the generic `SearchQueryResponse` directly (only defines `page` info) instead of dedicated response schemas that include an `items` array with actual search results
- Adds dedicated response schemas: `GroupRoleSearchResult`, `GroupMappingRuleSearchResult`, `RoleMappingRuleSearchResult`, `TenantRoleSearchResult`, `TenantMappingRuleSearchResult`
- Each endpoint is addressed in a dedicated commit
- Sanity check confirmed no other search endpoints have the same issue

## Test plan
- [ ] Verify OpenAPI spec validation passes (spectral lint)
- [ ] Verify generated code compiles successfully
- [ ] Verify E2E tests for the 5 affected search endpoints pass

Closes #46895