### PR TITLE
ci: add spectral rule to enforce all properties required

### DIFF
--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -8,6 +8,7 @@ functions:
   - verifyEventuallyConsistent
   - verifyRequiredPropertiesExist
   - verifyArrayPropertiesRequired
+  - verifyResponsePropertiesRequired
   - verifyDeprecatedEnumMembers
 functionsDir: ./spectral-functions
 rules:
@@ -121,6 +122,14 @@ rules:
     message: "{{error}}"
     then:
       function: verifyArrayPropertiesRequired
+
+  response-properties-must-be-required:
+    description: "All response body properties must be listed in `required`."
+    severity: error
+    given: "$.paths[*]"
+    message: "{{error}}"
+    then:
+      function: verifyResponsePropertiesRequired
 
   no-eventually-consistent-on-commands:
     description: "Command (mutating) operations must not have x-eventually-consistent: true."

--- a/zeebe/gateway-protocol/spectral-functions/verifyResponsePropertiesRequired.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyResponsePropertiesRequired.js
@@ -1,0 +1,112 @@
+// Spectral custom function to verify that ALL properties in response schemas
+// are listed in the `required` array.
+//
+// Applied via $.paths[*] in the traversal pass (rest-api.yaml), so $refs are
+// fully resolved. The function navigates from each path item into its HTTP
+// method operations → responses → content → schema, then recursively checks
+// every nested schema (including allOf-composed schemas, nested objects, and
+// array items).
+//
+// IMPORTANT: Error paths are anchored at the operation level (method node)
+// rather than pointing deep into the resolved schema. This prevents Spectral's
+// $ref source-mapping from duplicating errors — once at the reference site
+// (under paths) and again at the definition site (under components).
+//
+// Fields that are not required cause SDK generators to produce optional/union
+// types (e.g. `string | undefined`), which complicates consumer code and
+// obscures the actual API contract. The convention is to list every response
+// field in the `required` array.
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+module.exports = (input, _opts, context) => {
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+
+  const errors = [];
+
+  // input is a path item; iterate over HTTP methods.
+  for (const method of HTTP_METHODS) {
+    const operation = input[method];
+    if (!operation || typeof operation !== 'object' || !operation.responses) {
+      continue;
+    }
+
+    // Anchor all error paths at the operation level so they never cross
+    // a $ref boundary (response schemas are typically $ref'd to components).
+    const operationPath = [...context.path, method];
+
+    for (const [code, response] of Object.entries(operation.responses)) {
+      if (!response || !response.content) continue;
+
+      for (const [, mediaObj] of Object.entries(response.content)) {
+        if (!mediaObj || !mediaObj.schema) continue;
+
+        checkSchema(mediaObj.schema, operationPath, errors, new Set());
+      }
+    }
+  }
+
+  return errors;
+};
+
+// Aggregate `required` entries and `properties` from a schema and its allOf
+// members into a single view for the current schema level.
+function collectRequiredAndProperties(schema, requiredSet, propertyEntries) {
+  if (!schema || typeof schema !== 'object') return;
+
+  if (Array.isArray(schema.required)) {
+    schema.required.forEach((name) => requiredSet.add(name));
+  }
+
+  if (schema.properties && typeof schema.properties === 'object') {
+    for (const [name, prop] of Object.entries(schema.properties)) {
+      propertyEntries.push({ name, schema: prop });
+    }
+  }
+
+  if (Array.isArray(schema.allOf)) {
+    schema.allOf.forEach((sub) =>
+      collectRequiredAndProperties(sub, requiredSet, propertyEntries)
+    );
+  }
+}
+
+function checkSchema(schema, anchorPath, errors, visited) {
+  if (!schema || typeof schema !== 'object') return;
+
+  // Prevent infinite loops on circular $refs.
+  if (visited.has(schema)) return;
+  visited.add(schema);
+
+  // Aggregate required + properties across allOf at this level.
+  const requiredSet = new Set();
+  const propertyEntries = [];
+  collectRequiredAndProperties(schema, requiredSet, propertyEntries);
+
+  for (const { name, schema: propSchema } of propertyEntries) {
+    if (!propSchema || typeof propSchema !== 'object') continue;
+
+    if (!requiredSet.has(name)) {
+      errors.push({
+        message: `Response property \`${name}\` must be listed in \`required\`.`,
+        path: anchorPath,
+      });
+    }
+
+    // Recurse into nested objects and allOf compositions.
+    if (propSchema.properties || propSchema.allOf) {
+      checkSchema(propSchema, anchorPath, errors, visited);
+    }
+
+    // Recurse into array items.
+    if (
+      propSchema.type === 'array' &&
+      propSchema.items &&
+      typeof propSchema.items === 'object'
+    ) {
+      checkSchema(propSchema.items, anchorPath, errors, visited);
+    }
+  }
+}

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/rest-api.yaml
@@ -1,0 +1,51 @@
+# Entry point for response-properties-must-be-required rule tests.
+# Mirrors the real spec structure: paths $ref to domain files.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — response-properties-must-be-required
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid cases ──────────────────────────────────────────────
+  # All properties required (flat object)
+  /valid-flat/get:
+    $ref: 'things.yaml#/paths/~1valid-flat~1get'
+
+  # All properties required via allOf composition
+  /valid-allof/search:
+    $ref: 'things.yaml#/paths/~1valid-allof~1search'
+
+  # allOf with required and properties split across members
+  /valid-allof-split/search:
+    $ref: 'things.yaml#/paths/~1valid-allof-split~1search'
+
+  # Nested object with all properties required
+  /valid-nested/get:
+    $ref: 'things.yaml#/paths/~1valid-nested~1get'
+
+  # Response with no properties (empty schema)
+  /valid-empty/get:
+    $ref: 'things.yaml#/paths/~1valid-empty~1get'
+
+  # ── Invalid cases ───────────────────────────────────────────
+  # One property not in required
+  /invalid-missing-one/get:
+    $ref: 'things.yaml#/paths/~1invalid-missing-one~1get'
+
+  # Multiple properties not in required
+  /invalid-missing-many/get:
+    $ref: 'things.yaml#/paths/~1invalid-missing-many~1get'
+
+  # Nested object has a non-required property
+  /invalid-nested/get:
+    $ref: 'things.yaml#/paths/~1invalid-nested~1get'
+
+  # allOf composition with missing required entry
+  /invalid-allof/search:
+    $ref: 'things.yaml#/paths/~1invalid-allof~1search'
+
+  # Array items contain an object with non-required property
+  /invalid-items-recurse/search:
+    $ref: 'things.yaml#/paths/~1invalid-items-recurse~1search'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/search-models.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/search-models.yaml
@@ -1,0 +1,17 @@
+# Shared search models for response-properties-required fixture.
+components:
+  schemas:
+    SearchQueryResponse:
+      type: object
+      required:
+        - page
+      properties:
+        page:
+          type: object
+          description: Pagination information about the search results.
+          required:
+            - totalItems
+          properties:
+            totalItems:
+              type: integer
+              description: The total number of items matching the query.

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/things.yaml
@@ -1,0 +1,318 @@
+# Domain file with paths and schemas for testing response-properties-must-be-required.
+# Contains both valid and invalid cases, each at a distinct API path.
+
+## ─── Path definitions ──────────────────────────────────────────────────────────
+
+paths:
+
+  # ── Valid: flat object, all properties required ───────────────────
+  /valid-flat/get:
+    get:
+      tags: [Test]
+      operationId: validFlat
+      summary: Get a thing (valid)
+      description: All properties are listed in required.
+      responses:
+        "200":
+          description: The thing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidFlatResult'
+
+  # ── Valid: allOf composition, all properties required ─────────────
+  /valid-allof/search:
+    post:
+      tags: [Test]
+      operationId: validAllof
+      summary: Search things (valid)
+      description: All properties required with allOf composition.
+      responses:
+        "200":
+          description: The search results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidAllOfResult'
+
+  # ── Valid: allOf with required and properties split across members ─
+  /valid-allof-split/search:
+    post:
+      tags: [Test]
+      operationId: validAllofSplit
+      summary: Search with split allOf (valid)
+      description: required list in one allOf member, properties in another.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidAllOfSplitResult'
+
+  # ── Valid: nested object, all properties required ─────────────────
+  /valid-nested/get:
+    get:
+      tags: [Test]
+      operationId: validNested
+      summary: Get nested (valid)
+      description: Nested object has all properties required.
+      responses:
+        "200":
+          description: Result with nested object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidNestedResult'
+
+  # ── Valid: response with no properties ────────────────────────────
+  /valid-empty/get:
+    get:
+      tags: [Test]
+      operationId: validEmpty
+      summary: Get empty (valid)
+      description: Response schema has no properties.
+      responses:
+        "200":
+          description: Empty result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyResult'
+
+  # ── Invalid: one property not in required ─────────────────────────
+  /invalid-missing-one/get:
+    get:
+      tags: [Test]
+      operationId: invalidMissingOne
+      summary: Get thing (invalid - one missing)
+      description: One property is not required.
+      responses:
+        "200":
+          description: The thing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MissingOneResult'
+
+  # ── Invalid: multiple properties not in required ──────────────────
+  /invalid-missing-many/get:
+    get:
+      tags: [Test]
+      operationId: invalidMissingMany
+      summary: Get thing (invalid - many missing)
+      description: Multiple properties are not required.
+      responses:
+        "200":
+          description: The thing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MissingManyResult'
+
+  # ── Invalid: nested object has non-required property ──────────────
+  /invalid-nested/get:
+    get:
+      tags: [Test]
+      operationId: invalidNested
+      summary: Get nested (invalid)
+      description: Nested object has a non-required property.
+      responses:
+        "200":
+          description: Result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidNestedResult'
+
+  # ── Invalid: allOf composition with missing required entry ────────
+  /invalid-allof/search:
+    post:
+      tags: [Test]
+      operationId: invalidAllof
+      summary: Search (invalid - allOf)
+      description: allOf composed schema has a property not in required.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidAllOfResult'
+
+  # ── Invalid: array items with non-required property (recursion) ───
+  /invalid-items-recurse/search:
+    post:
+      tags: [Test]
+      operationId: invalidItemsRecurse
+      summary: Search with recursive items (invalid)
+      description: Array items schema contains an object with a non-required property.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemsRecurseResult'
+
+
+## ─── Schema definitions ────────────────────────────────────────────────────────
+
+components:
+  schemas:
+
+    # ── Valid: flat object, all required ──────────────────────────────
+    ValidFlatResult:
+      type: object
+      required:
+        - name
+        - status
+        - count
+      properties:
+        name:
+          type: string
+          description: The name.
+        status:
+          type: string
+          description: The status.
+        count:
+          type: integer
+          description: The count.
+
+    # ── Valid: allOf composition, all required ────────────────────────
+    ValidAllOfResult:
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidFlatResult'
+
+    # ── Valid: allOf split required / properties ──────────────────────
+    ValidAllOfSplitResult:
+      type: object
+      allOf:
+        - type: object
+          required:
+            - items
+        - type: object
+          properties:
+            items:
+              description: The things.
+              type: array
+              items:
+                $ref: '#/components/schemas/ValidFlatResult'
+
+    # ── Valid: nested object, all required ────────────────────────────
+    ValidNestedResult:
+      type: object
+      required:
+        - metadata
+      properties:
+        metadata:
+          type: object
+          description: Metadata about the thing.
+          required:
+            - label
+            - tags
+          properties:
+            label:
+              type: string
+              description: A label.
+            tags:
+              description: Tags associated with the thing.
+              type: array
+              items:
+                type: string
+
+    # ── Valid: empty schema ───────────────────────────────────────────
+    EmptyResult:
+      type: object
+      description: An empty result.
+
+    # ── Invalid: one property not required ────────────────────────────
+    MissingOneResult:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name.
+        status:
+          type: string
+          description: The status.
+
+    # ── Invalid: multiple properties not required ─────────────────────
+    MissingManyResult:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name.
+        status:
+          type: string
+          description: The status.
+        count:
+          type: integer
+          description: The count.
+
+    # ── Invalid: nested object with non-required property ─────────────
+    InvalidNestedResult:
+      type: object
+      required:
+        - metadata
+      properties:
+        metadata:
+          type: object
+          description: Metadata about the thing.
+          required:
+            - label
+          properties:
+            label:
+              type: string
+              description: A label.
+            priority:
+              type: integer
+              description: The priority.
+
+    # ── Invalid: allOf with missing required ──────────────────────────
+    InvalidAllOfResult:
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidFlatResult'
+
+    # ── Invalid: array items with non-required property ───────────────
+    ItemsRecurseResult:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ThingWithBadFieldResult'
+
+    ThingWithBadFieldResult:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name.
+        category:
+          type: string
+          description: The category.

