### PR TITLE
feat: support variables in FEEL evaluation from the java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
@@ -16,6 +16,8 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.EvaluateExpressionResponse;
+import java.io.InputStream;
+import java.util.Map;
 
 /** Command to evaluate an expression. */
 public interface EvaluateExpressionCommandStep1 {
@@ -30,5 +32,58 @@ public interface EvaluateExpressionCommandStep1 {
 
   interface EvaluateExpressionCommandStep2
       extends CommandWithTenantStep<EvaluateExpressionCommandStep2>,
-          FinalCommandStep<EvaluateExpressionResponse> {}
+          FinalCommandStep<EvaluateExpressionResponse>,
+          CommandWithVariables<EvaluateExpressionCommandStep2> {
+
+    /**
+     * Set the variables for the expression evaluation.
+     *
+     * @param variables the variables JSON document as String
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    @Override
+    EvaluateExpressionCommandStep2 variables(String variables);
+
+    /**
+     * Set the variables for the expression evaluation.
+     *
+     * @param variables the variables document as object to be serialized to JSON
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    @Override
+    EvaluateExpressionCommandStep2 variables(Object variables);
+
+    /**
+     * Set the variables for the expression evaluation.
+     *
+     * @param variables the variables JSON document as stream
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    @Override
+    EvaluateExpressionCommandStep2 variables(InputStream variables);
+
+    /**
+     * Set the variables for the expression evaluation.
+     *
+     * @param variables the variables document as map
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    @Override
+    EvaluateExpressionCommandStep2 variables(Map<String, Object> variables);
+
+    /**
+     * Set a single variable for the expression evaluation.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    @Override
+    EvaluateExpressionCommandStep2 variable(String key, Object value);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
@@ -32,10 +32,10 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class EvaluateExpressionCommandImpl
+    extends CommandWithVariables<EvaluateExpressionCommandStep2>
     implements EvaluateExpressionCommandStep1, EvaluateExpressionCommandStep2 {
 
   private final ExpressionEvaluationRequest request;
-  private final JsonMapper jsonMapper;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
@@ -43,7 +43,7 @@ public class EvaluateExpressionCommandImpl
       final CamundaClientConfiguration config,
       final HttpClient httpClient,
       final JsonMapper jsonMapper) {
-    this.jsonMapper = jsonMapper;
+    super(jsonMapper);
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     request = new ExpressionEvaluationRequest();
@@ -64,6 +64,12 @@ public class EvaluateExpressionCommandImpl
   }
 
   @Override
+  protected EvaluateExpressionCommandStep2 setVariablesInternal(final String variables) {
+    request.setVariables(objectMapper.fromJsonAsMap(variables));
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<EvaluateExpressionResponse> requestTimeout(
       final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -75,7 +81,7 @@ public class EvaluateExpressionCommandImpl
     final HttpCamundaFuture<EvaluateExpressionResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
         "/expression/evaluation",
-        jsonMapper.toJson(request),
+        objectMapper.toJson(request),
         httpRequestConfig.build(),
         ExpressionEvaluationResult.class,
         EvaluateExpressionResponseImpl::new,

--- a/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
@@ -26,12 +26,24 @@ import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public final class EvaluateExpressionTest extends ClientRestTest {
+
+  private static Map<String, Object> variablesMap(
+      final String k1, final Object v1, final String k2, final Object v2) {
+    final Map<String, Object> map = new HashMap<>();
+    map.put(k1, v1);
+    map.put(k2, v2);
+    return map;
+  }
 
   @Test
   void shouldEvaluateExpression() {
@@ -68,6 +80,107 @@ public final class EvaluateExpressionTest extends ClientRestTest {
         .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
         .extractingBody(ExpressionEvaluationRequest.class)
         .isEqualTo(new ExpressionEvaluationRequest().expression(expression).tenantId(tenantId));
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithVariablesAsMap() {
+    // given
+    final String expression = "=x + y";
+    final Map<String, Object> variables = variablesMap("x", 10, "y", 20);
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(30));
+
+    // when
+    client.newEvaluateExpressionCommand().expression(expression).variables(variables).send().join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(
+            new ExpressionEvaluationRequest()
+                .expression(expression)
+                .tenantId("<default>")
+                .variables(variables));
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithVariablesAsJsonString() {
+    // given
+    final String expression = "=x + y";
+    final String variablesJson = "{\"x\": 10, \"y\": 20}";
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(30));
+
+    // when
+    client
+        .newEvaluateExpressionCommand()
+        .expression(expression)
+        .variables(variablesJson)
+        .send()
+        .join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(
+            new ExpressionEvaluationRequest()
+                .expression(expression)
+                .tenantId("<default>")
+                .variables(variablesMap("x", 10, "y", 20)));
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithVariablesAsInputStream() {
+    // given
+    final String expression = "=x + y";
+    final String variablesJson = "{\"x\": 10, \"y\": 20}";
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(30));
+
+    // when
+    client
+        .newEvaluateExpressionCommand()
+        .expression(expression)
+        .variables(new ByteArrayInputStream(variablesJson.getBytes(StandardCharsets.UTF_8)))
+        .send()
+        .join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(
+            new ExpressionEvaluationRequest()
+                .expression(expression)
+                .tenantId("<default>")
+                .variables(variablesMap("x", 10, "y", 20)));
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithSingleVariable() {
+    // given
+    final String expression = "=x * 2";
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(20));
+
+    // when
+    client.newEvaluateExpressionCommand().expression(expression).variable("x", 10).send().join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(
+            new ExpressionEvaluationRequest()
+                .expression(expression)
+                .tenantId("<default>")
+                .variables(Collections.singletonMap("x", 10)));
   }
 
   @Test

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -463,7 +463,7 @@ public class RequestMapper {
   public static Either<ProblemDetail, ExpressionEvaluationRequest> toExpressionEvaluationRequest(
       final String expression,
       final String tenantId,
-      final Map<String, Object> context,
+      final Map<String, Object> variables,
       final boolean isMultiTenancyEnabled) {
     final var validator =
         validateTenantId(tenantId, isMultiTenancyEnabled, "Expression Evaluation");
@@ -475,7 +475,7 @@ public class RequestMapper {
               INVALID_ARGUMENT.name()));
     }
     return validator.map(
-        validTenantId -> new ExpressionEvaluationRequest(expression, validTenantId, context));
+        validTenantId -> new ExpressionEvaluationRequest(expression, validTenantId, variables));
   }
 
   public static Either<ProblemDetail, DeployResourcesRequest> toDeployResourceRequest(

--- a/service/src/main/java/io/camunda/service/ExpressionServices.java
+++ b/service/src/main/java/io/camunda/service/ExpressionServices.java
@@ -47,10 +47,10 @@ public final class ExpressionServices extends ApiServices<ExpressionServices> {
     return sendBrokerRequest(
         new BrokerExpressionEvaluationRequest()
             .setExpression(request.expression())
-            .setVariables(request.context())
+            .setVariables(request.variables())
             .setTenantId(request.tenantId()));
   }
 
   public record ExpressionEvaluationRequest(
-      String expression, String tenantId, Map<String, Object> context) {}
+      String expression, String tenantId, Map<String, Object> variables) {}
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -46,9 +46,9 @@ components:
           type: string
           description: Required when the expression references tenant-scoped cluster variables
           example: "tenant_123"
-        context:
+        variables:
           type: object
-          description: Optional context variables for expression evaluation. These variables are only used for the current evaluation and do not persist beyond it.
+          description: Optional variables for expression evaluation. These variables are only used for the current evaluation and do not persist beyond it.
           example:
             x: 10
             y: 20

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ExpressionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ExpressionController.java
@@ -45,7 +45,7 @@ public class ExpressionController {
     return RequestMapper.toExpressionEvaluationRequest(
             request.getExpression(),
             request.getTenantId(),
-            request.getContext(),
+            request.getVariables(),
             multiTenancyCfg.isChecksEnabled())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::evaluateExpression);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
@@ -99,7 +99,7 @@ public class ExpressionControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldEvaluateExpressionWithContext() {
+  void shouldEvaluateExpressionWithVariables() {
     // given
     final var expressionRecord = mock(ExpressionRecord.class);
     when(expressionRecord.getExpression()).thenReturn("=x + y");
@@ -114,7 +114,7 @@ public class ExpressionControllerTest extends RestControllerTest {
         {
             "expression": "=x + y",
             "tenantId": "tenant1",
-            "context": {
+            "variables": {
                 "x": 4,
                 "y": 6
             }
@@ -144,7 +144,7 @@ public class ExpressionControllerTest extends RestControllerTest {
     final var capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.expression()).isEqualTo("=x + y");
     assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
-    assertThat(capturedRequest.context()).isEqualTo(Map.of("x", 4, "y", 6));
+    assertThat(capturedRequest.variables()).isEqualTo(Map.of("x", 4, "y", 6));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Java client changes related to https://github.com/camunda/camunda/issues/46332
Previous PRs:
- https://github.com/camunda/camunda/pull/46681
- https://github.com/camunda/camunda/pull/46846

Besides the Java client changes needed to support passing on variables, I renamed the `context` field in the API to `variables` as this aligns with how we call similar fields and allows us to benefit from the existing `CommandWithVariables` in the client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46335 
