### PR TITLE
[Backport stable/8.9] feat: use job worker name as fallback for overrides

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
@@ -28,6 +28,8 @@ import io.camunda.client.annotation.value.SourceAware.FromDefaultProperty;
 import io.camunda.client.annotation.value.SourceAware.FromOverrideProperty;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -92,16 +94,21 @@ public class PropertyBasedJobWorkerValueCustomizer implements JobWorkerValueCust
     final String workerName = editedJobWorkerValue.getName().value();
     findWorkerOverride(workerType, workerName)
         .ifPresent(
-            jobWorkerValue -> {
-              LOG.debug("Worker '{}': Applying overrides {}", workerType, jobWorkerValue);
-              copyProperties(jobWorkerValue, editedJobWorkerValue, OverrideSource.worker);
+            e -> {
+              LOG.debug("Worker {}: Applying overrides {}", e.getKey(), e.getValue());
+              copyProperties(e.getValue(), editedJobWorkerValue, OverrideSource.worker);
             });
   }
 
-  private Optional<CamundaClientJobWorkerProperties> findWorkerOverride(
+  private Optional<Entry<String, CamundaClientJobWorkerProperties>> findWorkerOverride(
       final String type, final String name) {
+    final String template = "with %s '%s'";
     return ofNullable(camundaClientProperties.getWorker().getOverride().get(type))
-        .or(() -> ofNullable(camundaClientProperties.getWorker().getOverride().get(name)));
+        .map(p -> Map.entry(String.format(template, "type", type), p))
+        .or(
+            () ->
+                ofNullable(camundaClientProperties.getWorker().getOverride().get(name))
+                    .map(p -> Map.entry(String.format(template, "name", name), p)));
   }
 
   private Supplier<List<String>> fetchVariablesSuppliers(

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
@@ -89,7 +89,8 @@ public class PropertyBasedJobWorkerValueCustomizer implements JobWorkerValueCust
       copyProperties(defaults, editedJobWorkerValue, OverrideSource.defaults);
     }
     final String workerType = editedJobWorkerValue.getType().value();
-    findWorkerOverride(workerType)
+    final String workerName = editedJobWorkerValue.getName().value();
+    findWorkerOverride(workerType, workerName)
         .ifPresent(
             jobWorkerValue -> {
               LOG.debug("Worker '{}': Applying overrides {}", workerType, jobWorkerValue);
@@ -97,8 +98,10 @@ public class PropertyBasedJobWorkerValueCustomizer implements JobWorkerValueCust
             });
   }
 
