### PR TITLE
Ignore whitespace in optimize's spring.config.import

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
@@ -105,4 +105,68 @@ public class ExtraConfigurationConfigImportIT extends AbstractCCSMIT {
                 .getNumberOfReplicas())
         .isEqualTo(6);
   }
+
+  /** Regression test for <a href="https://github.com/camunda/camunda/issues/47472">#47472</a> */
+  @Test
+  void shouldLoadEnvYamlImportedFromApplicationCcsmProfile() throws Exception {
+    // given: a setup mimicking Kubernetes ConfigMap with application-ccsm.yaml importing files
+    // where the import is comma-delimited with whitespaces
+    Files.writeString(
+        configDir.resolve("application-ccsm.yaml"),
+        """
+        spring:
+          config:
+            import: optional:file:%s/boat.yaml, optional:file:%s/about.yaml, optional:file:%s/env.yaml
+        """
+            .formatted(
+                configDir.toAbsolutePath(),
+                configDir.toAbsolutePath(),
+                configDir.toAbsolutePath()));
+
+    Files.writeString(
+        configDir.resolve("about.yaml"),
+        """
+        logging:
+          level:
+            ROOT: DEBUG
+            io.camunda.modeler: DEBUG
+        """);
+
+    Files.writeString(
+        configDir.resolve("boat.yaml"),
+        """
+        logging:
+          level:
+            ROOT: INFO
+            io.camunda.modeler: INFO
+        """);
+
+    Files.writeString(
+        configDir.resolve("env.yaml"),
+        """
+        zeebe:
+          enabled: true
+          partitionCount: 3
+          name: "zeebe-record"
+        """);
+
+    Files.writeString(
+        configDir.resolve("environment-config.yaml"),
+        """
+        spring:
+          servlet:
+            multipart:
+              max-file-size: "10MB"
+              max-request-size: "10MB"
+          profiles:
+            active: "ccsm"
+        """);
+
+    // when: optimize is restarted
+    startAndUseNewOptimizeInstance();
+
+    // then: Optimize-specific config from env.yaml is accessible via ConfigurationService
+    final var configService = embeddedOptimizeExtension.getConfigurationService();
+    assertThat(configService.getConfiguredZeebe().getPartitionCount()).isEqualTo(3);
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilder.java
@@ -142,6 +142,7 @@ public class ConfigurationServiceBuilder {
             "Resolving config locations from spring.config.import and spring.config.location");
         LOG.debug("spring.config.import is: {}", springConfigImport);
         for (String file : StringUtils.commaDelimitedListToStringArray(springConfigImport)) {
+          file = file.trim();
           LOG.debug("Considering config import file: {}", file);
           if (file.startsWith("optional:")) {
             file = file.substring("optional:".length());
@@ -155,8 +156,8 @@ public class ConfigurationServiceBuilder {
           } else {
             // if spring.config.location is set, then for each location, we need to add a file from
             // the import relative to it
-            for (final String path :
-                StringUtils.commaDelimitedListToStringArray(springConfigLocation)) {
+            for (String path : StringUtils.commaDelimitedListToStringArray(springConfigLocation)) {
+              path = path.trim();
               // remove trailing slashes to avoid double slashes when
               final var normalizedPath = path.replaceAll("/+$", "");
               final String resolvedFile = normalizedPath + "/" + file;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilder.java
@@ -143,6 +143,10 @@ public class ConfigurationServiceBuilder {
         LOG.debug("spring.config.import is: {}", springConfigImport);
         for (String file : StringUtils.commaDelimitedListToStringArray(springConfigImport)) {
           file = file.trim();
+          if (!StringUtils.hasText(file)) {
+            LOG.debug("Skipping blank config import entry");
+            continue;
+          }
           LOG.debug("Considering config import file: {}", file);
           if (file.startsWith("optional:")) {
             file = file.substring("optional:".length());
@@ -158,6 +162,10 @@ public class ConfigurationServiceBuilder {
             // the import relative to it
             for (String path : StringUtils.commaDelimitedListToStringArray(springConfigLocation)) {
               path = path.trim();
+              if (!StringUtils.hasText(path)) {
+                LOG.debug("Skipping blank config path entry");
+                continue;
+              }
               // remove trailing slashes to avoid double slashes when
               final var normalizedPath = path.replaceAll("/+$", "");
               final String resolvedFile = normalizedPath + "/" + file;

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
@@ -126,7 +126,12 @@ class ConfigurationServiceBuilderTest {
               "path-should-be-ignored/",
               List.of(
                   "/absolute/path/config-from-import.yaml",
-                  "/another-absolute/path/another-config.yaml")));
+                  "/another-absolute/path/another-config.yaml")),
+          Arguments.arguments(
+              "multiple paths with spaces in spring.config.location should be resolved correctly",
+              "config-from-import.yaml",
+              "my-path/ , another-path/ ",
+              List.of("my-path/config-from-import.yaml", "another-path/config-from-import.yaml")));
     }
 
     private static class FakeEnvironment extends AbstractEnvironment {

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
@@ -131,6 +131,16 @@ class ConfigurationServiceBuilderTest {
               "multiple paths with spaces in spring.config.location should be resolved correctly",
               "config-from-import.yaml",
               "my-path/ , another-path/ ",
+              List.of("my-path/config-from-import.yaml", "another-path/config-from-import.yaml")),
+          Arguments.arguments(
+              "empty file in import should be ignored",
+              "config-from-import.yaml, ,another-config.yaml",
+              "my-path/",
+              List.of("my-path/config-from-import.yaml", "my-path/another-config.yaml")),
+          Arguments.arguments(
+              "empty path in location should be ignored",
+              "config-from-import.yaml",
+              "my-path/, ,another-path/",
               List.of("my-path/config-from-import.yaml", "another-path/config-from-import.yaml")));
     }
 

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
@@ -105,7 +105,28 @@ class ConfigurationServiceBuilderTest {
               "optional prefix with file protocol and relative path should be resolved relatively",
               "optional:file:config-from-import.yaml",
               "my-path/",
-              List.of("my-path/config-from-import.yaml")));
+              List.of("my-path/config-from-import.yaml")),
+          Arguments.arguments(
+              "multiple absolute paths in import should be added as is",
+              "/absolute/path/config-from-import.yaml,/another-absolute/path/another-config.yaml",
+              "path-should-be-ignored/",
+              List.of(
+                  "/absolute/path/config-from-import.yaml",
+                  "/another-absolute/path/another-config.yaml")),
+          Arguments.arguments(
+              "multiple absolute paths with optional:file: prefix should be added as is",
+              "optional:file:/absolute/path/config-from-import.yaml,optional:file:/another-absolute/path/another-config.yaml",
+              "path-should-be-ignored/",
+              List.of(
+                  "/absolute/path/config-from-import.yaml",
+                  "/another-absolute/path/another-config.yaml")),
+          Arguments.arguments(
+              "multiple absolute paths with spaces and optional:file: prefix should be added as is",
+              "optional:file:/absolute/path/config-from-import.yaml , optional:file:/another-absolute/path/another-config.yaml",
+              "path-should-be-ignored/",
+              List.of(
+                  "/absolute/path/config-from-import.yaml",
+                  "/another-absolute/path/another-config.yaml")));
     }
 
     private static class FakeEnvironment extends AbstractEnvironment {


### PR DESCRIPTION
## Description

Optimize allows users to load multiple extra Spring configuration files using `spring.config.import` (and `spring.config.location`) as comma-delimited strings. However, when users include whitespace between the comma-separated entries (e.g. `optional:file:/config/a.yaml, optional:file:/config/b.yaml`), only the first configuration is loaded. The subsequent entries retain leading whitespace which prevents them from being recognized as absolute paths, effectively making them point to non-existent relative paths.

This PR fixes the issue by trimming each entry in both `spring.config.import` and `spring.config.location` after splitting the comma-delimited string. This ensures all configuration files are correctly loaded regardless of whitespace.

### Changes
- **Trim `spring.config.import` and `spring.config.location` entries**: After splitting by comma, each entry is now trimmed of leading/trailing whitespace.
- **Unit test**: Added test coverage for comma-delimited `spring.config.imports` with whitespace.
- **Integration test**: Added a regression test covering the real-world scenario reported by a user.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47472
