### PR TITLE
Limit how many docs we reindex and delete in a single call to ES/OS when archiving

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -149,6 +149,7 @@ orchestration:
         zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: "1h"
         zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
         zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+        zeebe.broker.exporters.camundaexporter.args.history.delayBetweenRuns: 1000
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+// Use to repeatedly call an async task until a condition is met.
+// NB avoiding using closures for this as with all the callbacks it can
+// easily lead to memory leaks if not used carefully. By using an explicit class
+// we can ensure that the state is properly cleaned up after completion.
+final class AsyncRepeatUntil<T> {
+  private final CompletableFuture<Void> finalFuture = new CompletableFuture<>();
+  private final Supplier<CompletableFuture<T>> asyncTask;
+  private final Predicate<T> until;
+
+  private AsyncRepeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    this.asyncTask = asyncTask;
+    this.until = until;
+  }
+
+  private void next() {
+    try {
+      asyncTask.get().thenAccept(this::completeOrNext).exceptionally(this::completeExceptionally);
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private void completeOrNext(final T result) {
+    try {
+      if (until.test(result)) {
+        finalFuture.complete(null);
+      } else {
+        next();
+      }
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private Void completeExceptionally(final Throwable err) {
+    finalFuture.completeExceptionally(err);
+    return null;
+  }
+
+  static <T> CompletableFuture<Void> repeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    final var repeat = new AsyncRepeatUntil<>(asyncTask, until);
+
+    repeat.next();
+
+    return repeat.finalFuture;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -309,8 +309,16 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .maxDocs(MAX_DELETE_DOCS)
             .build();
 
+    // From: https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query
+    //
+    // Parameters like requests_per_second and max_docs on a request with slices are distributed
+    // proportionally to each sub-request. Combine that with the earlier point about distribution
+    // being uneven and you should conclude that using max_docs with slices might not result in
+    // exactly max_docs documents being deleted.
+    //
+    // so we need to always do an extra call to ensure we have definitely deleted everything
     return AsyncRepeatUntil.repeatUntil(
-        () -> deleteDocuments(request), reindexed -> reindexed < MAX_DELETE_DOCS);
+        () -> deleteDocuments(request), reindexed -> reindexed == 0);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -23,6 +23,7 @@ import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.ReindexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
@@ -65,6 +66,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
   private static final Slices AUTO_SLICES =
       Slices.of(slices -> slices.computed(SlicesCalculation.Auto));
+  private static final long MAX_REINDEX_DOCS = 10_000L;
+  private static final long MAX_DELETE_DOCS = 10_000L;
   private final int partitionId;
   private final HistoryConfiguration config;
   private final IndexTemplateDescriptor listViewTemplateDescriptor;
@@ -303,17 +306,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .slices(AUTO_SLICES)
             .conflicts(Conflicts.Proceed)
             .query(buildFilterQuery(keysByField, filters))
+            .maxDocs(MAX_DELETE_DOCS)
             .build();
 
-    final var timer = Timer.start();
-    return client
-        .deleteByQuery(request)
-        .whenCompleteAsync(
-            (response, error) ->
-                metrics.measureArchiverDelete(response != null ? response.total() : null, timer),
-            executor)
-        .thenApplyAsync(DeleteByQueryResponse::total, executor)
-        .thenApplyAsync(ok -> null, executor);
+    return AsyncRepeatUntil.repeatUntil(
+        () -> deleteDocuments(request), reindexed -> reindexed < MAX_DELETE_DOCS);
   }
 
   @Override
@@ -341,16 +338,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .conflicts(Conflicts.Proceed)
             .scroll(REINDEX_SCROLL_TIMEOUT)
             .slices(AUTO_SLICES)
+            .maxDocs(MAX_REINDEX_DOCS)
             .build();
 
-    final var timer = Timer.start();
-    return client
-        .reindex(request)
-        .whenCompleteAsync(
-            (response, error) ->
-                metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
-            executor)
-        .thenApplyAsync(ignored -> null, executor);
+    return AsyncRepeatUntil.repeatUntil(
+        () -> reindexDocuments(request), reindexed -> reindexed < MAX_REINDEX_DOCS);
   }
 
   @Override
@@ -364,6 +356,28 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                             config.getArchivingTimePoint(), partitionId)));
 
     return client.count(countRequest).thenApplyAsync(res -> Math.toIntExact(res.count()));
