### PR TITLE
Load Optimize spring.config props as lists

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
@@ -169,4 +169,71 @@ public class ExtraConfigurationConfigImportIT extends AbstractCCSMIT {
     final var configService = embeddedOptimizeExtension.getConfigurationService();
     assertThat(configService.getConfiguredZeebe().getPartitionCount()).isEqualTo(3);
   }
+
+  /** Regression test for <a href="https://github.com/camunda/camunda/issues/47473">#47473</a> */
+  @Test
+  void shouldLoadEnvYamlImportedAsList() throws Exception {
+    // given: a setup mimicking Kubernetes ConfigMap with application-ccsm.yaml importing files
+    // where the import is specified as a list
+    Files.writeString(
+        configDir.resolve("application-ccsm.yaml"),
+        """
+        spring:
+          config:
+            import:
+              - optional:file:%s/boat.yaml
+              - optional:file:%s/about.yaml
+              - optional:file:%s/env.yaml
+        """
+            .formatted(
+                configDir.toAbsolutePath(),
+                configDir.toAbsolutePath(),
+                configDir.toAbsolutePath()));
+
+    Files.writeString(
+        configDir.resolve("about.yaml"),
+        """
+        logging:
+          level:
+            ROOT: DEBUG
+            io.camunda.modeler: DEBUG
+        """);
+
+    Files.writeString(
+        configDir.resolve("boat.yaml"),
+        """
+        logging:
+          level:
+            ROOT: INFO
+            io.camunda.modeler: INFO
+        """);
+
+    Files.writeString(
+        configDir.resolve("env.yaml"),
+        """
+        zeebe:
+          enabled: true
+          partitionCount: 3
+          name: "zeebe-record"
+        """);
+
+    Files.writeString(
+        configDir.resolve("environment-config.yaml"),
+        """
+        spring:
+          servlet:
+            multipart:
+              max-file-size: "10MB"
+              max-request-size: "10MB"
+          profiles:
+            active: "ccsm"
+        """);
+
+    // when: optimize is restarted
+    startAndUseNewOptimizeInstance();
+
+    // then: Optimize-specific config from env.yaml is accessible via ConfigurationService
+    final var configService = embeddedOptimizeExtension.getConfigurationService();
+    assertThat(configService.getConfiguredZeebe().getPartitionCount()).isEqualTo(3);
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilder.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.util.configuration;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
@@ -134,15 +135,15 @@ public class ConfigurationServiceBuilder {
     static List<String> resolveConfigLocations(final Environment environment) {
       final List<String> locations = new ArrayList<>();
 
-      final String springConfigImport = environment.getProperty("spring.config.import");
-      final String springConfigLocation = environment.getProperty("spring.config.location");
+      final List<String> springConfigImport = getListProperty(environment, "spring.config.import");
+      final List<String> springConfigLocation =
+          getListProperty(environment, "spring.config.location");
 
       if (springConfigImport != null) {
         LOG.debug(
             "Resolving config locations from spring.config.import and spring.config.location");
         LOG.debug("spring.config.import is: {}", springConfigImport);
-        for (String file : StringUtils.commaDelimitedListToStringArray(springConfigImport)) {
-          file = file.trim();
+        for (String file : springConfigImport) {
           if (!StringUtils.hasText(file)) {
             LOG.debug("Skipping blank config import entry");
             continue;
@@ -160,8 +161,7 @@ public class ConfigurationServiceBuilder {
           } else {
             // if spring.config.location is set, then for each location, we need to add a file from
             // the import relative to it
-            for (String path : StringUtils.commaDelimitedListToStringArray(springConfigLocation)) {
-              path = path.trim();
+            for (final String path : springConfigLocation) {
               if (!StringUtils.hasText(path)) {
                 LOG.debug("Skipping blank config path entry");
                 continue;
@@ -176,6 +176,39 @@ public class ConfigurationServiceBuilder {
         }
       }
       return locations;
+    }
+
+    /**
+     * Workaround for spring-framework bug: Environment.getProperty() method cannot process list
+     * items #35179.
+     *
+     * @see <a href="https://github.com/spring-projects/spring-framework/issues/35179">issue</a>
+     * @see <a
+     *     href="https://github.com/spring-projects/spring-framework/issues/35179#issuecomment-3989747033">workaround</a>
+     */
+    private static List<String> getListProperty(
+        final Environment environment, final String propertyName) {
+      final String directMatch = environment.getProperty(propertyName);
+      if (directMatch != null) {
+        // direct matches may still be comma delimited
+        final var asArray = StringUtils.commaDelimitedListToStringArray(directMatch);
+        // comma delimitation may require whitespace trimming
+        return Arrays.stream(asArray).map(String::trim).toList();
+      }
+      final List<String> collectedValues = new ArrayList<>();
+      for (int index = 0; index < Integer.MAX_VALUE; index++) {
+        final String indexedKey = propertyName + "[" + index + "]";
+        if (!environment.containsProperty(indexedKey)) {
+          break;
+        }
+        final String rawIndexedValue = environment.getProperty(indexedKey);
+        if (rawIndexedValue == null) {
+          continue;
+        }
+        // indexed values may still require whitespace trimming
+        collectedValues.add(rawIndexedValue.trim());
+      }
+      return collectedValues.isEmpty() ? null : collectedValues;
     }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilder.java
@@ -9,7 +9,6 @@ package io.camunda.optimize.service.util.configuration;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
@@ -188,12 +187,11 @@ public class ConfigurationServiceBuilder {
      */
     private static List<String> getListProperty(
         final Environment environment, final String propertyName) {
-      final String directMatch = environment.getProperty(propertyName);
+      @SuppressWarnings("unchecked")
+      final List<String> directMatch =
+          (List<String>) environment.getProperty(propertyName, List.class);
       if (directMatch != null) {
-        // direct matches may still be comma delimited
-        final var asArray = StringUtils.commaDelimitedListToStringArray(directMatch);
-        // comma delimitation may require whitespace trimming
-        return Arrays.stream(asArray).map(String::trim).toList();
+        return directMatch;
       }
       final List<String> collectedValues = new ArrayList<>();
       for (int index = 0; index < Integer.MAX_VALUE; index++) {

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.util.StringUtils;
 
 class ConfigurationServiceBuilderTest {
 
@@ -35,6 +36,33 @@ class ConfigurationServiceBuilderTest {
       final FakeEnvironment environment = new FakeEnvironment();
       environment.setProperty("spring.config.import", importValue);
       environment.setProperty("spring.config.location", locationValue);
+
+      // when
+      final var configLocations = ConfigEnvironment.resolveConfigLocations(environment);
+
+      // then
+      Assertions.assertThat(configLocations).containsExactlyElementsOf(expectedLocations);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("configLocationCases")
+    void shouldResolveConfigLocationsFromEnvironmentAsList(
+        final String caseName,
+        final String importValues,
+        final String locationValues,
+        final List<String> expectedLocations) {
+      // given
+      final FakeEnvironment environment = new FakeEnvironment();
+
+      // with spring.config values loaded as lists
+      final var strings = StringUtils.commaDelimitedListToStringArray(importValues);
+      for (var i = 0; i < strings.length; i++) {
+        environment.setProperty("spring.config.import[" + i + "]", strings[i]);
+      }
+      final var locationStrings = StringUtils.commaDelimitedListToStringArray(locationValues);
+      for (var i = 0; i < locationStrings.length; i++) {
+        environment.setProperty("spring.config.location[" + i + "]", locationStrings[i]);
+      }
 
       // when
       final var configLocations = ConfigEnvironment.resolveConfigLocations(environment);

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceBuilderTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.util.StringUtils;
 
 class ConfigurationServiceBuilderTest {
 
@@ -27,15 +26,19 @@ class ConfigurationServiceBuilderTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("configLocationCases")
-    void shouldResolveConfigLocationsFromEnvironment(
+    void shouldResolveConfigLocationsFromEnvironmentAsCommaSeparatedList(
         final String caseName,
-        final String importValue,
-        final String locationValue,
+        final List<String> importFiles,
+        final List<String> locationPaths,
         final List<String> expectedLocations) {
       // given
       final FakeEnvironment environment = new FakeEnvironment();
-      environment.setProperty("spring.config.import", importValue);
-      environment.setProperty("spring.config.location", locationValue);
+      if (importFiles != null) {
+        environment.setProperty("spring.config.import", String.join(",", importFiles));
+      }
+      if (locationPaths != null) {
+        environment.setProperty("spring.config.location", String.join(",", locationPaths));
+      }
 
       // when
       final var configLocations = ConfigEnvironment.resolveConfigLocations(environment);
@@ -46,22 +49,45 @@ class ConfigurationServiceBuilderTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("configLocationCases")
-    void shouldResolveConfigLocationsFromEnvironmentAsList(
+    void shouldResolveConfigLocationsFromEnvironmentAsCommaSeparatedListWithWhitespace(
         final String caseName,
-        final String importValues,
-        final String locationValues,
+        final List<String> importFiles,
+        final List<String> locationPaths,
         final List<String> expectedLocations) {
       // given
       final FakeEnvironment environment = new FakeEnvironment();
-
-      // with spring.config values loaded as lists
-      final var strings = StringUtils.commaDelimitedListToStringArray(importValues);
-      for (var i = 0; i < strings.length; i++) {
-        environment.setProperty("spring.config.import[" + i + "]", strings[i]);
+      if (importFiles != null) {
+        environment.setProperty("spring.config.import", String.join(" , ", importFiles));
       }
-      final var locationStrings = StringUtils.commaDelimitedListToStringArray(locationValues);
-      for (var i = 0; i < locationStrings.length; i++) {
-        environment.setProperty("spring.config.location[" + i + "]", locationStrings[i]);
+      if (locationPaths != null) {
+        environment.setProperty("spring.config.location", String.join(" , ", locationPaths));
+      }
+
+      // when
+      final var configLocations = ConfigEnvironment.resolveConfigLocations(environment);
+
+      // then
+      Assertions.assertThat(configLocations).containsExactlyElementsOf(expectedLocations);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("configLocationCases")
+    void shouldResolveConfigLocationsFromEnvironmentAsIndexedProperties(
+        final String caseName,
+        final List<String> importFiles,
+        final List<String> locationPaths,
+        final List<String> expectedLocations) {
+      // given
+      final FakeEnvironment environment = new FakeEnvironment();
+      if (importFiles != null) {
+        for (var i = 0; i < importFiles.size(); i++) {
+          environment.setProperty("spring.config.import[" + i + "]", importFiles.get(i));
+        }
+      }
+      if (locationPaths != null) {
+        for (var i = 0; i < locationPaths.size(); i++) {
+          environment.setProperty("spring.config.location[" + i + "]", locationPaths.get(i));
+        }
       }
 
       // when
@@ -76,29 +102,30 @@ class ConfigurationServiceBuilderTest {
           Arguments.arguments("no import files or locations", null, null, List.of()),
           Arguments.arguments(
               "only import files",
-              "config-from-import.yaml,another-config.yaml",
+              List.of("config-from-import.yaml", "another-config.yaml"),
               null,
               List.of("config-from-import.yaml", "another-config.yaml")),
-          Arguments.arguments("only locations", null, "my-path/,another-path/", List.of()),
+          Arguments.arguments(
+              "only locations", null, List.of("my-path/", "another-path/"), List.of()),
           Arguments.arguments(
               "single import",
-              "config-from-import.yaml",
-              "my-path/",
+              List.of("config-from-import.yaml"),
+              List.of("my-path/"),
               List.of("my-path/config-from-import.yaml")),
           Arguments.arguments(
               "multiple files in single import",
-              "config-from-import.yaml,another-config.yaml",
-              "my-path/",
+              List.of("config-from-import.yaml", "another-config.yaml"),
+              List.of("my-path/"),
               List.of("my-path/config-from-import.yaml", "my-path/another-config.yaml")),
           Arguments.arguments(
               "single file in multiple locations",
-              "config-from-import.yaml",
-              "my-path/,another-path/",
+              List.of("config-from-import.yaml"),
+              List.of("my-path/", "another-path/"),
               List.of("my-path/config-from-import.yaml", "another-path/config-from-import.yaml")),
           Arguments.arguments(
               "multiple files in multiple locations",
-              "config-from-import.yaml,another-config.yaml",
-              "my-path/,another-path/",
+              List.of("config-from-import.yaml", "another-config.yaml"),
+              List.of("my-path/", "another-path/"),
               List.of(
                   "my-path/config-from-import.yaml",
                   "another-path/config-from-import.yaml",
@@ -106,69 +133,61 @@ class ConfigurationServiceBuilderTest {
                   "another-path/another-config.yaml")),
           Arguments.arguments(
               "absolute path as file in import should be added as is",
-              "/absolute/path/config-from-import.yaml",
-              "path-should-be-ignored/",
+              List.of("/absolute/path/config-from-import.yaml"),
+              List.of("path-should-be-ignored/"),
               List.of("/absolute/path/config-from-import.yaml")),
           Arguments.arguments(
               "optional prefix should be ignored",
-              "optional:config-from-import.yaml",
-              "my-path/",
+              List.of("optional:config-from-import.yaml"),
+              List.of("my-path/"),
               List.of("my-path/config-from-import.yaml")),
           Arguments.arguments(
               "optional prefix with absolute path should be ignored and path should be added as is",
-              "optional:/absolute/path/config-from-import.yaml",
-              "path-should-be-ignored/",
+              List.of("optional:/absolute/path/config-from-import.yaml"),
+              List.of("path-should-be-ignored/"),
               List.of("/absolute/path/config-from-import.yaml")),
           Arguments.arguments(
               "file protocol with absolute path in import should be added as absolute file path",
-              "file:/absolute/path/config-from-import.yaml",
-              "path-should-be-ignored/",
+              List.of("file:/absolute/path/config-from-import.yaml"),
+              List.of("path-should-be-ignored/"),
               List.of("/absolute/path/config-from-import.yaml")),
           Arguments.arguments(
               "optional prefix with file protocol and absolute path in import should be absolute",
-              "optional:file:/absolute/path/config-from-import.yaml",
-              "path-should-be-ignored/",
+              List.of("optional:file:/absolute/path/config-from-import.yaml"),
+              List.of("path-should-be-ignored/"),
               List.of("/absolute/path/config-from-import.yaml")),
           Arguments.arguments(
               "optional prefix with file protocol and relative path should be resolved relatively",
-              "optional:file:config-from-import.yaml",
-              "my-path/",
+              List.of("optional:file:config-from-import.yaml"),
+              List.of("my-path/"),
               List.of("my-path/config-from-import.yaml")),
           Arguments.arguments(
               "multiple absolute paths in import should be added as is",
-              "/absolute/path/config-from-import.yaml,/another-absolute/path/another-config.yaml",
-              "path-should-be-ignored/",
+              List.of(
+                  "/absolute/path/config-from-import.yaml",
+                  "/another-absolute/path/another-config.yaml"),
+              List.of("path-should-be-ignored/"),
               List.of(
                   "/absolute/path/config-from-import.yaml",
                   "/another-absolute/path/another-config.yaml")),
           Arguments.arguments(
               "multiple absolute paths with optional:file: prefix should be added as is",
-              "optional:file:/absolute/path/config-from-import.yaml,optional:file:/another-absolute/path/another-config.yaml",
-              "path-should-be-ignored/",
+              List.of(
+                  "optional:file:/absolute/path/config-from-import.yaml",
+                  "optional:file:/another-absolute/path/another-config.yaml"),
+              List.of("path-should-be-ignored/"),
               List.of(
                   "/absolute/path/config-from-import.yaml",
                   "/another-absolute/path/another-config.yaml")),
-          Arguments.arguments(
-              "multiple absolute paths with spaces and optional:file: prefix should be added as is",
-              "optional:file:/absolute/path/config-from-import.yaml , optional:file:/another-absolute/path/another-config.yaml",
-              "path-should-be-ignored/",
-              List.of(
-                  "/absolute/path/config-from-import.yaml",
-                  "/another-absolute/path/another-config.yaml")),
-          Arguments.arguments(
-              "multiple paths with spaces in spring.config.location should be resolved correctly",
-              "config-from-import.yaml",
-              "my-path/ , another-path/ ",
-              List.of("my-path/config-from-import.yaml", "another-path/config-from-import.yaml")),
           Arguments.arguments(
               "empty file in import should be ignored",
-              "config-from-import.yaml, ,another-config.yaml",
-              "my-path/",
+              List.of("config-from-import.yaml", "", "another-config.yaml"),
+              List.of("my-path/"),
               List.of("my-path/config-from-import.yaml", "my-path/another-config.yaml")),
           Arguments.arguments(
               "empty path in location should be ignored",
-              "config-from-import.yaml",
-              "my-path/, ,another-path/",
+              List.of("config-from-import.yaml"),
+              List.of("my-path/", "", "another-path/"),
               List.of("my-path/config-from-import.yaml", "another-path/config-from-import.yaml")));
     }
 


### PR DESCRIPTION
## Description

Adds support for `spring.config.import` and `spring.config.location` properties specified as YAML lists in Optimize's `ConfigurationServiceBuilder`.

```
spring:
  config:
    import:
      - optional:file:/boat.yaml
      - optional:file:/about.yaml
      - optional:file:/env.yaml
```

When these properties are specified as YAML lists (rather than comma-delimited strings), Spring loads them as indexed properties (e.g. `spring.config.import[0]`, `spring.config.import[1]`, ...). However, Spring's `Environment.getProperty()` cannot resolve indexed list properties directly ([spring-framework#35179](https://github.com/spring-projects/spring-framework/issues/35179)), causing Optimize to silently ignore all listed config files.

This PR introduces a `getListProperty()` helper that:
1. First attempts a direct `getProperty()` lookup (for comma-delimited string values)
2. Falls back to iterating over indexed properties (`propertyName[0]`, `propertyName[1]`, ...) to collect list entries

This is a workaround for the upstream Spring Framework bug, following the approach suggested in [spring-framework#35179 (comment)](https://github.com/spring-projects/spring-framework/issues/35179#issuecomment-3989747033).

### Changes

- **`ConfigurationServiceBuilder.java`** — Refactored `resolveConfigLocations()` to use the new `getListProperty()` method instead of `Environment.getProperty()` + manual comma-splitting. Whitespace trimming is now handled centrally in `getListProperty()`.
- **`ConfigurationServiceBuilderTest.java`** — Added a parameterized test (`shouldResolveConfigLocationsFromEnvironmentAsList`) that runs all existing test cases with properties loaded as indexed list entries, ensuring parity between comma-delimited and YAML list formats.
- **`ExtraConfigurationConfigImportIT.java`** — Added an integration-level regression test (`shouldLoadEnvYamlImportedAsList`) that mimics a Kubernetes ConfigMap setup where `spring.config.import` is specified as a YAML list importing multiple files.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47473