### PR TITLE
feat: add support for using official Camunda Docker images in load test

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -33,6 +33,11 @@ on:
         type: string
         default: ""
         required: false
+      use-official-docker-images:
+        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
+        type: boolean
+        required: false
+        default: false
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
@@ -77,6 +82,11 @@ on:
         type: string
         default: ""
         required: false
+      use-official-docker-images:
+        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
+        type: boolean
+        required: false
+        default: false
       platform-helm-values:
         description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'
         type: string
@@ -269,8 +279,11 @@ jobs:
           file: operate.Dockerfile
 
   build-load-test-images:
+    # Build load test images when:
+    # 1. No reuse-tag is provided (building from scratch), OR
+    # 2. Using official docker images (since there are no official starter/worker images, we must build them)
     name: Build Starter and Worker
-    if: ${{ inputs.reuse-tag == '' }}
+    if: ${{ inputs.reuse-tag == '' || inputs.use-official-docker-images == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: calculate-image-tag
@@ -381,9 +394,11 @@ jobs:
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set global.image.pullSecrets[0].name=harbor-registry
-          --set zeebe.image.repository=${{ env.IMAGE_REPOSITORY }}/zeebe
+          --set zeebe.image.repository=${{ inputs.use-official-docker-images && 'camunda/zeebe' || 'team-zeebe/zeebe' }}
+          --set zeebe.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}
           --set zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set zeebeGateway.image.repository=${{ env.IMAGE_REPOSITORY }}/zeebe
+          --set zeebeGateway.image.repository=${{ inputs.use-official-docker-images && 'camunda/zeebe' || 'team-zeebe/zeebe' }}
+          --set zeebeGateway.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}
           --set zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}


### PR DESCRIPTION

## Description
- This is a backporting PR for stable 8.7 and 8.6. too

This pull request introduces support for using official Camunda Docker images from Docker Hub in the load test workflow, providing more flexibility for deployments. The changes add a new input to the workflow, update image selection logic, and ensure compatibility with official images in both the workflow and Helm chart configuration.

**Workflow and deployment flexibility:**

* Added a new boolean input `use-official-docker-images` to `.github/workflows/camunda-load-test.yml`, allowing users to choose between official Camunda Docker images from Docker Hub or building images from source. [[1]](diffhunk://#diff-38f8fadb6cc10a82a3db16c869fcf3011395c384211d2658d0557ce2258fb4d0R36-R40) [[2]](diffhunk://#diff-38f8fadb6cc10a82a3db16c869fcf3011395c384211d2658d0557ce2258fb4d0R85-R89)
* Updated the condition for the `build-load-test-images` job to also trigger when using official images, ensuring starter/worker images are built as needed.

**Results of Load Testing**:
- https://github.com/camunda/camunda/actions/runs/22570980134
- https://github.com/camunda/camunda/actions/runs/22571022996


closes #41842 
