### PR TITLE
perf: flowControl onAppend when the lock is released

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -25,7 +25,7 @@ import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
 import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * Maintains a view of in-flight entries as they are being appended, written, committed and finally
@@ -93,7 +93,7 @@ public final class FlowControl implements AppendListener {
   private volatile long lastProcessedPosition = -1;
   private volatile long lastExportedPosition;
 
-  private final NavigableMap<Long, InFlightEntry> inFlight = new TreeMap<>();
+  private final NavigableMap<Long, InFlightEntry> inFlight = new ConcurrentSkipListMap<>();
 
   public FlowControl(final LogStreamMetrics metrics) {
     this(metrics, StabilizingAIMDLimit.newBuilder().build(), RateLimit.disabled());

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -161,13 +161,16 @@ public final class FlowControl implements AppendListener {
     return Either.right(new InFlightEntry(metrics, copiedMetadata, requestListener));
   }
 
-  public void onAppend(final InFlightEntry entry, final long highestPosition) {
+  public void registerEntry(final long highestPosition, final InFlightEntry entry) {
+    inFlight.put(highestPosition, entry);
+  }
+
+  public void onAppended(final InFlightEntry entry) {
     entry.onAppend();
     metrics.increaseInflightAppends();
     final var clearable = inFlight.headMap(lastProcessedPosition, true);
     clearable.forEach((position, inFlightEntry) -> inFlightEntry.cleanup());
     clearable.clear();
-    inFlight.put(highestPosition, entry);
   }
 
   @Override

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -40,10 +40,13 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * Access patterns:
  *
  * <ol>
- *   <li>Calls to {@link #tryAcquire(WriteContext, List)} from the sequencer, serialized through the
- *       sequencers write lock.
- *   <li>Calls to {@link #onAppend(InFlightEntry, long)} from the sequencer, serialized through the
- *       sequencers write lock.
+ *   <li>Calls to {@link #tryAcquire(WriteContext, List)} from the sequencer, outside the
+ *       sequencer's write lock. Multiple calls can overlap concurrently.
+ *   <li>Calls to {@link #registerEntry(long, InFlightEntry)} from the sequencer, under the
+ *       sequencer's write lock. Only one call at a time.
+ *   <li>Calls to {@link #onAppended(InFlightEntry)} from the sequencer, outside the sequencer's
+ *       write lock. Multiple calls can overlap concurrently and may also overlap with {@link
+ *       #onWrite(long, long)} and {@link #onCommit(long, long)} callbacks.
  *   <li>Calls to {@link #onWrite(long, long)} from the log storage, serialized through the single
  *       raft thread.
  *   <li>Calls to {@link #onCommit(long, long)} from the log storage, serialized through the single
@@ -52,23 +55,21 @@ import java.util.concurrent.ConcurrentSkipListMap;
  *       stream processor actor.
  * </ol>
  *
- * The order in which these methods are called is weakly constrained:
+ * The entry is registered in the {@link #inFlight} map via {@link #registerEntry(long,
+ * InFlightEntry)} inside the sequencer lock, before {@code logStorage.append} is called. This
+ * guarantees that the entry is present in the map when {@link #onWrite(long, long)} and {@link
+ * #onCommit(long, long)} callbacks fire.
  *
- * <ul>
- *   <li>{@link #tryAcquire(WriteContext, List)} and {@link #onAppend(InFlightEntry, long)} are
- *       always called in that order and before any other methods.
- *   <li>{@link #onWrite(long, long)} and {@link #onCommit(long, long)} and {@link
- *       #onProcessed(long)} can be called in any order.
- * </ul>
+ * <p>{@link #onWrite(long, long)} and {@link #onCommit(long, long)} and {@link #onProcessed(long)}
+ * can be called in any order.
  *
- * The weak ordering forces us to program quite defensively and carefully choose where and how we
- * modify internal state.
- *
- * <p>The {@link #inFlight} map is only modified in the {@link #onAppend(InFlightEntry, long)}
- * method. All other methods only read from it.
+ * <p>The {@link #inFlight} map is a {@link ConcurrentSkipListMap}. It is modified by {@link
+ * #registerEntry(long, InFlightEntry)} (under the sequencer lock) and read from other methods.
+ * Because readers ({@code onWrite}, {@code onCommit}, {@code onProcessed}) run on different
+ * threads, the concurrent map provides the necessary visibility guarantees.
  *
  * <p>A volatile field {@link #lastProcessedPosition} is only modified in {@link #onProcessed(long)}
- * and used in {@link #onAppend(InFlightEntry, long)} to clean up old entries.
+ * and used in {@link #onAppended(InFlightEntry)} to clean up old entries.
  *
  * <p>The RateMeasurement#observe method only returns true when a new observation value is
  * available. This way we prevent updating the metrics too often with repeated values. We use the

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -107,21 +107,23 @@ final class Sequencer implements LogStreamWriter, Closeable {
     final int batchLength = calculateBatchLength(appendEntries);
 
     lock.lock();
+    final long highestPosition;
     try {
       final var currentPosition = position;
-      final var highestPosition = currentPosition + batchSize - 1;
+      highestPosition = currentPosition + batchSize - 1;
       final var sequencedBatch =
           new SequencedBatch(
               clock.millis(), currentPosition, sourcePosition, appendEntries, batchLength);
-      flowControl.onAppend(inFlightEntry, highestPosition);
+      flowControl.registerEntry(highestPosition, inFlightEntry);
       logStorage.append(currentPosition, highestPosition, sequencedBatch, flowControl);
       position = currentPosition + batchSize;
-      return Either.right(highestPosition);
     } finally {
       lock.unlock();
       sequencerMetrics.observeBatchLengthBytes(batchLength);
       sequencerMetrics.observeBatchSize(batchSize);
     }
+    flowControl.onAppended(inFlightEntry);
+    return Either.right(highestPosition);
   }
 
   /**


### PR DESCRIPTION
## Description
The sequencer lock should be held the minimum time possible. However, I think that lock was also used for modifying FlowControl from one thread. 
- [X] Make `FlowControl` access thread safe: `ConcurrentSkipList` is used instead of `TreeMap`.

Note that this might have been required even before the fix as:
- onCommit: performs a `get` from raft thread
- onAppend: modifies the map (under the Sequencer lock before this change)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
