### PR TITLE
AlwaysGreen - Update Image Tag - stable/8.9

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -198,8 +198,8 @@ jobs:
             # Use explicitly provided version
             echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # For PRs: <maven-version>-pr<number> (e.g., 8.9.0-SNAPSHOT-pr123)
-            echo "tag=${MAVEN_VERSION}-pr${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            # For PRs: <maven-version>-pr<PR_NUMBER>-run<run_id>-a<run_attempt>
+            echo "tag=${MAVEN_VERSION}-pr${{ github.event.pull_request.number }}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           else
             # For manual dispatch: <maven-version>-<short-sha> (e.g., 8.9.0-SNAPSHOT-abc1234)
             SHA_SHORT="${GITHUB_SHA::7}"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

**Why**
Harbor image tags need to be immutable and we also rely on tag patterns for replication filtering. The current PR tag format (`<base-version>-pr<PR_NUMBER>`) is not unique across reruns of the same workflow, which can cause collisions and overwrite attempts.

**What**
Standardize PR image tags to:

`<base-version>-pr<PR_NUMBER>-run<run_id>-a<run_attempt>`

**Benefits**

- Always unique, even when the same PR workflow is re-run (run_id + run_attempt).
- Keeps a clear -pr pattern to filter on for replication rules.
- Avoids accidental overwrites and improves traceability back to a specific workflow run/attempt.

**Scope**
Applies to the Docker image tag computed in the docker-build-helm-integration workflow for pull_request runs; downstream Helm integration/E2E jobs automatically consume the resulting tag via the workflow output.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
