### PR TITLE
perf: do not forward auth claims in gateway where authorizations  are disabled

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogWithoutAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogWithoutAuthorizationsIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auditlog;
+
+import static io.camunda.it.auditlog.AuditLogUtils.DEFAULT_USERNAME;
+import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_A;
+import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_A_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.AuditLogActorTypeEnum;
+import io.camunda.client.api.search.enums.AuditLogEntityTypeEnum;
+import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Verifies that audit log entries contain correct actor information when authorizations are
+ * disabled. This configuration (auth enabled, authorizations disabled) triggered a bug where
+ * identity claims were dropped along with authorization claims.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class AuditLogWithoutAuthorizationsIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsDisabled()
+          // withAuthenticatedAccess must be done after disabling authorizations as that implicitly
+          // set withUnauthenticatedAccess()
+          .withAuthenticatedAccess();
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldSetActorWhenAuthorizationsDisabled(
+      final boolean useRestApi, @Authenticated final CamundaClient client) {
+    client.newDeployResourceCommand().addProcessModel(PROCESS_A, "a.bpmn").send().join();
+
+    final var commandStep1 = client.newCreateInstanceCommand();
+    if (useRestApi) {
+      commandStep1.useRest();
+    } else {
+      commandStep1.useGrpc();
+    }
+    final var instance = commandStep1.bpmnProcessId(PROCESS_A_ID).latestVersion().send().join();
+
+    Awaitility.await("Audit log entry is created for the process instance")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var auditLogs =
+                  client
+                      .newAuditLogSearchRequest()
+                      .filter(
+                          f ->
+                              f.entityType(AuditLogEntityTypeEnum.PROCESS_INSTANCE)
+                                  .operationType(AuditLogOperationTypeEnum.CREATE)
+                                  .processInstanceKey("" + instance.getProcessInstanceKey()))
+                      .send()
+                      .join();
+
+              assertThat(auditLogs.items())
+                  .hasSize(1)
+                  .allSatisfy(
+                      log -> {
+                        assertThat(log.getProcessInstanceKey())
+                            .isEqualTo("" + instance.getProcessInstanceKey());
+                        assertThat(log.getActorId()).isEqualTo(DEFAULT_USERNAME);
+                        assertThat(log.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
+                      });
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogWithoutAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogWithoutAuthorizationsIT.java
@@ -43,6 +43,7 @@ public class AuditLogWithoutAuthorizationsIT {
           .withAuthorizationsDisabled()
           // withAuthenticatedAccess must be done after disabling authorizations as that implicitly
           // set withUnauthenticatedAccess()
+          // TODO: decouple authorizations & authentication setups
           .withAuthenticatedAccess();
 
   @ParameterizedTest

--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -27,23 +27,23 @@ import java.util.Map;
  *
  * <p>Authorization claims (JWT token claims, group memberships) are only needed for authorization
  * and multi-tenancy checks in the engine, and are skipped when both are disabled. Callers can check
- * {@link #isAuthorizationClaimsEnabled()} to avoid computing these values when not needed.
+ * {@link #shouldIncludeAuthorizationClaims()} to avoid computing these values when not needed.
  */
 public class BrokerRequestAuthorizationConverter {
 
   private final boolean camundaGroupsEnabled;
-  private final boolean authorizationClaimsEnabled;
+  private final boolean shouldIncludeAuthorizationClaims;
 
   public BrokerRequestAuthorizationConverter(final SecurityConfiguration securityConfiguration) {
     camundaGroupsEnabled = securityConfiguration.getAuthentication().isCamundaGroupsEnabled();
-    authorizationClaimsEnabled =
+    shouldIncludeAuthorizationClaims =
         securityConfiguration.getAuthorizations().isEnabled()
             || securityConfiguration.getMultiTenancy().isChecksEnabled();
   }
 
   /** Returns whether authorization claims (token claims, groups) are needed in broker requests. */
-  public boolean isAuthorizationClaimsEnabled() {
-    return authorizationClaimsEnabled;
+  public boolean shouldIncludeAuthorizationClaims() {
+    return shouldIncludeAuthorizationClaims;
   }
 
   public Map<String, Object> convert(final CamundaAuthentication authentication) {
@@ -76,7 +76,7 @@ public class BrokerRequestAuthorizationConverter {
       claims.put(AUTHORIZED_CLIENT_ID, clientId);
     }
 
-    if (authorizationClaimsEnabled) {
+    if (shouldIncludeAuthorizationClaims) {
       if (!camundaGroupsEnabled && groups != null) {
         claims.put(USER_GROUPS_CLAIMS, groups);
       }

--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -15,8 +15,20 @@ import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 
 import io.camunda.security.configuration.SecurityConfiguration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+/**
+ * Converts authentication information into the claims map embedded in broker requests.
+ *
+ * <p>Identity claims (username, clientId) are always included because the exporter reads them from
+ * the record to populate the audit log actor (see {@code AuditLogActor.of}). Skipping these would
+ * cause audit log entries to have no actor information.
+ *
+ * <p>Authorization claims (JWT token claims, group memberships) are only needed for authorization
+ * and multi-tenancy checks in the engine, and are skipped when both are disabled. Callers can check
+ * {@link #isAuthorizationClaimsEnabled()} to avoid computing these values when not needed.
+ */
 public class BrokerRequestAuthorizationConverter {
 
   private final boolean camundaGroupsEnabled;
@@ -29,41 +41,51 @@ public class BrokerRequestAuthorizationConverter {
             || securityConfiguration.getMultiTenancy().isChecksEnabled();
   }
 
-  public Map<String, Object> convert(final CamundaAuthentication authentication) {
-    final var authorization = new HashMap<String, Object>();
+  /** Returns whether authorization claims (token claims, groups) are needed in broker requests. */
+  public boolean isAuthorizationClaimsEnabled() {
+    return authorizationClaimsEnabled;
+  }
 
-    if (authentication.isAnonymous()) {
-      authorization.put(AUTHORIZED_ANONYMOUS_USER, true);
-      return authorization;
+  public Map<String, Object> convert(final CamundaAuthentication authentication) {
+    return convert(
+        authentication.isAnonymous(),
+        authentication.authenticatedUsername(),
+        authentication.authenticatedClientId(),
+        authentication.authenticatedGroupIds(),
+        authentication.claims());
+  }
+
+  public Map<String, Object> convert(
+      final boolean isAnonymous,
+      final String username,
+      final String clientId,
+      final List<String> groups,
+      final Map<String, Object> tokenClaims) {
+
+    if (isAnonymous) {
+      return Map.of(AUTHORIZED_ANONYMOUS_USER, true);
     }
 
-    // Identity claims are always sent because the exporter reads them from the record to populate
-    // the audit log actor (see AuditLogActor.of). Skipping these would cause audit log entries to
-    // have no actor information.
-    final var username = authentication.authenticatedUsername();
-    final var clientId = authentication.authenticatedClientId();
+    final var claims = new HashMap<String, Object>();
 
     if (username != null) {
-      authorization.put(AUTHORIZED_USERNAME, username);
+      claims.put(AUTHORIZED_USERNAME, username);
     }
 
     if (clientId != null) {
-      authorization.put(AUTHORIZED_CLIENT_ID, clientId);
+      claims.put(AUTHORIZED_CLIENT_ID, clientId);
     }
 
-    // Authorization claims (JWT token claims, group memberships) are only needed for authorization
-    // and multi-tenancy checks in the engine. Skip them when both are disabled.
     if (authorizationClaimsEnabled) {
-      if (!camundaGroupsEnabled) {
-        authorization.put(USER_GROUPS_CLAIMS, authentication.authenticatedGroupIds());
+      if (!camundaGroupsEnabled && groups != null) {
+        claims.put(USER_GROUPS_CLAIMS, groups);
       }
 
-      final var claims = authentication.claims();
-      if (claims != null) {
-        authorization.put(USER_TOKEN_CLAIMS, claims);
+      if (tokenClaims != null) {
+        claims.put(USER_TOKEN_CLAIMS, tokenClaims);
       }
     }
 
-    return authorization;
+    return claims;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -20,30 +20,28 @@ import java.util.Map;
 public class BrokerRequestAuthorizationConverter {
 
   private final boolean camundaGroupsEnabled;
-  private final boolean authorizationEmbeddingEnabled;
+  private final boolean authorizationClaimsEnabled;
 
   public BrokerRequestAuthorizationConverter(final SecurityConfiguration securityConfiguration) {
     camundaGroupsEnabled = securityConfiguration.getAuthentication().isCamundaGroupsEnabled();
-    authorizationEmbeddingEnabled =
+    authorizationClaimsEnabled =
         securityConfiguration.getAuthorizations().isEnabled()
             || securityConfiguration.getMultiTenancy().isChecksEnabled();
   }
 
   public Map<String, Object> convert(final CamundaAuthentication authentication) {
-    if (!authorizationEmbeddingEnabled) {
-      return Map.of();
-    }
-
     final var authorization = new HashMap<String, Object>();
+
     if (authentication.isAnonymous()) {
       authorization.put(AUTHORIZED_ANONYMOUS_USER, true);
       return authorization;
     }
 
+    // Identity claims are always sent because the exporter reads them from the record to populate
+    // the audit log actor (see AuditLogActor.of). Skipping these would cause audit log entries to
+    // have no actor information.
     final var username = authentication.authenticatedUsername();
     final var clientId = authentication.authenticatedClientId();
-    final var groups = authentication.authenticatedGroupIds();
-    final var claims = authentication.claims();
 
     if (username != null) {
       authorization.put(AUTHORIZED_USERNAME, username);
@@ -53,12 +51,17 @@ public class BrokerRequestAuthorizationConverter {
       authorization.put(AUTHORIZED_CLIENT_ID, clientId);
     }
 
-    if (!camundaGroupsEnabled) {
-      authorization.put(USER_GROUPS_CLAIMS, groups);
-    }
+    // Authorization claims (JWT token claims, group memberships) are only needed for authorization
+    // and multi-tenancy checks in the engine. Skip them when both are disabled.
+    if (authorizationClaimsEnabled) {
+      if (!camundaGroupsEnabled) {
+        authorization.put(USER_GROUPS_CLAIMS, authentication.authenticatedGroupIds());
+      }
 
-    if (claims != null) {
-      authorization.put(USER_TOKEN_CLAIMS, claims);
+      final var claims = authentication.claims();
+      if (claims != null) {
+        authorization.put(USER_TOKEN_CLAIMS, claims);
+      }
     }
 
     return authorization;

--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -20,12 +20,19 @@ import java.util.Map;
 public class BrokerRequestAuthorizationConverter {
 
   private final boolean camundaGroupsEnabled;
+  private final boolean authorizationEmbeddingEnabled;
 
   public BrokerRequestAuthorizationConverter(final SecurityConfiguration securityConfiguration) {
     camundaGroupsEnabled = securityConfiguration.getAuthentication().isCamundaGroupsEnabled();
+    authorizationEmbeddingEnabled =
+        securityConfiguration.getAuthorizations().isEnabled()
+            || securityConfiguration.getMultiTenancy().isChecksEnabled();
   }
 
   public Map<String, Object> convert(final CamundaAuthentication authentication) {
+    if (!authorizationEmbeddingEnabled) {
+      return Map.of();
+    }
 
     final var authorization = new HashMap<String, Object>();
     if (authentication.isAnonymous()) {

--- a/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
@@ -24,6 +24,22 @@ import org.junit.jupiter.api.Test;
 public class BrokerRequestAuthorizationConverterTest {
 
   @Test
+  void shouldReturnEmptyMapWhenAuthorizationAndMultiTenancyDisabled() {
+    // given
+    final var authentication = CamundaAuthentication.of(b -> b.user("foo"));
+    final var securityConfiguration = new SecurityConfiguration();
+    securityConfiguration.getAuthorizations().setEnabled(false);
+    securityConfiguration.getMultiTenancy().setChecksEnabled(false);
+    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(brokerRequestAuth).isEmpty();
+  }
+
+  @Test
   void shouldContainAnonymousClaim() {
     // given
     final var authentication = CamundaAuthentication.anonymous();

--- a/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class BrokerRequestAuthorizationConverterTest {
 
   @Test
-  void shouldOnlyContainIdentityClaimsWhenAuthorizationAndMultiTenancyDisabled() {
+  void shouldOnlyContainAuthenticationClaimsWhenAuthorizationAndMultiTenancyDisabled() {
     // given
     final var authentication = CamundaAuthentication.of(b -> b.user("foo"));
     final var securityConfiguration = new SecurityConfiguration();

--- a/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class BrokerRequestAuthorizationConverterTest {
 
   @Test
-  void shouldReturnEmptyMapWhenAuthorizationAndMultiTenancyDisabled() {
+  void shouldOnlyContainIdentityClaimsWhenAuthorizationAndMultiTenancyDisabled() {
     // given
     final var authentication = CamundaAuthentication.of(b -> b.user("foo"));
     final var securityConfiguration = new SecurityConfiguration();
@@ -35,8 +35,11 @@ public class BrokerRequestAuthorizationConverterTest {
     // when
     final var brokerRequestAuth = converter.convert(authentication);
 
-    // then
-    assertThat(brokerRequestAuth).isEmpty();
+    // then — identity claims are present (for audit logging), but no authorization claims
+    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).containsEntry(AUTHORIZED_USERNAME, "foo");
+    assertThat(brokerRequestAuth).doesNotContainKey(USER_TOKEN_CLAIMS);
+    assertThat(brokerRequestAuth).doesNotContainKey(USER_GROUPS_CLAIMS);
   }
 
   @Test

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -90,6 +90,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-auth</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.gateway;
 
 import io.atomix.utils.net.Address;
-import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
@@ -89,17 +89,18 @@ public final class EndpointManager {
   private final ActivateJobsHandler<ActivateJobsResponse> activateJobsHandler;
   private final RequestRetryHandler requestRetryHandler;
   private final StreamJobsHandler streamJobsHandler;
+  private final boolean authorizationEmbeddingEnabled;
 
   public EndpointManager(
       final BrokerClient brokerClient,
       final ActivateJobsHandler<ActivateJobsResponse> activateJobsHandler,
       final StreamJobsHandler streamJobsHandler,
-      final MultiTenancyConfiguration multiTenancy) {
+      final SecurityConfiguration securityConfiguration) {
     this(
         brokerClient,
         activateJobsHandler,
         streamJobsHandler,
-        multiTenancy,
+        securityConfiguration,
         VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH);
   }
 
@@ -107,15 +108,18 @@ public final class EndpointManager {
       final BrokerClient brokerClient,
       final ActivateJobsHandler<ActivateJobsResponse> activateJobsHandler,
       final StreamJobsHandler streamJobsHandler,
-      final MultiTenancyConfiguration multiTenancy,
+      final SecurityConfiguration securityConfiguration,
       final int maxVariableNameLength) {
     this.brokerClient = brokerClient;
     this.activateJobsHandler = activateJobsHandler;
     this.streamJobsHandler = streamJobsHandler;
     topologyManager = brokerClient.getTopologyManager();
     requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
-    RequestMapper.setMultiTenancyEnabled(multiTenancy.isChecksEnabled());
+    RequestMapper.setMultiTenancyEnabled(securityConfiguration.getMultiTenancy().isChecksEnabled());
     RequestMapper.setMaxVariableNameLength(maxVariableNameLength);
+    authorizationEmbeddingEnabled =
+        securityConfiguration.getAuthorizations().isEnabled()
+            || securityConfiguration.getMultiTenancy().isChecksEnabled();
   }
 
   private void addBrokerInfo(
@@ -188,7 +192,8 @@ public final class EndpointManager {
       final ServerCallStreamObserver<ActivatedJob> responseObserver) {
     try {
       final JobActivationProperties brokerRequest =
-          RequestMapper.toJobActivationProperties(request, getClaims());
+          RequestMapper.toJobActivationProperties(
+              request, authorizationEmbeddingEnabled ? getClaims() : Map.of());
 
       streamJobsHandler.handle(request.getType(), brokerRequest, responseObserver);
     } catch (final Exception e) {
@@ -519,7 +524,9 @@ public final class EndpointManager {
 
     final BrokerRequest<BrokerResponseT> brokerRequest = requestMapper.apply(grpcRequest);
 
-    brokerRequest.setAuthorization(getClaims());
+    if (authorizationEmbeddingEnabled) {
+      brokerRequest.setAuthorization(getClaims());
+    }
 
     return brokerRequest;
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -192,8 +192,7 @@ public final class EndpointManager {
       final ServerCallStreamObserver<ActivatedJob> responseObserver) {
     try {
       final JobActivationProperties brokerRequest =
-          RequestMapper.toJobActivationProperties(
-              request, authorizationEmbeddingEnabled ? getClaims() : Map.of());
+          RequestMapper.toJobActivationProperties(request, getClaims());
 
       streamJobsHandler.handle(request.getType(), brokerRequest, responseObserver);
     } catch (final Exception e) {
@@ -523,38 +522,38 @@ public final class EndpointManager {
       throws Exception {
 
     final BrokerRequest<BrokerResponseT> brokerRequest = requestMapper.apply(grpcRequest);
-
-    if (authorizationEmbeddingEnabled) {
-      brokerRequest.setAuthorization(getClaims());
-    }
-
+    brokerRequest.setAuthorization(getClaims());
     return brokerRequest;
   }
 
   private Map<String, Object> getClaims() throws Exception {
     final Map<String, Object> claims = new HashMap<>();
 
-    // retrieve the user claims from the context and add them to the authorization if present
-    final Map<String, Object> userClaims =
-        Context.current().call(AuthenticationHandler.Oidc.USER_CLAIMS::get);
-    claims.put(Authorization.USER_TOKEN_CLAIMS, userClaims);
-
-    // retrieve the username from the context and add it to the authorization if present
+    // Identity claims are always sent because the exporter reads them from the record to populate
+    // the audit log actor (see AuditLogActor.of). Skipping these would cause audit log entries to
+    // have no actor information.
     final String username = Context.current().call(AuthenticationHandler.USERNAME::get);
     if (username != null) {
       claims.put(Authorization.AUTHORIZED_USERNAME, username);
     }
 
-    // retrieve the client id from the context and add it to the authorization if present
     final String clientId = Context.current().call(AuthenticationHandler.CLIENT_ID::get);
     if (clientId != null) {
       claims.put(Authorization.AUTHORIZED_CLIENT_ID, clientId);
     }
 
-    final List<String> groupsClaims =
-        Context.current().call(AuthenticationHandler.GROUPS_CLAIMS::get);
-    if (groupsClaims != null) {
-      claims.put(Authorization.USER_GROUPS_CLAIMS, groupsClaims);
+    // Authorization claims (JWT token claims, group memberships) are only needed for authorization
+    // and multi-tenancy checks in the engine. Skip them when both are disabled.
+    if (authorizationEmbeddingEnabled) {
+      final Map<String, Object> userClaims =
+          Context.current().call(AuthenticationHandler.Oidc.USER_CLAIMS::get);
+      claims.put(Authorization.USER_TOKEN_CLAIMS, userClaims);
+
+      final List<String> groupsClaims =
+          Context.current().call(AuthenticationHandler.GROUPS_CLAIMS::get);
+      if (groupsClaims != null) {
+        claims.put(Authorization.USER_GROUPS_CLAIMS, groupsClaims);
+      }
     }
 
     return claims;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -529,7 +529,7 @@ public final class EndpointManager {
 
     List<String> groups = null;
     Map<String, Object> tokenClaims = null;
-    if (authorizationConverter.isAuthorizationClaimsEnabled()) {
+    if (authorizationConverter.shouldIncludeAuthorizationClaims()) {
       groups = Context.current().call(AuthenticationHandler.GROUPS_CLAIMS::get);
       tokenClaims = Context.current().call(AuthenticationHandler.Oidc.USER_CLAIMS::get);
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.gateway;
 
 import io.atomix.utils.net.Address;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -76,7 +76,6 @@ import io.grpc.Context;
 import io.grpc.stub.ServerCallStreamObserver;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,7 +88,7 @@ public final class EndpointManager {
   private final ActivateJobsHandler<ActivateJobsResponse> activateJobsHandler;
   private final RequestRetryHandler requestRetryHandler;
   private final StreamJobsHandler streamJobsHandler;
-  private final boolean authorizationEmbeddingEnabled;
+  private final BrokerRequestAuthorizationConverter authorizationConverter;
 
   public EndpointManager(
       final BrokerClient brokerClient,
@@ -117,9 +116,7 @@ public final class EndpointManager {
     requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
     RequestMapper.setMultiTenancyEnabled(securityConfiguration.getMultiTenancy().isChecksEnabled());
     RequestMapper.setMaxVariableNameLength(maxVariableNameLength);
-    authorizationEmbeddingEnabled =
-        securityConfiguration.getAuthorizations().isEnabled()
-            || securityConfiguration.getMultiTenancy().isChecksEnabled();
+    authorizationConverter = new BrokerRequestAuthorizationConverter(securityConfiguration);
   }
 
   private void addBrokerInfo(
@@ -527,36 +524,17 @@ public final class EndpointManager {
   }
 
   private Map<String, Object> getClaims() throws Exception {
-    final Map<String, Object> claims = new HashMap<>();
-
-    // Identity claims are always sent because the exporter reads them from the record to populate
-    // the audit log actor (see AuditLogActor.of). Skipping these would cause audit log entries to
-    // have no actor information.
     final String username = Context.current().call(AuthenticationHandler.USERNAME::get);
-    if (username != null) {
-      claims.put(Authorization.AUTHORIZED_USERNAME, username);
-    }
-
     final String clientId = Context.current().call(AuthenticationHandler.CLIENT_ID::get);
-    if (clientId != null) {
-      claims.put(Authorization.AUTHORIZED_CLIENT_ID, clientId);
+
+    List<String> groups = null;
+    Map<String, Object> tokenClaims = null;
+    if (authorizationConverter.isAuthorizationClaimsEnabled()) {
+      groups = Context.current().call(AuthenticationHandler.GROUPS_CLAIMS::get);
+      tokenClaims = Context.current().call(AuthenticationHandler.Oidc.USER_CLAIMS::get);
     }
 
-    // Authorization claims (JWT token claims, group memberships) are only needed for authorization
-    // and multi-tenancy checks in the engine. Skip them when both are disabled.
-    if (authorizationEmbeddingEnabled) {
-      final Map<String, Object> userClaims =
-          Context.current().call(AuthenticationHandler.Oidc.USER_CLAIMS::get);
-      claims.put(Authorization.USER_TOKEN_CLAIMS, userClaims);
-
-      final List<String> groupsClaims =
-          Context.current().call(AuthenticationHandler.GROUPS_CLAIMS::get);
-      if (groupsClaims != null) {
-        claims.put(Authorization.USER_GROUPS_CLAIMS, groupsClaims);
-      }
-    }
-
-    return claims;
+    return authorizationConverter.convert(false, username, clientId, groups, tokenClaims);
   }
 
   private <BrokerResponseT, GrpcResponseT> void consumeResponse(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway;
 
 import com.google.rpc.Code;
-import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -240,8 +239,6 @@ public final class Gateway implements CloseableSilently {
       final ActivateJobsHandler<ActivateJobsResponse> activateJobsHandler,
       final StreamJobsHandler streamJobsHandler) {
     final NetworkCfg network = gatewayCfg.getNetwork();
-    final MultiTenancyConfiguration multiTenancy = securityConfiguration.getMultiTenancy();
-
     final var serverBuilder = applyNetworkConfig(network);
     applyExecutorConfiguration(serverBuilder);
     applySecurityConfiguration(serverBuilder);
@@ -251,7 +248,7 @@ public final class Gateway implements CloseableSilently {
             brokerClient,
             activateJobsHandler,
             streamJobsHandler,
-            multiTenancy,
+            securityConfiguration,
             maxVariableNameLength);
     final var gatewayGrpcService = new GatewayGrpcService(endpointManager);
     return buildServer(serverBuilder, gatewayGrpcService);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.gateway.api.util;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.Claim;
-import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -99,9 +98,9 @@ public final class StubbedGateway {
     final var clientStreamAdapter = new StreamJobsHandler(jobStreamer);
     actorScheduler.submitActor(clientStreamAdapter).join();
 
-    final MultiTenancyConfiguration multiTenancy = securityConfiguration.getMultiTenancy();
     final EndpointManager endpointManager =
-        new EndpointManager(brokerClient, activateJobsHandler, clientStreamAdapter, multiTenancy);
+        new EndpointManager(
+            brokerClient, activateJobsHandler, clientStreamAdapter, securityConfiguration);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
     final InProcessServerBuilder serverBuilder =
         InProcessServerBuilder.forName(SERVER_NAME)
@@ -238,6 +237,11 @@ public final class StubbedGateway {
       // below, we reserve some time for a client to register for a job type
       Awaitility.await("wait until stream is registered")
           .until(() -> registeredStreams.containsKey(jobType));
+    }
+
+    public JobActivationProperties getStreamMetadata(final String streamType) {
+      final var consumer = registeredStreams.get(BufferUtil.wrapString(streamType));
+      return consumer != null ? consumer.metadata() : null;
     }
 
     public void setFailOnAdd(final Throwable failure) {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGatewayRule.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGatewayRule.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.api.util;
 
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.gateway.RequestMapper;
 import io.camunda.zeebe.gateway.api.util.StubbedGateway.StubbedJobStreamer;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
@@ -50,6 +51,8 @@ public final class StubbedGatewayRule extends ExternalResource {
   @Override
   protected void after() {
     gateway.stop();
+    // Reset static state set by EndpointManager to avoid polluting other tests in the same JVM
+    RequestMapper.setMultiTenancyEnabled(false);
   }
 
   public StubbedGateway getGateway() {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithoutAuthorizationInfoTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithoutAuthorizationInfoTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.gateway.api.deployment.DeployResourceStub;
+import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
+import io.camunda.zeebe.gateway.api.process.CreateProcessInstanceStub;
+import io.camunda.zeebe.gateway.api.signal.BroadcastSignalStub;
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that when both authorization and multi-tenancy checks are disabled, the gateway does NOT
+ * embed claims into broker requests (saving MsgPack serialization cost).
+ */
+public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
+
+  private final ActivateJobsStub activateJobsStub = new ActivateJobsStub();
+
+  public BrokerRequestWithoutAuthorizationInfoTest() {
+    super(
+        config -> {},
+        security -> {
+          security.getAuthorizations().setEnabled(false);
+          security.getMultiTenancy().setChecksEnabled(false);
+        });
+  }
+
+  @Before
+  public void setup() {
+    new DeployResourceStub().registerWith(brokerClient);
+    new CreateProcessInstanceStub().registerWith(brokerClient);
+    new BroadcastSignalStub().registerWith(brokerClient);
+    activateJobsStub.registerWith(brokerClient);
+  }
+
+  @Test
+  public void deployResourceRequestShouldNotContainClaims() {
+    // when
+    final DeployResourceResponse response =
+        client.deployResource(DeployResourceRequest.newBuilder().build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertNoClaims();
+  }
+
+  @Test
+  public void createProcessInstanceRequestShouldNotContainClaims() {
+    // when
+    final CreateProcessInstanceResponse response =
+        client.createProcessInstance(CreateProcessInstanceRequest.newBuilder().build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertNoClaims();
+  }
+
+  @Test
+  public void activateJobsRequestShouldNotContainClaims() {
+    // given
+    final String jobType = "testType";
+    final String jobWorker = "testWorker";
+    final int maxJobsToActivate = 1;
+    activateJobsStub.addAvailableJobs(jobType, maxJobsToActivate);
+
+    // when
+    final Iterator<ActivateJobsResponse> response =
+        client.activateJobs(
+            ActivateJobsRequest.newBuilder()
+                .setType(jobType)
+                .setWorker(jobWorker)
+                .setMaxJobsToActivate(maxJobsToActivate)
+                .build());
+    assertThat(response.hasNext()).isTrue();
+
+    // then
+    assertNoClaims();
+  }
+
+  @Test
+  public void broadcastSignalRequestShouldNotContainClaims() {
+    // when
+    final BroadcastSignalResponse response =
+        client.broadcastSignal(BroadcastSignalRequest.newBuilder().build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertNoClaims();
+  }
+
+  @Test
+  public void streamActivatedJobsRequestShouldNotContainClaims() {
+    // given
+    final String jobType = "testStreamType";
+    final var request =
+        StreamActivatedJobsRequest.newBuilder()
+            .setType(jobType)
+            .setWorker("testWorker")
+            .setTimeout(Duration.ofMinutes(1).toMillis())
+            .addAllFetchVariable(List.of("foo"))
+            .build();
+
+    // when
+    asyncClient.streamActivatedJobs(
+        request, new io.camunda.zeebe.gateway.api.job.TestStreamObserver());
+    jobStreamer.waitStreamToBeAvailable(BufferUtil.wrapString(jobType));
+
+    // then
+    final var metadata = jobStreamer.getStreamMetadata(jobType);
+    assertThat(metadata).isNotNull();
+    assertThat(metadata.claims()).isEmpty();
+  }
+
+  private void assertNoClaims() {
+    final BrokerExecuteCommand<?> brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getAuthorization().hasAnyClaims()).isFalse();
+  }
+}

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithoutAuthorizationInfoTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithoutAuthorizationInfoTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.gateway.api.deployment.DeployResourceStub;
 import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
@@ -32,8 +33,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Verifies that when both authorization and multi-tenancy checks are disabled, the gateway does NOT
- * embed claims into broker requests (saving MsgPack serialization cost).
+ * Verifies that when both authorization and multi-tenancy checks are disabled, the gateway only
+ * embeds identity claims (username, client ID) but skips authorization claims (token claims, group
+ * memberships) to save MsgPack serialization cost.
  */
 public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
 
@@ -64,7 +66,7 @@ public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
     assertThat(response).isNotNull();
 
     // then
-    assertNoClaims();
+    assertNoAuthorizationClaims();
   }
 
   @Test
@@ -75,7 +77,7 @@ public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
     assertThat(response).isNotNull();
 
     // then
-    assertNoClaims();
+    assertNoAuthorizationClaims();
   }
 
   @Test
@@ -97,7 +99,7 @@ public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
     assertThat(response.hasNext()).isTrue();
 
     // then
-    assertNoClaims();
+    assertNoAuthorizationClaims();
   }
 
   @Test
@@ -108,7 +110,7 @@ public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
     assertThat(response).isNotNull();
 
     // then
-    assertNoClaims();
+    assertNoAuthorizationClaims();
   }
 
   @Test
@@ -131,11 +133,14 @@ public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
     // then
     final var metadata = jobStreamer.getStreamMetadata(jobType);
     assertThat(metadata).isNotNull();
-    assertThat(metadata.claims()).isEmpty();
+    assertThat(metadata.claims()).doesNotContainKey(Authorization.USER_TOKEN_CLAIMS);
+    assertThat(metadata.claims()).doesNotContainKey(Authorization.USER_GROUPS_CLAIMS);
   }
 
-  private void assertNoClaims() {
+  private void assertNoAuthorizationClaims() {
     final BrokerExecuteCommand<?> brokerRequest = brokerClient.getSingleBrokerRequest();
-    assertThat(brokerRequest.getAuthorization().hasAnyClaims()).isFalse();
+    final var claims = brokerRequest.getAuthorization().toDecodedMap();
+    assertThat(claims).doesNotContainKey(Authorization.USER_TOKEN_CLAIMS);
+    assertThat(claims).doesNotContainKey(Authorization.USER_GROUPS_CLAIMS);
   }
 }


### PR DESCRIPTION
## Description
When both camunda.security.authorizations.enabled=false and camunda.security.multiTenancy.checksEnabled=false, the gateway no longer serializes JWT claims into MsgPack for every broker command.
It's not possible to not send anything as we need information about **who** in Audit log. As a result, we always send those informations, but we don't send the USER_TOKEN and GROUP_TOKEN as they will not be used. 

GRPC:
- refactor to use `BrokerRequestAuthorizationConverter` from security-core same as REST. 
  - there's no way to set an ANONYMOUS user, so the flag is always false 

REST:
- `BrokerRequestAuthorizationConverter` receives `SecurityConfiguration` and will send only identity claims (who) when authorizations & multitenancy are off.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #46873
