### PR TITLE
Enable Load tests with no secondary storage

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -69,12 +69,13 @@ on:
         required: false
         default: false
       secondary-storage-type:
-        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch" or "postgresql"'
+        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch", "postgresql" or "none"'
         type: choice
         options:
         - elasticsearch
         - opensearch
         - postgresql
+        - none
         default: elasticsearch
   workflow_call:
     inputs:
@@ -132,7 +133,7 @@ on:
         required: false
         default: false
       secondary-storage-type:
-        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch" or "postgresql"'
+        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch", "postgresql" or "none"'
         # type choice is invalid here
         type: string
         required: false

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -89,9 +89,20 @@ Depending on the test variant, different process models are created and executed
 
 All of this is deployed in an Infra-team-maintained Google Kubernetes Engine (GKE) cluster (`camunda-benchmark-prod`). Access is managed via [Teleport](https://camunda.teleport.sh). Container images are stored in `registry.camunda.cloud/team-zeebe`. Details about the benchmark cluster infrastructure can be found in the [infra-core repository](https://github.com/camunda/infra-core/), and specifically in the [benchmark cluster access guide](https://github.com/camunda/infra-core/blob/stage/docs/kubernetes-cluster/benchmark-cluster-access.md).
 
-For posterity, the deployment between 8.8 and pre-8.8 differs slightly. The Platform Helm  Chart will now deploy a single Camunda application (replicated), whereas previously, the Zeebe Broker and Zeebe Gateways were deployed standalone.
+For posterity, the deployment between 8.8 and pre-8.8 differs slightly. The Platform Helm  Chart will now deploy a single Camunda application (replicated), whereas previously, the Zeebe Brokers and Zeebe Gateways were deployed standalone.
 
 ![setup](assets/setup.png)
+
+#### Secondary Storage Options
+
+Load tests can be configured with different secondary storage backends to validate Camunda's performance and reliability across various deployment scenarios:
+
+* **Elasticsearch** (default): Deploys a three-node Elasticsearch cluster. This is the standard configuration used to validate exporter performance and archiving throughput.
+* **OpenSearch**: Deploys an OpenSearch cluster as an alternative to Elasticsearch.
+* **PostgreSQL**: Deploys a PostgreSQL database for RDBMS-based secondary storage testing.
+* **None**: Runs load tests without any secondary storage. This is useful for testing the core orchestration engine performance in isolation, without the overhead of exporting data to a secondary database. In this mode, Camunda exporters are disabled.
+
+The secondary storage type can be specified when creating a load test via the `newLoadTest.sh` script or the GitHub workflow inputs.
 
 ### Endurance test variants
 

--- a/load-tests/camunda-platform-no-secondary-storage.yaml
+++ b/load-tests/camunda-platform-no-secondary-storage.yaml
@@ -1,0 +1,97 @@
+# Values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # Our default is ELASTICSEARCH
+  # We need to explicitly enable ELS as per default this is disabled now
+  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
+  elasticsearch:
+    enabled: false
+  # Disable global ingress
+  ingress:
+    enabled: false
+  image:
+    # Image.repository defines the repository from which to fetch the docker images
+    repository: "registry.camunda.cloud/team-zeebe"
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: SNAPSHOT
+    ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    pullPolicy: Always
+    ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets:
+      - name: harbor-registry
+  # By default, we run without Identity
+  identity:
+    auth:
+      enabled: false
+
+identity:
+  enabled: false
+
+identityKeycloak:
+  enabled: false
+
+optimize:
+  enabled: false
+
+connectors:
+  enabled: false
+
+webModeler:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  exporters:
+    camunda:
+      enabled: false
+  # We need to explicitly set the secondary storage type to ELS
+  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
+  data:
+    secondaryStorage:
+      type: none
+  # We set extra configuration to configure additional settings for Camunda application, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+        # RocksDB memory limit setting, limits the overall RocksDB memory usage
+        # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
+        zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"
+  history:
+    retention:
+      enabled: false
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: false

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -31,6 +31,19 @@ will be created with the given name. If you used `.` before `./newLoadTest.sh`
 the script will also change your directory after running, so you can directly start
 to configure your load test.
 
+#### Secondary storage options
+
+You can specify a secondary storage type as the second argument:
+
+```
+. ./newLoadTest.sh my-load-test-name elasticsearch  # Default - uses Elasticsearch
+. ./newLoadTest.sh my-load-test-name opensearch     # Uses OpenSearch
+. ./newLoadTest.sh my-load-test-name postgresql     # Uses PostgreSQL (RDBMS)
+. ./newLoadTest.sh my-load-test-name none           # No secondary storage
+```
+
+The `none` option runs load tests without any secondary storage, which disables Camunda exporters. This is useful for testing the core orchestration engine performance in isolation.
+
 ### How to configure a load test
 
 The load test configuration is done via the `camunda-platform-values.yaml` file (copied to your namespace folder).

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -13,7 +13,7 @@ additional_platform_configuration ?=
 # Optional: additional Helm configuration for the load test release.
 # Use this to pass extra `--set`/`-f` flags when installing/upgrading the load tests.
 # See the load test README for example values and guidance.
-additional_load_test_configuration ?=
+additional_load_test_configuration ?= --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
 
 # Construct platform values files based on configuration
 platform_values := -f camunda-platform-values.yaml
@@ -23,6 +23,8 @@ ifeq ($(secondary_storage),postgresql)
 platform_values += -f camunda-platform-values-rdbms.yaml
 else ifeq ($(secondary_storage),opensearch)
 platform_values += -f camunda-platform-values-opensearch.yaml
+else ifeq ($(secondary_storage),none)
+platform_values += -f camunda-platform-no-secondary-storage.yaml
 endif
 
 # Add Optimize values if enabled

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -11,7 +11,7 @@ Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
-  secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql. Default: elasticsearch.
+  secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, none. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 7.
   enable_optimize    Optional. true|false to enable Optimize. Default: false.
 
@@ -50,9 +50,9 @@ fi
 
 # Validate secondaryStorage value
 secondaryStorage="${2:-elasticsearch}"
-if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "opensearch" && "$secondaryStorage" != "postgresql" ]]; then
+if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "opensearch" && "$secondaryStorage" != "postgresql" && "$secondaryStorage" != "none" ]]; then
   echo "Error: Invalid secondary storage type '$secondaryStorage'"
-  echo "Allowed values are: elasticsearch, opensearch, postgresql"
+  echo "Allowed values are: elasticsearch, opensearch, postgresql, none"
   exit 1
 fi
 


### PR DESCRIPTION
## Description

* Add values files to configure the platform chart and OC to not use any secondary storage
* Adding option to configure secondary storage as none this will make sure that we set up a load test without any secondary storage nor export configured
* It should allows us to load test engine performance (with distributed system) only
* Add documentation for none as option for secondary storage to be used with load tests

## Related issues

see related https://camunda.slack.com/archives/C0ACRH1J96H/p1772177425670129?thread_ts=1772176978.511819&cid=C0ACRH1J96H
