### PR TITLE
ci: migrate load test infra to new cluster (8.6 backport)

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -312,9 +312,11 @@ jobs:
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set global.image.pullSecrets[0].name=harbor-registry
-          --set zeebe.image.repository=${{ env.IMAGE_REPOSITORY }}/zeebe
+          --set zeebe.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}
+          --set zeebe.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/zeebe' }}
           --set zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set zeebeGateway.image.repository=${{ env.IMAGE_REPOSITORY }}/zeebe
+          --set zeebeGateway.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}
+          --set zeebeGateway.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/zeebe' }}
           --set zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -1,10 +1,16 @@
 # description: This GitHub workflow deploys a load test with a camunda cluster under test.
 # We use this workflow to start ad-hoc load tests or weekly medic load tests.
 # The health of the cluster and results of the load tests are monitored by Core team's regularly.
-# https://grafana.dev.zeebe.io/login
+# https://dashboard.benchmark.camunda.cloud/
 # called by: zeebe-medic-benchmarks.yml, zeebe-pr-benchmark.yaml
 # type: CI
 # owner: camunda/orchestration-cluster-team
+#
+# Infos from Infra:
+# - Using the infra benchmark prod cluster requires to use Teleport to authenticate.
+# - Camunda images are pushed to registry.camunda.cloud/team-zeebe and pulled from there.
+#   To use them in a namespace, the namespace must be labeled with "registry=harbor"
+#   You must also set the image pull secret to "harbor-registry" in the helm values.
 name: Camunda load test
 on:
   workflow_dispatch:
@@ -102,7 +108,12 @@ on:
         default: false
 
 env:
+  CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe  # change this to "infra-benchmark-dev-github-action-zeebe" when experimenting
   HELM_CHART: camunda-platform-8.6
+  # Namespaces MUST start with c8 due to access policy
+  NAMESPACE: c8-${{ inputs.name }}
+  IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
 
 defaults:
   run:
@@ -150,6 +161,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
@@ -173,22 +185,10 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild -P\!include-optimize
-      - uses: google-github-actions/auth@v2
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GCR
-        uses: docker/login-action@v3
-        with:
-          registry: gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/build-platform-docker
         name: Build Camunda Docker Image
         with:
-          repository: 'gcr.io/zeebe-io/zeebe'
+          repository: '${{ env.IMAGE_REPOSITORY }}/zeebe'
           revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
@@ -220,30 +220,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GAR
-        uses: docker/login-action@v3
-        with:
-          registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl zeebe/benchmarks/project -am install
       - name: Build Starter Image
-        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter -P\!include-optimize -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Build Worker Image
-        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -276,31 +264,36 @@ jobs:
         with:
           repository: 'camunda/camunda-platform-helm'
           ref: 'main'
-      - uses: google-github-actions/auth@v2
+      # Authenticate with Teleport
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v2.3.5
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Create namespace if not exists
         run: |
-          if ! kubectl get namespace ${{ inputs.name }} >/dev/null 2>&1; then
-            kubectl create namespace ${{ inputs.name }}
+          if ! kubectl get namespace ${{ env.NAMESPACE }} >/dev/null 2>&1; then
+            kubectl create namespace ${{ env.NAMESPACE }}
           else
-            echo "Namespace '${{ inputs.name }}' already exists"
+            echo "Namespace '${{ env.NAMESPACE }}' already exists"
           fi
-      - name: Label namespace with creator
-        run: >
-          kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
-      - name: Label namespace with deadline
+      - name: Label namespace
         run: |
+          kubectl label namespace ${{ env.NAMESPACE }} created-by=${{ github.actor }} --overwrite
+          kubectl label namespace ${{ env.NAMESPACE }} registry=harbor --overwrite
           # Calculate deadline date with the TTL days from now
-          # Use basic ISO date format (YYYY-MM-DD), as it is compatible with kubectl label values
-          # Must use minus (-) instead of / to be compatible with kubectl label value restrictions
           deadlineDate=$(date -d "+${{ inputs.ttl }} days" +%Y-%m-%d)
