### PR TITLE
fix: reset retry backoff

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerChangeSet.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerChangeSet.java
@@ -151,6 +151,7 @@ public sealed interface JobWorkerChangeSet {
               reset(jobWorkerValue.getStreamEnabled(), jobWorkerValue::setStreamEnabled),
               reset(jobWorkerValue.getStreamTimeout(), jobWorkerValue::setStreamTimeout),
               reset(jobWorkerValue.getMaxRetries(), jobWorkerValue::setMaxRetries),
+              reset(jobWorkerValue.getRetryBackoff(), jobWorkerValue::setRetryBackoff),
               reset(jobWorkerValue.getTenantFilter(), jobWorkerValue::setTenantFilter))
           .reduce(false, Boolean::logicalOr);
     }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobWorkerChangeSetTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobWorkerChangeSetTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class JobWorkerChangeSetTest {
+
   @Test
   void shouldUpdateTenantIds() {
     final JobWorkerValue jobWorkerValue = new JobWorkerValue();
@@ -173,5 +174,17 @@ public class JobWorkerChangeSetTest {
     resetChangeSet.applyChanges(jobWorkerValue);
     assertThat(jobWorkerValue.getTenantFilter())
         .isEqualTo(new FromAnnotation<>(TenantFilter.PROVIDED));
+  }
+
+  @Test
+  void shouldResetRetryBackoff() {
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    jobWorkerValue.setRetryBackoff(
+        new FromRuntimeOverride<>(
+            Duration.ofSeconds(10), new FromAnnotation<>(Duration.ofSeconds(20))));
+    final ResetChangeSet resetChangeSet = new ResetChangeSet();
+    resetChangeSet.applyChanges(jobWorkerValue);
+    assertThat(jobWorkerValue.getRetryBackoff())
+        .isEqualTo(new FromAnnotation<>(Duration.ofSeconds(20)));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes an issue where the retry backoff is not reset properly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
