### PR TITLE
refactor: backport load test infra migration and fixes to stable/8.9

### DIFF
--- a/.github/scripts/clean-up-load-test-namespaces.sh
+++ b/.github/scripts/clean-up-load-test-namespaces.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deletes Kubernetes namespaces whose "deadline-date" label is on or before the given date.
+# This ensures namespaces are still cleaned up even if the workflow didn't run on their exact deadline day.
+#
+# Usage: clean-up-load-test-namespaces.sh [--execute] [DATE]
+#   --execute: actually delete namespaces (default is dry-run)
+#   DATE:      optional date in YYYY-MM-DD format (defaults to today)
+#
+# Outputs:
+#   NAMESPACES: multiline list of deleted namespaces (written to $GITHUB_OUTPUT if set)
+
+dryRun=true
+if [[ "${1:-}" == "--execute" ]]; then
+  dryRun=false
+  shift
+fi
+
+currentDate=$(date -d "${1:-}" +'%Y-%m-%d' 2>/dev/null || date +'%Y-%m-%d')
+echo "Date used for deletion: $currentDate"
+
+if [[ "$dryRun" == true ]]; then
+  echo "Running in DRY-RUN mode. No namespaces will be deleted. Pass --execute to delete."
+fi
+
+namespacesDeleted=""
+
+for row in $(kubectl get namespace -l deadline-date -o json | jq -r '.items[] | "\(.metadata.name)=\(.metadata.labels["deadline-date"])"');
+do
+  ns="${row%%=*}"
+  deadlineDate="${row#*=}"
+  if [[ "${deadlineDate//-/}" -le "${currentDate//-/}" ]]; then
+    if [[ "$dryRun" == true ]]; then
+      echo "[DRY-RUN] Would delete namespace: $ns (deadline: $deadlineDate)"
+    else
+      kubectl delete namespace "$ns" --wait=false
+    fi
+    namespacesDeleted+=" * $ns (deadline: $deadlineDate)\n"
+  fi
+done
+
+echo -e "Namespaces eligible for deletion:\n$namespacesDeleted"
+
+# Write output for GitHub Actions if running in CI
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo 'NAMESPACES<<EOF'
+    echo "$namespacesDeleted"
+    echo 'EOF'
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -1,4 +1,4 @@
-# description: This workflow deletes eligible load tests when reaching their deadline
+# description: This workflow deletes eligible load tests that reached or passed their deadline
 # type: CI
 # owner: camunda/orchestration-cluster-team
 name: camunda-load-test-clean-up.yml
@@ -8,9 +8,13 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'Date in YYYY-MM-DD format to delete load tests for (defaults to current date)'
+        description: 'Namespaces with deadline-date on or before this date (YYYY-MM-DD) will be deleted. Defaults to current date.'
         type: string
         required: false
+
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 
 defaults:
   run:
@@ -19,8 +23,11 @@ defaults:
     shell: bash
 
 jobs:
-  delete-load-tests-that-reached-deadline:
-    name: Delete load tests that reached deadline
+  # Legacy job: clean up old GKE-based benchmark infrastructure.
+  # Will be removed once migration to the new benchmark infrastructure is complete.
+  # TODO: remove this job after migration is complete, see https://github.com/camunda/team-infrastructure/issues/829
+  delete-load-tests-legacy:
+    name: Delete load tests (legacy infra)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -38,26 +45,63 @@ jobs:
           location: europe-west1-b
       - name: Delete namespaces eligible for deletion
         id: delete-namespaces
