### PR TITLE
fix: list "required" response fields in global task listeners API

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -257,7 +257,13 @@ components:
     GlobalTaskListenerResult:
       type: object
       required:
+        - id
+        - type
+        - retries
         - eventTypes
+        - afterNonGlobal
+        - priority
+        - source
       allOf:
         - $ref: '#/components/schemas/GlobalTaskListenerBase'
       properties:


### PR DESCRIPTION
All response fields must be either in the `required` array or explicitly marked `nullable: true`. This specification is the single source of truth that drives QA test generation, SDK generation, and API compatibility verification.

For global task listeners, all fields in the response should be set (possibly with a default value).


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #47302
