### PR TITLE
ci: add dependency cycle check to unified CI workflow

### DIFF
--- a/.github/actions/adjust-pom-for-license-analysis/README.md
+++ b/.github/actions/adjust-pom-for-license-analysis/README.md
@@ -1,0 +1,34 @@
+# adjust-pom-for-license-analysis
+
+Adjusts `pom.xml` files so that Maven analysis tools (FOSSA, depgraph, etc.) can correctly resolve
+the full module hierarchy from `bom/pom.xml` as the root.
+
+## Purpose
+
+The monorepo's Maven structure uses `bom/pom.xml` and `parent/pom.xml` as separate top-level
+modules. Analysis tools that expect a single root POM need these files adjusted so that:
+
+- `parent/pom.xml` includes the repo root (`./..`) as a module
+- `bom/pom.xml` includes `parent` (`"./../parent"`) as a module
+- The root `pom.xml` no longer lists `bom` and `parent` as modules (to avoid circular references)
+- `optimize/pom.xml` excludes the `qa` module (FOSSA workaround)
+
+## Inputs
+
+None.
+
+## Outputs
+
+None.
+
+## Example usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/adjust-pom-for-license-analysis
+```
+
+## Owner
+
+@camunda/monorepo-devops-team

--- a/.github/actions/adjust-pom-for-license-analysis/action.yml
+++ b/.github/actions/adjust-pom-for-license-analysis/action.yml
@@ -1,0 +1,30 @@
+---
+name: Adjust POM for license analysis
+description: |
+  Adjusts pom.xml files so that Maven analysis tools (FOSSA, depgraph, etc.)
+  can correctly resolve the full module hierarchy from bom/pom.xml as the root.
+
+# owner: @camunda/monorepo-devops-team
+
+runs:
+  using: composite
+  steps:
+    - name: Adjust pom.xml files for analysis
+      shell: bash
+      run: |
+        # The bom/pom.xml must be the actual root, otherwise, analysis tools won't detect the hierarchy correctly
+        yq -i \
+          '.project.modules.module += "./.."' \
+          parent/pom.xml
+        yq -i \
+          '.project.modules.module += "./../parent"' \
+          bom/pom.xml
+        # Remove bom and parent from the list of modules of ./pom.xml
+        yq -i \
+          'del(.project.modules.module[] | select(. == "bom" or . == "parent"))' \
+          pom.xml
+        # Remove optimize/qa module as a bug in FOSSA prevents scope filtering
+        # TODO remove this workaround once FOSSA is fixed
+        yq -i \
+          'del(.project.modules.module[] | select(. == "qa"))' \
+          optimize/pom.xml

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -94,23 +94,7 @@ jobs:
 
     - name: Adjust pom.xml files for FOSSA
       if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
-      run: |
-        # The bom/pom.xml must be the actual root, otherwise, FOSSA won't detect the hierarchy correctly
-        yq -i \
-          '.project.modules.module += "./.."' \
-          parent/pom.xml
-        yq -i \
-          '.project.modules.module += "./../parent"' \
-          bom/pom.xml
-        # Remove bom and parent from the list of modules of ./pom.xml
-        yq -i \
-          'del(.project.modules.module[] | select(. == "bom" or . == "parent"))' \
-          pom.xml
-        # Remove optimize/qa module as a bug in FOSSA prevents scope filtering
-        # TODO remove this workaround once FOSSA is fixed
-        yq -i \
-          'del(.project.modules.module[] | select(. == "qa"))' \
-          optimize/pom.xml
+      uses: ./.github/actions/adjust-pom-for-license-analysis
 
     - name: Analyze project
       uses: camunda/infra-global-github-actions/fossa/analyze@ddce99387a10a4d578e4d7d8e6c6626dcd3d8fd3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,8 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/adjust-pom-for-license-analysis
       - name: Check for dependency cycles
+        # Command here is the same used by fossa analyze
+        # and found by enabling the `-debug` flag
         run: |
           ./mvnw com.github.ferstl:depgraph-maven-plugin:4.0.1:aggregate \
             -DgraphFormat=text \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,22 @@ jobs:
     runs-on: gcp-core-16-default
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
+    strategy:
+      fail-fast: false
+      # The matrix is necessary to run separate analyses
+      matrix:
+        project:
+        - name: c8run
+          path: ./c8run
+        - name: optimize
+          path: ./optimize
+          maven-config: |
+            -DskipQaBuild=true
+        - name: single-app
+          path: ./
+          maven-config: |
+            -Dquickly=true
+            -DskipQaBuild=true
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-build
@@ -207,7 +223,16 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: ./.github/actions/adjust-pom-for-license-analysis
+        # These steps have been taken from check-licenses.yml workflow
+      - name: Adjust pom.xml files for FOSSA
+        if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
+        uses: ./.github/actions/adjust-pom-for-license-analysis
+      - name: Update Maven configs
+        if: matrix.project.maven-config != ''
+        env:
+          MAVEN_CONFIG: ${{ matrix.project.maven-config }}
+        run: |
+          echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
       - name: Check for dependency cycles
         # Command here is the same used by fossa analyze
         # and found by enabling the `-debug` flag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          job_name: "dependency-cycle-check/${{ matrix.project.name }}"
           build_status: ${{ job.status }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
           POM_PATH: ${{ matrix.project.path}}/pom.xml
         run: |
           ./mvnw com.github.ferstl:depgraph-maven-plugin:4.0.1:aggregate \
-            -f "$POM_PATH"
+            -f "$POM_PATH" \
             -DgraphFormat=text \
             -DmergeScopes \
             -DreduceEdges=false \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "Dependency Cycle Check"
     needs: [ detect-changes ]
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-16-default
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,42 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  dependency-cycle-check:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    name: "Dependency Cycle Check"
+    needs: [ detect-changes ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: dependency-cycle-check
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/adjust-pom-for-license-analysis
+      - name: Check for dependency cycles
+        run: |
+          ./mvnw com.github.ferstl:depgraph-maven-plugin:4.0.1:aggregate \
+            -DgraphFormat=text \
+            -DmergeScopes \
+            -DreduceEdges=false \
+            -DshowVersions=true \
+            -DshowGroupIds=true \
+            -DshowOptional=true \
+            -DrepeatTransitiveDependenciesInTextGraph=true
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   build-platform-frontend:
     if: needs.detect-changes.outputs.frontend-changes == 'true'
     needs: [ detect-changes ]
@@ -1359,6 +1395,7 @@ jobs:
       - client-components
       - commitlint
       - database-integration-tests
+      - dependency-cycle-check
       - detect-changes
       - docker-checks
       - general-unit-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,10 @@ jobs:
       # The matrix is necessary to run separate analyses
       matrix:
         project:
-        - name: c8run
-          path: ./c8run
+        # Not necessary - this is a completely different module
+        # written in Go
+        # - name: c8run
+        #   path: ./c8run
         - name: optimize
           path: ./optimize
           maven-config: |
@@ -225,7 +227,7 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
         # These steps have been taken from check-licenses.yml workflow
       - name: Adjust pom.xml files for FOSSA
-        if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
+        # if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
         uses: ./.github/actions/adjust-pom-for-license-analysis
       - name: Update Maven configs
         if: matrix.project.maven-config != ''
@@ -236,8 +238,11 @@ jobs:
       - name: Check for dependency cycles
         # Command here is the same used by fossa analyze
         # and found by enabling the `-debug` flag
+        env:
+          POM_PATH: ${{ matrix.project.path}}/pom.xml
         run: |
           ./mvnw com.github.ferstl:depgraph-maven-plugin:4.0.1:aggregate \
+            -f "$POM_PATH"
             -DgraphFormat=text \
             -DmergeScopes \
             -DreduceEdges=false \


### PR DESCRIPTION
## Summary

Adds a **dependency cycle check** to the Unified CI workflow (`ci.yml`) that detects Maven dependency cycles using the `depgraph-maven-plugin`.

Related to https://camunda.slack.com/archives/C071KP5BTHB/p1771601443548359

## Changes

- **New composite action** `.github/actions/adjust-pom-for-license-analysis` — extracts the shared `yq`-based pom.xml adjustments (parent, bom, root, optimize) into a reusable action
- **Updated `check-licenses.yml`** — replaced inline shell commands with the new composite action
- **New `dependency-cycle-check` job in `ci.yml`** — gated on `java-code-changes`, uses `setup-build`, calls the composite action, then runs:
  ```
  ./mvnw com.github.ferstl:depgraph-maven-plugin:4.0.1:aggregate \
    -DgraphFormat=text -DmergeScopes -DreduceEdges=false \
    -DshowVersions=true -DshowGroupIds=true -DshowOptional=true \
    -DrepeatTransitiveDependenciesInTextGraph=true
  ```
- Added `dependency-cycle-check` to `check-results` needs list

## How it works

The depgraph plugin will fail with an Overflow error if a dependency cycle is present, which naturally fails the CI job. The pom.xml adjustments restructure the module hierarchy so that `bom/pom.xml` acts as the root for analysis tools.

## Testing

- actionlint passes (only pre-existing runner-label warnings for custom GCP runners)
- No new workflow syntax issues introduced