### PR TITLE
ci: add spectral rule to enforce all properties required

### DIFF
--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -8,6 +8,7 @@ functions:
   - verifyEventuallyConsistent
   - verifyRequiredPropertiesExist
   - verifyArrayPropertiesRequired
+  - verifyResponsePropertiesRequired
   - verifyDeprecatedEnumMembers
 functionsDir: ./spectral-functions
 rules:
@@ -121,6 +122,14 @@ rules:
     message: "{{error}}"
     then:
       function: verifyArrayPropertiesRequired
+
+  response-properties-must-be-required:
+    description: "All response body properties must be listed in `required`."
+    severity: error
+    given: "$.paths[*]"
+    message: "{{error}}"
+    then:
+      function: verifyResponsePropertiesRequired
 
   no-eventually-consistent-on-commands:
     description: "Command (mutating) operations must not have x-eventually-consistent: true."

--- a/zeebe/gateway-protocol/spectral-functions/verifyResponsePropertiesRequired.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyResponsePropertiesRequired.js
@@ -1,0 +1,112 @@
+// Spectral custom function to verify that ALL properties in response schemas
+// are listed in the `required` array.
+//
+// Applied via $.paths[*] in the traversal pass (rest-api.yaml), so $refs are
+// fully resolved. The function navigates from each path item into its HTTP
+// method operations → responses → content → schema, then recursively checks
+// every nested schema (including allOf-composed schemas, nested objects, and
+// array items).
+//
+// IMPORTANT: Error paths are anchored at the operation level (method node)
+// rather than pointing deep into the resolved schema. This prevents Spectral's
+// $ref source-mapping from duplicating errors — once at the reference site
+// (under paths) and again at the definition site (under components).
+//
+// Fields that are not required cause SDK generators to produce optional/union
+// types (e.g. `string | undefined`), which complicates consumer code and
+// obscures the actual API contract. The convention is to list every response
+// field in the `required` array.
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+module.exports = (input, _opts, context) => {
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+
+  const errors = [];
+
+  // input is a path item; iterate over HTTP methods.
+  for (const method of HTTP_METHODS) {
+    const operation = input[method];
+    if (!operation || typeof operation !== 'object' || !operation.responses) {
+      continue;
+    }
+
+    // Anchor all error paths at the operation level so they never cross
+    // a $ref boundary (response schemas are typically $ref'd to components).
+    const operationPath = [...context.path, method];
+
+    for (const [code, response] of Object.entries(operation.responses)) {
+      if (!response || !response.content) continue;
+
+      for (const [, mediaObj] of Object.entries(response.content)) {
+        if (!mediaObj || !mediaObj.schema) continue;
+
+        checkSchema(mediaObj.schema, operationPath, errors, new Set());
+      }
+    }
+  }
+
+  return errors;
+};
+
+// Aggregate `required` entries and `properties` from a schema and its allOf
+// members into a single view for the current schema level.
+function collectRequiredAndProperties(schema, requiredSet, propertyEntries) {
+  if (!schema || typeof schema !== 'object') return;
+
+  if (Array.isArray(schema.required)) {
+    schema.required.forEach((name) => requiredSet.add(name));
+  }
+
+  if (schema.properties && typeof schema.properties === 'object') {
+    for (const [name, prop] of Object.entries(schema.properties)) {
+      propertyEntries.push({ name, schema: prop });
+    }
+  }
+
+  if (Array.isArray(schema.allOf)) {
+    schema.allOf.forEach((sub) =>
+      collectRequiredAndProperties(sub, requiredSet, propertyEntries)
+    );
+  }
+}
+
+function checkSchema(schema, anchorPath, errors, visited) {
+  if (!schema || typeof schema !== 'object') return;
+
+  // Prevent infinite loops on circular $refs.
+  if (visited.has(schema)) return;
+  visited.add(schema);
+
+  // Aggregate required + properties across allOf at this level.
+  const requiredSet = new Set();
+  const propertyEntries = [];
+  collectRequiredAndProperties(schema, requiredSet, propertyEntries);
+
+  for (const { name, schema: propSchema } of propertyEntries) {
+    if (!propSchema || typeof propSchema !== 'object') continue;
+
+    if (!requiredSet.has(name)) {
+      errors.push({
+        message: `Response property \`${name}\` must be listed in \`required\`.`,
+        path: anchorPath,
+      });
+    }
+
+    // Recurse into nested objects and allOf compositions.
+    if (propSchema.properties || propSchema.allOf) {
+      checkSchema(propSchema, anchorPath, errors, visited);
+    }
+
+    // Recurse into array items.
+    if (
+      propSchema.type === 'array' &&
+      propSchema.items &&
+      typeof propSchema.items === 'object'
+    ) {
+      checkSchema(propSchema.items, anchorPath, errors, visited);
+    }
+  }
+}

