### PR TITLE
[Backport stable/8.9] fix: forbid synchronous `CompletableFuture` callbacks in actor-scoped classes

### DIFF
--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -45,6 +45,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.tngtech.archunit</groupId>
       <artifactId>archunit</artifactId>
       <scope>test</scope>

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/scheduler/CompletableFutureCallbackArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/scheduler/CompletableFutureCallbackArchTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.scheduler;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Ensures that actor-scoped code does not use synchronous callback methods on {@link
+ * CompletableFuture}.
+ *
+ * <p>Synchronous callback methods ({@code whenComplete}, {@code thenApply}, {@code handle}, etc.)
+ * execute the callback on whichever thread completes the future. When actor code chains a callback
+ * on a {@link CompletableFuture} returned by an external service (e.g. a backup store backed by S3,
+ * the Raft layer, or a messaging service), the callback may run on a non-actor thread. If that
+ * callback accesses actor-owned state (RocksDB column families, shared data structures, etc.), the
+ * result is a race condition that can cause data corruption or a JVM crash (SIGSEGV).
+ *
+ * <p>The fix is to always use the async variant with the actor executor:
+ *
+ * <pre>{@code
+ * // UNSAFE: callback runs on the completing thread (e.g. Netty I/O thread)
+ * backupStore.save(backup).whenComplete((result, error) -> { ... });
+ *
+ * // SAFE: callback is dispatched to the actor thread
+ * backupStore.save(backup).whenCompleteAsync((result, error) -> { ... }, executor);
+ * }</pre>
+ *
+ * <p>A class is considered "actor-scoped" if it extends {@link Actor} or declares a field of type
+ * {@link ConcurrencyControl} (the actor scheduling interface) or any subtype (for example, {@link
+ * ActorControl}).
+ *
+ * @see <a href="https://github.com/camunda/camunda/pull/47359">PR #47359</a> for an example of this
+ *     bug class causing a JVM crash.
+ */
+@AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.DoNotIncludeTests.class)
+public class CompletableFutureCallbackArchTest {
+
+  @ArchTest
+  static final ArchRule ACTOR_CODE_SHOULD_USE_ASYNC_COMPLETABLE_FUTURE_CALLBACKS =
+      classes()
+          .that(useActorConcurrencyControl())
+          .should(notCallSyncCompletableFutureCallbacks())
+          .because(
+              "synchronous callback methods on CompletableFuture execute on the completing "
+                  + "thread (e.g. a Netty I/O thread), not the actor thread. Use the async "
+                  + "variant with the actor executor instead, e.g. "
+                  + ".whenCompleteAsync(callback, concurrencyControl)");
+
+  /**
+   * Synchronous callback methods on {@link CompletableFuture} / {@link CompletionStage} that
+   * execute the callback on the completing thread. Each of these has an {@code *Async} counterpart
+   * that accepts an {@link java.util.concurrent.Executor}.
+   */
+  private static final Set<String> SYNC_CALLBACK_METHODS =
+      Set.of(
+          "whenComplete",
+          "handle",
+          "thenApply",
+          "thenAccept",
+          "thenRun",
+          "thenCompose",
+          "exceptionally",
+          "acceptEither",
+          "applyToEither",
+          "runAfterBoth",
+          "runAfterEither",
+          "thenAcceptBoth",
+          "thenCombine");
+
+  private static DescribedPredicate<JavaClass> useActorConcurrencyControl() {
+    return new DescribedPredicate<>("use actor concurrency control") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        if (javaClass.isAssignableTo(Actor.class)) {
+          return true;
+        }
+        // Match classes with a ConcurrencyControl or ActorControl field, but exclude fields whose
+        // type extends Actor — those are references to other actors, not indicators that THIS class
+        // is actor-scoped. For example, Broker has a BrokerStartupActor field but Broker itself is
+        // not actor-scoped.
+        return javaClass.getAllFields().stream()
+            .anyMatch(
+                field -> {
+                  final var fieldType = field.getRawType();
+                  return fieldType.isAssignableTo(ConcurrencyControl.class)
+                      && !fieldType.isAssignableTo(Actor.class);
+                });
+      }
+    };
+  }
+
+  private static ArchCondition<JavaClass> notCallSyncCompletableFutureCallbacks() {
+    return new ArchCondition<>(
+        "not call synchronous callback methods on CompletableFuture or CompletionStage") {
+      @Override
+      public void check(final JavaClass item, final ConditionEvents events) {
+        item.getMethodCallsFromSelf().stream()
+            .filter(CompletableFutureCallbackArchTest::isSyncCallbackOnCompletableFuture)
+            .forEach(
+                call ->
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            item,
+                            String.format(
+                                "%s calls %s.%s() at %s — use %sAsync() with the actor executor instead",
+                                item.getName(),
+                                call.getTargetOwner().getSimpleName(),
+                                call.getName(),
+                                call.getSourceCodeLocation(),
+                                call.getName()))));
+      }
+    };
+  }
+
+  private static boolean isSyncCallbackOnCompletableFuture(final JavaMethodCall call) {
+    if (!SYNC_CALLBACK_METHODS.contains(call.getName())) {
+      return false;
+    }
+    final var targetOwner = call.getTargetOwner();
+    return targetOwner.isAssignableTo(CompletableFuture.class)
+        || targetOwner.isAssignableTo(CompletionStage.class);
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/scheduler/CompletableFutureCallbackArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/scheduler/CompletableFutureCallbackArchTest.java
@@ -22,6 +22,8 @@ import com.tngtech.archunit.lang.SimpleConditionEvent;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 /**
  * Ensures that actor-scoped code does not use synchronous callback methods on {@link
@@ -34,11 +36,14 @@ import java.util.concurrent.CompletionStage;
  * callback accesses actor-owned state (RocksDB column families, shared data structures, etc.), the
  * result is a race condition that can cause data corruption or a JVM crash (SIGSEGV).
  *
- * <p>The fix is to always use the async variant with the actor executor:
+ * <p>The fix is to always use the async variant with an explicit actor executor:
  *
  * <pre>{@code
  * // UNSAFE: callback runs on the completing thread (e.g. Netty I/O thread)
  * backupStore.save(backup).whenComplete((result, error) -> { ... });
+ *
+ * // ALSO UNSAFE: callback runs on the default ForkJoinPool, not the actor thread
+ * backupStore.save(backup).whenCompleteAsync((result, error) -> { ... });
  *
  * // SAFE: callback is dispatched to the actor thread
  * backupStore.save(backup).whenCompleteAsync((result, error) -> { ... }, executor);
@@ -58,10 +63,11 @@ public class CompletableFutureCallbackArchTest {
   static final ArchRule ACTOR_CODE_SHOULD_USE_ASYNC_COMPLETABLE_FUTURE_CALLBACKS =
       classes()
           .that(useActorConcurrencyControl())
-          .should(notCallSyncCompletableFutureCallbacks())
+          .should(notCallUnsafeCompletableFutureCallbacks())
           .because(
               "synchronous callback methods on CompletableFuture execute on the completing "
-                  + "thread (e.g. a Netty I/O thread), not the actor thread. Use the async "
+                  + "thread (e.g. a Netty I/O thread), not the actor thread, and *Async variants "
+                  + "without an explicit Executor use the default ForkJoinPool. Use the async "
                   + "variant with the actor executor instead, e.g. "
                   + ".whenCompleteAsync(callback, concurrencyControl)");
 
@@ -86,6 +92,13 @@ public class CompletableFutureCallbackArchTest {
           "thenAcceptBoth",
           "thenCombine");
 
+  /**
+   * Async callback methods that, when called <em>without</em> an explicit {@link Executor}, use the
+   * default {@link java.util.concurrent.ForkJoinPool} — which is also unsafe for actor-scoped code.
+   */
+  private static final Set<String> ASYNC_CALLBACK_METHODS =
+      SYNC_CALLBACK_METHODS.stream().map(name -> name + "Async").collect(Collectors.toSet());
+
   private static DescribedPredicate<JavaClass> useActorConcurrencyControl() {
     return new DescribedPredicate<>("use actor concurrency control") {
       @Override
@@ -108,25 +121,39 @@ public class CompletableFutureCallbackArchTest {
     };
   }
 
-  private static ArchCondition<JavaClass> notCallSyncCompletableFutureCallbacks() {
+  private static ArchCondition<JavaClass> notCallUnsafeCompletableFutureCallbacks() {
     return new ArchCondition<>(
-        "not call synchronous callback methods on CompletableFuture or CompletionStage") {
+        "not call synchronous callback methods on CompletableFuture or CompletionStage, "
+            + "and not call *Async variants without an explicit Executor") {
       @Override
       public void check(final JavaClass item, final ConditionEvents events) {
         item.getMethodCallsFromSelf().stream()
-            .filter(CompletableFutureCallbackArchTest::isSyncCallbackOnCompletableFuture)
-            .forEach(
+            .filter(
                 call ->
-                    events.add(
-                        SimpleConditionEvent.violated(
-                            item,
-                            String.format(
-                                "%s calls %s.%s() at %s — use %sAsync() with the actor executor instead",
-                                item.getName(),
-                                call.getTargetOwner().getSimpleName(),
-                                call.getName(),
-                                call.getSourceCodeLocation(),
-                                call.getName()))));
+                    isSyncCallbackOnCompletableFuture(call) || isAsyncCallbackWithoutExecutor(call))
+            .forEach(
+                call -> {
+                  final String message;
+                  if (isSyncCallbackOnCompletableFuture(call)) {
+                    message =
+                        String.format(
+                            "%s calls %s.%s() at %s — use %sAsync() with the actor executor instead",
+                            item.getName(),
+                            call.getTargetOwner().getSimpleName(),
+                            call.getName(),
+                            call.getSourceCodeLocation(),
+                            call.getName());
+                  } else {
+                    message =
+                        String.format(
+                            "%s calls %s.%s() without an Executor at %s — pass the actor executor as the second argument",
+                            item.getName(),
+                            call.getTargetOwner().getSimpleName(),
+                            call.getName(),
+                            call.getSourceCodeLocation());
+                  }
+                  events.add(SimpleConditionEvent.violated(item, message));
+                });
       }
     };
   }
@@ -135,6 +162,22 @@ public class CompletableFutureCallbackArchTest {
     if (!SYNC_CALLBACK_METHODS.contains(call.getName())) {
       return false;
     }
+    return isOnCompletableFutureOrCompletionStage(call);
+  }
+
+  private static boolean isAsyncCallbackWithoutExecutor(final JavaMethodCall call) {
+    if (!ASYNC_CALLBACK_METHODS.contains(call.getName())) {
+      return false;
+    }
+    if (!isOnCompletableFutureOrCompletionStage(call)) {
+      return false;
+    }
+    // The call is unsafe if none of the parameters is an Executor
+    return call.getTarget().getRawParameterTypes().stream()
+        .noneMatch(param -> param.isAssignableTo(Executor.class));
+  }
+
+  private static boolean isOnCompletableFutureOrCompletionStage(final JavaMethodCall call) {
     final var targetOwner = call.getTargetOwner();
     return targetOwner.isAssignableTo(CompletableFuture.class)
         || targetOwner.isAssignableTo(CompletionStage.class);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -111,7 +111,7 @@ final class BackupServiceImpl {
                 availableBackups, inProgressBackup, concurrencyControl, backupSaved);
           }
         },
-        concurrencyControl::run);
+        concurrencyControl);
 
     backupSaved.onComplete((ignore, error) -> closeInProgressBackup(inProgressBackup));
     backupSaved.onSuccess(ignore -> confirmBackup(inProgressBackup));
