### PR TITLE
[Backport stable/8.9] feat: track identity names in the audit log

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformer.java
@@ -22,6 +22,7 @@ public class GroupEntityAuditLogTransformer implements AuditLogTransformer<Group
   public void transform(final Record<GroupRecordValue> record, final AuditLogEntry log) {
     final GroupRecordValue value = record.getValue();
     log.setEntityKey(value.getGroupId())
+        .setEntityDescription(value.getName())
         .setRelatedEntityKey(value.getEntityId())
         .setRelatedEntityType(
             AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(value.getEntityType()));

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleAuditLogTransformer.java
@@ -21,6 +21,6 @@ public class RoleAuditLogTransformer implements AuditLogTransformer<RoleRecordVa
   @Override
   public void transform(final Record<RoleRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(value.getRoleId());
+    log.setEntityKey(value.getRoleId()).setEntityDescription(value.getName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformer.java
@@ -22,6 +22,7 @@ public class RoleEntityAuditLogTransformer implements AuditLogTransformer<RoleRe
   public void transform(final Record<RoleRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setEntityKey(value.getRoleId())
+        .setEntityDescription(value.getName())
         .setRelatedEntityKey(value.getEntityId())
         .setRelatedEntityType(
             AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(value.getEntityType()));

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformer.java
@@ -20,6 +20,7 @@ public class TenantAuditLogTransformer implements AuditLogTransformer<TenantReco
 
   @Override
   public void transform(final Record<TenantRecordValue> record, final AuditLogEntry log) {
-    log.setEntityKey(record.getValue().getTenantId());
+    final var value = record.getValue();
+    log.setEntityKey(value.getTenantId()).setEntityDescription(value.getName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformer.java
@@ -22,6 +22,7 @@ public class TenantEntityAuditLogTransformer implements AuditLogTransformer<Tena
   public void transform(final Record<TenantRecordValue> record, final AuditLogEntry log) {
     final TenantRecordValue value = record.getValue();
     log.setEntityKey(value.getTenantId())
+        .setEntityDescription(value.getName())
         .setRelatedEntityKey(value.getEntityId())
         .setRelatedEntityType(
             AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(value.getEntityType()));

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformer.java
@@ -21,6 +21,6 @@ public class UserAuditLogTransformer implements AuditLogTransformer<UserRecordVa
   @Override
   public void transform(final Record<UserRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(value.getUsername());
+    log.setEntityKey(value.getUsername()).setEntityDescription(value.getName());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformerTest.java
@@ -34,6 +34,7 @@ class GroupEntityAuditLogTransformerTest {
             .from(factory.generateObject(GroupRecordValue.class))
             .withEntityType(EntityType.MAPPING_RULE)
             .withGroupId("test-group")
+            .withName("Test Group")
             .withGroupKey(789L)
             .build();
 
@@ -47,6 +48,7 @@ class GroupEntityAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-group");
+    assertThat(entity.getEntityDescription()).isEqualTo("Test Group");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.ASSIGN);
     assertThat(entity.getRelatedEntityKey()).isEqualTo(recordValue.getEntityId());
     assertThat(entity.getRelatedEntityType()).isEqualTo(AuditLogEntityType.MAPPING_RULE);

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleAuditLogTransformerTest.java
@@ -44,6 +44,7 @@ class RoleAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("role-123");
+    assertThat(entity.getEntityDescription()).isEqualTo("Test Role");
   }
 
   @Test

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformerTest.java
@@ -32,6 +32,7 @@ class RoleEntityAuditLogTransformerTest {
         ImmutableRoleRecordValue.builder()
             .from(factory.generateObject(RoleRecordValue.class))
             .withRoleId("role-123")
+            .withName("Test Role")
             .withEntityId("entity-id")
             .withEntityType(EntityType.USER)
             .build();
@@ -46,6 +47,7 @@ class RoleEntityAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("role-123");
+    assertThat(entity.getEntityDescription()).isEqualTo("Test Role");
     assertThat(entity.getRelatedEntityKey()).isEqualTo("entity-id");
     assertThat(entity.getRelatedEntityType()).isEqualTo(AuditLogEntityType.USER);
   }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformerTest.java
@@ -31,6 +31,7 @@ class TenantAuditLogTransformerTest {
         ImmutableTenantRecordValue.builder()
             .from(factory.generateObject(TenantRecordValue.class))
             .withTenantId("test-tenant")
+            .withName("Test Tenant")
             .withTenantKey(456L)
             .build();
 
@@ -44,6 +45,7 @@ class TenantAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
+    assertThat(entity.getEntityDescription()).isEqualTo("Test Tenant");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformerTest.java
@@ -33,6 +33,7 @@ class TenantEntityAuditLogTransformerTest {
         ImmutableTenantRecordValue.builder()
             .from(factory.generateObject(TenantRecordValue.class))
             .withTenantId("test-tenant")
+            .withName("Test Tenant")
             .withTenantKey(456L)
             .withEntityType(EntityType.GROUP)
             .build();
@@ -47,6 +48,7 @@ class TenantEntityAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
+    assertThat(entity.getEntityDescription()).isEqualTo("Test Tenant");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.ASSIGN);
     assertThat(entity.getRelatedEntityKey()).isEqualTo(recordValue.getEntityId());
     assertThat(entity.getRelatedEntityType()).isEqualTo(AuditLogEntityType.GROUP);

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformerTest.java
@@ -31,6 +31,7 @@ class UserAuditLogTransformerTest {
         ImmutableUserRecordValue.builder()
             .from(factory.generateObject(UserRecordValue.class))
             .withUsername("testuser")
+            .withName("Test User")
             .withUserKey(123L)
             .build();
 
@@ -44,6 +45,7 @@ class UserAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("testuser");
+    assertThat(entity.getEntityDescription()).isEqualTo("Test User");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 


### PR DESCRIPTION
# Description
Backport of #47218 to `stable/8.9`.

relates to #47235