--- a/zeebe/gateway-protocol/spectral-functions/verifyResponsePropertiesRequired.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyResponsePropertiesRequired.js
@@ -7,10 +7,9 @@
 // every nested schema (including allOf-composed schemas, nested objects, and
 // array items).
 //
-// IMPORTANT: Error paths are anchored at the operation level (method node)
-// rather than pointing deep into the resolved schema. This prevents Spectral's
-// $ref source-mapping from duplicating errors — once at the reference site
-// (under paths) and again at the definition site (under components).
+// IMPORTANT: Error paths are anchored at the operation node under `paths` to
+// stay on the `paths` side of any $ref boundary. Response/property location
+// detail is appended as a synthetic suffix so each violation remains distinct.
 //
 // Fields that are not required cause SDK generators to produce optional/union
 // types (e.g. `string | undefined`), which complicates consumer code and
@@ -33,17 +32,23 @@ module.exports = (input, _opts, context) => {
       continue;
     }
 
-    // Anchor all error paths at the operation level so they never cross
-    // a $ref boundary (response schemas are typically $ref'd to components).
     const operationPath = [...context.path, method];
 
     for (const [code, response] of Object.entries(operation.responses)) {
       if (!response || !response.content) continue;
 
-      for (const [, mediaObj] of Object.entries(response.content)) {
+      for (const [mediaType, mediaObj] of Object.entries(response.content)) {
         if (!mediaObj || !mediaObj.schema) continue;
 
-        checkSchema(mediaObj.schema, operationPath, errors, new Set());
+        const schemaLocation = `responses/${code}/content/${mediaType}/schema`;
+
+        checkSchema(
+          mediaObj.schema,
+          operationPath,
+          schemaLocation,
+          errors,
+          new Set()
+        );
       }
     }
   }
