### PR TITLE
fix: convert AuthorizationRequest to record for proper equals/hashCode

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequest.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequest.java
@@ -35,12 +35,11 @@ public record AuthorizationRequest(
       "Insufficient permissions to perform operation '%s' on resource '%s'";
   private static final String FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE_IDS =
       FORBIDDEN_ERROR_MESSAGE + ", required resource identifiers are one of '[*, %s]'";
-  private static final String FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE_PROPERTIES =
-      FORBIDDEN_ERROR_MESSAGE + ", resource did not match property constraints '[%s]'";
   private static final String FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE_IDS_AND_PROPERTIES =
       FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE_IDS
           + " or resource must match property constraints '[%s]'";
-
+  private static final String FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE_PROPERTIES =
+      FORBIDDEN_ERROR_MESSAGE + ", resource did not match property constraints '[%s]'";
   private static final String FORBIDDEN_FOR_TENANT_ERROR_MESSAGE =
       "Expected to perform operation '%s' on resource '%s' for tenant '%s', but user is not assigned to this tenant";
   private static final String NOT_FOUND_FOR_TENANT_ERROR_MESSAGE =
@@ -97,7 +96,7 @@ public record AuthorizationRequest(
     private Map<String, Object> authorizationClaims;
     private AuthorizationResourceType resourceType;
     private PermissionType permissionType;
-    private final Set<String> resourceIds = new HashSet<>();
+    private Set<String> resourceIds = new HashSet<>();
     private ResourceAuthorizationProperties resourceProperties;
     private String tenantId;
     private boolean isNewResource;
@@ -172,12 +171,16 @@ public record AuthorizationRequest(
       final var isTenantOwnedResource = tenantId != null && !tenantId.isEmpty();
       final var isTriggeredByInternalCommand = command != null && command.isInternalCommand();
 
+      if (resourceIds instanceof HashSet<String>) {
+        resourceIds = Collections.unmodifiableSet(resourceIds);
+      }
+
       return new AuthorizationRequest(
           claims,
           resourceType,
           permissionType,
           tenantId,
-          Collections.unmodifiableSet(resourceIds),
+          resourceIds,
           resourceProperties,
           isNewResource,
           isTenantOwnedResource,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequest.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequest.java
@@ -20,7 +20,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
-public final class AuthorizationRequest {
+public record AuthorizationRequest(
+    Map<String, Object> claims,
+    AuthorizationResourceType resourceType,
+    PermissionType permissionType,
+    String tenantId,
+    Set<String> resourceIds,
+    ResourceAuthorizationProperties resourceProperties,
+    boolean isNewResource,
+    boolean isTenantOwnedResource,
+    boolean isTriggeredByInternalCommand) {
 
   private static final String FORBIDDEN_ERROR_MESSAGE =
       "Insufficient permissions to perform operation '%s' on resource '%s'";
@@ -37,80 +46,8 @@ public final class AuthorizationRequest {
   private static final String NOT_FOUND_FOR_TENANT_ERROR_MESSAGE =
       "Expected to perform operation '%s' on resource '%s', but no resource was found for tenant '%s'";
 
-  private final Map<String, Object> claims;
-  private final AuthorizationResourceType resourceType;
-  private final PermissionType permissionType;
-  private final String tenantId;
-  private final Set<String> resourceIds;
-  private final ResourceAuthorizationProperties resourceProperties;
-  private final boolean isNewResource;
-  private final boolean isTenantOwnedResource;
-  private final boolean isTriggeredByInternalCommand;
-
-  private AuthorizationRequest(final Builder builder) {
-    claims = resolveClaims(builder);
-    resourceType = builder.resourceType;
-    permissionType = builder.permissionType;
-    tenantId = builder.tenantId;
-    resourceIds = Collections.unmodifiableSet(builder.resourceIds);
-    resourceProperties = builder.resourceProperties;
-    isNewResource = builder.isNewResource;
-    isTenantOwnedResource = deriveTenantOwnedResource(builder);
-    isTriggeredByInternalCommand = deriveTriggeredByInternalCommand(builder);
-  }
-
-  private static Map<String, Object> resolveClaims(final Builder builder) {
-    final var claims =
-        builder.command != null ? builder.command.getAuthorizations() : builder.authorizationClaims;
-    return Collections.unmodifiableMap(Objects.requireNonNullElse(claims, Collections.emptyMap()));
-  }
-
-  private static boolean deriveTenantOwnedResource(final Builder builder) {
-    return builder.tenantId != null && !builder.tenantId.isEmpty();
-  }
-
-  private static boolean deriveTriggeredByInternalCommand(final Builder builder) {
-    return builder.command != null && builder.command.isInternalCommand();
-  }
-
-  public Map<String, Object> claims() {
-    return claims;
-  }
-
-  public AuthorizationResourceType resourceType() {
-    return resourceType;
-  }
-
-  public PermissionType permissionType() {
-    return permissionType;
-  }
-
-  public String tenantId() {
-    return tenantId;
-  }
-
-  public Set<String> resourceIds() {
-    return resourceIds;
-  }
-
-  public ResourceAuthorizationProperties resourceProperties() {
-    return resourceProperties;
-  }
-
   public boolean hasResourceProperties() {
     return resourceProperties != null && resourceProperties.hasProperties();
-  }
-
-  public boolean isNewResource() {
-    return isNewResource;
-  }
-
-  public boolean isTenantOwnedResource() {
-    return isTenantOwnedResource;
-  }
-
-  public boolean isTriggeredByInternalCommand() {
-    return isTriggeredByInternalCommand;
   }
 
   public String getForbiddenErrorMessage() {
@@ -231,7 +168,26 @@ public final class AuthorizationRequest {
         throw new IllegalStateException("command and authorizationClaims are mutually exclusive");
       }
 
-      return new AuthorizationRequest(this);
+      final var claims = resolveClaims();
+      final var isTenantOwnedResource = tenantId != null && !tenantId.isEmpty();
+      final var isTriggeredByInternalCommand = command != null && command.isInternalCommand();
+
+      return new AuthorizationRequest(
+          claims,
+          resourceType,
+          permissionType,
+          tenantId,
+          Collections.unmodifiableSet(resourceIds),
+          resourceProperties,
+          isNewResource,
+          isTenantOwnedResource,
+          isTriggeredByInternalCommand);
+    }
+
+    private Map<String, Object> resolveClaims() {
+      final var claims = command != null ? command.getAuthorizations() : authorizationClaims;
+      return Collections.unmodifiableMap(
+          Objects.requireNonNullElse(claims, Collections.emptyMap()));
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequestTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequestTest.java
@@ -111,6 +111,16 @@ class AuthorizationRequestTest {
                   .authorizationClaims(Map.of(Authorization.AUTHORIZED_USERNAME, "userB"))
                   .resourceType(AuthorizationResourceType.RESOURCE)
                   .permissionType(PermissionType.READ)
+                  .build()),
+          // Different resource properties
+          Arguments.of(
+              baseRequestBuilder()
+                  .resourceProperties(
+                      UserTaskAuthorizationProperties.builder().assignee("user1").build())
+                  .build(),
+              baseRequestBuilder()
+                  .resourceProperties(
+                      UserTaskAuthorizationProperties.builder().assignee("user2").build())
                   .build()));
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequestTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequestTest.java
@@ -35,6 +35,95 @@ class AuthorizationRequestTest {
 
   @Nested
   @TestInstance(Lifecycle.PER_CLASS)
+  class EqualsAndHashCodeTest {
+
+    @Test
+    void shouldBeEqualWhenBuiltWithSameParameters() {
+      // given
+      final var request1 =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of(Authorization.AUTHORIZED_USERNAME, "user"))
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+              .permissionType(PermissionType.READ)
+              .addResourceId("resource-1")
+              .tenantId("tenant-1")
+              .isNewResource(true)
+              .build();
+
+      final var request2 =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of(Authorization.AUTHORIZED_USERNAME, "user"))
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+              .permissionType(PermissionType.READ)
+              .addResourceId("resource-1")
+              .tenantId("tenant-1")
+              .isNewResource(true)
+              .build();
+
+      // when / then
+      assertThat(request1).isEqualTo(request2);
+      assertThat(request1.hashCode()).isEqualTo(request2.hashCode());
+    }
+
+    @ParameterizedTest
+    @MethodSource("unequalRequestInputs")
+    void shouldNotBeEqualWhenBuiltWithDifferentParameters(
+        final AuthorizationRequest request1, final AuthorizationRequest request2) {
+      // when / then
+      assertThat(request1).isNotEqualTo(request2);
+      assertThat(request1.hashCode()).isNotEqualTo(request2.hashCode());
+    }
+
+    Stream<Arguments> unequalRequestInputs() {
+      return Stream.of(
+          // Different resource type
+          Arguments.of(
+              baseRequestBuilder()
+                  .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                  .build(),
+              baseRequestBuilder()
+                  .resourceType(AuthorizationResourceType.DECISION_DEFINITION)
+                  .build()),
+          // Different permission type
+          Arguments.of(
+              baseRequestBuilder().permissionType(PermissionType.READ).build(),
+              baseRequestBuilder().permissionType(PermissionType.UPDATE).build()),
+          // Different resource ids
+          Arguments.of(
+              baseRequestBuilder().addResourceId("id1").build(),
+              baseRequestBuilder().addResourceId("id2").build()),
+          // Different tenant id
+          Arguments.of(
+              baseRequestBuilder().tenantId("tenant-1").build(),
+              baseRequestBuilder().tenantId("tenant-2").build()),
+          // Different isNewResource
+          Arguments.of(
+              baseRequestBuilder().isNewResource(true).build(),
+              baseRequestBuilder().isNewResource(false).build()),
+          // Different claims
+          Arguments.of(
+              AuthorizationRequest.builder()
+                  .authorizationClaims(Map.of(Authorization.AUTHORIZED_USERNAME, "userA"))
+                  .resourceType(AuthorizationResourceType.RESOURCE)
+                  .permissionType(PermissionType.READ)
+                  .build(),
+              AuthorizationRequest.builder()
+                  .authorizationClaims(Map.of(Authorization.AUTHORIZED_USERNAME, "userB"))
+                  .resourceType(AuthorizationResourceType.RESOURCE)
+                  .permissionType(PermissionType.READ)
+                  .build()));
+    }
+
+    private AuthorizationRequest.Builder baseRequestBuilder() {
+      return AuthorizationRequest.builder()
+          .authorizationClaims(Map.of())
+          .resourceType(AuthorizationResourceType.RESOURCE)
+          .permissionType(PermissionType.READ);
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
   class BuildAuthorizationRequestValidationTest {
 
     @Test


### PR DESCRIPTION
## Description
AuthorizationRequest is used as a cache key in a Guava LoadingCache but lacked equals/hashCode, making the cache ineffective. Converting to a record auto-generates these methods based on all components.

Backport to 8.8 will be done after #46918 is merged

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47193 
