### PR TITLE
Fix banned instances metrics in dashboard.

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -264,7 +264,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition))\nor sum(max(zeebe_banned_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition))",
+              "expr": "sum(max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition))\nor sum(max(zeebe_banned_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition))",
               "legendFormat": "{{namespace}}",
               "range": true,
               "refId": "A"
@@ -3676,7 +3676,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition)\nor max(zeebe_banned_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition)",
+              "expr": "max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition)\nor max(zeebe_banned_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition)",
               "legendFormat": "{{namespace}} {{partition}}",
               "range": true,
               "refId": "A"

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -150,7 +150,7 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public String getName() {
-      return "zeebe.banned.instances.total";
+      return "zeebe.banned.instances.count";
     }
 
     @Override


### PR DESCRIPTION
## Description

The word "total" in "zeebe_banned_instances_total" was being cut by Prometheus because this is a gauge and not a counter, and apparently, that word is reserved for counters. The metric should keep being a gauge since we want to be able to set the value at startup.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/47203