@@ -193,7 +193,7 @@ final class BackupServiceImpl {
                 future.completeExceptionally("Failed to save backup", error);
               }
             },
-            concurrencyControl::run);
+            concurrencyControl);
     return future;
   }
 
@@ -291,7 +291,7 @@ final class BackupServiceImpl {
                         future.complete(backupStatuses.stream().max(BackupStatusCode.BY_STATUS));
                       }
                     },
-                    executor::run));
+                    executor));
     return future;
   }
 
@@ -306,16 +306,19 @@ final class BackupServiceImpl {
                           Optional.empty(),
                           Optional.of(partitionId),
                           CheckpointPattern.of(lastCheckpointId)))
-                  .thenAccept(backups -> backups.forEach(this::failInProgressBackup))
-                  .exceptionally(
+                  .thenAcceptAsync(
+                      backups -> backups.forEach(b -> failInProgressBackup(b, executor)), executor)
+                  .exceptionallyAsync(
                       failure -> {
                         LOG.warn("Failed to list backups that should be marked as failed", failure);
                         return null;
-                      }));
+                      },
+                      executor));
     }
   }
 
-  private void failInProgressBackup(final BackupStatus backupStatus) {
+  private void failInProgressBackup(
+      final BackupStatus backupStatus, final ConcurrencyControl executor) {
     if (backupStatus.statusCode() != BackupStatusCode.IN_PROGRESS) {
       return;
     }
@@ -326,12 +329,14 @@ final class BackupServiceImpl {
 
     backupStore
         .markFailed(backupStatus.id(), "Backup is cancelled due to leader change.")
-        .thenAccept(ignore -> LOG.trace("Marked backup {} as failed.", backupStatus.id()))
-        .exceptionally(
+        .thenAcceptAsync(
+            ignore -> LOG.trace("Marked backup {} as failed.", backupStatus.id()), executor)
+        .exceptionallyAsync(
             failed -> {
               LOG.warn("Failed to mark backup {} as failed", backupStatus.id(), failed);
               return null;
-            });
+            },
+            executor);
   }
 
   ActorFuture<Void> writeBackupDeletionCommand(
@@ -364,7 +369,7 @@ final class BackupServiceImpl {
 
     backupStore
         .list(pattern)
-        .thenCompose(
+        .thenComposeAsync(
             backups ->
                 CompletableFuture.allOf(
                     backups.stream()
@@ -372,17 +377,20 @@ final class BackupServiceImpl {
                             backup ->
                                 backupStore
                                     .markDeleted(backup.id())
-                                    .thenCompose(ignored -> backupStore.delete(backup.id())))
-                        .toArray(CompletableFuture[]::new)))
-        .exceptionally(
+                                    .thenComposeAsync(
+                                        ignored -> backupStore.delete(backup.id()), executor))
+                        .toArray(CompletableFuture[]::new)),
+            executor)
+        .exceptionallyAsync(
             error -> {
               LOG.warn(
                   "Failed to delete backup for checkpoint {} from backup store",
                   checkpointId,
                   error);
               return null;
-            })
-        .whenCompleteAsync(result, executor::run);
+            },
+            executor)
+        .whenCompleteAsync(result, executor);
     return result;
   }
 