@@ -53,7 +58,12 @@ module.exports = (input, _opts, context) => {
 
 // Aggregate `required` entries and `properties` from a schema and its allOf
 // members into a single view for the current schema level.
-function collectRequiredAndProperties(schema, requiredSet, propertyEntries) {
+function collectRequiredAndProperties(
+  schema,
+  requiredSet,
+  propertyEntries,
+  propertyPath
+) {
   if (!schema || typeof schema !== 'object') return;
 
   if (Array.isArray(schema.required)) {
@@ -62,18 +72,33 @@ function collectRequiredAndProperties(schema, requiredSet, propertyEntries) {
 
   if (schema.properties && typeof schema.properties === 'object') {
     for (const [name, prop] of Object.entries(schema.properties)) {
-      propertyEntries.push({ name, schema: prop });
+      propertyEntries.push({
+        name,
+        schema: prop,
+        path: [...propertyPath, 'properties', name],
+      });
     }
   }
 
   if (Array.isArray(schema.allOf)) {
-    schema.allOf.forEach((sub) =>
-      collectRequiredAndProperties(sub, requiredSet, propertyEntries)
+    schema.allOf.forEach((sub, i) =>
+      collectRequiredAndProperties(sub, requiredSet, propertyEntries, [
+        ...propertyPath,
+        'allOf',
+        i,
+      ])
     );
   }
 }
 
-function checkSchema(schema, anchorPath, errors, visited) {
+function checkSchema(
+  schema,
+  anchorPath,
+  schemaLocation,
+  errors,
+  visited,
+  propertyPath = []
+) {
   if (!schema || typeof schema !== 'object') return;
 
   // Prevent infinite loops on circular $refs.
@@ -83,21 +108,34 @@ function checkSchema(schema, anchorPath, errors, visited) {
   // Aggregate required + properties across allOf at this level.
   const requiredSet = new Set();
   const propertyEntries = [];
-  collectRequiredAndProperties(schema, requiredSet, propertyEntries);
+  collectRequiredAndProperties(
+    schema,
+    requiredSet,
+    propertyEntries,
+    propertyPath
+  );
 
-  for (const { name, schema: propSchema } of propertyEntries) {
+  for (const { name, schema: propSchema, path: propPath } of propertyEntries) {
     if (!propSchema || typeof propSchema !== 'object') continue;
 
     if (!requiredSet.has(name)) {
+      const renderedPath = propPath.join('/');
       errors.push({
-        message: `Response property \`${name}\` must be listed in \`required\`.`,
-        path: anchorPath,
+        message: `Response property \`${name}\` at \`${schemaLocation}/${renderedPath}\` must be listed in \`required\`.`,
+        path: [...anchorPath, `${schemaLocation}/${renderedPath}`],
       });
     }
 
     // Recurse into nested objects and allOf compositions.
     if (propSchema.properties || propSchema.allOf) {
-      checkSchema(propSchema, anchorPath, errors, visited);
+      checkSchema(
+        propSchema,
+        anchorPath,
+        schemaLocation,
+        errors,
+        visited,
+        propPath
+      );
     }
 
     // Recurse into array items.
@@ -106,7 +144,14 @@ function checkSchema(schema, anchorPath, errors, visited) {
       propSchema.items &&
       typeof propSchema.items === 'object'
     ) {
-      checkSchema(propSchema.items, anchorPath, errors, visited);
+      checkSchema(
+        propSchema.items,
+        anchorPath,
+        schemaLocation,
+        errors,
+        visited,
+        [...propPath, 'items']
+      );
     }
   }
 }

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/rest-api.yaml
@@ -1,0 +1,51 @@
+# Entry point for response-properties-must-be-required rule tests.
+# Mirrors the real spec structure: paths $ref to domain files.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — response-properties-must-be-required
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid cases ──────────────────────────────────────────────
+  # All properties required (flat object)
+  /valid-flat/get:
+    $ref: 'things.yaml#/paths/~1valid-flat~1get'
+
+  # All properties required via allOf composition
+  /valid-allof/search:
+    $ref: 'things.yaml#/paths/~1valid-allof~1search'
+
+  # allOf with required and properties split across members
+  /valid-allof-split/search:
+    $ref: 'things.yaml#/paths/~1valid-allof-split~1search'
+
+  # Nested object with all properties required
+  /valid-nested/get:
+    $ref: 'things.yaml#/paths/~1valid-nested~1get'
+
+  # Response with no properties (empty schema)
+  /valid-empty/get:
+    $ref: 'things.yaml#/paths/~1valid-empty~1get'
+
+  # ── Invalid cases ───────────────────────────────────────────
+  # One property not in required
+  /invalid-missing-one/get:
+    $ref: 'things.yaml#/paths/~1invalid-missing-one~1get'
+
+  # Multiple properties not in required
+  /invalid-missing-many/get:
+    $ref: 'things.yaml#/paths/~1invalid-missing-many~1get'
+
+  # Nested object has a non-required property
+  /invalid-nested/get:
+    $ref: 'things.yaml#/paths/~1invalid-nested~1get'
+
+  # allOf composition with missing required entry
+  /invalid-allof/search:
+    $ref: 'things.yaml#/paths/~1invalid-allof~1search'
+
+  # Array items contain an object with non-required property
+  /invalid-items-recurse/search:
+    $ref: 'things.yaml#/paths/~1invalid-items-recurse~1search'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/search-models.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/search-models.yaml
@@ -1,0 +1,17 @@
+# Shared search models for response-properties-required fixture.
+components:
+  schemas:
+    SearchQueryResponse:
+      type: object
+      required:
+        - page
+      properties:
+        page:
+          type: object
+          description: Pagination information about the search results.
+          required:
+            - totalItems
+          properties:
+            totalItems:
+              type: integer
+              description: The total number of items matching the query.

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/things.yaml
@@ -1,0 +1,318 @@
+# Domain file with paths and schemas for testing response-properties-must-be-required.
+# Contains both valid and invalid cases, each at a distinct API path.
+
+## ─── Path definitions ──────────────────────────────────────────────────────────
+
+paths:
+
+  # ── Valid: flat object, all properties required ───────────────────
+  /valid-flat/get:
+    get:
+      tags: [Test]
+      operationId: validFlat
+      summary: Get a thing (valid)
+      description: All properties are listed in required.
+      responses:
+        "200":
+          description: The thing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidFlatResult'
+
+  # ── Valid: allOf composition, all properties required ─────────────
+  /valid-allof/search:
+    post:
+      tags: [Test]
+      operationId: validAllof
+      summary: Search things (valid)
+      description: All properties required with allOf composition.
+      responses:
+        "200":
+          description: The search results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidAllOfResult'
+
+  # ── Valid: allOf with required and properties split across members ─
+  /valid-allof-split/search:
+    post:
+      tags: [Test]
+      operationId: validAllofSplit
+      summary: Search with split allOf (valid)
+      description: required list in one allOf member, properties in another.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidAllOfSplitResult'
+
+  # ── Valid: nested object, all properties required ─────────────────
+  /valid-nested/get:
+    get:
+      tags: [Test]
+      operationId: validNested
+      summary: Get nested (valid)
+      description: Nested object has all properties required.
+      responses:
+        "200":
+          description: Result with nested object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidNestedResult'
+
+  # ── Valid: response with no properties ────────────────────────────
+  /valid-empty/get:
+    get:
+      tags: [Test]
+      operationId: validEmpty
+      summary: Get empty (valid)
+      description: Response schema has no properties.
+      responses:
+        "200":
+          description: Empty result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyResult'
+
+  # ── Invalid: one property not in required ─────────────────────────
+  /invalid-missing-one/get:
+    get:
+      tags: [Test]
+      operationId: invalidMissingOne
+      summary: Get thing (invalid - one missing)
+      description: One property is not required.
+      responses:
+        "200":
+          description: The thing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MissingOneResult'
+
+  # ── Invalid: multiple properties not in required ──────────────────
+  /invalid-missing-many/get:
+    get:
+      tags: [Test]
+      operationId: invalidMissingMany
+      summary: Get thing (invalid - many missing)
+      description: Multiple properties are not required.
+      responses:
+        "200":
+          description: The thing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MissingManyResult'
+
+  # ── Invalid: nested object has non-required property ──────────────
+  /invalid-nested/get:
+    get:
+      tags: [Test]
+      operationId: invalidNested
+      summary: Get nested (invalid)
+      description: Nested object has a non-required property.
+      responses:
+        "200":
+          description: Result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidNestedResult'
+
+  # ── Invalid: allOf composition with missing required entry ────────
+  /invalid-allof/search:
+    post:
+      tags: [Test]
+      operationId: invalidAllof
+      summary: Search (invalid - allOf)
+      description: allOf composed schema has a property not in required.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidAllOfResult'
+
+  # ── Invalid: array items with non-required property (recursion) ───
+  /invalid-items-recurse/search:
+    post:
+      tags: [Test]
+      operationId: invalidItemsRecurse
+      summary: Search with recursive items (invalid)
+      description: Array items schema contains an object with a non-required property.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemsRecurseResult'
+
+
+## ─── Schema definitions ────────────────────────────────────────────────────────
+
+components:
+  schemas:
+
+    # ── Valid: flat object, all required ──────────────────────────────
+    ValidFlatResult:
+      type: object
+      required:
+        - name
+        - status
+        - count
+      properties:
+        name:
+          type: string
+          description: The name.
+        status:
+          type: string
+          description: The status.
+        count:
+          type: integer
+          description: The count.
+
+    # ── Valid: allOf composition, all required ────────────────────────
+    ValidAllOfResult:
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidFlatResult'
+
+    # ── Valid: allOf split required / properties ──────────────────────
+    ValidAllOfSplitResult:
+      type: object
+      allOf:
+        - type: object
+          required:
+            - items
+        - type: object
+          properties:
+            items:
+              description: The things.
+              type: array
+              items:
+                $ref: '#/components/schemas/ValidFlatResult'
+
+    # ── Valid: nested object, all required ────────────────────────────
+    ValidNestedResult:
+      type: object
+      required:
+        - metadata
+      properties:
+        metadata:
+          type: object
+          description: Metadata about the thing.
+          required:
+            - label
+            - tags
+          properties:
+            label:
+              type: string
+              description: A label.
+            tags:
+              description: Tags associated with the thing.
+              type: array
+              items:
+                type: string
+
+    # ── Valid: empty schema ───────────────────────────────────────────
+    EmptyResult:
+      type: object
+      description: An empty result.
+
+    # ── Invalid: one property not required ────────────────────────────
+    MissingOneResult:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name.
+        status:
+          type: string
+          description: The status.
+
+    # ── Invalid: multiple properties not required ─────────────────────
+    MissingManyResult:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name.
+        status:
+          type: string
+          description: The status.
+        count:
+          type: integer
+          description: The count.
+
+    # ── Invalid: nested object with non-required property ─────────────
+    InvalidNestedResult:
+      type: object
+      required:
+        - metadata
+      properties:
+        metadata:
+          type: object
+          description: Metadata about the thing.
+          required:
+            - label
+          properties:
+            label:
+              type: string
+              description: A label.
+            priority:
+              type: integer
+              description: The priority.
+
+    # ── Invalid: allOf with missing required ──────────────────────────
+    InvalidAllOfResult:
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidFlatResult'
+
+    # ── Invalid: array items with non-required property ───────────────
+    ItemsRecurseResult:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ThingWithBadFieldResult'
+
+    ThingWithBadFieldResult:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name.
+        category:
+          type: string
+          description: The category.

--- a/zeebe/gateway-protocol/spectral-tests/verifyResponsePropertiesRequired.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyResponsePropertiesRequired.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule } = require('./helpers');
+
+const RULE = 'response-properties-must-be-required';
+const FIXTURE = 'response-properties-required';
+
+/**
+ * Filter violations whose JSON path includes the given API path segment.
+ * Error paths are anchored at the operation level (e.g. ['paths', '/valid-flat/get', 'get']),
+ * so we match against the API path element (index 1).
+ */
+function filterByApiPath(violations, apiPathSegment) {
+  return violations.filter(
+    (v) => Array.isArray(v.path) && v.path[1] === apiPathSegment
+  );
+}
+
+describe('verifyResponsePropertiesRequired', () => {
+  let violations;
+
+  before(() => {
+    const allResults = lintFixture(FIXTURE);
+    violations = filterByRule(allResults, RULE);
+  });
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid: flat object with all properties required', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-flat/get');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: allOf composition with all properties required', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-allof/search');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: allOf with required and properties in separate members', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-allof-split/search');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: nested object with all properties required', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-nested/get');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: empty schema with no properties', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-empty/get');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid: one property not in required', () => {
+    it('flags one violation', () => {
+      const v = filterByApiPath(violations, '/invalid-missing-one/get');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByApiPath(violations, '/invalid-missing-one/get');
+      assert.match(v[0].message, /status/);
+      assert.match(v[0].message, /must be listed in `required`/);
+    });
+  });
+
+  describe('invalid: multiple properties not in required', () => {
+    it('flags three violations', () => {
+      const v = filterByApiPath(violations, '/invalid-missing-many/get');
+      assert.equal(v.length, 3);
+    });
+
+    it('reports each missing property', () => {
+      const v = filterByApiPath(violations, '/invalid-missing-many/get');
+      const messages = v.map((e) => e.message);
+      assert.ok(messages.some((m) => /name/.test(m)));
+      assert.ok(messages.some((m) => /status/.test(m)));
+      assert.ok(messages.some((m) => /count/.test(m)));
+    });
+  });
+
+  describe('invalid: nested object with non-required property', () => {
+    it('flags one violation', () => {
+      const v = filterByApiPath(violations, '/invalid-nested/get');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByApiPath(violations, '/invalid-nested/get');
+      assert.match(v[0].message, /priority/);
+      assert.match(v[0].message, /must be listed in `required`/);
+    });
+  });
+
+  describe('invalid: allOf composition with missing required entry', () => {
+    it('flags one violation', () => {
+      const v = filterByApiPath(violations, '/invalid-allof/search');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByApiPath(violations, '/invalid-allof/search');
+      assert.match(v[0].message, /items/);
+      assert.match(v[0].message, /must be listed in `required`/);
+    });
+  });
+
+  describe('invalid: array items with non-required property (recursion)', () => {
+    it('flags one violation in the item schema', () => {
+      const v = filterByApiPath(violations, '/invalid-items-recurse/search');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByApiPath(violations, '/invalid-items-recurse/search');
+      assert.match(v[0].message, /category/);
+    });
+  });
+
+  // ── Total count ──────────────────────────────────────────────────
+
+  it('produces exactly 7 violations across all paths', () => {
+    assert.equal(violations.length, 7);
+  });
+});

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -38,6 +38,9 @@ components:
         - salesPlanType
         - c8Links
         - canLogout
