### PR TITLE
deps: downgrade maven surefire plugin to 3.5.2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -525,6 +525,16 @@
       "addLabels": [
         "automerge"
       ]
+    },
+    {
+      "description": "Skip maven-surefire-plugin updates, as 3.5.4 has an issue with inner class tests reports https://github.com/apache/maven-surefire/issues/3203, causing the retry of the wrong tests. 3.5.3 version has a bug preventing ArchUnit tests from running.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.apache.maven.plugins:maven-surefire-plugin"
+      ],
+      "enabled": false
     }
   ],
   "dockerfile": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -527,14 +527,17 @@
       ]
     },
     {
-      "description": "Skip maven-surefire-plugin updates, as 3.5.4 has an issue with inner class tests reports https://github.com/apache/maven-surefire/issues/3203, causing the retry of the wrong tests. 3.5.3 version has a bug preventing ArchUnit tests from running.",
+      "description": "maven-surefire-plugin 3.5.4 has an issue with inner class tests reports https://github.com/apache/maven-surefire/issues/3203, causing the retry of the wrong tests. 3.5.3 version has a bug preventing ArchUnit tests from running. Enable PRs but block auto-merge until the upstream bug is confirmed fixed.",
       "matchManagers": [
         "maven"
       ],
       "matchPackageNames": [
         "org.apache.maven.plugins:maven-surefire-plugin"
       ],
-      "enabled": false
+      "automerge": false,
+      "prBodyNotes": [
+        "**Manual verification required before merging:** Check that [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203) (inner class test report bug in 3.5.4) is fixed in this version. Do **not** merge until confirmed."
+      ]
     }
   ],
   "dockerfile": {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -239,7 +239,7 @@
     <plugin.version.shade>3.6.1</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.9.8.2</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.5</plugin.version.surefire>
+    <plugin.version.surefire>3.5.2</plugin.version.surefire>
     <plugin.version.versions>2.21.0</plugin.version.versions>
     <plugin.version.frontend-maven>2.0.0</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.4.0</plugin.version.maven-source>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
[Slack discussion](https://camunda.slack.com/archives/C071KP5BTHB/p1772519071383669)

When an inner class test fails with a real failure, on test retry, surefire does not re-run the same test. The retried test passed, and makes the CI green, while a failing test should have been caught
This seems to be caused by https://github.com/apache/maven-surefire/issues/3203

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
