### PR TITLE
fix: anchor cross-minor no-op bridge plan at X.Y.0 to prevent silent registry override

### DIFF
--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/CurrentVersionNoOperationUpgradePlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/CurrentVersionNoOperationUpgradePlanFactory.java
@@ -18,7 +18,7 @@ public class CurrentVersionNoOperationUpgradePlanFactory implements UpgradePlanF
   public UpgradePlan createUpgradePlan() {
     return UpgradePlanBuilder.createUpgradePlan()
         .fromVersion(PreviousVersion.PREVIOUS_VERSION_MAJOR_MINOR)
-        .toVersion(Version.VERSION)
+        .toVersion(Version.getMajorAndMinor(Version.VERSION) + ".0")
         .build();
   }
 

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/main/UpgradeProcedureIT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/main/UpgradeProcedureIT.java
@@ -54,8 +54,8 @@ public class UpgradeProcedureIT extends AbstractUpgradeIT {
             String.format(
                 "Schema version saved in Metadata [%s] must be one of [%s, %s]",
                 metadataIndexVersion,
-                PreviousVersion.PREVIOUS_VERSION_MAJOR_MINOR,
-                Version.VERSION));
+                previousVersionMajorMinorUpgradePlan.getFromVersion().getValue(),
+                previousVersionMajorMinorUpgradePlan.getToVersion().getValue()));
 
     assertThat(getMetadataVersion()).isEqualTo(metadataIndexVersion);
   }
@@ -70,7 +70,8 @@ public class UpgradeProcedureIT extends AbstractUpgradeIT {
         .isThrownBy(() -> upgradeProcedure.performUpgrade(previousVersionMajorMinorUpgradePlan));
 
     // then
-    assertThat(getMetadataVersion()).isEqualTo(Version.VERSION);
+    assertThat(getMetadataVersion())
+        .isEqualTo(previousVersionMajorMinorUpgradePlan.getToVersion().getValue());
   }
 
   @Test
@@ -83,7 +84,8 @@ public class UpgradeProcedureIT extends AbstractUpgradeIT {
         .isThrownBy(() -> upgradeProcedure.performUpgrade(previousVersionMajorMinorUpgradePlan));
 
     // then
-    assertThat(getMetadataVersion()).isEqualTo(Version.VERSION);
+    assertThat(getMetadataVersion())
+        .isEqualTo(previousVersionMajorMinorUpgradePlan.getToVersion().getValue());
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes a bug in `CurrentVersionNoOperationUpgradePlanFactory` where the cross-minor upgrade bridge plan could be **silently dropped** from `UpgradePlanRegistry`, causing cross-minor upgrades to fail when at least one patch of the target minor has already been released.

### Problem

`CurrentVersionNoOperationUpgradePlanFactory` registers a no-op bridge plan for cross-minor upgrades (e.g. `8.8 -> 8.9`) with `toVersion = Version.VERSION` (e.g. `8.9.3`).

However, `UpgradePlanRegistry` uses `putIfAbsent` or overrides it if exlicit plan targeting same version is present when registering plans:

https://github.com/camunda/camunda/blob/66fe2cb2bcf3a788c6dcc5aedc925a321808b138/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistry.java#L45-L53

This means that if an explicit patch plan already occupies the key `8.9.3` (e.g. `8.9.2 -> 8.9.3`), the cross-minor bridge is **silently discarded** — leaving no registered plan capable of bridging from `8.8` to `8.9.3`.

### When does this occur?

The bug surfaces during a cross-minor upgrade (e.g. `8.8 -> 8.9.x`) when **both** of the following are true:
- No explicit `8.8 -> 8.9.0` plan is present
- At least one patch of the target minor has been released (i.e. `8.9.1`, `8.9.2`, ...)

#### ✅ Cases where upgrade works:
- Upgrading directly from `8.8 -> 8.9.0` (first release of new minor) — no patch plans exist yet to claim the `8.9.0` key, so the bridge is registered successfully.
- An explicit `8.8 -> 8.9.0` plan is present — `putIfAbsent` keeps the explicit plan and the bridge is registered at a different key, so the chain remains intact.

#### ❌ Case where upgrade fails:
- Upgrading from `8.8 -> 8.9.1` (or any later `8.9.x`) when no explicit cross-minor plan exists:
  - The explicit patch plan `8.9.0 -> 8.9.1` already occupies key `8.9.1`
  - The cross-minor bridge targeting `8.9.1` is silently dropped by `putIfAbsent`
  - No plan bridges `8.8 -> 8.9.1` — the first available plan in the chain is `8.9.0 -> 8.9.1`
  - Upgrade fails schema validation: DB schema version (e.g. `8.8.5`) doesn't match the expected `fromVersion` (`8.9.0`)
  - Customer is forced into a two-step workaround: `8.8 -> 8.9.0`, then `8.9.0 -> 8.9.1`

### Solution

Anchor the cross-minor bridge at `X.Y.0` instead of `X.Y.currentPatch`:

```java
// in CurrentVersionNoOperationUpgradePlanFactory
// Before
.toVersion(Version.VERSION)

// After
.toVersion(Version.getMajorAndMinor(Version.VERSION) + ".0")
```

Since explicit patch plans always target `.1`, `.2`, etc., the `X.Y.0` key is **never claimed by a patch plan**, guaranteeing the cross-minor bridge is always present in the registry.

### What's NOT in this PR

- Removal of `CurrentVersionNoOperationUpgradePlanFactory` entirely — this is a potential follow-up in #47166 once the auto-generation approach from #46523 matures.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #40258