-        run: |
-          currentDate=$(date -d "${{ inputs.date }}" +'%Y-%m-%d')
-          echo "Date used for deletion: $currentDate"
-          namespacesDeleted=""
-          for ns in $(kubectl get namespace --selector=deadline-date="$currentDate" -o json | jq -r '.items[].metadata.name');
-          do
-            kubectl delete namespace "$ns" --wait=false
-            namespacesDeleted+=" * $ns\n"
-          done
+        run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${{ inputs.date }}"
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":meow_trash: *Load tests have been cleaned up (legacy):*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.delete-namespaces.outputs.namespaces }}"
+                  }
+                }
+              ]
+            }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-          echo -e "Namespaces deleted:\n$namespacesDeleted"
-          # With multiline strings the output needs to be set differently.
-          #
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
-          #
-          {
-            echo 'NAMESPACES<<EOF'
-            echo "$namespacesDeleted"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+  delete-load-tests:
+    name: Delete load tests (new infra)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+      - name: Delete namespaces eligible for deletion
+        id: delete-namespaces
+        run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${{ inputs.date }}"
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -1,10 +1,17 @@
 # description: This workflow deploys a load test with a camunda cluster under test.
 # We use this workflow to start ad-hoc load tests or weekly medic load tests.
 # The health of the cluster and results of the load tests are monitored by Core team's regularly.
-# https://grafana.dev.zeebe.io/login
+# https://dashboard.benchmark.camunda.cloud/
 # called by: camunda-weekly-load-tests.yml, camunda-pr-load-test.yaml
 # type: CI
 # owner: camunda/orchestration-cluster-team
+#
+# Infos from Infra:
+# - Using the infra benchmark prod cluster requires to use Teleport to authenticate.
+# - Camunda images are pushed to registry.camunda.cloud/team-zeebe and pulled from there.
+#   To use them in a namespace, the namespace must be labeled with "registry=harbor"
+#   You must also set the image pull secret to "harbor-registry" in the helm values.
+
 name: Camunda load test
 on:
   workflow_dispatch:
@@ -132,7 +139,12 @@ on:
         default: elasticsearch
 
 env:
+  CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe  # change this to "infra-benchmark-dev-github-action-zeebe" when experimenting
   HELM_CHART: camunda-platform-8.9
+  # Namespaces MUST start with c8 due to access policy
+  NAMESPACE: ${{ startsWith(inputs.name, 'c8-') && inputs.name || format('c8-{0}', inputs.name) }}
+  IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
 
 defaults:
   run:
@@ -224,6 +236,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
@@ -251,22 +264,10 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild -P\!include-optimize
-      - uses: google-github-actions/auth@v3
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GCR
-        uses: docker/login-action@v3
-        with:
-          registry: gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/build-platform-docker
         name: Build Camunda Docker Image
         with:
-          repository: 'gcr.io/zeebe-io/zeebe'
+          repository: '${{ env.IMAGE_REPOSITORY }}/camunda'
           revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
@@ -295,30 +296,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GAR
-        uses: docker/login-action@v3
-        with:
-          registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl load-tests/load-tester -am install
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -351,14 +340,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      - uses: google-github-actions/auth@v3
+      # Authenticate with Teleport
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v3.0.0
+            version: 17.2.2
+
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+            proxy: camunda.teleport.sh:443
+            token: ${{ env.TELEPORT_JOIN_TOKEN }}
+            kubernetes-cluster: ${{ env.CLUSTER }}
+
       - name: Create namespace if not exists
         run: |
           cd load-tests/setup
@@ -366,13 +360,17 @@ jobs:
           # the GitHub action by default. We need to correctly configure the git user here to make it work
           git config user.name ${{ github.actor }}
           # Create the namespace for the load test
-          ./newLoadTest.sh ${{ inputs.name }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
+          ./newLoadTest.sh ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
+          # Annotate namespace with the workflow run URL for traceability
+          kubectl annotate namespace ${{ env.NAMESPACE }} \
+            "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --overwrite
       - name: Install latest Camunda Platform
         run: |
-          cd load-tests/setup/${{ inputs.name }}
+          cd load-tests/setup/${{ env.NAMESPACE }}
 
           # Build additional load test configuration
-          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}"
+          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set global.image.repository=${{ env.IMAGE_REPOSITORY }} --set global.image.pullSecrets[0].name=harbor-registry"
           # Append load-test-load configuration if not empty
           if [[ -n "${{ needs.calculate-scenario-config.outputs.load-test-load }}" ]]; then
             load_test_config="$load_test_config ${{ needs.calculate-scenario-config.outputs.load-test-load }}"
@@ -381,7 +379,7 @@ jobs:
           make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \
             secondary_storage=${{ inputs.secondary-storage-type }} \
             enable_optimize=${{ inputs.enable-optimize }} \
-            additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'gcr.io' }} --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'zeebe-io/zeebe' }} --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.platform-helm-values }}" \
+            additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }} --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/camunda' }} --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.platform-helm-values }}" \
             additional_load_test_configuration="$load_test_config"
       - name: Summarize platform deployment
         if: success()
