### PR TITLE
[Backport stable/8.8] CI: derive flaky rerun count from event type

### DIFF
--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -25,6 +25,7 @@ env:
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_OWNER: Core Features
   TEST_TYPE: Unit
+  FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
 
 defaults:
   run:
@@ -66,7 +67,7 @@ jobs:
           ./mvnw -Dtest=${{inputs.componentName}}${{inputs.suite}}TestSuite
           -Dsurefire.failIfNoSpecifiedTests=false -B -T 2 --no-snapshot-updates
           -D forkCount=7 -D skipITs -D skipQaBuild=true -D skipChecks -Dskip.docker
-          -D surefire.rerunFailingTestsCount=3 -D junitThreadCount=16 -P skipFrontendBuild
+          -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }} -D junitThreadCount=16 -P skipFrontendBuild
           -pl '-:optimize-schema-integrity-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -29,6 +29,7 @@ env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Zeebe
+  FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
 
 jobs:
   smoke-tests:
@@ -88,7 +89,7 @@ jobs:
           EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
         run: >
           ./mvnw -B --no-snapshot-updates
-          -DskipUTs -DskipChecks -Dsurefire.rerunFailingTestsCount=3
+          -DskipUTs -DskipChecks -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -pl qa/integration-tests
           -P smoke-test,extract-flaky-tests
           -D excludedGroups="$EXCLUDED_TEST_GROUPS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ defaults:
 env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
+  FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
 
 jobs:
   detect-changes:
@@ -352,7 +353,7 @@ jobs:
         run: >
           ./mvnw -B -T 2 --no-snapshot-updates
           -D forkCount=7
-          -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
+          -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -D junitThreadCount=16
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ env.GENERAL_UT_MODULES }}
@@ -444,7 +445,7 @@ jobs:
         run: >
           ./mvnw -B -T 2 --no-snapshot-updates
           -D forkCount=7
-          -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
+          -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -D junitThreadCount=16
           -D argLine="@{argLine} -Xmx4g"
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
@@ -782,7 +783,7 @@ jobs:
           -D forkCount=1
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -D failsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }} -D flaky.test.reportDir=failsafe-reports
           -P rdbms,extract-flaky-tests
           -pl qa/acceptance-tests
           verify
@@ -1024,7 +1025,7 @@ jobs:
           -D forkCount=${{ matrix.maven-test-fork-count }}
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -D failsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }} -D flaky.test.reportDir=failsafe-reports
           -Dio.camunda.process.test.camundaDockerImageName="${{ env.CAMUNDA_DOCKER_IMAGE_NAME }}"
           -Dio.camunda.process.test.camundaDockerImageVersion="${{ env.DOCKER_IMAGE_TAG }}"
           -Dio.camunda.process.test.camundaVersion="${{ env.DOCKER_IMAGE_TAG }}"
@@ -1093,7 +1094,7 @@ jobs:
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >
           ./mvnw -B --no-snapshot-updates
-          -D skipITs -D skipQaBuild=false -D skipChecks -Dsurefire.rerunFailingTestsCount=3
+          -D skipITs -D skipQaBuild=false -D skipChecks -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -P skipFrontendBuild,extract-flaky-tests
           -pl :camunda-archunit-tests
           -am
@@ -1212,7 +1213,7 @@ jobs:
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >
           ./mvnw -pl dist/ --no-snapshot-updates -DskipChecks -Dassembly.skipAssembly=true
-          -DskipUTs -Dit.test=*DockerIT -Dfailsafe.rerunFailingTestsCount=3
+          -DskipUTs -Dit.test=*DockerIT -Dfailsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -P parallel-tests,extract-flaky-tests
           -Dcamunda.docker.test.enabled=true
           -Dcamunda.docker.test.image="${{ env.LOCAL_DOCKER_IMAGE }}:${{ steps.build-camunda-docker.outputs.version }}"


### PR DESCRIPTION
# Description
Backport of #47015 to `stable/8.8`.

relates to camunda/camunda#46679 camunda/camunda#46713