### PR TITLE
[Backport stable/optimize-8.6] fix: upgrade test containers to `1.21.4`

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -352,7 +352,7 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-test-container</artifactId>
-      <version>3.6.5</version>
+      <version>3.6.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -316,6 +316,13 @@
         <version>${jakarta.rs-api.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>1.21.4</version>
+        <scope>test</scope>
+      </dependency>
+
       <!-- Override Spring Boot's logback version to address CVEs -->
       <dependency>
         <groupId>ch.qos.logback</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -94,7 +94,7 @@
     <version.asm>9.3</version.asm>
     <version.testcontainers>1.20.1</version.testcontainers>
     <version.netflix.concurrency>0.5.2</version.netflix.concurrency>
-    <version.zeebe-test-container>3.6.5</version.zeebe-test-container>
+    <version.zeebe-test-container>3.6.9</version.zeebe-test-container>
     <version.feel-scala>1.18.0</version.feel-scala>
     <version.dmn-scala>1.10.0</version.dmn-scala>
     <version.rest-assured>5.5.0</version.rest-assured>


### PR DESCRIPTION
# Description
Backport of #46247 to `stable/optimize-8.6`.

relates to 
original author: @konstantinos-mylosis