-          kubectl label namespace ${{ inputs.name }} deadline-date="$deadlineDate" --overwrite
+          kubectl label namespace ${{ env.NAMESPACE }} deadline-date="$deadlineDate" --overwrite
+      - name: Annotate namespace
+        run: |
+          kubectl annotate namespace ${{ env.NAMESPACE }} \
+            "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --overwrite
       - name: Add Camunda Helm repo
         run: |
           helm repo add camunda https://helm.camunda.io/
@@ -308,22 +301,21 @@ jobs:
       - name: Find previous Helm chart release version
         id: find-chart-release
         run: |
-          echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
+          echo "chart-release=$(helm get metadata -o json --namespace ${{ env.NAMESPACE }} ${{ env.NAMESPACE }} | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
       - name: Build dependencies of Camunda Platform
         run: helm dependency build charts/${{ env.HELM_CHART }}/
       - name: Install latest Camunda Platform
         run: >
-          helm upgrade --install ${{ inputs.name }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
-          --namespace ${{ inputs.name }}
+          helm upgrade --install ${{ env.NAMESPACE }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
+          --namespace ${{ env.NAMESPACE }}
           --reset-then-reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set zeebe.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'gcr.io/zeebe-io/zeebe' }}
+          --set global.image.pullSecrets[0].name=harbor-registry
+          --set zeebe.image.repository=${{ env.IMAGE_REPOSITORY }}/zeebe
           --set zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set zeebe.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || ''}}
-          --set zeebeGateway.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'gcr.io/zeebe-io/zeebe' }}
+          --set zeebeGateway.image.repository=${{ env.IMAGE_REPOSITORY }}/zeebe
           --set zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set zeebeGateway.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || ''}}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}
