### PR TITLE
fix: startup script supports all restore modes

### DIFF
--- a/zeebe/docker/utils/startup.sh
+++ b/zeebe/docker/utils/startup.sh
@@ -3,12 +3,16 @@
 if [ "$ZEEBE_STANDALONE_GATEWAY" = "true" ]; then
     exec /usr/local/zeebe/bin/gateway
 elif [ "$ZEEBE_RESTORE" = "true" ]; then
-  if [ "$ZEEBE_RESTORE_FROM_BACKUP_ID" ]; then
+  if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
     exec /usr/local/zeebe/bin/restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
-  elif [ -z "$ZEEBE_RESTORE_TO_TIMESTAMP" ]; then
-    exec /usr/local/zeebe/bin/restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
-  else
+  elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
     exec /usr/local/zeebe/bin/restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+  elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+    exec /usr/local/zeebe/bin/restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+  elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+    exec /usr/local/zeebe/bin/restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+  else
+    exec /usr/local/zeebe/bin/restore
   fi
 else
   exec /usr/local/zeebe/bin/broker


### PR DESCRIPTION
Supports parameter-less restore and restore with just `--to` but without `--from`.
