### PR TITLE
[Backport stable/8.8]perf: when auth & multi tenants are disabled, authorization should not slow down processors

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -161,6 +161,9 @@ public class BpmnJobActivationBehavior {
 
   private boolean isAuthorized(
       final JobActivationProperties jobActivationProperties, final JobRecord jobRecord) {
+    if (authorizationCheckBehavior.shouldSkipAllChecks()) {
+      return true;
+    }
 
     final var ownerTenantId = jobRecord.getTenantId();
     final var tenantIds = jobActivationProperties.tenantIds().stream().toList();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -161,9 +161,6 @@ public class BpmnJobActivationBehavior {
 
   private boolean isAuthorized(
       final JobActivationProperties jobActivationProperties, final JobRecord jobRecord) {
-    if (authorizationCheckBehavior.shouldSkipAllChecks()) {
-      return true;
-    }
 
     final var ownerTenantId = jobRecord.getTenantId();
     final var tenantIds = jobActivationProperties.tenantIds().stream().toList();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -401,9 +401,6 @@ public final class AuthorizationCheckBehavior {
    * @return true if assigned or multi-tenancy is disabled, false otherwise
    */
   public boolean isAssignedToTenant(final TypedRecord<?> command, final String tenantId) {
-    if (!multiTenancyEnabled) {
-      return true;
-    }
     return tenantResolver.isAssignedToTenant(
         AuthorizationRequest.builder().command(command).tenantId(tenantId).build());
   }
@@ -417,10 +414,6 @@ public final class AuthorizationCheckBehavior {
    *     authorized to access
    */
   public AuthorizedTenants getAuthorizedTenantIds(final TypedRecord<?> command) {
-    if (shouldSkipAllChecks()) {
-      return AuthorizedTenants.DEFAULT_TENANTS;
-    }
-
     return tenantResolver.getAuthorizedTenants(command.getAuthorizations());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -129,7 +129,7 @@ public final class AuthorizationCheckBehavior {
       return Either.right(null);
     }
 
-    return isAuthorized(requests);
+    return isAuthorized(request);
   }
 
   private Either<Rejection, Void> checkAuthorized(final AuthorizationRequest request) {
@@ -156,14 +156,18 @@ public final class AuthorizationCheckBehavior {
     return getRejection(aggregatedRejections);
   }
 
-  // Helper methods
-  private boolean shouldSkipAllChecks() {
+  /**
+   * Returns {@code true} when both authorization and multi-tenancy are disabled, meaning no
+   * authorization or tenant check will ever reject a request. Callers can use this to avoid
+   * constructing an {@link AuthorizationRequest} (and the associated allocations) when the result
+   * would always be authorized.
+   */
+  public boolean shouldSkipAllChecks() {
     return !authorizationsEnabled && !multiTenancyEnabled;
   }
 
   private boolean shouldSkipAuthorization(final AuthorizationRequest request) {
-    return (!authorizationsEnabled && !multiTenancyEnabled)
-        || claimsExtractor.isAuthorizedAnonymousUser(request.claims());
+    return shouldSkipAllChecks() || claimsExtractor.isAuthorizedAnonymousUser(request.claims());
   }
 
   private AuthorizationResult checkPrimaryAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -52,6 +52,7 @@ public final class AuthorizationCheckBehavior {
       "Expected to %s with key '%s', but no %s was found";
   public static final String NOT_FOUND_FOR_TENANT_ERROR_MESSAGE =
       "Expected to perform operation '%s' on resource '%s', but no resource was found for tenant '%s'";
+  private static final Either<Rejection, Void> AUTHORIZED = Either.right(null);
   private final MappingRuleState mappingRuleState;
   private final ClaimsExtractor claimsExtractor;
   private final TenantResolver tenantResolver;
@@ -110,6 +111,9 @@ public final class AuthorizationCheckBehavior {
    *     {@link Void} if the user is authorized
    */
   public Either<Rejection, Void> isAuthorized(final AuthorizationRequest request) {
+    if (shouldSkipAllChecks()) {
+      return AUTHORIZED;
+    }
     try {
       return authorizationsCache.get(request);
     } catch (final ExecutionException e) {
@@ -124,11 +128,11 @@ public final class AuthorizationCheckBehavior {
     if (request.isTriggeredByInternalCommand()) {
       return Either.right(null);
     }
-    return isAuthorized(request);
+
+    return isAuthorized(requests);
   }
 
   private Either<Rejection, Void> checkAuthorized(final AuthorizationRequest request) {
-
     if (shouldSkipAuthorization(request)) {
       return Either.right(null);
     }
@@ -139,20 +143,24 @@ public final class AuthorizationCheckBehavior {
         checkPrimaryAuthorization(request, aggregatedRejections);
 
     if (primaryResult.hasBothAccess()) {
-      return Either.right(null);
+      return AUTHORIZED;
     }
 
     final AuthorizationResult mappingRuleResult =
         checkMappingRuleAuthorization(request, primaryResult, aggregatedRejections);
 
     if (mappingRuleResult.hasBothAccess()) {
-      return Either.right(null);
+      return AUTHORIZED;
     }
 
     return getRejection(aggregatedRejections);
   }
 
   // Helper methods
+  private boolean shouldSkipAllChecks() {
+    return !authorizationsEnabled && !multiTenancyEnabled;
+  }
+
   private boolean shouldSkipAuthorization(final AuthorizationRequest request) {
     return (!authorizationsEnabled && !multiTenancyEnabled)
         || claimsExtractor.isAuthorizedAnonymousUser(request.claims());
@@ -389,6 +397,9 @@ public final class AuthorizationCheckBehavior {
    * @return true if assigned or multi-tenancy is disabled, false otherwise
    */
   public boolean isAssignedToTenant(final TypedRecord<?> command, final String tenantId) {
+    if (!multiTenancyEnabled) {
+      return true;
+    }
     return tenantResolver.isAssignedToTenant(
         AuthorizationRequest.builder().command(command).tenantId(tenantId).build());
   }
@@ -402,6 +413,10 @@ public final class AuthorizationCheckBehavior {
    *     authorized to access
    */
   public AuthorizedTenants getAuthorizedTenantIds(final TypedRecord<?> command) {
+    if (shouldSkipAllChecks()) {
+      return AuthorizedTenants.DEFAULT_TENANTS;
+    }
+
     return tenantResolver.getAuthorizedTenants(command.getAuthorizations());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -487,6 +487,9 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
 
   private Either<Rejection, JobRecord> checkAuthorization(
       final TypedRecord<JobRecord> command, final JobRecord job) {
+    if (authCheckBehavior.shouldSkipAllChecks()) {
+      return Either.right(job);
+    }
     final var request =
         AuthorizationRequest.builder()
             .command(command)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -63,6 +63,9 @@ public class JobUpdateBehaviour {
 
   public Either<Rejection, JobRecord> isAuthorized(
       final TypedRecord<JobRecord> command, final JobRecord job) {
+    if (authCheckBehavior.shouldSkipAllChecks()) {
+      return Either.right(job);
+    }
     final var authRequest =
         AuthorizationRequest.builder()
             .command(command)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -189,6 +189,9 @@ public final class MessageCorrelationCorrelateProcessor
       final TypedRecord<MessageCorrelationRecord> command,
       final Subscriptions correlatingSubscriptions,
       final String tenantId) {
+    if (authCheckBehavior.shouldSkipAllChecks()) {
+      return Optional.empty();
+    }
     final AtomicReference<AuthorizationRequest> request = new AtomicReference<>();
     final AtomicReference<Rejection> rejection = new AtomicReference<>();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -95,20 +95,22 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
 
   @Override
   public void processRecord(final TypedRecord<MessageRecord> command) {
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.MESSAGE)
-            .permissionType(PermissionType.CREATE)
-            .tenantId(command.getValue().getTenantId())
-            .newResource()
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
-    if (isAuthorized.isLeft()) {
-      final var rejection = isAuthorized.getLeft();
-      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
-      return;
+    if (!authCheckBehavior.shouldSkipAllChecks()) {
+      final var authRequest =
+          AuthorizationRequest.builder()
+              .command(command)
+              .resourceType(AuthorizationResourceType.MESSAGE)
+              .permissionType(PermissionType.CREATE)
+              .tenantId(command.getValue().getTenantId())
+              .newResource()
+              .build();
+      final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
+      if (isAuthorized.isLeft()) {
+        final var rejection = isAuthorized.getLeft();
+        rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+        responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+        return;
+      }
     }
 
     messageRecord = command.getValue();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -151,7 +151,7 @@ public class ProcessInstanceCreationHelper {
   public Either<Rejection, DeployedProcess> isAuthorized(
       final TypedRecord<ProcessInstanceCreationRecord> command,
       final DeployedProcess deployedProcess) {
-    // check if auth is disabled entirely
+    // skip authorization and multi-tenancy checks if all such checks are disabled
     if (authCheckBehavior.shouldSkipAllChecks()) {
       return Either.right(deployedProcess);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -151,6 +151,11 @@ public class ProcessInstanceCreationHelper {
   public Either<Rejection, DeployedProcess> isAuthorized(
       final TypedRecord<ProcessInstanceCreationRecord> command,
       final DeployedProcess deployedProcess) {
+    // check if auth is disabled entirely
+    if (authCheckBehavior.shouldSkipAllChecks()) {
+      return Either.right(deployedProcess);
+    }
+
     final var processId = bufferAsString(deployedProcess.getBpmnProcessId());
     final var request =
         AuthorizationRequest.builder()


### PR DESCRIPTION
# Description
Backport of #47241 to `stable/8.8`.

relates to #46874 #46873