+        - displayName
+        - email
+        - username
       properties:
         username:
           description: The username of the user.

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -320,6 +320,8 @@ components:
         - actorType
         - actorId
         - errors
+        - endDate
+        - startDate
       type: object
       properties:
         batchOperationKey:
@@ -375,6 +377,10 @@ components:
             $ref: '#/components/schemas/BatchOperationError'
 
     BatchOperationError:
+      required:
+        - message
+        - partitionId
+        - type
       type: object
       properties:
         partitionId:
@@ -468,6 +474,13 @@ components:
       type: object
       required:
         - rootProcessInstanceKey
+        - batchOperationKey
+        - errorMessage
+        - itemKey
+        - operationType
+        - processedDate
+        - processInstanceKey
+        - state
       properties:
         operationType:
           $ref: '#/components/schemas/BatchOperationTypeEnum'
@@ -500,11 +513,14 @@ components:
             - CANCELED
             - FAILED
         processedDate:
-          description: the date this item was processed.
+          description: |
+            The date this item was processed.
+            This is `null` if the item has not yet been processed.
+          nullable: true
           type: string
           format: date-time
         errorMessage:
-          description: the error message from the engine in case of a failed operation.
+          description: The error message from the engine in case of a failed operation.
           nullable: true
           type: string
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -49,6 +49,7 @@ components:
         - replicationFactor
         - gatewayVersion
         - lastCompletedChangeId
