### PR TITLE
Feat/rdbms field length 256

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/h2.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/h2.properties
@@ -9,7 +9,7 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 count.limit=LIMIT #{page.maxTotalHits}
-userCharColumn.size=400
+userCharColumn.size=256
 variableValue.previewSize=8191
 errorMessage.size=4000
 treePath.size=8191

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/mariadb.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/mariadb.properties
@@ -9,7 +9,7 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 count.limit=LIMIT #{page.maxTotalHits}
-userCharColumn.size=400
+userCharColumn.size=256
 variableValue.previewSize=8191
 errorMessage.size=4000
 treePath.size=8191

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/mssql.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/mssql.properties
@@ -9,7 +9,7 @@
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=OFFSET 0 ROWS FETCH NEXT #{page.size} ROWS ONLY
 count.limit=ORDER BY col OFFSET 0 ROWS FETCH NEXT #{page.maxTotalHits} ROWS ONLY
-userCharColumn.size=400
+userCharColumn.size=256
 variableValue.previewSize=8191
 errorMessage.size=4000
 treePath.size=8191

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/mysql.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/mysql.properties
@@ -9,7 +9,7 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 count.limit=LIMIT #{page.maxTotalHits}
-userCharColumn.size=400
+userCharColumn.size=256
 variableValue.previewSize=8191
 treePath.size=8191
 errorMessage.size=4000

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/oracle.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/oracle.properties
@@ -9,7 +9,9 @@
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=FETCH NEXT #{page.size} ROWS ONLY
 count.limit=FETCH NEXT #{page.maxTotalHits} ROWS ONLY
-# the character limit here is 256, but Oracle uses bytes here, so we set 512 to be safe, as the default character encoding, Java validates against is UTF16, which can use up to 2 bytes per character
+# Oracle enforces this limit in bytes rather than characters. We want to allow ~256 characters,
+# so we configure a 512-byte limit here to be safe under common multi-byte Oracle database
+# character sets (for example AL32UTF8), where a character can require up to 2 bytes.
 userCharColumn.size=512
 charColumn.maxBytes=4000
 variableValue.previewSize=4000

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/oracle.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/oracle.properties
@@ -9,7 +9,8 @@
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=FETCH NEXT #{page.size} ROWS ONLY
 count.limit=FETCH NEXT #{page.maxTotalHits} ROWS ONLY
