### PR TITLE
feat: add metrics to track archiver docs deleted/reindexed + bulk operations

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -197,7 +197,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .publishPercentileHistogram()
             .register(meterRegistry);
     archiverDeletedDocs =
-        Counter.builder(meterName("archiver.docs")).tags("type", "delete").register(meterRegistry);
+        Counter.builder(meterName("archiver.docs"))
+            .tags("type", "delete")
+            .description("Count of how many documents the archiver has deleted from old indices.")
+            .register(meterRegistry);
     archiverReindexTimer =
         Timer.builder(meterName("archiver.request.duration"))
             .description(
@@ -206,7 +209,11 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .publishPercentileHistogram()
             .register(meterRegistry);
     archiverReindexedDocs =
-        Counter.builder(meterName("archiver.docs")).tags("type", "reindex").register(meterRegistry);
+        Counter.builder(meterName("archiver.docs"))
+            .tags("type", "reindex")
+            .description(
+                "Count of how many documents the archiver has reindexed to copy over to the dated indices, from old indices.")
+            .register(meterRegistry);
     archivingDuration =
         Timer.builder(meterName("archiver.duration"))
             .description(
@@ -234,7 +241,11 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .description("How many items were exported in one bulk request")
             .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
             .register(meterRegistry);
-    bulkOperations = Counter.builder(meterName("bulk.operations")).register(meterRegistry);
+    bulkOperations =
+        Counter.builder(meterName("bulk.operations"))
+            .description(
+                "Count of many secondary storage operations have been done via exporter bulk requests")
+            .register(meterRegistry);
     flushDuration =
         Timer.builder(meterName("flush.duration.seconds"))
             .description("Flush duration of bulk exporters in seconds")

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -86,6 +86,8 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   private final Timer archiverSearchTimer;
   private final Timer archiverDeleteTimer;
+  private final Counter archiverDeletedDocs;
+  private final Counter archiverReindexedDocs;
   private final Timer archiverReindexTimer;
   private Timer.Sample flushLatencyMeasurement;
   private final Timer archivingDuration;
@@ -193,6 +195,8 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tags("type", "delete")
             .publishPercentileHistogram()
             .register(meterRegistry);
+    archiverDeletedDocs =
+        Counter.builder(meterName("archiver.docs")).tags("type", "delete").register(meterRegistry);
     archiverReindexTimer =
         Timer.builder(meterName("archiver.request.duration"))
             .description(
@@ -200,6 +204,8 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tags("type", "reindex")
             .publishPercentileHistogram()
             .register(meterRegistry);
+    archiverReindexedDocs =
+        Counter.builder(meterName("archiver.docs")).tags("type", "reindex").register(meterRegistry);
     archivingDuration =
         Timer.builder(meterName("archiver.duration"))
             .description(
@@ -395,11 +401,17 @@ public class CamundaExporterMetrics implements AutoCloseable {
     return NAMESPACE + "." + name;
   }
 
-  public void measureArchiverDelete(final Sample timer) {
+  public void measureArchiverDelete(final Long docsDeleted, final Sample timer) {
+    if (docsDeleted != null) {
+      archiverDeletedDocs.increment(docsDeleted);
+    }
     timer.stop(archiverDeleteTimer);
   }
 
-  public void measureArchiverReindex(final Sample timer) {
+  public void measureArchiverReindex(final Long docsReindexed, final Sample timer) {
+    if (docsReindexed != null) {
+      archiverReindexedDocs.increment(docsReindexed);
+    }
     timer.stop(archiverReindexTimer);
   }
 
@@ -417,7 +429,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(batchOperationsArchiving);
     meterRegistry.remove(archiverSearchTimer);
     meterRegistry.remove(archiverDeleteTimer);
+    meterRegistry.remove(archiverDeletedDocs);
     meterRegistry.remove(archiverReindexTimer);
+    meterRegistry.remove(archiverReindexedDocs);
     meterRegistry.remove(archivingDuration);
     meterRegistry.remove(bulkSize);
     meterRegistry.remove(flushDuration);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -92,6 +92,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private Timer.Sample flushLatencyMeasurement;
   private final Timer archivingDuration;
   private final DistributionSummary bulkSize;
+  private final Counter bulkOperations;
   private final Timer flushDuration;
   private final Counter failedFlush;
   private final Timer recordExportDuration;
@@ -233,6 +234,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .description("How many items were exported in one bulk request")
             .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
             .register(meterRegistry);
+    bulkOperations = Counter.builder(meterName("bulk.operations")).register(meterRegistry);
     flushDuration =
         Timer.builder(meterName("flush.duration.seconds"))
             .description("Flush duration of bulk exporters in seconds")
@@ -284,6 +286,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void recordBulkSize(final int bulkSize) {
     this.bulkSize.record(bulkSize);
+  }
+
+  public void recordBulkOperations(final int operations) {
+    bulkOperations.increment(operations);
   }
 
   public void recordFailedFlush() {
@@ -434,6 +440,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(archiverReindexedDocs);
     meterRegistry.remove(archivingDuration);
     meterRegistry.remove(bulkSize);
+    meterRegistry.remove(bulkOperations);
     meterRegistry.remove(flushDuration);
     meterRegistry.remove(failedFlush);
     meterRegistry.remove(recordExportDuration);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -258,8 +258,10 @@ public class ElasticsearchBatchRequest implements BatchRequest {
       final BulkResponse bulkResponse = esClient.bulk(bulkRequest);
       final List<BulkResponseItem> items = bulkResponse.items();
       validateNoErrors(items, customErrorHandlers);
+      if (metrics != null) {
+        metrics.recordBulkOperations(bulkRequest.operations().size());
+      }
     } catch (final IOException | ElasticsearchException ex) {
-
       throw new PersistenceException(
           "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -257,6 +257,9 @@ public class OpensearchBatchRequest implements BatchRequest {
       final BulkResponse bulkItemResponses = osClient.bulk(bulkRequest);
       final List<BulkResponseItem> items = bulkItemResponses.items();
       validateNoErrors(items, customErrorHandlers);
+      if (metrics != null) {
+        metrics.recordBulkOperations(bulkRequest.operations().size());
+      }
     } catch (final IOException | OpenSearchException ex) {
       throw new PersistenceException(
           "Error when processing bulk request against OpenSearch: " + ex.getMessage(), ex);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -308,7 +308,10 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return client
         .deleteByQuery(request)
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverDelete(timer), executor)
+        .whenCompleteAsync(
+            (response, error) ->
+                metrics.measureArchiverDelete(response != null ? response.total() : null, timer),
+            executor)
         .thenApplyAsync(DeleteByQueryResponse::total, executor)
         .thenApplyAsync(ok -> null, executor);
   }
@@ -343,7 +346,10 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return client
         .reindex(request)
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverReindex(timer), executor)
+        .whenCompleteAsync(
+            (response, error) ->
+                metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
+            executor)
         .thenApplyAsync(ignored -> null, executor);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -309,7 +309,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.deleteByQuery(request))
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverDelete(timer), executor)
+        .whenCompleteAsync(
+            (response, error) ->
+                metrics.measureArchiverDelete(response != null ? response.total() : null, timer),
+            executor)
         .thenApplyAsync(DeleteByQueryResponse::total, executor)
         .thenApplyAsync(ok -> null, executor);
   }
@@ -343,7 +346,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.reindex(request))
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverReindex(timer), executor)
+        .whenCompleteAsync(
+            (response, error) ->
+                metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
+            executor)
         .thenApplyAsync(ignored -> null, executor);
   }
 


### PR DESCRIPTION
Just adding a few metrics more directly related to work done by ES (at least from the exporters POV)

Refs: #45301