+        - clusterId
       properties:
         brokers:
           description: A list of brokers that are part of this cluster.

--- a/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -125,6 +125,9 @@ components:
       type: string
 
     ProcessInstanceReference:
+      required:
+        - processDefinitionKey
+        - processInstanceKey
       type: object
       properties:
         processDefinitionKey:

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -426,6 +426,13 @@ components:
         - decisionDefinitionType
         - evaluatedInputs
         - matchedRules
+        - decisionDefinitionId
+        - decisionDefinitionKey
+        - decisionDefinitionName
+        - decisionDefinitionVersion
+        - decisionEvaluationInstanceKey
+        - output
+        - tenantId
       x-semantic-provider:
         - decisionEvaluationInstanceKey
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -377,8 +377,8 @@ components:
         - $ref: '#/components/schemas/DecisionInstanceResult'
         - type: object
           required:
-          - evaluatedInputs
-          - matchedRules
+            - evaluatedInputs
+            - matchedRules
           properties:
             evaluatedInputs:
               type: array
@@ -394,6 +394,10 @@ components:
                 The matched rules of the decision instance.
 
     EvaluatedDecisionInputItem:
+      required:
+        - inputId
+        - inputName
+        - inputValue
       type: object
       description: A decision input that was evaluated within this decision evaluation.
       properties:
