### PR TITLE
[Backport stable/8.9] perf: when auth & multi tenants are disabled, authorization should not slow down processors

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -161,9 +161,6 @@ public class BpmnJobActivationBehavior {
 
   private boolean isAuthorized(
       final JobActivationProperties jobActivationProperties, final JobRecord jobRecord) {
-    if (authorizationCheckBehavior.shouldSkipAllChecks()) {
-      return true;
-    }
 
     final var ownerTenantId = jobRecord.getTenantId();
     final var isTenantAuthorized =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -161,6 +161,9 @@ public class BpmnJobActivationBehavior {
 
   private boolean isAuthorized(
       final JobActivationProperties jobActivationProperties, final JobRecord jobRecord) {
+    if (authorizationCheckBehavior.shouldSkipAllChecks()) {
+      return true;
+    }
 
     final var ownerTenantId = jobRecord.getTenantId();
     final var isTenantAuthorized =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -173,6 +173,16 @@ public final class AuthorizationCheckBehavior {
   }
 
   /**
+   * Returns {@code true} when both authorization and multi-tenancy are disabled, meaning no
+   * authorization or tenant check will ever reject a request. Callers can use this to avoid
+   * constructing an {@link AuthorizationRequest} (and the associated allocations) when the result
+   * would always be authorized.
+   */
+  public boolean shouldSkipAllChecks() {
+    return !authorizationsEnabled && !multiTenancyEnabled;
+  }
+
+  /**
    * Checks if a user is authorized through ANY of the provided authorization requests, or if the
    * request is triggered by an internal command (in which case authorization is bypassed). Returns
    * success if at least one request is authorized (OR/disjunctive logic).
@@ -232,14 +242,8 @@ public final class AuthorizationCheckBehavior {
     return Either.left(RejectionAggregator.aggregate(aggregatedRejections));
   }
 
-  // Helper methods
-  private boolean shouldSkipAllChecks() {
-    return !authorizationsEnabled && !multiTenancyEnabled;
-  }
-
   private boolean shouldSkipAuthorization(final AuthorizationRequest request) {
-    return (!authorizationsEnabled && !multiTenancyEnabled)
-        || claimsExtractor.isAuthorizedAnonymousUser(request.claims());
+    return shouldSkipAllChecks() || claimsExtractor.isAuthorizedAnonymousUser(request.claims());
   }
 
   private AuthorizationResult checkPrimaryAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -140,11 +140,11 @@ public final class AuthorizationCheckBehavior {
    * @return Either containing a rejection if ALL requests failed, or Void if any succeeded
    */
   public Either<Rejection, Void> isAnyAuthorized(final AuthorizationRequest... requests) {
-    if (shouldSkipAllChecks()) {
-      return AUTHORIZED;
-    }
     if (requests == null || requests.length == 0) {
       throw new IllegalArgumentException("No authorization requests provided");
+    }
+    if (shouldSkipAllChecks()) {
+      return AUTHORIZED;
     }
 
     final List<Rejection> rejections = new ArrayList<>();
@@ -193,11 +193,11 @@ public final class AuthorizationCheckBehavior {
    */
   public Either<Rejection, Void> isAnyAuthorizedOrInternalCommand(
       final AuthorizationRequest... requests) {
-    if (shouldSkipAllChecks()) {
-      return AUTHORIZED;
-    }
     if (requests == null || requests.length == 0) {
       throw new IllegalArgumentException("No authorization requests provided");
+    }
+    if (shouldSkipAllChecks()) {
+      return AUTHORIZED;
     }
 
     // bypass authorization if any request is from an internal command

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -115,6 +115,9 @@ public final class AuthorizationCheckBehavior {
    *     {@link Void} if the user is authorized
    */
   public Either<Rejection, Void> isAuthorized(final AuthorizationRequest request) {
+    if (shouldSkipAllChecks()) {
+      return AUTHORIZED;
+    }
     try {
       return authorizationsCache.get(request);
     } catch (final ExecutionException e) {
@@ -137,6 +140,9 @@ public final class AuthorizationCheckBehavior {
    * @return Either containing a rejection if ALL requests failed, or Void if any succeeded
    */
   public Either<Rejection, Void> isAnyAuthorized(final AuthorizationRequest... requests) {
+    if (shouldSkipAllChecks()) {
+      return AUTHORIZED;
+    }
     if (requests == null || requests.length == 0) {
       throw new IllegalArgumentException("No authorization requests provided");
     }
@@ -177,6 +183,9 @@ public final class AuthorizationCheckBehavior {
    */
   public Either<Rejection, Void> isAnyAuthorizedOrInternalCommand(
       final AuthorizationRequest... requests) {
+    if (shouldSkipAllChecks()) {
+      return AUTHORIZED;
+    }
     if (requests == null || requests.length == 0) {
       throw new IllegalArgumentException("No authorization requests provided");
     }
@@ -224,6 +233,10 @@ public final class AuthorizationCheckBehavior {
   }
 
   // Helper methods
+  private boolean shouldSkipAllChecks() {
+    return !authorizationsEnabled && !multiTenancyEnabled;
+  }
+
   private boolean shouldSkipAuthorization(final AuthorizationRequest request) {
     return (!authorizationsEnabled && !multiTenancyEnabled)
         || claimsExtractor.isAuthorizedAnonymousUser(request.claims());
@@ -472,6 +485,9 @@ public final class AuthorizationCheckBehavior {
    * @return true if assigned or multi-tenancy is disabled, false otherwise
    */
   public boolean isAssignedToTenant(final TypedRecord<?> command, final String tenantId) {
+    if (!multiTenancyEnabled) {
+      return true;
+    }
     return tenantResolver.isAssignedToTenant(command.getAuthorizations(), tenantId);
   }
 
@@ -484,6 +500,9 @@ public final class AuthorizationCheckBehavior {
    *     authorized to access
    */
   public AuthorizedTenants getAuthorizedTenantIds(final TypedRecord<?> command) {
+    if (shouldSkipAllChecks()) {
+      return AuthorizedTenants.DEFAULT_TENANTS;
+    }
     return getAuthorizedTenantIds(command.getAuthorizations());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -489,9 +489,6 @@ public final class AuthorizationCheckBehavior {
    * @return true if assigned or multi-tenancy is disabled, false otherwise
    */
   public boolean isAssignedToTenant(final TypedRecord<?> command, final String tenantId) {
-    if (!multiTenancyEnabled) {
-      return true;
-    }
     return tenantResolver.isAssignedToTenant(command.getAuthorizations(), tenantId);
   }
 
@@ -504,9 +501,6 @@ public final class AuthorizationCheckBehavior {
    *     authorized to access
    */
   public AuthorizedTenants getAuthorizedTenantIds(final TypedRecord<?> command) {
-    if (shouldSkipAllChecks()) {
-      return AuthorizedTenants.DEFAULT_TENANTS;
-    }
     return getAuthorizedTenantIds(command.getAuthorizations());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -521,6 +521,9 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
 
   private Either<Rejection, JobRecord> checkAuthorization(
       final TypedRecord<JobRecord> command, final JobRecord job) {
+    if (authCheckBehavior.shouldSkipAllChecks()) {
+      return Either.right(job);
+    }
     final var request =
         AuthorizationRequest.builder()
             .command(command)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -63,6 +63,9 @@ public class JobUpdateBehaviour {
 
   public Either<Rejection, JobRecord> isAuthorized(
       final TypedRecord<JobRecord> command, final JobRecord job) {
+    if (authCheckBehavior.shouldSkipAllChecks()) {
+      return Either.right(job);
+    }
     final var authRequest =
         AuthorizationRequest.builder()
             .command(command)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -191,6 +191,9 @@ public final class MessageCorrelationCorrelateProcessor
       final TypedRecord<MessageCorrelationRecord> command,
       final Subscriptions correlatingSubscriptions,
       final String tenantId) {
+    if (authCheckBehavior.shouldSkipAllChecks()) {
+      return Optional.empty();
+    }
     final AtomicReference<AuthorizationRequest> request = new AtomicReference<>();
     final AtomicReference<Rejection> rejection = new AtomicReference<>();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -95,21 +95,23 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
 
   @Override
   public void processRecord(final TypedRecord<MessageRecord> command) {
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.MESSAGE)
-            .permissionType(PermissionType.CREATE)
-            .tenantId(command.getValue().getTenantId())
-            .newResource()
-            .addResourceId(command.getValue().getName())
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
-    if (isAuthorized.isLeft()) {
-      final var rejection = isAuthorized.getLeft();
-      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
-      return;
+    if (!authCheckBehavior.shouldSkipAllChecks()) {
+      final var authRequest =
+          AuthorizationRequest.builder()
+              .command(command)
+              .resourceType(AuthorizationResourceType.MESSAGE)
+              .permissionType(PermissionType.CREATE)
+              .tenantId(command.getValue().getTenantId())
+              .newResource()
+              .addResourceId(command.getValue().getName())
+              .build();
+      final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
+      if (isAuthorized.isLeft()) {
+        final var rejection = isAuthorized.getLeft();
+        rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+        responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+        return;
+      }
     }
 
     messageRecord = command.getValue();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -168,6 +168,11 @@ public class ProcessInstanceCreationHelper {
   public Either<Rejection, DeployedProcess> isAuthorized(
       final TypedRecord<ProcessInstanceCreationRecord> command,
       final DeployedProcess deployedProcess) {
+    // check if auth is disabled entirely
+    if (authCheckBehavior.shouldSkipAllChecks()) {
+      return Either.right(deployedProcess);
+    }
+
     final var processId = bufferAsString(deployedProcess.getBpmnProcessId());
     final var request =
         AuthorizationRequest.builder()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -168,7 +168,7 @@ public class ProcessInstanceCreationHelper {
   public Either<Rejection, DeployedProcess> isAuthorized(
       final TypedRecord<ProcessInstanceCreationRecord> command,
       final DeployedProcess deployedProcess) {
-    // check if auth is disabled entirely
+    // skip authorization and multi-tenancy checks if all such checks are disabled
     if (authCheckBehavior.shouldSkipAllChecks()) {
       return Either.right(deployedProcess);
     }


### PR DESCRIPTION
# Description
Backport of #46874 to `stable/8.9`.

relates to #46873