### PR TITLE
[Backport stable/8.9] fix: list "required" response fields in global task listeners API

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -257,7 +257,13 @@ components:
     GlobalTaskListenerResult:
       type: object
       required:
+        - id
+        - type
+        - retries
         - eventTypes
+        - afterNonGlobal
+        - priority
+        - source
       allOf:
         - $ref: '#/components/schemas/GlobalTaskListenerBase'
       properties:


### PR DESCRIPTION
# Description
Backport of #47321 to `stable/8.9`.

relates to 