@@ -395,12 +403,13 @@ final class BackupServiceImpl {
                 .list(
                     new BackupIdentifierWildcardImpl(
                         Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(pattern)))
-                .thenAccept(availableBackupsFuture::complete)
-                .exceptionally(
+                .thenAcceptAsync(availableBackupsFuture::complete, executor)
+                .exceptionallyAsync(
                     error -> {
                       availableBackupsFuture.completeExceptionally(error);
                       return null;
-                    }));
+                    },
+                    executor));
     return availableBackupsFuture;
   }
 
@@ -451,12 +460,14 @@ final class BackupServiceImpl {
           // status
           backupStore
               .markFailed(backupId, failureReason)
-              .thenAccept(ignore -> LOG.trace("Successfully created failed backup {}", backupId))
-              .exceptionally(
+              .thenAcceptAsync(
+                  ignore -> LOG.trace("Successfully created failed backup {}", backupId), executor)
+              .exceptionallyAsync(
                   error -> {
                     LOG.debug("Failed to create failed backup {}", backupId, error);
                     return null;
-                  });
+                  },
+                  executor);
         });
   }
 
@@ -479,7 +490,7 @@ final class BackupServiceImpl {
                         buildRangeStatuses(future, ranges);
                       }
                     },
-                    executor::run);
+                    executor);
           } catch (final Exception e) {
             LOG.atError().setCause(e).log("Failed to sync backup metadata");
             future.completeExceptionally(e);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -211,7 +211,7 @@ final class InProgressBackupImpl implements InProgressBackup {
       }
       journalInfoProvider
           .getTailSegments(maxIndex)
-          .whenComplete(
+          .whenCompleteAsync(
               (tailSegments, throwable) -> {
                 if (throwable != null) {
                   LOG.atError()
@@ -244,7 +244,8 @@ final class InProgressBackupImpl implements InProgressBackup {
                   segmentsFileSet = new NamedFileSetImpl(map);
                   filesCollected.complete(null);
                 }
-              });
+              },
+              concurrencyControl);
     } catch (final Exception e) {
       LOG.atError()
           .addKeyValue("backup", backupId)

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -201,15 +201,17 @@ public class BackupRetention extends Actor {
     final ActorFuture<Collection<BackupStatus>> requestFuture = createFuture();
     backupStore
         .list(identifier)
-        .thenApply(backups -> backups.stream().sorted(BACKUP_STATUS_COMPARATOR).toList())
-        .whenComplete(
+        .thenApplyAsync(
+            backups -> backups.stream().sorted(BACKUP_STATUS_COMPARATOR).toList(), actor)
+        .whenCompleteAsync(
             (backups, throwable) -> {
               if (throwable != null) {
                 requestFuture.completeExceptionally(throwable);
               } else {
                 requestFuture.complete(backups);
               }
-            });
+            },
+            actor);
     return requestFuture;
   }
 
