### PR TITLE
Job Time Series aggregation (ES/OS implementation)

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -19,10 +19,12 @@ import io.camunda.db.rdbms.sql.columns.JobWorkerStatisticsColumn;
 import io.camunda.search.clients.reader.JobMetricsBatchReader;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -159,6 +161,12 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
             .toList();
 
     return workerStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
+  }
+
+  @Override
+  public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
+      final JobTimeSeriesStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException("Time series statistics are not implemented yet");
   }
 
   /** Inner reader for worker statistics to provide typed AbstractEntityReader methods. */

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
@@ -12,6 +12,7 @@ import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
 import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
 import io.camunda.search.clients.aggregator.SearchChildrenAggregator;
 import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
 import io.camunda.search.clients.aggregator.SearchFilterAggregator;
 import io.camunda.search.clients.aggregator.SearchFiltersAggregator;
 import io.camunda.search.clients.aggregator.SearchMaxAggregator;
@@ -51,6 +52,7 @@ import io.camunda.search.es.transformers.aggregator.SearchBucketSortAggregationT
 import io.camunda.search.es.transformers.aggregator.SearchCardinalityAggregationTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchChildrenAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchCompositeAggregatorTransformer;
+import io.camunda.search.es.transformers.aggregator.SearchDateHistogramAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchFilterAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchFiltersAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchMaxAggregatorTransformer;
@@ -153,6 +155,8 @@ public final class ElasticsearchTransformers {
     mappers.put(SearchTermsAggregator.class, new SearchTermsAggregatorTransformer(mappers));
     mappers.put(SearchTopHitsAggregator.class, new SearchTopHitsAggregatorTransformer(mappers));
     mappers.put(SearchCompositeAggregator.class, new SearchCompositeAggregatorTransformer(mappers));
+    mappers.put(
+        SearchDateHistogramAggregator.class, new SearchDateHistogramAggregatorTransformer(mappers));
     mappers.put(SearchChildrenAggregator.class, new SearchChildrenAggregatorTransformer(mappers));
     mappers.put(SearchParentAggregator.class, new SearchParentAggregatorTransformer(mappers));
     mappers.put(SearchSumAggregator.class, new SearchSumAggregatorTransformer(mappers));

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -12,6 +12,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket;
+import co.elastic.clients.elasticsearch._types.aggregations.DateHistogramBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketAggregateBase;
 import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketBase;
@@ -141,6 +142,7 @@ public class SearchAggregationResultTransformer<T>
                   case final StringTermsBucket b -> b.key().stringValue();
                   case final LongTermsBucket b ->
                       b.keyAsString() != null ? b.keyAsString() : String.valueOf(b.key());
+                  case final DateHistogramBucket b -> String.valueOf(b.key());
                   case final CompositeBucket b ->
                       b.key().values().stream()
                           .map(SearchAggregationResultTransformer::fieldValueToString)
@@ -197,6 +199,7 @@ public class SearchAggregationResultTransformer<T>
             case Sterms -> res = transformMultiBucketAggregate(warnDocError(aggregate.sterms()));
             case Lterms -> res = transformMultiBucketAggregate(warnDocError(aggregate.lterms()));
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
+            case DateHistogram -> res = transformMultiBucketAggregate(aggregate.dateHistogram());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());
             case Max -> res = transformSingleMetricAggregate(aggregate.max());

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchCompositeAggregatorTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchCompositeAggregatorTransformer.java
@@ -11,9 +11,12 @@ import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource;
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeDateHistogramAggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeTermsAggregation.Builder;
 import io.camunda.search.clients.aggregator.SearchAggregator;
 import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
 import io.camunda.search.clients.aggregator.SearchTermsAggregator;
 import io.camunda.search.clients.transformers.query.Cursor;
 import io.camunda.search.es.transformers.ElasticsearchTransformers;
@@ -60,11 +63,27 @@ public class SearchCompositeAggregatorTransformer
                               case final SearchTermsAggregator terms ->
                                   sourceBuilder.terms(
                                       termsBuilder -> buildTerms(terms, termsBuilder));
+                              case final SearchDateHistogramAggregator dateHistogram ->
+                                  sourceBuilder.dateHistogram(
+                                      b -> buildDateHistogram(dateHistogram, b));
                               default ->
                                   throw new IllegalStateException(
                                       "Unsupported aggregator type: " + agg.getClass());
                             })))
         .collect(Collectors.toList());
+  }
+
+  private CompositeDateHistogramAggregation.Builder buildDateHistogram(
+      final SearchDateHistogramAggregator dateHistogram,
+      final CompositeDateHistogramAggregation.Builder builder) {
+    builder.field(dateHistogram.field());
+    switch (dateHistogram.interval()) {
+      case final DateHistogramInterval.Fixed fixed ->
+          builder.fixedInterval(i -> i.time(fixed.toExpression()));
+      case final DateHistogramInterval.Calendar calendar ->
+          builder.calendarInterval(i -> i.time(calendar.getExpression()));
+    }
+    return builder;
   }
 
   private Builder buildTerms(final SearchTermsAggregator terms, final Builder termsBuilder) {

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchDateHistogramAggregatorTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchDateHistogramAggregatorTransformer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregator;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
+import co.elastic.clients.elasticsearch._types.aggregations.DateHistogramAggregation;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+
+public final class SearchDateHistogramAggregatorTransformer
+    extends AggregatorTransformer<SearchDateHistogramAggregator, Aggregation> {
+
+  public SearchDateHistogramAggregatorTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchDateHistogramAggregator value) {
+    final var aggBuilder = new DateHistogramAggregation.Builder().field(value.field());
+
+    switch (value.interval()) {
+      case final DateHistogramInterval.Fixed fixed ->
+          aggBuilder.fixedInterval(i -> i.time(fixed.toExpression()));
+      case final DateHistogramInterval.Calendar cal ->
+          aggBuilder.calendarInterval(toEsCalendarInterval(cal));
+    }
+
+    final var builder = new Aggregation.Builder().dateHistogram(aggBuilder.build());
+    applySubAggregations(builder, value);
+    return builder.build();
+  }
+
+  private static CalendarInterval toEsCalendarInterval(final DateHistogramInterval.Calendar value) {
+    return switch (value) {
+      case Second -> CalendarInterval.Second;
+      case Minute -> CalendarInterval.Minute;
+      case Hour -> CalendarInterval.Hour;
+      case Day -> CalendarInterval.Day;
+      case Week -> CalendarInterval.Week;
+      case Month -> CalendarInterval.Month;
+      case Quarter -> CalendarInterval.Quarter;
+      case Year -> CalendarInterval.Year;
+    };
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/SearchDateHistogramAggregatorTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/SearchDateHistogramAggregatorTransformerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.aggregator.SearchAggregatorBuilders;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class SearchDateHistogramAggregatorTransformerTest
+    extends AbstractSearchAggregatorTransformerTest<SearchDateHistogramAggregator> {
+
+  private static Stream<Arguments> provideAggregations() {
+    return Stream.of(
+        // fixed interval via Fixed(Duration)
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", new DateHistogramInterval.Fixed(Duration.ofMinutes(1))),
+            "{'date_histogram':{'field':'startTime','fixed_interval':'1m'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", new DateHistogramInterval.Fixed(Duration.ofHours(1))),
+            "{'date_histogram':{'field':'startTime','fixed_interval':'1h'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", new DateHistogramInterval.Fixed(Duration.ofMinutes(5))),
+            "{'date_histogram':{'field':'startTime','fixed_interval':'5m'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", new DateHistogramInterval.Fixed(Duration.ofHours(2))),
+            "{'date_histogram':{'field':'startTime','fixed_interval':'2h'}}"),
+        // calendar interval
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", DateHistogramInterval.Calendar.Day),
+            "{'date_histogram':{'calendar_interval':'day','field':'startTime'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", DateHistogramInterval.Calendar.Month),
+            "{'date_histogram':{'calendar_interval':'month','field':'startTime'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", DateHistogramInterval.Calendar.Year),
+            "{'date_histogram':{'calendar_interval':'year','field':'startTime'}}"),
+        // fixed interval with sub-aggregations
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram()
+                .name("byTime")
+                .field("startTime")
+                .interval(new DateHistogramInterval.Fixed(Duration.ofMinutes(5)))
+                .aggregations(SearchAggregatorBuilders.sum("count", "createdCount"))
+                .build(),
+            "{'aggregations':{'count':{'sum':{'field':'createdCount'}}},'date_histogram':{'field':'startTime','fixed_interval':'5m'}}"));
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullName() {
+    assertThatThrownBy(
+            () ->
+                SearchAggregatorBuilders.dateHistogram()
+                    .field("startTime")
+                    .interval(new DateHistogramInterval.Fixed(Duration.ofMinutes(1)))
+                    .build())
+        .hasMessageContaining("name must not be null")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    assertThatThrownBy(
+            () ->
+                SearchAggregatorBuilders.dateHistogram()
+                    .name("byTime")
+                    .interval(new DateHistogramInterval.Fixed(Duration.ofMinutes(1)))
+                    .build())
+        .hasMessageContaining("field must not be null")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullInterval() {
+    assertThatThrownBy(
+            () ->
+                SearchAggregatorBuilders.dateHistogram().name("byTime").field("startTime").build())
+        .hasMessageContaining("interval must not be null")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnSubMillisecondDuration() {
+    assertThatThrownBy(() -> new DateHistogramInterval.Fixed(Duration.ofNanos(1)).toExpression())
+        .hasMessageContaining("sub-millisecond")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNonPositiveDuration() {
+    assertThatThrownBy(() -> new DateHistogramInterval.Fixed(Duration.ZERO))
+        .hasMessageContaining("duration must be positive")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new DateHistogramInterval.Fixed(Duration.ofMinutes(-1)))
+        .hasMessageContaining("duration must be positive")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Override
+  protected Class<SearchDateHistogramAggregator> getTransformerClass() {
+    return SearchDateHistogramAggregator.class;
+  }
+}

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
 import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
 import io.camunda.search.clients.aggregator.SearchChildrenAggregator;
 import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
 import io.camunda.search.clients.aggregator.SearchFilterAggregator;
 import io.camunda.search.clients.aggregator.SearchFiltersAggregator;
 import io.camunda.search.clients.aggregator.SearchMaxAggregator;
@@ -50,6 +51,7 @@ import io.camunda.search.os.transformers.aggregator.SearchBucketSortAggregationT
 import io.camunda.search.os.transformers.aggregator.SearchCardinalityAggregationTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchChildrenAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchCompositeAggregatorTransformer;
+import io.camunda.search.os.transformers.aggregator.SearchDateHistogramAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchFilterAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchFiltersAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchMaxAggregatorTransformer;
@@ -153,6 +155,8 @@ public final class OpensearchTransformers {
     mappers.put(SearchTermsAggregator.class, new SearchTermsAggregatorTransformer(mappers));
     mappers.put(SearchTopHitsAggregator.class, new SearchTopHitsAggregatorTransformer(mappers));
     mappers.put(SearchCompositeAggregator.class, new SearchCompositeAggregatorTransformer(mappers));
+    mappers.put(
+        SearchDateHistogramAggregator.class, new SearchDateHistogramAggregatorTransformer(mappers));
     mappers.put(SearchChildrenAggregator.class, new SearchChildrenAggregatorTransformer(mappers));
     mappers.put(SearchParentAggregator.class, new SearchParentAggregatorTransformer(mappers));
     mappers.put(SearchSumAggregator.class, new SearchSumAggregatorTransformer(mappers));

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -29,6 +29,7 @@ import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.CardinalityAggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeAggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeBucket;
+import org.opensearch.client.opensearch._types.aggregations.DateHistogramBucket;
 import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
 import org.opensearch.client.opensearch._types.aggregations.MultiBucketAggregateBase;
 import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
@@ -144,6 +145,7 @@ public class SearchAggregationResultTransformer<T>
                   case final StringTermsBucket b -> b.key();
                   case final LongTermsBucket b ->
                       b.keyAsString() != null ? b.keyAsString() : String.valueOf(b.key().signed());
+                  case final DateHistogramBucket b -> String.valueOf(b.key());
                   case final CompositeBucket b ->
                       b.key().values().stream()
                           .map(SearchAggregationResultTransformer::fieldValueToString)
@@ -200,6 +202,7 @@ public class SearchAggregationResultTransformer<T>
             case Sterms -> res = transformMultiBucketAggregate(warnDocError(aggregate.sterms()));
             case Lterms -> res = transformMultiBucketAggregate(warnDocError(aggregate.lterms()));
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
+            case DateHistogram -> res = transformMultiBucketAggregate(aggregate.dateHistogram());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());
             case Max -> res = transformSingleMetricAggregate(aggregate.max());

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchCompositeAggregatorTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchCompositeAggregatorTransformer.java
@@ -9,6 +9,8 @@ package io.camunda.search.os.transformers.aggregator;
 
 import io.camunda.search.clients.aggregator.SearchAggregator;
 import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
 import io.camunda.search.clients.aggregator.SearchTermsAggregator;
 import io.camunda.search.clients.transformers.query.Cursor;
 import io.camunda.search.os.transformers.OpensearchTransformers;
@@ -20,6 +22,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.CompositeAggregation;
 import org.opensearch.client.opensearch._types.aggregations.CompositeAggregationSource;
+import org.opensearch.client.opensearch._types.aggregations.CompositeDateHistogramAggregationSource;
 import org.opensearch.client.opensearch._types.aggregations.CompositeTermsAggregationSource.Builder;
 
 public class SearchCompositeAggregatorTransformer
@@ -60,11 +63,27 @@ public class SearchCompositeAggregatorTransformer
                               case final SearchTermsAggregator terms ->
                                   sourceBuilder.terms(
                                       termsBuilder -> buildTerms(terms, termsBuilder));
+                              case final SearchDateHistogramAggregator dateHistogram ->
+                                  sourceBuilder.dateHistogram(
+                                      b -> buildDateHistogram(dateHistogram, b));
                               default ->
                                   throw new IllegalStateException(
                                       "Unsupported aggregator type: " + agg.getClass());
                             })))
         .collect(Collectors.toList());
