### PR TITLE
fix: retry snapshot reservation with re-discovery during backup

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -152,8 +152,7 @@ final class BackupServiceImpl {
             .setMessage("No existing backup found, taking a new backup")
             .log();
         inProgressBackup
-            .findValidSnapshot()
-            .andThen(ok -> inProgressBackup.reserveSnapshot(), concurrencyControl)
+            .reserveSnapshot()
             .andThen(inProgressBackup::findSegmentFiles, concurrencyControl)
             .andThen(ok -> inProgressBackup.findSnapshotFiles(), concurrencyControl)
             .onComplete(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
@@ -11,9 +11,7 @@ import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import java.util.OptionalLong;
-import java.util.Set;
 
 interface InProgressBackup {
 
@@ -22,8 +20,6 @@ interface InProgressBackup {
   BackupDescriptor backupDescriptor();
 
   BackupIdentifier id();
-
-  ActorFuture<Set<PersistedSnapshot>> findValidSnapshot();
 
   ActorFuture<Void> reserveSnapshot();
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 final class InProgressBackupImpl implements InProgressBackup {
 
   private static final Logger LOG = LoggerFactory.getLogger(InProgressBackupImpl.class);
+  private static final int MAX_RESERVATION_ATTEMPTS = 3;
 
   private final PersistedSnapshotStore snapshotStore;
   private final BackupIdentifier backupId;
@@ -140,19 +141,23 @@ final class InProgressBackupImpl implements InProgressBackup {
   public ActorFuture<Void> reserveSnapshot() {
     final ActorFuture<Void> future = concurrencyControl.createFuture();
     if (hasSnapshot) {
-      // Try reserve snapshot in the order - latest snapshot first
-      final var snapshotIterator =
-          availableValidSnapshots.stream()
-              .sorted(Comparator.comparingLong(PersistedSnapshot::getCompactionBound).reversed())
-              .iterator();
-
-      tryReserveAnySnapshot(snapshotIterator, future);
+      tryReserveWithRetry(future, MAX_RESERVATION_ATTEMPTS);
     } else {
       // No snapshot to reserve
       future.complete(null);
     }
 
     return future;
+  }
+
+  private void tryReserveWithRetry(final ActorFuture<Void> future, final int remainingAttempts) {
+    // Try reserve snapshot in the order - latest snapshot first
+    final var snapshotIterator =
+        availableValidSnapshots.stream()
+            .sorted(Comparator.comparingLong(PersistedSnapshot::getCompactionBound).reversed())
+            .iterator();
+
+    tryReserveAnySnapshot(snapshotIterator, future, remainingAttempts);
   }
 
   @Override
@@ -374,7 +379,9 @@ final class InProgressBackupImpl implements InProgressBackup {
   }
 
   private void tryReserveAnySnapshot(
-      final Iterator<PersistedSnapshot> snapshotIterator, final ActorFuture<Void> future) {
+      final Iterator<PersistedSnapshot> snapshotIterator,
+      final ActorFuture<Void> future,
+      final int remainingAttempts) {
     final var snapshot = snapshotIterator.next();
 
     LOG.atTrace()
@@ -393,7 +400,27 @@ final class InProgressBackupImpl implements InProgressBackup {
                   .setCause(error)
                   .setMessage("Failed to reserve snapshot, trying next available snapshot")
                   .log();
-              tryReserveAnySnapshot(snapshotIterator, future);
+              tryReserveAnySnapshot(snapshotIterator, future, remainingAttempts);
+            } else if (remainingAttempts > 1) {
+              LOG.atDebug()
+                  .addKeyValue("backup", backupId)
+                  .addKeyValue("remainingAttempts", remainingAttempts - 1)
+                  .setCause(error)
+                  .setMessage("Failed to reserve any available snapshot, re-discovering snapshots")
+                  .log();
+              findValidSnapshot()
+                  .onComplete(
+                      (snapshots, findError) -> {
+                        if (findError != null) {
+                          future.completeExceptionally(findError);
+                        } else if (!hasSnapshot) {
+                          future.completeExceptionally(
+                              new SnapshotNotFoundException(
+                                  "No snapshots available after re-discovery"));
+                        } else {
+                          tryReserveWithRetry(future, remainingAttempts - 1);
+                        }
+                      });
             } else {
               LOG.atError()
                   .addKeyValue("backup", backupId)

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -94,8 +94,7 @@ final class InProgressBackupImpl implements InProgressBackup {
     return backupId;
   }
 
-  @Override
-  public ActorFuture<Set<PersistedSnapshot>> findValidSnapshot() {
+  private ActorFuture<Set<PersistedSnapshot>> findValidSnapshot() {
     final ActorFuture<Set<PersistedSnapshot>> result = concurrencyControl.createFuture();
     snapshotStore
         .getAvailableSnapshots()
@@ -140,14 +139,23 @@ final class InProgressBackupImpl implements InProgressBackup {
   @Override
   public ActorFuture<Void> reserveSnapshot() {
     final ActorFuture<Void> future = concurrencyControl.createFuture();
-    if (hasSnapshot) {
-      tryReserveWithRetry(future, MAX_RESERVATION_ATTEMPTS);
-    } else {
-      // No snapshot to reserve
-      future.complete(null);
-    }
-
+    findAndReserveSnapshot(future, MAX_RESERVATION_ATTEMPTS);
     return future;
+  }
+
+  private void findAndReserveSnapshot(final ActorFuture<Void> future, final int remainingAttempts) {
+    findValidSnapshot()
+        .onComplete(
+            (snapshots, findError) -> {
+              if (findError != null) {
+                future.completeExceptionally(findError);
+              } else if (!hasSnapshot) {
+                // No snapshot to reserve
+                future.complete(null);
+              } else {
+                tryReserveWithRetry(future, remainingAttempts);
+              }
+            });
   }
 
   private void tryReserveWithRetry(final ActorFuture<Void> future, final int remainingAttempts) {
@@ -408,19 +416,7 @@ final class InProgressBackupImpl implements InProgressBackup {
                   .setCause(error)
                   .setMessage("Failed to reserve any available snapshot, re-discovering snapshots")
                   .log();
-              findValidSnapshot()
-                  .onComplete(
-                      (snapshots, findError) -> {
-                        if (findError != null) {
-                          future.completeExceptionally(findError);
-                        } else if (!hasSnapshot) {
-                          future.completeExceptionally(
-                              new SnapshotNotFoundException(
-                                  "No snapshots available after re-discovery"));
-                        } else {
-                          tryReserveWithRetry(future, remainingAttempts - 1);
-                        }
-                      });
+              findAndReserveSnapshot(future, remainingAttempts - 1);
             } else {
               LOG.atError()
                   .addKeyValue("backup", backupId)

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -48,7 +48,6 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
-import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.util.Either;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
@@ -56,7 +55,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -153,7 +151,7 @@ class BackupServiceImplTest {
   void shouldFailBackupWhenNoValidSnapshotFound() {
     // given
     final ControllableInProgressBackup inProgressBackup =
-        new ControllableInProgressBackup().failOnFindValidSnapshot();
+        new ControllableInProgressBackup().failOnReserveSnapshot();
 
     // when
     final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
@@ -831,8 +829,6 @@ class BackupServiceImplTest {
 
     private final BackupIdentifier id;
     private final BackupDescriptor checkpointDescriptor;
-    private ActorFuture<Set<PersistedSnapshot>> findValidSnapshotFuture =
-        TestActorFuture.completedFuture(null);
     private ActorFuture<Void> reserveSnapshotFuture = TestActorFuture.completedFuture(null);
     private ActorFuture<Void> findSnapshotFilesFuture = TestActorFuture.completedFuture(null);
     private ActorFuture<Void> findSegmentFilesFuture = TestActorFuture.completedFuture(null);
@@ -857,11 +853,6 @@ class BackupServiceImplTest {
     @Override
     public BackupIdentifier id() {
       return id;
-    }
-
-    @Override
-    public ActorFuture<Set<PersistedSnapshot>> findValidSnapshot() {
-      return findValidSnapshotFuture;
     }
 
     @Override
@@ -910,11 +901,6 @@ class BackupServiceImplTest {
 
     ControllableInProgressBackup failOnReserveSnapshot() {
       reserveSnapshotFuture = failedFuture();
-      return this;
-    }
-
-    ControllableInProgressBackup failOnFindValidSnapshot() {
-      findValidSnapshotFuture = failedFuture();
       return this;
     }
   }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -197,6 +198,32 @@ class InProgressBackupImplTest {
     // then
     assertThat(backup.descriptor().snapshotId()).hasValue(oldValidSnapshot.getId());
     verify(oldValidSnapshot).reserve();
+  }
+
+  @Test
+  void shouldRetryReservationByRediscoveringSnapshots(
+      @Mock final SnapshotReservation snapshotReservation) {
+    // given - a snapshot that was deleted between find and reserve (e.g. after leader change)
+    final var deletedSnapshot = snapshotWith(1L, 5L);
+    failOnReserve(deletedSnapshot);
+
+    // a new snapshot becomes available on retry
+    final var newSnapshot = snapshotWith(2L, 6L);
+    onReserve(newSnapshot, snapshotReservation);
+
+    // first discovery returns the soon-to-be-deleted snapshot,
+    // second discovery (after retry) returns the new one
+    when(snapshotStore.getAvailableSnapshots())
+        .thenReturn(TestActorFuture.completedFuture(Set.of(deletedSnapshot)))
+        .thenReturn(TestActorFuture.completedFuture(Set.of(newSnapshot)));
+
+    // when
+    final var future = inProgressBackup.reserveSnapshot();
+
+    // then - succeeds after re-discovering snapshots
+    assertThat(future).succeedsWithin(Duration.ofMillis(100));
+    verify(newSnapshot).reserve();
+    verify(snapshotStore, times(2)).getAvailableSnapshots();
   }
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
@@ -80,22 +80,7 @@ class InProgressBackupImplTest {
     setAvailableSnapshots(Set.of());
 
     // when
-    final var future = inProgressBackup.findValidSnapshot();
-
-    // then
-    assertThat(future).succeedsWithin(Duration.ofMillis(100));
-  }
-
-  @Test
-  void shouldCompleteFutureWhenValidSnapshotFound() {
-    // given
-    final var validSnapshot = snapshotWith(1L, 5L);
-    final var invalidSnapshot = snapshotWith(8L, 20L);
-    final Set<PersistedSnapshot> snapshots = Set.of(validSnapshot, invalidSnapshot);
-    setAvailableSnapshots(snapshots);
-
-    // when
-    final var future = inProgressBackup.findValidSnapshot();
+    final var future = inProgressBackup.reserveSnapshot();
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(100));
@@ -108,9 +93,8 @@ class InProgressBackupImplTest {
     when(invalidSnapshot.getId()).thenReturn("snapshot-1");
     setAvailableSnapshots(Set.of(invalidSnapshot));
 
-    // when - then
     // when
-    final var future = inProgressBackup.findValidSnapshot();
+    final var future = inProgressBackup.reserveSnapshot();
 
     // then
     assertThat(future)
@@ -130,7 +114,7 @@ class InProgressBackupImplTest {
     setAvailableSnapshots(Set.of(invalidSnapshot));
 
     // when
-    final var future = inProgressBackup.findValidSnapshot();
+    final var future = inProgressBackup.reserveSnapshot();
 
     // then
     assertThat(future)
@@ -154,20 +138,6 @@ class InProgressBackupImplTest {
     // then
     assertThat(backup.descriptor().snapshotId()).hasValue(validSnapshot.getId());
     verify(validSnapshot).reserve();
-  }
-
-  @Test
-  void shouldNotFailReservationWhenNoSnapshotExists() {
-    // given
-    setAvailableSnapshots(Set.of());
-
-    inProgressBackup.findValidSnapshot().join();
-
-    // when
-    final var future = inProgressBackup.reserveSnapshot();
-
-    // then
-    assertThat(future).succeedsWithin(Duration.ofMillis(100));
   }
 
   @Test
@@ -197,7 +167,7 @@ class InProgressBackupImplTest {
     final Set<PersistedSnapshot> snapshots = Set.of(validSnapshot);
     setAvailableSnapshots(snapshots);
 
-    inProgressBackup.findValidSnapshot().join();
+    // when
     final var future = inProgressBackup.reserveSnapshot();
 
     // then
@@ -237,7 +207,6 @@ class InProgressBackupImplTest {
     final Set<PersistedSnapshot> snapshots = Set.of(validSnapshot);
     setAvailableSnapshots(snapshots);
 
-    inProgressBackup.findValidSnapshot().join();
     inProgressBackup.reserveSnapshot().join();
 
     // when
@@ -305,7 +274,8 @@ class InProgressBackupImplTest {
   }
 
   @Test
-  void shouldIgnoreSnapshotWithExporterPositionTooFarAhead() {
+  void shouldIgnoreSnapshotWithExporterPositionTooFarAhead(
+      @Mock final SnapshotReservation snapshotReservation) {
     // given
     final var checkpointPosition = inProgressBackup.backupDescriptor().checkpointPosition();
     final var validExporterPosition = checkpointPosition - 1L;
@@ -313,13 +283,14 @@ class InProgressBackupImplTest {
 
     final var validSnapshot = snapshotWith(1L, 1L, validExporterPosition);
     final var invalidSnapshot = snapshotWith(1L, 1L, invalidExporterPosition);
+    onReserve(validSnapshot, snapshotReservation);
     setAvailableSnapshots(Set.of(validSnapshot, invalidSnapshot));
 
     // when
-    final var validSnapshots = inProgressBackup.findValidSnapshot().join();
+    inProgressBackup.reserveSnapshot().join();
 
-    // then
-    assertThat(validSnapshots).singleElement().isEqualTo(validSnapshot);
+    // then - only the valid snapshot should be reserved
+    verify(validSnapshot).reserve();
   }
 
   @Test
@@ -337,7 +308,7 @@ class InProgressBackupImplTest {
     setAvailableSnapshots(Set.of(s1, s2, s3));
 
     // then - error message explains all invalid snapshots
-    assertThat(inProgressBackup.findValidSnapshot())
+    assertThat(inProgressBackup.reserveSnapshot())
         .failsWithin(Duration.ofMillis(200))
         .withThrowableOfType(ExecutionException.class)
         .withRootCauseInstanceOf(SnapshotNotFoundException.class)
@@ -363,7 +334,6 @@ class InProgressBackupImplTest {
   }
 
   private Backup collectBackupContents() {
-    inProgressBackup.findValidSnapshot().join();
     inProgressBackup.reserveSnapshot().join();
     inProgressBackup.findSegmentFiles().join();
     inProgressBackup.findSnapshotFiles().join();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupReplicatedPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupReplicatedPartitionTest.java
@@ -135,17 +135,7 @@ class BackupReplicatedPartitionTest {
             .findAny()
             .map(b -> b.getConfig().getCluster().getNodeId())
             .orElseThrow();
-    final var initialSnapshot = clusteringRule.getSnapshot(clusteringRule.getBroker(anyFollower));
     clusteringRule.forceNewLeaderForPartition(anyFollower, 1);
-    // On leader change, we take a new snapshot. Make sure that happened before taking a new
-    // backup, otherwise the backup might fail when the initial snapshot is deleted right before
-    // reservation.
-    Awaitility.await()
-        .timeout(Duration.ofSeconds(15))
-        .untilAsserted(
-            () ->
-                assertThat(clusteringRule.getSnapshot(clusteringRule.getBroker(anyFollower)))
-                    .isNotEqualTo(initialSnapshot));
 
     client.createSingleJob(JOB_TYPE);
 


### PR DESCRIPTION
Makes backup snapshot reservation resilient to concurrent snapshot changes by retrying with re-discovery up to 3 times.

When taking a backup, the system first discovers valid snapshots via `findValidSnapshot()`, then reserves one via `reserveSnapshot()`. There is a race window between these two steps: a new snapshot can be persisted (e.g. after a leader transition), which deletes the previously discovered snapshot before it can be reserved. When only one snapshot was available, this caused the backup to fail with `SnapshotNotFoundException`.

Now, when all discovered snapshots fail to reserve in `InProgressBackupImpl.tryReserveAnySnapshot()`, the code calls `findValidSnapshot()` again to re-discover the current set of available snapshots and retries reservation. This cycle repeats up to 3 total attempts. The flaky Awaitility wait in `BackupReplicatedPartitionTest.shouldTakeNewBackupAfterLeaderChange` — which tried to work around this race by waiting for a new snapshot after leader change — is removed since the backup system itself now handles the race.