-  private Optional<CamundaClientJobWorkerProperties> findWorkerOverride(final String type) {
-    return ofNullable(camundaClientProperties.getWorker().getOverride().get(type));
+  private Optional<CamundaClientJobWorkerProperties> findWorkerOverride(
+      final String type, final String name) {
+    return ofNullable(camundaClientProperties.getWorker().getOverride().get(type))
+        .or(() -> ofNullable(camundaClientProperties.getWorker().getOverride().get(name)));
   }
 
   private Supplier<List<String>> fetchVariablesSuppliers(

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
@@ -572,6 +572,21 @@ public class PropertyBasedJobWorkerValueCustomizerTest {
     assertThat(properties.getTenantFilter()).isEqualTo(TenantFilter.PROVIDED);
   }
 
+  @Test
+  void shouldFindJobWorkerByName() {
+    final CamundaClientProperties properties = properties();
+    final CamundaClientJobWorkerProperties overrides = new CamundaClientJobWorkerProperties();
+    overrides.setStreamEnabled(true);
+    properties.getWorker().getOverride().put("NAME", overrides);
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    jobWorkerValue.setName(new FromAnnotation<>("NAME"));
+    assertThat(jobWorkerValue.getStreamEnabled().value()).isNull();
+    final PropertyBasedJobWorkerValueCustomizer customizer =
+        new PropertyBasedJobWorkerValueCustomizer(properties);
+    customizer.customize(jobWorkerValue);
+    assertThat(jobWorkerValue.getStreamEnabled().value()).isTrue();
+  }
+
   private record Input<T>(
       String displayName,
       BiConsumer<CamundaClientJobWorkerProperties, T> setter,

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
@@ -591,12 +591,10 @@ public class PropertyBasedJobWorkerValueCustomizerTest {
   void shouldPreferTypeOverrideOverNameOverride() {
     final CamundaClientProperties properties = properties();
 
-    final CamundaClientJobWorkerProperties typeOverride =
-        new CamundaClientJobWorkerProperties();
+    final CamundaClientJobWorkerProperties typeOverride = new CamundaClientJobWorkerProperties();
     typeOverride.setStreamEnabled(true);
 
-    final CamundaClientJobWorkerProperties nameOverride =
-        new CamundaClientJobWorkerProperties();
+    final CamundaClientJobWorkerProperties nameOverride = new CamundaClientJobWorkerProperties();
     nameOverride.setStreamEnabled(false);
 
     properties.getWorker().getOverride().put("MY_TYPE", typeOverride);
@@ -615,6 +613,7 @@ public class PropertyBasedJobWorkerValueCustomizerTest {
     // job type override should take precedence over name override
     assertThat(jobWorkerValue.getStreamEnabled().value()).isTrue();
   }
+
   private record Input<T>(
       String displayName,
       BiConsumer<CamundaClientJobWorkerProperties, T> setter,

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
@@ -587,6 +587,34 @@ public class PropertyBasedJobWorkerValueCustomizerTest {
     assertThat(jobWorkerValue.getStreamEnabled().value()).isTrue();
   }
 
+  @Test
+  void shouldPreferTypeOverrideOverNameOverride() {
+    final CamundaClientProperties properties = properties();
+
+    final CamundaClientJobWorkerProperties typeOverride =
+        new CamundaClientJobWorkerProperties();
+    typeOverride.setStreamEnabled(true);
+
+    final CamundaClientJobWorkerProperties nameOverride =
+        new CamundaClientJobWorkerProperties();
+    nameOverride.setStreamEnabled(false);
+
+    properties.getWorker().getOverride().put("MY_TYPE", typeOverride);
+    properties.getWorker().getOverride().put("MY_NAME", nameOverride);
+
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    jobWorkerValue.setType(new FromAnnotation<>("MY_TYPE"));
+    jobWorkerValue.setName(new FromAnnotation<>("MY_NAME"));
+
+    assertThat(jobWorkerValue.getStreamEnabled().value()).isNull();
+
+    final PropertyBasedJobWorkerValueCustomizer customizer =
+        new PropertyBasedJobWorkerValueCustomizer(properties);
+    customizer.customize(jobWorkerValue);
+
+    // job type override should take precedence over name override
+    assertThat(jobWorkerValue.getStreamEnabled().value()).isTrue();
+  }
   private record Input<T>(
       String displayName,
       BiConsumer<CamundaClientJobWorkerProperties, T> setter,

--- a/qa/compatibility-test/src/test/java/io/camunda/qa/compatibility/CompatibilityJobWorkerOverridesByNameIT.java
+++ b/qa/compatibility-test/src/test/java/io/camunda/qa/compatibility/CompatibilityJobWorkerOverridesByNameIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.compatibility;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.annotation.value.JobWorkerValue;
+import io.camunda.client.annotation.value.SourceAware;
+import io.camunda.client.annotation.value.SourceAware.FromDefaultProperty;
+import io.camunda.client.annotation.value.SourceAware.FromOverrideProperty;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
+
+@SpringBootTest(
+    classes = CompatibilityJobWorkerOverridesByNameIT.TestApplication.class,
+    properties = {
+      "spring.main.web-application-type=none",
+      "camunda.client.worker.defaults.timeout=PT45S",
+      "camunda.client.worker.defaults.max-jobs-active=10",
+      "camunda.client.worker.override.compatibility-override-worker.timeout=PT12S",
+      "camunda.client.worker.override.compatibility-override-worker.poll-interval=PT2S",
+      "camunda.client.worker.override.compatibility-override-worker.max-retries=3",
+      "camunda.client.worker.override.compatibility-override-worker.tenant-ids[0]=tenant-a",
+      "camunda.client.worker.override.compatibility-override-worker.tenant-ids[1]=tenant-b"
+    })
+@CamundaSpringProcessTest
+class CompatibilityJobWorkerOverridesByNameIT {
+  private static final String WORKER_TYPE = "test";
+  private static final String WORKER_NAME = "compatibility-override-worker";
+
+  @Autowired private JobWorkerManager jobWorkerManager;
+
+  @Test
+  void shouldApplyDefaultsAndOverridesForJobWorker() {
+    final JobWorkerValue jobWorkerValue = jobWorkerManager.getJobWorker(WORKER_TYPE);
+
+    assertThat(jobWorkerValue.getTimeout()).isInstanceOf(FromOverrideProperty.class);
+    assertThat(jobWorkerValue.getTimeout().value()).isEqualTo(Duration.ofSeconds(12));
+
+    assertThat(jobWorkerValue.getPollInterval()).isInstanceOf(FromOverrideProperty.class);
+    assertThat(jobWorkerValue.getPollInterval().value()).isEqualTo(Duration.ofSeconds(2));
+
+    assertThat(jobWorkerValue.getMaxRetries()).isInstanceOf(FromOverrideProperty.class);
+    assertThat(jobWorkerValue.getMaxRetries().value()).isEqualTo(3);
+
+    assertThat(jobWorkerValue.getMaxJobsActive()).isInstanceOf(FromDefaultProperty.class);
+    assertThat(jobWorkerValue.getMaxJobsActive().value()).isEqualTo(10);
+
+    final List<SourceAware<String>> tenantIds = jobWorkerValue.getTenantIds();
+    assertThat(tenantIds).hasSize(2);
+    assertThat(tenantIds).allMatch(FromOverrideProperty.class::isInstance);
+    assertThat(tenantIds.stream().map(SourceAware::value).toList())
+        .containsExactly("tenant-a", "tenant-b");
+  }
+
+  @Component
+  public static class OverrideWorker {
+
+    @JobWorker(type = WORKER_TYPE, name = WORKER_NAME, autoComplete = false)
+    public void handleJob() {}
+  }
+
+  @SpringBootConfiguration
+  @EnableAutoConfiguration
+  @Import({OverrideWorker.class, CompatibilityTestSupportConfiguration.class})
+  static class TestApplication {}
+}


### PR DESCRIPTION
# Description
Backport of #46115 to `stable/8.9`.

relates to 