@@ -404,13 +408,16 @@ components:
           type: string
           description: The name of the decision input.
         inputValue:
-          description: The description of the decision input.
+          description: The value of the decision input.
           type: string
 
     EvaluatedDecisionOutputItem:
       required:
         - ruleId
         - ruleIndex
+        - outputId
+        - outputName
+        - outputValue
       type: object
       description: The evaluated decision outputs.
       properties:
@@ -436,6 +443,8 @@ components:
     MatchedDecisionRuleItem:
       required:
         - evaluatedOutputs
+        - ruleId
+        - ruleIndex
       type: object
       description: A decision rule that matched within this decision evaluation.
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -270,6 +270,14 @@ components:
       x-semantic-provider:
         - decisionDefinitionKey
         - decisionRequirementsKey
+      required:
+        - decisionDefinitionId
+        - decisionDefinitionKey
+        - decisionRequirementsId
+        - decisionRequirementsKey
+        - name
+        - tenantId
+        - version
       properties:
         decisionDefinitionId:
           allOf:
@@ -308,6 +316,13 @@ components:
       type: object
       x-semantic-provider:
         - decisionRequirementsKey
+      required:
+        - decisionRequirementsId
+        - decisionRequirementsKey
+        - decisionRequirementsName
+        - resourceName
+        - tenantId
+        - version
       properties:
         decisionRequirementsId:
           description: The id of the deployed decision requirements.
