### PR TITLE
chore: fixing the required properties in the cluster variable yaml

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -368,6 +368,8 @@ components:
           description: The new value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
     ClusterVariableResult:
       type: object
+      required:
+        - value
       allOf:
         - $ref: '#/components/schemas/ClusterVariableResultBase'
       properties:
@@ -377,6 +379,9 @@ components:
     ClusterVariableSearchResult:
       description: Cluster variable search response item.
       type: object
+      required:
+        - value
+        - isTruncated
       allOf:
         - $ref: '#/components/schemas/ClusterVariableResultBase'
       properties:
@@ -392,6 +397,7 @@ components:
       required:
         - name
         - scope
+        - tenantId
       properties:
         name:
           type: string


### PR DESCRIPTION
This pull request introduces updates to the OpenAPI schema for cluster variables in `zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml`. The changes improve the accuracy and completeness of required fields for cluster variable-related objects, ensuring better validation and clearer API contracts.

**Schema validation improvements:**

* Added `value` as a required field for `ClusterVariableResult` to ensure responses always include the variable value.
* Added both `value` and `isTruncated` as required fields for `ClusterVariableSearchResult`, clarifying the expected response structure for variable searches.

**Tenant identification enhancements:**

* Added `tenantId` as a required field to relevant schema definitions, improving multi-tenant support and data isolation.


Following https://camunda.slack.com/archives/C08F5RD5X8B/p1772427868056259 message