### PR TITLE
fix: correct processesStatus reference in ListView component

### DIFF
--- a/operate/client/src/App/Processes/ListView/index.tsx
+++ b/operate/client/src/App/Processes/ListView/index.tsx
@@ -38,10 +38,7 @@ const ListView: React.FC = observer(() => {
 
   const filters = getProcessInstanceFilters(location.search);
   const {process, tenant, version} = filters;
-  const {
-    state: {status: processesStatus},
-    isInitialLoadComplete,
-  } = processesStore;
+  const {isInitialLoadComplete} = processesStore;
   const filtersJSON = JSON.stringify(filters);
 
   useEffect(() => {
@@ -86,7 +83,7 @@ const ListView: React.FC = observer(() => {
     const disposer = reaction(
       () => variableFilterStore.state.variable,
       () => {
-        if (processesStatus === 'fetched') {
+        if (processesStore.state.status === 'fetched') {
           tracking.track({
             eventName: 'process-instances-filtered',
             filterName: 'variable',
@@ -98,26 +95,33 @@ const ListView: React.FC = observer(() => {
     );
 
     return disposer;
-  }, [processesStatus]);
+  }, []);
 
   useEffect(() => {
-    if (processesStatus === 'fetched') {
-      if (
-        process !== undefined &&
-        processesStore.getProcess({
-          bpmnProcessId: process,
-          tenantId: tenant,
-        }) === undefined
-      ) {
-        navigate(deleteSearchParams(location, ['process', 'version']));
-        notificationsStore.displayNotification({
-          kind: 'error',
-          title: 'Process could not be found',
-          isDismissable: true,
-        });
-      }
-    }
-  }, [process, tenant, navigate, processesStatus, location]);
+    const disposer = reaction(
+      () => processesStore.state.status,
+      () => {
+        if (processesStore.state.status === 'fetched') {
+          if (
+            process !== undefined &&
+            processesStore.getProcess({
+              bpmnProcessId: process,
+              tenantId: tenant,
+            }) === undefined
+          ) {
+            navigate(deleteSearchParams(location, ['process', 'version']));
+            notificationsStore.displayNotification({
+              kind: 'error',
+              title: 'Process could not be found',
+              isDismissable: true,
+            });
+          }
+        }
+      },
+    );
+
+    return disposer;
+  }, [process, tenant, location, navigate]);
 
   const processDefinitionKey = processesStore.getProcessId({
     process,

--- a/operate/client/src/App/Processes/ListView/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/tests/index.test.tsx
@@ -284,7 +284,9 @@ describe('Instances', () => {
       },
     });
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
 
     await waitFor(() => expect(handleRefetchSpy).toHaveBeenCalledTimes(1));
 
@@ -310,7 +312,9 @@ describe('Instances', () => {
       },
     });
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
     await waitFor(() => expect(handleRefetchSpy).toHaveBeenCalledTimes(3));
 
     mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
@@ -329,7 +333,9 @@ describe('Instances', () => {
     expect(screen.getByTestId('diagram-spinner')).toBeInTheDocument();
     expect(screen.getByTestId('data-table-skeleton')).toBeInTheDocument();
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('pathname')).toHaveTextContent(/^\/processes/);


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
It seems that the processStore status variable is getting stale due to the way it is being accessed.
I changed the logic to use a reaction and access the store state directly instead. this seems to fix the problem.

It can be reproduced locally by just saving the page in dev mode while a process is selected, this runs the hot module replacement which unmounts the component, causing the store to reset & the error to appear. The error notification appears.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #42157