@@ -389,7 +387,7 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             ## Camunda platform \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ env.NAMESPACE }} -n ${{ env.NAMESPACE }})
             \`\`\`
           EOF
       - name: Summarize load test deployment
@@ -397,10 +395,10 @@ jobs:
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             # Load test
-            The test has been set up successfully. You can observe it [here](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?var-namespace=${{ inputs.name }})
+            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})
             ## Load test \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }}-test -n ${{ inputs.name }})
+            $(helm get values ${{ env.NAMESPACE }}-test -n ${{ env.NAMESPACE }})
             \`\`\`
           EOF
       - name: Observe build status

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -27,13 +27,13 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     outputs:
-      sanitized-name: ${{ steps.sanitize.outputs.branch_name }}
+      sanitized-name: c8-${{ steps.sanitize.outputs.branch_name }}
     steps:
       - id: sanitize
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main
         with:
           branch: ${{ github.event.pull_request.head.ref }}
-          max_length: 53
+          max_length: 50  # reduced to account for load-test prefix "c8-"" and potential suffixes for uniqueness
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -106,7 +106,7 @@ jobs:
         with:
           path: artifacts
       - name: Comment PR with profiling results
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -87,7 +87,7 @@ Our [load test Helm Chart](https://github.com/camunda/camunda-load-tests-helm) d
 
 Depending on the test variant, different process models are created and executed by the Starter and Worker applications. They only differ in configurations, which can be done by the respective [camunda-load-test](https://github.com/camunda/camunda-load-tests-helm) Helm chart, and their [values files](https://github.com/camunda/camunda-load-tests-helm/blob/main/charts/camunda-load-tests/values.yaml).
 
-All of this is deployed in a Zeebe-maintained (as of now; 16 Jun 2025) Google Kubernetes Engine (GKE) cluster (zeebe-cluster), in its own zeebe-io Google Cloud Project (GCP). Details of the general infrastructure, which is deployed related to observability (Prometheus), can be found in the [Zeebe infrastructure repository](https://github.com/camunda/zeebe-infra).
+All of this is deployed in an Infra-team-maintained Google Kubernetes Engine (GKE) cluster (`camunda-benchmark-prod`). Access is managed via [Teleport](https://camunda.teleport.sh). Container images are stored in `registry.camunda.cloud/team-zeebe`. Details about the benchmark cluster infrastructure can be found in the [infra-core repository](https://github.com/camunda/infra-core/), and specifically in the [benchmark cluster access guide](https://github.com/camunda/infra-core/blob/stage/docs/kubernetes-cluster/benchmark-cluster-access.md).
 
 For posterity, the deployment between 8.8 and pre-8.8 differs slightly. The Platform Helm  Chart will now deploy a single Camunda application (replicated), whereas previously, the Zeebe Broker and Zeebe Gateways were deployed standalone.
 
@@ -162,7 +162,7 @@ Similar to the stress test from above, we ran the artificial (normal) process mo
 
 Observability plays a vital role in running such kind of tests. Since the beginning of our load testing practices, the Zeebe team, spent significant efforts in adding metrics into the system and building Grafana dashboards to support them.
 
-The metrics exported by our applications are stored in a self-hosted Prometheus instance and can be observed with a self-hosted [Grafana instance](https://grafana.dev.zeebe.io/?orgId=1). To log in, a GitHub account must be used, which must be part of the mono repository.
+The metrics exported by our applications are stored in a [Prometheus instance](https://monitor.benchmark.camunda.cloud/) and can be observed with the [Grafana instance](https://dashboard.benchmark.camunda.cloud/?orgId=1). These applications sit behind a vouch-enabled proxy, so only Okta login is required to access them.
 
 A general Grafana dashboard, covering all sorts of metrics, is the [Zeebe Dashboard](https://github.com/camunda/camunda/blob/main/monitor/grafana/zeebe.json). There are more tailored dashboards that exist in the corresponding monitoring folder.
 
@@ -180,7 +180,7 @@ For every [supported/maintained](https://confluence.camunda.com/pages/viewpage.a
 
 **Goal:** Validating the reliability of our releases and detecting earlier issues, especially with alpha versions and updates.
 
-**Validation:** The tailored [Zeebe Medic Dashboard](https://grafana.dev.zeebe.io/d/zeebe-medic-benchmark/zeebe-medic-benchmarks?orgId=1&refresh=1m), can be used to observe and validate the performance of the different load tests
+**Validation:** The tailored [Zeebe Medic Dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-medic-benchmark/zeebe-medic-benchmarks?orgId=1&refresh=1m), can be used to observe and validate the performance of the different load tests
 
 As of today (16 Jun 2025), we have load tests running:
 
@@ -217,7 +217,6 @@ An example payload looks like this:
     "inputs": {
       "name": benchmark_name,
       "ref": zeebe_ref_name,
-      "cluster": "zeebe-cluster",
       "stable-vms": stable_vms
     }
 }
@@ -240,22 +239,22 @@ In addition to our release tests, we ran weekly load tests for all [endurance te
 
 **Goal:** Validating the reliability of our current main, and detecting earlier issues, allowing us to detect newly introduced instabilities and potential memory leaks or performance degradation.
 
-**Validation:** The tailored [Zeebe Medic Dashboard](https://grafana.dev.zeebe.io/d/zeebe-medic-benchmark/zeebe-medic-benchmarks?orgId=1&refresh=1m), can be used to observe and validate the performance of the different load tests
+**Validation:** The tailored [Zeebe Medic Dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-medic-benchmark/zeebe-medic-benchmarks?orgId=1&refresh=1m), can be used to observe and validate the performance of the different load tests
 
 As an example, we have the following tests running:
 
 * medic-y-2025-cw-22-a60d64da-test-latency
-* medic-y-2025-cw-22-a60d64da-test-mixed
+* medic-y-2025-cw-22-a60d64da-test-realistic
 * medic-y-2025-cw-22-a60d64da-test-typical
 * medic-y-2025-cw-23-a799b041-test-typical
 * medic-y-2025-cw-23-a799b041-test-latency
-* medic-y-2025-cw-23-a799b041-test-mixed
+* medic-y-2025-cw-23-a799b041-test-realistic
 * medic-y-2025-cw-24-0c3f2664-test-typical
 * medic-y-2025-cw-24-0c3f2664-test-latency
-* medic-y-2025-cw-24-0c3f2664-test-mixed
+* medic-y-2025-cw-24-0c3f2664-test-realistic
 * medic-y-2025-cw-25-59a095c4-test-typical
 * medic-y-2025-cw-25-59a095c4-test-latency
-* medic-y-2025-cw-25-59a095c4-test-mixed
+* medic-y-2025-cw-25-59a095c4-test-realistic
 
 #### Daily load tests
 
@@ -277,9 +276,9 @@ On top of the previous scenarios, we support running ad-hoc load tests. They can
 
 **Goal:** The goal of these ad-hoc load tests is to have a quick way to validate certain changes (reducing the feedback loop). The intentions can be manifold, may it be stability/reliability, performance, or something else.
 
-**Validation:** The more general [Zeebe Dashboard](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?orgId=1), should be used to observe and validate the performance of the different load tests. If performance is the motivator of such a test, it might be helpful to use the [Camunda Performance](https://grafana.dev.zeebe.io/d/camunda-benchmarks/camunda-performance?orgId=1) Dashboard.
+**Validation:** The more general [Zeebe Dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?orgId=1), should be used to observe and validate the performance of the different load tests. If performance is the motivator of such a test, it might be helpful to use the [Camunda Performance](https://dashboard.benchmark.camunda.cloud/d/camunda-benchmarks/camunda-performance?orgId=1) Dashboard.
 
-**Requirement:** Please make sure that load test namespaces are always prefixed with your initials, to allow us to identify who created the tests and reach out if necessary.
+**Requirement:** Please make sure that load test namespaces are always prefixed with your initials, to allow us to identify who created the tests and reach out if necessary. Note that the `c8-` namespace prefix is added implicitly by the tooling (due to cluster access policies). For example, a name like `pp-stable-vms-october` will result in the Kubernetes namespace `c8-pp-stable-vms-october`.
 
 ##### Labeling a PR
 
@@ -335,26 +334,26 @@ To set up a load test from your local machine you need to have several tools ins
 
 Follow these guide's to install each of them:
 
-* gcloud https://cloud.google.com/sdk/install
+* tsh (Teleport CLI) https://goteleport.com/docs/installation/
 * Kubectl https://kubernetes.io/de/docs/tasks/tools/install-kubectl/
 * Helm 3.*  https://helm.sh/docs/intro/install/
 * docker https://docs.docker.com/install/
 * kubens/kubectx https://github.com/ahmetb/kubectx
 * OPTIONAL go https://golang.org/doc/install
 
+For detailed instructions on accessing the benchmark cluster, see the [benchmark cluster access guide](https://github.com/camunda/infra-core/blob/stage/docs/kubernetes-cluster/benchmark-cluster-access.md).
+
 Some of the necessary steps you need to do are:
 
 ```sh