+  }
+
+  private CompositeDateHistogramAggregationSource.Builder buildDateHistogram(
+      final SearchDateHistogramAggregator dateHistogram,
+      final CompositeDateHistogramAggregationSource.Builder builder) {
+    builder.field(dateHistogram.field());
+    switch (dateHistogram.interval()) {
+      case final DateHistogramInterval.Fixed fixed ->
+          builder.fixedInterval(t -> t.time(fixed.toExpression()));
+      case final DateHistogramInterval.Calendar cal ->
+          builder.calendarInterval(t -> t.time(cal.getExpression()));
+    }
+    return builder;
   }
 
   private Builder buildTerms(final SearchTermsAggregator terms, final Builder termsBuilder) {

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchDateHistogramAggregatorTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchDateHistogramAggregatorTransformer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.aggregator;
+
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
+import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregation;
+
+public class SearchDateHistogramAggregatorTransformer
+    extends AggregatorTransformer<SearchDateHistogramAggregator, Aggregation> {
+
+  public SearchDateHistogramAggregatorTransformer(final OpensearchTransformers mappers) {
+    super(mappers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchDateHistogramAggregator value) {
+    final var aggBuilder = new DateHistogramAggregation.Builder().field(value.field());
+
+    switch (value.interval()) {
+      case final DateHistogramInterval.Fixed fixed ->
+          aggBuilder.fixedInterval(t -> t.time(fixed.toExpression()));
+      case final DateHistogramInterval.Calendar cal ->
+          aggBuilder.calendarInterval(toOsCalendarInterval(cal));
+    }
+
+    final var builder = new Aggregation.Builder().dateHistogram(aggBuilder.build());
+    applySubAggregations(builder, value);
+    return builder.build();
+  }
+
+  private static CalendarInterval toOsCalendarInterval(final DateHistogramInterval.Calendar value) {
+    return switch (value) {
+      case Second -> CalendarInterval.Second;
+      case Minute -> CalendarInterval.Minute;
+      case Hour -> CalendarInterval.Hour;
+      case Day -> CalendarInterval.Day;
+      case Week -> CalendarInterval.Week;
+      case Month -> CalendarInterval.Month;
+      case Quarter -> CalendarInterval.Quarter;
+      case Year -> CalendarInterval.Year;
+    };
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/SearchDateHistogramAggregatorTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/SearchDateHistogramAggregatorTransformerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.aggregator.SearchAggregatorBuilders;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class SearchDateHistogramAggregatorTransformerTest
+    extends AbstractSearchAggregatorTransformerTest<SearchDateHistogramAggregator> {
+
+  private static Stream<Arguments> provideAggregations() {
+    return Stream.of(
+        // fixed interval via Fixed(Duration)
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", new DateHistogramInterval.Fixed(Duration.ofMinutes(1))),
+            "{'date_histogram':{'field':'startTime','fixed_interval':'1m'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", new DateHistogramInterval.Fixed(Duration.ofHours(1))),
+            "{'date_histogram':{'field':'startTime','fixed_interval':'1h'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", new DateHistogramInterval.Fixed(Duration.ofMinutes(5))),
+            "{'date_histogram':{'field':'startTime','fixed_interval':'5m'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", new DateHistogramInterval.Fixed(Duration.ofHours(2))),
+            "{'date_histogram':{'field':'startTime','fixed_interval':'2h'}}"),
+        // calendar interval
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", DateHistogramInterval.Calendar.Day),
+            "{'date_histogram':{'calendar_interval':'day','field':'startTime'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", DateHistogramInterval.Calendar.Month),
+            "{'date_histogram':{'calendar_interval':'month','field':'startTime'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram(
+                "byTime", "startTime", DateHistogramInterval.Calendar.Year),
+            "{'date_histogram':{'calendar_interval':'year','field':'startTime'}}"),
+        // fixed interval with sub-aggregations
+        Arguments.arguments(
+            SearchAggregatorBuilders.dateHistogram()
+                .name("byTime")
+                .field("startTime")
+                .interval(new DateHistogramInterval.Fixed(Duration.ofMinutes(5)))
+                .aggregations(SearchAggregatorBuilders.sum("count", "createdCount"))
+                .build(),
+            "{'aggregations':{'count':{'sum':{'field':'createdCount'}}},'date_histogram':{'field':'startTime','fixed_interval':'5m'}}"));
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullName() {
+    assertThatThrownBy(
+            () ->
+                SearchAggregatorBuilders.dateHistogram()
+                    .field("startTime")
+                    .interval(new DateHistogramInterval.Fixed(Duration.ofMinutes(1)))
+                    .build())
+        .hasMessageContaining("name must not be null")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    assertThatThrownBy(
+            () ->
+                SearchAggregatorBuilders.dateHistogram()
+                    .name("byTime")
+                    .interval(new DateHistogramInterval.Fixed(Duration.ofMinutes(1)))
+                    .build())
+        .hasMessageContaining("field must not be null")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullInterval() {
+    assertThatThrownBy(
+            () ->
+                SearchAggregatorBuilders.dateHistogram().name("byTime").field("startTime").build())
+        .hasMessageContaining("interval must not be null")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnSubMillisecondDuration() {
+    assertThatThrownBy(() -> new DateHistogramInterval.Fixed(Duration.ofNanos(1)).toExpression())
+        .hasMessageContaining("sub-millisecond")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNonPositiveDuration() {
+    assertThatThrownBy(() -> new DateHistogramInterval.Fixed(Duration.ZERO))
+        .hasMessageContaining("duration must be positive")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new DateHistogramInterval.Fixed(Duration.ofMinutes(-1)))
+        .hasMessageContaining("duration must be positive")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Override
+  protected Class<SearchDateHistogramAggregator> getTransformerClass() {
+    return SearchDateHistogramAggregator.class;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchAggregatorBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchAggregatorBuilders.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients.aggregator;
 
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.sort.SortOption.FieldSorting;
 import java.util.List;
@@ -103,5 +104,14 @@ public final class SearchAggregatorBuilders {
 
   public static SearchCardinalityAggregator cardinality(final String name, final String field) {
     return cardinality().name(name).field(field).build();
+  }
+
+  public static SearchDateHistogramAggregator.Builder dateHistogram() {
+    return new SearchDateHistogramAggregator.Builder();
+  }
+
+  public static SearchDateHistogramAggregator dateHistogram(
+      final String name, final String field, final DateHistogramInterval interval) {
+    return dateHistogram().name(name).field(field).interval(interval).build();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchDateHistogramAggregator.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchDateHistogramAggregator.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregator;
+
+import io.camunda.util.DurationUtil;
+import io.camunda.util.ObjectBuilder;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A date-histogram aggregation that buckets documents by time.
+ *
+ * <p>Use {@link DateHistogramInterval.Fixed} for arbitrary durations (e.g. {@code "5m"}) or {@link
+ * DateHistogramInterval.Calendar} for calendar-aligned buckets (e.g. day, week, month).
+ */
+public record SearchDateHistogramAggregator(
+    String name, String field, DateHistogramInterval interval, List<SearchAggregator> aggregations)
+    implements SearchAggregator {
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public List<SearchAggregator> getAggregations() {
+    return aggregations;
+  }
+
+  public static final class Builder extends SearchAggregator.AbstractBuilder<Builder>
+      implements ObjectBuilder<SearchDateHistogramAggregator> {
+
+    private String field;
+    private DateHistogramInterval interval;
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    public Builder field(final String value) {
+      field = value;
+      return this;
+    }
+
+    /**
+     * Sets an interval of fixed duration (e.g. {@code "5m"}, {@code "1h"}) or a calendar-aligned
+     * unit (e.g. day, month).
+     *
+     * @see DateHistogramInterval for details.
+     */
+    public Builder interval(final DateHistogramInterval value) {
+      interval = value;
+      return this;
+    }
+
+    @Override
+    public SearchDateHistogramAggregator build() {
+      Objects.requireNonNull(name, "name must not be null");
+      Objects.requireNonNull(field, "field must not be null");
+      Objects.requireNonNull(interval, "interval must not be null");
+      return new SearchDateHistogramAggregator(name, field, interval, aggregations);
+    }
+  }
+
+  /**
+   * Sealed type representing the two kinds of date-histogram intervals.
+   *
+   * <ul>
+   *   <li>{@link Fixed} — arbitrary fixed duration (e.g. {@code "5m"}, {@code "1h"}).
+   *   <li>{@link Calendar} — calendar-aligned unit (second, minute, …, year).
+   * </ul>
+   */
+  public sealed interface DateHistogramInterval
+      permits DateHistogramInterval.Fixed, DateHistogramInterval.Calendar {
+
+    /**
+     * A fixed-duration interval expressed as a {@link Duration}.
+     *
+     * <p>Call {@link #toExpression()} to obtain the ES/OS notation string (e.g. {@code "5m"}). The
+     * duration is converted to the coarsest exact unit (days → hours → minutes → seconds →
+     * milliseconds). Sub-millisecond durations are rejected.
+     */
+    record Fixed(Duration duration) implements DateHistogramInterval {
+
+      public Fixed {
+        Objects.requireNonNull(duration, "duration must not be null");
+        if (duration.isNegative() || duration.isZero()) {
+          throw new IllegalArgumentException("duration must be positive");
+        }
+        if (!duration.truncatedTo(ChronoUnit.MILLIS).equals(duration)) {
+          throw new IllegalArgumentException(
+              "duration has sub-millisecond precision, which is not supported by ES/OS fixed intervals");
+        }
+      }
+
+      /** Returns the ES/OS fixed-interval expression, e.g. {@code "5m"} or {@code "2h"}. */
+      public String toExpression() {
+        return DurationUtil.toEsOsInterval(duration);
+      }
+    }
+
+    /**
+     * A calendar-aligned interval unit.
+     *
+     * <p>Each constant carries both the human-readable name used by the search engines and the
+     * canonical short expression (e.g. {@code "1d"} for {@link #Day}).
+     */
+    enum Calendar implements DateHistogramInterval {
+      Second("second", "1s"),
+      Minute("minute", "1m"),
+      Hour("hour", "1h"),
+      Day("day", "1d"),
+      Week("week", "1w"),
+      Month("month", "1M"),
+      Quarter("quarter", "1q"),
+      Year("year", "1y");
+
+      private final String name;
+      private final String expression;
+
+      Calendar(final String name, final String expression) {
+        this.name = name;
+        this.expression = expression;
+      }
+
+      /** Returns the name used by ES / OS (e.g. {@code "day"}). */
+      public String getName() {
+        return name;
+      }
+
+      /** Returns the canonical short expression (e.g. {@code "1d"}). */
+      public String getExpression() {
+        return expression;
+      }
+    }
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DocumentBasedReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DocumentBasedReader.java
@@ -7,7 +7,13 @@
  */
 package io.camunda.search.clients.reader;
 
+import io.camunda.search.aggregation.result.CursorForwardPaginatedAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.filter.FilterBase;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.TypedSearchQuery;
+import io.camunda.search.sort.SortOption;
+import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
 public abstract class DocumentBasedReader {
@@ -23,5 +29,24 @@ public abstract class DocumentBasedReader {
 
   protected SearchClientBasedQueryExecutor getSearchExecutor() {
     return executor;
+  }
+
+  protected <
+          F extends FilterBase,
+          S extends SortOption,
+          E,
+          R extends CursorForwardPaginatedAggregationResult<E>>
+      SearchQueryResult<E> aggregateToResult(
+          final TypedSearchQuery<F, S> query,
+          final Class<R> resultClass,
+          final ResourceAccessChecks resourceAccessChecks) {
+    final CursorForwardPaginatedAggregationResult<E> aggResult =
+        getSearchExecutor().aggregate(query, resultClass, resourceAccessChecks);
+    return new SearchQueryResult<>(
+        aggResult.items().size(),
+        !aggResult.items().isEmpty(),
+        aggResult.items(),
+        null,
+        aggResult.endCursor());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
@@ -8,13 +8,16 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
+import io.camunda.search.aggregation.result.JobTimeSeriesStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobWorkerStatisticsAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -40,28 +43,20 @@ public class JobMetricsBatchDocumentReader extends DocumentBasedReader
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    final var aggResult =
-        getSearchExecutor()
-            .aggregate(query, JobTypeStatisticsAggregationResult.class, resourceAccessChecks);
-    return new SearchQueryResult<>(
-        aggResult.items().size(),
-        !aggResult.items().isEmpty(),
-        aggResult.items(),
-        null,
-        aggResult.endCursor());
+    return aggregateToResult(query, JobTypeStatisticsAggregationResult.class, resourceAccessChecks);
   }
 
   @Override
   public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
       final JobWorkerStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    final var aggResult =
-        getSearchExecutor()
-            .aggregate(query, JobWorkerStatisticsAggregationResult.class, resourceAccessChecks);
-    return new SearchQueryResult<>(
-        aggResult.items().size(),
-        !aggResult.items().isEmpty(),
-        aggResult.items(),
-        null,
-        aggResult.endCursor());
+    return aggregateToResult(
+        query, JobWorkerStatisticsAggregationResult.class, resourceAccessChecks);
+  }
+
+  @Override
+  public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
+      final JobTimeSeriesStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return aggregateToResult(
+        query, JobTimeSeriesStatisticsAggregationResult.class, resourceAccessChecks);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -12,6 +12,7 @@ import io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation;
 import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
+import io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation;
 import io.camunda.search.aggregation.JobTypeStatisticsAggregation;
 import io.camunda.search.aggregation.JobWorkerStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
@@ -27,6 +28,7 @@ import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggre
 import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
+import io.camunda.search.aggregation.result.JobTimeSeriesStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobWorkerStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
@@ -46,6 +48,7 @@ import io.camunda.search.clients.transformers.aggregation.DecisionDefinitionLate
 import io.camunda.search.clients.transformers.aggregation.GlobalJobStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByErrorAggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.JobTimeSeriesStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.JobTypeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.JobWorkerStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionFlowNodeStatisticsAggregationTransformer;
@@ -61,6 +64,7 @@ import io.camunda.search.clients.transformers.aggregation.result.DecisionDefinit
 import io.camunda.search.clients.transformers.aggregation.result.GlobalJobStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.JobTimeSeriesStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.JobTypeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.JobWorkerStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
@@ -118,6 +122,7 @@ import io.camunda.search.clients.transformers.filter.GroupFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GroupMemberFilterTransformer;
 import io.camunda.search.clients.transformers.filter.IncidentFilterTransformer;
 import io.camunda.search.clients.transformers.filter.JobFilterTransformer;
+import io.camunda.search.clients.transformers.filter.JobTimeSeriesStatisticsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.JobTypeStatisticsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.JobWorkerStatisticsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.MappingRuleFilterTransformer;
@@ -190,6 +195,7 @@ import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.GroupMemberFilter;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.JobFilter;
+import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
 import io.camunda.search.filter.JobTypeStatisticsFilter;
 import io.camunda.search.filter.JobWorkerStatisticsFilter;
 import io.camunda.search.filter.MappingRuleFilter;
@@ -229,6 +235,7 @@ import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuer
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.MappingRuleQuery;
@@ -446,6 +453,7 @@ public final class ServiceTransformers {
             GlobalJobStatisticsQuery.class,
             JobTypeStatisticsQuery.class,
             JobWorkerStatisticsQuery.class,
+            JobTimeSeriesStatisticsQuery.class,
             GlobalListenerQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
@@ -604,6 +612,10 @@ public final class ServiceTransformers {
         new JobWorkerStatisticsFilterTransformer(
             indexDescriptors.get(JobMetricsBatchTemplate.class)));
     mappers.put(
+        JobTimeSeriesStatisticsFilter.class,
+        new JobTimeSeriesStatisticsFilterTransformer(
+            indexDescriptors.get(JobMetricsBatchTemplate.class)));
+    mappers.put(
         ProcessDefinitionStatisticsFilter.class,
         new ProcessDefinitionStatisticsFilterTransformer(
             mappers, indexDescriptors.get(ListViewTemplate.class)));
@@ -680,6 +692,9 @@ public final class ServiceTransformers {
     mappers.put(JobTypeStatisticsAggregation.class, new JobTypeStatisticsAggregationTransformer());
     mappers.put(
         JobWorkerStatisticsAggregation.class, new JobWorkerStatisticsAggregationTransformer());
+    mappers.put(
+        JobTimeSeriesStatisticsAggregation.class,
+        new JobTimeSeriesStatisticsAggregationTransformer());
 
     // aggregation result
     mappers.put(
@@ -722,5 +737,8 @@ public final class ServiceTransformers {
     mappers.put(
         JobWorkerStatisticsAggregationResult.class,
         new JobWorkerStatisticsAggregationResultTransformer());
+    mappers.put(
+        JobTimeSeriesStatisticsAggregationResult.class,
+        new JobTimeSeriesStatisticsAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/JobTimeSeriesStatisticsAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/JobTimeSeriesStatisticsAggregationTransformer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_BY_TIME;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COMPOSITE_SIZE;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_SOURCE_NAME_TIME;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_COMPLETED_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_CREATED_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_FAILED_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_LAST_COMPLETED_AT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_LAST_CREATED_AT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_LAST_FAILED_AT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_START_TIME;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.composite;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.dateHistogram;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.filter;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.max;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.sum;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+
+import io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import java.util.Optional;
+
+public class JobTimeSeriesStatisticsAggregationTransformer
+    implements AggregationTransformer<JobTimeSeriesStatisticsAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<JobTimeSeriesStatisticsAggregation, ServiceTransformers> value) {
+
+    final var aggregation = value.getLeft();
+    final var filter = aggregation.filter();
+
+    // Created filter bucket with count and lastUpdatedAt sub-aggregations
+    final var createdAgg =
+        filter()
+            .name(AGGREGATION_CREATED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_CREATED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_CREATED_AT))
+            .build();
+
+    // Completed filter bucket with count and lastUpdatedAt sub-aggregations
+    final var completedAgg =
+        filter()
+            .name(AGGREGATION_COMPLETED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_COMPLETED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_COMPLETED_AT))
+            .build();
+
+    // Failed filter bucket with count and lastUpdatedAt sub-aggregations
+    final var failedAgg =
+        filter()
+            .name(AGGREGATION_FAILED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_FAILED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_FAILED_AT))
+            .build();
+
+    // Date histogram source for composite aggregation bucketed by time
+    final var byTimeSource =
+        dateHistogram()
+            .name(AGGREGATION_SOURCE_NAME_TIME)
+            .field(FIELD_START_TIME)
+            .interval(new DateHistogramInterval.Fixed(filter.resolution()))
+            .build();
+
+    // Composite aggregation for pagination support
+    final var page = aggregation.page();
+    final var byTimeAgg =
+        composite()
+            .name(AGGREGATION_BY_TIME)
+            .size(
+                Optional.ofNullable(page)
+                    .map(SearchQueryPage::size)
+                    .orElse(AGGREGATION_COMPOSITE_SIZE))
+            .after(Optional.ofNullable(page).map(SearchQueryPage::after).orElse(null))
+            .sources(List.of(byTimeSource))
+            .aggregations(createdAgg, completedAgg, failedAgg)
+            .build();
+
+    return List.of(byTimeAgg);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/JobTimeSeriesStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/JobTimeSeriesStatisticsAggregationResultTransformer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_BY_TIME;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+
+import io.camunda.search.aggregation.result.JobTimeSeriesStatisticsAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class JobTimeSeriesStatisticsAggregationResultTransformer
+    implements AggregationResultTransformer<JobTimeSeriesStatisticsAggregationResult> {
+
+  @Override
+  public JobTimeSeriesStatisticsAggregationResult apply(
+      final Map<String, AggregationResult> aggregations) {
+
+    final var byTimeAgg = aggregations.get(AGGREGATION_BY_TIME);
+    if (byTimeAgg == null || byTimeAgg.aggregations() == null) {
+      return new JobTimeSeriesStatisticsAggregationResult(Collections.emptyList(), null);
+    }
+
+    final var perTimeBuckets = byTimeAgg.aggregations();
+
+    final List<JobTimeSeriesStatisticsEntity> items =
+        perTimeBuckets.entrySet().stream()
+            .sorted(Comparator.comparingLong(e -> parseLong(e.getKey())))
+            .map(
+                entry -> {
+                  final String bucketKey = entry.getKey();
+                  final var agg = entry.getValue();
+                  if (agg == null || agg.aggregations() == null || agg.aggregations().isEmpty()) {
+                    return null;
+                  }
+
+                  final OffsetDateTime time = parseTimestamp(bucketKey);
+                  final var subAggregations = agg.aggregations();
+
+                  final var createdMetric =
+                      extractStatusMetric(subAggregations, AGGREGATION_CREATED);
+                  final var completedMetric =
+                      extractStatusMetric(subAggregations, AGGREGATION_COMPLETED);
+                  final var failedMetric = extractStatusMetric(subAggregations, AGGREGATION_FAILED);
+
+                  return new JobTimeSeriesStatisticsEntity(
+                      time, createdMetric, completedMetric, failedMetric);
+                })
+            .filter(Objects::nonNull)
+            .toList();
+
+    return new JobTimeSeriesStatisticsAggregationResult(items, byTimeAgg.endCursor());
+  }
+
+  private OffsetDateTime parseTimestamp(final String bucketKey) {
+    try {
+      final long epochMillis = Long.parseLong(bucketKey);
+      if (epochMillis > 0) {
+        return OffsetDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC);
+      }
+    } catch (final NumberFormatException ignored) {
+      // fall through — key is not an epoch millis
+    }
+    return null;
+  }
+
+  private long parseLong(final String bucketKey) {
+    try {
+      return Long.parseLong(bucketKey);
+    } catch (final NumberFormatException ignored) {
+      return Long.MAX_VALUE; // unparseable keys sort last
+    }
+  }
+
+  private StatusMetric extractStatusMetric(
+      final Map<String, AggregationResult> aggregations, final String bucketName) {
+    final var bucketAgg = aggregations.get(bucketName);
+    if (bucketAgg == null || bucketAgg.aggregations() == null) {
+      return new StatusMetric(0L, null);
+    }
+
+    final var subAggregations = bucketAgg.aggregations();
+    final long count = extractDocCount(subAggregations);
+    final OffsetDateTime lastUpdatedAt = extractMaxTimestamp(subAggregations);
+
+    return new StatusMetric(count, lastUpdatedAt);
+  }
+
+  private long extractDocCount(final Map<String, AggregationResult> aggregations) {
+    final var agg = aggregations.get(AGGREGATION_COUNT);
+    if (agg != null && agg.docCount() != null) {
+      return agg.docCount();
+    }
+    return 0L;
+  }
+
+  private OffsetDateTime extractMaxTimestamp(final Map<String, AggregationResult> aggregations) {
+    final var agg = aggregations.get(AGGREGATION_LAST_UPDATED_AT);
+    if (agg != null && agg.docCount() != null) {
+      final long epochMillis = agg.docCount();
+      if (epochMillis > 0) {
+        return OffsetDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC);
+      }
+    }
+    return null;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobTimeSeriesStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobTimeSeriesStatisticsFilterTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JobTimeSeriesStatisticsFilterTransformer
+    extends IndexFilterTransformer<JobTimeSeriesStatisticsFilter> {
+
+  public JobTimeSeriesStatisticsFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final JobTimeSeriesStatisticsFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+
+    if (filter.from() != null) {
+      queries.addAll(
+          dateTimeOperations(
+              JobMetricsBatchTemplate.START_TIME, List.of(Operation.gte(filter.from()))));
+    }
+
+    if (filter.to() != null) {
+      queries.addAll(
+          dateTimeOperations(
+              JobMetricsBatchTemplate.END_TIME, List.of(Operation.lte(filter.to()))));
+    }
+
+    // jobType is required for time-series statistics
+    if (filter.jobType() != null) {
+      queries.add(term(JobMetricsBatchTemplate.JOB_TYPE, filter.jobType()));
+    }
+
+    return queries.isEmpty() ? matchAll() : and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return matchAll();
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/aggregator/SearchDateHistogramAggregatorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/aggregator/SearchDateHistogramAggregatorTest.java
@@ -39,7 +39,7 @@ class SearchDateHistogramAggregatorTest {
     // hours — exact, no sub-hour remainder
     "PT1H,  1h",
     "PT2H,  2h",
-    "PT48H, 48h",
+    "PT48H, 2d",
     // days — exact, no sub-day remainder
     "P1D,  1d",
     "P7D,  7d",

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/aggregator/SearchDateHistogramAggregatorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/aggregator/SearchDateHistogramAggregatorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval.Fixed;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class SearchDateHistogramAggregatorTest {
+
+  // -----------------------------------------------------------------------
+  // toExpression — happy path
+  // -----------------------------------------------------------------------
+
+  @ParameterizedTest(name = "{0} -> \"{1}\"")
+  @CsvSource({
+    // milliseconds
+    "PT0.001S, 1ms",
+    "PT0.500S, 500ms",
+    "PT0.999S, 999ms",
+    // seconds — exact, no sub-second remainder
+    "PT1S,  1s",
+    "PT30S, 30s",
+    "PT59S, 59s",
+    // minutes — exact, no sub-minute remainder
+    "PT1M,  1m",
+    "PT5M,  5m",
+    "PT90M, 90m",
+    // hours — exact, no sub-hour remainder
+    "PT1H,  1h",
+    "PT2H,  2h",
+    "PT48H, 48h",
+    // days — exact, no sub-day remainder
+    "P1D,  1d",
+    "P7D,  7d",
+    "P30D, 30d",
+  })
+  void shouldConvertToExpression(final String isoDuration, final String expectedExpression) {
+    final var fixed = new Fixed(Duration.parse(isoDuration));
+    assertThat(fixed.toExpression()).isEqualTo(expectedExpression.trim());
+  }
+
+  @Test
+  void shouldUseCoarsestExactUnit() {
+    // 60 seconds → minutes wins over seconds
+    assertThat(new Fixed(Duration.ofSeconds(60)).toExpression()).isEqualTo("1m");
+    // 3600 seconds → hours wins over minutes
+    assertThat(new Fixed(Duration.ofSeconds(3600)).toExpression()).isEqualTo("1h");
+    // 86400 seconds → days wins over hours
+    assertThat(new Fixed(Duration.ofSeconds(86_400)).toExpression()).isEqualTo("1d");
+    // 90 minutes — not a whole number of hours, stays as minutes
+    assertThat(new Fixed(Duration.ofMinutes(90)).toExpression()).isEqualTo("90m");
+    // 25 hours — not a whole number of days, stays as hours
+    assertThat(new Fixed(Duration.ofHours(25)).toExpression()).isEqualTo("25h");
+    // 1500 ms — not a whole number of seconds, stays as ms
+    assertThat(new Fixed(Duration.ofMillis(1500)).toExpression()).isEqualTo("1500ms");
+  }
+
+  // -----------------------------------------------------------------------
+  // Construction guards
+  // -----------------------------------------------------------------------
+
+  @Test
+  void shouldRejectNullDuration() {
+    assertThatThrownBy(() -> new Fixed(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("duration must not be null");
+  }
+
+  @Test
+  void shouldRejectZeroDuration() {
+    assertThatThrownBy(() -> new Fixed(Duration.ZERO))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("duration must be positive");
+  }
+
+  @Test
+  void shouldRejectNegativeDuration() {
+    assertThatThrownBy(() -> new Fixed(Duration.ofMinutes(-5)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("duration must be positive");
+  }
+
+  @Test
+  void shouldRejectSubMillisecondDuration() {
+    // 1 nanosecond — rejected at construction, not at toExpression()
+    assertThatThrownBy(() -> new Fixed(Duration.ofNanos(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sub-millisecond");
+    // 1 microsecond
+    assertThatThrownBy(() -> new Fixed(Duration.ofNanos(1_000)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sub-millisecond");
+    // 1 ms + 1 ns — has sub-millisecond part
+    assertThatThrownBy(() -> new Fixed(Duration.ofMillis(1).plusNanos(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sub-millisecond");
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/JobTimeSeriesStatisticsAggregationTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/JobTimeSeriesStatisticsAggregationTransformerTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_BY_TIME;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_SOURCE_NAME_TIME;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_COMPLETED_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_CREATED_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_FAILED_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_LAST_COMPLETED_AT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_LAST_CREATED_AT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_LAST_FAILED_AT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.FIELD_START_TIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator;
+import io.camunda.search.clients.aggregator.SearchDateHistogramAggregator.DateHistogramInterval;
+import io.camunda.search.clients.aggregator.SearchFilterAggregator;
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
+import io.camunda.search.clients.aggregator.SearchSumAggregator;
+import io.camunda.search.clients.query.SearchMatchAllQuery;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JobTimeSeriesStatisticsAggregationTransformerTest {
+
+  private static final OffsetDateTime FROM = OffsetDateTime.parse("2024-07-28T00:00:00Z");
+  private static final OffsetDateTime TO = OffsetDateTime.parse("2024-07-29T00:00:00Z");
+
+  private final JobTimeSeriesStatisticsAggregationTransformer transformer =
+      new JobTimeSeriesStatisticsAggregationTransformer();
+
+  private final ServiceTransformers transformers =
+      ServiceTransformers.newInstance(new IndexDescriptors("", true));
+
+  /** Builds a filter with the given explicit resolution (may be null for auto-computed). */
+  private static JobTimeSeriesStatisticsFilter filter(final Duration resolution) {
+    return FilterBuilders.jobTimeSeriesStatistics(
+        b -> b.from(FROM).to(TO).jobType("test-job").resolution(resolution));
+  }
+
+  @Test
+  void shouldBuildExpectedAggregationStructure() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(50).after("cursor123"));
+    final var aggregation =
+        new JobTimeSeriesStatisticsAggregation(page, filter(Duration.ofMinutes(1)));
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    assertThat(aggregations).hasSize(1);
+
+    assertThat(aggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchCompositeAggregator.class,
+            compositeAgg -> {
+              assertThat(compositeAgg.name()).isEqualTo(AGGREGATION_BY_TIME);
+              assertThat(compositeAgg.size()).isEqualTo(50);
+              assertThat(compositeAgg.after()).isEqualTo("cursor123");
+              assertThat(compositeAgg.sources()).hasSize(1);
+              assertThat(compositeAgg.aggregations()).hasSize(3);
+            });
+  }
+
+  @Test
+  void shouldBuildDateHistogramSourceWithCorrectFieldAndInterval() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(100));
+    final var aggregation =
+        new JobTimeSeriesStatisticsAggregation(page, filter(Duration.ofMinutes(5)));
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+
+    assertThat(compositeAgg.sources()).hasSize(1);
+    assertThat(compositeAgg.sources().get(0))
+        .isInstanceOfSatisfying(
+            SearchDateHistogramAggregator.class,
+            dateHistogramSource -> {
+              assertThat(dateHistogramSource.name()).isEqualTo(AGGREGATION_SOURCE_NAME_TIME);
+              assertThat(dateHistogramSource.field()).isEqualTo(FIELD_START_TIME);
+              assertThat(dateHistogramSource.interval())
+                  .isEqualTo(new DateHistogramInterval.Fixed(Duration.ofMinutes(5)));
+            });
+  }
+
+  @Test
+  void shouldBuildFilterBucketsForEachStatus() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(100));
+    final var aggregation =
+        new JobTimeSeriesStatisticsAggregation(page, filter(Duration.ofHours(1)));
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+    final var subAggregations = compositeAgg.aggregations();
+
+    assertThat(subAggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            createdAgg -> {
+              assertThat(createdAgg.name()).isEqualTo(AGGREGATION_CREATED);
+              assertThat(createdAgg.query().queryOption()).isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  createdAgg.aggregations(), FIELD_CREATED_COUNT, FIELD_LAST_CREATED_AT);
+            });
+
+    assertThat(subAggregations.get(1))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            completedAgg -> {
+              assertThat(completedAgg.name()).isEqualTo(AGGREGATION_COMPLETED);
+              assertThat(completedAgg.query().queryOption())
+                  .isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  completedAgg.aggregations(), FIELD_COMPLETED_COUNT, FIELD_LAST_COMPLETED_AT);
+            });
+
+    assertThat(subAggregations.get(2))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            failedAgg -> {
+              assertThat(failedAgg.name()).isEqualTo(AGGREGATION_FAILED);
+              assertThat(failedAgg.query().queryOption()).isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  failedAgg.aggregations(), FIELD_FAILED_COUNT, FIELD_LAST_FAILED_AT);
+            });
+  }
+
+  @Test
+  void shouldBuildSubAggregationsWithCorrectTypes() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(100));
+    final var aggregation =
+        new JobTimeSeriesStatisticsAggregation(page, filter(Duration.ofMinutes(1)));
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+
+    compositeAgg.aggregations().stream()
+        .filter(SearchFilterAggregator.class::isInstance)
+        .map(SearchFilterAggregator.class::cast)
+        .forEach(
+            filterAgg -> {
+              assertThat(filterAgg.aggregations()).hasSize(2);
+
+              assertThat(filterAgg.aggregations().get(0))
+                  .isInstanceOfSatisfying(
+                      SearchSumAggregator.class,
+                      sumAgg -> assertThat(sumAgg.name()).isEqualTo(AGGREGATION_COUNT));
+
+              assertThat(filterAgg.aggregations().get(1))
+                  .isInstanceOfSatisfying(
+                      SearchMaxAggregator.class,
+                      maxAgg -> assertThat(maxAgg.name()).isEqualTo(AGGREGATION_LAST_UPDATED_AT));
+            });
+  }
+
+  @Test
+  void shouldUsePageSizeAndCursor() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(42).after("someCursor"));
+    final var aggregation =
+        new JobTimeSeriesStatisticsAggregation(page, filter(Duration.ofMinutes(1)));
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+    assertThat(compositeAgg.size()).isEqualTo(42);
+    assertThat(compositeAgg.after()).isEqualTo("someCursor");
+  }
+
+  @Test
+  void shouldUseDefaultSizeWhenPageIsNull() {
+    // given
+    final var aggregation =
+        new JobTimeSeriesStatisticsAggregation(null, filter(Duration.ofMinutes(1)));
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+    assertThat(compositeAgg.size()).isEqualTo(10000);
+    assertThat(compositeAgg.after()).isNull();
+  }
+
+  @Test
+  void shouldAutoComputeResolutionWhenNotProvided() {
+    // given — 1 day window, no explicit resolution → (24h / 1000) = ~86s, floored to 1m minimum
+    final var aggregation =
+        new JobTimeSeriesStatisticsAggregation(SearchQueryPage.of(b -> b.size(100)), filter(null));
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then — resolution must be at least the minimum (1 minute)
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+    final var source = (SearchDateHistogramAggregator) compositeAgg.sources().get(0);
+    assertThat(source.interval())
+        .isInstanceOfSatisfying(
+            DateHistogramInterval.Fixed.class,
+            fixed ->
+                assertThat(fixed.duration())
+                    .isGreaterThanOrEqualTo(JobTimeSeriesStatisticsFilter.MIN_RESOLUTION));
+  }
+
+  private void assertSubAggregations(
+      final List<SearchAggregator> subAggs,
+      final String expectedCountField,
+      final String expectedLastUpdatedAtField) {
+    assertThat(subAggs).hasSize(2);
+
+    assertThat(subAggs.get(0))
+        .isInstanceOfSatisfying(
+            SearchSumAggregator.class,
+            sumAgg -> {
+              assertThat(sumAgg.name()).isEqualTo(AGGREGATION_COUNT);
+              assertThat(sumAgg.field()).isEqualTo(expectedCountField);
+            });
+
+    assertThat(subAggs.get(1))
+        .isInstanceOfSatisfying(
+            SearchMaxAggregator.class,
+            maxAgg -> {
+              assertThat(maxAgg.name()).isEqualTo(AGGREGATION_LAST_UPDATED_AT);
+              assertThat(maxAgg.field()).isEqualTo(expectedLastUpdatedAtField);
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/JobTimeSeriesStatisticsAggregationResultTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/JobTimeSeriesStatisticsAggregationResultTransformerTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_BY_TIME;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.core.AggregationResult;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class JobTimeSeriesStatisticsAggregationResultTransformerTest {
+
+  private final JobTimeSeriesStatisticsAggregationResultTransformer transformer =
+      new JobTimeSeriesStatisticsAggregationResultTransformer();
+
+  @Test
+  public void shouldReturnEmptyListWhenAggregationsEmpty() {
+    // given
+    final Map<String, AggregationResult> input = Map.of();
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.endCursor()).isNull();
+  }
+
+  @Test
+  public void shouldTransformSingleTimeBucket() {
+    // given
+    final long bucketEpochMillis = 1706800000000L;
+    final long createdCount = 10L;
+    final long completedCount = 8L;
+    final long failedCount = 1L;
+    final long createdTimestamp = 1706800100000L;
+    final long completedTimestamp = 1706800200000L;
+    final long failedTimestamp = 1706800300000L;
+    final String endCursor = "cursor123";
+
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TIME,
+            byTimeBucket(
+                Map.of(
+                    String.valueOf(bucketEpochMillis),
+                    timeBucket(
+                        createdCount,
+                        createdTimestamp,
+                        completedCount,
+                        completedTimestamp,
+                        failedCount,
+                        failedTimestamp)),
+                endCursor));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.endCursor()).isEqualTo(endCursor);
+
+    final var entity = result.items().get(0);
+    assertThat(entity.time())
+        .isEqualTo(
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(bucketEpochMillis), ZoneOffset.UTC));
+
+    assertThat(entity.created().count()).isEqualTo(createdCount);
+    assertThat(entity.created().lastUpdatedAt())
+        .isEqualTo(
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(createdTimestamp), ZoneOffset.UTC));
+
+    assertThat(entity.completed().count()).isEqualTo(completedCount);
+    assertThat(entity.completed().lastUpdatedAt())
+        .isEqualTo(
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(completedTimestamp), ZoneOffset.UTC));
+
+    assertThat(entity.failed().count()).isEqualTo(failedCount);
+    assertThat(entity.failed().lastUpdatedAt())
+        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(failedTimestamp), ZoneOffset.UTC));
+  }
+
+  @Test
+  public void shouldTransformMultipleTimeBucketsOrderedByTime() {
+    // given — buckets inserted in reverse chronological order to verify sorting
+    final long t1 = 1706800000000L;
+    final long t2 = 1706800060000L;
+    final long t3 = 1706800120000L;
+
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TIME,
+            byTimeBucket(
+                Map.of(
+                    String.valueOf(t3), timeBucket(5, 0L, 4, 0L, 0, 0L),
+                    String.valueOf(t1), timeBucket(10, 0L, 9, 0L, 1, 0L),
+                    String.valueOf(t2), timeBucket(7, 0L, 6, 0L, 0, 0L)),
+                "endCursor"));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then — items must be ordered ascending by time
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).time())
+        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(t1), ZoneOffset.UTC));
+    assertThat(result.items().get(1).time())
+        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(t2), ZoneOffset.UTC));
+    assertThat(result.items().get(2).time())
+        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(t3), ZoneOffset.UTC));
+  }
+
+  @Test
+  public void shouldHandleZeroCountsAndNullTimestamps() {
+    // given
+    final long bucketKey = 1706800000000L;
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TIME,
+            byTimeBucket(
+                Map.of(String.valueOf(bucketKey), timeBucket(0, null, 0, null, 0, null)), null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.endCursor()).isNull();
+
+    final var entity = result.items().get(0);
+    assertThat(entity.created().count()).isZero();
+    assertThat(entity.created().lastUpdatedAt()).isNull();
+    assertThat(entity.completed().count()).isZero();
+    assertThat(entity.completed().lastUpdatedAt()).isNull();
+    assertThat(entity.failed().count()).isZero();
+    assertThat(entity.failed().lastUpdatedAt()).isNull();
+  }
+
+  @Test
+  public void shouldHandleMissingSubAggregations() {
+    // given — bucket exists but has no sub-aggregations
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TIME,
+            byTimeBucket(Map.of("1706800000000", new AggregationResult(10L, Map.of())), null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then — entity with empty aggregations should be filtered out
+    assertThat(result.items()).isEmpty();
+    assertThat(result.endCursor()).isNull();
+  }
+
+  @Test
+  public void shouldHandleNullByTimeAggregation() {
+    // given
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_BY_TIME, new AggregationResult(0L, Map.of()));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.endCursor()).isNull();
+  }
+
+  // ---- helpers ----
+
+  private static AggregationResult byTimeBucket(
+      final Map<String, AggregationResult> timeBuckets, final String endCursor) {
+    return new AggregationResult(0L, timeBuckets, List.of(), endCursor);
+  }
+
+  private static AggregationResult timeBucket(
+      final long createdCount,
+      final Long createdTimestamp,
+      final long completedCount,
+      final Long completedTimestamp,
+      final long failedCount,
+      final Long failedTimestamp) {
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_CREATED, statusBucket(createdCount, createdTimestamp),
+            AGGREGATION_COMPLETED, statusBucket(completedCount, completedTimestamp),
+            AGGREGATION_FAILED, statusBucket(failedCount, failedTimestamp));
+    return new AggregationResult(0L, subAggs);
+  }
+
+  private static AggregationResult statusBucket(final long count, final Long lastUpdatedAtMillis) {
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_COUNT,
+            new AggregationResult(count, Map.of()),
+            AGGREGATION_LAST_UPDATED_AT,
+            new AggregationResult(lastUpdatedAtMillis, Map.of()));
+    return new AggregationResult(0L, subAggs);
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchReader.java
@@ -8,9 +8,11 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -26,4 +28,7 @@ public interface JobMetricsBatchReader extends SearchClientReader {
 
   SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
       JobWorkerStatisticsQuery query, ResourceAccessChecks resourceAccessChecks);
