### PR TITLE
[Backport stable/8.8] ci: add flaky test retries to compatibility workflows

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -30,6 +30,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  FLAKY_TEST_RERUN_COUNT: '3'
+
 jobs:
   prepare-versions:
     name: Prepare Version Matrix
@@ -351,6 +354,8 @@ jobs:
             -P compatibility-test
             -pl qa/acceptance-tests
             -Dcamunda.compatibility.test.version=${{ matrix.server }}
+            -Dfailsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+            -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
             -DfailIfNoTests=false
 
       - name: Record tested combination

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -29,6 +29,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  FLAKY_TEST_RERUN_COUNT: '3'
+
 jobs:
   prepare-versions:
     name: Prepare Version Matrix
@@ -494,6 +497,8 @@ jobs:
             -DskipUTs
             -Dio.camunda.process.test.camundaDockerImageVersion=${{ matrix.server }}
             -Dio.camunda.process.test.connectorsDockerImageVersion=${{ steps.connectors-version.outputs.version }}
+            -Dfailsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+            -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
             -DfailIfNoTests=false
             ${{ steps.api-version.outputs.extra-props }}
 

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -30,6 +30,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  FLAKY_TEST_RERUN_COUNT: '3'
+
 jobs:
   prepare-versions:
     name: Prepare Version Matrix
@@ -367,6 +370,8 @@ jobs:
             verify
             -pl qa/compatibility-test
             -Dio.camunda.process.test.camundaDockerImageVersion=${{ matrix.server }}
+            -Dfailsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+            -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
             -DfailIfNoTests=false
             ${{ steps.test-exclusions.outputs.excludes }}
 


### PR DESCRIPTION
# Description
Backport of #47322 to `stable/8.8`.

relates to 