### PR TITLE
Document batching for archiving

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -85,6 +85,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private final Counter auditLogsArchived;
 
   private final Timer archiverSearchTimer;
+  private final Timer archiverDocBatchSearchTimer;
   private final Timer archiverDeleteTimer;
   private final Counter archiverDeletedDocs;
   private final Counter archiverReindexedDocs;
@@ -186,6 +187,13 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .description(
                 "Duration of how long it takes to run the search request to resolve completed entities, that need to be archived.")
             .tags("type", "search")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+    archiverDocBatchSearchTimer =
+        Timer.builder(meterName("archiver.request.duration"))
+            .description(
+                "Duration of how long it takes to run the search request to resolve the IDs of documents, that need to be archived.")
+            .tags("type", "doc-batch-search")
             .publishPercentileHistogram()
             .register(meterRegistry);
     archiverDeleteTimer =
@@ -292,6 +300,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void measureArchiverSearch(final Timer.Sample sample) {
     sample.stop(archiverSearchTimer);
+  }
+
+  public void measureDocBatchArchiverSearch(final Timer.Sample sample) {
+    sample.stop(archiverDocBatchSearchTimer);
   }
 
   public void recordBulkSize(final int bulkSize) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+// Use to repeatedly call an async task until a condition is met.
+// NB avoiding using closures for this as with all the callbacks it can
+// easily lead to memory leaks if not used carefully. By using an explicit class
+// we can ensure that the state is properly cleaned up after completion.
+final class AsyncRepeatUntil<T> {
+  private final CompletableFuture<Void> finalFuture = new CompletableFuture<>();
+  private final Supplier<CompletableFuture<T>> asyncTask;
+  private final Predicate<T> until;
+
+  private AsyncRepeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    this.asyncTask = asyncTask;
+    this.until = until;
+  }
+
+  private void next() {
+    try {
+      asyncTask.get().thenAccept(this::completeOrNext).exceptionally(this::completeExceptionally);
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private void completeOrNext(final T result) {
+    try {
+      if (until.test(result)) {
+        finalFuture.complete(null);
+      } else {
+        next();
+      }
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private Void completeExceptionally(final Throwable err) {
+    finalFuture.completeExceptionally(err);
+    return null;
+  }
+
+  static <T> CompletableFuture<Void> repeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    final var repeat = new AsyncRepeatUntil<>(asyncTask, until);
+
+    repeat.next();
+
+    return repeat.finalFuture;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -435,9 +435,10 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       return CompletableFuture.completedFuture(null);
     }
 
+    final var query = QueryBuilders.bool(q -> q.filter(b -> b.ids(id -> id.values(docIds))));
     final var request =
         new ReindexRequest.Builder()
-            .source(src -> src.index(sourceIndexName).query(buildIdTermsQuery("_id", docIds)))
+            .source(src -> src.index(sourceIndexName).query(query))
             .dest(dest -> dest.index(destinationIndexName))
             .conflicts(Conflicts.Proceed)
             .scroll(REINDEX_SCROLL_TIMEOUT)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -19,12 +19,14 @@ import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import co.elastic.clients.elasticsearch.core.ReindexRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
@@ -65,6 +67,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
   private static final Slices AUTO_SLICES =
       Slices.of(slices -> slices.computed(SlicesCalculation.Auto));
+  private static final int MAX_DOCS_BATCH_SIZE = 10_000;
   private final int partitionId;
   private final HistoryConfiguration config;
   private final IndexTemplateDescriptor listViewTemplateDescriptor;
@@ -354,6 +357,20 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @Override
+  public CompletableFuture<Void> moveDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
+    return AsyncRepeatUntil.repeatUntil(
+        () ->
+            moveBatchOfDocuments(
+                sourceIndexName, destinationIndexName, keysByField, filters, executor),
+        docsMoved -> docsMoved < MAX_DOCS_BATCH_SIZE);
+  }
+
+  @Override
   public CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival() {
     final var countRequest =
         CountRequest.of(
@@ -364,6 +381,102 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                             config.getArchivingTimePoint(), partitionId)));
 
     return client.count(countRequest).thenApplyAsync(res -> Math.toIntExact(res.count()));
+  }
+
+  public CompletableFuture<Integer> moveBatchOfDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
+    return searchForDocIdsBatch(sourceIndexName, keysByField, filters)
+        .thenComposeAsync(
+            docIds ->
+                reindexDocumentsById(sourceIndexName, destinationIndexName, docIds)
+                    .thenApply(ok -> docIds),
+            executor)
+        .thenComposeAsync(
+            docIds -> setIndexLifeCycle(destinationIndexName).thenApply(ok -> docIds), executor)
+        .thenComposeAsync(
+            docIds -> deleteDocumentsById(sourceIndexName, docIds).thenApply(ok -> docIds),
+            executor)
+        .thenApply(List::size);
+  }
+
+  private CompletableFuture<List<String>> searchForDocIdsBatch(
+      final String sourceIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters) {
+
+    final var query = buildFilterQuery(keysByField, filters);
+
+    final var request =
+        new SearchRequest.Builder()
+            .index(sourceIndexName)
+            .query(query)
+            .size(MAX_DOCS_BATCH_SIZE)
+            .source(s -> s.fetch(false))
+            .build();
+
+    final var timer = Timer.start();
+    return client
+        .search(request)
+        .whenCompleteAsync(
+            (response, error) -> metrics.measureDocBatchArchiverSearch(timer), executor)
+        .thenApply(
+            response -> {
+              return response.hits().hits().stream().map(Hit::id).toList();
+            });
+  }
+
+  private CompletableFuture<Void> reindexDocumentsById(
+      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final var request =
+        new ReindexRequest.Builder()
+            .source(src -> src.index(sourceIndexName).query(buildIdTermsQuery("_id", docIds)))
+            .dest(dest -> dest.index(destinationIndexName))
+            .conflicts(Conflicts.Proceed)
+            .scroll(REINDEX_SCROLL_TIMEOUT)
+            .slices(AUTO_SLICES)
+            .build();
+
+    final var timer = Timer.start();
+    return client
+        .reindex(request)
+        .whenCompleteAsync(
+            (response, error) ->
+                metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
+            executor)
+        .thenApplyAsync(ignored -> null, executor);
+  }
+
+  private CompletableFuture<Void> deleteDocumentsById(
+      final String sourceIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final var operations =
+        docIds.stream()
+            .map(docId -> new BulkOperation.Builder().delete(d -> d.id(docId)).build())
+            .toList();
+
+    final var request =
+        new BulkRequest.Builder().index(sourceIndexName).operations(operations).build();
+
+    final var timer = Timer.start();
+    return client
+        .bulk(request)
+        .whenCompleteAsync(
+            (response, error) ->
+                metrics.measureArchiverDelete(
+                    response != null ? (long) response.items().size() : null, timer),
+            executor)
+        .thenApplyAsync(ignored -> null, executor);
   }
 
   private Query finishedProcessInstancesQuery(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntilTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntilTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class AsyncRepeatUntilTest {
+
+  @Test
+  void shouldCompleteWhenTaskCompletes() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(() -> CompletableFuture.completedFuture(1), result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    // ensure no exceptions are thrown
+    future.join();
+  }
+
+  @Test
+  void shouldNotCompleteWhenTaskDoesNotComplete() {
+    // given
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(CompletableFuture::new, result -> true);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsAsync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            // task fails in an async manner
+            () -> CompletableFuture.failedFuture(new RuntimeException("future failed")),
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("future failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsSync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> {
+              // task fails, but in a non-async way
+              throw new RuntimeException("task failed");
+            },
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("task failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenUntilFails() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(1),
+            result -> {
+              throw new RuntimeException("until failed");
+            });
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("until failed");
+  }
+
+  @Test
+  void shouldCompleteWhenConditionMet() {
+    // given
+    final var counter = new AtomicInteger();
+
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(counter.getAndIncrement()),
+            result -> result >= 5);
+
+    future.join();
+
+    // then
+    assertThat(counter.get()).isEqualTo(6);
+  }
+
+  @Test
+  void shouldRunTasksSerially() {
+    // given
+    final CompletableFuture<Integer> future1 = new CompletableFuture<>();
+    final CompletableFuture<Integer> future2 = new CompletableFuture<>();
+
+    final Supplier<CompletableFuture<Integer>> taskSupplier = mock(Supplier.class);
+
+    when(taskSupplier.get()).thenReturn(future1).thenReturn(future2);
+
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(taskSupplier, result -> result >= 2);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    verify(taskSupplier).get();
+
+    // when
+    // complete the first task, which should trigger the second task to be called
+    future1.complete(1);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    verify(taskSupplier, times(2)).get();
+
+    // when
+    // complete the second task, which should complete the future
+    future2.complete(2);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    verify(taskSupplier, times(2)).get();
+
+    future.join();
+  }
+}


### PR DESCRIPTION
This changes things so we no longer do a (potentially) unbounded reindex and delete in the archiver.  Instead we make an extra call to first get a list of doc IDs that match the search (with a limit on how many IDs we fetch).  Then we feed that into the reindex call and also use those same IDs for a bulk request for the deletes.  Despite the extra search this appears to be faster.  I think because deleting via a bulk request seems to be _much_ quicker (as in about 1s quicker) than delete by query and is much quicker than the time taken by the extra search.

I suspect some of the speed up is due to ES using a default `scroll_size` of 1,000 for delete by query, but now we're getting all the matching docs in one call.  Plus bulk deleting seems to be pretty efficient.