### PR TITLE
[Backport stable/8.8] fix: handle multiple field value kinds in ProcessViewRawDataInterpreter* sorting logic

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/ProcessViewRawDataInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/ProcessViewRawDataInterpreterES.java
@@ -19,6 +19,7 @@ import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.V
 import static io.camunda.optimize.service.db.util.ProcessVariableHelper.getNestedVariableNameField;
 import static io.camunda.optimize.service.db.util.ProcessVariableHelper.getNestedVariableValueField;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch._types.ScriptField;
 import co.elastic.clients.elasticsearch._types.ScriptSortType;
@@ -251,7 +252,15 @@ public class ProcessViewRawDataInterpreterES extends AbstractProcessViewRawDataI
               if (sorting.isPresent()
                   && sorting.get().getBy().isPresent()
                   && ProcessInstanceIndex.DURATION.equals(sorting.get().getBy().get())) {
-                processInstance.setDuration(Math.round(hit.sort().get(0).doubleValue()));
+                final FieldValue fieldValue = hit.sort().getFirst();
+                switch (fieldValue._kind()) {
+                  case Double -> processInstance.setDuration(Math.round(fieldValue.doubleValue()));
+                  case Long -> processInstance.setDuration(fieldValue.longValue());
+                  default ->
+                      LOG.error(
+                          "Unexpected field value kind {} for duration sort field",
+                          fieldValue._kind());
+                }
               } else {
                 final long currentTime =
                     Long.parseLong(hit.fields().get(CURRENT_TIME).to(List.class).get(0).toString());


### PR DESCRIPTION
# Description
Backport of #47085 to `stable/8.8`.

relates to camunda/camunda#40752
original author: @danielkelemen