### PR TITLE
[Backport stable/8.9] fix: move primary check to AdminApiRequestHandler before step-down

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/StepDownTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/StepDownTest.java
@@ -7,7 +7,11 @@
  */
 package io.atomix.raft.partition;
 
-import io.atomix.cluster.MemberId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
@@ -16,105 +20,101 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
-final class StepDownIfNotPrimaryTest {
+final class StepDownTest {
   @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Test
-  void shouldStepDownIfNotPrimary(@TempDir final Path tempDir) throws IllegalAccessException {
+  void shouldStepDownWhenPriorityElectionEnabled(@TempDir final Path tempDir)
+      throws IllegalAccessException {
     // given
-    final var primaryMemberId = new MemberId("2");
     final var partitionId = new PartitionId("group", 1);
-    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
+    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, null);
 
     final var raftPartitionConfig = new RaftPartitionConfig();
+    raftPartitionConfig.setPriorityElectionEnabled(true);
     final var partition =
         new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
-    Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
+    when(mockRaftPartitionServer.stepDown()).thenReturn(CompletableFuture.completedFuture(null));
 
     // To avoid having to start a server, just mock one.
     FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
 
-    // when -- enabling priority election and marking a different member as primary
-    raftPartitionConfig.setPriorityElectionEnabled(true);
+    // when
+    partition.stepDownForLeaderBalancing();
 
-    // then -- current member should step down
-    Assertions.assertThat(partition.shouldStepDown()).isTrue();
+    // then
+    verify(mockRaftPartitionServer).stepDown();
   }
 
   @Test
-  void shouldNotStepDownIfPrimary(@TempDir final Path tempDir) throws IllegalAccessException {
-    // given
-    final var partitionId = new PartitionId("group", 1);
-    final var primaryMemberId = new MemberId("1");
-    final var raftPartitionConfig = new RaftPartitionConfig();
-    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
-    final var partition =
-        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
-
-    final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
-    Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
-
-    // To avoid having to start a server, just mock one.
-    FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
-
-    // when -- enabling priority election and with current member as primary
-    raftPartitionConfig.setPriorityElectionEnabled(true);
-
-    // then -- current member should not step down
-    Assertions.assertThat(partition.shouldStepDown()).isFalse();
-  }
-
-  @Test
-  void shouldNotStepDownIfPriorityElectionDisabled(@TempDir final Path tempDir)
+  void shouldNotStepDownWhenPriorityElectionDisabled(@TempDir final Path tempDir)
       throws IllegalAccessException {
     // given
     final var partitionId = new PartitionId("group", 1);
     final var raftPartitionConfig = new RaftPartitionConfig();
-    final var primaryMemberId = new MemberId("2");
-    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
-    final var partition =
-        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
-    final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
-    Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
-
-    // To avoid having to start a server, just mock one.
-    FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
-
-    // when -- disabling priority election
     raftPartitionConfig.setPriorityElectionEnabled(false);
-
-    // then -- current member should not step down
-    Assertions.assertThat(partition.shouldStepDown()).isFalse();
-  }
-
-  @Test
-  void shouldNotStepDownIfPartitionHasNoPrimary(@TempDir final Path tempDir)
-      throws IllegalAccessException {
-    // given
-    final var partitionId = new PartitionId("group", 1);
-    final MemberId primaryMemberId = null;
-    final var raftPartitionConfig = new RaftPartitionConfig();
-    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
+    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, null);
     final var partition =
         new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
-    Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
 
     // To avoid having to start a server, just mock one.
     FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
 
-    // when -- no primary known for this partition
-    raftPartitionConfig.setPriorityElectionEnabled(true);
+    // when
+    partition.stepDownForLeaderBalancing();
 
-    // then -- current member should not step down
-    Assertions.assertThat(partition.shouldStepDown()).isFalse();
+    // then
+    verify(mockRaftPartitionServer, never()).stepDown();
+  }
+
+  @Test
+  void shouldNotStepDownWhenServerIsNull(@TempDir final Path tempDir) {
+    // given
+    final var partitionId = new PartitionId("group", 1);
+    final var raftPartitionConfig = new RaftPartitionConfig();
+    raftPartitionConfig.setPriorityElectionEnabled(true);
+    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, null);
+    final var partition =
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
+    // server is null by default
+
+    // when
+    final var result = partition.stepDownForLeaderBalancing();
+
+    // then - should complete successfully without doing anything
+    assertThat(result).isCompletedWithValue(null);
+  }
+
+  @Test
+  void shouldAlwaysStepDownWhenCallingStepDown(@TempDir final Path tempDir)
+      throws IllegalAccessException {
+    // given
+    final var partitionId = new PartitionId("group", 1);
+    final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, null);
+
+    final var raftPartitionConfig = new RaftPartitionConfig();
+    raftPartitionConfig.setPriorityElectionEnabled(false); // even when priority election disabled
+    final var partition =
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
+    final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
+    when(mockRaftPartitionServer.stepDown()).thenReturn(CompletableFuture.completedFuture(null));
+
+    // To avoid having to start a server, just mock one.
+    FieldUtils.writeField(partition, "server", mockRaftPartitionServer, true);
+
+    // when
+    partition.stepDown();
+
+    // then - stepDown should always call server.stepDown() regardless of priority election
+    verify(mockRaftPartitionServer).stepDown();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -142,7 +142,8 @@ public final class PartitionManagerImpl
             securityConfig,
             searchClientsProxy,
             brokerRequestAuthorizationConverter,