@@ -310,7 +312,7 @@ public class BackupRetention extends Actor {
     }
 
     CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
-        .thenAccept(
+        .thenAcceptAsync(
             ignore -> {
               metrics
                   .forPartition(context.partitionId)
@@ -320,8 +322,9 @@ public class BackupRetention extends Actor {
                     .forPartition(context.partitionId)
                     .setEarliestBackupId(context.earliestBackupInNewRange);
               }
-            })
-        .whenComplete(
+            },
+            actor)
+        .whenCompleteAsync(
             (result, error) -> {
               if (error != null) {
                 LOG.error(
@@ -329,8 +332,9 @@ public class BackupRetention extends Actor {
                     context.partitionId,
                     error);
               }
-            })
-        .whenComplete(future);
+            },
+            actor)
+        .whenCompleteAsync(future, actor);
     return future;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
@@ -81,7 +81,7 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
 
     brokerClient
         .sendRequestWithRetry(new BrokerPartitionBootstrappedRequest(partitionId))
-        .whenComplete(bootstrapFuture);
+        .whenCompleteAsync(bootstrapFuture, concurrencyControl);
     return bootstrapFuture.andThen(
         response -> {
           LOGGER.debug("Received response from partition bootstrap request {}", response);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -76,12 +76,13 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
           try {
             nodeIdProvider
                 .scale(clusterMembers.size())
-                .thenAccept(ignore -> result.complete(null))
-                .exceptionally(
+                .thenAcceptAsync(ignore -> result.complete(null), concurrencyControl)
+                .exceptionallyAsync(
                     e -> {
                       result.completeExceptionally(e);
                       return null;
-                    });
+                    },
+                    concurrencyControl);
           } catch (final Exception e) {
             result.completeExceptionally(e);
           }
@@ -101,12 +102,13 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
           try {
             nodeIdProvider
                 .scale(clusterMembers.size())
-                .thenAccept(ignore -> result.complete(null))
-                .exceptionally(
+                .thenAcceptAsync(ignore -> result.complete(null), concurrencyControl)
+                .exceptionallyAsync(
                     e -> {
                       result.completeExceptionally(e);
                       return null;
-                    });
+                    },
+                    concurrencyControl);
           } catch (final Exception e) {
             result.completeExceptionally(e);
           }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -98,15 +98,16 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
                     .map(
                         partition ->
                             getPartitionStatus(partition)
-                                .whenComplete(
+                                .whenCompleteAsync(
                                     (ps, error) -> {
                                       if (error == null) {
                                         partitionStatuses.put(partition.getPartitionId(), ps);
                                       }
-                                    }))
+                                    },
+                                    actor))
                     .toList();
             CompletableFuture.allOf(statusFutures.toArray(CompletableFuture[]::new))