-## Init gcloud
-gcloud init
-gcloud config set project zeebe-io
-gcloud container clusters get-credentials zeebe-cluster --zone europe-west1-b --project zeebe-io
+## Authenticate to the benchmark cluster via Teleport
+tsh login --proxy=camunda.teleport.sh:443
+tsh kube login camunda-benchmark-prod
 
-## to use google cloud docker registry
-gcloud auth configure-docker
-
-## install kubectl via gcloud cli
-gcloud components install kubectl
+## Log in to the Harbor container registry
+## Zeebe team members have push access by default.
+## If you don't have access, request it in the #ask-infra Slack channel.
+docker login registry.camunda.cloud
 
 ## install helm
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
@@ -381,12 +380,12 @@ These are the components to install on Windows:
 * Docker
 
 These are the components to install within the WSL:
-* gcloud https://cloud.google.com/sdk/install?hl=de
+* tsh (Teleport CLI) https://goteleport.com/docs/installation/
 * Kubectl https://kubernetes.io/de/docs/tasks/tools/install-kubectl/
 * Helm 3.*  https://helm.sh/docs/intro/install/
 * kubens/kubectx https://github.com/ahmetb/kubectx
 
-When following the instructions above, execute all commands that deal with Docker in a Windows shell, and exeucte all other commands in the WSL shell.
+When following the instructions above, execute all commands that deal with Docker in a Windows shell, and execute all other commands in the WSL shell.
 
 ###### Installing manually
 