+
+  SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
+      JobTimeSeriesStatisticsQuery query, ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -409,7 +409,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
       final JobTimeSeriesStatisticsQuery query) {
-    throw new UnsupportedOperationException("Job time-series statistics is not yet implemented");
+    return doReadWithResourceAccessController(
+        access -> readers.jobMetricsBatchReader().getJobTimeSeriesStatistics(query, access));
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/JobTimeSeriesStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/JobTimeSeriesStatisticsAggregation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AggregationPaginated;
+
+public record JobTimeSeriesStatisticsAggregation(
+    SearchQueryPage page, JobTimeSeriesStatisticsFilter filter)
+    implements AggregationBase, AggregationPaginated {
+
+  // Composite aggregation name
+  public static final String AGGREGATION_BY_TIME = "byTime";
+
+  // Composite aggregation source name
+  public static final String AGGREGATION_SOURCE_NAME_TIME = "time";
+
+  // Default size for composite aggregation
+  public static final int AGGREGATION_COMPOSITE_SIZE = 10000;
+
+  // Filter bucket names (within each time bucket)
+  public static final String AGGREGATION_CREATED = "created";
+  public static final String AGGREGATION_COMPLETED = "completed";
+  public static final String AGGREGATION_FAILED = "failed";
+
+  // Sub-aggregation names (used within each filter bucket)
+  public static final String AGGREGATION_COUNT = "count";
+  public static final String AGGREGATION_LAST_UPDATED_AT = "lastUpdatedAt";
+
+  // Field names for aggregations
+  public static final String FIELD_START_TIME = "startTime";
+  public static final String FIELD_CREATED_COUNT = "createdCount";
+  public static final String FIELD_COMPLETED_COUNT = "completedCount";
+  public static final String FIELD_FAILED_COUNT = "failedCount";
+  public static final String FIELD_LAST_CREATED_AT = "lastCreatedAt";
+  public static final String FIELD_LAST_COMPLETED_AT = "lastCompletedAt";
+  public static final String FIELD_LAST_FAILED_AT = "lastFailedAt";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/CursorForwardPaginatedAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/CursorForwardPaginatedAggregationResult.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.search.aggregation.result;
 
-import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import java.util.List;
 
-public record JobWorkerStatisticsAggregationResult(
-    List<JobWorkerStatisticsEntity> items, String endCursor)
-    implements CursorForwardPaginatedAggregationResult<JobWorkerStatisticsEntity> {}
+/** Marker interface for aggregation results that expose a page of items and a cursor. */
+public interface CursorForwardPaginatedAggregationResult<E> extends AggregationResultBase {
+
+  List<E> items();
+
+  String endCursor();
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/JobTimeSeriesStatisticsAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/JobTimeSeriesStatisticsAggregationResult.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.search.aggregation.result;
 
-import io.camunda.search.entities.JobWorkerStatisticsEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import java.util.List;
 
-public record JobWorkerStatisticsAggregationResult(
-    List<JobWorkerStatisticsEntity> items, String endCursor)
-    implements CursorForwardPaginatedAggregationResult<JobWorkerStatisticsEntity> {}
+public record JobTimeSeriesStatisticsAggregationResult(
+    List<JobTimeSeriesStatisticsEntity> items, String endCursor)
+    implements CursorForwardPaginatedAggregationResult<JobTimeSeriesStatisticsEntity> {}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/JobTypeStatisticsAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/JobTypeStatisticsAggregationResult.java
@@ -11,4 +11,5 @@ import io.camunda.search.entities.JobTypeStatisticsEntity;
 import java.util.List;
 
 public record JobTypeStatisticsAggregationResult(
-    List<JobTypeStatisticsEntity> items, String endCursor) implements AggregationResultBase {}
+    List<JobTypeStatisticsEntity> items, String endCursor)
+    implements CursorForwardPaginatedAggregationResult<JobTypeStatisticsEntity> {}

--- a/search/search-domain/src/main/java/io/camunda/search/query/JobTimeSeriesStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/JobTimeSeriesStatisticsQuery.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.query;
 
+import io.camunda.search.aggregation.AggregationBase;
+import io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -36,8 +38,8 @@ public record JobTimeSeriesStatisticsQuery(
   }
 
   @Override
-  public io.camunda.search.aggregation.AggregationBase aggregation() {
-    return null;
+  public AggregationBase aggregation() {
+    return new JobTimeSeriesStatisticsAggregation(page, filter);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/util/DurationUtil.java
+++ b/search/search-domain/src/main/java/io/camunda/util/DurationUtil.java
@@ -8,9 +8,13 @@
 package io.camunda.util;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 public final class DurationUtil {
+
+  private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
+  private static final long MILLIS_PER_HOUR = Duration.ofHours(1).toMillis();
+  private static final long MILLIS_PER_MINUTE = Duration.ofMinutes(1).toMillis();
+  private static final long MILLIS_PER_SECOND = Duration.ofSeconds(1).toMillis();
 
   private DurationUtil() {}
 
@@ -25,27 +29,27 @@ public final class DurationUtil {
   }
 
   public static String toEsOsInterval(final Duration duration) {
-    final long seconds = duration.getSeconds();
-    if (seconds <= 0) {
-      throw new IllegalArgumentException("Duration must be greater than zero seconds: " + duration);
+    if (duration.isNegative() || duration.isZero()) {
+      throw new IllegalArgumentException("Duration must be greater than zero: " + duration);
     }
 
-    if (seconds % ChronoUnit.YEARS.getDuration().getSeconds() == 0) {
-      return (seconds / ChronoUnit.YEARS.getDuration().getSeconds()) + "y";
-    } else if (seconds % ChronoUnit.MONTHS.getDuration().getSeconds() == 0) {
-      return (seconds / ChronoUnit.MONTHS.getDuration().getSeconds()) + "M";
-    } else if (seconds % ChronoUnit.WEEKS.getDuration().getSeconds() == 0) {
-      return (seconds / ChronoUnit.WEEKS.getDuration().getSeconds()) + "w";
-    } else if (seconds % ChronoUnit.DAYS.getDuration().getSeconds() == 0) {
-      return (seconds / ChronoUnit.DAYS.getDuration().getSeconds()) + "d";
-    } else if (seconds % ChronoUnit.HOURS.getDuration().getSeconds() == 0) {
-      return (seconds / ChronoUnit.HOURS.getDuration().getSeconds()) + "h";
-    } else if (seconds % ChronoUnit.MINUTES.getDuration().getSeconds() == 0) {
-      return (seconds / ChronoUnit.MINUTES.getDuration().getSeconds()) + "m";
-    } else if (seconds % ChronoUnit.SECONDS.getDuration().getSeconds() == 0) {
-      return (seconds / ChronoUnit.SECONDS.getDuration().getSeconds()) + "s";
-    } else {
-      throw new IllegalArgumentException("Duration must be a whole number of seconds: " + duration);
+    final long millis = duration.toMillis();
+    if (isWholeMultiple(millis, MILLIS_PER_DAY)) {
+      return (millis / MILLIS_PER_DAY) + "d";
     }
+    if (isWholeMultiple(millis, MILLIS_PER_HOUR)) {
+      return (millis / MILLIS_PER_HOUR) + "h";
+    }
+    if (isWholeMultiple(millis, MILLIS_PER_MINUTE)) {
+      return (millis / MILLIS_PER_MINUTE) + "m";
+    }
+    if (isWholeMultiple(millis, MILLIS_PER_SECOND)) {
+      return (millis / MILLIS_PER_SECOND) + "s";
+    }
+    return millis + "ms";
+  }
+
+  private static boolean isWholeMultiple(final long value, final long unit) {
+    return value > 0 && value % unit == 0;
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/util/DurationUtil.java
+++ b/search/search-domain/src/main/java/io/camunda/util/DurationUtil.java
@@ -8,6 +8,7 @@
 package io.camunda.util;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 public final class DurationUtil {
 
@@ -21,5 +22,30 @@ public final class DurationUtil {
   /** Returns the smaller of two durations. */
   public static Duration min(final Duration a, final Duration b) {
     return a.compareTo(b) <= 0 ? a : b;
+  }
+
+  public static String toEsOsInterval(final Duration duration) {
+    final long seconds = duration.getSeconds();
+    if (seconds <= 0) {
+      throw new IllegalArgumentException("Duration must be greater than zero seconds: " + duration);
+    }
+
+    if (seconds % ChronoUnit.YEARS.getDuration().getSeconds() == 0) {
+      return (seconds / ChronoUnit.YEARS.getDuration().getSeconds()) + "y";
+    } else if (seconds % ChronoUnit.MONTHS.getDuration().getSeconds() == 0) {
+      return (seconds / ChronoUnit.MONTHS.getDuration().getSeconds()) + "M";
+    } else if (seconds % ChronoUnit.WEEKS.getDuration().getSeconds() == 0) {
+      return (seconds / ChronoUnit.WEEKS.getDuration().getSeconds()) + "w";
+    } else if (seconds % ChronoUnit.DAYS.getDuration().getSeconds() == 0) {
+      return (seconds / ChronoUnit.DAYS.getDuration().getSeconds()) + "d";
+    } else if (seconds % ChronoUnit.HOURS.getDuration().getSeconds() == 0) {
+      return (seconds / ChronoUnit.HOURS.getDuration().getSeconds()) + "h";
+    } else if (seconds % ChronoUnit.MINUTES.getDuration().getSeconds() == 0) {
+      return (seconds / ChronoUnit.MINUTES.getDuration().getSeconds()) + "m";
+    } else if (seconds % ChronoUnit.SECONDS.getDuration().getSeconds() == 0) {
+      return (seconds / ChronoUnit.SECONDS.getDuration().getSeconds()) + "s";
+    } else {
+      throw new IllegalArgumentException("Duration must be a whole number of seconds: " + duration);
+    }
   }
 }

--- a/search/search-domain/src/test/java/io/camunda/util/DurationUtilTest.java
+++ b/search/search-domain/src/test/java/io/camunda/util/DurationUtilTest.java
@@ -63,6 +63,13 @@ public class DurationUtilTest {
 
   @ParameterizedTest(name = "{0} -> \"{1}\"")
   @CsvSource({
+    // nanoseconds (exact — no sub-millisecond remainder)
+    "PT0.000000001S, 0ms",
+    "PT0.000000500S, 0ms",
+    // milliseconds
+    "PT0.001S, 1ms",
+    "PT0.500S, 500ms",
+    "PT0.999S, 999ms",
     // seconds
     "PT1S,  1s",
     "PT30S, 30s",
@@ -78,13 +85,8 @@ public class DurationUtilTest {
     // days (exact — no sub-day remainder)
     "P1D,   1d",
     // weeks (exact multiple of 7 days)
-    "P7D,   1w",
-    "P14D,  2w",
-    "P15D,  15d", // not a whole number of weeks, stays as days
-    // months (ChronoUnit.MONTHS ≈ 30.4375 days; 2629800 s)
-    "P30DT10H30M, 43830m",
-    // years (ChronoUnit.YEARS ≈ 365.2425 days; 31557600 s)
-    "P365DT5H49M12S, 1y",
+    "P7D,   7d",
+    "P14D,  14d"
   })
   void shouldConvertToEsOsInterval(final String isoDuration, final String expectedExpression) {
     assertThat(DurationUtil.toEsOsInterval(Duration.parse(isoDuration)))
@@ -103,8 +105,11 @@ public class DurationUtilTest {
     assertThat(DurationUtil.toEsOsInterval(Duration.ofSeconds(3_600))).isEqualTo("1h");
     // 86400 s → days, not hours
     assertThat(DurationUtil.toEsOsInterval(Duration.ofSeconds(86_400))).isEqualTo("1d");
-    // 7 days → weeks, not days
-    assertThat(DurationUtil.toEsOsInterval(Duration.ofDays(7))).isEqualTo("1w");
+    // 7 days → days as this is the largest unit that divides it exactly; not weeks as weeks are not
+    // a built-in unit in ES/OS intervals
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofDays(7))).isEqualTo("7d");
+    // 1000 ms = 1 s → expressed as seconds, not milliseconds
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofMillis(1_000))).isEqualTo("1s");
   }
 
   @Test
@@ -115,6 +120,8 @@ public class DurationUtilTest {
     assertThat(DurationUtil.toEsOsInterval(Duration.ofHours(25))).isEqualTo("25h");
     // 10 days — not a whole number of weeks
     assertThat(DurationUtil.toEsOsInterval(Duration.ofDays(10))).isEqualTo("10d");
+    // 1500 ms — not a whole number of seconds
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofMillis(1_500))).isEqualTo("1500ms");
   }
 
   // -----------------------------------------------------------------------
@@ -122,12 +129,12 @@ public class DurationUtilTest {
   // -----------------------------------------------------------------------
 
   @Test
-  void shouldThrowForSubSecondDuration() {
-    assertThatThrownBy(() -> DurationUtil.toEsOsInterval(Duration.ofMillis(500)))
+  void shouldThrowForZeroOrNegativeDuration() {
+    assertThatThrownBy(() -> DurationUtil.toEsOsInterval(Duration.ZERO))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Duration must be greater than zero seconds: PT0.5S");
-    assertThatThrownBy(() -> DurationUtil.toEsOsInterval(Duration.ofNanos(1)))
+        .hasMessageContaining("greater than zero");
+    assertThatThrownBy(() -> DurationUtil.toEsOsInterval(Duration.ofMinutes(-1)))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Duration must be greater than zero seconds: PT0.000000001S");
+        .hasMessageContaining("greater than zero");
   }
 }

--- a/search/search-domain/src/test/java/io/camunda/util/DurationUtilTest.java
+++ b/search/search-domain/src/test/java/io/camunda/util/DurationUtilTest.java
@@ -8,11 +8,18 @@
 package io.camunda.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class DurationUtilTest {
+
+  // -----------------------------------------------------------------------
+  // min / max
+  // -----------------------------------------------------------------------
 
   @Test
   void minReturnsFirstWhenSmaller() {
@@ -48,5 +55,79 @@ public class DurationUtilTest {
   void maxReturnsEitherWhenEqual() {
     final var duration = Duration.ofMinutes(1);
     assertThat(DurationUtil.max(duration, duration)).isEqualTo(duration);
+  }
+
+  // -----------------------------------------------------------------------
+  // toEsOsInterval — parameterised happy path
+  // -----------------------------------------------------------------------
+
+  @ParameterizedTest(name = "{0} -> \"{1}\"")
+  @CsvSource({
+    // seconds
+    "PT1S,  1s",
+    "PT30S, 30s",
+    "PT59S, 59s",
+    // minutes (exact — no sub-minute remainder)
+    "PT1M,  1m",
+    "PT5M,  5m",
+    "PT90M, 90m",
+    // hours (exact — no sub-hour remainder)
+    "PT1H,  1h",
+    "PT2H,  2h",
+    "PT48H, 2d",
+    // days (exact — no sub-day remainder)
+    "P1D,   1d",
+    // weeks (exact multiple of 7 days)
+    "P7D,   1w",
+    "P14D,  2w",
+    "P15D,  15d", // not a whole number of weeks, stays as days
+    // months (ChronoUnit.MONTHS ≈ 30.4375 days; 2629800 s)
+    "P30DT10H30M, 43830m",
+    // years (ChronoUnit.YEARS ≈ 365.2425 days; 31557600 s)
+    "P365DT5H49M12S, 1y",
+  })
+  void shouldConvertToEsOsInterval(final String isoDuration, final String expectedExpression) {
+    assertThat(DurationUtil.toEsOsInterval(Duration.parse(isoDuration)))
+        .isEqualTo(expectedExpression.trim());
+  }
+
+  // -----------------------------------------------------------------------
+  // toEsOsInterval — coarsest-unit logic
+  // -----------------------------------------------------------------------
+
+  @Test
+  void shouldPickCoarsestExactUnit() {
+    // 60 s → minutes, not seconds
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofSeconds(60))).isEqualTo("1m");
+    // 3600 s → hours, not minutes
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofSeconds(3_600))).isEqualTo("1h");
+    // 86400 s → days, not hours
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofSeconds(86_400))).isEqualTo("1d");
+    // 7 days → weeks, not days
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofDays(7))).isEqualTo("1w");
+  }
+
+  @Test
+  void shouldNotCoarsenWhenNotExactMultiple() {
+    // 90 minutes — not a whole number of hours
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofMinutes(90))).isEqualTo("90m");
+    // 25 hours — not a whole number of days
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofHours(25))).isEqualTo("25h");
+    // 10 days — not a whole number of weeks
+    assertThat(DurationUtil.toEsOsInterval(Duration.ofDays(10))).isEqualTo("10d");
+  }
+
+  // -----------------------------------------------------------------------
+  // toEsOsInterval — error cases
+  // -----------------------------------------------------------------------
+
+  @Test
+  void shouldThrowForSubSecondDuration() {
+    assertThatThrownBy(() -> DurationUtil.toEsOsInterval(Duration.ofMillis(500)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duration must be greater than zero seconds: PT0.5S");
+    assertThatThrownBy(() -> DurationUtil.toEsOsInterval(Duration.ofNanos(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duration must be greater than zero seconds: PT0.000000001S");
   }
 }


### PR DESCRIPTION
## Description
**Commit 1:** Add support for DateHistogram ES/OS aggregations
**Commit 2:**: Add ES/OS implementation for the job time series endpoint

This pull request introduces support for date histogram aggregations in both Elasticsearch and OpenSearch search clients, enabling time-based bucketing for search queries. The changes include new transformers for handling `SearchDateHistogramAggregator`, integration with the existing aggregation transformation infrastructure, and comprehensive tests to ensure correct behavior and error handling.

**Support for Date Histogram Aggregations:**

* Added new transformer classes to handle `SearchDateHistogramAggregator` for Elasticsearch and OpenSearch, enabling both fixed and calendar interval bucketing in search queries.
* Registered the new transformers in the respective transformer registries (`ElasticsearchTransformers` and `OpensearchTransformers`) to ensure correct mapping and processing of date histogram aggregators. [[1]](diffhunk://#diff-919958141c3d20edbe5ff1f61580b28675c1bc08402f2cf22e814fbf91068ddfR158-R159) [[2]](diffhunk://#diff-9d31bfdda577f8eb2c0e77817bff09f9c711903ca85d75d4f48c894af3c569ccR158-R159)

**Enhancements to Aggregation Result Transformation:**

* Updated aggregation result transformers to handle `DateHistogramBucket` types, ensuring that date histogram results are correctly extracted and represented in the output. [[1]](diffhunk://#diff-94c46f968e4dd355de4ecb06fe2856786e47cd2ba3bfc7d41a8b8df98d5de5bbR145) [[2]](diffhunk://#diff-94c46f968e4dd355de4ecb06fe2856786e47cd2ba3bfc7d41a8b8df98d5de5bbR202) [[3]](diffhunk://#diff-c4991e7b556bf18f2f29858e87fd27a635491dea74c5ebb0d54d8ca7ad041062R148)

**Codebase Maintenance:**

* Updated import statements and internal APIs to include the new aggregator and its dependencies across the relevant modules. [[1]](diffhunk://#diff-919958141c3d20edbe5ff1f61580b28675c1bc08402f2cf22e814fbf91068ddfR15) [[2]](diffhunk://#diff-919958141c3d20edbe5ff1f61580b28675c1bc08402f2cf22e814fbf91068ddfR55) [[3]](diffhunk://#diff-9d31bfdda577f8eb2c0e77817bff09f9c711903ca85d75d4f48c894af3c569ccR14) [[4]](diffhunk://#diff-9d31bfdda577f8eb2c0e77817bff09f9c711903ca85d75d4f48c894af3c569ccR54) [[5]](diffhunk://#diff-2cf536784dfe2433d072be19b13ba9ed2e22a48ffd6bb1e67c3937afd7d0f4a3R14-R19) [[6]](diffhunk://#diff-2cf536784dfe2433d072be19b13ba9ed2e22a48ffd6bb1e67c3937afd7d0f4a3R66-R88) [[7]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R22-R27)

**Other:**

* Added a stub for job time series statistics in the RDBMS batch reader, throwing an unsupported exception for now.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43056
