### PR TITLE
fix: declare batch operations responses required and nullable fields 

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -221,6 +221,9 @@ paths:
 components:
   schemas:
     BatchOperationCreatedResult:
+      required:
+        - batchOperationKey
+        - batchOperationType
       description: The created batch operation.
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -308,6 +308,14 @@ components:
 
     BatchOperationResponse:
       required:
+        - batchOperationKey
+        - batchOperationType
+        - state
+        - operationsCompletedCount
+        - operationsFailedCount
+        - operationsTotalCount
+        - actorType
+        - actorId
         - errors
       type: object
       properties:
@@ -334,10 +342,17 @@ components:
           format: date-time
           nullable: true
         actorType:
-          $ref: 'audit-logs.yaml#/components/schemas/AuditLogActorTypeEnum'
+          description: |
+            The type of the actor who performed the operation.
+            This is `null` if the batch operation was created before 8.9,
+            or if the actor information is not available.
+          nullable: true
+          allOf:
+            - $ref: 'audit-logs.yaml#/components/schemas/AuditLogActorTypeEnum'
         actorId:
           type: string
           description: The ID of the actor who performed the operation. Available for batch operations created since 8.9.
+          nullable: true
         operationsTotalCount:
           type: integer
           description: The total number of items contained in this batch operation.


### PR DESCRIPTION
## Description

- Marked `BatchOperationCreatedResult` response fields as required.
- Expanded the `required` list for `BatchOperationResponse` (including counts/state/type).
- Documented `actorType` as nullable (pre-8.9 / missing actor info) and marked `actorId` as nullable.
- 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #47302