@@ -333,9 +325,9 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Camunda platform \`${{ inputs.name }}\` values
+            ## Camunda platform \`${{ env.NAMESPACE }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ env.NAMESPACE }} -n ${{ env.NAMESPACE }})
             \`\`\`
           EOF
       - name: Observe build status
@@ -371,14 +363,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: google-github-actions/auth@v2
+      # Authenticate with Teleport
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v2.3.5
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Add Load test Helm repo
         run: |
           helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/
@@ -386,24 +381,26 @@ jobs:
       - name: Find previous Helm chart release version
         id: find-chart-release
         run: |
-          echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }}-test | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
+          echo "chart-release=$(helm get metadata -o json --namespace ${{ env.NAMESPACE }} ${{ env.NAMESPACE }}-test | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
       - name: Install load test
         run: >
-          helm upgrade --install ${{ inputs.name }}-test camunda-load-tests/camunda-load-tests
+          helm upgrade --install ${{ env.NAMESPACE }}-test camunda-load-tests/camunda-load-tests
           --wait --timeout 35m0s
-          --namespace ${{ inputs.name }}
+          --namespace ${{ env.NAMESPACE }}
           --reuse-values
           --render-subchart-notes
           --set global.connect.serviceName=zeebe-gateway
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set global.image.repository=${{ env.IMAGE_REPOSITORY }}
+          --set global.image.pullSecrets[0].name=harbor-registry
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.load-test-load }}
       - name: Setup leader balancing
         run: |
-          if ! kubectl get cronjob leader-balancer --namespace ${{ inputs.name }} &>/dev/null; then
+          if ! kubectl get cronjob leader-balancer --namespace ${{ env.NAMESPACE }} &>/dev/null; then
             kubectl create cronjob leader-balancer \
-              --namespace ${{ inputs.name }} \
+              --namespace ${{ env.NAMESPACE }} \
               --image=curlimages/curl:7.87.0 \
               --schedule="*/10 * * * *" \
               -- curl -L -v -X POST http://zeebe-gateway:9600/actuator/rebalance
@@ -415,10 +412,10 @@ jobs:
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             # Load test
-            The test has been set up successfully. You can observe it [here](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?var-namespace=${{ inputs.name }})
-            ## Load test \`${{ inputs.name }}\` values
+            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})
+            ## Load test \`${{ env.NAMESPACE }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }}-test -n ${{ inputs.name }})
+            $(helm get values ${{ env.NAMESPACE }}-test -n ${{ env.NAMESPACE }})
             \`\`\`
           EOF
       - name: Observe build status

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - closed
 
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+
 jobs:
   sanitize-branch-name:
     name: Sanitize Branch Name
@@ -46,14 +50,18 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: google-github-actions/auth@v2
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v2.2.2
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Delete benchmarks
         run: |
-          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}"
+          kubectl delete ns "c8-${{ needs.sanitize-branch-name.outputs.sanitized-name }}"

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -15,13 +15,14 @@ global:
     enabled: false
   image:
     # Image.repository defines the repository from which to fetch the docker images
-    repository: "gcr.io/zeebe-io"
+    repository: "registry.camunda.cloud/team-zeebe"
     # Image.tag defines the tag / version which should be used in the chart
     tag: 8.6.0
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-    pullSecrets: []
+    pullSecrets:
+      - name: harbor-registry
   # By default, we run without Identity
   identity:
     auth:
@@ -59,7 +60,7 @@ zeebe:
   # Image configuration to configure the zeebe image specifics
   image:
     # Image.repository defines which image repository to use
-    repository: camunda/zeebe
+    repository: registry.camunda.cloud/team-zeebe/zeebe
     tag: 8.6.0
   # ClusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
@@ -168,6 +169,12 @@ zeebe:
   nodeSelector:
     cloud.google.com/gke-nodepool: n2-standard-2
 
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-2
+      effect: NoSchedule
+
   # PvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
   pvcAccessMode: [ "ReadWriteOnce" ]
   # PvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
@@ -182,7 +189,7 @@ zeebeGateway:
   # Image configuration to configure the zeebe-gateway image specifics
   image:
     # Image.repository defines which image repository to use
-    repository: camunda/zeebe
+    repository: registry.camunda.cloud/team-zeebe/zeebe
     tag: 8.6.0
   # LogLevel defines the log level which is used by the gateway
   logLevel: debug
@@ -268,3 +275,10 @@ elasticsearch:
       limits:
         cpu: 2
         memory: 6Gi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: n2-standard-2
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-2
+        effect: NoSchedule

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -160,19 +160,19 @@ zeebe:
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
   resources:
     limits:
-      cpu: 1700m
+      cpu: 2000m
       memory: 4Gi
     requests:
-      cpu: 1350m
+      cpu: 2000m
       memory: 4Gi
 
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-2
+    cloud.google.com/gke-nodepool: n2-standard-4
 
   tolerations:
     - key: nodepool
       operator: Equal
-      value: n2-standard-2
+      value: n2-standard-4
       effect: NoSchedule
 
   # PvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes

--- a/zeebe/benchmarks/setup/default/Makefile
+++ b/zeebe/benchmarks/setup/default/Makefile
@@ -5,7 +5,7 @@ all: benchmark
 
 .PHONY: benchmark
 benchmark:
-	helm install --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml --skip-crds
+	helm install --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml -f values-preemptible.yaml --skip-crds
 
 # To deploy the Zeebe pods on stable nodes, use this job
 .PHONY: benchmark-stable
@@ -16,7 +16,7 @@ benchmark-stable:
 # To apply the templates use k apply -f zeebe-benchmark/templates/
 .PHONY: template
 template:
-	helm template $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml --skip-crds --output-dir .
+	helm template $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml -f values-preemptible.yaml --skip-crds --output-dir .
 
 .PHONY: template-stable
 template-stable:

--- a/zeebe/benchmarks/setup/default/values-preemptible.yaml
+++ b/zeebe/benchmarks/setup/default/values-preemptible.yaml
@@ -1,0 +1,11 @@
+# Additional values file to run Zeebe on preemptible/spot VMs
+zeebe:
+  # Require n2-standard-2 to ensure the broker is the only application running on its node
+  nodeSelector:
+    cloud.google.com/gke-nodepool: n2-standard-2
+
+  tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-2
+    effect: NoSchedule

--- a/zeebe/benchmarks/setup/default/values-preemptible.yaml
+++ b/zeebe/benchmarks/setup/default/values-preemptible.yaml
@@ -1,11 +1,11 @@
 # Additional values file to run Zeebe on preemptible/spot VMs
 zeebe:
-  # Require n2-standard-2 to ensure the broker is the only application running on its node
+  # Require n2-standard-4 to ensure the broker is the only application running on its node
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-2
+    cloud.google.com/gke-nodepool: n2-standard-4
 
   tolerations:
   - key: nodepool
     operator: Equal
-    value: n2-standard-2
+    value: n2-standard-4
     effect: NoSchedule

--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -1,15 +1,14 @@
 # Additional values file to run Zeebe on stable VMs
 zeebe:
-  # Require n2-standard-2 to ensure the broker is the only application running on its node
+  # Require n2-standard-2-stable to ensure the broker is the only application running on its node
   nodeSelector:
     cloud.google.com/gke-nodepool: n2-standard-2-stable
 
-  # Ignore the stable VM node taints
   tolerations:
-    - key: cloud.google.com/gke-spot
-      operator: Equal
-      effect: NoSchedule
-      value: 'false'
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-2-stable
+    effect: NoSchedule
 
 # Support of 10.x camunda platform
 zeebeGateway:
@@ -25,9 +24,8 @@ zeebeGateway:
               - key: cloud.google.com/gke-spot
                 operator: DoesNotExist
 
-  # Ignore the stable VM node taints
   tolerations:
-    - key: cloud.google.com/gke-spot
-      operator: Equal
-      effect: NoSchedule
-      value: 'false'
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-2-stable
+    effect: NoSchedule

--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -1,13 +1,13 @@
 # Additional values file to run Zeebe on stable VMs
 zeebe:
-  # Require n2-standard-2-stable to ensure the broker is the only application running on its node
+  # Require n2-standard-4-stable to ensure the broker is the only application running on its node
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-2-stable
+    cloud.google.com/gke-nodepool: n2-standard-4-stable
 
   tolerations:
   - key: nodepool
     operator: Equal
-    value: n2-standard-2-stable
+    value: n2-standard-4-stable
     effect: NoSchedule
 
 # Support of 10.x camunda platform
@@ -27,5 +27,5 @@ zeebeGateway:
   tolerations:
   - key: nodepool
     operator: Equal
-    value: n2-standard-2-stable
+    value: n2-standard-4-stable
     effect: NoSchedule

--- a/zeebe/benchmarks/setup/default/values.yaml
+++ b/zeebe/benchmarks/setup/default/values.yaml
@@ -28,7 +28,7 @@ global:
   # Image configuration to be used in each sub chart
   image:
     # Image.repository defines the repository from which to fetch the docker images
-    repository: "gcr.io/zeebe-io"
+    repository: "registry.camunda.cloud/team-zeebe"
     # Image.tag defines the tag / version which should be used in the chart
     tag: SNAPSHOT
     # Image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy


### PR DESCRIPTION
## Description

Backport of PR #47212 (8.7) adapted for the 8.6 branch structure.

Migrates the load test infrastructure from the old `zeebe-cluster` to the new `camunda-benchmark-prod` cluster.

## Changes

### Authentication
- Replace Google Cloud Workload Identity (`google-github-actions/auth@v2` + `get-gke-credentials`) with Teleport (`teleport-actions/setup@v1` + `teleport-actions/auth-k8s@v2`)

### Image Registry
- Migrate from `gcr.io/zeebe-io` to `registry.camunda.cloud/team-zeebe` (Harbor)
- Add `harbor: true` to `setup-build` action
- Add `harbor-registry` pull secret to helm values
- Add `registry=harbor` namespace label

### Namespace
- Add `c8-` prefix to all namespace references (required by access policy)
- Add `workflow-run-url` annotation for traceability

### Grafana
- Update dashboard URL from `grafana.dev.zeebe.io` to `dashboard.benchmark.camunda.cloud`

### Node Scheduling
- Add `nodepool` tolerations for zeebe and elasticsearch
- Create `values-preemptible.yaml` for spot VM scheduling
- Update `values-stable.yaml` with new `nodepool` tolerations
- Add `-f values-preemptible.yaml` to Makefile `benchmark`/`template` targets

## Files changed
- `.github/workflows/camunda-load-test.yml`
- `.github/workflows/zeebe-pr-benchmark.yaml`
- `zeebe/benchmarks/camunda-platform-values.yaml`
- `zeebe/benchmarks/setup/default/Makefile`
- `zeebe/benchmarks/setup/default/values.yaml`
- `zeebe/benchmarks/setup/default/values-stable.yaml`
- `zeebe/benchmarks/setup/default/values-preemptible.yaml` (new)

## Related
- Backport of #47212 (8.7)
- Original PR: #46258 (8.8)