### PR TITLE
[Backport stable/8.9] Correctly handle BusinessID nullness in the API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
@@ -40,7 +40,7 @@ public interface ProcessInstanceEvent {
   /**
    * The business id of this process instance.
    *
-   * @return the business id, or an empty string if not set
+   * @return the business id, or null if not set
    */
   String getBusinessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
@@ -75,7 +75,7 @@ public interface ProcessInstanceResult {
   /**
    * The business id of this process instance.
    *
-   * @return the business id, or an empty string if not set
+   * @return the business id, or null if not set
    */
   String getBusinessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
@@ -40,7 +40,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
     processInstanceKey = response.getProcessInstanceKey();
     tenantId = response.getTenantId();
     tags = Collections.unmodifiableSet(new HashSet<>(response.getTagsList()));
-    businessId = response.getBusinessId();
+    businessId = response.hasBusinessId() ? response.getBusinessId() : null;
   }
 
   public CreateProcessInstanceResponseImpl(final CreateProcessInstanceResult response) {

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -62,7 +62,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
     variables = response.getVariables();
     tenantId = response.getTenantId();
     tags = Collections.unmodifiableSet(new HashSet<>(response.getTagsList()));
-    businessId = response.getBusinessId();
+    businessId = response.hasBusinessId() ? response.getBusinessId() : null;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
@@ -59,6 +59,7 @@ public final class CreateProcessInstanceTest extends ClientTest {
     assertThat(response.getVersion()).isEqualTo(12);
     assertThat(response.getProcessInstanceKey()).isEqualTo(32);
     assertThat(response.getTenantId()).isEqualTo("");
+    assertThat(response.getBusinessId()).isNull();
 
     final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
     assertThat(request.getProcessDefinitionKey()).isEqualTo(123);

--- a/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceWithResultTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceWithResultTest.java
@@ -58,6 +58,7 @@ public final class CreateProcessInstanceWithResultTest extends ClientTest {
     final VariablesPojo result = response.getVariablesAsType(VariablesPojo.class);
     assertThat(result.getKey()).isEqualTo("val");
     assertThat(response.getTenantId()).isEqualTo("");
+    assertThat(response.getBusinessId()).isNull();
 
     final CreateProcessInstanceWithResultRequest request = gatewayService.getLastRequest();
     assertThat(request.getRequest().getProcessDefinitionKey()).isEqualTo(123);

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
@@ -521,15 +522,21 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final String businessId) {
     addRequestHandler(
         CreateProcessInstanceRequest.class,
-        request ->
-            CreateProcessInstanceResponse.newBuilder()
-                .setProcessDefinitionKey(processDefinitionKey)
-                .setBpmnProcessId(bpmnProcessId)
-                .setVersion(version)
-                .setProcessInstanceKey(processInstanceKey)
-                .addAllTags(tags)
-                .setBusinessId(businessId)
-                .build());
+        request -> {
+          final Builder builder =
+              CreateProcessInstanceResponse.newBuilder()
+                  .setProcessDefinitionKey(processDefinitionKey)
+                  .setBpmnProcessId(bpmnProcessId)
+                  .setVersion(version)
+                  .setProcessInstanceKey(processInstanceKey)
+                  .addAllTags(tags);
+          if (!businessId.isEmpty()) {
+            builder.setBusinessId(businessId);
+          } else {
+            builder.clearBusinessId();
+          }
+          return builder.build();
+        });
   }
 
   public void onEvaluateDecisionRequest(final EvaluateDecisionResponse evaluateDecisionResponse) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
@@ -61,6 +61,7 @@ public class ProcessInstanceCreateIT {
     assertThat(processInstanceCreation.getVersion()).isEqualTo(process.getVersion());
     assertThat(processInstanceCreation.getTenantId()).isEqualTo(process.getTenantId());
     assertThat(processInstanceCreation.getTags()).isEqualTo(TAGS);
+    assertThat(processInstanceCreation.getBusinessId()).isEqualTo(null);
 
     waitForProcessInstance(
         camundaClient,
@@ -111,6 +112,7 @@ public class ProcessInstanceCreateIT {
     assertThat(processInstanceCreation.getTenantId()).isEqualTo(process.getTenantId());
     assertThat(processInstanceCreation.getVariablesAsMap()).isEqualTo(variables);
     assertThat(processInstanceCreation.getTags()).isEqualTo(TAGS);
+    assertThat(processInstanceCreation.getBusinessId()).isEqualTo(null);
 
     waitForProcessInstance(
         camundaClient,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
@@ -61,7 +61,7 @@ public class ProcessInstanceCreateIT {
     assertThat(processInstanceCreation.getVersion()).isEqualTo(process.getVersion());
     assertThat(processInstanceCreation.getTenantId()).isEqualTo(process.getTenantId());
     assertThat(processInstanceCreation.getTags()).isEqualTo(TAGS);
-    assertThat(processInstanceCreation.getBusinessId()).isEqualTo(null);
+    assertThat(processInstanceCreation.getBusinessId()).isNull();
 
     waitForProcessInstance(
         camundaClient,
@@ -112,7 +112,7 @@ public class ProcessInstanceCreateIT {
     assertThat(processInstanceCreation.getTenantId()).isEqualTo(process.getTenantId());
     assertThat(processInstanceCreation.getVariablesAsMap()).isEqualTo(variables);
     assertThat(processInstanceCreation.getTags()).isEqualTo(TAGS);
-    assertThat(processInstanceCreation.getBusinessId()).isEqualTo(null);
+    assertThat(processInstanceCreation.getBusinessId()).isNull();
 
     waitForProcessInstance(
         camundaClient,

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -264,7 +264,7 @@ public final class RequestMapper extends RequestUtil {
         .setVariables(ensureJsonSet(grpcRequest.getVariables()))
         .setStartInstructions(grpcRequest.getStartInstructionsList())
         .setTags(Set.copyOf(grpcRequest.getTagsList()))
-        .setBusinessId(grpcRequest.getBusinessId());
+        .setBusinessId(grpcRequest.hasBusinessId() ? grpcRequest.getBusinessId() : "");
 
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -191,15 +191,20 @@ public final class ResponseMapper {
 
   public static CreateProcessInstanceResponse toCreateProcessInstanceResponse(
       final long key, final ProcessInstanceCreationRecord brokerResponse) {
-    return CreateProcessInstanceResponse.newBuilder()
-        .setProcessDefinitionKey(brokerResponse.getProcessDefinitionKey())
-        .setBpmnProcessId(bufferAsString(brokerResponse.getBpmnProcessIdBuffer()))
-        .setVersion(brokerResponse.getVersion())
-        .setTenantId(brokerResponse.getTenantId())
-        .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
-        .addAllTags(brokerResponse.getTags())
-        .setBusinessId(brokerResponse.getBusinessId())
-        .build();
+    final var builder =
+        CreateProcessInstanceResponse.newBuilder()
+            .setProcessDefinitionKey(brokerResponse.getProcessDefinitionKey())
+            .setBpmnProcessId(bufferAsString(brokerResponse.getBpmnProcessIdBuffer()))
+            .setVersion(brokerResponse.getVersion())
+            .setTenantId(brokerResponse.getTenantId())
+            .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
+            .addAllTags(brokerResponse.getTags());
+    if (brokerResponse.hasBusinessId()) {
+      builder.setBusinessId(brokerResponse.getBusinessId());
+    } else {
+      builder.clearBusinessId();
+    }
+    return builder.build();
   }
 
   public static CreateProcessInstanceWithResultResponse toCreateProcessInstanceWithResultResponse(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
@@ -43,7 +43,7 @@ public final class CreateProcessInstanceTest extends GatewayTest {
     assertThat(response.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
     assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     assertThat(response.getTagsList()).containsAll(stub.getTags());
-    assertThat(response.getBusinessId()).isEmpty();
+    assertThat(response.hasBusinessId()).isFalse();
 
     final BrokerCreateProcessInstanceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(ProcessInstanceCreationIntent.CREATE);
@@ -78,6 +78,7 @@ public final class CreateProcessInstanceTest extends GatewayTest {
 
     final BrokerCreateProcessInstanceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     final ProcessInstanceCreationRecord brokerRequestValue = brokerRequest.getRequestWriter();
+    assertThat(brokerRequestValue.hasBusinessId()).isTrue();
     assertThat(brokerRequestValue.getBusinessId()).isEqualTo(businessId);
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -278,7 +278,7 @@ message CreateProcessInstanceRequest {
   // enforcement is enabled, the engine will reject creation if another root process instance
   // with the same business id is already active for the same process definition.
   // Note that any active child process instances with the same business id are not taken into account.
-  string businessId = 10;
+  optional string businessId = 10;
 }
 
 message ProcessInstanceCreationStartInstruction {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -321,8 +321,8 @@ message CreateProcessInstanceResponse {
   string tenantId = 5;
   // tags attached to a process instance
   repeated string tags = 6;
-  // the business id of the created process instance, or empty if not set
-  string businessId = 7;
+  // the business id of the created process instance
+  optional string businessId = 7;
 }
 
 message CreateProcessInstanceWithResultRequest {
@@ -354,8 +354,8 @@ message CreateProcessInstanceWithResultResponse {
   string tenantId = 6;
   // tags attached to a process instance
   repeated string tags = 7;
-  // the business id of the created process instance, or empty if not set
-  string businessId = 8;
+  // the business id of the created process instance
+  optional string businessId = 8;
 }
 
 message EvaluateDecisionRequest {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -195,6 +195,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return this;
   }
 
+  public boolean hasBusinessId() {
+    return businessIdProperty.getValue().capacity() > 0;
+  }
+
   @JsonIgnore
   public boolean hasStartInstructions() {
     return !startInstructionsProperty.isEmpty();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
@@ -68,6 +68,7 @@ public final class CreateProcessInstanceTest {
     assertThat(processInstance.getBpmnProcessId()).isEqualTo(processId);
     assertThat(processInstance.getVersion()).isEqualTo(2);
     assertThat(processInstance.getProcessDefinitionKey()).isEqualTo(secondProcessDefinitionKey);
+    assertThat(processInstance.getBusinessId()).isNull();
   }
 
   @ParameterizedTest
@@ -85,6 +86,7 @@ public final class CreateProcessInstanceTest {
     assertThat(processInstance.getBpmnProcessId()).isEqualTo(processId);
     assertThat(processInstance.getVersion()).isEqualTo(1);
     assertThat(processInstance.getProcessDefinitionKey()).isEqualTo(firstProcessDefinitionKey);
+    assertThat(processInstance.getBusinessId()).isNull();
   }
 
   @ParameterizedTest
@@ -101,6 +103,7 @@ public final class CreateProcessInstanceTest {
     assertThat(processInstance.getBpmnProcessId()).isEqualTo(processId);
     assertThat(processInstance.getVersion()).isEqualTo(1);
     assertThat(processInstance.getProcessDefinitionKey()).isEqualTo(firstProcessDefinitionKey);
+    assertThat(processInstance.getBusinessId()).isNull();
   }
 
   @ParameterizedTest
@@ -153,6 +156,25 @@ public final class CreateProcessInstanceTest {
             .getFirst();
 
     assertThat(createdEvent.getValue().getTags()).isEqualTo(tags);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldCreateWithBusinessId(final boolean useRest, final TestInfo testInfo) {
+    // given
+    deployProcesses(testInfo, useRest);
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        getCommand(client, useRest)
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .businessId("bizniz")
+            .send()
+            .join();
+
+    // then
+    assertThat(processInstance.getBusinessId()).isEqualTo("bizniz");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
# Description
Backport of #46838 to `stable/8.9`.

relates to #46722

BREAKING CHANGE: This adjusts a property that was not yet released in any stable releases.