### PR TITLE
[Backport stable/optimize-8.7] fix: Show ellipsis for large titles on Optimize

### DIFF
--- a/optimize/client/src/components/Home/Collection.scss
+++ b/optimize/client/src/components/Home/Collection.scss
@@ -4,6 +4,19 @@
   height: 100%;
   padding-block: spacing.$spacing-06;
 
+  .titleContainer {
+    max-width: 100vh;
+  }
+
+  .collectionName {
+    display: inline-block;
+    max-width: calc(100% - 40px);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+  }
+
   .layoutContainer {
     .cds--tab-content {
       padding: 0;

--- a/optimize/client/src/components/Home/Collection.scss
+++ b/optimize/client/src/components/Home/Collection.scss
@@ -4,19 +4,6 @@
   height: 100%;
   padding-block: spacing.$spacing-06;
 
-  .titleContainer {
-    max-width: 60vw;
-  }
-
-  .collectionName {
-    display: inline-block;
-    max-width: calc(100% - 40px);
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    vertical-align: middle;
-  }
-
   .layoutContainer {
     .cds--tab-content {
       padding: 0;

--- a/optimize/client/src/components/Home/Collection.scss
+++ b/optimize/client/src/components/Home/Collection.scss
@@ -5,7 +5,7 @@
   padding-block: spacing.$spacing-06;
 
   .titleContainer {
-    max-width: 100vh;
+    max-width: 100vw;
   }
 
   .collectionName {

--- a/optimize/client/src/components/Home/Collection.scss
+++ b/optimize/client/src/components/Home/Collection.scss
@@ -5,7 +5,7 @@
   padding-block: spacing.$spacing-06;
 
   .titleContainer {
-    max-width: 100vw;
+    max-width: 60vw;
   }
 
   .collectionName {

--- a/optimize/client/src/components/Home/CollectionHeader.scss
+++ b/optimize/client/src/components/Home/CollectionHeader.scss
@@ -5,9 +5,12 @@
   width: 100%;
 
   .text {
+    display: inline-block;
+    max-width: calc(60vw - 40px);
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
+    vertical-align: middle;
     white-space: nowrap;
   }
 

--- a/optimize/client/src/components/Home/CollectionHeader.scss
+++ b/optimize/client/src/components/Home/CollectionHeader.scss
@@ -1,6 +1,15 @@
 .CollectionHeader {
   align-items: center;
   margin-right: auto;
+  min-width: 0;
+  width: 100%;
+
+  .text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
   .skeletonText {
     margin: 0;

--- a/optimize/client/src/modules/components/EntityList/EntityList.scss
+++ b/optimize/client/src/modules/components/EntityList/EntityList.scss
@@ -15,6 +15,14 @@
     font-weight: 500;
   }
 
+  .entityName,
+  .rowName {
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
   thead th.tableHeader {
     white-space: nowrap;
 

--- a/optimize/client/src/modules/components/EntityList/EntityList.tsx
+++ b/optimize/client/src/modules/components/EntityList/EntityList.tsx
@@ -126,11 +126,13 @@ export default function EntityList({
           <div className="entityIcon">{row.icon}</div>
           <Stack gap={2} orientation="vertical">
             {row.link ? (
-              <Link title={row.name} className="cds--link" to={row.link}>
+              <Link title={row.name} className="cds--link entityName" to={row.link}>
                 {row.name}
               </Link>
             ) : (
-              <span className="rowName">{row.name}</span>
+              <span className="rowName" title={row.name}>
+                {row.name}
+              </span>
             )}
             <span>{row.type}</span>
           </Stack>

--- a/optimize/client/src/modules/components/navigation/NavItem/NavItem.scss
+++ b/optimize/client/src/modules/components/navigation/NavItem/NavItem.scss
@@ -8,4 +8,12 @@
   .arrow {
     align-self: center;
   }
+
+  .breadcrumb {
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+    white-space: nowrap;
+  }
 }


### PR DESCRIPTION
# Description
Backport of #46961 to `stable/optimize-8.7`.

relates to #46546