### PR TITLE
fix: update modification logic to handle terminated and completed instances

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -75,11 +75,18 @@ const ModificationDropdown: React.FC<Props> = observer(
       selectedElementInstanceKey !== null;
 
     // true if an element is selected from diagram or element history tree,
-    // and a single specific element instance is resolved for the selection
-    const isElementInstanceResolved = resolvedElementInstance !== null;
+    // and a single specific running element instance is resolved for the selection
+    const isResolvedInstanceRunning =
+      resolvedElementInstance?.state === 'ACTIVE' ||
+      resolvedElementInstance?.hasIncident;
 
     let selectedElementRunningInstancesCount = totalRunningInstancesCount;
-    if (isElementInstanceResolved && !isSelectedInstanceMultiInstanceBody) {
+    if (isSpecificElementInstanceSelected && !isResolvedInstanceRunning) {
+      selectedElementRunningInstancesCount = 0;
+    } else if (
+      isResolvedInstanceRunning &&
+      !isSelectedInstanceMultiInstanceBody
+    ) {
       selectedElementRunningInstancesCount = 1;
     }
 
@@ -91,7 +98,7 @@ const ModificationDropdown: React.FC<Props> = observer(
       elementId: selectedElementId ?? undefined,
       isSpecificElementInstanceSelected,
       isMultiInstanceBody: isSelectedInstanceMultiInstanceBody,
-      isElementInstanceKeyAvailable: isElementInstanceResolved,
+      isSingleRunningInstanceResolved: isResolvedInstanceRunning,
     });
     const canBeModified = useCanBeModified(selectedElementId ?? undefined);
     const {data: processInstance} = useProcessInstance();

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/index.test.tsx
@@ -480,6 +480,70 @@ describe('Modification Dropdown', () => {
     expect(screen.getByText(/Add/)).toBeInTheDocument();
   });
 
+  it('should not show modifications for a terminated element instance', async () => {
+    mockFetchElementInstance('terminated-instance-key').withSuccess({
+      elementInstanceKey: 'terminated-instance-key',
+      elementId: 'service-task-1',
+      elementName: 'Service Task 1',
+      type: 'SERVICE_TASK',
+      state: 'TERMINATED',
+      startDate: '2018-06-21',
+      endDate: '2018-06-22',
+      processDefinitionId: 'someKey',
+      processInstanceKey: 'instance_id',
+      processDefinitionKey: '2',
+      rootProcessInstanceKey: null,
+      hasIncident: false,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+
+    renderPopover([
+      `${Paths.processInstance('instance_id')}?elementId=service-task-1&elementInstanceKey=terminated-instance-key`,
+    ]);
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('dropdown-spinner'),
+    );
+
+    expect(screen.getByText(/No modifications available/)).toBeInTheDocument();
+    expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
+  });
+
+  it('should not show modifications for a completed element instance', async () => {
+    mockFetchElementInstance('completed-instance-key').withSuccess({
+      elementInstanceKey: 'completed-instance-key',
+      elementId: 'service-task-1',
+      elementName: 'Service Task 1',
+      type: 'SERVICE_TASK',
+      state: 'COMPLETED',
+      startDate: '2018-06-21',
+      endDate: '2018-06-22',
+      processDefinitionId: 'someKey',
+      processInstanceKey: 'instance_id',
+      processDefinitionKey: '2',
+      rootProcessInstanceKey: null,
+      hasIncident: false,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+
+    renderPopover([
+      `${Paths.processInstance('instance_id')}?elementId=service-task-1&elementInstanceKey=completed-instance-key`,
+    ]);
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('dropdown-spinner'),
+    );
+
+    expect(screen.getByText(/No modifications available/)).toBeInTheDocument();
+    expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
+  });
+
   it('should display message when there are multiple instances and hide when specific instance is selected', async () => {
     const {unmount} = renderPopover([
       `${Paths.processInstance('instance_id')}?elementId=service-task-1`,

--- a/operate/client/src/modules/hooks/modifications.test.tsx
+++ b/operate/client/src/modules/hooks/modifications.test.tsx
@@ -435,7 +435,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'StartEvent_1',
-            isElementInstanceKeyAvailable: true,
+            isSingleRunningInstanceResolved: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -451,7 +451,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_1daop2o',
-            isElementInstanceKeyAvailable: true,
+            isSingleRunningInstanceResolved: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -466,7 +466,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_0ruokei',
-            isElementInstanceKeyAvailable: true,
+            isSingleRunningInstanceResolved: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -482,7 +482,7 @@ describe('modifications hooks', () => {
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_1daop2o',
             isSpecificElementInstanceSelected: true,
-            isElementInstanceKeyAvailable: true,
+            isSingleRunningInstanceResolved: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -508,7 +508,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_1daop2o',
-            isElementInstanceKeyAvailable: true,
+            isSingleRunningInstanceResolved: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -566,7 +566,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_0ruokei',
-            isElementInstanceKeyAvailable: true,
+            isSingleRunningInstanceResolved: true,
           }),
         {wrapper: getWrapper()},
       );

--- a/operate/client/src/modules/hooks/modifications.ts
+++ b/operate/client/src/modules/hooks/modifications.ts
@@ -264,7 +264,7 @@ type UseAvailableModificationsParams = {
   elementId?: string;
   isSpecificElementInstanceSelected?: boolean;
   isMultiInstanceBody?: boolean;
-  isElementInstanceKeyAvailable?: boolean;
+  isSingleRunningInstanceResolved?: boolean;
 };
 
 const useAvailableModifications = ({
@@ -272,7 +272,7 @@ const useAvailableModifications = ({
   elementId,
   isSpecificElementInstanceSelected,
   isMultiInstanceBody,
-  isElementInstanceKeyAvailable,
+  isSingleRunningInstanceResolved,
 }: UseAvailableModificationsParams) => {
   const options: ModificationOption[] = [];
   const appendableFlowNodes = useAppendableFlowNodes();
@@ -300,7 +300,7 @@ const useAvailableModifications = ({
   }
 
   const isSingleOperationAllowed =
-    isElementInstanceKeyAvailable &&
+    isSingleRunningInstanceResolved &&
     runningElementInstanceCount === 1 &&
     !isSubProcess(businessObjects?.[elementId]);
 


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR fixes issue https://github.com/camunda/camunda/issues/45718 by preventing users from selecting and attempting to modify terminated, completed, or canceled element instances in the Operate UI. The fix updates the modification logic to properly check whether a resolved element instance is actually in a running state before allowing modification operations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45718