--- a/load-tests/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch.yaml
@@ -75,10 +75,17 @@ elasticsearch:
       accessModes: ["ReadWriteOnce"]
     resources:
       requests:
-        cpu: 3
+        cpu: 3000m
         memory: 3Gi
       limits:
-        cpu: 3
+        cpu: 3000m
         memory: 6Gi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: n2-standard-4
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-4
+        effect: NoSchedule
   extraConfig:
     logger.org.elasticsearch.deprecation: "OFF"

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -15,13 +15,14 @@ global:
     enabled: false
   image:
     # Image.repository defines the repository from which to fetch the docker images
-    repository: "gcr.io/zeebe-io"
+    repository: "registry.camunda.cloud/team-zeebe"
     # Image.tag defines the tag / version which should be used in the chart
     tag: SNAPSHOT
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-    pullSecrets: []
+    pullSecrets:
+      - name: harbor-registry
   # By default, we run without Identity
   identity:
     auth:
@@ -58,6 +59,8 @@ orchestration:
   # This means we will have pods like: camunda-0, camunda-1, camunda-2
   fullnameOverride: camunda
   image:
+    registry: docker.io
+    repository: camunda/camunda
     tag: "SNAPSHOT"
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
@@ -72,14 +75,20 @@ orchestration:
   # Resources of the orchestration cluster
   resources:
     requests:
-      cpu: 3500m
+      cpu: 3000m
       memory: 2Gi
     limits:
-      cpu: 3500m
+      cpu: 3000m
       memory: 2Gi
 
   nodeSelector:
     cloud.google.com/gke-nodepool: n2-standard-4
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
   ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
   pvcSize: "64Gi"

--- a/load-tests/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/prometheus-elasticsearch-exporter-values.yaml
@@ -1,6 +1,9 @@
 fullnameOverride: "prom-els-exporter"
 
 image:
+  # Route through colocated GAR pull-through cache to avoid quay.io rate limiting
+  # Original: quay.io/prometheuscommunity/elasticsearch-exporter
+  repository: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter"
   # Set your specific exporter version here
   tag: "v1.10.0"
 

--- a/load-tests/secondary-storage-values-opensearch.yaml
+++ b/load-tests/secondary-storage-values-opensearch.yaml
@@ -34,16 +34,25 @@ sysctlVmMaxMapCount: 262144
 
 resources:
   requests:
-    cpu: 3
+    cpu: 3000m
     memory: 4Gi
   limits:
-    cpu: 6
+    cpu: 3000m
     memory: 10Gi
 
 persistence:
   enabled: true
   size: 128Gi
   storageClass: "ssd"
