### PR TITLE
docs: added missing line continuations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ docker build \
   --tag camunda/zeebe:local \
   --build-arg DISTBALL='dist/target/camunda-zeebe*.tar.gz' \
   --target app \
-  --file ./camunda.Dockerfile
+  --file ./camunda.Dockerfile \
   .
 ```
 
@@ -186,7 +186,7 @@ docker build \
   --build-arg DISTBALL='dist/target/camunda-zeebe*.tar.gz' \
   --build-arg BASE='public' \
   --target app \
-  --file ./camunda.Dockerfile
+  --file ./camunda.Dockerfile \
   .
 ```
 


### PR DESCRIPTION
## Description

When I tried to execute the documented docker command, i got
```
ERROR: docker: 'docker buildx build' requires 1 argument

Usage:  docker buildx build [OPTIONS] PATH | URL | -

Run 'docker buildx build --help' for more information
bash: .: filename argument required
.: usage: . filename [arguments]
```

The '.' is the filenmae and is part of the docker command, so there must be a line contination character in the line before. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