-            sharedRocksDbResources);
+            sharedRocksDbResources,
+            clusterConfigurationService);
     managementService =
         new DefaultPartitionManagementService(
             clusterServices.getMembershipService(), clusterServices.getCommunicationService());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.logstreams.state.DbPositionSupplier;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -102,8 +103,7 @@ public final class ZeebePartitionFactory {
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private final SharedRocksDbResources sharedRocksDbResources;
-  private final io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
-      clusterConfigurationService;
+  private final ClusterConfigurationService clusterConfigurationService;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -124,8 +124,7 @@ public final class ZeebePartitionFactory {
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final SharedRocksDbResources sharedRocksDbResources,
-      final io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
-          clusterConfigurationService) {
+      final ClusterConfigurationService clusterConfigurationService) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -102,6 +102,8 @@ public final class ZeebePartitionFactory {
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private final SharedRocksDbResources sharedRocksDbResources;
+  private final io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
+      clusterConfigurationService;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -121,7 +123,9 @@ public final class ZeebePartitionFactory {
       final SecurityConfiguration securityConfig,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
-      final SharedRocksDbResources sharedRocksDbResources) {
+      final SharedRocksDbResources sharedRocksDbResources,
+      final io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
+          clusterConfigurationService) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -140,6 +144,7 @@ public final class ZeebePartitionFactory {
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
     this.sharedRocksDbResources = sharedRocksDbResources;
+    this.clusterConfigurationService = clusterConfigurationService;
   }
 
   public ZeebePartition constructPartition(
@@ -194,6 +199,7 @@ public final class ZeebePartitionFactory {
             securityConfig,
             partitionMeterRegistry);
     context.setDynamicPartitionConfig(initialPartitionConfig);
+    context.setClusterConfigurationService(clusterConfigurationService);
 
     final PartitionTransition newTransitionBehavior =
         new PartitionTransitionImpl(generateTransitionSteps());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
@@ -34,4 +34,6 @@ public interface ClusterConfigurationService extends AsyncClosable {
   ClusterConfiguration getInitialClusterConfiguration();
 
   ClusterChangeExecutor getClusterChangeExecutor();
+
+  ActorFuture<ClusterConfiguration> getLatestClusterConfiguration();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -128,6 +128,18 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   }
 
   @Override
+  public ActorFuture<ClusterConfiguration> getLatestClusterConfiguration() {
+    if (clusterConfigurationManagerService != null) {
+      return clusterConfigurationManagerService.getClusterTopology();
+    } else {
+      final CompletableActorFuture<ClusterConfiguration> future = new CompletableActorFuture<>();
+      future.completeExceptionally(
+          new IllegalStateException("ClusterConfigurationService is not started"));
+      return future;
+    }
+  }
+
+  @Override
   public ActorFuture<Void> closeAsync() {
     partitionDistribution = null;
     if (clusterConfigurationManagerService != null) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -117,6 +118,7 @@ public class PartitionStartupAndTransitionContextImpl
   private MeterRegistry transitionMeterRegistry;
   private volatile boolean migrationsPerformed = false;
   private final SnapshotApiRequestHandler snapshotApiRequestHandler;
+  private ClusterConfigurationService clusterConfigurationService;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -411,6 +413,17 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public ComponentTreeListener getComponentTreeListener() {
     return healthGraphMetrics;
+  }
+
+  @Override
+  public ClusterConfigurationService getClusterConfigurationService() {
+    return clusterConfigurationService;
+  }
+
+  @Override
+  public void setClusterConfigurationService(
+      final ClusterConfigurationService clusterConfigurationService) {
+    this.clusterConfigurationService = clusterConfigurationService;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
@@ -160,4 +161,8 @@ public interface PartitionTransitionContext extends PartitionContext {
   boolean areMigrationsPerformed();
 
   ComponentTreeListener getComponentTreeListener();
+
+  ClusterConfigurationService getClusterConfigurationService();
+
+  void setClusterConfigurationService(ClusterConfigurationService clusterConfigurationService);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
@@ -40,7 +40,12 @@ public final class AdminApiRequestHandlerStep implements PartitionTransitionStep
     final var schedulingService = context.getActorSchedulingService();
     final var transport = context.getGatewayBrokerTransport();
     final var handler =
-        new AdminApiRequestHandler(transport, context.getAdminAccess(), context.getRaftPartition());
+        new AdminApiRequestHandler(
+            transport,
+            context.getAdminAccess(),
+            context.getRaftPartition(),
+            context.getClusterConfigurationService(),
+            context.getNodeId());
     final var submitFuture = schedulingService.submitActor(handler);
     concurrencyControl.runOnCompletion(
         submitFuture,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
@@ -91,6 +92,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private boolean migrationsPerformed;
   private final ComponentTreeListener healthMetrics;
   private SnapshotCopy snapshotCopy;
+  private ClusterConfigurationService clusterConfigurationService;
 
   public TestPartitionTransitionContext() {
     transitionMeterRegistry = MicrometerUtil.wrap(startupMeterRegistry, PartitionKeyNames.tags(1));
@@ -375,6 +377,17 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public ComponentTreeListener getComponentTreeListener() {
     return healthMetrics;
+  }
+
+  @Override
+  public ClusterConfigurationService getClusterConfigurationService() {
+    return clusterConfigurationService;
+  }
+
+  @Override
+  public void setClusterConfigurationService(
+      final ClusterConfigurationService clusterConfigurationService) {
+    this.clusterConfigurationService = clusterConfigurationService;
   }
 
   public void setGatewayBrokerTransport(final AtomixServerTransport gatewayBrokerTransport) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @Execution(ExecutionMode.CONCURRENT)
@@ -99,8 +101,11 @@ final class AdminApiRequestHandlerTest {
     OtherRequest(
         @Mock final AtomixServerTransport transport,
         @Mock final PartitionAdminAccess adminAccess,
-        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition) {
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
     }
 
     @BeforeEach
@@ -137,11 +142,14 @@ final class AdminApiRequestHandlerTest {
     public PauseExportingRequest(
         @Mock final PartitionAdminAccess adminAccess,
         @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
-        @Mock final AtomixServerTransport transport) {
+        @Mock final AtomixServerTransport transport,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.adminAccess = adminAccess;
       final int partitionId = 1;
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -211,11 +219,14 @@ final class AdminApiRequestHandlerTest {
     public SoftPauseExportingRequest(
         @Mock final PartitionAdminAccess adminAccess,
         @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
-        @Mock final AtomixServerTransport transport) {
+        @Mock final AtomixServerTransport transport,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.adminAccess = adminAccess;
       final int partitionId = 1;
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -285,11 +296,14 @@ final class AdminApiRequestHandlerTest {
     public ResumeExportingRequest(
         @Mock final PartitionAdminAccess adminAccess,
         @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
-        @Mock final AtomixServerTransport transport) {
+        @Mock final AtomixServerTransport transport,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.adminAccess = adminAccess;
       final int partitionId = 1;
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -354,13 +368,19 @@ final class AdminApiRequestHandlerTest {
 
     private final AdminApiRequestHandler handler;
     private final RaftPartition raftPartition;
+    private final ClusterConfigurationService clusterConfigurationService;
+    private final int nodeId = 1;
 
     StepdownRequest(
         @Mock final AtomixServerTransport transport,
         @Mock final PartitionAdminAccess adminAccess,
-        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition) {
+        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.raftPartition = raftPartition;
-      handler = new AdminApiRequestHandler(transport, adminAccess, raftPartition);
+      this.clusterConfigurationService = clusterConfigurationService;
+      handler =
+          new AdminApiRequestHandler(
+              transport, adminAccess, raftPartition, clusterConfigurationService, nodeId);
     }
 
     @BeforeEach
@@ -376,6 +396,7 @@ final class AdminApiRequestHandlerTest {
 
       final var request = new AdminRequest();
       request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(1);
 
       // when
       final var responseFuture = handleRequest(request, handler);
@@ -414,6 +435,109 @@ final class AdminApiRequestHandlerTest {
 
       // then
       assertErrorCode(responseFuture, ErrorCode.PARTITION_LEADER_MISMATCH);
+    }
+
+    @Test
+    void shouldCallStepDownWhenNodeIsNotPrimary() {
+      // given
+      when(raftPartition.getRole()).thenReturn(Role.LEADER);
+      final var partitionId = 1;
+      final var primaryMemberId = io.atomix.cluster.MemberId.from("2");
+      final var clusterConfig =
+          Mockito.mock(io.camunda.zeebe.dynamic.config.state.ClusterConfiguration.class);
+      when(clusterConfig.getPrimaryMemberForPartition(partitionId))
+          .thenReturn(java.util.Optional.of(primaryMemberId));
+      when(clusterConfigurationService.getLatestClusterConfiguration())
+          .thenReturn(
+              io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(clusterConfig));
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(partitionId);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(raftPartition).stepDownForLeaderBalancing();
+    }
+
+    @Test
+    void shouldNotCallStepDownWhenNodeIsPrimary() {
+      // given
+      when(raftPartition.getRole()).thenReturn(Role.LEADER);
+      final var partitionId = 1;
+      final var primaryMemberId = io.atomix.cluster.MemberId.from("1"); // Same as nodeId
+      final var clusterConfig =
+          Mockito.mock(io.camunda.zeebe.dynamic.config.state.ClusterConfiguration.class);
+      when(clusterConfig.getPrimaryMemberForPartition(partitionId))
+          .thenReturn(java.util.Optional.of(primaryMemberId));
+      when(clusterConfigurationService.getLatestClusterConfiguration())
+          .thenReturn(
+              io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(clusterConfig));
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(partitionId);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(raftPartition, Mockito.never()).stepDownForLeaderBalancing();
+    }
+
+    @Test
+    void shouldNotCallStepDownWhenNoPrimaryFound() {
+      // given
+      when(raftPartition.getRole()).thenReturn(Role.LEADER);
+      final var partitionId = 1;
+      final var clusterConfig =
+          Mockito.mock(io.camunda.zeebe.dynamic.config.state.ClusterConfiguration.class);
+      when(clusterConfig.getPrimaryMemberForPartition(partitionId))
+          .thenReturn(java.util.Optional.empty());
+      when(clusterConfigurationService.getLatestClusterConfiguration())
+          .thenReturn(
+              io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(clusterConfig));
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(partitionId);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(raftPartition, Mockito.never()).stepDownForLeaderBalancing();
+    }
+
+    @Test
+    void shouldNotFailWhenConfigurationUnavailable() {
+      // given
+      when(raftPartition.getRole()).thenReturn(Role.LEADER);
+      final var partitionId = 1;
+      when(clusterConfigurationService.getLatestClusterConfiguration())
+          .thenReturn(
+              io.camunda.zeebe.scheduler.future.CompletableActorFuture.completedExceptionally(
+                  new RuntimeException("Config unavailable")));
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+      request.setPartitionId(partitionId);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then - should return success even though config retrieval failed
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(raftPartition, Mockito.never()).stepDownForLeaderBalancing();
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -377,6 +377,27 @@ public record ClusterConfiguration(
         .orElse(0);
   }
 
+  /**
+   * Returns the member with the highest priority for a given partition.
+   *
+   * @param partitionId the partition ID
+   * @return Optional containing the MemberId of the member with highest priority, or empty if
+   *     partition not found
+   */
+  public Optional<MemberId> getPrimaryMemberForPartition(final int partitionId) {
+    return members.entrySet().stream()
+        .filter(entry -> entry.getValue().hasPartition(partitionId))
+        .filter(entry -> entry.getValue().state() != State.LEFT)
+        .filter(entry -> entry.getValue().state() != State.UNINITIALIZED)
+        .filter(entry -> entry.getValue().getPartition(partitionId) != null)
+        .max(
+            (e1, e2) ->
+                Integer.compare(
+                    e1.getValue().getPartition(partitionId).priority(),
+                    e2.getValue().getPartition(partitionId).priority()))
+        .map(Entry::getKey);
+  }
+
   public ClusterConfigurationChangeOperation nextPendingOperation() {
     if (!hasPendingChanges()) {
       throw new NoSuchElementException();


### PR DESCRIPTION
# Description
Backport of #44898 to `stable/8.9`.

relates to #40036