-                .thenAccept(r -> future.complete(partitionStatuses));
+                .thenAcceptAsync(r -> future.complete(partitionStatuses), actor);
           }
         });
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -271,7 +271,7 @@ public final class AsyncSnapshotDirector extends Actor
     try {
       flushLog
           .call()
-          .whenComplete(
+          .whenCompleteAsync(
               (ignore, error) -> {
                 if (error != null) {
                   LOG.warn("Failed to flush journal before committing snapshot", error);
@@ -279,7 +279,8 @@ public final class AsyncSnapshotDirector extends Actor
                 } else {
                   future.complete(null);
                 }
-              });
+              },
+              actor);
     } catch (final Exception e) {
       LOG.warn("Failed to flush journal before committing snapshot", e);
       future.completeExceptionally(e);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -170,14 +170,15 @@ public class SnapshotApiRequestHandler
     final ActorFuture<Long> lastProcessedPosition = actor.createFuture();
     brokerClient
         .sendRequestWithRetry(new GetScaleUpProgress())
-        .thenApply(
+        .thenApplyAsync(
             r -> {
               LOG.atLevel(Level.DEBUG)
                   .addKeyValue("transferId", transferId)
                   .log("Received response from broker {}", r.getResponse());
               return r.getResponse().getScalingPosition();
-            })
-        .whenComplete(lastProcessedPosition);
+            },
+            actor)
+        .whenCompleteAsync(lastProcessedPosition, actor);
     return lastProcessedPosition;
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -127,7 +127,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
 
             brokerClient
                 .sendRequest(brokerRequest)
