### PR TITLE
[Backport stable/8.9] fix: add missing items schema to search endpoint response definitions

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -538,7 +538,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/GroupMappingRuleSearchResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -581,7 +581,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/GroupRoleSearchResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -801,6 +801,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GroupClientSearchQuerySortRequest'
+
+    GroupMappingRuleSearchResult:
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching mapping rules.
+          type: array
+          items:
+            $ref: 'mapping-rules.yaml#/components/schemas/MappingRuleResult'
+
+    GroupRoleSearchResult:
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching roles.
+          type: array
+          items:
+            $ref: 'roles.yaml#/components/schemas/RoleResult'
 
     GroupClientSearchQuerySortRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -657,7 +657,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/RoleMappingRuleSearchResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -919,6 +919,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RoleGroupSearchQuerySortRequest'
+
+    RoleMappingRuleSearchResult:
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching mapping rules.
+          type: array
+          items:
+            $ref: 'mapping-rules.yaml#/components/schemas/MappingRuleResult'
 
     RoleGroupSearchQuerySortRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -541,7 +541,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/TenantRoleSearchResult'
 
   /tenants/{tenantId}/roles/{roleId}:
     put:
@@ -729,7 +729,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+                $ref: '#/components/schemas/TenantMappingRuleSearchResult'
 
 ## Schema definitions
 
@@ -988,6 +988,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TenantGroupSearchQuerySortRequest'
+
+    TenantRoleSearchResult:
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching roles.
+          type: array
+          items:
+            $ref: 'roles.yaml#/components/schemas/RoleResult'
+
+    TenantMappingRuleSearchResult:
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching mapping rules.
+          type: array
+          items:
+            $ref: 'mapping-rules.yaml#/components/schemas/MappingRuleResult'
 
     TenantGroupSearchQuerySortRequest:
       type: object


### PR DESCRIPTION
# Description
Backport of #47153 to `stable/8.9`.

relates to camunda/camunda#46895