-userCharColumn.size=400
+# the character limit here is 256, but Oracle uses bytes here, so we set 512 to be safe, as the default character encoding, Java validates against is UTF16, which can use up to 2 bytes per character
+userCharColumn.size=512
 charColumn.maxBytes=4000
 variableValue.previewSize=4000
 errorMessage.size=4000

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/postgresql.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/postgresql.properties
@@ -9,7 +9,7 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 count.limit=LIMIT #{page.maxTotalHits}
-userCharColumn.size=400
+userCharColumn.size=256
 variableValue.previewSize=8191
 errorMessage.size=4000
 treePath.size=8191

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -36,7 +36,7 @@ public record RdbmsWriterConfig(
   public static final int DEFAULT_QUEUE_SIZE = 1000;
   // Default memory limit: 20MB - aligned with CamundaExporter's default
   public static final int DEFAULT_QUEUE_MEMORY_LIMIT = 20;
-  public static final int DEFAULT_MAX_VARCHAR_FIELD_LENGTH = 400;
+  public static final int DEFAULT_MAX_VARCHAR_FIELD_LENGTH = 256;
   public static final int DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE = 10000;
   public static final boolean DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION = true;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionCreateIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.client;
 
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
@@ -24,11 +25,10 @@ public class ProcessDefinitionCreateIT {
 
   @Test
   @EnabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
-  void shouldRejectProcessDefinitionOnRdbmsWhenIdIsTooLong() {
+  void shouldRejectProcessDefinitionOnRdbmsWhenNameIsTooLong() {
     final var processDefinition =
-        Bpmn.createExecutableProcess(
-                "p".repeat(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH + 1))
-            .name("my process")
+        Bpmn.createExecutableProcess("processId")
+            .name("p".repeat(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH + 1))
             .startEvent()
             .endEvent()
             .done();
@@ -42,7 +42,66 @@ public class ProcessDefinitionCreateIT {
             })
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining(
-            "ERROR: IDs must not be longer than the configured max-id-length of %d characters"
+            "ERROR: Names must not be longer than the configured max-name-length of %d characters"
                 .formatted(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH));
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void shouldRejectProcessDefinitionOnRdbmsWhenNameIsTooLongUtf8() {
+    final var processDefinition =
+        Bpmn.createExecutableProcess("processId")
+            .name("ü".repeat(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH + 1))
+            .startEvent()
+            .endEvent()
+            .done();
+
+    assertThatThrownBy(
+            () -> {
+              camundaClient
+                  .newDeployResourceCommand()
+                  .addProcessModel(processDefinition, "process.bpmn")
+                  .execute();
+            })
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining(
+            "ERROR: Names must not be longer than the configured max-name-length of %d characters"
+                .formatted(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH));
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void shouldDeployProcessDefinitionOnRdbmsWhenNameIsExactlyWithinSizeLimit() {
+    final var processDefinition =
+        Bpmn.createExecutableProcess("processId")
+            .name("p".repeat(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH))
+            .startEvent()
+            .endEvent()
+            .done();
+
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(processDefinition, "process.bpmn")
+        .execute();
+
+    waitForProcessesToBeDeployed(camundaClient, 1);
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void shouldDeployProcessDefinitionOnRdbmsWhenNameIsExactlyWithinSizeLimitUtf8() {
+    final var processDefinition =
+        Bpmn.createExecutableProcess("processId")
+            .name("ü".repeat(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH))
+            .startEvent()
+            .endEvent()
+            .done();
+
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(processDefinition, "process.bpmn")
+        .execute();
+
+    waitForProcessesToBeDeployed(camundaClient, 1);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
@@ -18,14 +18,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceStatisticsDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceVersionStatisticsDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.ProcessDefinitionFilter;
@@ -109,13 +110,12 @@ public class ProcessDefinitionIT {
   public void shouldStoreLongProcessDefinitionId(
       final CamundaRdbmsTestApplication testApplication) {
     final var rdbmsService = testApplication.getRdbmsService();
-    final var vendorDatabaseProperties = testApplication.bean(VendorDatabaseProperties.class);
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final var processDefinitionReader = rdbmsService.getProcessDefinitionReader();
 
     final var processDefinitionId =
         RandomStringUtils.insecure()
-            .nextAlphanumeric(vendorDatabaseProperties.userCharColumnSize());
+            .nextAlphanumeric(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
 
     final var processDefinition =
         ProcessDefinitionFixtures.createRandomized(b -> b.processDefinitionId(processDefinitionId));
@@ -135,6 +135,30 @@ public class ProcessDefinitionIT {
     assertThat(searchResult.items()).hasSize(1);
     assertThat(searchResult.items().getFirst().processDefinitionKey())
         .isEqualTo(processDefinition.processDefinitionKey());
+  }
+
+  @TestTemplate
+  public void shouldStoreLongUTF8ProcessDefinitionName(
+      final CamundaRdbmsTestApplication testApplication) {
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final var processDefinitionReader = rdbmsService.getProcessDefinitionReader();
+
+    final var name = "ü".repeat(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
+
+    final var processDefinition = ProcessDefinitionFixtures.createRandomized(b -> b.name(name));
+    createAndSaveProcessDefinition(rdbmsWriter, processDefinition);
+
+    final var searchResult =
+        processDefinitionReader.search(
+            new ProcessDefinitionQuery(
+                new ProcessDefinitionFilter.Builder().names(name).build(),
+                ProcessDefinitionSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().stream().map(ProcessDefinitionEntity::name))
+        .containsExactly(name);
   }
 
   @TestTemplate


### PR DESCRIPTION
This pull request reduces the maximum allowed length for user-defined character columns and process definition names/IDs from 400 to 256 characters across all supported RDBMS vendors (with Oracle set to 512 bytes for safety). It updates configuration files and code constants accordingly, and improves test coverage to ensure correct enforcement of these limits, including with UTF-8 characters.

**Configuration and Limits Update:**

* Reduced `userCharColumn.size` from 400 to 256 in vendor properties files for H2, MariaDB, MSSQL, MySQL, and PostgreSQL to enforce a lower maximum character length for user-defined columns. [[1]](diffhunk://#diff-2f2a2611251558fbabbb58c33e0811c140d1d2785470a17829c71e7b9c1393cfL12-R12) [[2]](diffhunk://#diff-f322a85d9f37f8da4f58777f3501822afcc47eee65e01d8e66a158aee3d6fb97L12-R12) [[3]](diffhunk://#diff-b48c23ebfdd3096240c902fb02f754b31b900c1f2bef7a5e714a07908819bb5cL12-R12) [[4]](diffhunk://#diff-926b403e05a21bd142b0d9ff8ba16457a181c9a554d3afd96bfcde9e363d9452L12-R12) [[5]](diffhunk://#diff-e6e2f0e8101ed9312d4f3632346958a56975369141d0bf64f0dcf0a158ca9746L12-R12)
* Updated Oracle's `userCharColumn.size` to 512 bytes (from 400), with a comment explaining the rationale due to UTF-16 encoding and byte-per-character differences.
* Changed the default maximum varchar field length constant in `RdbmsWriterConfig.java` from 400 to 256 to match new limits.

**Test Coverage Improvements:**

* Modified the process definition creation test to check name length (instead of ID length), and added new tests to verify rejection of names exceeding the limit, including with UTF-8 characters, and successful deployment when names are exactly at the limit. [[1]](diffhunk://#diff-ea994acbd88aa349e80a53cef5e2fc482d7e827ff3b90eeca50a662eb3f5ea9dR10-R32) [[2]](diffhunk://#diff-ea994acbd88aa349e80a53cef5e2fc482d7e827ff3b90eeca50a662eb3f5ea9dL45-R107)
* Added a new integration test to verify that a process definition with a long UTF-8 name (256 characters) is correctly stored and retrievable.

These changes ensure consistent enforcement of character limits for user-defined fields and process definitions across all supported databases.## Description

## Related issues

closes #47355 
