### PR TITLE
Add required response properties to message publish and correlation endpoint

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -167,6 +167,10 @@ components:
         The message key of the correlated message, as well as the first process instance key it
         correlated with.
       type: object
+      required:
+        - tenantId
+        - messageKey
+        - processInstanceKey
       properties:
         tenantId:
           description: The tenant ID of the correlated message
@@ -217,6 +221,9 @@ components:
     MessagePublicationResult:
       description: The message key of the published message.
       type: object
+      required:
+        - tenantId
+        - messageKey
       properties:
         tenantId:
           description: The tenant ID of the message.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Marks the response properties as required, meaning they cannot be `null`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

N/A, related to https://camunda.slack.com/archives/C08F5RD5X8B/p1772427868056259

relates to #47302
