### PR TITLE
[Backport stable/8.9] feat: add build-frontend flag to Camunda load test workflow

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -70,6 +70,7 @@ jobs:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
       ttl: 1
       scenario: max
+      build-frontend: true
 
   notify:
     name: Notify on failure

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -68,6 +68,11 @@ on:
         type: boolean
         required: false
         default: false
+      build-frontend:
+        description: 'Build the frontend as part of the load test image build'
+        type: boolean
+        required: false
+        default: true
       secondary-storage-type:
         description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch" or "postgresql"'
         type: choice
@@ -131,6 +136,11 @@ on:
         type: boolean
         required: false
         default: false
+      build-frontend:
+        description: 'Build the frontend as part of the load test image build'
+        type: boolean
+        required: false
+        default: true
       secondary-storage-type:
         description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch" or "postgresql"'
         # type choice is invalid here
@@ -244,18 +254,21 @@ jobs:
       - uses: ./.github/actions/build-frontend
         name: Build Operate Frontend
         id: build-operate-fe
+        if: ${{ inputs.build-frontend }}
         with:
           directory: ./operate/client
           package-manager: "npm"
       - uses: ./.github/actions/build-frontend
         name: Build Tasklist Frontend
         id: build-tasklist-fe
+        if: ${{ inputs.build-frontend }}
         with:
           directory: ./tasklist/client
           package-manager: "npm"
       - uses: ./.github/actions/build-frontend
         name: Build Identity Frontend
         id: build-identity-fe
+        if: ${{ inputs.build-frontend }}
         with:
           directory: ./identity/client
           package-manager: "npm"

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -72,7 +72,7 @@ on:
         description: 'Build the frontend as part of the load test image build'
         type: boolean
         required: false
-        default: true
+        default: false
       secondary-storage-type:
         description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch" or "postgresql"'
         type: choice
@@ -140,7 +140,7 @@ on:
         description: 'Build the frontend as part of the load test image build'
         type: boolean
         required: false
-        default: true
+        default: false
       secondary-storage-type:
         description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch" or "postgresql"'
         # type choice is invalid here

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -55,6 +55,7 @@ jobs:
       ttl: 28
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: typical
+      build-frontend: true
   setup-rdbms-typical-load-test:
     name: Postgres typical load test
     needs:
@@ -67,6 +68,7 @@ jobs:
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       secondary-storage-type: 'postgresql'
       scenario: typical
+      build-frontend: true
   setup-realistic-test:
     name: Realistic load test
     uses: ./.github/workflows/camunda-load-test.yml
@@ -78,6 +80,7 @@ jobs:
       ttl: 28
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: realistic
+      build-frontend: true
   setup-latency-test:
     name: Latency test
     uses: ./.github/workflows/camunda-load-test.yml
@@ -89,6 +92,7 @@ jobs:
       ttl: 28
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: latency
+      build-frontend: true
 
   notify:
     name: Notify on failure


### PR DESCRIPTION
# Description
Backport of #46644 to `stable/8.9`.

relates to 