### PR TITLE
perf: replace ConcurrentSkipListMap with ring buffer in FlowControl

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backpressure/LimitCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backpressure/LimitCfg.java
@@ -88,6 +88,19 @@ public final class LimitCfg implements ConfigurationEntry {
   }
 
   /**
+   * Returns the maximum concurrency allowed by the configured algorithm, or 0 if the algorithm does
+   * not define an explicit upper bound. Used to size the in-flight ring buffer in flow control.
+   */
+  public int maxConcurrency() {
+    return switch (algorithm) {
+      case AIMD -> aimd.getMaxLimit();
+      case FIXED -> fixed.getLimit();
+      case LEGACY_VEGAS -> legacyVegas.getMaxConcurrency();
+      default -> 0;
+    };
+  }
+
+  /**
    * @return null if disabled, (windowed) limit otherwise.
    */
   public Limit buildLimit() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -69,6 +69,10 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
 
   private LogStream buildLogStream(final PartitionTransitionContext context) {
     final var flowControlCfg = context.getBrokerCfg().getFlowControl();
+    final var requestLimitCfg =
+        flowControlCfg.getRequest() != null
+            ? flowControlCfg.getRequest()
+            : context.getBrokerCfg().getBackpressure();
     return logStreamBuilderSupplier
         .get()
         .withLogStorage(context.getLogStorage())
@@ -76,12 +80,10 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         .withPartitionId(context.getPartitionId())
         .withMaxFragmentSize(context.getMaxFragmentSize())
         .withClock(context.getStreamClock())
-        .withRequestLimit(
-            flowControlCfg.getRequest() != null
-                ? flowControlCfg.getRequest().buildLimit()
-                : context.getBrokerCfg().getBackpressure().buildLimit())
+        .withRequestLimit(requestLimitCfg.buildLimit())
         .withWriteRateLimit(
             flowControlCfg.getWrite() != null ? flowControlCfg.getWrite().buildLimit() : null)
+        .withInFlightCapacity(requestLimitCfg.maxConcurrency())
         .withMeterRegistry(context.getPartitionTransitionMeterRegistry())
         .build();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -73,6 +73,7 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         flowControlCfg.getRequest() != null
             ? flowControlCfg.getRequest()
             : context.getBrokerCfg().getBackpressure();
+    final var ringBufferSizeMultiplier = 100;
     return logStreamBuilderSupplier
         .get()
         .withLogStorage(context.getLogStorage())
@@ -83,7 +84,7 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         .withRequestLimit(requestLimitCfg.buildLimit())
         .withWriteRateLimit(
             flowControlCfg.getWrite() != null ? flowControlCfg.getWrite().buildLimit() : null)
-        .withInFlightCapacity(requestLimitCfg.maxConcurrency())
+        .withInFlightCapacity(requestLimitCfg.maxConcurrency() * ringBufferSizeMultiplier)
         .withMeterRegistry(context.getPartitionTransitionMeterRegistry())
         .build();
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -63,10 +63,11 @@ import java.util.List;
  *
  * <p>The {@link #inFlight} ring buffer is a fixed-capacity {@link RingBuffer} indexed by position.
  * It is modified by {@link #registerEntry(long, InFlightEntry)} (under the sequencer lock) and read
- * from other methods. The ring buffer uses an {@link java.util.concurrent.atomic.AtomicReferenceArray}
- * internally, providing volatile read/write semantics per slot. This ensures that entries written by
- * the sequencer thread are visible to the raft thread ({@code onWrite}, {@code onCommit}) and the
- * stream processor thread ({@code onProcessed}) without requiring external synchronization.
+ * from other methods. The ring buffer uses an {@link
+ * java.util.concurrent.atomic.AtomicReferenceArray} internally, providing volatile read/write
+ * semantics per slot. This ensures that entries written by the sequencer thread are visible to the
+ * raft thread ({@code onWrite}, {@code onCommit}) and the stream processor thread ({@code
+ * onProcessed}) without requiring external synchronization.
  *
  * <p>When a new entry is registered and the slot is already occupied (the previous entry was never
  * processed), the displaced entry's {@link InFlightEntry#cleanup()} is called to release resources.

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -210,7 +210,7 @@ public final class FlowControl implements AppendListener {
     final var inFlightEntry = inFlight.get(position);
     if (inFlightEntry != null) {
       inFlightEntry.onProcessed();
-      inFlight.remove(position, inFlightEntry);
+      inFlight.remove(inFlightEntry);
     }
     lastProcessedPosition = position;
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -95,19 +95,18 @@ public final class FlowControl implements AppendListener {
   private volatile long lastProcessedPosition = -1;
   private volatile long lastExportedPosition;
 
-  private static final int DEFAULT_IN_FLIGHT_CAPACITY = 1024 * 1024; // 1M slots, ~8MB array
   private final RingBuffer inFlight;
 
   public FlowControl(final LogStreamMetrics metrics) {
-    this(metrics, StabilizingAIMDLimit.newBuilder().build(), RateLimit.disabled());
+    this(metrics, StabilizingAIMDLimit.newBuilder().build(), RateLimit.disabled(), 0);
   }
 
   public FlowControl(
       final LogStreamMetrics metrics, final Limit requestLimit, final RateLimit writeRateLimit) {
-    this(metrics, requestLimit, writeRateLimit, DEFAULT_IN_FLIGHT_CAPACITY);
+    this(metrics, requestLimit, writeRateLimit, 0);
   }
 
-  FlowControl(
+  public FlowControl(
       final LogStreamMetrics metrics,
       final Limit requestLimit,
       final RateLimit writeRateLimit,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -24,8 +24,6 @@ import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
-import java.util.NavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * Maintains a view of in-flight entries as they are being appended, written, committed and finally
@@ -55,21 +53,23 @@ import java.util.concurrent.ConcurrentSkipListMap;
  *       stream processor actor.
  * </ol>
  *
- * The entry is registered in the {@link #inFlight} map via {@link #registerEntry(long,
+ * The entry is registered in the {@link #inFlight} ring buffer via {@link #registerEntry(long,
  * InFlightEntry)} inside the sequencer lock, before {@code logStorage.append} is called. This
- * guarantees that the entry is present in the map when {@link #onWrite(long, long)} and {@link
+ * guarantees that the entry is present in the buffer when {@link #onWrite(long, long)} and {@link
  * #onCommit(long, long)} callbacks fire.
  *
  * <p>{@link #onWrite(long, long)} and {@link #onCommit(long, long)} and {@link #onProcessed(long)}
  * can be called in any order.
  *
- * <p>The {@link #inFlight} map is a {@link ConcurrentSkipListMap}. It is modified by {@link
- * #registerEntry(long, InFlightEntry)} (under the sequencer lock) and read from other methods.
- * Because readers ({@code onWrite}, {@code onCommit}, {@code onProcessed}) run on different
- * threads, the concurrent map provides the necessary visibility guarantees.
+ * <p>The {@link #inFlight} ring buffer is a fixed-capacity {@link RingBuffer} indexed by position.
+ * It is modified by {@link #registerEntry(long, InFlightEntry)} (under the sequencer lock) and read
+ * from other methods. The ring buffer uses an {@link java.util.concurrent.atomic.AtomicReferenceArray}
+ * internally, providing volatile read/write semantics per slot. This ensures that entries written by
+ * the sequencer thread are visible to the raft thread ({@code onWrite}, {@code onCommit}) and the
+ * stream processor thread ({@code onProcessed}) without requiring external synchronization.
  *
- * <p>A volatile field {@link #lastProcessedPosition} is only modified in {@link #onProcessed(long)}
- * and used in {@link #onAppended(InFlightEntry)} to clean up old entries.
+ * <p>When a new entry is registered and the slot is already occupied (the previous entry was never
+ * processed), the displaced entry's {@link InFlightEntry#cleanup()} is called to release resources.
  *
  * <p>The RateMeasurement#observe method only returns true when a new observation value is
  * available. This way we prevent updating the metrics too often with repeated values. We use the
@@ -94,7 +94,8 @@ public final class FlowControl implements AppendListener {
   private volatile long lastProcessedPosition = -1;
   private volatile long lastExportedPosition;
 
-  private final NavigableMap<Long, InFlightEntry> inFlight = new ConcurrentSkipListMap<>();
+  private static final int DEFAULT_IN_FLIGHT_CAPACITY = 1024 * 1024; // 1M slots, ~8MB array
+  private final RingBuffer inFlight;
 
   public FlowControl(final LogStreamMetrics metrics) {
     this(metrics, StabilizingAIMDLimit.newBuilder().build(), RateLimit.disabled());
@@ -102,7 +103,16 @@ public final class FlowControl implements AppendListener {
 
   public FlowControl(
       final LogStreamMetrics metrics, final Limit requestLimit, final RateLimit writeRateLimit) {
+    this(metrics, requestLimit, writeRateLimit, DEFAULT_IN_FLIGHT_CAPACITY);
+  }
+
+  FlowControl(
+      final LogStreamMetrics metrics,
+      final Limit requestLimit,
+      final RateLimit writeRateLimit,
+      final int inFlightCapacity) {
     this.metrics = metrics;
+    this.inFlight = new RingBuffer(inFlightCapacity);
     setRequestLimit(requestLimit);
     setWriteRateLimit(writeRateLimit);
   }
@@ -169,9 +179,6 @@ public final class FlowControl implements AppendListener {
   public void onAppended(final InFlightEntry entry) {
     entry.onAppend();
     metrics.increaseInflightAppends();
-    final var clearable = inFlight.headMap(lastProcessedPosition, true);
-    clearable.forEach((position, inFlightEntry) -> inFlightEntry.cleanup());
-    clearable.clear();
   }
 
   @Override
@@ -203,6 +210,7 @@ public final class FlowControl implements AppendListener {
     final var inFlightEntry = inFlight.get(position);
     if (inFlightEntry != null) {
       inFlightEntry.onProcessed();
+      inFlight.remove(position);
     }
     lastProcessedPosition = position;
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -112,7 +112,7 @@ public final class FlowControl implements AppendListener {
       final RateLimit writeRateLimit,
       final int inFlightCapacity) {
     this.metrics = metrics;
-    this.inFlight = new RingBuffer(inFlightCapacity);
+    inFlight = new RingBuffer(inFlightCapacity);
     setRequestLimit(requestLimit);
     setWriteRateLimit(writeRateLimit);
   }
@@ -210,7 +210,7 @@ public final class FlowControl implements AppendListener {
     final var inFlightEntry = inFlight.get(position);
     if (inFlightEntry != null) {
       inFlightEntry.onProcessed();
-      inFlight.remove(position);
+      inFlight.remove(position, inFlightEntry);
     }
     lastProcessedPosition = position;
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -92,7 +92,6 @@ public final class FlowControl implements AppendListener {
           ActorClock::currentTimeMillis, Duration.ofMinutes(5), Duration.ofSeconds(10));
   private RateLimitThrottle writeRateThrottle;
   private volatile long lastWrittenPosition = -1;
-  private volatile long lastProcessedPosition = -1;
   private volatile long lastExportedPosition;
 
   private final RingBuffer inFlight;
@@ -212,7 +211,6 @@ public final class FlowControl implements AppendListener {
       inFlightEntry.onProcessed();
       inFlight.remove(inFlightEntry);
     }
-    lastProcessedPosition = position;
   }
 
   public void onExported(final long position) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -89,14 +89,18 @@ public final class InFlightEntry {
     final var requestListener = this.requestListener;
     if (requestListener != null) {
       requestListener.onIgnore();
+      metrics.decreaseInflightRequests();
+      this.requestListener = null;
     }
     final var writeTimer = this.writeTimer;
     if (writeTimer != null) {
       writeTimer.close();
+      this.writeTimer = null;
     }
     final var commitTimer = this.commitTimer;
     if (commitTimer != null) {
       commitTimer.close();
+      this.commitTimer = null;
     }
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -19,6 +19,20 @@ public final class InFlightEntry {
   CloseableSilently writeTimer;
   CloseableSilently commitTimer;
 
+  /**
+   * The position this entry was registered at in the ring buffer. Set by {@link RingBuffer#put}
+   * before the entry reference is published into the array. Used by {@link RingBuffer#get} to
+   * verify that the entry in a slot actually belongs to the requested position (guards against
+   * wraparound collisions).
+   *
+   * <p>This field is intentionally <em>not</em> volatile. Visibility is guaranteed by the {@link
+   * java.util.concurrent.atomic.AtomicReferenceArray} used in the ring buffer: {@code put} sets
+   * this field before the volatile write ({@code getAndSet}) that publishes the entry reference.
+   * Readers obtain the reference via a volatile read ({@code get}) on the same array slot, which
+   * establishes a happens-before edge that carries this plain write.
+   */
+  long position;
+
   public InFlightEntry(
       final LogStreamMetrics metrics,
       final LogAppendEntryMetadata entryMetadata,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -26,22 +26,27 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * the ring buffer.
  */
 final class RingBuffer {
+  private static final int DEFAULT_CAPACITY = 8 * 1024; // 8K slots
+
   private final AtomicReferenceArray<InFlightEntry> buffer;
   private final int mask;
 
   /**
-   * Creates a new ring buffer with the given capacity.
+   * Creates a new ring buffer with at least the given capacity. The actual capacity is rounded up to
+   * the next power of two. If {@code minCapacity} is 0, a default of {@value #DEFAULT_CAPACITY} is
+   * used.
    *
-   * @param capacity must be a positive power of two
-   * @throws IllegalArgumentException if capacity is not a positive power of two
+   * @param minCapacity must be non-negative
+   * @throws IllegalArgumentException if minCapacity is negative
    */
-  RingBuffer(final int capacity) {
-    if (capacity <= 0 || (capacity & (capacity - 1)) != 0) {
-      throw new IllegalArgumentException(
-          "capacity must be a positive power of two, got: " + capacity);
+  RingBuffer(final int minCapacity) {
+    if (minCapacity < 0) {
+      throw new IllegalArgumentException("capacity must be non-negative, got: " + minCapacity);
     }
-    mask = capacity - 1;
-    buffer = new AtomicReferenceArray<>(capacity);
+    final int requested = minCapacity == 0 ? DEFAULT_CAPACITY : minCapacity;
+    final int actualCapacity = requested == 1 ? 1 : Integer.highestOneBit(requested - 1) << 1;
+    mask = actualCapacity - 1;
+    buffer = new AtomicReferenceArray<>(actualCapacity);
   }
 
   /**

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -74,8 +74,8 @@ final class RingBuffer {
   }
 
   /** Removes the entry at the given position by nulling the slot. */
-  void remove(final long position) {
-    buffer.set((int) (position & mask), null);
+  void remove(final long position, final InFlightEntry entry) {
+    buffer.compareAndExchange((int) (position & mask), entry, null);
   }
 
   /** Returns the capacity of this ring buffer. */

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -32,9 +32,9 @@ final class RingBuffer {
   private final int mask;
 
   /**
-   * Creates a new ring buffer with at least the given capacity. The actual capacity is rounded up to
-   * the next power of two. If {@code minCapacity} is 0, a default of {@value #DEFAULT_CAPACITY} is
-   * used.
+   * Creates a new ring buffer with at least the given capacity. The actual capacity is rounded up
+   * to the next power of two. If {@code minCapacity} is 0, a default of {@value #DEFAULT_CAPACITY}
+   * is used.
    *
    * @param minCapacity must be non-negative
    * @throws IllegalArgumentException if minCapacity is negative

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -83,9 +83,12 @@ final class RingBuffer {
     return entry != null && entry.position == position ? entry : null;
   }
 
-  /** Removes the entry at the given position by nulling the slot. */
-  void remove(final long position, final InFlightEntry entry) {
-    buffer.compareAndExchange((int) (position & mask), entry, null);
+  /**
+   * Removes the entry at the given position by nulling the slot if the entry in the buffer matches
+   * {@param entry}
+   */
+  void remove(final InFlightEntry entry) {
+    buffer.compareAndExchange((int) (entry.position & mask), entry, null);
   }
 
   /** Returns the capacity of this ring buffer. */

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.flowcontrol;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * A fixed-capacity ring buffer for {@link InFlightEntry} instances, indexed by position. Uses
+ * power-of-two capacity with {@code & mask} indexing for O(1) operations.
+ *
+ * <p>Each slot has volatile read/write semantics via {@link AtomicReferenceArray}, ensuring
+ * visibility across threads without external synchronization.
+ *
+ * <h3>Wraparound safety</h3>
+ *
+ * <p>Because multiple positions map to the same slot (modular indexing), a slot may be overwritten
+ * by a newer position after a full wraparound. To guard against reading the wrong entry, {@link
+ * #put(long, InFlightEntry)} stamps the entry with the position before the volatile write, and
+ * {@link #get(long)} verifies that the entry's {@link InFlightEntry#position} matches the requested
+ * position. This keeps all concurrency concerns (position stamping + volatile publication) inside
+ * the ring buffer.
+ */
+final class RingBuffer {
+  private final AtomicReferenceArray<InFlightEntry> buffer;
+  private final int mask;
+
+  /**
+   * Creates a new ring buffer with the given capacity.
+   *
+   * @param capacity must be a positive power of two
+   * @throws IllegalArgumentException if capacity is not a positive power of two
+   */
+  RingBuffer(final int capacity) {
+    if (capacity <= 0 || (capacity & (capacity - 1)) != 0) {
+      throw new IllegalArgumentException(
+          "capacity must be a positive power of two, got: " + capacity);
+    }
+    mask = capacity - 1;
+    buffer = new AtomicReferenceArray<>(capacity);
+  }
+
+  /**
+   * Puts an entry at the given position. Stamps {@code entry.position} before the volatile write so
+   * that it is published together with the reference. If the slot was occupied, the displaced
+   * entry's {@link InFlightEntry#cleanup()} is called to release resources (timers, request
+   * listeners).
+   */
+  void put(final long position, final InFlightEntry entry) {
+    // Plain write, published by the volatile getAndSet below (happens-before).
+    entry.position = position;
+    final var displaced = buffer.getAndSet((int) (position & mask), entry);
+    if (displaced != null) {
+      displaced.cleanup();
+    }
+  }
+
+  /**
+   * Returns the entry at the given position, or null if the slot is empty or holds an entry for a
+   * different position (i.e. the slot was overwritten by a wraparound).
+   */
+  InFlightEntry get(final long position) {
+    final var entry = buffer.get((int) (position & mask));
+    return entry != null && entry.position == position ? entry : null;
+  }
+
+  /** Removes the entry at the given position by nulling the slot. */
+  void remove(final long position) {
+    buffer.set((int) (position & mask), null);
+  }
+
+  /** Returns the capacity of this ring buffer. */
+  int capacity() {
+    return buffer.length();
+  }
+}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -44,9 +44,19 @@ final class RingBuffer {
       throw new IllegalArgumentException("capacity must be non-negative, got: " + minCapacity);
     }
     final int requested = minCapacity == 0 ? DEFAULT_CAPACITY : minCapacity;
-    final int actualCapacity = requested == 1 ? 1 : Integer.highestOneBit(requested - 1) << 1;
+    final var actualCapacity = nextPowerOfTwo(requested);
     mask = actualCapacity - 1;
     buffer = new AtomicReferenceArray<>(actualCapacity);
+  }
+
+  private static int nextPowerOfTwo(final int minCapacity) {
+    final var capacity = minCapacity == 1 ? 1 : Integer.highestOneBit(minCapacity - 1) << 1;
+    if (capacity <= 0) {
+      throw new IllegalArgumentException(
+          "Expected next power of two of minCapacity to not overflow, but got %d from a minCapacity=%d"
+              .formatted(capacity, minCapacity));
+    }
+    return capacity;
   }
 
   /**

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import org.agrona.BitUtil;
 
 /**
  * A fixed-capacity ring buffer for {@link InFlightEntry} instances, indexed by position. Uses
@@ -44,19 +45,9 @@ final class RingBuffer {
       throw new IllegalArgumentException("capacity must be non-negative, got: " + minCapacity);
     }
     final int requested = minCapacity == 0 ? DEFAULT_CAPACITY : minCapacity;
-    final var actualCapacity = nextPowerOfTwo(requested);
+    final var actualCapacity = BitUtil.findNextPositivePowerOfTwo(requested);
     mask = actualCapacity - 1;
     buffer = new AtomicReferenceArray<>(actualCapacity);
-  }
-
-  private static int nextPowerOfTwo(final int minCapacity) {
-    final var capacity = minCapacity == 1 ? 1 : Integer.highestOneBit(minCapacity - 1) << 1;
-    if (capacity <= 0) {
-      throw new IllegalArgumentException(
-          "Expected next power of two of minCapacity to not overflow, but got %d from a minCapacity=%d"
-              .formatted(capacity, minCapacity));
-    }
-    return capacity;
   }
 
   /**

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -25,6 +25,7 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
   private InstantSource clock;
   private Limit requestLimit;
   private RateLimit writeRateLimit;
+  private int inFlightCapacity;
   private MeterRegistry meterRegistry;
 
   @Override
@@ -70,6 +71,12 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
   }
 
   @Override
+  public LogStreamBuilder withInFlightCapacity(final int inFlightCapacity) {
+    this.inFlightCapacity = inFlightCapacity;
+    return this;
+  }
+
+  @Override
   public LogStreamBuilder withMeterRegistry(final MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
     return this;
@@ -87,6 +94,7 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
         clock,
         requestLimit,
         writeRateLimit,
+        inFlightCapacity,
         meterRegistry);
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -46,13 +46,15 @@ public final class LogStreamImpl implements LogStream, CommitListener {
       final InstantSource clock,
       final Limit requestLimit,
       final RateLimit writeRateLimit,
+      final int inFlightCapacity,
       final MeterRegistry meterRegistry) {
     this.logName = logName;
 
     this.partitionId = partitionId;
     this.logStorage = logStorage;
     flowControl =
-        new FlowControl(new LogStreamMetrics(meterRegistry), requestLimit, writeRateLimit);
+        new FlowControl(
+            new LogStreamMetrics(meterRegistry), requestLimit, writeRateLimit, inFlightCapacity);
     sequencer =
         new Sequencer(
             logStorage,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
@@ -61,7 +61,7 @@ public interface LogStreamBuilder {
    * Sets the capacity of the in-flight entry ring buffer used by flow control. The actual capacity
    * is rounded up to the next power of two. If not set (or set to 0), a default is used.
    *
-   * @param capacity the minimum ring buffer capacity (must be positive)
+   * @param capacity the minimum ring buffer capacity (non-negative: 0 is used as default)
    * @return this builder
    */
   LogStreamBuilder withInFlightCapacity(int capacity);

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
@@ -58,6 +58,15 @@ public interface LogStreamBuilder {
   LogStreamBuilder withWriteRateLimit(RateLimit writeRateLimit);
 
   /**
+   * Sets the capacity of the in-flight entry ring buffer used by flow control. The actual capacity
+   * is rounded up to the next power of two. If not set (or set to 0), a default is used.
+   *
+   * @param capacity the minimum ring buffer capacity (must be positive)
+   * @return this builder
+   */
+  LogStreamBuilder withInFlightCapacity(int capacity);
+
+  /**
    * Sets the meter registry to collect metrics on.
    *
    * @param meterRegistry the new meter registry to collect metrics on

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -15,6 +15,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Nested;
@@ -40,9 +41,24 @@ final class RingBufferTest {
   @Test
   void removeNullsTheSlot() {
     final var buffer = new RingBuffer(4);
-    buffer.put(3, newEntry());
-    buffer.remove(3);
+    final var entry = newEntry();
+    buffer.put(3, entry);
+    buffer.remove(3, entry);
     assertThat(buffer.get(3)).isNull();
+  }
+
+  @Test
+  void removeDoesNotRemoveOverwrittenEntry() {
+    final var buffer = new RingBuffer(4);
+    final var position = 3;
+    final var positionWrapped = position + buffer.capacity();
+    final var entry = newEntry();
+    buffer.put(position, entry);
+    final var secondEntry = newEntry();
+    buffer.put(positionWrapped, secondEntry);
+    buffer.remove(position, entry);
+    assertThat(buffer.get(position)).isNull();
+    assertThat(buffer.get(positionWrapped)).isSameAs(secondEntry);
   }
 
   @Test
@@ -165,10 +181,12 @@ final class RingBufferTest {
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
-                  while (buffer.get(pos) == null) {
+                  InFlightEntry entry = null;
+                  while (entry == null) {
+                    entry = buffer.get(pos);
                     LockSupport.parkNanos(1);
                   }
-                  buffer.remove(pos);
+                  buffer.remove(pos, entry);
                   try {
                     assertThat(buffer.get(pos)).isNull();
                   } catch (final AssertionError e) {
@@ -250,7 +268,7 @@ final class RingBufferTest {
       final var buffer = new RingBuffer(smallCapacity);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
-      final var writerPosition = new java.util.concurrent.atomic.AtomicLong(0);
+      final var writerPosition = new AtomicLong(0);
 
       final var writer =
           new Thread(
@@ -262,8 +280,8 @@ final class RingBufferTest {
                 }
               });
 
-      final var hits = new java.util.concurrent.atomic.AtomicLong(0);
-      final var misses = new java.util.concurrent.atomic.AtomicLong(0);
+      final var hits = new AtomicLong(0);
+      final var misses = new AtomicLong(0);
 
       final var reader =
           new Thread(

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -89,8 +89,7 @@ final class RingBufferTest {
 
   @Test
   void constructorRejectsNegative() {
-    assertThatThrownBy(() -> new RingBuffer(-1))
-        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new RingBuffer(-1)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Nested

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.flowcontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.LockSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class RingBufferTest {
+
+  private static final LogStreamMetrics METRICS = new LogStreamMetrics(new SimpleMeterRegistry());
+
+  /** Creates a new InFlightEntry. Position is set by {@link RingBuffer#put}. */
+  private static InFlightEntry newEntry() {
+    return new InFlightEntry(METRICS, null, null);
+  }
+
+  @Test
+  void getReturnsStoredEntry() {
+    final var buffer = new RingBuffer(4);
+    final var entry = newEntry();
+    buffer.put(1, entry);
+    assertThat(buffer.get(1)).isSameAs(entry);
+  }
+
+  @Test
+  void removeNullsTheSlot() {
+    final var buffer = new RingBuffer(4);
+    buffer.put(3, newEntry());
+    buffer.remove(3);
+    assertThat(buffer.get(3)).isNull();
+  }
+
+  @Test
+  void getReturnsNullWhenPositionDoesNotMatch() {
+    // Position guard: after wraparound, get(oldPosition) returns null because
+    // the entry in the slot was stamped with the new position.
+    final var buffer = new RingBuffer(4);
+    buffer.put(5, newEntry());
+    // Overwrite slot with position 9 (same slot: 9 & 3 == 1 == 5 & 3)
+    final var lastEntry = newEntry();
+    buffer.put(9, lastEntry);
+    // get(5) should return null — the slot holds an entry for position 9
+    assertThat(buffer.get(5)).isNull();
+    // get(9) should return the entry
+    assertThat(buffer.get(9)).isNotNull().isSameAs(lastEntry);
+  }
+
+  @Test
+  void putSetsPositionOnEntry() {
+    final var buffer = new RingBuffer(4);
+    final var entry = newEntry();
+    buffer.put(42, entry);
+    assertThat(entry.position).isEqualTo(42);
+  }
+
+  @Test
+  void constructorRejectsNonPowerOfTwo() {
+    assertThatThrownBy(() -> new RingBuffer(3))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("power of two");
+  }
+
+  @Test
+  void constructorRejectsZero() {
+    assertThatThrownBy(() -> new RingBuffer(0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("power of two");
+  }
+
+  @Test
+  void constructorRejectsNegative() {
+    assertThatThrownBy(() -> new RingBuffer(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("power of two");
+  }
+
+  @Test
+  void capacityReturnsConfiguredSize() {
+    final var buffer = new RingBuffer(16);
+    assertThat(buffer.capacity()).isEqualTo(16);
+  }
+
+  @Nested
+  class ConcurrencyTests {
+
+    // Capacity must exceed ITERATIONS to avoid wraparound in tests that assert exact entries
+    private static final int CAPACITY = 1 << 17; // 131072
+    private static final int ITERATIONS = 100_000;
+
+    /**
+     * Simulates the FlowControl access pattern: one writer thread puts entries (sequencer), a
+     * reader thread reads them (raft thread). Verifies that entries written by the writer are
+     * visible to the reader.
+     */
+    @Test
+    void writerIsVisibleToReader() {
+      final var buffer = new RingBuffer(CAPACITY);
+      final var failures = new ConcurrentLinkedQueue<Throwable>();
+      final var startLatch = new CountDownLatch(1);
+
+      final var writer =
+          new Thread(
+              () -> {
+                awaitLatch(startLatch);
+                for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  buffer.put(pos, newEntry());
+                }
+              });
+
+      final var reader =
+          new Thread(
+              () -> {
+                awaitLatch(startLatch);
+                for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  InFlightEntry entry;
+                  while ((entry = buffer.get(pos)) == null) {
+                    LockSupport.parkNanos(1);
+                  }
+                  try {
+                    assertThat(entry.position).isEqualTo(pos);
+                  } catch (final AssertionError e) {
+                    failures.add(e);
+                    return;
+                  }
+                }
+              });
+
+      runAndAwait(startLatch, failures, writer, reader);
+      assertThat(failures).isEmpty();
+    }
+
+    /**
+     * Simulates the full lifecycle: writer puts entries, a second thread reads and then removes
+     * them (like onProcessed). Verifies removal is visible.
+     */
+    @Test
+    void removeIsVisibleAcrossThreads() {
+      final var buffer = new RingBuffer(CAPACITY);
+      final var failures = new ConcurrentLinkedQueue<Throwable>();
+      final var startLatch = new CountDownLatch(1);
+
+      final var writer =
+          new Thread(
+              () -> {
+                awaitLatch(startLatch);
+                for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  buffer.put(pos, newEntry());
+                }
+              });
+
+      final var processor =
+          new Thread(
+              () -> {
+                awaitLatch(startLatch);
+                for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  while (buffer.get(pos) == null) {
+                    LockSupport.parkNanos(1);
+                  }
+                  buffer.remove(pos);
+                  try {
+                    assertThat(buffer.get(pos)).isNull();
+                  } catch (final AssertionError e) {
+                    failures.add(e);
+                    return;
+                  }
+                }
+              });
+
+      runAndAwait(startLatch, failures, writer, processor);
+      assertThat(failures).isEmpty();
+    }
+
+    /**
+     * Multiple reader threads concurrently reading the same positions that a single writer is
+     * publishing. Mirrors the FlowControl pattern where onWrite (raft thread), onCommit (raft
+     * thread), and onProcessed (stream processor) may all read the same entry.
+     */
+    @Test
+    void multipleReadersSeeWriterUpdates() {
+      final var buffer = new RingBuffer(CAPACITY);
+      final var failures = new ConcurrentLinkedQueue<Throwable>();
+      final var startLatch = new CountDownLatch(1);
+
+      final var writer =
+          new Thread(
+              () -> {
+                awaitLatch(startLatch);
+                for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  buffer.put(pos, newEntry());
+                }
+              });
+
+      final var readers = new Thread[3];
+      for (int i = 0; i < readers.length; i++) {
+        readers[i] =
+            new Thread(
+                () -> {
+                  awaitLatch(startLatch);
+                  for (long pos = 1; pos <= ITERATIONS; pos++) {
+                    InFlightEntry entry;
+                    while ((entry = buffer.get(pos)) == null) {
+                      LockSupport.parkNanos(1);
+                    }
+                    try {
+                      assertThat(entry.position).isEqualTo(pos);
+                    } catch (final AssertionError e) {
+                      failures.add(e);
+                      return;
+                    }
+                  }
+                });
+      }
+
+      final var allThreads = new Thread[readers.length + 1];
+      allThreads[0] = writer;
+      System.arraycopy(readers, 0, allThreads, 1, readers.length);
+      runAndAwait(startLatch, failures, allThreads);
+      assertThat(failures).isEmpty();
+    }
+
+    /**
+     * Writer wraps around with a small capacity. The reader trails the writer using a shared
+     * progress counter, reading positions that the writer has recently written. This ensures both
+     * paths are exercised:
+     *
+     * <ul>
+     *   <li><b>Hit</b>: the entry is still in the slot (reader is close behind the writer)
+     *   <li><b>Miss</b>: the entry was displaced by a newer write (reader fell behind by more than
+     *       capacity positions)
+     * </ul>
+     *
+     * The test asserts that both hits and misses occurred and that every hit returned the correct
+     * entry (position guard was not bypassed).
+     */
+    @Test
+    void positionGuardWorksUnderConcurrentWraparound() {
+      final var smallCapacity = 64;
+      final var buffer = new RingBuffer(smallCapacity);
+      final var failures = new ConcurrentLinkedQueue<Throwable>();
+      final var startLatch = new CountDownLatch(1);
+      final var writerPosition = new java.util.concurrent.atomic.AtomicLong(0);
+
+      final var writer =
+          new Thread(
+              () -> {
+                awaitLatch(startLatch);
+                for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  buffer.put(pos, newEntry());
+                  writerPosition.set(pos);
+                }
+              });
+
+      final var hits = new java.util.concurrent.atomic.AtomicLong(0);
+      final var misses = new java.util.concurrent.atomic.AtomicLong(0);
+
+      final var reader =
+          new Thread(
+              () -> {
+                awaitLatch(startLatch);
+                long readerPos = 0;
+                while (readerPos < ITERATIONS) {
+                  final long writerPos = writerPosition.get();
+                  if (writerPos <= readerPos) {
+                    LockSupport.parkNanos(1);
+                    continue;
+                  }
+                  // Read a position that was recently written — may or may not have been displaced
+                  // by now. Read from (writerPos - smallCapacity + 1) to exercise the boundary
+                  // where entries are about to be displaced.
+                  final long readPos = Math.max(readerPos + 1, writerPos - smallCapacity + 1);
+                  readerPos = readPos;
+                  try {
+                    final var entry = buffer.get(readPos);
+                    if (entry != null) {
+                      assertThat(entry.position).isEqualTo(readPos);
+                      hits.incrementAndGet();
+                    } else {
+                      misses.incrementAndGet();
+                    }
+                  } catch (final AssertionError e) {
+                    failures.add(e);
+                    return;
+                  }
+                }
+              });
+
+      runAndAwait(startLatch, failures, writer, reader);
+      assertThat(failures).isEmpty();
+      assertThat(hits.get()).as("expected some hits (entry still present)").isGreaterThan(0);
+      assertThat(misses.get()).as("expected some misses (entry displaced)").isGreaterThan(0);
+    }
+
+    /** Starts all threads, releases the latch, and waits for all threads to finish. */
+    private void runAndAwait(
+        final CountDownLatch startLatch,
+        final ConcurrentLinkedQueue<Throwable> failures,
+        final Thread... threads) {
+      for (final var thread : threads) {
+        thread.setUncaughtExceptionHandler((t, e) -> failures.add(e));
+        thread.start();
+      }
+      startLatch.countDown();
+
+      Awaitility.await("threads complete")
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                for (final var thread : threads) {
+                  assertThat(thread.isAlive()).isFalse();
+                }
+              });
+    }
+
+    private void awaitLatch(final CountDownLatch latch) {
+      try {
+        latch.await();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -69,30 +69,28 @@ final class RingBufferTest {
   }
 
   @Test
-  void constructorRejectsNonPowerOfTwo() {
-    assertThatThrownBy(() -> new RingBuffer(3))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("power of two");
+  void constructorRoundsUpToNextPowerOfTwo() {
+    assertThat(new RingBuffer(1).capacity()).isEqualTo(1);
+    assertThat(new RingBuffer(2).capacity()).isEqualTo(2);
+    assertThat(new RingBuffer(3).capacity()).isEqualTo(4);
+    assertThat(new RingBuffer(5).capacity()).isEqualTo(8);
+    assertThat(new RingBuffer(7).capacity()).isEqualTo(8);
+    assertThat(new RingBuffer(9).capacity()).isEqualTo(16);
+    assertThat(new RingBuffer(1000).capacity()).isEqualTo(1024);
+    assertThat(new RingBuffer(1024).capacity()).isEqualTo(1024);
+    assertThat(new RingBuffer(1025).capacity()).isEqualTo(2048);
   }
 
   @Test
-  void constructorRejectsZero() {
-    assertThatThrownBy(() -> new RingBuffer(0))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("power of two");
+  void constructorUsesDefaultForZero() {
+    final var buffer = new RingBuffer(0);
+    assertThat(buffer.capacity()).isEqualTo(8192);
   }
 
   @Test
   void constructorRejectsNegative() {
     assertThatThrownBy(() -> new RingBuffer(-1))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("power of two");
-  }
-
-  @Test
-  void capacityReturnsConfiguredSize() {
-    final var buffer = new RingBuffer(16);
-    assertThat(buffer.capacity()).isEqualTo(16);
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Nested

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -43,7 +43,7 @@ final class RingBufferTest {
     final var buffer = new RingBuffer(4);
     final var entry = newEntry();
     buffer.put(3, entry);
-    buffer.remove(3, entry);
+    buffer.remove(entry);
     assertThat(buffer.get(3)).isNull();
   }
 
@@ -56,7 +56,7 @@ final class RingBufferTest {
     buffer.put(position, entry);
     final var secondEntry = newEntry();
     buffer.put(positionWrapped, secondEntry);
-    buffer.remove(position, entry);
+    buffer.remove(entry);
     assertThat(buffer.get(position)).isNull();
     assertThat(buffer.get(positionWrapped)).isSameAs(secondEntry);
   }
@@ -186,7 +186,7 @@ final class RingBufferTest {
                     entry = buffer.get(pos);
                     LockSupport.parkNanos(1);
                   }
-                  buffer.remove(pos, entry);
+                  buffer.remove(entry);
                   try {
                     assertThat(buffer.get(pos)).isNull();
                   } catch (final AssertionError e) {

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStreamBuilder.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStreamBuilder.java
@@ -69,6 +69,12 @@ public final class TestLogStreamBuilder implements LogStreamBuilder {
   }
 
   @Override
+  public TestLogStreamBuilder withInFlightCapacity(final int capacity) {
+    delegate.withInFlightCapacity(capacity);
+    return this;
+  }
+
+  @Override
   public TestLogStreamBuilder withMeterRegistry(final MeterRegistry meterRegistry) {
     delegate.withMeterRegistry(meterRegistry);
     return this;


### PR DESCRIPTION
## Description

Replace the unbounded ConcurrentSkipListMap<Long, InFlightEntry> with a fixed-capacity RingBuffer backed by AtomicReferenceArray. This reduces memory from ~500-600MB under high load to ~8KB (8k slots), and gives O(1) put/get/remove instead of O(log n).

The RingBuffer handles all concurrency concerns internally:
- Stamps each entry with its position before the volatile write
- Verifies position on get() to guard against wraparound collisions
- Calls cleanup() on displaced entries when a slot is overwritten

Removes the headMap-based cleanup from onAppended() since displaced entries are now cleaned up eagerly on overwrite.

The ringbuffer size is determined by the `LimitCfg` for the configurations that have a maxLimit. For the others we use the default of 8k. 

In general it's fairly strange that the processor is lagging behind more than 8k records, but we can change that in the future.
If it's lagging more than then, then the entry is just `cleanup()` and discarded. The writer is not blocked by this.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #39881
