### PR TITLE
test: update HC configuration

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -294,6 +294,7 @@ jobs:
       camunda-helm-git-ref: ${{ inputs.helmRepositoryBranchName || 'main' }}
       camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}
       namespace-prefix: monorepo
+      values-digest: true
       test-enabled: true
       e2e-enabled: true
       deployment-ttl: ${{ inputs.deployment-ttl || '' }}

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -294,7 +294,7 @@ jobs:
       camunda-helm-git-ref: ${{ inputs.helmRepositoryBranchName || 'main' }}
       camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}
       namespace-prefix: monorepo
-      values-digest: true
+      values-digest: true # include Helm values (incl. extra-values) in the computed digest so config/image changes get a new test deployment; must stay enabled here
       test-enabled: true
       e2e-enabled: true
       deployment-ttl: ${{ inputs.deployment-ttl || '' }}


### PR DESCRIPTION
## Description

After identity/admin changes, the profile was not added to SNAPSHOT. Infra suggested to add values-digest in [this thread.](https://camunda.slack.com/archives/C063D123AMD/p1772512034684079?thread_ts=1772461590.891839&cid=C063D123AMD)

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
