### PR TITLE
fix: marshal backup store callbacks to actor thread to prevent RocksDB crash

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -185,14 +185,15 @@ final class BackupServiceImpl {
     LOG.atDebug().addKeyValue("backup", inProgressBackup.id()).setMessage("Saving backup").log();
     backupStore
         .save(backup)
-        .whenComplete(
+        .whenCompleteAsync(
             (ignore, error) -> {
               if (error == null) {
                 future.complete(null);
               } else {
                 future.completeExceptionally("Failed to save backup", error);
               }
-            });
+            },
+            concurrencyControl::run);
     return future;
   }
 
@@ -272,7 +273,7 @@ final class BackupServiceImpl {
         () ->
             backupStore
                 .list(pattern)
-                .whenComplete(
+                .whenCompleteAsync(
                     (backupStatuses, throwable) -> {
                       if (throwable != null) {
                         LOG.atError()
@@ -289,7 +290,8 @@ final class BackupServiceImpl {
                             .log();
                         future.complete(backupStatuses.stream().max(BackupStatusCode.BY_STATUS));
                       }
-                    }));
+                    },
+                    executor::run));
     return future;
   }
 
@@ -380,7 +382,7 @@ final class BackupServiceImpl {
                   error);
               return null;
             })
-        .whenComplete(result);
+        .whenCompleteAsync(result, executor::run);
     return result;
   }
 
@@ -469,14 +471,15 @@ final class BackupServiceImpl {
           try {
             metadataSyncer
                 .store(partitionId, checkpoints, ranges)
-                .whenComplete(
+                .whenCompleteAsync(
                     (ignore, error) -> {
                       if (error != null) {
                         future.completeExceptionally(error);
                       } else {
                         buildRangeStatuses(future, ranges);
                       }
-                    });
+                    },
+                    executor::run);
           } catch (final Exception e) {
             LOG.atError().setCause(e).log("Failed to sync backup metadata");
             future.completeExceptionally(e);


### PR DESCRIPTION
Fixes a race condition causing JVM crashes (SIGSEGV) in `BackupReplicatedPartitionTest`.

`BackupServiceImpl` used `.whenComplete()` for async backup store callbacks (S3 writes, listing, deletion), which caused them to run on the backup store I/O thread (e.g. the AWS SDK Netty event loop) instead of the actor thread. When such a callback completed after the partition had transitioned to INACTIVE and the underlying RocksDB instance was already closed, it accessed freed native memory via `rocksdb::TransactionBaseImpl::Reinitialize`, crashing the JVM.

The `syncMetadata` code path was the most critical: its `.whenComplete()` callback invoked `buildRangeStatuses()`, which reads from `DbCheckpointMetadataState` (a RocksDB-backed column family). The other three sites (`saveBackup`, `getBackupStatus`, `deleteBackupIfExists`) completed `ActorFuture` instances from non-actor threads, which is also a thread-safety violation.

All four `.whenComplete()` call sites are now changed to `.whenCompleteAsync()` with the actor executor, matching the safe pattern already used in `takeBackup()`. This ensures callbacks are either executed on the actor thread (respecting actor lifecycle) or discarded if the actor is already closed.