### PR TITLE
[Do not merge] feat: check how incident.io action works

### DIFF
--- a/.github/workflows/incident-signal-phase1-poc.yml
+++ b/.github/workflows/incident-signal-phase1-poc.yml
@@ -5,6 +5,11 @@
 name: Incident Signal Phase 1 PoC
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/incident-signal-phase1-poc.yml"
   workflow_dispatch:
     inputs:
       failure-stage:
@@ -41,13 +46,16 @@ jobs:
       - name: Simulate deployment pipeline failure
         id: simulate
         run: |
+          failure_stage="helm-update"
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "failure_stage=${{ inputs.failure-stage }}" >> "$GITHUB_OUTPUT"
-          echo "run_url=${run_url}" >> "$GITHUB_OUTPUT"
+          {
+            echo "failure_stage=${failure_stage}"
+            echo "run_url=${run_url}"
+          } >> "$GITHUB_OUTPUT"
 
           {
             echo "## Phase 1 PoC - forced failure"
-            echo "- Stage: ${{ inputs.failure-stage }}"
+            echo "- Stage: ${failure_stage}"
             echo "- Run URL: ${run_url}"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -107,7 +115,7 @@ jobs:
             **Run URL:** ${{ needs.simulate-deploy-failure.outputs.run_url }}
             **Actor:** ${{ github.actor }}
           severity: "high"
-          deduplication-key: "${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ needs.simulate-deploy-failure.outputs.failure_stage }}-${{ inputs.deduplication-suffix }}"
+          deduplication-key: "${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ needs.simulate-deploy-failure.outputs.failure_stage }}"
           source-url: ${{ needs.simulate-deploy-failure.outputs.run_url }}
 
       - name: Record incident.io evidence

--- a/.github/workflows/incident-signal-phase1-poc.yml
+++ b/.github/workflows/incident-signal-phase1-poc.yml
@@ -1,0 +1,133 @@
+# description: Phase 1 PoC for workflow-failure signaling option (incident.io GHA)
+# type: CI
+# owner: TODO
+---
+name: Incident Signal Phase 1 PoC
+
+on:
+  workflow_dispatch:
+    inputs:
+      failure-stage:
+        description: "Synthetic failure stage label"
+        type: choice
+        options:
+          - helm-update
+          - kubectl-operations
+          - build-artifact
+        default: helm-update
+        required: true
+      deduplication-suffix:
+        description: "Optional suffix appended to deduplication keys"
+        type: string
+        default: ""
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  simulate-deploy-failure:
+    name: Simulate deploy failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      failure_stage: ${{ steps.simulate.outputs.failure_stage }}
+      run_url: ${{ steps.simulate.outputs.run_url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Simulate deployment pipeline failure
+        id: simulate
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "failure_stage=${{ inputs.failure-stage }}" >> "$GITHUB_OUTPUT"
+          echo "run_url=${run_url}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Phase 1 PoC - forced failure"
+            echo "- Stage: ${{ inputs.failure-stage }}"
+            echo "- Run URL: ${run_url}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Simulating failure to mirror deploy workflow failure signaling."
+          exit 1
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          user_description: "phase1-poc/simulate-deploy-failure"
+
+  notify-incident-io-gha:
+    name: Notify via incident.io GHA
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    needs: simulate-deploy-failure
+    if: |
+      always() &&
+      needs.simulate-deploy-failure.result == 'failure'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Import secrets from Vault
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions INCIDENT_IO_API_KEY | incident_io_api_key;
+            secret/data/products/camunda/ci/github-actions INCIDENT_IO_ALERT_SOURCE_ID | incident_io_alert_source_id;
+
+      - name: Dispatch incident alert
+        id: incident-alert
+        uses: incident-io/github-action@v0
+        with:
+          api-key: ${{ steps.secrets.outputs.incident_io_api_key }}
+          alert-source-id: ${{ steps.secrets.outputs.incident_io_alert_source_id }}
+          alert-title: "Phase 1 PoC workflow failure - ${{ needs.simulate-deploy-failure.outputs.failure_stage }}"
+          alert-description: |
+            **Phase:** 1 workflow-failure signaling PoC
+            **Option:** incident.io GHA
+            **Failure Stage:** ${{ needs.simulate-deploy-failure.outputs.failure_stage }}
+            **Repository:** ${{ github.repository }}
+            **Workflow:** ${{ github.workflow }}
+            **Run URL:** ${{ needs.simulate-deploy-failure.outputs.run_url }}
+            **Actor:** ${{ github.actor }}
+          severity: "high"
+          deduplication-key: "${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ needs.simulate-deploy-failure.outputs.failure_stage }}-${{ inputs.deduplication-suffix }}"
+          source-url: ${{ needs.simulate-deploy-failure.outputs.run_url }}
+
+      - name: Record incident.io evidence
+        if: always()
+        run: |
+          {
+            echo "## Option A evidence (incident.io GHA)"
+            echo "- Alert ID: ${{ steps.incident-alert.outputs.alert-id }}"
+            echo "- Alert URL: ${{ steps.incident-alert.outputs.alert-url }}"
+            echo "- Job status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: "phase1-poc/incident-io-gha"
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          user_description: "phase1-poc/incident-io-gha"

--- a/.github/workflows/incident-signal-phase1-poc.yml
+++ b/.github/workflows/incident-signal-phase1-poc.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Dispatch incident alert
         id: incident-alert
-        uses: incident-io/github-action@v0
+        uses: incident-io/github-action@7aa5f85e67679cd8fdf2a19aed3d5450335a004b
         with:
           api-key: ${{ steps.secrets.outputs.incident_io_api_key }}
           alert-source-id: ${{ steps.secrets.outputs.incident_io_alert_source_id }}


### PR DESCRIPTION
## Description

This pull request introduces a new GitHub Actions workflow, implementing a Phase 1 proof-of-concept (PoC) for workflow failure signaling using incident.io integration. The workflow simulates deployment failures, observes build status, and dispatches incident alerts via incident.io, with secrets securely managed through Vault. This setup is intended to test and demonstrate automated incident signaling for CI/CD failures.

Key additions and changes:

**Incident workflow implementation:**
* Added `.github/workflows/incident-signal-phase1-poc.yml` to define a new workflow for simulating deployment failures and signaling incidents via incident.io.

**Workflow structure and simulation:**
* Created a `simulate-deploy-failure` job that allows manual triggering with configurable failure stages, simulates a deployment failure, and outputs relevant context for downstream jobs.
* Integrated an `observe-build-status` step to monitor and record the status of the simulated build, using a custom local action.

**Incident alerting and evidence:**
* Added a `notify-incident-io-gha` job that triggers on simulated failure, imports secrets from Vault, dispatches an incident alert via incident.io, and records alert evidence in the workflow summary.
* Ensured deduplication and traceability by constructing a unique deduplication key and including run metadata in the alert description.

POC for https://github.com/camunda/camunda/issues/34235

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