@@ -337,6 +352,12 @@ components:
       type: object
       x-semantic-provider:
         - formKey
+      required:
+        - formId
+        - formKey
+        - resourceName
+        - tenantId
+        - version
       properties:
         formId:
           allOf:
@@ -363,6 +384,12 @@ components:
       x-semantic-provider:
         - resourceKey
       type: object
+      required:
+        - resourceId
+        - resourceKey
+        - resourceName
+        - tenantId
+        - version
       properties:
         resourceId:
           description: The resource id of the deployed resource.
@@ -404,6 +431,7 @@ components:
       type: object
       required:
         - resourceKey
+        - batchOperation
       properties:
         resourceKey:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -304,6 +304,11 @@ components:
 
     DocumentCreationFailureDetail:
       type: object
+      required:
+        - detail
+        - fileName
+        - status
+        - title
       properties:
         fileName:
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -400,6 +400,8 @@ components:
         - processInstanceKey
         - processDefinitionKey
         - rootProcessInstanceKey
+        - endDate
+        - incidentKey
       properties:
         processDefinitionId:
           description: The process definition ID associated to this element instance.

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -509,6 +509,10 @@ components:
 
     IncidentProcessInstanceStatisticsByErrorResult:
       type: object
+      required:
+        - activeInstancesWithErrorCount
+        - errorHashCode
+        - errorMessage
       properties:
         errorHashCode:
           type: integer
@@ -573,6 +577,13 @@ components:
 
     IncidentProcessInstanceStatisticsByDefinitionResult:
       type: object
+      required:
+        - activeInstancesWithErrorCount
+        - processDefinitionId
+        - processDefinitionKey
+        - processDefinitionName
+        - processDefinitionVersion
+        - tenantId
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -349,6 +349,7 @@ components:
         - listenerEventType
         - rootProcessInstanceKey
         - tags
+        - userTask
       properties:
         type:
           description: The type of the job (should match what was requested).
@@ -437,6 +438,13 @@ components:
         - candidateGroups
         - candidateUsers
         - changedAttributes
+        - action
+        - assignee
+        - dueDate
+        - followUpDate
+        - formKey
+        - priority
+        - userTaskKey
       type: object
       description: Contains properties of a user task.
       properties:
@@ -473,6 +481,7 @@ components:
         formKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/FormKey'
+          nullable: true
           description: The key of the form associated with the user task.
         priority:
           description: The priority of the user task.
@@ -662,6 +671,14 @@ components:
         - type
         - worker
         - rootProcessInstanceKey
+        - creationTime
+        - deadline
+        - deniedReason
+        - endTime
+        - errorCode
+        - errorMessage
+        - isDenied
+        - lastUpdateTime
       properties:
         customHeaders:
           description: A set of custom headers defined during modelling.
@@ -752,10 +769,12 @@ components:
           type: string
         creationTime:
           description: When the job was created. Field is present for jobs created after 8.9.
+          nullable: true
           type: string
           format: date-time
         lastUpdateTime:
           description: When the job was last updated. Field is present for jobs created after 8.9.
+          nullable: true
           type: string
           format: date-time
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -251,6 +251,17 @@ components:
       type: object
       required:
         - rootProcessInstanceKey
