### PR TITLE
feat: add restructured process instance header

### DIFF
--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
@@ -30,6 +30,7 @@ import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.9';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {getClientConfig} from 'modules/utils/getClientConfig';
 import pluralSuffix from 'modules/utils/pluralSuffix';
+import {useNavigate} from 'react-router-dom';
 
 const headerColumns = [
   'Process Instance Key',
@@ -83,6 +84,7 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
     hasIncident,
     processDefinitionId,
   } = processInstance;
+  const navigate = useNavigate();
   const tenantsById = useAvailableTenants();
   const tenantName = tenantsById[tenantId] ?? tenantId;
 
@@ -111,7 +113,8 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   return (
     <InstanceHeader
       state={processInstanceState}
-      showBackButton
+      backButtonLabel="Back"
+      onBackClick={() => navigate(-1)}
       leadingContent={
         <ProcessNameContainer>
           <ProcessNameLabel>

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
@@ -11,39 +11,40 @@ import {formatDate} from 'modules/utils/date';
 import {ProcessInstanceOperations} from './ProcessInstanceOperations';
 import {getProcessDefinitionName} from 'modules/utils/instance';
 import {Link} from 'modules/components/Link';
-import {Locations, Paths} from 'modules/Routes';
+import {Locations} from 'modules/Routes';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {tracking} from 'modules/tracking';
 import {InstanceHeader} from 'modules/components/InstanceHeaderNext';
 import {Skeleton} from 'modules/components/InstanceHeaderNext/Skeleton';
-import {VersionTag} from './styled';
+import {
+  IncidentCount,
+  ProcessNameContainer,
+  ProcessNameLabel,
+  VersionTag,
+} from './styled';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/useProcessInstanceIncidentsCount';
 import {hasCalledProcessInstances} from 'modules/bpmn-js/utils/hasCalledProcessInstances';
 import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.9';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {getClientConfig} from 'modules/utils/getClientConfig';
+import pluralSuffix from 'modules/utils/pluralSuffix';
 
 const headerColumns = [
-  'Process Name',
   'Process Instance Key',
   'Version',
   'Version Tag',
   'Tenant',
   'Start Date',
   'End Date',
-  'Parent Process Instance Key',
-  'Called Process Instances',
+  'Called Instances',
 ] as const;
 
 const skeletonColumns: {
   name: (typeof headerColumns)[number];
   skeletonWidth: string;
 }[] = [
-  {
-    name: 'Process Name',
-    skeletonWidth: '94px',
-  },
   {
     name: 'Process Instance Key',
     skeletonWidth: '136px',
@@ -61,11 +62,7 @@ const skeletonColumns: {
     skeletonWidth: '142px',
   },
   {
-    name: 'Parent Process Instance Key',
-    skeletonWidth: '142px',
-  },
-  {
-    name: 'Called Process Instances',
+    name: 'Called Instances',
     skeletonWidth: '142px',
   },
 ] as const;
@@ -82,7 +79,6 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
     tenantId,
     startDate,
     endDate,
-    parentProcessInstanceKey,
     state,
     hasIncident,
     processDefinitionId,
@@ -95,6 +91,9 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   const processDefinitionKey = useProcessDefinitionKeyContext();
   const {isPending, data: processInstanceXmlData} = useProcessInstanceXml({
     processDefinitionKey,
+  });
+  const incidentsCount = useProcessInstanceIncidentsCount(processInstanceKey, {
+    enabled: hasIncident,
   });
 
   if (processInstance === null || isPending) {
@@ -112,7 +111,19 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   return (
     <InstanceHeader
       state={processInstanceState}
-      hideBottomBorder={hasIncident}
+      showBackButton
+      leadingContent={
+        <ProcessNameContainer>
+          <ProcessNameLabel>
+            {getProcessDefinitionName(processInstance)}
+          </ProcessNameLabel>
+          {incidentsCount > 0 && (
+            <IncidentCount>
+              {pluralSuffix(incidentsCount, 'Incident')}
+            </IncidentCount>
+          )}
+        </ProcessNameContainer>
+      }
       headerColumns={headerColumns.filter((name) => {
         if (name === 'Tenant') {
           return isMultiTenancyEnabled;
@@ -120,13 +131,12 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
         if (name === 'Version Tag') {
           return hasVersionTag;
         }
+        if (name === 'End Date') {
+          return endDate !== null;
+        }
         return true;
       })}
       bodyColumns={[
-        {
-          title: getProcessDefinitionName(processInstance),
-          content: getProcessDefinitionName(processInstance),
-        },
         {title: processInstanceKey, content: processInstanceKey},
         {
           hideOverflowingContent: false,
@@ -177,40 +187,20 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
             ]
           : []),
         {
-          title: formatDate(startDate) ?? '--',
+          title: formatDate(startDate),
           content: formatDate(startDate),
           dataTestId: 'start-date',
         },
-        {
-          title: formatDate(endDate ?? null) ?? '--',
-          content: formatDate(endDate ?? null),
-          dataTestId: 'end-date',
-        },
-        {
-          title: parentProcessInstanceKey ?? 'None',
-          hideOverflowingContent: false,
-          content: (
-            <>
-              {parentProcessInstanceKey ? (
-                <Link
-                  to={Paths.processInstance(parentProcessInstanceKey)}
-                  title={`View parent instance ${parentProcessInstanceKey}`}
-                  aria-label={`View parent instance ${parentProcessInstanceKey}`}
-                  onClick={() => {
-                    tracking.track({
-                      eventName: 'navigation',
-                      link: 'process-details-parent-details',
-                    });
-                  }}
-                >
-                  {parentProcessInstanceKey}
-                </Link>
-              ) : (
-                'None'
-              )}
-            </>
-          ),
-        },
+        ...(endDate !== null
+          ? [
+              {
+                title: formatDate(endDate),
+                content: formatDate(endDate),
+                dataTestId: 'end-date',
+              },
+            ]
+          : []),
+
         {
           hideOverflowingContent: false,
           content: (

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/styled.tsx
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {styles} from '@carbon/elements';
 import {Tag} from '@carbon/react';
 import styled from 'styled-components';
 
@@ -13,4 +14,29 @@ const VersionTag = styled(Tag)`
   margin-left: 0;
 `;
 
-export {VersionTag};
+const ProcessNameContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-right: var(--cds-spacing-05);
+`;
+
+const ProcessNameLabel = styled.span`
+  ${styles.label02};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+
+  &:has(+ span) {
+    ${styles.label01};
+  }
+`;
+
+const IncidentCount = styled.span`
+  ${styles.label02};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  color: var(--cds-support-error);
+`;
+
+export {VersionTag, ProcessNameContainer, ProcessNameLabel, IncidentCount};

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/tests/index.test.tsx
@@ -14,16 +14,13 @@ import {
 } from 'modules/testing-library';
 import {getProcessDefinitionName} from 'modules/utils/instance';
 import {ProcessInstanceHeader} from '../index';
-import {
-  mockInstance,
-  mockInstanceWithParentInstance,
-  Wrapper,
-} from './index.setup';
+import {mockInstance, Wrapper} from './index.setup';
 
 import {
   createUser,
   mockCallActivityProcessXML,
   mockProcessXML,
+  searchResult,
 } from 'modules/testUtils';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {notificationsStore} from 'modules/stores/notifications';
@@ -34,6 +31,8 @@ import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mo
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {mockDeleteProcessInstance} from 'modules/mocks/api/v2/processInstances/deleteProcessInstance';
+import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
+import {mockIncidents} from 'App/ProcessInstance/IncidentsWrapper/tests/mocks';
 
 vi.mock('modules/stores/notifications', () => ({
   notificationsStore: {
@@ -82,22 +81,62 @@ describe('InstanceHeader', () => {
         }" instances`,
       }),
     ).toHaveTextContent(mockInstance.processDefinitionVersion.toString());
-    expect(screen.getByText(mockInstance.endDate ?? '--')).toBeInTheDocument();
-    expect(screen.getByText('--')).toBeInTheDocument();
     expect(
       screen.getByTestId(`${mockInstance.state}-icon`),
     ).toBeInTheDocument();
-    expect(screen.getByText('Process Name')).toBeInTheDocument();
     expect(screen.getByText('Process Instance Key')).toBeInTheDocument();
     expect(screen.getByText('Version')).toBeInTheDocument();
     expect(screen.getByText('Start Date')).toBeInTheDocument();
-    expect(screen.getByText('End Date')).toBeInTheDocument();
-    expect(screen.getByText('Parent Process Instance Key')).toBeInTheDocument();
-    expect(screen.getByText('Called Process Instances')).toBeInTheDocument();
-    expect(screen.getAllByText('None').length).toBe(2);
+    expect(screen.queryByText('End Date')).not.toBeInTheDocument();
+    expect(screen.getByText('Called Instances')).toBeInTheDocument();
+    expect(screen.getAllByText('None').length).toBe(1);
     expect(
       screen.queryByRole('link', {name: /view all/i}),
     ).not.toBeInTheDocument();
+  });
+
+  it('should render an end date for finished process instances', async () => {
+    const finishedInstance = {
+      ...mockInstance,
+      status: 'COMPLETED',
+      endDate: '2020-06-21 00:00:00',
+    };
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+
+    render(<ProcessInstanceHeader processInstance={finishedInstance} />, {
+      wrapper: Wrapper,
+    });
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('instance-header-skeleton'),
+    );
+
+    expect(screen.getByText('End Date')).toBeInTheDocument();
+    expect(screen.getByText(finishedInstance.endDate)).toBeInTheDocument();
+  });
+
+  it('should render an incidents count for process instances with incidents', async () => {
+    const finishedInstance = {
+      ...mockInstance,
+      state: 'ACTIVE',
+      hasIncident: true,
+    } satisfies typeof mockInstance;
+    mockSearchIncidentsByProcessInstance(
+      finishedInstance.processInstanceKey,
+    ).withSuccess(mockIncidents);
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+
+    render(<ProcessInstanceHeader processInstance={finishedInstance} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(await screen.findByText('2 Incidents')).toBeInTheDocument();
+    expect(screen.getByTestId(`INCIDENT-icon`)).toBeInTheDocument();
+    expect(
+      screen.getByText(finishedInstance.processDefinitionName),
+    ).toBeInTheDocument();
   });
 
   it('should render "View All" link for call activity process', async () => {
@@ -157,41 +196,6 @@ describe('InstanceHeader', () => {
 
     expect(screen.getByTestId('pathname')).toHaveTextContent(/^\/processes$/);
     expect(panelStatesStore.state.isFiltersCollapsed).toBe(false);
-  });
-
-  it('should render parent Process Instance Key', async () => {
-    mockQueryBatchOperationItems().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
-
-    render(
-      <ProcessInstanceHeader
-        processInstance={{
-          ...mockInstance,
-          parentProcessInstanceKey: '8724390842390124',
-        }}
-      />,
-      {
-        wrapper: Wrapper,
-      },
-    );
-
-    await waitForElementToBeRemoved(
-      screen.queryByTestId('instance-header-skeleton'),
-    );
-
-    expect(
-      screen.getByRole('link', {
-        description: `View parent instance ${mockInstanceWithParentInstance.parentProcessInstanceKey}`,
-      }),
-    ).toBeInTheDocument();
   });
 
   it('should show spinner when instance has active operations', async () => {

--- a/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
+++ b/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
@@ -10,7 +10,6 @@ import {Button} from '@carbon/react';
 import {Container, Table, Th, Td} from './styled';
 import {StateIcon} from 'modules/components/StateIcon';
 import {ArrowLeft} from '@carbon/react/icons';
-import {useNavigate} from 'react-router-dom';
 
 type Column = {
   title?: string;
@@ -26,7 +25,8 @@ type Props = {
   leadingContent?: React.ReactNode;
   additionalContent?: React.ReactNode;
   hideBottomBorder?: boolean;
-  showBackButton?: boolean;
+  backButtonLabel?: string;
+  onBackClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 const InstanceHeader: React.FC<Props> = ({
@@ -36,25 +36,25 @@ const InstanceHeader: React.FC<Props> = ({
   leadingContent,
   additionalContent,
   hideBottomBorder = false,
-  showBackButton = false,
+  backButtonLabel = 'Back',
+  onBackClick,
 }) => {
-  const navigate = useNavigate();
-
   return (
     <Container
       data-testid="instance-header"
       $hideBottomBorder={hideBottomBorder}
     >
-      {showBackButton && (
+      {onBackClick && (
         <Button
           kind="ghost"
           size="sm"
           renderIcon={ArrowLeft}
           hasIconOnly
-          iconDescription="Back"
+          iconDescription={backButtonLabel}
+          aria-label={backButtonLabel}
           tooltipPosition="bottom"
-          aria-label="Back"
-          onClick={() => navigate(-1)}
+          tooltipAlignment="start"
+          onClick={onBackClick}
         />
       )}
       <StateIcon state={state} size={24} data-testid={`${state}-icon`} />

--- a/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
+++ b/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
@@ -6,8 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {Button} from '@carbon/react';
 import {Container, Table, Th, Td} from './styled';
 import {StateIcon} from 'modules/components/StateIcon';
+import {ArrowLeft} from '@carbon/react/icons';
+import {useNavigate} from 'react-router-dom';
 
 type Column = {
   title?: string;
@@ -20,24 +23,43 @@ type Props = {
   state: React.ComponentProps<typeof StateIcon>['state'];
   headerColumns: string[];
   bodyColumns: Column[];
+  leadingContent?: React.ReactNode;
   additionalContent?: React.ReactNode;
   hideBottomBorder?: boolean;
+  showBackButton?: boolean;
 };
 
 const InstanceHeader: React.FC<Props> = ({
   state,
   headerColumns,
   bodyColumns,
+  leadingContent,
   additionalContent,
   hideBottomBorder = false,
+  showBackButton = false,
 }) => {
+  const navigate = useNavigate();
+
   return (
     <Container
       data-testid="instance-header"
       $hideBottomBorder={hideBottomBorder}
     >
+      {showBackButton && (
+        <Button
+          kind="ghost"
+          size="sm"
+          renderIcon={ArrowLeft}
+          hasIconOnly
+          iconDescription="Back"
+          tooltipPosition="bottom"
+          aria-label="Back"
+          onClick={() => navigate(-1)}
+        />
+      )}
       <StateIcon state={state} size={24} data-testid={`${state}-icon`} />
 
+      {leadingContent}
       <Table>
         <thead>
           <tr>

--- a/operate/client/src/modules/components/InstanceHeaderNext/styled.ts
+++ b/operate/client/src/modules/components/InstanceHeaderNext/styled.ts
@@ -14,12 +14,15 @@ import {
 } from '@carbon/react';
 
 const Table = styled.table`
-  width: 100%;
-  padding-left: var(--cds-spacing-05);
-  table-layout: fixed;
+  table-layout: auto;
   border-collapse: separate;
-  border-spacing: var(--cds-spacing-01);
+  border-spacing: 0 var(--cds-spacing-01);
   color: var(--cds-text-secondary);
+
+  th:not(:first-child),
+  td:not(:first-child) {
+    padding-left: var(--cds-spacing-07);
+  }
 `;
 
 const Th = styled.th`
@@ -57,6 +60,7 @@ const Container = styled.header<ContainerProps>`
     return css`
       display: flex;
       align-items: center;
+      gap: var(--cds-spacing-05);
       background-color: var(--cds-layer-01);
       padding: var(--cds-spacing-02) var(--cds-spacing-05);
       border-bottom: 1px solid var(--cds-border-subtle-01);
@@ -64,6 +68,10 @@ const Container = styled.header<ContainerProps>`
       css`
         border-bottom: none;
       `}
+
+      & > :last-child {
+        margin-left: auto;
+      }
     `;
   }}
 `;

--- a/operate/client/src/modules/utils/date/formatDate.test.ts
+++ b/operate/client/src/modules/utils/date/formatDate.test.ts
@@ -38,6 +38,6 @@ describe('formatDate', () => {
     const givenDate = new Date('2019-11-06T14:24:15.422');
     const expectedDate = '2019-11-06 14:24:15';
 
-    expect(formatDate(givenDate, null)).toEqual(expectedDate);
+    expect(formatDate(givenDate, 'custom')).toEqual(expectedDate);
   });
 });

--- a/operate/client/src/modules/utils/date/formatDate.ts
+++ b/operate/client/src/modules/utils/date/formatDate.ts
@@ -14,8 +14,8 @@ function parseDate(dateString: string | Date) {
 
 function formatDate(
   dateString: string | Date | null,
-  placeholder: string | null = '--',
-) {
+  placeholder = '--',
+): string {
   return dateString
     ? format(parseDate(dateString), 'yyyy-MM-dd HH:mm:ss')
     : placeholder;


### PR DESCRIPTION
## Description

Updates the process instance header with the changes from the design mockup. The process name aligns with the mock-up (although a bit simplified), but I am unsure if it is really the intended approach. It feels a bit inconsistent between PIs with(-out) incidents, and decision instances...