--- a/zeebe/gateway-protocol/spectral-tests/verifyResponsePropertiesRequired.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyResponsePropertiesRequired.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule } = require('./helpers');
+
+const RULE = 'response-properties-must-be-required';
+const FIXTURE = 'response-properties-required';
+
+/**
+ * Filter violations whose JSON path includes the given API path segment.
+ * Error paths are anchored at the operation level (e.g. ['paths', '/valid-flat/get', 'get']),
+ * so we match against the API path element (index 1).
+ */
+function filterByApiPath(violations, apiPathSegment) {
+  return violations.filter(
+    (v) => Array.isArray(v.path) && v.path[1] === apiPathSegment
+  );
+}
+
+describe('verifyResponsePropertiesRequired', () => {
+  let violations;
+
+  before(() => {
+    const allResults = lintFixture(FIXTURE);
+    violations = filterByRule(allResults, RULE);
+  });
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid: flat object with all properties required', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-flat/get');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: allOf composition with all properties required', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-allof/search');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: allOf with required and properties in separate members', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-allof-split/search');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: nested object with all properties required', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-nested/get');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: empty schema with no properties', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-empty/get');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid: one property not in required', () => {
+    it('flags one violation', () => {
+      const v = filterByApiPath(violations, '/invalid-missing-one/get');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByApiPath(violations, '/invalid-missing-one/get');
+      assert.match(v[0].message, /status/);
+      assert.match(v[0].message, /must be listed in `required`/);
+    });
+  });
+
+  describe('invalid: multiple properties not in required', () => {
+    it('flags three violations', () => {
+      const v = filterByApiPath(violations, '/invalid-missing-many/get');
+      assert.equal(v.length, 3);
+    });
+
+    it('reports each missing property', () => {
+      const v = filterByApiPath(violations, '/invalid-missing-many/get');
+      const messages = v.map((e) => e.message);
+      assert.ok(messages.some((m) => /name/.test(m)));
+      assert.ok(messages.some((m) => /status/.test(m)));
+      assert.ok(messages.some((m) => /count/.test(m)));
+    });
+  });
+
+  describe('invalid: nested object with non-required property', () => {
+    it('flags one violation', () => {
+      const v = filterByApiPath(violations, '/invalid-nested/get');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByApiPath(violations, '/invalid-nested/get');
+      assert.match(v[0].message, /priority/);
+      assert.match(v[0].message, /must be listed in `required`/);
+    });
+  });
+
+  describe('invalid: allOf composition with missing required entry', () => {
+    it('flags one violation', () => {
+      const v = filterByApiPath(violations, '/invalid-allof/search');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByApiPath(violations, '/invalid-allof/search');
+      assert.match(v[0].message, /items/);
+      assert.match(v[0].message, /must be listed in `required`/);
+    });
+  });
+
+  describe('invalid: array items with non-required property (recursion)', () => {
+    it('flags one violation in the item schema', () => {
+      const v = filterByApiPath(violations, '/invalid-items-recurse/search');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByApiPath(violations, '/invalid-items-recurse/search');
+      assert.match(v[0].message, /category/);
+    });
+  });
+
+  // ── Total count ──────────────────────────────────────────────────
+
+  it('produces exactly 7 violations across all paths', () => {
+    assert.equal(violations.length, 7);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add a Spectral rule that enforces all response schema fields are in the required array.

This should only be merged once the entire specification response schema surface is `required`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