+        - correlationKey
+        - elementId
+        - elementInstanceKey
+        - lastUpdatedDate
+        - messageName
+        - messageSubscriptionKey
+        - messageSubscriptionState
+        - processDefinitionId
+        - processDefinitionKey
+        - processInstanceKey
+        - tenantId
       properties:
         messageSubscriptionKey:
           allOf:
@@ -263,10 +274,12 @@ components:
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+          nullable: true
           description: The process definition key associated with this message subscription.
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          nullable: true
           description: The process instance key associated with this message subscription.
         rootProcessInstanceKey:
           description: |
@@ -283,6 +296,7 @@ components:
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
+          nullable: true
           description: The element instance key associated with this message subscription.
         messageSubscriptionState:
           $ref: '#/components/schemas/MessageSubscriptionStateEnum'
@@ -295,6 +309,7 @@ components:
           type: string
         correlationKey:
           type: string
+          nullable: true
           description: The correlation key of the message subscription.
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
@@ -401,9 +416,24 @@ components:
 
     CorrelatedMessageSubscriptionResult:
       type: object
+      required:
+        - correlationKey
+        - correlationTime
+        - elementId
+        - messageKey
+        - messageName
+        - partitionId
+        - processDefinitionId
+        - processInstanceKey
+        - subscriptionKey
+        - tenantId
+        - rootProcessInstanceKey
+        - elementInstanceKey
+        - processDefinitionKey
       properties:
         correlationKey:
           description: The correlation key of the message.
+          nullable: true
           type: string
         correlationTime:
           description: The time when the message was correlated.
@@ -415,7 +445,10 @@ components:
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
-          description: The element instance key that received the message.
+          nullable: true
+          description: |
+            The element instance key that received the message.
+            It is `null` for start event subscriptions.
         messageKey:
           allOf:
             - $ref: '#/components/schemas/MessageKey'
@@ -455,18 +488,6 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID associated with this correlated message subscription.
-      required:
-        - correlationKey
-        - correlationTime
-        - elementId
-        - messageKey
-        - messageName
-        - partitionId
-        - processDefinitionId
-        - processInstanceKey
-        - subscriptionKey
-        - tenantId
-        - rootProcessInstanceKey
 
     CorrelatedMessageSubscriptionSearchQuery:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -451,6 +451,12 @@ components:
     ProcessElementStatisticsResult:
       description: Process element statistics response.
       type: object
+      required:
+        - active
+        - canceled
+        - completed
+        - elementId
+        - incidents
       properties:
         elementId:
           allOf:
@@ -500,6 +506,12 @@ components:
 
     ProcessDefinitionMessageSubscriptionStatisticsResult:
       type: object
+      required:
+        - activeSubscriptions
+        - processDefinitionId
+        - processDefinitionKey
+        - processInstancesWithActiveSubscriptions
+        - tenantId
       properties:
         processDefinitionId:
           description: The process definition ID associated with this message subscription.
@@ -551,6 +563,13 @@ components:
     ProcessDefinitionInstanceStatisticsResult:
       description: Process definition instance statistics response.
       type: object
+      required:
+        - activeInstancesWithIncidentCount
+        - activeInstancesWithoutIncidentCount
+        - hasMultipleVersions
+        - latestProcessDefinitionName
+        - processDefinitionId
+        - tenantId
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -915,6 +915,7 @@ components:
         - variables
         - processInstanceKey
         - tags
+        - businessId
       type: object
       properties:
         processDefinitionId:
@@ -1336,6 +1337,12 @@ components:
       type: object
       required:
         - rootProcessInstanceKey
+        - elementId
+        - processDefinitionId
+        - processDefinitionKey
+        - processInstanceKey
+        - sequenceFlowId
+        - tenantId
       properties:
         sequenceFlowId:
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -184,6 +184,9 @@ components:
             $ref: '#/components/schemas/VariableSearchResult'
 
     VariableSearchResult:
+      required:
+        - isTruncated
+        - value
       description: Variable search response item.
       type: object
       allOf:


### PR DESCRIPTION
## Description

Add a Spectral rule that enforces that all properties in response schema object are in the required array.

This should only be merged once the entire specification response schema surface is `required`.

I will add the strong spec with all fields required to this PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46390
