### PR TITLE
fix: add pagination for the add-release-commits script

### DIFF
--- a/.github/scripts/add-release-comments.sh
+++ b/.github/scripts/add-release-comments.sh
@@ -5,27 +5,24 @@
 
 set -euo pipefail
 
-RELEASES_FILE=$(mktemp)
-trap 'rm -f "$RELEASES_FILE"' EXIT
-
-CUTOFF_DATE=$(gdate -d "-${DAYS_BACK} days" --iso-8601)
+CUTOFF_DATE=$(date -d "-${DAYS_BACK} days" --iso-8601)
 echo "Looking for releases since: $CUTOFF_DATE"
 
-# Fetch releases from GitHub API into a temp file to preserve control characters
-gh api repos/$REPOSITORY/releases \
+# Fetch releases from GitHub API
+RELEASES=$(gh api repos/$REPOSITORY/releases \
   --jq ".[] | select(.published_at > \"$CUTOFF_DATE\") | {tag_name, html_url, published_at, body}" \
-  --paginate > "$RELEASES_FILE"
+  --paginate)
 
-if [ ! -s "$RELEASES_FILE" ]; then
+if [ -z "$RELEASES" ]; then
   echo "No releases found since $CUTOFF_DATE"
   exit 0
 fi
 
 echo "Found releases:"
-jq -r '.tag_name + " - " + .published_at' "$RELEASES_FILE"
+echo "$RELEASES" | jq -r '.tag_name + " - " + .published_at'
 
 # Process each release
-jq -c '.' "$RELEASES_FILE" | while read -r release; do
+echo "$RELEASES" | jq -c '.' | while read -r release; do
   TAG_NAME=$(echo "$release" | jq -r '.tag_name')
   RELEASE_URL=$(echo "$release" | jq -r '.html_url')
   PUBLISHED_AT=$(echo "$release" | jq -r '.published_at')
@@ -75,7 +72,7 @@ jq -c '.' "$RELEASES_FILE" | while read -r release; do
     fi
     
     # Check if release comment already exists
-    COMMENT_EXISTS=$(gh api repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments \
+    COMMENT_EXISTS=$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
       --paginate \
       --jq ".[] | select(.body | contains(\"This has been released in version [$TAG_NAME]\")) | .id" | head -n 1 || true)
     

--- a/.github/scripts/add-release-comments.sh
+++ b/.github/scripts/add-release-comments.sh
@@ -5,24 +5,27 @@
 
 set -euo pipefail
 
-CUTOFF_DATE=$(date -d "-${DAYS_BACK} days" --iso-8601)
+RELEASES_FILE=$(mktemp)
+trap 'rm -f "$RELEASES_FILE"' EXIT
+
+CUTOFF_DATE=$(gdate -d "-${DAYS_BACK} days" --iso-8601)
 echo "Looking for releases since: $CUTOFF_DATE"
 
-# Fetch releases from GitHub API
-RELEASES=$(gh api repos/$REPOSITORY/releases \
+# Fetch releases from GitHub API into a temp file to preserve control characters
+gh api repos/$REPOSITORY/releases \
   --jq ".[] | select(.published_at > \"$CUTOFF_DATE\") | {tag_name, html_url, published_at, body}" \
-  --paginate)
+  --paginate > "$RELEASES_FILE"
 
-if [ -z "$RELEASES" ]; then
+if [ ! -s "$RELEASES_FILE" ]; then
   echo "No releases found since $CUTOFF_DATE"
   exit 0
 fi
 
 echo "Found releases:"
-echo "$RELEASES" | jq -r '.tag_name + " - " + .published_at'
+jq -r '.tag_name + " - " + .published_at' "$RELEASES_FILE"
 
 # Process each release
-echo "$RELEASES" | jq -c '.' | while read -r release; do
+jq -c '.' "$RELEASES_FILE" | while read -r release; do
   TAG_NAME=$(echo "$release" | jq -r '.tag_name')
   RELEASE_URL=$(echo "$release" | jq -r '.html_url')
   PUBLISHED_AT=$(echo "$release" | jq -r '.published_at')
@@ -73,6 +76,7 @@ echo "$RELEASES" | jq -c '.' | while read -r release; do
     
     # Check if release comment already exists
     COMMENT_EXISTS=$(gh api repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments \
+      --paginate \
       --jq ".[] | select(.body | contains(\"This has been released in version [$TAG_NAME]\")) | .id" | head -n 1 || true)
     
     if [ -n "$COMMENT_EXISTS" ]; then


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add pagination for the add-release-commits script.
Otherwise, duplicate comments can be left for issues that have a lot of comments (30+).

Example of affected issue with duplicate comments: https://github.com/camunda/camunda/issues/11253#issuecomment-3748548793 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
