### PR TITLE
feat: Support multiple JWKS endpoints per OIDC issuer

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/CompositeJWKSource.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CompositeJWKSource.java
@@ -50,7 +50,7 @@ public class CompositeJWKSource<C extends SecurityContext> implements JWKSource<
           return keys;
         }
       } catch (final KeySourceException e) {
-        LOG.warn("JWK source failed, trying next source", e);
+        LOG.warn("JWK source [{}] failed, trying next source", source, e);
         lastException = e;
       }
     }

--- a/authentication/src/main/java/io/camunda/authentication/config/CompositeJWKSource.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CompositeJWKSource.java
@@ -50,7 +50,7 @@ public class CompositeJWKSource<C extends SecurityContext> implements JWKSource<
           return keys;
         }
       } catch (final KeySourceException e) {
-        LOG.warn("JWK source failed, trying next source: {}", e.getMessage());
+        LOG.warn("JWK source failed, trying next source", e);
         lastException = e;
       }
     }

--- a/authentication/src/main/java/io/camunda/authentication/config/CompositeJWKSource.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CompositeJWKSource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A composite {@link JWKSource} that delegates to multiple underlying JWK sources, returning keys
+ * from the first source that produces a non-empty result.
+ *
+ * <p>Sources are tried in order. If a source throws a {@link KeySourceException}, it is logged and
+ * the next source is attempted. If all sources return empty or fail, the last exception is rethrown
+ * (or an empty list is returned if no exceptions occurred).
+ *
+ * <p>This class is thread-safe: the source list is immutable and each delegate {@link JWKSource} is
+ * responsible for its own internal thread safety.
+ *
+ * @param <C> the security context type
+ */
+public class CompositeJWKSource<C extends SecurityContext> implements JWKSource<C> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CompositeJWKSource.class);
+
+  private final List<JWKSource<C>> sources;
+
+  public CompositeJWKSource(final List<JWKSource<C>> sources) {
+    this.sources = List.copyOf(sources);
+  }
+
+  @Override
+  public List<JWK> get(final JWKSelector jwkSelector, final C context) throws KeySourceException {
+    KeySourceException lastException = null;
+
+    for (final JWKSource<C> source : sources) {
+      try {
+        final List<JWK> keys = source.get(jwkSelector, context);
+        if (keys != null && !keys.isEmpty()) {
+          return keys;
+        }
+      } catch (final KeySourceException e) {
+        LOG.warn("JWK source failed, trying next source: {}", e.getMessage());
+        lastException = e;
+      }
+    }
+
+    if (lastException != null) {
+      throw lastException;
+    }
+
+    return List.of();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/IssuerAwareJWSKeySelector.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/IssuerAwareJWSKeySelector.java
@@ -14,6 +14,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.proc.JWTClaimsSetAwareJWSKeySelector;
 import java.security.Key;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,13 +36,25 @@ public class IssuerAwareJWSKeySelector implements JWTClaimsSetAwareJWSKeySelecto
 
   private final List<ClientRegistration> clientRegistrations;
   private final JWSKeySelectorFactory jwsKeySelectorFactory;
+  private final Map<String, List<String>> additionalJwkSetUrisByIssuer;
   private final Map<String, JWSKeySelector<SecurityContext>> selectors;
 
   public IssuerAwareJWSKeySelector(
       final List<ClientRegistration> clientRegistrations,
       final JWSKeySelectorFactory jwsKeySelectorFactory) {
+    this(clientRegistrations, jwsKeySelectorFactory, Collections.emptyMap());
+  }
+
+  public IssuerAwareJWSKeySelector(
+      final List<ClientRegistration> clientRegistrations,
+      final JWSKeySelectorFactory jwsKeySelectorFactory,
+      final Map<String, List<String>> additionalJwkSetUrisByIssuer) {
     this.clientRegistrations = List.copyOf(clientRegistrations);
     this.jwsKeySelectorFactory = jwsKeySelectorFactory;
+    this.additionalJwkSetUrisByIssuer =
+        additionalJwkSetUrisByIssuer != null
+            ? Map.copyOf(additionalJwkSetUrisByIssuer)
+            : Collections.emptyMap();
     selectors = new ConcurrentHashMap<>();
   }
 
@@ -85,6 +98,7 @@ public class IssuerAwareJWSKeySelector implements JWTClaimsSetAwareJWSKeySelecto
     final var clientRegistration = getClientRegistrationByIssuer(issuer);
     final var providerDetails = clientRegistration.getProviderDetails();
     final var jwkSetUri = providerDetails.getJwkSetUri();
-    return jwsKeySelectorFactory.createJWSKeySelector(jwkSetUri);
+    final var additionalUris = additionalJwkSetUrisByIssuer.get(issuer);
+    return jwsKeySelectorFactory.createJWSKeySelector(jwkSetUri, additionalUris);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
@@ -16,9 +16,11 @@ import com.nimbusds.jose.proc.SecurityContext;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Factory for creating {@link JWSKeySelector} instances based on a configured set of allowed {@link
@@ -61,7 +63,7 @@ public class JWSKeySelectorFactory {
    * @throws IllegalArgumentException if the URI is malformed
    */
   public JWSKeySelector<SecurityContext> createJWSKeySelector(final String jwkSetUri) {
-    if (jwkSetUri == null || jwkSetUri.isBlank()) {
+    if (!StringUtils.hasText(jwkSetUri)) {
       throw new IllegalArgumentException(ERROR_MISSING_JWK_SET_URI);
     }
 
@@ -83,19 +85,19 @@ public class JWSKeySelectorFactory {
    */
   public JWSKeySelector<SecurityContext> createJWSKeySelector(
       final String jwkSetUri, final List<String> additionalJwkSetUris) {
-    if (additionalJwkSetUris == null || additionalJwkSetUris.isEmpty()) {
+    if (CollectionUtils.isEmpty(additionalJwkSetUris)) {
       return createJWSKeySelector(jwkSetUri);
     }
 
-    if (jwkSetUri == null || jwkSetUri.isBlank()) {
+    if (!StringUtils.hasText(jwkSetUri)) {
       throw new IllegalArgumentException(ERROR_MISSING_JWK_SET_URI);
     }
 
-    final var sources = new ArrayList<JWKSource<SecurityContext>>();
-    sources.add(createJWKSource(toURL(jwkSetUri)));
-    for (final String uri : additionalJwkSetUris) {
-      sources.add(createJWKSource(toURL(uri)));
-    }
+    final var sources =
+        Stream.concat(
+                Stream.of(jwkSetUri), additionalJwkSetUris.stream().filter(StringUtils::hasText))
+            .map(uri -> createJWKSource(toURL(uri)))
+            .toList();
 
     final var compositeSource = new CompositeJWKSource<>(sources);
     return new JWSVerificationKeySelector<>(getJWSAlgorithms(), compositeSource);

--- a/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
@@ -16,6 +16,8 @@ import com.nimbusds.jose.proc.SecurityContext;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -67,6 +69,36 @@ public class JWSKeySelectorFactory {
     final var jwkSource = createJWKSource(url);
     final var jwsAlgorithms = getJWSAlgorithms();
     return new JWSVerificationKeySelector<>(jwsAlgorithms, jwkSource);
+  }
+
+  /**
+   * Creates a {@link JWSKeySelector} for the given primary JWK Set URI and optional additional
+   * URIs. When additional URIs are provided, a {@link CompositeJWKSource} is used to aggregate keys
+   * from all sources.
+   *
+   * @param jwkSetUri the primary JWK Set URI
+   * @param additionalJwkSetUris additional JWK Set URIs to query for key resolution
+   * @return a {@link JWSVerificationKeySelector} configured with the allowed algorithms
+   * @throws IllegalArgumentException if the primary URI is malformed
+   */
+  public JWSKeySelector<SecurityContext> createJWSKeySelector(
+      final String jwkSetUri, final List<String> additionalJwkSetUris) {
+    if (additionalJwkSetUris == null || additionalJwkSetUris.isEmpty()) {
+      return createJWSKeySelector(jwkSetUri);
+    }
+
+    if (jwkSetUri == null || jwkSetUri.isBlank()) {
+      throw new IllegalArgumentException(ERROR_MISSING_JWK_SET_URI);
+    }
+
+    final var sources = new ArrayList<JWKSource<SecurityContext>>();
+    sources.add(createJWKSource(toURL(jwkSetUri)));
+    for (final String uri : additionalJwkSetUris) {
+      sources.add(createJWKSource(toURL(uri)));
+    }
+
+    final var compositeSource = new CompositeJWKSource<>(sources);
+    return new JWSVerificationKeySelector<>(getJWSAlgorithms(), compositeSource);
   }
 
   /**

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcAccessTokenDecoderFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcAccessTokenDecoderFactory.java
@@ -16,7 +16,9 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,11 +67,27 @@ public class OidcAccessTokenDecoderFactory {
    */
   public JwtDecoder createIssuerAwareAccessTokenDecoder(
       final List<ClientRegistration> clientRegistrations) {
+    return createIssuerAwareAccessTokenDecoder(clientRegistrations, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a {@link JwtDecoder} that supports multiple OIDC Providers by resolving issuer-specific
+   * keys and validation logic at runtime, with support for additional JWK Set URIs per issuer.
+   *
+   * @param clientRegistrations the list of client registrations to support
+   * @param additionalJwkSetUrisByIssuer a map of issuer URI to additional JWK Set URIs
+   * @return a {@link JwtDecoder} capable of handling multiple issuers with multi-JWKS support
+   * @throws IllegalArgumentException if any registration is missing an issuer URI
+   */
+  public JwtDecoder createIssuerAwareAccessTokenDecoder(
+      final List<ClientRegistration> clientRegistrations,
+      final Map<String, List<String>> additionalJwkSetUrisByIssuer) {
     LOG.debug(
         "Creating an Issuer Aware JwtDecoder for multiple OIDC Providers: {}",
         clientRegistrations.size());
     validateClientRegistrationsHaveIssuer(clientRegistrations);
-    final var jwtProcessor = createIssuerAwareJwtProcessor(clientRegistrations);
+    final var jwtProcessor =
+        createIssuerAwareJwtProcessor(clientRegistrations, additionalJwkSetUrisByIssuer);
     final var jwtValidator = createIssuerAwareJwtValidator(clientRegistrations);
     return createNimbusJwtDecoder(jwtProcessor, jwtValidator);
   }
@@ -106,8 +124,22 @@ public class OidcAccessTokenDecoderFactory {
    * @throws IllegalArgumentException if the registration is missing a JWK Set URI
    */
   public JwtDecoder createAccessTokenDecoder(final ClientRegistration clientRegistration) {
+    return createAccessTokenDecoder(clientRegistration, null);
+  }
+
+  /**
+   * Creates a {@link JwtDecoder} for a single OIDC Identity Provider with optional additional JWK
+   * Set URIs.
+   *
+   * @param clientRegistration the client registration to use
+   * @param additionalJwkSetUris additional JWK Set URIs for key resolution
+   * @return a {@link JwtDecoder} for that client
+   * @throws IllegalArgumentException if the registration is missing a JWK Set URI
+   */
+  public JwtDecoder createAccessTokenDecoder(
+      final ClientRegistration clientRegistration, final List<String> additionalJwkSetUris) {
     LOG.debug("Creating JwtDecoder for OIDC Provider {}", clientRegistration.getRegistrationId());
-    final var jwtProcessor = createJwtProcessor(clientRegistration);
+    final var jwtProcessor = createJwtProcessor(clientRegistration, additionalJwkSetUris);
     final var jwtValidator = createJwtValidator(clientRegistration);
     return createNimbusJwtDecoder(jwtProcessor, jwtValidator);
   }
@@ -156,8 +188,23 @@ public class OidcAccessTokenDecoderFactory {
    */
   protected ConfigurableJWTProcessor<SecurityContext> createIssuerAwareJwtProcessor(
       final List<ClientRegistration> clientRegistrations) {
+    return createIssuerAwareJwtProcessor(clientRegistrations, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a {@link ConfigurableJWTProcessor} that is aware of multiple issuers and supports
+   * additional JWK Set URIs per issuer.
+   *
+   * @param clientRegistrations the list of client registrations
+   * @param additionalJwkSetUrisByIssuer a map of issuer URI to additional JWK Set URIs
+   * @return a configured JWT processor
+   */
+  protected ConfigurableJWTProcessor<SecurityContext> createIssuerAwareJwtProcessor(
+      final List<ClientRegistration> clientRegistrations,
+      final Map<String, List<String>> additionalJwkSetUrisByIssuer) {
     final var jwsKeySelector =
-        new IssuerAwareJWSKeySelector(clientRegistrations, jwsKeySelectorFactory);
+        new IssuerAwareJWSKeySelector(
+            clientRegistrations, jwsKeySelectorFactory, additionalJwkSetUrisByIssuer);
     return createAndCustomizeJwtProcessor(
         processor -> processor.setJWTClaimsSetAwareJWSKeySelector(jwsKeySelector));
   }
@@ -170,8 +217,22 @@ public class OidcAccessTokenDecoderFactory {
    */
   protected ConfigurableJWTProcessor<SecurityContext> createJwtProcessor(
       final ClientRegistration clientRegistration) {
+    return createJwtProcessor(clientRegistration, null);
+  }
+
+  /**
+   * Creates a {@link ConfigurableJWTProcessor} for a single issuer with optional additional JWK Set
+   * URIs.
+   *
+   * @param clientRegistration the client registration
+   * @param additionalJwkSetUris additional JWK Set URIs for key resolution
+   * @return a configured JWT processor
+   */
+  protected ConfigurableJWTProcessor<SecurityContext> createJwtProcessor(
+      final ClientRegistration clientRegistration, final List<String> additionalJwkSetUris) {
     final var jwkSetUri = getJWKSetUri(clientRegistration);
-    final var jwsKeySelector = jwsKeySelectorFactory.createJWSKeySelector(jwkSetUri);
+    final var jwsKeySelector =
+        jwsKeySelectorFactory.createJWSKeySelector(jwkSetUri, additionalJwkSetUris);
     return createAndCustomizeJwtProcessor(processor -> processor.setJWSKeySelector(jwsKeySelector));
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcAccessTokenDecoderFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcAccessTokenDecoderFactory.java
@@ -139,6 +139,7 @@ public class OidcAccessTokenDecoderFactory {
   public JwtDecoder createAccessTokenDecoder(
       final ClientRegistration clientRegistration, final List<String> additionalJwkSetUris) {
     LOG.debug("Creating JwtDecoder for OIDC Provider {}", clientRegistration.getRegistrationId());
+    LOG.debug("Additional JWK Set URIs: {}", additionalJwkSetUris);
     final var jwtProcessor = createJwtProcessor(clientRegistration, additionalJwkSetUris);
     final var jwtValidator = createJwtValidator(clientRegistration);
     return createNimbusJwtDecoder(jwtProcessor, jwtValidator);

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -768,8 +768,16 @@ public class WebSecurityConfig {
           .collect(
               toMap(
                   OidcAuthenticationConfiguration::getIssuerUri,
-                  OidcAuthenticationConfiguration::getAdditionalJwkSetUris,
-                  (a, b) -> a));
+                  config -> List.copyOf(config.getAdditionalJwkSetUris()),
+                  (a, b) -> {
+                    if (!a.equals(b)) {
+                      throw new IllegalStateException(
+                          "Multiple OIDC providers share the same issuer URI with different"
+                              + " additional JWKS URIs. Ensure each issuer has a consistent"
+                              + " configuration.");
+                    }
+                    return a;
+                  }));
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -718,18 +718,27 @@ public class WebSecurityConfig {
     @Bean
     public JwtDecoder jwtDecoder(
         final OidcAccessTokenDecoderFactory oidcAccessTokenDecoderFactory,
-        final ClientRegistrationRepository clientRegistrationRepository) {
+        final ClientRegistrationRepository clientRegistrationRepository,
+        final OidcAuthenticationConfigurationRepository oidcProviderRepository) {
       final var repository = (Iterable<ClientRegistration>) clientRegistrationRepository;
       final var clientRegistrations =
           StreamSupport.stream(repository.spliterator(), false).toList();
 
+      final var additionalJwkSetUrisByIssuer =
+          buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository);
+
       if (clientRegistrations.size() == 1) {
         final var clientRegistration = clientRegistrations.getFirst();
+        final var additionalUris =
+            additionalJwkSetUrisByIssuer.get(
+                clientRegistration.getProviderDetails().getIssuerUri());
         LOG.info(
             "Create Access Token JWT Decoder for OIDC Provider: {}",
             clientRegistration.getRegistrationId());
         return new SupplierJwtDecoder(
-            () -> oidcAccessTokenDecoderFactory.createAccessTokenDecoder(clientRegistration));
+            () ->
+                oidcAccessTokenDecoderFactory.createAccessTokenDecoder(
+                    clientRegistration, additionalUris));
       } else {
         LOG.info(
             "Create Issuer Aware JWT Decoder for multiple OIDC Providers: [{}]",
@@ -739,8 +748,23 @@ public class WebSecurityConfig {
         return new SupplierJwtDecoder(
             () ->
                 oidcAccessTokenDecoderFactory.createIssuerAwareAccessTokenDecoder(
-                    clientRegistrations));
+                    clientRegistrations, additionalJwkSetUrisByIssuer));
       }
+    }
+
+    private Map<String, List<String>> buildAdditionalJwkSetUrisByIssuer(
+        final OidcAuthenticationConfigurationRepository oidcProviderRepository) {
+      return oidcProviderRepository.getOidcAuthenticationConfigurations().values().stream()
+          .filter(
+              config ->
+                  config.getIssuerUri() != null
+                      && config.getAdditionalJwkSetUris() != null
+                      && !config.getAdditionalJwkSetUris().isEmpty())
+          .collect(
+              toMap(
+                  OidcAuthenticationConfiguration::getIssuerUri,
+                  OidcAuthenticationConfiguration::getAdditionalJwkSetUris,
+                  (a, b) -> a));
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -631,9 +631,14 @@ public class WebSecurityConfig {
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
         final OidcAccessTokenDecoderFactory oidcAccessTokenDecoderFactory,
         final TokenClaimsConverter tokenClaimsConverter,
-        final HttpServletRequest request) {
+        final HttpServletRequest request,
+        final OidcAuthenticationConfigurationRepository oidcProviderRepository) {
       return new OidcUserAuthenticationConverter(
-          authorizedClientRepository, oidcAccessTokenDecoderFactory, tokenClaimsConverter, request);
+          authorizedClientRepository,
+          oidcAccessTokenDecoderFactory,
+          tokenClaimsConverter,
+          request,
+          buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository));
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/converter/OidcUserAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/OidcUserAuthenticationConverter.java
@@ -11,6 +11,8 @@ import io.camunda.authentication.config.OidcAccessTokenDecoderFactory;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,16 +39,35 @@ public class OidcUserAuthenticationConverter
   private final TokenClaimsConverter tokenClaimsConverter;
   private final HttpServletRequest request;
   private final Map<String, JwtDecoder> jwtDecoders;
+  private final Map<String, List<String>> additionalJwkSetUrisByIssuer;
 
   public OidcUserAuthenticationConverter(
       final OAuth2AuthorizedClientRepository authorizedClientRepository,
       final OidcAccessTokenDecoderFactory accessTokenDecoderFactory,
       final TokenClaimsConverter tokenClaimsConverter,
       final HttpServletRequest request) {
+    this(
+        authorizedClientRepository,
+        accessTokenDecoderFactory,
+        tokenClaimsConverter,
+        request,
+        Collections.emptyMap());
+  }
+
+  public OidcUserAuthenticationConverter(
+      final OAuth2AuthorizedClientRepository authorizedClientRepository,
+      final OidcAccessTokenDecoderFactory accessTokenDecoderFactory,
+      final TokenClaimsConverter tokenClaimsConverter,
+      final HttpServletRequest request,
+      final Map<String, List<String>> additionalJwkSetUrisByIssuer) {
     this.authorizedClientRepository = authorizedClientRepository;
     this.accessTokenDecoderFactory = accessTokenDecoderFactory;
     this.tokenClaimsConverter = tokenClaimsConverter;
     this.request = request;
+    this.additionalJwkSetUrisByIssuer =
+        additionalJwkSetUrisByIssuer != null
+            ? additionalJwkSetUrisByIssuer
+            : Collections.emptyMap();
     jwtDecoders = new ConcurrentHashMap<>();
   }
 
@@ -114,7 +135,12 @@ public class OidcUserAuthenticationConverter
     final var clientRegistrationId = clientRegistration.getRegistrationId();
     return jwtDecoders.computeIfAbsent(
         clientRegistrationId,
-        k -> accessTokenDecoderFactory.createAccessTokenDecoder(clientRegistration));
+        k -> {
+          final var issuerUri = clientRegistration.getProviderDetails().getIssuerUri();
+          final var additionalUris = additionalJwkSetUrisByIssuer.get(issuerUri);
+          return accessTokenDecoderFactory.createAccessTokenDecoder(
+              clientRegistration, additionalUris);
+        });
   }
 
   protected Map<String, Object> getIdTokenClaims(

--- a/authentication/src/main/java/io/camunda/authentication/converter/OidcUserAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/OidcUserAuthenticationConverter.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
@@ -66,7 +67,9 @@ public class OidcUserAuthenticationConverter
     this.request = request;
     this.additionalJwkSetUrisByIssuer =
         additionalJwkSetUrisByIssuer != null
-            ? additionalJwkSetUrisByIssuer
+            ? additionalJwkSetUrisByIssuer.entrySet().stream()
+                .collect(
+                    Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> List.copyOf(e.getValue())))
             : Collections.emptyMap();
     jwtDecoders = new ConcurrentHashMap<>();
   }

--- a/authentication/src/test/java/io/camunda/authentication/config/CompositeJWKSourceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/CompositeJWKSourceTest.java
@@ -21,6 +21,7 @@ import com.nimbusds.jose.jwk.JWKSelector;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 final class CompositeJWKSourceTest {
@@ -174,5 +175,106 @@ final class CompositeJWKSourceTest {
     // then - composite should still work with the original source
     final var result = composite.get(selector, null);
     assertThat(result).containsExactly(jwk);
+  }
+
+  @Test
+  @DisplayName("Empty sources list should return empty on get()")
+  void shouldReturnEmptyWhenConstructedWithNoSources() throws KeySourceException {
+    // given
+    final var composite = new CompositeJWKSource<SecurityContext>(List.of());
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Three sources: key found at third after first two return empty")
+  void shouldFallThroughMultipleSourcesToFindKey() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceC = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenReturn(List.of());
+    when(sourceB.get(any(), any())).thenReturn(List.of());
+    when(sourceC.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB, sourceC));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).containsExactly(jwk);
+  }
+
+  @Test
+  @DisplayName("Three sources: first throws, second empty, third returns keys")
+  void shouldHandleMixedFailureModesAcrossMultipleSources() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceC = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenThrow(new KeySourceException("source A network error"));
+    when(sourceB.get(any(), any())).thenReturn(List.of());
+    when(sourceC.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB, sourceC));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).containsExactly(jwk);
+  }
+
+  @Test
+  @DisplayName("RuntimeException from source propagates immediately without trying next sources")
+  void shouldPropagateRuntimeExceptionWithoutCatching() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenThrow(new NullPointerException("unexpected NPE"));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB));
+
+    // when // then — RuntimeException is NOT caught, propagates immediately
+    assertThatThrownBy(() -> composite.get(selector, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unexpected NPE");
+    verify(sourceB, never()).get(any(), any());
+  }
+
+  @Test
+  @DisplayName("Short-circuit: when first source has keys, second and third are never called")
+  void shouldShortCircuitAndNotCallRemainingSourcesAfterMatch() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceC = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB, sourceC));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).containsExactly(jwk);
+    verify(sourceB, never()).get(any(), any());
+    verify(sourceC, never()).get(any(), any());
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/CompositeJWKSourceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/CompositeJWKSourceTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class CompositeJWKSourceTest {
+
+  private final JWKSelector selector = mock(JWKSelector.class);
+  private final JWK jwk = mock(JWK.class);
+
+  @Test
+  void shouldReturnKeysFromFirstSourceWhenNonEmpty() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).containsExactly(jwk);
+    verify(sourceB, never()).get(any(), any());
+  }
+
+  @Test
+  void shouldFallToSecondSourceWhenFirstReturnsEmpty() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenReturn(List.of());
+    when(sourceB.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).containsExactly(jwk);
+  }
+
+  @Test
+  void shouldFallToSecondSourceWhenFirstThrowsKeySourceException() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenThrow(new KeySourceException("source A failed"));
+    when(sourceB.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).containsExactly(jwk);
+  }
+
+  @Test
+  void shouldRethrowLastExceptionWhenAllSourcesFail() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenThrow(new KeySourceException("source A failed"));
+    when(sourceB.get(any(), any())).thenThrow(new KeySourceException("source B failed"));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB));
+
+    // when // then
+    assertThatThrownBy(() -> composite.get(selector, null))
+        .isInstanceOf(KeySourceException.class)
+        .hasMessage("source B failed");
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenAllSourcesReturnEmpty() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenReturn(List.of());
+    when(sourceB.get(any(), any())).thenReturn(List.of());
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldWorkWithSingleSource() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> source = mock(JWKSource.class);
+    when(source.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var composite = new CompositeJWKSource<>(List.of(source));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).containsExactly(jwk);
+  }
+
+  @Test
+  void shouldHandleNullReturnFromSourceAsEmpty() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceA = mock(JWKSource.class);
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> sourceB = mock(JWKSource.class);
+    when(sourceA.get(any(), any())).thenReturn(null);
+    when(sourceB.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var composite = new CompositeJWKSource<>(List.of(sourceA, sourceB));
+
+    // when
+    final var result = composite.get(selector, null);
+
+    // then
+    assertThat(result).containsExactly(jwk);
+  }
+
+  @Test
+  void shouldPreserveImmutabilityOfSourceList() throws KeySourceException {
+    // given
+    @SuppressWarnings("unchecked")
+    final JWKSource<SecurityContext> source = mock(JWKSource.class);
+    when(source.get(any(), any())).thenReturn(List.of(jwk));
+
+    final var mutableList = new java.util.ArrayList<JWKSource<SecurityContext>>();
+    mutableList.add(source);
+    final var composite = new CompositeJWKSource<>(mutableList);
+
+    // when - modify the original list after construction
+    mutableList.clear();
+
+    // then - composite should still work with the original source
+    final var result = composite.get(selector, null);
+    assertThat(result).containsExactly(jwk);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
@@ -190,6 +190,87 @@ final class JWSKeySelectorFactoryTest {
     assertThat(keys).isNotEmpty();
   }
 
+  @Test
+  void shouldSelectKeyFromPrimaryWhenSameKidExistsAtBothEndpoints() throws Exception {
+    // given — both endpoints expose kid="shared-kid" but with different RSA key material.
+    // This documents the short-circuit behavior: the primary source's key is always
+    // returned when the kid matches, regardless of actual signing key.
+    final var primaryKeySharedKid =
+        new RSAKeyGenerator(2048)
+            .keyID("shared-kid")
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .generate();
+    final var additionalKeySharedKid =
+        new RSAKeyGenerator(2048)
+            .keyID("shared-kid")
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .generate();
+
+    final var primaryPath = "/primary-shared-kid/.well-known/jwks.json";
+    final var additionalPath = "/additional-shared-kid/.well-known/jwks.json";
+    mockJwksEndpoint(primaryPath, primaryKeySharedKid);
+    mockJwksEndpoint(additionalPath, additionalKeySharedKid);
+
+    final var selector =
+        factory.createJWSKeySelector(baseUrl() + primaryPath, List.of(baseUrl() + additionalPath));
+
+    // JWT signed with the ADDITIONAL key's material, but same kid="shared-kid"
+    final var jwt = createSignedJwt(additionalKeySharedKid, "shared-kid");
+
+    // when — key selector finds kid="shared-kid" at primary (short-circuit)
+    final var keys = selector.selectJWSKeys(jwt.getHeader(), (SecurityContext) null);
+
+    // then — keys are returned (from primary), but they are the WRONG key material
+    // for this token. Signature verification would fail at the JwtDecoder level.
+    // The composite source does not fall through because the primary returned a non-empty result.
+    assertThat(keys).hasSize(1);
+  }
+
+  @Test
+  void shouldResolveDisjointKeysFromCorrectSourcesLikeWalmartScenario() throws Exception {
+    // given — simulates the Walmart/PingFederate scenario:
+    // Primary JWKS (standard) has kid="web-ui-kid" for Web UI tokens
+    // Additional JWKS (custom) has kid="m2m-kid" for M2M tokens
+    // The key sets are disjoint (different kids at each endpoint).
+    final var webUiKey =
+        new RSAKeyGenerator(2048)
+            .keyID("web-ui-kid")
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .generate();
+    final var m2mKey =
+        new RSAKeyGenerator(2048)
+            .keyID("m2m-kid")
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .generate();
+
+    final var standardJwksPath = "/standard/.well-known/jwks.json";
+    final var customJwksPath = "/custom/.well-known/jwks.json";
+    mockJwksEndpoint(standardJwksPath, webUiKey);
+    mockJwksEndpoint(customJwksPath, m2mKey);
+
+    final var selector =
+        factory.createJWSKeySelector(
+            baseUrl() + standardJwksPath, List.of(baseUrl() + customJwksPath));
+
+    // when — Web UI token with kid="web-ui-kid" resolves from primary
+    final var webUiJwt = createSignedJwt(webUiKey, "web-ui-kid");
+    final var webUiKeys = selector.selectJWSKeys(webUiJwt.getHeader(), (SecurityContext) null);
+
+    // then
+    assertThat(webUiKeys).isNotEmpty();
+
+    // when — M2M token with kid="m2m-kid" falls through to additional
+    final var m2mJwt = createSignedJwt(m2mKey, "m2m-kid");
+    final var m2mKeys = selector.selectJWSKeys(m2mJwt.getHeader(), (SecurityContext) null);
+
+    // then
+    assertThat(m2mKeys).isNotEmpty();
+  }
+
   private static String baseUrl() {
     return "http://localhost:" + wireMock.getPort();
   }

--- a/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
@@ -134,6 +134,62 @@ final class JWSKeySelectorFactoryTest {
     assertThat(keys).isNotEmpty();
   }
 
+  @Test
+  void shouldThrowWhenAdditionalUriIsMalformed() {
+    // given
+    final var primaryPath = "/primary-malformed/.well-known/jwks.json";
+    mockJwksEndpoint(primaryPath, primaryKey);
+
+    // when // then
+    assertThatThrownBy(
+            () -> factory.createJWSKeySelector(baseUrl() + primaryPath, List.of("not-a-valid-url")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowWhenAdditionalUriIsBlank() {
+    // given
+    final var primaryPath = "/primary-blank/.well-known/jwks.json";
+    mockJwksEndpoint(primaryPath, primaryKey);
+
+    // when // then
+    assertThatThrownBy(() -> factory.createJWSKeySelector(baseUrl() + primaryPath, List.of("")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldResolveKeyFromSecondAdditionalSourceWithMultipleAdditionalUris() throws Exception {
+    // given — primary + 2 additional sources, key only at second additional
+    final var primaryPath = "/primary-multi/.well-known/jwks.json";
+    final var additional1Path = "/additional1-multi/.well-known/jwks.json";
+    final var additional2Path = "/additional2-multi/.well-known/jwks.json";
+
+    final var additional2Key =
+        new RSAKeyGenerator(2048)
+            .keyID("additional2-kid")
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .generate();
+
+    mockJwksEndpoint(primaryPath, primaryKey);
+    mockJwksEndpoint(additional1Path, additionalKey);
+    mockJwksEndpoint(additional2Path, additional2Key);
+
+    final var selector =
+        factory.createJWSKeySelector(
+            baseUrl() + primaryPath,
+            List.of(baseUrl() + additional1Path, baseUrl() + additional2Path));
+
+    // JWT signed with the second additional key's kid
+    final var jwt = createSignedJwt(additional2Key, "additional2-kid");
+
+    // when
+    final var keys = selector.selectJWSKeys(jwt.getHeader(), (SecurityContext) null);
+
+    // then
+    assertThat(keys).isNotEmpty();
+  }
+
   private static String baseUrl() {
     return "http://localhost:" + wireMock.getPort();
   }

--- a/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.JSONObjectUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.http.HttpStatus;
+
+final class JWSKeySelectorFactoryTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+  private static RSAKey primaryKey;
+  private static RSAKey additionalKey;
+
+  private final JWSKeySelectorFactory factory = new JWSKeySelectorFactory();
+
+  @BeforeAll
+  static void generateKeys() throws JOSEException {
+    primaryKey =
+        new RSAKeyGenerator(2048)
+            .keyID("primary-kid")
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .generate();
+
+    additionalKey =
+        new RSAKeyGenerator(2048)
+            .keyID("additional-kid")
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .generate();
+  }
+
+  @Test
+  void shouldDelegateToSingleArgWhenAdditionalUrisNull() {
+    // given
+    final var jwkSetUri = baseUrl() + "/primary/.well-known/jwks.json";
+    mockJwksEndpoint("/primary/.well-known/jwks.json", primaryKey);
+
+    // when
+    final var selector = factory.createJWSKeySelector(jwkSetUri, null);
+
+    // then
+    assertThat(selector).isNotNull();
+  }
+
+  @Test
+  void shouldDelegateToSingleArgWhenAdditionalUrisEmpty() {
+    // given
+    final var jwkSetUri = baseUrl() + "/primary/.well-known/jwks.json";
+    mockJwksEndpoint("/primary/.well-known/jwks.json", primaryKey);
+
+    // when
+    final var selector = factory.createJWSKeySelector(jwkSetUri, List.of());
+
+    // then
+    assertThat(selector).isNotNull();
+  }
+
+  @Test
+  void shouldThrowWhenPrimaryJwkSetUriMissingWithAdditionalUris() {
+    // when // then
+    assertThatThrownBy(() -> factory.createJWSKeySelector(null, List.of("http://example.com/jwks")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldResolveKeyFromPrimarySource() throws Exception {
+    // given
+    final var primaryPath = "/primary-resolve/.well-known/jwks.json";
+    final var additionalPath = "/additional-resolve/.well-known/jwks.json";
+    mockJwksEndpoint(primaryPath, primaryKey);
+    mockJwksEndpoint(additionalPath, additionalKey);
+
+    final var selector =
+        factory.createJWSKeySelector(baseUrl() + primaryPath, List.of(baseUrl() + additionalPath));
+
+    final var jwt = createSignedJwt(primaryKey, "primary-kid");
+
+    // when
+    final var keys = selector.selectJWSKeys(jwt.getHeader(), (SecurityContext) null);
+
+    // then
+    assertThat(keys).isNotEmpty();
+  }
+
+  @Test
+  void shouldResolveKeyFromAdditionalSourceWhenPrimaryDoesNotHaveIt() throws Exception {
+    // given
+    final var primaryPath = "/primary-miss/.well-known/jwks.json";
+    final var additionalPath = "/additional-hit/.well-known/jwks.json";
+    // primary has primaryKey, additional has additionalKey
+    mockJwksEndpoint(primaryPath, primaryKey);
+    mockJwksEndpoint(additionalPath, additionalKey);
+
+    final var selector =
+        factory.createJWSKeySelector(baseUrl() + primaryPath, List.of(baseUrl() + additionalPath));
+
+    // JWT signed with the additional key's kid
+    final var jwt = createSignedJwt(additionalKey, "additional-kid");
+
+    // when
+    final var keys = selector.selectJWSKeys(jwt.getHeader(), (SecurityContext) null);
+
+    // then
+    assertThat(keys).isNotEmpty();
+  }
+
+  private static String baseUrl() {
+    return "http://localhost:" + wireMock.getPort();
+  }
+
+  private static void mockJwksEndpoint(final String path, final RSAKey key) {
+    final var jwksBody = JSONObjectUtils.toJSONString(new JWKSet(key.toPublicJWK()).toJSONObject());
+    wireMock
+        .getRuntimeInfo()
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlEqualTo(path))
+                .willReturn(WireMock.jsonResponse(jwksBody, HttpStatus.OK.value())));
+  }
+
+  private static SignedJWT createSignedJwt(final RSAKey key, final String kid)
+      throws JOSEException {
+    final var jwt =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(kid).build(),
+            new JWTClaimsSet.Builder()
+                .subject("test")
+                .issuer("http://issuer.example.com")
+                .expirationTime(new Date(new Date().getTime() + 60_000))
+                .build());
+    jwt.sign(new RSASSASigner(key));
+    return jwt;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
@@ -147,14 +147,20 @@ final class JWSKeySelectorFactoryTest {
   }
 
   @Test
-  void shouldThrowWhenAdditionalUriIsBlank() {
-    // given
+  void shouldSkipBlankAdditionalUriAndResolveFromPrimary() throws Exception {
+    // given — blank additional URI should be silently filtered out
     final var primaryPath = "/primary-blank/.well-known/jwks.json";
     mockJwksEndpoint(primaryPath, primaryKey);
 
-    // when // then
-    assertThatThrownBy(() -> factory.createJWSKeySelector(baseUrl() + primaryPath, List.of("")))
-        .isInstanceOf(IllegalArgumentException.class);
+    final var selector = factory.createJWSKeySelector(baseUrl() + primaryPath, List.of(""));
+
+    final var jwt = createSignedJwt(primaryKey, "primary-kid");
+
+    // when
+    final var keys = selector.selectJWSKeys(jwt.getHeader(), (SecurityContext) null);
+
+    // then — key is resolved from primary, blank URI was skipped
+    assertThat(keys).isNotEmpty();
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
@@ -544,6 +544,65 @@ public class JwtDecoderTest extends AbstractWebSecurityConfigTest {
       assertThatCode(() -> decoder.decode(jwt2)).doesNotThrowAnyException();
     }
 
+    @Test
+    void shouldFailWhenSameKidExistsAtBothEndpointsAndTokenSignedWithAdditionalKey()
+        throws JOSEException {
+      // given — both endpoints expose kid="shared-kid" but with different RSA key material.
+      // This documents a known limitation of short-circuit key selection:
+      // the decoder picks the primary key (wrong material) and signature verification fails.
+      final var primaryKeySharedKid =
+          new RSAKeyGenerator(2048)
+              .keyID("shared-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+      final var additionalKeySharedKid =
+          new RSAKeyGenerator(2048)
+              .keyID("shared-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", primaryKeySharedKid.toPublicJWK().toJSONString());
+      mockJwksEndpoint("/additional/jwks", additionalKeySharedKid.toPublicJWK().toJSONString());
+
+      // JWT signed with the ADDITIONAL key's material, but same kid="shared-kid"
+      final var jwt = signAndSerialize(additionalKeySharedKid, "shared-kid");
+
+      // when // then — decoder fails because primary key material is selected (short-circuit)
+      // and signature verification fails with the wrong key
+      assertThatThrownBy(() -> decoder.decode(jwt)).isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    void shouldDecodeTokenWhenSameKidExistsAtBothEndpointsAndTokenSignedWithPrimaryKey()
+        throws JOSEException {
+      // given — same kid at both endpoints, but token signed with the PRIMARY key.
+      // This succeeds because the primary key is selected first (short-circuit) and
+      // it matches the signing key.
+      final var primaryKeySharedKid =
+          new RSAKeyGenerator(2048)
+              .keyID("shared-kid-ok")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+      final var additionalKeySharedKid =
+          new RSAKeyGenerator(2048)
+              .keyID("shared-kid-ok")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", primaryKeySharedKid.toPublicJWK().toJSONString());
+      mockJwksEndpoint("/additional/jwks", additionalKeySharedKid.toPublicJWK().toJSONString());
+
+      // JWT signed with the PRIMARY key
+      final var jwt = signAndSerialize(primaryKeySharedKid, "shared-kid-ok");
+
+      // when // then — succeeds: primary key is selected and matches
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
     private String signAndSerialize(final RSAKey key, final String kid) throws JOSEException {
       final var jwt =
           new SignedJWT(

--- a/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
@@ -11,6 +11,7 @@ import static com.nimbusds.jose.JOSEObjectType.JWT;
 import static io.camunda.authentication.config.OidcAccessTokenDecoderFactory.AT_JWT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -38,6 +39,7 @@ import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import java.util.Date;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -47,6 +49,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
@@ -266,6 +269,167 @@ public class JwtDecoderTest extends AbstractWebSecurityConfigTest {
               WireMock.get(
                       WireMock.urlMatching(".*/" + realm + "/.well-known/openid-configuration"))
                   .willReturn(WireMock.jsonResponse(response, HttpStatus.OK.value())));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.authentication.unprotected-api=false",
+        "camunda.security.authentication.method=oidc",
+        "camunda.security.authentication.oidc.client-id=example",
+        "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+        "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+        "camunda.security.authentication.oidc.token-uri=token.example.com",
+      })
+  class SingleOidcProviderWithAdditionalJwks {
+
+    @RegisterExtension
+    static WireMockExtension wireMock =
+        WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+    @Autowired private JwtDecoder decoder;
+
+    @DynamicPropertySource
+    static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+      final var issuerUri = "http://localhost:" + wireMock.getPort() + "/issuer";
+      registry.add("camunda.security.authentication.oidc.issuer-uri", () -> issuerUri);
+      registry.add(
+          "camunda.security.authentication.oidc.jwk-set-uri",
+          () -> "http://localhost:" + wireMock.getPort() + "/primary/jwks");
+      registry.add(
+          "camunda.security.authentication.oidc.additional-jwk-set-uris[0]",
+          () -> "http://localhost:" + wireMock.getPort() + "/additional/jwks");
+
+      // mock OIDC discovery endpoint so Spring can resolve the issuer during context startup
+      final var openidConfig =
+          "{\"issuer\": \""
+              + issuerUri
+              + "\","
+              + "\"token_endpoint\": \"token.example.com\","
+              + "\"jwks_uri\": \"http://localhost:"
+              + wireMock.getPort()
+              + "/primary/jwks\","
+              + "\"subject_types_supported\": [\"public\"]"
+              + "}";
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(WireMock.urlMatching(".*/issuer/.well-known/openid-configuration"))
+                  .willReturn(WireMock.jsonResponse(openidConfig, HttpStatus.OK.value())));
+    }
+
+    @Test
+    void shouldDecodeTokenSignedWithPrimaryJwksKey() throws JOSEException {
+      // given
+      final var primaryKey =
+          new RSAKeyGenerator(2048)
+              .keyID("primary-a1")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", primaryKey.toPublicJWK().toJSONString());
+      mockJwksEndpoint("/additional/jwks", "{\"keys\":[]}");
+
+      final var jwt = signAndSerialize(primaryKey, "primary-a1");
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldDecodeTokenSignedWithAdditionalJwksKey() throws JOSEException {
+      // given
+      final var additionalKey =
+          new RSAKeyGenerator(2048)
+              .keyID("additional-b1")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint("/additional/jwks", additionalKey.toPublicJWK().toJSONString());
+
+      final var jwt = signAndSerialize(additionalKey, "additional-b1");
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailForUnknownKid() throws JOSEException {
+      // given
+      final var unknownKey =
+          new RSAKeyGenerator(2048)
+              .keyID("unknown-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint("/additional/jwks", "{\"keys\":[]}");
+
+      final var jwt = signAndSerialize(unknownKey, "unknown-kid");
+
+      // when // then
+      assertThatThrownBy(() -> decoder.decode(jwt)).isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    void shouldFallThroughToAdditionalWhenPrimaryHasNoMatchingKey() throws JOSEException {
+      // given
+      final var primaryKey =
+          new RSAKeyGenerator(2048)
+              .keyID("primary-only")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+      final var additionalKey =
+          new RSAKeyGenerator(2048)
+              .keyID("additional-only")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      // primary exposes primaryKey, additional exposes additionalKey
+      mockJwksEndpoint("/primary/jwks", primaryKey.toPublicJWK().toJSONString());
+      mockJwksEndpoint("/additional/jwks", additionalKey.toPublicJWK().toJSONString());
+
+      // JWT signed with the additional key
+      final var jwt = signAndSerialize(additionalKey, "additional-only");
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    private void mockJwksEndpoint(final String path, final String keyJson) {
+      final String body;
+      if (keyJson.startsWith("{\"keys\"")) {
+        body = keyJson;
+      } else {
+        body = "{\"keys\":[" + keyJson + "]}";
+      }
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(WireMock.urlEqualTo(path))
+                  .willReturn(WireMock.jsonResponse(body, HttpStatus.OK.value())));
+    }
+
+    private String signAndSerialize(final RSAKey key, final String kid) throws JOSEException {
+      final var jwt =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256).type(JWT).keyID(kid).build(),
+              new Builder()
+                  .subject("alice")
+                  .issuer("http://localhost:" + wireMock.getPort() + "/issuer")
+                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                  .build());
+      jwt.sign(new RSASSASigner(key));
+      return jwt.serialize();
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
@@ -28,10 +28,12 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.util.JSONObjectUtils;
 import com.nimbusds.jwt.JWTClaimsSet.Builder;
 import com.nimbusds.jwt.SignedJWT;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
@@ -419,6 +421,129 @@ public class JwtDecoderTest extends AbstractWebSecurityConfigTest {
                   .willReturn(WireMock.jsonResponse(body, HttpStatus.OK.value())));
     }
 
+    @Test
+    void shouldDecodeTokenAfterKeyRotationAtPrimarySource() throws JOSEException {
+      // given - initial key at primary
+      final var initialKey =
+          new RSAKeyGenerator(2048)
+              .keyID("rotated-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+      mockJwksEndpoint("/primary/jwks", initialKey.toPublicJWK().toJSONString());
+      mockJwksEndpoint("/additional/jwks", "{\"keys\":[]}");
+
+      // decode succeeds with initial key
+      final var jwt1 = signAndSerialize(initialKey, "rotated-kid");
+      assertThatCode(() -> decoder.decode(jwt1)).doesNotThrowAnyException();
+
+      // when - key is rotated: new key with different kid published at primary
+      final var rotatedKey =
+          new RSAKeyGenerator(2048)
+              .keyID("rotated-kid-v2")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+      mockJwksEndpoint("/primary/jwks", rotatedKey.toPublicJWK().toJSONString());
+
+      final var jwt2 = signAndSerialize(rotatedKey, "rotated-kid-v2");
+
+      // then - decoder re-fetches JWKS and succeeds
+      assertThatCode(() -> decoder.decode(jwt2)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldDecodeTokenSignedWithEcKeyFromAdditionalJwks() throws JOSEException {
+      // given — EC key at additional source, primary is empty
+      final var ecKey =
+          new ECKeyGenerator(Curve.P_256)
+              .keyID("ec-additional-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.ES256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint(
+          "/additional/jwks",
+          JSONObjectUtils.toJSONString(new JWKSet(ecKey.toPublicJWK()).toJSONObject()));
+
+      final var jwt =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.ES256)
+                  .type(JWT)
+                  .keyID("ec-additional-kid")
+                  .build(),
+              new Builder()
+                  .subject("alice")
+                  .issuer("http://localhost:" + wireMock.getPort() + "/issuer")
+                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                  .build());
+      jwt.sign(new ECDSASigner(ecKey));
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt.serialize())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldDecodeTokenWhenPrimaryJwksReturnsServerError() throws JOSEException {
+      // given — primary returns HTTP 500, additional has the key
+      final var additionalKey =
+          new RSAKeyGenerator(2048)
+              .keyID("error-fallback-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      // mock primary to return 500
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(WireMock.urlEqualTo("/primary/jwks"))
+                  .willReturn(
+                      WireMock.aResponse()
+                          .withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                          .withBody("Internal Server Error")));
+
+      mockJwksEndpoint("/additional/jwks", additionalKey.toPublicJWK().toJSONString());
+
+      final var jwt = signAndSerialize(additionalKey, "error-fallback-kid");
+
+      // when // then — should fall through to additional after primary fails
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldDecodeAfterKeyRotationAtAdditionalSource() throws JOSEException {
+      // given — initial key at additional
+      final var initialAdditionalKey =
+          new RSAKeyGenerator(2048)
+              .keyID("additional-rotate-v1")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint("/additional/jwks", initialAdditionalKey.toPublicJWK().toJSONString());
+
+      final var jwt1 = signAndSerialize(initialAdditionalKey, "additional-rotate-v1");
+      assertThatCode(() -> decoder.decode(jwt1)).doesNotThrowAnyException();
+
+      // when — rotate key at additional source
+      final var rotatedAdditionalKey =
+          new RSAKeyGenerator(2048)
+              .keyID("additional-rotate-v2")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+      mockJwksEndpoint("/additional/jwks", rotatedAdditionalKey.toPublicJWK().toJSONString());
+
+      final var jwt2 = signAndSerialize(rotatedAdditionalKey, "additional-rotate-v2");
+
+      // then — re-fetch should pick up the rotated key
+      assertThatCode(() -> decoder.decode(jwt2)).doesNotThrowAnyException();
+    }
+
     private String signAndSerialize(final RSAKey key, final String kid) throws JOSEException {
       final var jwt =
           new SignedJWT(
@@ -426,6 +551,325 @@ public class JwtDecoderTest extends AbstractWebSecurityConfigTest {
               new Builder()
                   .subject("alice")
                   .issuer("http://localhost:" + wireMock.getPort() + "/issuer")
+                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                  .build());
+      jwt.sign(new RSASSASigner(key));
+      return jwt.serialize();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.authentication.unprotected-api=false",
+        "camunda.security.authentication.method=oidc",
+        "camunda.security.authentication.oidc.client-id=example",
+        "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+        "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+        "camunda.security.authentication.oidc.token-uri=token.example.com",
+      })
+  class SingleOidcProviderWithMultipleAdditionalJwks {
+
+    @RegisterExtension
+    static WireMockExtension wireMock =
+        WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+    @Autowired private JwtDecoder decoder;
+
+    @DynamicPropertySource
+    static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+      final var issuerUri = "http://localhost:" + wireMock.getPort() + "/issuer";
+      registry.add("camunda.security.authentication.oidc.issuer-uri", () -> issuerUri);
+      registry.add(
+          "camunda.security.authentication.oidc.jwk-set-uri",
+          () -> "http://localhost:" + wireMock.getPort() + "/primary/jwks");
+      registry.add(
+          "camunda.security.authentication.oidc.additional-jwk-set-uris[0]",
+          () -> "http://localhost:" + wireMock.getPort() + "/additional1/jwks");
+      registry.add(
+          "camunda.security.authentication.oidc.additional-jwk-set-uris[1]",
+          () -> "http://localhost:" + wireMock.getPort() + "/additional2/jwks");
+
+      final var openidConfig =
+          "{\"issuer\": \""
+              + issuerUri
+              + "\","
+              + "\"token_endpoint\": \"token.example.com\","
+              + "\"jwks_uri\": \"http://localhost:"
+              + wireMock.getPort()
+              + "/primary/jwks\","
+              + "\"subject_types_supported\": [\"public\"]"
+              + "}";
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(WireMock.urlMatching(".*/issuer/.well-known/openid-configuration"))
+                  .willReturn(WireMock.jsonResponse(openidConfig, HttpStatus.OK.value())));
+    }
+
+    @Test
+    void shouldDecodeTokenWithKeyFromSecondAdditionalSource() throws JOSEException {
+      // given — key only at the second additional JWKS endpoint
+      final var keyAtSecondAdditional =
+          new RSAKeyGenerator(2048)
+              .keyID("second-additional-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint("/additional1/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint("/additional2/jwks", keyAtSecondAdditional.toPublicJWK().toJSONString());
+
+      final var jwt =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256)
+                  .type(JWT)
+                  .keyID("second-additional-kid")
+                  .build(),
+              new Builder()
+                  .subject("alice")
+                  .issuer("http://localhost:" + wireMock.getPort() + "/issuer")
+                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                  .build());
+      jwt.sign(new RSASSASigner(keyAtSecondAdditional));
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt.serialize())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailWhenKeyNotAtAnySource() throws JOSEException {
+      // given — key not present at any of the 3 sources
+      final var unknownKey =
+          new RSAKeyGenerator(2048)
+              .keyID("nowhere-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint("/additional1/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint("/additional2/jwks", "{\"keys\":[]}");
+
+      final var jwt =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256).type(JWT).keyID("nowhere-kid").build(),
+              new Builder()
+                  .subject("alice")
+                  .issuer("http://localhost:" + wireMock.getPort() + "/issuer")
+                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                  .build());
+      jwt.sign(new RSASSASigner(unknownKey));
+
+      // when // then
+      assertThatThrownBy(() -> decoder.decode(jwt.serialize())).isInstanceOf(JwtException.class);
+    }
+
+    private void mockJwksEndpoint(final String path, final String keyJson) {
+      final String body;
+      if (keyJson.startsWith("{\"keys\"")) {
+        body = keyJson;
+      } else {
+        body = "{\"keys\":[" + keyJson + "]}";
+      }
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(WireMock.urlEqualTo(path))
+                  .willReturn(WireMock.jsonResponse(body, HttpStatus.OK.value())));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.authentication.unprotected-api=false",
+        "camunda.security.authentication.method=oidc",
+        "camunda.security.authentication.providers.oidc.foo.client-id=foo",
+        "camunda.security.authentication.providers.oidc.foo.redirect-uri=redirect.foo.com",
+        "camunda.security.authentication.providers.oidc.foo.authorization-uri=authorization.foo.com",
+        "camunda.security.authentication.providers.oidc.foo.token-uri=token.foo.com",
+        "camunda.security.authentication.providers.oidc.bar.client-id=bar",
+        "camunda.security.authentication.providers.oidc.bar.redirect-uri=redirect.bar.com",
+        "camunda.security.authentication.providers.oidc.bar.authorization-uri=authorization.bar.com",
+        "camunda.security.authentication.providers.oidc.bar.token-uri=token.bar.com",
+      })
+  class MultipleOidcProvidersWithAdditionalJwks {
+
+    static final String REALM_FOO = "foo";
+    static final String REALM_BAR = "bar";
+
+    @RegisterExtension
+    static WireMockExtension wireMock =
+        WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+    @Autowired private JwtDecoder decoder;
+
+    @DynamicPropertySource
+    static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+      final var fooIssuerUri = "http://localhost:" + wireMock.getPort() + "/" + REALM_FOO;
+      final var barIssuerUri = "http://localhost:" + wireMock.getPort() + "/" + REALM_BAR;
+
+      registry.add(
+          "camunda.security.authentication.providers.oidc.foo.issuer-uri", () -> fooIssuerUri);
+      registry.add(
+          "camunda.security.authentication.providers.oidc.bar.issuer-uri", () -> barIssuerUri);
+
+      // additional JWKS for foo provider
+      registry.add(
+          "camunda.security.authentication.providers.oidc.foo.additional-jwk-set-uris[0]",
+          () -> "http://localhost:" + wireMock.getPort() + "/foo-additional/jwks");
+
+      // OIDC discovery for foo
+      final var fooConfig =
+          "{\"issuer\": \""
+              + fooIssuerUri
+              + "\","
+              + "\"token_endpoint\": \"token.foo.com\","
+              + "\"jwks_uri\": \"http://localhost:"
+              + wireMock.getPort()
+              + "/realms/foo/protocol/openid-connect/certs\","
+              + "\"subject_types_supported\": [\"public\"]"
+              + "}";
+      mockOpenidConfigurationResponse(REALM_FOO, fooConfig);
+
+      // OIDC discovery for bar
+      final var barConfig =
+          "{\"issuer\": \""
+              + barIssuerUri
+              + "\","
+              + "\"token_endpoint\": \"token.bar.com\","
+              + "\"jwks_uri\": \"http://localhost:"
+              + wireMock.getPort()
+              + "/realms/bar/protocol/openid-connect/certs\","
+              + "\"subject_types_supported\": [\"public\"]"
+              + "}";
+      mockOpenidConfigurationResponse(REALM_BAR, barConfig);
+    }
+
+    @Test
+    void shouldDecodeTokenFromFooPrimaryJwks() throws JOSEException {
+      // given
+      final var fooKey =
+          new RSAKeyGenerator(2048)
+              .keyID("foo-primary-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/realms/foo/protocol/openid-connect/certs", fooKey.toPublicJWK());
+      mockJwksEndpoint("/foo-additional/jwks", "{\"keys\":[]}");
+
+      final var jwt = signAndSerialize(fooKey, "foo-primary-kid", REALM_FOO);
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldDecodeTokenFromFooAdditionalJwks() throws JOSEException {
+      // given
+      final var additionalKey =
+          new RSAKeyGenerator(2048)
+              .keyID("foo-additional-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/realms/foo/protocol/openid-connect/certs", "{\"keys\":[]}");
+      mockJwksEndpoint("/foo-additional/jwks", additionalKey.toPublicJWK());
+
+      final var jwt = signAndSerialize(additionalKey, "foo-additional-kid", REALM_FOO);
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldDecodeTokenFromBarWithoutAdditionalJwks() throws JOSEException {
+      // given - bar has no additional JWKS configured
+      final var barKey =
+          new RSAKeyGenerator(2048)
+              .keyID("bar-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/realms/bar/protocol/openid-connect/certs", barKey.toPublicJWK());
+
+      final var jwt = signAndSerialize(barKey, "bar-kid", REALM_BAR);
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailForUnknownIssuer() throws JOSEException {
+      // given - token from unknown issuer
+      final var unknownKey =
+          new RSAKeyGenerator(2048)
+              .keyID("unknown-issuer-kid")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      final var jwt =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256)
+                  .type(JWT)
+                  .keyID("unknown-issuer-kid")
+                  .build(),
+              new Builder()
+                  .subject("alice")
+                  .issuer("http://localhost:" + wireMock.getPort() + "/unknown")
+                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                  .build());
+      jwt.sign(new RSASSASigner(unknownKey));
+
+      // when // then
+      assertThatThrownBy(() -> decoder.decode(jwt.serialize())).isInstanceOf(JwtException.class);
+    }
+
+    private void mockJwksEndpoint(final String path, final JWK key) {
+      mockJwksEndpoint(path, "{\"keys\":[" + key.toPublicJWK().toJSONString() + "]}");
+    }
+
+    private void mockJwksEndpoint(final String path, final String body) {
+      final String responseBody;
+      if (body.startsWith("{\"keys\"")) {
+        responseBody = body;
+      } else {
+        responseBody = "{\"keys\":[" + body + "]}";
+      }
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(WireMock.urlEqualTo(path))
+                  .willReturn(WireMock.jsonResponse(responseBody, HttpStatus.OK.value())));
+    }
+
+    static void mockOpenidConfigurationResponse(final String realm, final String response) {
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(
+                      WireMock.urlMatching(".*/" + realm + "/.well-known/openid-configuration"))
+                  .willReturn(WireMock.jsonResponse(response, HttpStatus.OK.value())));
+    }
+
+    private String signAndSerialize(final RSAKey key, final String kid, final String realm)
+        throws JOSEException {
+      final var jwt =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256).type(JWT).keyID(kid).build(),
+              new Builder()
+                  .subject("alice")
+                  .issuer("http://localhost:" + wireMock.getPort() + "/" + realm)
                   .expirationTime(new Date(new Date().getTime() + 60 * 1000))
                   .build());
       jwt.sign(new RSASSASigner(key));

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.converter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -237,5 +238,148 @@ public class OidcUserAuthenticationConverterTest {
     verify(oidcAccessTokenDecoderFactory)
         .createAccessTokenDecoder(eq(clientRegistration), urisCaptor.capture());
     assertThat(urisCaptor.getValue()).isEqualTo(additionalUris);
+  }
+
+  @Test
+  public void shouldPassNullWhenIssuerNotInAdditionalUrisMap() {
+    // given — converter configured with additional URIs for a different issuer
+    final var converter =
+        new OidcUserAuthenticationConverter(
+            authorizedClientRepository,
+            oidcAccessTokenDecoderFactory,
+            tokenClaimsConverter,
+            request,
+            Map.of("https://other-issuer.example.com", List.of("https://other/jwks")));
+
+    final var oidcUser = mock(OidcUser.class);
+    when(oidcUser.getAttributes()).thenReturn(Map.of("sub", "test-user"));
+
+    final var authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(oidcUser);
+
+    final var accessToken = mock(OAuth2AccessToken.class);
+    when(accessToken.getTokenValue()).thenReturn("test-access-token");
+
+    final var providerDetails = mock(ClientRegistration.ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn("https://my-issuer.example.com");
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getRegistrationId()).thenReturn("my-reg");
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
+
+    final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
+        .thenReturn(authorizedClient);
+
+    final var jwt = mock(Jwt.class);
+    when(jwt.getClaims()).thenReturn(Map.of("sub", "test-user"));
+    when(oidcAccessTokenDecoderFactory.createAccessTokenDecoder(any(), any()))
+        .thenReturn(jwtDecoder);
+    when(jwtDecoder.decode(any())).thenReturn(jwt);
+    when(tokenClaimsConverter.convert(any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("foo")));
+
+    // when
+    converter.convert(authentication);
+
+    // then — null is passed because issuer is not in the map
+    verify(oidcAccessTokenDecoderFactory)
+        .createAccessTokenDecoder(eq(clientRegistration), isNull());
+  }
+
+  @Test
+  public void shouldCacheDecoderForSameClientRegistration() {
+    // given — converter with additional URIs
+    final var issuer = "https://issuer.example.com";
+    final var converter =
+        new OidcUserAuthenticationConverter(
+            authorizedClientRepository,
+            oidcAccessTokenDecoderFactory,
+            tokenClaimsConverter,
+            request,
+            Map.of(issuer, List.of("https://issuer.example.com/extra/jwks")));
+
+    final var providerDetails = mock(ClientRegistration.ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn(issuer);
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getRegistrationId()).thenReturn("cached-reg");
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
+
+    final var accessToken = mock(OAuth2AccessToken.class);
+    when(accessToken.getTokenValue()).thenReturn("token-1", "token-2");
+
+    final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
+        .thenReturn(authorizedClient);
+
+    final var oidcUser = mock(OidcUser.class);
+    when(oidcUser.getAttributes()).thenReturn(Map.of("sub", "test-user"));
+    final var authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(oidcUser);
+
+    final var jwt = mock(Jwt.class);
+    when(jwt.getClaims()).thenReturn(Map.of("sub", "test-user"));
+    when(oidcAccessTokenDecoderFactory.createAccessTokenDecoder(any(), any()))
+        .thenReturn(jwtDecoder);
+    when(jwtDecoder.decode(any())).thenReturn(jwt);
+    when(tokenClaimsConverter.convert(any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("foo")));
+
+    // when — convert twice with the same client registration
+    converter.convert(authentication);
+    converter.convert(authentication);
+
+    // then — decoder factory called only once (cached)
+    verify(oidcAccessTokenDecoderFactory, times(1)).createAccessTokenDecoder(any(), any());
+  }
+
+  @Test
+  public void shouldPassNullWhenConstructedWithoutAdditionalUris() {
+    // given — converter created with 4-arg constructor (no additional URIs)
+    final var converter =
+        new OidcUserAuthenticationConverter(
+            authorizedClientRepository,
+            oidcAccessTokenDecoderFactory,
+            tokenClaimsConverter,
+            request);
+
+    final var oidcUser = mock(OidcUser.class);
+    when(oidcUser.getAttributes()).thenReturn(Map.of("sub", "test-user"));
+
+    final var authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(oidcUser);
+
+    final var accessToken = mock(OAuth2AccessToken.class);
+    when(accessToken.getTokenValue()).thenReturn("test-access-token");
+
+    final var providerDetails = mock(ClientRegistration.ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn("https://issuer.example.com");
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getRegistrationId()).thenReturn("no-additional");
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
+
+    final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
+        .thenReturn(authorizedClient);
+
+    final var jwt = mock(Jwt.class);
+    when(jwt.getClaims()).thenReturn(Map.of("sub", "test-user"));
+    when(oidcAccessTokenDecoderFactory.createAccessTokenDecoder(any(), any()))
+        .thenReturn(jwtDecoder);
+    when(jwtDecoder.decode(any())).thenReturn(jwt);
+    when(tokenClaimsConverter.convert(any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("foo")));
+
+    // when
+    converter.convert(authentication);
+
+    // then — null passed because empty map has no entry for this issuer
+    verify(oidcAccessTokenDecoderFactory)
+        .createAccessTokenDecoder(eq(clientRegistration), isNull());
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
@@ -18,9 +18,11 @@ import static org.mockito.Mockito.when;
 import io.camunda.authentication.config.OidcAccessTokenDecoderFactory;
 import io.camunda.security.auth.CamundaAuthentication;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -47,7 +49,8 @@ public class OidcUserAuthenticationConverterTest {
   @BeforeEach
   void setup() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    when(oidcAccessTokenDecoderFactory.createAccessTokenDecoder(any())).thenReturn(jwtDecoder);
+    when(oidcAccessTokenDecoderFactory.createAccessTokenDecoder(any(), any()))
+        .thenReturn(jwtDecoder);
   }
 
   @Test
@@ -89,8 +92,11 @@ public class OidcUserAuthenticationConverterTest {
     final var accessToken = mock(OAuth2AccessToken.class);
     when(accessToken.getTokenValue()).thenReturn(accessTokenValue);
 
+    final var providerDetails = mock(ClientRegistration.ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn("https://issuer.example.com");
     final var clientRegistration = mock(ClientRegistration.class);
     when(clientRegistration.getRegistrationId()).thenReturn("bar");
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
 
     final var authorizedClient = mock(OAuth2AuthorizedClient.class);
     when(authorizedClient.getAccessToken()).thenReturn(accessToken);
@@ -154,8 +160,11 @@ public class OidcUserAuthenticationConverterTest {
     final var accessToken = mock(OAuth2AccessToken.class);
     when(accessToken.getTokenValue()).thenReturn(accessTokenValue);
 
+    final var providerDetails = mock(ClientRegistration.ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn("https://issuer.example.com");
     final var clientRegistration = mock(ClientRegistration.class);
     when(clientRegistration.getRegistrationId()).thenReturn("bar");
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
 
     final var authorizedClient = mock(OAuth2AuthorizedClient.class);
     when(authorizedClient.getAccessToken()).thenReturn(accessToken);
@@ -174,5 +183,59 @@ public class OidcUserAuthenticationConverterTest {
     assertThat(userToken).isEqualTo(expectedAuthentication);
     verify(oidcUser).getAttributes();
     verify(tokenClaimsConverter).convert(eq(idTokenClaims));
+  }
+
+  @Test
+  public void shouldPassAdditionalJwkSetUrisToDecoderFactory() {
+    // given
+    final var issuer = "https://issuer.example.com";
+    final var additionalUris = List.of("https://issuer.example.com/extra/jwks");
+    final var converter =
+        new OidcUserAuthenticationConverter(
+            authorizedClientRepository,
+            oidcAccessTokenDecoderFactory,
+            tokenClaimsConverter,
+            request,
+            Map.of(issuer, additionalUris));
+
+    final var oidcUser = mock(OidcUser.class);
+    when(oidcUser.getAttributes()).thenReturn(Map.of("sub", "test-user"));
+
+    final var authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(oidcUser);
+
+    final var accessToken = mock(OAuth2AccessToken.class);
+    when(accessToken.getTokenValue()).thenReturn("test-access-token");
+
+    final var providerDetails = mock(ClientRegistration.ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn(issuer);
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getRegistrationId()).thenReturn("test-reg");
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
+
+    final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
+        .thenReturn(authorizedClient);
+
+    final var jwt = mock(Jwt.class);
+    final Map<String, Object> claims = Map.of("sub", "test-user");
+    when(jwt.getClaims()).thenReturn(claims);
+    when(oidcAccessTokenDecoderFactory.createAccessTokenDecoder(any(), any()))
+        .thenReturn(jwtDecoder);
+    when(jwtDecoder.decode(any())).thenReturn(jwt);
+    when(tokenClaimsConverter.convert(any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("foo")));
+
+    // when
+    converter.convert(authentication);
+
+    // then
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<List<String>> urisCaptor = ArgumentCaptor.forClass(List.class);
+    verify(oidcAccessTokenDecoderFactory)
+        .createAccessTokenDecoder(eq(clientRegistration), urisCaptor.capture());
+    assertThat(urisCaptor.getValue()).isEqualTo(additionalUris);
   }
 }

--- a/docs/adr/identity/0001-multi-jwks-endpoints-per-issuer.md
+++ b/docs/adr/identity/0001-multi-jwks-endpoints-per-issuer.md
@@ -31,8 +31,8 @@ the JWK source layer, avoiding modifications to the higher-level Spring Security
 The integration path is:
 
 1. **Configuration**: Add `additionalJwkSetUris` (type `List<String>`) to
-   `OidcAuthenticationConfiguration`. The property is optional and defaults to an empty list,
-   preserving full backward compatibility.
+   `OidcAuthenticationConfiguration`. The property is optional and remains `null` (unset) unless
+   explicitly configured, preserving full backward compatibility.
 
 2. **CompositeJWKSource**: A new `JWKSource<SecurityContext>` implementation that wraps multiple
    `RemoteJWKSet` instances. Key selection iterates through delegates in order, returning keys from

--- a/docs/adr/identity/0001-multi-jwks-endpoints-per-issuer.md
+++ b/docs/adr/identity/0001-multi-jwks-endpoints-per-issuer.md
@@ -1,0 +1,60 @@
+# ADR-0001: Support Multiple JWKS Endpoints per OIDC Issuer
+
+## Status
+
+Proposed
+
+## Context
+
+Camunda's OIDC authentication currently supports only a single JWK Set URI per issuer. In some
+enterprise deployments, a single OIDC issuer may serve tokens signed by keys hosted at different
+JWKS endpoints. For example, an identity provider may use separate JWKS URIs for different signing
+key sets while sharing the same issuer claim (`iss`). Tokens signed with key IDs (KIDs) not present
+at the configured primary JWKS endpoint fail JWT verification, even though they are legitimately
+issued by the same trusted issuer.
+
+This limitation prevents Camunda from operating correctly in environments where key material is
+distributed across multiple JWKS endpoints for the same issuer.
+
+See: https://github.com/camunda/product-hub/issues/3472
+
+## Decision
+
+We will extend the OIDC configuration to accept an optional list of additional JWK Set URIs
+(`additionalJwkSetUris`) alongside the existing `jwkSetUri` property.
+
+At the Nimbus JOSE+JWT library level, we will introduce a `CompositeJWKSource` that aggregates
+multiple `JWKSource` instances. During key selection, the composite source queries each delegate
+source in order and returns the first successful match. This approach keeps the change localized to
+the JWK source layer, avoiding modifications to the higher-level Spring Security decoder pipeline.
+
+The integration path is:
+
+1. **Configuration**: Add `additionalJwkSetUris` (type `List<String>`) to
+   `OidcAuthenticationConfiguration`. The property is optional and defaults to an empty list,
+   preserving full backward compatibility.
+
+2. **CompositeJWKSource**: A new `JWKSource<SecurityContext>` implementation that wraps multiple
+   `RemoteJWKSet` instances. Key selection iterates through delegates in order, returning keys from
+   the first source that provides a match.
+
+3. **Decoder pipeline wiring**: `JWSKeySelectorFactory`, `IssuerAwareJWSKeySelector`, and
+   `OidcAccessTokenDecoderFactory` are extended with overloaded methods that accept the additional
+   URIs. `WebSecurityConfig` builds and passes the additional URIs map when constructing the decoder.
+
+## Consequences
+
+### Positive
+
+- Operators can configure multiple JWKS endpoints per issuer without deploying custom infrastructure
+  (e.g., a JWKS proxy/aggregator).
+- The change is fully backward compatible: when `additionalJwkSetUris` is not configured, behavior
+  is identical to the current implementation.
+- The `CompositeJWKSource` is a self-contained component that can be tested independently.
+
+### Negative
+
+- Key resolution latency may increase in the worst case when a KID is not found in the primary
+  source and subsequent sources must be queried.
+- Operators must ensure that the additional JWKS endpoints are reachable and trusted, as there is no
+  automatic discovery mechanism for additional endpoints.

--- a/docs/adr/identity/0001-multi-jwks-endpoints-per-issuer.md
+++ b/docs/adr/identity/0001-multi-jwks-endpoints-per-issuer.md
@@ -58,3 +58,4 @@ The integration path is:
   source and subsequent sources must be queried.
 - Operators must ensure that the additional JWKS endpoints are reachable and trusted, as there is no
   automatic discovery mechanism for additional endpoints.
+

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -39,6 +39,7 @@ public class OidcAuthenticationConfiguration {
   private String redirectUri;
   private List<String> scope = Arrays.asList("openid", "profile");
   private String jwkSetUri;
+  private List<String> additionalJwkSetUris;
   private String authorizationUri;
   private String endSessionEndpointUri;
   private String tokenUri;
@@ -140,6 +141,14 @@ public class OidcAuthenticationConfiguration {
 
   public void setJwkSetUri(final String jwkSetUri) {
     this.jwkSetUri = jwkSetUri;
+  }
+
+  public List<String> getAdditionalJwkSetUris() {
+    return additionalJwkSetUris;
+  }
+
+  public void setAdditionalJwkSetUris(final List<String> additionalJwkSetUris) {
+    this.additionalJwkSetUris = additionalJwkSetUris;
   }
 
   public String getAuthorizationUri() {
@@ -278,6 +287,7 @@ public class OidcAuthenticationConfiguration {
         || redirectUri != null
         || !Arrays.asList("openid", "profile").equals(scope)
         || jwkSetUri != null
+        || additionalJwkSetUris != null
         || authorizationUri != null
         || endSessionEndpointUri != null
         || tokenUri != null
@@ -315,6 +325,7 @@ public class OidcAuthenticationConfiguration {
     private String redirectUri;
     private List<String> scope = Arrays.asList("openid", "profile");
     private String jwkSetUri;
+    private List<String> additionalJwkSetUris;
     private String authorizationUri;
     private String endSessionEndpointUri;
     private String tokenUri;
@@ -374,6 +385,11 @@ public class OidcAuthenticationConfiguration {
 
     public Builder jwkSetUri(final String jwkSetUri) {
       this.jwkSetUri = jwkSetUri;
+      return this;
+    }
+
+    public Builder additionalJwkSetUris(final List<String> additionalJwkSetUris) {
+      this.additionalJwkSetUris = additionalJwkSetUris;
       return this;
     }
 
@@ -466,6 +482,7 @@ public class OidcAuthenticationConfiguration {
       config.setEndSessionEndpointUri(endSessionEndpointUri);
       config.setScope(scope);
       config.setJwkSetUri(jwkSetUri);
+      config.setAdditionalJwkSetUris(additionalJwkSetUris);
       config.setAuthorizationUri(authorizationUri);
       config.setTokenUri(tokenUri);
       config.setAuthorizeRequest(authorizeRequestConfiguration);


### PR DESCRIPTION
## Summary

Adds support for configuring multiple JWK Set URIs per OIDC issuer, enabling Camunda to verify tokens signed by keys hosted at different JWKS endpoints for the same identity provider.

- Add `additionalJwkSetUris` configuration property to `OidcAuthenticationConfiguration`
- Implement `CompositeJWKSource` that aggregates multiple `JWKSource` instances with short-circuit key resolution
- Wire multi-JWKS support into the decoder pipeline (`JWSKeySelectorFactory`, `IssuerAwareJWSKeySelector`, `OidcAccessTokenDecoderFactory`, `WebSecurityConfig`)
- Wire additional JWKS URIs into `OidcUserAuthenticationConverter` so the Web UI access token decoding path also uses `CompositeJWKSource`
- Fully backward compatible: when `additionalJwkSetUris` is not configured, all existing code paths work unchanged

## Related Issues

- Feature request: https://github.com/camunda/product-hub/issues/3472
- Implementation tracking: #47213
- Sub-issues: #47214, #47215, #47216, #47217

## Architecture Decision

See [ADR-0001: Support Multiple JWKS Endpoints per OIDC Issuer](https://github.com/camunda/camunda/pull/47219/changes#diff-cfede2d2259e5b71e8087dec44e914af74accac3f508c8a333dc131a2316c405)

## Token Decoding Paths

| Path | Uses CompositeJWKSource? | When Used |
|------|-------------------------|-----------|
| `jwtDecoder` bean (resource server) | **YES** | Bearer token auth on API endpoints (M2M) |
| `OidcUserAuthenticationConverter.getJwtDecoder()` | **YES** | Browser user session — access token decoding on resource requests |
| `OidcIdTokenDecoderFactory` (Spring built-in) | NO (by design) | OIDC login flow — ID token decoding. Primary `jwk-set-uri` must contain the ID token signing key. |

## Configuration

```yaml
camunda:
  security:
    authentication:
      oidc:
        jwk-set-uri: "https://idp.example.com/pf/JWKS"                  # primary (ID tokens + standard keys)
        additional-jwk-set-uris:
          - "https://idp.example.com/ext/tokenmgr/jwtUpn"               # additional (M2M/API access tokens)
```

Environment variable equivalent:
```
CAMUNDA_SECURITY_AUTHENTICATION_OIDC_JWKSETURI=https://idp.example.com/pf/JWKS
CAMUNDA_SECURITY_AUTHENTICATION_OIDC_ADDITIONALJWKSETURIS_0_=https://idp.example.com/ext/tokenmgr/jwtUpn
```

## Changed Files

### New
- `CompositeJWKSource.java` — Composite `JWKSource<SecurityContext>` that queries delegates in order, returning keys from the first source with a match
- `CompositeJWKSourceTest.java` — 13 unit tests covering single-source, multi-source, fallback, error, immutability, and short-circuit scenarios
- `JWSKeySelectorFactoryTest.java` — 10 unit tests for the new overloaded `createJWSKeySelector` method including same-kid-different-keys and disjoint keys scenarios
- `docs/adr/identity/0001-multi-jwks-endpoints-per-issuer.md` — ADR documenting the design decision

### Modified
- `OidcAuthenticationConfiguration.java` — Added `additionalJwkSetUris` field, getter/setter, builder method, and `isSet()` check
- `JWSKeySelectorFactory.java` — Added `createJWSKeySelector(String, List<String>)` overload that builds `CompositeJWKSource`
- `IssuerAwareJWSKeySelector.java` — New constructor accepting `Map<String, List<String>>` additional URIs by issuer
- `OidcAccessTokenDecoderFactory.java` — Overloaded methods accepting additional URIs for both single-issuer and multi-issuer paths
- `WebSecurityConfig.java` — Builds additional URIs map from config and passes through to both the `jwtDecoder` bean and `oidcUserAuthenticationConverter` bean
- `OidcUserAuthenticationConverter.java` — New 5-arg constructor accepting `additionalJwkSetUrisByIssuer`; `getJwtDecoder()` now passes per-issuer additional URIs to the decoder factory
- `JwtDecoderTest.java` — Added test cases for additional JWKS URI scenarios including same-kid-different-keys
- `OidcUserAuthenticationConverterTest.java` — Added tests for additional URIs wiring, issuer-not-in-map, decoder caching, backward compat

## Known Limitations

- `OidcIdTokenDecoderFactory` (Spring's built-in) does NOT use `additionalJwkSetUris`. The primary `jwk-set-uri` must contain the signing key for ID tokens. This is by design — Spring's `OidcIdTokenDecoderFactory` is `final` and reads `jwkSetUri` directly from `ClientRegistration.ProviderDetails`.
- When the same `kid` exists at multiple JWKS endpoints with different key material, the short-circuit behavior returns the key from the first matching source. This is a documented design choice, not a bug — operators must ensure key IDs are unique across configured endpoints.

## Test Plan

- [x] `CompositeJWKSource`: single source, multi-source, fallback, error, immutability, short-circuit (13 tests)
- [x] `JWSKeySelectorFactory`: null/empty additional URIs, composite builder, malformed URI, blank URI, multiple additional sources, same-kid-different-keys, disjoint keys (10 tests)
- [x] `JwtDecoder` single provider with additional JWKS: primary key, additional key, unknown kid, fallthrough, EC algorithm, HTTP 500 fallback, key rotation, same-kid-different-keys fail/success (10 tests)
- [x] `JwtDecoder` single provider with multiple additional JWKS: key from second additional, key missing from all (2 tests)
- [x] `JwtDecoder` multiple providers with additional JWKS: foo primary, foo additional, bar without additional, unknown issuer (4 tests)
- [x] `JwtDecoder` backward compatibility: single and multi-provider without additional URIs (40 tests)
- [x] `OidcUserAuthenticationConverter`: additional URIs wiring, issuer-not-in-map passes null, decoder caching, 4-arg constructor backward compat, access token conversion, ID token fallback (9 tests)
- [x] **All 88 tests pass**