+  }
+
+  private CompletableFuture<Long> deleteDocuments(final DeleteByQueryRequest request) {
+    final var timer = Timer.start();
+    return client
+        .deleteByQuery(request)
+        .whenCompleteAsync(
+            (response, error) ->
+                metrics.measureArchiverDelete(response != null ? response.total() : null, timer),
+            executor)
+        .thenApplyAsync(DeleteByQueryResponse::total);
+  }
+
+  private CompletableFuture<Long> reindexDocuments(final ReindexRequest request) {
+    final var timer = Timer.start();
+    return client
+        .reindex(request)
+        .whenCompleteAsync(
+            (response, error) ->
+                metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
+            executor)
+        .thenApplyAsync(ReindexResponse::total);
   }
 
   private Query finishedProcessInstancesQuery(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntilTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntilTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class AsyncRepeatUntilTest {
+
+  @Test
+  void shouldCompleteWhenTaskCompletes() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(() -> CompletableFuture.completedFuture(1), result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    // ensure no exceptions are thrown
+    future.join();
+  }
+
+  @Test
+  void shouldNotCompleteWhenTaskDoesNotComplete() {
+    // given
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(CompletableFuture::new, result -> true);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsAsync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            // task fails in an async manner
+            () -> CompletableFuture.failedFuture(new RuntimeException("future failed")),
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("future failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsSync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> {
+              // task fails, but in a non-async way
+              throw new RuntimeException("task failed");
+            },
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("task failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenUntilFails() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(1),
+            result -> {
+              throw new RuntimeException("until failed");
+            });
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("until failed");
+  }
+
+  @Test
+  void shouldCompleteWhenConditionMet() {
+    // given
+    final var counter = new AtomicInteger();
+
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(counter.getAndIncrement()),
+            result -> result >= 5);
+
+    future.join();
+
+    // then
+    assertThat(counter.get()).isEqualTo(6);
+  }
+
+  @Test
+  void shouldRunTasksSerially() {
+    // given
+    final CompletableFuture<Integer> future1 = new CompletableFuture<>();
+    final CompletableFuture<Integer> future2 = new CompletableFuture<>();
+
+    final Supplier<CompletableFuture<Integer>> taskSupplier = mock(Supplier.class);
+
+    when(taskSupplier.get()).thenReturn(future1).thenReturn(future2);
+
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(taskSupplier, result -> result >= 2);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    verify(taskSupplier).get();
+
+    // when
+    // complete the first task, which should trigger the second task to be called
+    future1.complete(1);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    verify(taskSupplier, times(2)).get();
+
+    // when
+    // complete the second task, which should complete the future
+    future2.complete(2);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    verify(taskSupplier, times(2)).get();
+
+    future.join();
+  }
+}


### PR DESCRIPTION
Both `reindex` and `deleteByQuery` support a `maxDocs` option, so we can use that to limit how large the requests will actually be.  This should help us avoid cases where these requests timeout and/or put extra load on ES/OS.

In theory then we might be able to have a larger default batch size for how many process instances we want to archive per batch.

From: https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query
> Parameters like requests_per_second and max_docs on a request with slices are distributed proportionally to each sub-request. Combine that with the earlier point about distribution being uneven and you should conclude that using max_docs with slices might not result in exactly max_docs documents being deleted.

so this might not work without also no longer using slices.  This does explain a discrepancy I've been seeing in some charts though (more docs reindexed than deleted).