-                .whenComplete(handleBrokerResponse(request, requestState, delegate));
+                .whenCompleteAsync(handleBrokerResponse(request, requestState, delegate), actor);
 
           } else {
             // enough jobs activated or no more partitions left to check
@@ -223,13 +223,14 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
     final var request = toFailJobRequest(job, message);
     brokerClient
         .sendRequestWithRetry(request)
-        .whenComplete(
+        .whenCompleteAsync(
             (response, error) -> {
               if (error != null) {
                 Loggers.GATEWAY_LOGGER.info(
                     "Failed to reactivate job {} due to {}", job.key(), error.getMessage());
               }
-            });
+            },
+            actor);
   }
 
   private BrokerFailJobRequest toFailJobRequest(final ActivatedJob job, final String errorMessage) {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
@@ -165,9 +165,9 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
     final var requestBytes = requestContext.getRequestBytes();
     messagingService
         .sendAndReceive(nodeAddress, requestContext.getTopicName(), requestBytes, calculateTimeout)
-        .whenComplete(
-            (response, errorOnRequest) ->
-                actor.run(() -> handleResponse(requestContext, response, errorOnRequest)));
+        .whenCompleteAsync(
+            (response, errorOnRequest) -> handleResponse(requestContext, response, errorOnRequest),
+            actor);
   }
 
   private void handleResponse(

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -123,7 +123,7 @@ public final class RemoteStreamTransport<M> extends Actor {
             Function.identity(),
             receiver,
             REQUEST_TIMEOUT)
-        .thenApply(ok -> null);
+        .thenApplyAsync(ok -> null, actor);
   }
 
   private void onRestartStreamsResponse(


### PR DESCRIPTION
# Description
Backport of #47373 to `stable/8.9`.

relates to #47359