### PR TITLE
fix: update image repository for official Docker support in load test

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -313,10 +313,10 @@ jobs:
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set global.image.pullSecrets[0].name=harbor-registry
           --set zeebe.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}
-          --set zeebe.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/zeebe' }}
+          --set zeebe.image.repository=${{ inputs.use-official-docker-images && 'camunda/zeebe' || 'team-zeebe/zeebe' }}
           --set zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set zeebeGateway.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}
-          --set zeebeGateway.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/zeebe' }}
+          --set zeebeGateway.image.repository=${{ inputs.use-official-docker-images && 'camunda/zeebe' || 'team-zeebe/zeebe' }}
           --set zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}


### PR DESCRIPTION

## Description
- This PR updates the repository image from '`camunda/camunda`' to '`camunda/zeebe'`, (to provide official Docker image support in load testing)
- This is primarily done because in version 8.7 and before, the repository used to push the artefact was camunda/zeebe.

closes #41842 
