### PR TITLE
[Backport stable/8.7] fix: move primary check to AdminApiRequestHandler before step-down

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -28,7 +28,6 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
@@ -250,35 +249,17 @@ public final class RaftPartition implements Partition, HealthMonitorable {
   }
 
   /**
-   * Tries to step down if the following conditions are met:
+   * Step down for leader balancing. Only steps down if priority election is enabled.
    *
-   * <ul>
-   *   <li>priority election is enabled
-   *   <li>the partition distributor determined a primary node
-   *   <li>this node is not the primary
-   * </ul>
+   * @return a future that completes when the step down is complete, or completes immediately if
+   *     priority election is not enabled or server is not available
    */
-  public CompletableFuture<Void> stepDownIfNotPrimary() {
-    if (shouldStepDown()) {
-      LOG.info(
-          "Decided that {} should step down as {} from partition {} because {} is primary",
-          server.getMemberId(),
-          server.getRole(),
-          partitionMetadata.id(),
-          partitionMetadata.getPrimary().orElse(null));
-      return stepDown();
+  public CompletableFuture<Void> stepDownForLeaderBalancing() {
+    if (server != null && config.isPriorityElectionEnabled()) {
+      return server.stepDown();
     } else {
       return CompletableFuture.completedFuture(null);
     }
-  }
-
-  @VisibleForTesting
-  public boolean shouldStepDown() {
-    final var primary = partitionMetadata.getPrimary();
-    return server != null
-        && config.isPriorityElectionEnabled()
-        && primary.isPresent()
-        && !primary.get().equals(server.getMemberId());
   }
 
   public CompletableFuture<Void> stop() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/StepDownTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/StepDownTest.java
@@ -7,7 +7,11 @@
  */
 package io.atomix.raft.partition;
 
-import io.atomix.cluster.MemberId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
@@ -16,105 +20,101 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
-final class StepDownIfNotPrimaryTest {
+final class StepDownTest {
   @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Test
-  void shouldStepDownIfNotPrimary(@TempDir final Path tempDir) throws IllegalAccessException {
+  void shouldStepDownWhenPriorityElectionEnabled(@TempDir final Path tempDir)
+      throws IllegalAccessException {
     // given
-    final var primaryMemberId = new MemberId("2");
     final var partitionId = new PartitionId("group", 1);
-    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
+    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, null);
 
     final var raftPartitionConfig = new RaftPartitionConfig();
+    raftPartitionConfig.setPriorityElectionEnabled(true);
     final var partition =
         new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
-    Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
+    when(mockRaftPartitionServer.stepDown()).thenReturn(CompletableFuture.completedFuture(null));
 
     // To avoid having to start a server, just mock one.
     FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
 
-    // when -- enabling priority election and marking a different member as primary
-    raftPartitionConfig.setPriorityElectionEnabled(true);
+    // when
+    partition.stepDownForLeaderBalancing();
 
-    // then -- current member should step down
-    Assertions.assertThat(partition.shouldStepDown()).isTrue();
+    // then
+    verify(mockRaftPartitionServer).stepDown();
   }
 
   @Test
-  void shouldNotStepDownIfPrimary(@TempDir final Path tempDir) throws IllegalAccessException {
-    // given
-    final var partitionId = new PartitionId("group", 1);
-    final var primaryMemberId = new MemberId("1");
-    final var raftPartitionConfig = new RaftPartitionConfig();
-    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
-    final var partition =
-        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
-
-    final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
-    Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
-
-    // To avoid having to start a server, just mock one.
-    FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
-
-    // when -- enabling priority election and with current member as primary
-    raftPartitionConfig.setPriorityElectionEnabled(true);
-
-    // then -- current member should not step down
-    Assertions.assertThat(partition.shouldStepDown()).isFalse();
-  }
-
-  @Test
-  void shouldNotStepDownIfPriorityElectionDisabled(@TempDir final Path tempDir)
+  void shouldNotStepDownWhenPriorityElectionDisabled(@TempDir final Path tempDir)
       throws IllegalAccessException {
     // given
     final var partitionId = new PartitionId("group", 1);
     final var raftPartitionConfig = new RaftPartitionConfig();
-    final var primaryMemberId = new MemberId("2");
-    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
-    final var partition =
-        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
-    final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
-    Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
-
-    // To avoid having to start a server, just mock one.
-    FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
-
-    // when -- disabling priority election
     raftPartitionConfig.setPriorityElectionEnabled(false);
-
-    // then -- current member should not step down
-    Assertions.assertThat(partition.shouldStepDown()).isFalse();
-  }
-
-  @Test
-  void shouldNotStepDownIfPartitionHasNoPrimary(@TempDir final Path tempDir)
-      throws IllegalAccessException {
-    // given
-    final var partitionId = new PartitionId("group", 1);
-    final MemberId primaryMemberId = null;
-    final var raftPartitionConfig = new RaftPartitionConfig();
-    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
+    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, null);
     final var partition =
         new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
-    Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
 
     // To avoid having to start a server, just mock one.
     FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
 
-    // when -- no primary known for this partition
-    raftPartitionConfig.setPriorityElectionEnabled(true);
+    // when
+    partition.stepDownForLeaderBalancing();
 
-    // then -- current member should not step down
-    Assertions.assertThat(partition.shouldStepDown()).isFalse();
+    // then
+    verify(mockRaftPartitionServer, never()).stepDown();
+  }
+
+  @Test
+  void shouldNotStepDownWhenServerIsNull(@TempDir final Path tempDir) {
+    // given
+    final var partitionId = new PartitionId("group", 1);
+    final var raftPartitionConfig = new RaftPartitionConfig();
+    raftPartitionConfig.setPriorityElectionEnabled(true);
+    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, null);
+    final var partition =
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
+    // server is null by default
+
+    // when
+    final var result = partition.stepDownForLeaderBalancing();
+
+    // then - should complete successfully without doing anything
+    assertThat(result).isCompletedWithValue(null);
+  }
+
+  @Test
+  void shouldAlwaysStepDownWhenCallingStepDown(@TempDir final Path tempDir)
+      throws IllegalAccessException {
+    // given
+    final var partitionId = new PartitionId("group", 1);
+    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, null);
+
+    final var raftPartitionConfig = new RaftPartitionConfig();
+    raftPartitionConfig.setPriorityElectionEnabled(false); // even when priority election disabled
+    final var partition =
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
+    final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
+    when(mockRaftPartitionServer.stepDown()).thenReturn(CompletableFuture.completedFuture(null));
+
+    // To avoid having to start a server, just mock one.
+    FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
+
+    // when
+    partition.stepDown();
+
+    // then - stepDown should always call server.stepDown() regardless of priority election
+    verify(mockRaftPartitionServer).stepDown();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -113,7 +113,8 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
             listeners,
             partitionRaftListeners,
             topologyManager,
-            featureFlags);
+            featureFlags,
+            clusterConfigurationService);
     managementService =
         new DefaultPartitionManagementService(
             clusterServices.getMembershipService(), clusterServices.getCommunicationService());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -88,6 +88,8 @@ public final class ZeebePartitionFactory {
   private final TopologyManagerImpl topologyManager;
   private final FeatureFlags featureFlags;
   private final List<PartitionRaftListener> partitionRaftListeners;
+  private final io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
+      clusterConfigurationService;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -102,7 +104,9 @@ public final class ZeebePartitionFactory {
       final List<PartitionListener> partitionListeners,
       final List<PartitionRaftListener> partitionRaftListeners,
       final TopologyManagerImpl topologyManager,
-      final FeatureFlags featureFlags) {
+      final FeatureFlags featureFlags,
+      final io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
+          clusterConfigurationService) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -116,6 +120,7 @@ public final class ZeebePartitionFactory {
     this.partitionRaftListeners = partitionRaftListeners;
     this.topologyManager = topologyManager;
     this.featureFlags = featureFlags;
+    this.clusterConfigurationService = clusterConfigurationService;
   }
 
   public ZeebePartition constructPartition(
@@ -156,6 +161,7 @@ public final class ZeebePartitionFactory {
             partitionMeterRegistry,
             brokerHealthCheckService);
     context.setDynamicPartitionConfig(initialPartitionConfig);
+    context.setClusterConfigurationService(clusterConfigurationService);
 
     final PartitionTransition newTransitionBehavior =
         new PartitionTransitionImpl(generateTransitionSteps());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -88,8 +89,7 @@ public final class ZeebePartitionFactory {
   private final TopologyManagerImpl topologyManager;
   private final FeatureFlags featureFlags;
   private final List<PartitionRaftListener> partitionRaftListeners;
-  private final io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
-      clusterConfigurationService;
+  private final ClusterConfigurationService clusterConfigurationService;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -105,8 +105,7 @@ public final class ZeebePartitionFactory {
       final List<PartitionRaftListener> partitionRaftListeners,
       final TopologyManagerImpl topologyManager,
       final FeatureFlags featureFlags,
-      final io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
-          clusterConfigurationService) {
+      final ClusterConfigurationService clusterConfigurationService) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
@@ -28,4 +28,6 @@ public interface ClusterConfigurationService extends AsyncClosable {
   void removeInconsistentConfigurationListener();
 
   ClusterConfiguration getInitialClusterConfiguration();
+
+  ActorFuture<ClusterConfiguration> getLatestClusterConfiguration();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -115,6 +115,18 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   }
 
   @Override
+  public ActorFuture<ClusterConfiguration> getLatestClusterConfiguration() {
+    if (clusterConfigurationManagerService != null) {
+      return clusterConfigurationManagerService.getClusterTopology();
+    } else {
+      final CompletableActorFuture<ClusterConfiguration> future = new CompletableActorFuture<>();
+      future.completeExceptionally(
+          new IllegalStateException("ClusterConfigurationService is not started"));
+      return future;
+    }
+  }
+
+  @Override
   public ActorFuture<Void> closeAsync() {
     partitionDistribution = null;
     if (clusterConfigurationManagerService != null) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -111,6 +112,7 @@ public class PartitionStartupAndTransitionContextImpl
   private final HealthTreeMetrics healthGraphMetrics;
   private final BrokerHealthCheckService brokerHealthCheckService;
   private volatile boolean migrationsPerformed = false;
+  private ClusterConfigurationService clusterConfigurationService;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -394,6 +396,17 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public ComponentTreeListener getComponentTreeListener() {
     return healthGraphMetrics;
+  }
+
+  @Override
+  public ClusterConfigurationService getClusterConfigurationService() {
+    return clusterConfigurationService;
+  }
+
+  @Override
+  public void setClusterConfigurationService(
+      final ClusterConfigurationService clusterConfigurationService) {
+    this.clusterConfigurationService = clusterConfigurationService;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
@@ -154,4 +155,8 @@ public interface PartitionTransitionContext extends PartitionContext {
   boolean areMigrationsPerformed();
 
   ComponentTreeListener getComponentTreeListener();
+
+  ClusterConfigurationService getClusterConfigurationService();
+
+  void setClusterConfigurationService(ClusterConfigurationService clusterConfigurationService);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
@@ -40,7 +40,12 @@ public final class AdminApiRequestHandlerStep implements PartitionTransitionStep
     final var schedulingService = context.getActorSchedulingService();
     final var transport = context.getGatewayBrokerTransport();
     final var handler =
-        new AdminApiRequestHandler(transport, context.getAdminAccess(), context.getRaftPartition());
+        new AdminApiRequestHandler(
+            transport,
+            context.getAdminAccess(),
+            context.getRaftPartition(),
+            context.getClusterConfigurationService(),
+            context.getNodeId());
     final var submitFuture = schedulingService.submitActor(handler);
     concurrencyControl.runOnCompletion(
         submitFuture,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
@@ -86,6 +87,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private MeterRegistry transitionMeterRegistry;
   private boolean migrationsPerformed;
   private final ComponentTreeListener healthMetrics;
+  private ClusterConfigurationService clusterConfigurationService;
 
   public TestPartitionTransitionContext() {
     transitionMeterRegistry = MicrometerUtil.wrap(startupMeterRegistry, PartitionKeyNames.tags(1));
@@ -351,6 +353,17 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public ComponentTreeListener getComponentTreeListener() {
     return healthMetrics;
+  }
+
+  @Override
+  public ClusterConfigurationService getClusterConfigurationService() {
+    return clusterConfigurationService;
+  }
+
+  @Override
+  public void setClusterConfigurationService(
+      final ClusterConfigurationService clusterConfigurationService) {
+    this.clusterConfigurationService = clusterConfigurationService;
   }
 
   public void setGatewayBrokerTransport(final AtomixServerTransport gatewayBrokerTransport) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @Execution(ExecutionMode.CONCURRENT)
@@ -99,8 +101,11 @@ final class AdminApiRequestHandlerTest {
     OtherRequest(
         @Mock final AtomixServerTransport transport,
         @Mock final PartitionAdminAccess adminAccess,
-        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition) {
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
     }
 
     @BeforeEach
@@ -137,11 +142,14 @@ final class AdminApiRequestHandlerTest {
     public PauseExportingRequest(
         @Mock final PartitionAdminAccess adminAccess,
         @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
-        @Mock final AtomixServerTransport transport) {
+        @Mock final AtomixServerTransport transport,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.adminAccess = adminAccess;
       final int partitionId = 1;
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -211,11 +219,14 @@ final class AdminApiRequestHandlerTest {
     public SoftPauseExportingRequest(
         @Mock final PartitionAdminAccess adminAccess,
         @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
-        @Mock final AtomixServerTransport transport) {
+        @Mock final AtomixServerTransport transport,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.adminAccess = adminAccess;
       final int partitionId = 1;
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -285,11 +296,14 @@ final class AdminApiRequestHandlerTest {
     public ResumeExportingRequest(
         @Mock final PartitionAdminAccess adminAccess,
         @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
-        @Mock final AtomixServerTransport transport) {
+        @Mock final AtomixServerTransport transport,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.adminAccess = adminAccess;
       final int partitionId = 1;
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -354,13 +368,19 @@ final class AdminApiRequestHandlerTest {
 
     private final AdminApiRequestHandler handler;
     private final RaftPartition raftPartition;
+    private final ClusterConfigurationService clusterConfigurationService;
+    private final int nodeId = 1;
 
     StepdownRequest(
         @Mock final AtomixServerTransport transport,
         @Mock final PartitionAdminAccess adminAccess,
-        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition) {
+        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.raftPartition = raftPartition;
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+      this.clusterConfigurationService = clusterConfigurationService;
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, nodeId);
     }
 
     @BeforeEach
@@ -376,6 +396,7 @@ final class AdminApiRequestHandlerTest {
 
       final var request = new AdminRequest();
       request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(1);
 
       // when
       final var responseFuture = handleRequest(request, handler);
@@ -414,6 +435,109 @@ final class AdminApiRequestHandlerTest {
 
       // then
       assertErrorCode(responseFuture, ErrorCode.PARTITION_LEADER_MISMATCH);
+    }
+
+    @Test
+    void shouldCallStepDownWhenNodeIsNotPrimary() {
+      // given
+      when(raftPartition.getRole()).thenReturn(Role.LEADER);
+      final var partitionId = 1;
+      final var primaryMemberId = io.atomix.cluster.MemberId.from("2");
+      final var clusterConfig =
+          Mockito.mock(io.camunda.zeebe.dynamic.config.state.ClusterConfiguration.class);
+      when(clusterConfig.getPrimaryMemberForPartition(partitionId))
+          .thenReturn(java.util.Optional.of(primaryMemberId));
+      when(clusterConfigurationService.getLatestClusterConfiguration())
+          .thenReturn(
+              io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(clusterConfig));
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(partitionId);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(raftPartition).stepDownForLeaderBalancing();
+    }
+
+    @Test
+    void shouldNotCallStepDownWhenNodeIsPrimary() {
+      // given
+      when(raftPartition.getRole()).thenReturn(Role.LEADER);
+      final var partitionId = 1;
+      final var primaryMemberId = io.atomix.cluster.MemberId.from("1"); // Same as nodeId
+      final var clusterConfig =
+          Mockito.mock(io.camunda.zeebe.dynamic.config.state.ClusterConfiguration.class);
+      when(clusterConfig.getPrimaryMemberForPartition(partitionId))
+          .thenReturn(java.util.Optional.of(primaryMemberId));
+      when(clusterConfigurationService.getLatestClusterConfiguration())
+          .thenReturn(
+              io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(clusterConfig));
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(partitionId);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(raftPartition, Mockito.never()).stepDownForLeaderBalancing();
+    }
+
+    @Test
+    void shouldNotCallStepDownWhenNoPrimaryFound() {
+      // given
+      when(raftPartition.getRole()).thenReturn(Role.LEADER);
+      final var partitionId = 1;
+      final var clusterConfig =
+          Mockito.mock(io.camunda.zeebe.dynamic.config.state.ClusterConfiguration.class);
+      when(clusterConfig.getPrimaryMemberForPartition(partitionId))
+          .thenReturn(java.util.Optional.empty());
+      when(clusterConfigurationService.getLatestClusterConfiguration())
+          .thenReturn(
+              io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(clusterConfig));
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(partitionId);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(raftPartition, Mockito.never()).stepDownForLeaderBalancing();
+    }
+
+    @Test
+    void shouldNotFailWhenConfigurationUnavailable() {
+      // given
+      when(raftPartition.getRole()).thenReturn(Role.LEADER);
+      final var partitionId = 1;
+      when(clusterConfigurationService.getLatestClusterConfiguration())
+          .thenReturn(
+              io.camunda.zeebe.scheduler.future.CompletableActorFuture.completedExceptionally(
+                  new RuntimeException("Config unavailable")));
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(partitionId);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then - should return success even though config retrieval failed
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(raftPartition, Mockito.never()).stepDownForLeaderBalancing();
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -281,6 +281,27 @@ public record ClusterConfiguration(
         .orElse(0);
   }
 
+  /**
+   * Returns the member with the highest priority for a given partition.
+   *
+   * @param partitionId the partition ID
+   * @return Optional containing the MemberId of the member with highest priority, or empty if
+   *     partition not found
+   */
+  public Optional<MemberId> getPrimaryMemberForPartition(final int partitionId) {
+    return members.entrySet().stream()
+        .filter(entry -> entry.getValue().hasPartition(partitionId))
+        .filter(entry -> entry.getValue().state() != State.LEFT)
+        .filter(entry -> entry.getValue().state() != State.UNINITIALIZED)
+        .filter(entry -> entry.getValue().getPartition(partitionId) != null)
+        .max(
+            (e1, e2) ->
+                Integer.compare(
+                    e1.getValue().getPartition(partitionId).priority(),
+                    e2.getValue().getPartition(partitionId).priority()))
+        .map(Entry::getKey);
+  }
+
   public ClusterConfigurationChangeOperation nextPendingOperation() {
     if (!hasPendingChanges()) {
       throw new NoSuchElementException();


### PR DESCRIPTION
# Description
Backport of #44898 to `stable/8.7`.

relates to #40036