+
+nodeSelector:
+  cloud.google.com/gke-nodepool: n2-standard-4
+
+tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-4
+    effect: NoSchedule
 
 antiAffinity: "hard"
 

--- a/load-tests/secondary-storage-values-postgresql.yaml
+++ b/load-tests/secondary-storage-values-postgresql.yaml
@@ -14,8 +14,17 @@ primary:
       memory: 4Gi
       cpu: 3000m
     limits:
+      cpu: 3000m
       memory: 6Gi
-      cpu: 6000m
+
+  nodeSelector:
+    cloud.google.com/gke-nodepool: n2-standard-4
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
   persistence:
     size: 128Gi

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -87,6 +87,7 @@ install-platform: setup-leader-balancer
 		--reset-then-reuse-values \
 		--render-subchart-notes \
 		$(platform_values) \
+		-f values-preemptible.yaml \
 		$(additional_platform_configuration)
 
 # Install/upgrade Camunda Platform on stable VMs
@@ -129,6 +130,7 @@ setup-leader-balancer:
 template:
 	helm template $(namespace) camunda/$(helm_chart) \
 		$(platform_values) \
+		-f values-preemptible.yaml \
 		--output-dir .
 
 .PHONY: template-stable

--- a/load-tests/setup/default/values-preemptible.yaml
+++ b/load-tests/setup/default/values-preemptible.yaml
@@ -1,13 +1,13 @@
-# Additional values file to run Zeebe on stable VMs
+# Additional values file to run Zeebe on preemptible/spot VMs
 # https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
 orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4-stable
+    cloud.google.com/gke-nodepool: n2-standard-4
 
   tolerations:
   - key: nodepool
     operator: Equal
-    value: n2-standard-4-stable
+    value: n2-standard-4
     effect: NoSchedule

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -18,6 +18,12 @@ fi
 helm_chart="camunda-platform-8.9"
 namespace="$1"
 
+# Add c8- prefix if not present
+if [[ ! "$namespace" =~ ^c8- ]]; then
+  namespace="c8-$namespace"
+  echo "Namespace prefix added: $namespace"
+fi
+
 # Validate secondaryStorage value
 secondaryStorage="${2:-elasticsearch}"
 if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "opensearch" && "$secondaryStorage" != "postgresql" ]]; then
@@ -84,6 +90,9 @@ else
   deadline_date="unknown"
 fi
 kubectl label namespace $namespace deadline-date="${deadline_date}" --overwrite
+
+# Label namespace with registry (required to inject image pull secrets)
+kubectl label namespace "$namespace" registry=harbor --overwrite
 
 # Copy default folder to new namespace folder
 cp -rv default/ $namespace


### PR DESCRIPTION
## Description

Backport of #42549, #46560, and #46932 to `stable/8.9` — migrates load test infrastructure to the new benchmark cluster, fixes storage pod scheduling, and syncs all load test files with `main`.

All changed files are now **identical to `main`**.

## Changes

### Infrastructure migration (from #42549)
- Switch from GKE direct auth to **Teleport-based authentication**
- Migrate image registry from `gcr.io` to `registry.camunda.cloud` (Harbor)
- Add `c8-` namespace prefix (access policy requirement)
- Add `nodeSelector` and `tolerations` for orchestration and ES pods
- Add `values-preemptible.yaml` for spot VM scheduling
- Refactor cleanup workflow with shared script and new infra job
- Add `registry=harbor` label to namespace creation
- Update `values-stable.yaml` tolerations for new nodepool taints

### Storage scheduling fix (from #46560)
- Added `primary.nodeSelector` and `primary.tolerations` for PostgreSQL
- Added top-level `nodeSelector` and `tolerations` for OpenSearch
- Normalized CPU limits to `3000m` across all values files
- Added namespace annotation `github.com/workflow-run-url` for traceability

### Naming and image fixes (from #46932)
- Image repository: `team-zeebe/zeebe` → `team-zeebe/camunda` (Harbor) / `camunda/camunda` (Docker Hub)
- Add `c8-` namespace prefix logic in `newLoadTest.sh`
- Smart NAMESPACE env var (preserves existing `c8-` prefix)

### Additional sync with main
- Remove `create-credentials` Makefile target
- Update PR load test `sanitized-name` to include `c8-` prefix
- Update docs with Teleport instructions and new dashboard URLs
- Bump `actions/github-script` to v8