### PR TITLE
feat: C8Run uses admin profile instead of identity

### DIFF
--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -5,7 +5,7 @@
 Access each component using the following URLs:
 - Operate:                {{.OperateURL}}
 - Tasklist:               {{.TasklistURL}}
-- Identity:               {{.IdentityURL}}
+- Admin:                  {{.AdminURL}}
 
 Login with:
 - Username: {{.Username}}

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -37,7 +37,7 @@ type opener interface {
 type StartupSummary struct {
 	OperateURL           string
 	TasklistURL          string
-	IdentityURL          string
+	AdminURL             string
 	Username             string
 	Password             string
 	OrchestrationAPI     string
@@ -109,11 +109,11 @@ func isRunning(ctx context.Context, name, url string, retries int, delay time.Du
 func PrintStatus(settings types.C8RunSettings) error {
 	// For non-docker mode we respect the --port flag for all apps (they share the same port).
 	// In docker mode we keep the predefined mapped ports and ignore any custom --port value.
-	operatePort, tasklistPort, identityPort, camundaPort := settings.Port, settings.Port, settings.Port, settings.Port
+	operatePort, tasklistPort, adminPort, camundaPort := settings.Port, settings.Port, settings.Port, settings.Port
 	if settings.Docker {
 		operatePort = 8080
 		tasklistPort = 8080
-		identityPort = 8080
+		adminPort = 8080
 		camundaPort = 8080
 		if settings.Port != 8080 { // warn that user provided port is ignored in docker mode
 			log.Warn().Int("provided_port", settings.Port).Msg("--port flag is ignored in docker mode; using fixed container port mappings")
@@ -139,7 +139,7 @@ func PrintStatus(settings types.C8RunSettings) error {
 	data := StartupSummary{
 		OperateURL:           fmt.Sprintf("%s://localhost:%d/operate", protocol, operatePort),
 		TasklistURL:          fmt.Sprintf("%s://localhost:%d/tasklist", protocol, tasklistPort),
-		IdentityURL:          fmt.Sprintf("%s://localhost:%d/identity", protocol, identityPort),
+		AdminURL:             fmt.Sprintf("%s://localhost:%d/admin", protocol, adminPort),
 		Username:             username,
 		Password:             password,
 		OrchestrationAPI:     fmt.Sprintf("%s://localhost:%d/v2/", protocol, camundaPort),

--- a/c8run/internal/health/camunda_test.go
+++ b/c8run/internal/health/camunda_test.go
@@ -67,7 +67,7 @@ func TestPrintStatus_NonDockerUsesPortFlag(t *testing.T) {
     expectedEndpoints := map[string]string{
         "Operate":                   "http://localhost:9090/operate",
         "Tasklist":                  "http://localhost:9090/tasklist",
-        "Identity":                  "http://localhost:9090/identity",
+        "Admin":                     "http://localhost:9090/admin",
         "Orchestration Cluster API": "http://localhost:9090/v2/",
         "Orchestration Cluster":     "http://localhost:9090/mcp/cluster",
     }
@@ -93,7 +93,7 @@ func TestPrintStatus_DockerModeIgnoresPortFlag(t *testing.T) {
     expectedEndpoints := map[string]string{
         "Operate":                   "http://localhost:8080/operate",
         "Tasklist":                  "http://localhost:8080/tasklist",
-        "Identity":                  "http://localhost:8080/identity",
+        "Admin":                     "http://localhost:8080/admin",
         "Orchestration Cluster API": "http://localhost:8080/v2/",
         "Orchestration Cluster":     "http://localhost:8080/mcp/cluster",
     }
@@ -101,7 +101,7 @@ func TestPrintStatus_DockerModeIgnoresPortFlag(t *testing.T) {
         assertEndpointForLabel(t, out, label, endpoint)
     }
     // Ensure the provided (ignored) port is not shown for those endpoints
-    if strings.Contains(out, "http://localhost:9090/operate") || strings.Contains(out, "http://localhost:9090/tasklist") || strings.Contains(out, "http://localhost:9090/identity") || strings.Contains(out, "http://localhost:9090/v2/") || strings.Contains(out, "http://localhost:9090/mcp/cluster") {
+    if strings.Contains(out, "http://localhost:9090/operate") || strings.Contains(out, "http://localhost:9090/tasklist") || strings.Contains(out, "http://localhost:9090/admin") || strings.Contains(out, "http://localhost:9090/v2/") || strings.Contains(out, "http://localhost:9090/mcp/cluster") {
         t.Fatalf("docker mode should ignore custom port 9090; output: %s", out)
     }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
