### PR TITLE
ci: fix preview env smoke test version literal

### DIFF
--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -88,13 +88,13 @@ jobs:
       fail-fast: false
       matrix:
         deployment:
-        - version: 8.8
+        - version: '8.8'
           host: ${{ needs.deploy-8-8.outputs.host-name }}
           run: ${{ needs.deploy-8-8.result == 'success' }}
-        - version: 8.9
+        - version: '8.9'
           host: ${{ needs.deploy-8-9.outputs.host-name }}
           run: ${{ needs.deploy-8-9.result == 'success' }}
-        - version: 8.10
+        - version: '8.10'
           host: ${{ needs.deploy-8-10.outputs.host-name }}
           run: ${{ needs.deploy-8-10.result == 'success' }}
         exclude:


### PR DESCRIPTION
## Description

Problem: https://github.com/camunda/camunda/actions/runs/22564020839

Follow-up to https://github.com/camunda/camunda/pull/46532 which introduced a literal `8.10` value in GHA yaml that gets converted to `8.1` - protect it by using `'8.10'`. The relevant test suite [does not exist yet](https://github.com/camunda/c8-cross-component-e2e-tests/pull/1716) so I'll ping the team, but this fix is needed anyways: https://github.com/camunda/c8-cross-component-e2e-tests/tree/main/tests/SM-8.10

Demo: https://github.com/camunda/camunda/actions/runs/22569040822

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not needed as this is a scheduled job on main

## Related issues

Related https://github.com/camunda/camunda/issues/46249
