### PR TITLE
46209 reduce global listener tests flakiness

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
-import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -29,6 +28,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
@@ -65,15 +65,24 @@ final class GlobalListenersInitializerIT {
   @Test
   void shouldInitializeGlobalListenersWhenConfigurationChanges() {
     // Given a broker with a given global listeners configuration
-    ZEEBE.unifiedConfig().getCluster().setGlobalListeners(createGlobalListenersCfg("global1"));
+    final String initialListener = UUID.randomUUID().toString();
+    ZEEBE
+        .unifiedConfig()
+        .getCluster()
+        .setGlobalListeners(createGlobalListenersCfg(initialListener));
     restartBroker();
 
     // Wait for configuration to be distributed to all partitions and keep track of the last
     // position for each partition, this way we can filter records for the assertions to only
     // include records actually generated after the restart.
-    waitForConfigurationDistributionComplete();
+    waitForConfigurationDistributionComplete(initialListener);
     final var lastPositionByPartition =
         RecordingExporter.globalListenerBatchRecords(GlobalListenerBatchIntent.CONFIGURED)
+            .filter(
+                r ->
+                    r.getValue().getListeners().stream()
+                        .map(GlobalListenerRecordValue::getId)
+                        .anyMatch(initialListener::equals))
             .limit(PARTITIONS_COUNT)
             .collect(Collectors.toMap(Record::getPartitionId, Record::getPosition));
 
@@ -81,7 +90,7 @@ final class GlobalListenersInitializerIT {
     ZEEBE
         .unifiedConfig()
         .getCluster()
-        .setGlobalListeners(createGlobalListenersCfg("global1", "global2"));
+        .setGlobalListeners(createGlobalListenersCfg(initialListener, "newListener"));
     restartBroker();
 
     // Then multiple listener mutation events and one configuration event are created for each
@@ -116,14 +125,14 @@ final class GlobalListenersInitializerIT {
                   record.getIntent() == GlobalListenerIntent.UPDATED
                       && ((GlobalListenerRecordValue) record.getValue())
                           .getId()
-                          .equals("GlobalListener_global1"),
+                          .equals(initialListener),
               "Expected an UPDATE event for the old listener")
           .anyMatch(
               record ->
                   record.getIntent() == GlobalListenerIntent.CREATED
                       && ((GlobalListenerRecordValue) record.getValue())
                           .getId()
-                          .equals("GlobalListener_global2"),
+                          .equals("newListener"),
               "Expected a CREATE event for the new listener")
           .anyMatch(
               record -> record.getIntent() == GlobalListenerBatchIntent.CONFIGURED,
@@ -146,15 +155,24 @@ final class GlobalListenersInitializerIT {
   @Test
   void shouldInitializeGlobalListenersWhenConfigurationIsRemoved() {
     // Given a broker with a given global listeners configuration
-    ZEEBE.unifiedConfig().getCluster().setGlobalListeners(createGlobalListenersCfg("global"));
+    final String initialListener = UUID.randomUUID().toString();
+    ZEEBE
+        .unifiedConfig()
+        .getCluster()
+        .setGlobalListeners(createGlobalListenersCfg(initialListener));
     restartBroker();
 
     // Wait for configuration to be distributed to all partitions and keep track of the last
     // position for each partition, this way we can filter records for the assertions to only
     // include records actually generated after the restart.
-    waitForConfigurationDistributionComplete();
+    waitForConfigurationDistributionComplete(initialListener);
     final var lastPositionByPartition =
         RecordingExporter.globalListenerBatchRecords(GlobalListenerBatchIntent.CONFIGURED)
+            .filter(
+                r ->
+                    r.getValue().getListeners().stream()
+                        .map(GlobalListenerRecordValue::getId)
+                        .anyMatch(initialListener::equals))
             .limit(PARTITIONS_COUNT)
             .collect(Collectors.toMap(Record::getPartitionId, Record::getPosition));
 
@@ -194,7 +212,7 @@ final class GlobalListenersInitializerIT {
                   record.getIntent() == GlobalListenerIntent.DELETED
                       && ((GlobalListenerRecordValue) record.getValue())
                           .getId()
-                          .equals("GlobalListener_global"),
+                          .equals(initialListener),
               "Expected a DELETE event for the old listener")
           .anyMatch(
               record -> record.getIntent() == GlobalListenerBatchIntent.CONFIGURED,
@@ -217,20 +235,32 @@ final class GlobalListenersInitializerIT {
   @Test
   void shouldNotInitializeGlobalListenersWhenConfigurationIsNotChanged() {
     // Given a broker with a given global listeners configuration
-    ZEEBE.unifiedConfig().getCluster().setGlobalListeners(createGlobalListenersCfg("global1"));
+    final String initialListener = UUID.randomUUID().toString();
+    ZEEBE
+        .unifiedConfig()
+        .getCluster()
+        .setGlobalListeners(createGlobalListenersCfg(initialListener));
     restartBroker();
 
     // Wait for configuration to be distributed to all partitions and keep track of the last
     // position for each partition, this way we can filter records for the assertions to only
     // include records actually generated after the restart.
-    waitForConfigurationDistributionComplete();
+    waitForConfigurationDistributionComplete(initialListener);
     final var lastPositionByPartition =
         RecordingExporter.globalListenerBatchRecords(GlobalListenerBatchIntent.CONFIGURED)
+            .filter(
+                r ->
+                    r.getValue().getListeners().stream()
+                        .map(GlobalListenerRecordValue::getId)
+                        .anyMatch(initialListener::equals))
             .limit(PARTITIONS_COUNT)
             .collect(Collectors.toMap(Record::getPartitionId, Record::getPosition));
 
     // When the configuration is not changed and the broker is restarted
-    ZEEBE.unifiedConfig().getCluster().setGlobalListeners(createGlobalListenersCfg("global1"));
+    ZEEBE
+        .unifiedConfig()
+        .getCluster()
+        .setGlobalListeners(createGlobalListenersCfg(initialListener));
     restartBroker();
 
     // Note: we send a clock reset command so we have a record we can limit our RecordingExporter on
@@ -248,15 +278,15 @@ final class GlobalListenersInitializerIT {
         .hasSize(0);
   }
 
-  private GlobalListenersCfg createGlobalListenersCfg(final String... types) {
+  private GlobalListenersCfg createGlobalListenersCfg(final String... listenerIds) {
     final GlobalListenersCfg globalListenersCfg = new GlobalListenersCfg();
     globalListenersCfg.setUserTask(
-        Arrays.stream(types)
+        Arrays.stream(listenerIds)
             .map(
-                type -> {
+                id -> {
                   final GlobalListenerCfg listenerCfg = new GlobalListenerCfg();
-                  listenerCfg.setId("GlobalListener_" + type);
-                  listenerCfg.setType(type);
+                  listenerCfg.setId(id);
+                  listenerCfg.setType(id);
                   listenerCfg.setEventTypes(List.of("all"));
                   return listenerCfg;
                 })
@@ -272,17 +302,24 @@ final class GlobalListenersInitializerIT {
     ZEEBE.awaitCompleteTopology(1, PARTITIONS_COUNT, 1, Duration.ofSeconds(30));
   }
 
-  private void waitForConfigurationDistributionComplete() {
+  private void waitForConfigurationDistributionComplete(final String expectedListenerId) {
     Awaitility.await()
         .untilAsserted(
             () -> {
               // Wait for configuration to be applied on all partitions
-              assertThat(
-                      RecordingExporter.globalListenerBatchRecords(
-                              GlobalListenerBatchIntent.CONFIGURED)
-                          .limit(PARTITIONS_COUNT)
-                          .map(Record::getPartitionId))
+              final var configuredEvents =
+                  RecordingExporter.globalListenerBatchRecords(GlobalListenerBatchIntent.CONFIGURED)
+                      .filter(
+                          r ->
+                              r.getValue().getListeners().stream()
+                                  .map(GlobalListenerRecordValue::getId)
+                                  .anyMatch(expectedListenerId::equals))
+                      .limit(PARTITIONS_COUNT)
+                      .toList();
+              assertThat(configuredEvents.stream().map(Record::getPartitionId).toList())
                   .containsExactlyInAnyOrderElementsOf(PARTITION_IDS);
+
+              final var distributionKey = configuredEvents.getFirst().getKey();
               // Wait for main partition to complete the distribution on all partitions
               // Waiting only for the events to be exported in each partition is not enough because
               // the main partitions could not have received the acknowledgment of the command
@@ -292,9 +329,8 @@ final class GlobalListenersInitializerIT {
                       RecordingExporter.commandDistributionRecords(
                               CommandDistributionIntent.FINISHED)
                           .withDistributionIntent(GlobalListenerBatchIntent.CONFIGURE)
-                          .limit(PARTITIONS_COUNT - 1)
-                          .map(Record::getValue)
-                          .map(CommandDistributionRecordValue::getPartitionId))
+                          .withRecordKey(distributionKey)
+                          .limit(PARTITIONS_COUNT - 1))
                   .hasSize(PARTITIONS_COUNT - 1);
             });
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
@@ -103,10 +103,13 @@ final class GlobalListenersInitializerIT {
             .collect(Collectors.groupingBy(Record::getPartitionId));
     // Check that events are distributed to all partitions
     Assertions.assertThat(listenerRecordsByPartition.keySet())
+        .as("Expected events to be generated in all partitions")
         .containsExactlyInAnyOrderElementsOf(PARTITION_IDS);
     // Check that for each partition, we have the expected events with the expected types
     for (final var records : listenerRecordsByPartition.values()) {
       assertThat(records)
+          .as(
+              "Expected 3 events for each partition: an UPDATE for the old listener, a CREATE for the new listener and a CONFIGURED")
           .hasSize(3)
           .anyMatch(
               record ->
@@ -114,14 +117,14 @@ final class GlobalListenersInitializerIT {
                       && ((GlobalListenerRecordValue) record.getValue())
                           .getId()
                           .equals("GlobalListener_global1"),
-              "Expected an UPDATE event for GlobalListener_global1")
+              "Expected an UPDATE event for the old listener")
           .anyMatch(
               record ->
                   record.getIntent() == GlobalListenerIntent.CREATED
                       && ((GlobalListenerRecordValue) record.getValue())
                           .getId()
                           .equals("GlobalListener_global2"),
-              "Expected a CREATE event for GlobalListener_global2")
+              "Expected a CREATE event for the new listener")
           .anyMatch(
               record -> record.getIntent() == GlobalListenerBatchIntent.CONFIGURED,
               "Expected a CONFIGURED event");
@@ -135,7 +138,9 @@ final class GlobalListenersInitializerIT {
             .map(GlobalListenerBatchRecord.class::cast)
             .map(GlobalListenerBatchRecord::getGlobalListenerBatchKey)
             .collect(Collectors.toSet());
-    Assertions.assertThat(configurationKeys).hasSize(1);
+    Assertions.assertThat(configurationKeys)
+        .as("Expected the same configuration key to be used in all partitions")
+        .hasSize(1);
   }
 
   @Test
@@ -176,10 +181,13 @@ final class GlobalListenersInitializerIT {
             .collect(Collectors.groupingBy(Record::getPartitionId));
     // Check that events are distributed to all partitions
     Assertions.assertThat(listenerRecordsByPartition.keySet())
+        .as("Expected events to be generated in all partitions")
         .containsExactlyInAnyOrderElementsOf(PARTITION_IDS);
     // Check that for each partition, we have the expected events with the expected types
     for (final var records : listenerRecordsByPartition.values()) {
       assertThat(records)
+          .as(
+              "Expected 2 events for each partition: a DELETE for the old listener and a CONFIGURED")
           .hasSize(2)
           .anyMatch(
               record ->
@@ -187,7 +195,7 @@ final class GlobalListenersInitializerIT {
                       && ((GlobalListenerRecordValue) record.getValue())
                           .getId()
                           .equals("GlobalListener_global"),
-              "Expected a DELETE event for GlobalListener_global")
+              "Expected a DELETE event for the old listener")
           .anyMatch(
               record -> record.getIntent() == GlobalListenerBatchIntent.CONFIGURED,
               "Expected a CONFIGURED event");
@@ -201,7 +209,9 @@ final class GlobalListenersInitializerIT {
             .map(GlobalListenerBatchRecord.class::cast)
             .map(GlobalListenerBatchRecord::getGlobalListenerBatchKey)
             .collect(Collectors.toSet());
-    Assertions.assertThat(configurationKeys).hasSize(1);
+    Assertions.assertThat(configurationKeys)
+        .as("Expected the same configuration key to be used in all partitions")
+        .hasSize(1);
   }
 
   @Test
@@ -234,6 +244,7 @@ final class GlobalListenersInitializerIT {
                 .limit(r -> r.getIntent().equals(ClockIntent.RESET))
                 .globalListenerBatchRecords()
                 .withIntent(GlobalListenerBatchIntent.CONFIGURED))
+        .as("Expected no CONFIGURED event to be generated when the configuration is not changed")
         .hasSize(0);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
@@ -28,14 +28,15 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 @ZeebeIntegration
 final class GlobalListenersInitializerIT {
@@ -63,9 +64,9 @@ final class GlobalListenersInitializerIT {
   }
 
   @Test
-  void shouldInitializeGlobalListenersWhenConfigurationChanges() {
+  void shouldInitializeGlobalListenersWhenConfigurationChanges(final TestInfo testInfo) {
     // Given a broker with a given global listeners configuration
-    final String initialListener = UUID.randomUUID().toString();
+    final String initialListener = uniqueListenerName(testInfo);
     ZEEBE
         .unifiedConfig()
         .getCluster()
@@ -153,9 +154,9 @@ final class GlobalListenersInitializerIT {
   }
 
   @Test
-  void shouldInitializeGlobalListenersWhenConfigurationIsRemoved() {
+  void shouldInitializeGlobalListenersWhenConfigurationIsRemoved(final TestInfo testInfo) {
     // Given a broker with a given global listeners configuration
-    final String initialListener = UUID.randomUUID().toString();
+    final String initialListener = uniqueListenerName(testInfo);
     ZEEBE
         .unifiedConfig()
         .getCluster()
@@ -233,9 +234,9 @@ final class GlobalListenersInitializerIT {
   }
 
   @Test
-  void shouldNotInitializeGlobalListenersWhenConfigurationIsNotChanged() {
+  void shouldNotInitializeGlobalListenersWhenConfigurationIsNotChanged(final TestInfo testInfo) {
     // Given a broker with a given global listeners configuration
-    final String initialListener = UUID.randomUUID().toString();
+    final String initialListener = uniqueListenerName(testInfo);
     ZEEBE
         .unifiedConfig()
         .getCluster()
@@ -333,5 +334,12 @@ final class GlobalListenersInitializerIT {
                           .limit(PARTITIONS_COUNT - 1))
                   .hasSize(PARTITIONS_COUNT - 1);
             });
+  }
+
+  // to produce something like: `shouldInitializeGlobalListenersWhenConfigurationChanges-aB3xZ`
+  private static String uniqueListenerName(final TestInfo testInfo) {
+    return testInfo.getTestMethod().orElseThrow().getName()
+        + "-"
+        + RandomStringUtils.insecure().nextAlphanumeric(5);
   }
 }


### PR DESCRIPTION
## Description

This PR enhances the reliability of the `GlobalListenerInitializerIT` test by avoiding that events generated in a test case bleed through to a different test case, ensuring that assertions are performed only on relevant events.

In `GlobalListenerInitializerIT`, assertions are made on the generated events in the various partitions. In order to do that, it is necessary to know which records are actually related to the latest configuration changes, excluding previous events.

This was done by waiting for `CONFIGURED` events and their related `FINISHED` distribution events coming from the previous configuration change and by then looking only at events after those.
The assumption was that only events generated in the test itself would be found through the `RecordingExporter`, but this is not always the case. The result was that distribution events from a previous test could be detected, causing then the assertions to start considering events too early.

To ensure that the distribution of the configuration change initiated in the current test is actually completed:

- a new unique listener name is generated in each test
- when waiting for the distribution to be complete, events referencing that specific listener name are searched for, ensuring they do not come from a previous test

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46209 
