### PR TITLE
refactor: add nullable/required to document API responses

### DIFF
--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/response/DocumentMetadataImpl.java
@@ -29,10 +29,10 @@ import java.util.Map;
 @Deprecated
 public class DocumentMetadataImpl implements DocumentMetadata {
 
-  private final io.camunda.zeebe.client.protocol.rest.DocumentMetadata response;
+  private final io.camunda.zeebe.client.protocol.rest.DocumentMetadataResponse response;
 
   public DocumentMetadataImpl(
-      final io.camunda.zeebe.client.protocol.rest.DocumentMetadata response) {
+      final io.camunda.zeebe.client.protocol.rest.DocumentMetadataResponse response) {
     this.response = response;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
@@ -22,9 +22,10 @@ import java.util.Map;
 
 public class DocumentMetadataImpl implements DocumentMetadata {
 
-  private final io.camunda.client.protocol.rest.DocumentMetadata response;
+  private final io.camunda.client.protocol.rest.DocumentMetadataResponse response;
 
-  public DocumentMetadataImpl(final io.camunda.client.protocol.rest.DocumentMetadata response) {
+  public DocumentMetadataImpl(
+      final io.camunda.client.protocol.rest.DocumentMetadataResponse response) {
     this.response = response;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/document/DocumentReferenceResponseImplSerializationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/document/DocumentReferenceResponseImplSerializationTest.java
@@ -22,7 +22,7 @@ import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.command.StreamUtil;
 import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
-import io.camunda.client.protocol.rest.DocumentMetadata;
+import io.camunda.client.protocol.rest.DocumentMetadataResponse;
 import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
 import java.io.IOException;
@@ -54,7 +54,7 @@ public class DocumentReferenceResponseImplSerializationTest {
             .contentHash("content-hash")
             .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
             .metadata(
-                new DocumentMetadata()
+                new DocumentMetadataResponse()
                     .contentType("content-type")
                     .expiresAt("2025-06-28T07:32:28.93912+02:00")
                     .fileName("file-name"));

--- a/clients/java/src/test/java/io/camunda/client/document/DocumentReferenceResponseImplSerializationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/document/DocumentReferenceResponseImplSerializationTest.java
@@ -27,7 +27,6 @@ import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 public class DocumentReferenceResponseImplSerializationTest {
@@ -58,7 +57,6 @@ public class DocumentReferenceResponseImplSerializationTest {
                 new DocumentMetadataResponse()
                     .contentType("content-type")
                     .expiresAt("2025-06-28T07:32:28.93912+02:00")
-                    .customProperties(Collections.emptyMap())
                     .fileName("file-name"));
     final DocumentReferenceResponse response = new DocumentReferenceResponseImpl(documentReference);
     final String json = jsonMapper.toJson(response);

--- a/clients/java/src/test/java/io/camunda/client/document/DocumentReferenceResponseImplSerializationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/document/DocumentReferenceResponseImplSerializationTest.java
@@ -27,6 +27,7 @@ import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 public class DocumentReferenceResponseImplSerializationTest {
@@ -57,6 +58,7 @@ public class DocumentReferenceResponseImplSerializationTest {
                 new DocumentMetadataResponse()
                     .contentType("content-type")
                     .expiresAt("2025-06-28T07:32:28.93912+02:00")
+                    .customProperties(Collections.emptyMap())
                     .fileName("file-name"));
     final DocumentReferenceResponse response = new DocumentReferenceResponseImpl(documentReference);
     final String json = jsonMapper.toJson(response);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -36,7 +36,7 @@ import io.camunda.gateway.protocol.model.DeploymentResourceResult;
 import io.camunda.gateway.protocol.model.DeploymentResult;
 import io.camunda.gateway.protocol.model.DocumentCreationBatchResponse;
 import io.camunda.gateway.protocol.model.DocumentCreationFailureDetail;
-import io.camunda.gateway.protocol.model.DocumentMetadata;
+import io.camunda.gateway.protocol.model.DocumentMetadataResponse;
 import io.camunda.gateway.protocol.model.DocumentReference;
 import io.camunda.gateway.protocol.model.DocumentReference.CamundaDocumentTypeEnum;
 import io.camunda.gateway.protocol.model.EvaluateConditionalResult;
@@ -313,7 +313,7 @@ public final class ResponseMapper {
   public static DocumentReference toDocumentReference(final DocumentReferenceResponse response) {
     final var internalMetadata = response.metadata();
     final var externalMetadata =
-        new DocumentMetadata()
+        new DocumentMetadataResponse()
             .expiresAt(
                 Optional.ofNullable(internalMetadata.expiresAt())
                     .map(Object::toString)

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -375,6 +375,7 @@ components:
           nullable: true
 
     DocumentMetadataResponse:
+      description: Information about the document that is returned in responses.
       type: object
       allOf:
         - $ref: '#/components/schemas/DocumentMetadata'

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -397,6 +397,7 @@ components:
           type: string
           format: date-time
           description: The date and time when the document expires.
+          nullable: true
         size:
           type: integer
           format: int64
@@ -405,14 +406,17 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition that created the document.
+          nullable: true
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance that created the document.
+          nullable: true
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
+          nullable: true
 
     DocumentLinkRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -280,6 +280,7 @@ components:
         - camunda.document.type
         - storeId
         - documentId
+        - contentHash
         - metadata
       properties:
         camunda.document.type:

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -299,7 +299,7 @@ components:
           description: The hash of the document.
           nullable: true
         metadata:
-          $ref: '#/components/schemas/DocumentMetadata'
+          $ref: '#/components/schemas/DocumentMetadataResponse'
 
     DocumentCreationFailureDetail:
       type: object
@@ -337,37 +337,52 @@ components:
                 $ref: '#/components/schemas/DocumentReference'
 
     DocumentMetadata:
-      required:
-        - customProperties
       description: Information about the document.
       type: object
       properties:
         contentType:
           type: string
           description: The content type of the document.
+          nullable: true
         fileName:
           type: string
           description: The name of the file.
+          nullable: true
         expiresAt:
           type: string
           format: date-time
           description: The date and time when the document expires.
+          nullable: true
         size:
           type: integer
           format: int64
           description: The size of the document in bytes.
+          nullable: true
         processDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition that created the document.
+          nullable: true
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance that created the document.
+          nullable: true
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
+          nullable: true
+
+    DocumentMetadataResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/DocumentMetadata'
+      required:
+        - fileName
+        - size
+        - contentType
+        - customProperties
 
     DocumentLinkRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -383,6 +383,14 @@ components:
         - size
         - contentType
         - customProperties
+      properties:
+        # Override the nullability of customProperties to prevent issues with code generation
+        # (arrays are always guaranteed to be present in responses)
+        customProperties:
+          type: object
+          description: Custom properties of the document.
+          additionalProperties: true
+          nullable: false
 
     DocumentLinkRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -409,7 +409,6 @@ components:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
-          nullable: true
 
     DocumentLinkRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -344,36 +344,29 @@ components:
         contentType:
           type: string
           description: The content type of the document.
-          nullable: true
         fileName:
           type: string
           description: The name of the file.
-          nullable: true
         expiresAt:
           type: string
           format: date-time
           description: The date and time when the document expires.
-          nullable: true
         size:
           type: integer
           format: int64
           description: The size of the document in bytes.
-          nullable: true
         processDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition that created the document.
-          nullable: true
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance that created the document.
-          nullable: true
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
-          nullable: true
 
     DocumentMetadataResponse:
       description: Information about the document that is returned in responses.

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -378,21 +378,41 @@ components:
     DocumentMetadataResponse:
       description: Information about the document that is returned in responses.
       type: object
-      allOf:
-        - $ref: '#/components/schemas/DocumentMetadata'
       required:
         - fileName
+        - expiresAt
         - size
         - contentType
         - customProperties
+        - processDefinitionId
+        - processInstanceKey
       properties:
-        # Override the nullability of customProperties to prevent issues with code generation
-        # (arrays are always guaranteed to be present in responses)
+        contentType:
+          type: string
+          description: The content type of the document.
+        fileName:
+          type: string
+          description: The name of the file.
+        expiresAt:
+          type: string
+          format: date-time
+          description: The date and time when the document expires.
+        size:
+          type: integer
+          format: int64
+          description: The size of the document in bytes.
+        processDefinitionId:
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
+          description: The ID of the process definition that created the document.
+        processInstanceKey:
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          description: The key of the process instance that created the document.
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
-          nullable: false
 
     DocumentLinkRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -276,6 +276,11 @@ components:
   schemas:
     DocumentReference:
       type: object
+      required:
+        - camunda.document.type
+        - storeId
+        - documentId
+        - metadata
       properties:
         camunda.document.type:
           type: string
@@ -292,6 +297,7 @@ components:
         contentHash:
           type: string
           description: The hash of the document.
+          nullable: true
         metadata:
           $ref: '#/components/schemas/DocumentMetadata'
 
@@ -331,7 +337,7 @@ components:
                 $ref: '#/components/schemas/DocumentReference'
 
     DocumentMetadata:
-      required: 
+      required:
         - customProperties
       description: Information about the document.
       type: object
@@ -374,6 +380,9 @@ components:
 
     DocumentLink:
       type: object
+      required:
+        - url
+        - expiresAt
       properties:
         url:
           type: string


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add `nullable`/`required` annotations to the response objects of the Document API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #47302
