### PR TITLE
[Backport stable/8.9] fix: replace RequestDispatcher.forward with HttpServletRequestWrapper

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilter.java
@@ -48,9 +48,13 @@ public class CCSMRequestAdjustmentFilter implements Filter {
 
     /* transform /external/api -> /api/external */
     if (requestURI.startsWith("/external/api/")) {
+<<<<<<< HEAD
       final String rewrittenURI =
           httpRequest.getContextPath()
               + requestURI.replaceFirst("/external/api/", "/api/external/");
+=======
+      final String rewrittenURI = requestURI.replaceFirst("/external/api/", "/api/external/");
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
       chain.doFilter(new PathRewritingRequestWrapper(httpRequest, rewrittenURI), response);
       return;
     }

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSMRequestAdjustmentFilterTest.java
@@ -125,8 +125,13 @@ public class CCSMRequestAdjustmentFilterTest {
   class ContextPathHandling {
 
     @Test
+<<<<<<< HEAD
     void contextPathIsKeptOnRewrite() throws Exception {
       // given — request has a context path that should be kept on rewrite
+=======
+    void contextPathStrippedBeforeRewrite() throws Exception {
+      // given — request has a context path that should be stripped first
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
       final CCSMRequestAdjustmentFilter filter = createFilter();
       when(request.getContextPath()).thenReturn("/optimize");
       when(request.getRequestURI()).thenReturn("/optimize/external/api/some-endpoint");
@@ -140,9 +145,13 @@ public class CCSMRequestAdjustmentFilterTest {
       verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
 
       final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
+<<<<<<< HEAD
       assertThat(wrappedRequest.getRequestURI())
           .describedAs("Rewritten URI must retain the context path")
           .isEqualTo("/optimize/api/external/some-endpoint");
+=======
+      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/api/external/some-endpoint");
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
     }
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilterTest.java
@@ -111,9 +111,13 @@ public class CCSaasRequestAdjustmentFilterTest {
       verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
 
       final HttpServletRequest wrappedRequest = (HttpServletRequest) requestCaptor.getValue();
+<<<<<<< HEAD
       assertThat(wrappedRequest.getRequestURI())
           .describedAs("Should no longer contain '/{clusterId}' prefix")
           .isEqualTo("/");
+=======
+      assertThat(wrappedRequest.getRequestURI()).isEqualTo("/");
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
     }
   }
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/tomcat/PathRewritingRequestWrapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/tomcat/PathRewritingRequestWrapperTest.java
@@ -32,7 +32,11 @@ class PathRewritingRequestWrapperTest {
     void returnsRewrittenURI() {
       // given — no forward attribute set (normal REQUEST dispatch)
       final HttpServletRequest original = mock(HttpServletRequest.class);
+<<<<<<< HEAD
       final HttpServletRequest wrapper =
+=======
+      final PathRewritingRequestWrapper wrapper =
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
           new PathRewritingRequestWrapper(original, "/api/some-endpoint");
 
       // when / then
@@ -47,7 +51,11 @@ class PathRewritingRequestWrapperTest {
       when(original.getServerName()).thenReturn("example.com");
       when(original.getServerPort()).thenReturn(443);
 
+<<<<<<< HEAD
       final HttpServletRequest wrapper =
+=======
+      final PathRewritingRequestWrapper wrapper =
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
           new PathRewritingRequestWrapper(original, "/api/some-endpoint");
 
       // when / then
@@ -61,7 +69,12 @@ class PathRewritingRequestWrapperTest {
       final HttpServletRequest original = mock(HttpServletRequest.class);
       when(original.getServletPath()).thenReturn("/original/servlet/path");
 
+<<<<<<< HEAD
       final HttpServletRequest wrapper = new PathRewritingRequestWrapper(original, "/rewritten");
+=======
+      final PathRewritingRequestWrapper wrapper =
+          new PathRewritingRequestWrapper(original, "/rewritten");
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
 
       // when / then — getServletPath must NOT be overridden
       assertThat(wrapper.getServletPath()).isEqualTo("/original/servlet/path");
@@ -122,7 +135,11 @@ class PathRewritingRequestWrapperTest {
       final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
       when(original.getRequestDispatcher("/index.html")).thenReturn(expectedDispatcher);
 
+<<<<<<< HEAD
       final HttpServletRequest wrapper = new PathRewritingRequestWrapper(original, "/");
+=======
+      final PathRewritingRequestWrapper wrapper = new PathRewritingRequestWrapper(original, "/");
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
 
       // when
       final RequestDispatcher result = wrapper.getRequestDispatcher("index.html");
@@ -139,7 +156,12 @@ class PathRewritingRequestWrapperTest {
       final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
       when(original.getRequestDispatcher("/api/resource.html")).thenReturn(expectedDispatcher);
 
+<<<<<<< HEAD
       final HttpServletRequest wrapper = new PathRewritingRequestWrapper(original, "/api/endpoint");
+=======
+      final PathRewritingRequestWrapper wrapper =
+          new PathRewritingRequestWrapper(original, "/api/endpoint");
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
 
       // when
       final RequestDispatcher result = wrapper.getRequestDispatcher("resource.html");
@@ -156,7 +178,11 @@ class PathRewritingRequestWrapperTest {
       final RequestDispatcher expectedDispatcher = mock(RequestDispatcher.class);
       when(original.getRequestDispatcher("/absolute/path")).thenReturn(expectedDispatcher);
 
+<<<<<<< HEAD
       final HttpServletRequest wrapper = new PathRewritingRequestWrapper(original, "/");
+=======
+      final PathRewritingRequestWrapper wrapper = new PathRewritingRequestWrapper(original, "/");
+>>>>>>> 9f2dcfda (fix: replace RequestDispatcher.forward with HttpServletRequestWrapper)
 
       // when
       final RequestDispatcher result = wrapper.getRequestDispatcher("/absolute/path");


### PR DESCRIPTION
# Description
Backport of #47004 to `stable/8.9`.

relates to #46344