### PR TITLE
feat: extend diagram controls

### DIFF
--- a/operate/client/e2e-playwright/a11y/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/a11y/processInstance.spec.ts
@@ -156,7 +156,7 @@ test.describe('process detail', () => {
     validateResults(results);
 
     await page.getByRole('button', {name: /continue/i}).click();
-    await page.getByTestId('diagram').getByText('Signal user task').click();
+    await processInstancePage.diagram.getFlowNodeById('Activity_0dex012').click();
     await page
       .getByRole('button', {name: 'Add single element instance'})
       .click();

--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
@@ -188,8 +188,8 @@ test.describe('process instance migration', () => {
     await migrationView.selectTargetSourceElement('Check payment');
 
     const elements = page
-      .getByTestId('diagram')
-      .getByText('Check payment', {exact: true});
+      .getByTestId('diagram-canvas')
+      .locator('[data-element-id="checkPayment"]');
 
     await commonPage.addDownArrow(elements.first());
     await commonPage.addDownArrow(elements.nth(1));
@@ -359,13 +359,17 @@ test.describe('process instance migration', () => {
     await migrationView.selectTargetProcess('Ad Hoc Subprocess Target');
     await migrationView.selectTargetVersion('2');
 
-    // Verify ad hoc subprocess element is shown
+    // Verify ad hoc subprocess element is shown in both diagrams
     await expect(
-      page.getByText('Ad Hoc Subprocess', {exact: true}),
-    ).toHaveCount(4);
+      page
+        .getByTestId('diagram-canvas')
+        .locator('[data-element-id="AD_HOC_SUBPROCESS"]'),
+    ).toHaveCount(2);
 
-    // Verify user task element is shown
-    await expect(page.getByText('A', {exact: true})).toHaveCount(2);
+    // Verify user task element is shown in the source diagram
+    await expect(
+      page.getByTestId('diagram-canvas').locator('[data-element-id="A"]'),
+    ).toHaveCount(1);
 
     // Map the ad hoc subprocess
     await migrationView.mapElement({

--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
@@ -187,9 +187,7 @@ test.describe('process instance migration', () => {
 
     await migrationView.selectTargetSourceElement('Check payment');
 
-    const elements = page
-      .getByTestId('diagram-canvas')
-      .locator('[data-element-id="checkPayment"]');
+    const elements = processesPage.diagram.getFlowNodeById('checkPayment');
 
     await commonPage.addDownArrow(elements.first());
     await commonPage.addDownArrow(elements.nth(1));
@@ -361,14 +359,12 @@ test.describe('process instance migration', () => {
 
     // Verify ad hoc subprocess element is shown in both diagrams
     await expect(
-      page
-        .getByTestId('diagram-canvas')
-        .locator('[data-element-id="AD_HOC_SUBPROCESS"]'),
+      processesPage.diagram.getFlowNodeById('AD_HOC_SUBPROCESS'),
     ).toHaveCount(2);
 
     // Verify user task element is shown in the source diagram
     await expect(
-      page.getByTestId('diagram-canvas').locator('[data-element-id="A"]'),
+      processesPage.diagram.getFlowNodeById('A'),
     ).toHaveCount(1);
 
     // Map the ad hoc subprocess

--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
@@ -63,7 +63,10 @@ test.describe('process instance modification', () => {
       path: 'e2e-playwright/docs-screenshots/process-instance-modification/modification-mode.png',
     });
 
-    await page.getByTestId('diagram').getByText('Message task').nth(0).click();
+    await page
+      .getByTestId('diagram-canvas')
+      .locator('[data-element-id="messageTask"]')
+      .click();
 
     await expect(
       page.getByRole('button', {
@@ -96,7 +99,10 @@ test.describe('process instance modification', () => {
 
     await commonPage.deleteArrows();
 
-    await page.getByText('Last task').click();
+    await page
+      .getByTestId('diagram-canvas')
+      .locator('[data-element-id="lastTask"]')
+      .click();
 
     await expect(
       page.getByRole('button', {name: /Add single element instance/i}),
@@ -152,7 +158,10 @@ test.describe('process instance modification', () => {
 
     await page.getByRole('button', {name: 'Continue'}).click();
 
-    await page.getByTestId('diagram').getByText('Message task').nth(0).click();
+    await page
+      .getByTestId('diagram-canvas')
+      .locator('[data-element-id="messageTask"]')
+      .click();
 
     await expect(
       page.getByRole('button', {
@@ -174,7 +183,9 @@ test.describe('process instance modification', () => {
 
     await moveTokenButton.click();
 
-    const lastTaskElement = page.getByTestId('diagram').getByText('Last task');
+    const lastTaskElement = await page
+      .getByTestId('diagram-canvas')
+      .locator('[data-element-id="lastTask"]');
 
     await commonPage.addDownArrow(lastTaskElement);
 

--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
@@ -63,10 +63,7 @@ test.describe('process instance modification', () => {
       path: 'e2e-playwright/docs-screenshots/process-instance-modification/modification-mode.png',
     });
 
-    await page
-      .getByTestId('diagram-canvas')
-      .locator('[data-element-id="messageTask"]')
-      .click();
+    await processInstancePage.diagram.getFlowNodeById('messageTask').click();
 
     await expect(
       page.getByRole('button', {
@@ -99,10 +96,7 @@ test.describe('process instance modification', () => {
 
     await commonPage.deleteArrows();
 
-    await page
-      .getByTestId('diagram-canvas')
-      .locator('[data-element-id="lastTask"]')
-      .click();
+    await processInstancePage.diagram.getFlowNodeById('lastTask').click();
 
     await expect(
       page.getByRole('button', {name: /Add single element instance/i}),
@@ -158,10 +152,7 @@ test.describe('process instance modification', () => {
 
     await page.getByRole('button', {name: 'Continue'}).click();
 
-    await page
-      .getByTestId('diagram-canvas')
-      .locator('[data-element-id="messageTask"]')
-      .click();
+    await processInstancePage.diagram.getFlowNodeById('messageTask').click();
 
     await expect(
       page.getByRole('button', {
@@ -183,9 +174,8 @@ test.describe('process instance modification', () => {
 
     await moveTokenButton.click();
 
-    const lastTaskElement = await page
-      .getByTestId('diagram-canvas')
-      .locator('[data-element-id="lastTask"]');
+    const lastTaskElement =
+      processInstancePage.diagram.getFlowNodeById('lastTask');
 
     await commonPage.addDownArrow(lastTaskElement);
 
@@ -419,7 +409,7 @@ test.describe('process instance modification', () => {
 
     await page.getByRole('button', {name: 'Continue'}).click();
 
-    const timerEvent = await page.locator('[data-element-id="timerEvent"]');
+    const timerEvent = processInstancePage.diagram.getFlowNodeById('timerEvent');
 
     await commonPage.addDownArrow(timerEvent);
 

--- a/operate/client/e2e-playwright/pages/components/Diagram.ts
+++ b/operate/client/e2e-playwright/pages/components/Diagram.ts
@@ -11,6 +11,7 @@ import type {Locator, Page} from '@playwright/test';
 export class Diagram {
   private page: Page;
   readonly diagram: Locator;
+  readonly diagramCanvas: Locator;
   readonly popover: Locator;
   readonly resetDiagramZoomButton: Locator;
   readonly diagramSpinner: Locator;
@@ -19,6 +20,7 @@ export class Diagram {
   constructor(page: Page) {
     this.page = page;
     this.diagram = this.page.getByTestId('diagram');
+    this.diagramCanvas = this.page.getByTestId('diagram-canvas');
     this.popover = this.page.getByTestId('popover');
     this.resetDiagramZoomButton = this.page.getByRole('button', {
       name: /Reset diagram zoom/i,
@@ -64,9 +66,15 @@ export class Diagram {
   }
 
   getElement(elementName: string) {
-    return this.diagram
-      .locator('.djs-element')
+    return this.diagramCanvas
+      .locator('.djs-element[data-element-id]')
       .filter({hasText: new RegExp(`^${elementName}$`, 'i')});
+  }
+
+  getFlowNodeById(elementId: string) {
+    return this.diagramCanvas.locator(
+      `.djs-element[data-element-id="${elementId}"]`,
+    );
   }
 
   clickGateway(gatewayName: string) {
@@ -83,13 +91,13 @@ export class Diagram {
   }
 
   async getLabeledElement(eventName: string) {
-    const eventLabel = this.diagram
+    const eventLabel = this.diagramCanvas
       .locator('.djs-element')
       .filter({hasText: new RegExp(`${eventName}`, 'i')});
 
     const labelId = await eventLabel.getAttribute('data-element-id');
     const eventId = labelId?.split(/_label$/)[0];
-    return this.diagram.locator(`[data-element-id="${eventId}"]`);
+    return this.diagramCanvas.locator(`[data-element-id="${eventId}"]`);
   }
 
   showMetaData() {
@@ -99,7 +107,7 @@ export class Diagram {
   }
 
   getExecutionCount(elementId: string) {
-    return this.diagram.evaluate(
+    return this.diagramCanvas.evaluate(
       (node, {elementId}) => {
         const completedOverlay: HTMLDivElement | null = node.querySelector(
           `[data-container-id="${elementId}"] [data-testid="state-overlay-completed"]`,

--- a/operate/client/e2e-playwright/tests/decisionNavigation.spec.ts
+++ b/operate/client/e2e-playwright/tests/decisionNavigation.spec.ts
@@ -89,10 +89,10 @@ test.describe('Decision Navigation', () => {
 
     await expect(page.getByTestId('diagram')).toBeInViewport();
     await expect(
-      page.getByTestId('diagram').getByText(/define approver/i),
+      page.getByTestId('diagram').locator('[data-element-id="Activity_1tjwahx"]'),
     ).toBeVisible();
 
-    await page.getByTestId('diagram').getByText('Define approver').click();
+    await page.getByTestId('diagram').locator('[data-element-id="Activity_1tjwahx"]').click();
 
     await expect(page.getByTestId('popover')).toBeVisible();
     await page
@@ -130,7 +130,7 @@ test.describe('Decision Navigation', () => {
     await expect(page.getByTestId('diagram')).toBeInViewport();
 
     await expect(
-      page.getByTestId('diagram').getByText(/define approver/i),
+      page.getByTestId('diagram').locator('[data-element-id="Activity_1tjwahx"]'),
     ).toBeVisible();
 
     await page

--- a/operate/client/e2e-playwright/tests/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/tests/processInstance.spec.ts
@@ -296,7 +296,7 @@ test.describe('Process Instance', () => {
     await expect(diagram.getElement('fill form')).toBeVisible();
     await expect(popover.getByText(/retries left/i)).toBeVisible();
 
-    await diagram.diagram.getByText('collapsedSubProcess').click();
+    await diagram.diagramCanvas.getByText('collapsedSubProcess').click();
 
     await expect(
       popover.getByText(/flow node instance key/i),

--- a/operate/client/e2e-playwright/visual/modifications.spec.ts
+++ b/operate/client/e2e-playwright/visual/modifications.spec.ts
@@ -85,7 +85,7 @@ test.describe('modifications', () => {
         name: /continue/i,
       })
       .click();
-    await page.getByTestId('diagram').getByText('Signal user task').click();
+    await processInstancePage.diagram.getFlowNodeById('Activity_0dex012').click();
     await page
       .getByRole('button', {name: 'Add single element instance'})
       .click();

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -24,7 +24,7 @@
         "bpmn-js": "18.12.0",
         "bpmn-moddle": "10.0.0",
         "date-fns": "4.1.0",
-        "diagram-js-minimap": "^5.3.0",
+        "diagram-js-minimap": "5.3.0",
         "dmn-js": "17.7.0",
         "dmn-js-decision-table": "17.7.0",
         "dmn-js-drd": "17.7.0",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -24,6 +24,7 @@
         "bpmn-js": "18.12.0",
         "bpmn-moddle": "10.0.0",
         "date-fns": "4.1.0",
+        "diagram-js-minimap": "^5.3.0",
         "dmn-js": "17.7.0",
         "dmn-js-decision-table": "17.7.0",
         "dmn-js-drd": "17.7.0",
@@ -173,6 +174,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -748,6 +750,7 @@
       "integrity": "sha512-BY241uKsNyR37z4BS1/Boce16iqFU4EUrbES4z8n5u2kc1VDef3v3ljPbNEKWwq1Z9U9SHriNrwDKoKMYPMSFQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.3",
         "@carbon/feature-flags": "1.0.0",
@@ -1013,6 +1016,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1036,6 +1040,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2345,6 +2350,7 @@
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.3.tgz",
       "integrity": "sha512-di3QfGmRleiDN85+E6OoJHCr/vq/wX9Z8l/Jt4mqHoLcbLEa46dkZ/qSgl4pYFby1Q6BKEwfwGIav15Ay7szlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mixpanel/rrdom": "^2.0.0-alpha.18",
         "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18",
@@ -2385,7 +2391,8 @@
       "version": "2.0.0-alpha.18.2",
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.2.tgz",
       "integrity": "sha512-OomKIB6GTx5xvCLJ7iic2khT/t/tnCJUex13aEqsbSqIT/UzUUsqf+LTrgUK5ex+f6odmkCNjre2y5jvpNqn+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.5.0",
@@ -3571,6 +3578,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -3631,6 +3639,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3922,6 +3931,7 @@
       "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3931,6 +3941,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3941,6 +3952,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4043,6 +4055,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -4278,6 +4291,7 @@
       "integrity": "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/mocker": "4.0.18",
         "@vitest/utils": "4.0.18",
@@ -4301,6 +4315,7 @@
       "integrity": "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -4505,6 +4520,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -4552,6 +4568,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5008,6 +5025,7 @@
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.12.0.tgz",
       "integrity": "sha512-Dg2O+r7jpBwLgWGpManc7P4ZfZQfxTVi2xNtXR3Q2G5Hx1RVYVFoNsQED8+FPCgjy6m7ZQbxKP1sjCJt5rbtBg==",
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
         "diagram-js": "^15.9.0",
@@ -5078,6 +5096,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6268,6 +6287,7 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.9.0.tgz",
       "integrity": "sha512-9FRoItWkrZnGalrqs0ekwS9wSuHQI2dzO+kJyHKa1hhMJPMBGrjR/cg0XMTpaLo2Vu9/gKL1o19P3sN4/YmIAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.1",
@@ -6297,6 +6317,17 @@
       },
       "peerDependencies": {
         "diagram-js": "*"
+      }
+    },
+    "node_modules/diagram-js-minimap": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-5.3.0.tgz",
+      "integrity": "sha512-FO2yDA8td4Vnu4Yg72ZIA7n6vIOtZWAH0wwwfcg9qrZIfVaaQFgmOpa+RdIBGZtzURZb43HJr5hyiOe3yo2xDA==",
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0",
+        "tiny-svg": "^4.1.4"
       }
     },
     "node_modules/didi": {
@@ -6844,6 +6875,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6904,6 +6936,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7592,6 +7625,7 @@
       "resolved": "https://registry.npmjs.org/final-form/-/final-form-5.0.0.tgz",
       "integrity": "sha512-HByosvP7x3N4bWTCPoBeUeoMatadewRifxaH3qhCQI2DBwFNO0m5wxETLVUXNGWz2yokdSCMdJEvtjfZoXnqDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.0"
       },
@@ -7608,6 +7642,7 @@
       "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-4.0.0.tgz",
       "integrity": "sha512-ya1mbjTmEcmZ8ettYHp/eB4UpfuSjpLJ+grpaQsgxqi1P0wrm+syr/7qLbbslxNLSDA1zoSUthWVCB1O6B9fqg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "final-form": "^5.0.0"
       }
@@ -8311,6 +8346,7 @@
       "integrity": "sha512-2m7bEo/6D+pbxFkFKY/2QOVdknxxXyrXyDdVFobJcQyvfv3985MY+VVwyRZoVJylQG+mzPY5/uDNuXygp8jObA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inferno-shared": "5.6.3",
         "inferno-vnode-flags": "5.6.3",
@@ -10258,6 +10294,7 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -10316,6 +10353,7 @@
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.0.0.tgz",
       "integrity": "sha512-ZjE3D0EtU3Qp6ZpxBckGFydIQi++feYvhvxhjNYKGzlC8+2lpcO0lS86WC/B+s2lbAqjrlOMYCQqu6mHAtz2cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-dash": "^5.0.0"
       }
@@ -10351,6 +10389,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -11071,6 +11110,7 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -11172,6 +11212,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11395,6 +11436,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11407,6 +11449,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11434,6 +11477,7 @@
       "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-7.0.0.tgz",
       "integrity": "sha512-aEeAWbSsCLVXa4GBkJtjjyhPyX4L/Pgp5P/jXZwdz0YYcK6Zs/0PkgB+qWMSyIsbbGGE7m9yYlSpui5E5Gx26A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4"
       },
@@ -11818,6 +11862,7 @@
       "integrity": "sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12043,6 +12088,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -12890,6 +12936,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.11.tgz",
       "integrity": "sha512-opzgceGlQ5rdZdGwf9ddLW7EM2F4L7tgsgLn6fFzQ2JgE5EVQ4HZwNkcgB1p8WfOBx1GEZP3fa66ajJmtXhSrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -13394,6 +13441,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13678,6 +13726,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13954,6 +14003,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -14107,6 +14157,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -14675,6 +14726,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -20,7 +20,7 @@
     "bpmn-js": "18.12.0",
     "bpmn-moddle": "10.0.0",
     "date-fns": "4.1.0",
-    "diagram-js-minimap": "^5.3.0",
+    "diagram-js-minimap": "5.3.0",
     "dmn-js": "17.7.0",
     "dmn-js-decision-table": "17.7.0",
     "dmn-js-drd": "17.7.0",

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -20,6 +20,7 @@
     "bpmn-js": "18.12.0",
     "bpmn-moddle": "10.0.0",
     "date-fns": "4.1.0",
+    "diagram-js-minimap": "^5.3.0",
     "dmn-js": "17.7.0",
     "dmn-js-decision-table": "17.7.0",
     "dmn-js-drd": "17.7.0",

--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -14,6 +14,9 @@ import NavigatedViewer, {
 import OutlineModule from 'bpmn-js/lib/features/outline';
 // @ts-expect-error Could not find a declaration file for module '@bpmn-io/element-templates-icons-renderer'
 import ElementTemplatesIconsRenderer from '@bpmn-io/element-template-icon-renderer';
+// @ts-expect-error Could not find a declaration file for module 'diagram-js-minimap'
+import minimapModule from 'diagram-js-minimap';
+import 'diagram-js-minimap/assets/diagram-js-minimap.css';
 import isEqual from 'lodash/isEqual';
 import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
 import {isNonSelectableElement} from './utils/isNonSelectableElement';
@@ -279,7 +282,11 @@ class BpmnJS {
       container,
       bpmnRenderer: bpmnRendererColors,
       canvas: {deferUpdate: true},
-      additionalModules: [ElementTemplatesIconsRenderer, OutlineModule],
+      additionalModules: [
+        ElementTemplatesIconsRenderer,
+        OutlineModule,
+        minimapModule,
+      ],
     });
   };
 
@@ -445,6 +452,33 @@ class BpmnJS {
   findRootId = (selectedElementId: string) => {
     return this.#navigatedViewer?.get('canvas')?.findRoot(selectedElementId)
       ?.businessObject.id;
+  };
+
+  notifyResize = () => {
+    const canvas = this.#navigatedViewer?.get('canvas');
+    if (canvas) {
+      canvas.resized();
+    }
+  };
+
+  toggleMinimap = () => {
+    const minimap = this.#navigatedViewer?.get('minimap');
+    if (minimap) {
+      const isOpen = minimap.isOpen();
+      if (isOpen) {
+        minimap.close();
+      } else {
+        minimap.open();
+      }
+    }
+  };
+
+  isMinimapOpen = (): boolean => {
+    const minimap = this.#navigatedViewer?.get('minimap');
+    if (minimap) {
+      return minimap.isOpen() ?? false;
+    }
+    return false;
   };
 }
 

--- a/operate/client/src/modules/components/Diagram/DiagramControlsNext/index.test.tsx
+++ b/operate/client/src/modules/components/Diagram/DiagramControlsNext/index.test.tsx
@@ -25,12 +25,18 @@ describe('<DiagramControls />', () => {
   it('should render diagram controls', async () => {
     const handleZoomIn = vi.fn(),
       handleZoomOut = vi.fn(),
-      handleZoomReset = vi.fn();
+      handleZoomReset = vi.fn(),
+      handleFullscreen = vi.fn(),
+      handleMinimapToggle = vi.fn();
     const {user} = render(
       <DiagramControls
         handleZoomIn={handleZoomIn}
         handleZoomOut={handleZoomOut}
         handleZoomReset={handleZoomReset}
+        handleFullscreen={handleFullscreen}
+        isFullscreen={false}
+        handleMinimapToggle={handleMinimapToggle}
+        isMinimapOpen={false}
         processDefinitionKey={MOCK_PROCESS_DEFINITION_KEY}
       />,
       {wrapper: Wrapper},
@@ -59,16 +65,94 @@ describe('<DiagramControls />', () => {
     expect(handleZoomIn).not.toHaveBeenCalled();
   });
 
-  it('should not render download button', async () => {
-    const handleZoomIn = vi.fn(),
-      handleZoomOut = vi.fn(),
-      handleZoomReset = vi.fn();
+  it('should render fullscreen button and toggle', async () => {
+    const handleFullscreen = vi.fn();
+    const {user, rerender} = render(
+      <DiagramControls
+        handleZoomIn={vi.fn()}
+        handleZoomOut={vi.fn()}
+        handleZoomReset={vi.fn()}
+        handleFullscreen={handleFullscreen}
+        isFullscreen={false}
+        handleMinimapToggle={vi.fn()}
+        isMinimapOpen={false}
+      />,
+      {wrapper: Wrapper},
+    );
 
+    const enterButton = screen.getByRole('button', {
+      name: 'Enter fullscreen',
+    });
+    expect(enterButton).toBeInTheDocument();
+
+    await user.click(enterButton);
+    expect(handleFullscreen).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <DiagramControls
+        handleZoomIn={vi.fn()}
+        handleZoomOut={vi.fn()}
+        handleZoomReset={vi.fn()}
+        handleFullscreen={handleFullscreen}
+        isFullscreen={true}
+        handleMinimapToggle={vi.fn()}
+        isMinimapOpen={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Exit fullscreen'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should render minimap button and toggle', async () => {
+    const handleMinimapToggle = vi.fn();
+    const {user, rerender} = render(
+      <DiagramControls
+        handleZoomIn={vi.fn()}
+        handleZoomOut={vi.fn()}
+        handleZoomReset={vi.fn()}
+        handleFullscreen={vi.fn()}
+        isFullscreen={false}
+        handleMinimapToggle={handleMinimapToggle}
+        isMinimapOpen={false}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    const showButton = screen.getByRole('button', {name: 'Show minimap'});
+    expect(showButton).toBeInTheDocument();
+
+    await user.click(showButton);
+    expect(handleMinimapToggle).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <DiagramControls
+        handleZoomIn={vi.fn()}
+        handleZoomOut={vi.fn()}
+        handleZoomReset={vi.fn()}
+        handleFullscreen={vi.fn()}
+        isFullscreen={false}
+        handleMinimapToggle={handleMinimapToggle}
+        isMinimapOpen={true}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Hide minimap'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render download button', async () => {
     render(
       <DiagramControls
-        handleZoomIn={handleZoomIn}
-        handleZoomOut={handleZoomOut}
-        handleZoomReset={handleZoomReset}
+        handleZoomIn={vi.fn()}
+        handleZoomOut={vi.fn()}
+        handleZoomReset={vi.fn()}
+        handleFullscreen={vi.fn()}
+        isFullscreen={false}
+        handleMinimapToggle={vi.fn()}
+        isMinimapOpen={false}
       />,
       {wrapper: Wrapper},
     );

--- a/operate/client/src/modules/components/Diagram/DiagramControlsNext/index.tsx
+++ b/operate/client/src/modules/components/Diagram/DiagramControlsNext/index.tsx
@@ -6,12 +6,20 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Add, CenterCircle, Subtract} from '@carbon/react/icons';
 import {
-  ButtonContainer,
-  ZoomResetButton,
-  ZoomOutButton,
-  ZoomInButton,
+  Add,
+  CenterCircle,
+  Subtract,
+  Maximize,
+  Minimize,
+  Plan,
+} from '@carbon/react/icons';
+import {
+  ControlsContainer,
+  ButtonsGroup,
+  DownloadGroup,
+  ControlButton,
+  MinimapButton,
   DownloadBPMNDefinitionXML,
 } from './styled';
 
@@ -19,6 +27,10 @@ type Props = {
   handleZoomReset: () => void;
   handleZoomIn: () => void;
   handleZoomOut: () => void;
+  handleFullscreen: () => void;
+  isFullscreen: boolean;
+  handleMinimapToggle: () => void;
+  isMinimapOpen: boolean;
   processDefinitionKey?: string;
 };
 
@@ -26,46 +38,75 @@ const DiagramControls: React.FC<Props> = ({
   handleZoomReset,
   handleZoomIn,
   handleZoomOut,
+  handleFullscreen,
+  isFullscreen,
+  handleMinimapToggle,
+  isMinimapOpen,
   processDefinitionKey,
 }) => {
   return (
-    <ButtonContainer>
-      <ZoomResetButton
-        size="sm"
-        kind="tertiary"
-        align="left"
-        label="Reset diagram zoom"
-        aria-label="Reset diagram zoom"
-        onClick={handleZoomReset}
-      >
-        <CenterCircle />
-      </ZoomResetButton>
-      <ZoomInButton
-        size="sm"
-        kind="tertiary"
-        align="left"
-        label="Zoom in diagram"
-        aria-label="Zoom in diagram"
-        onClick={handleZoomIn}
-      >
-        <Add />
-      </ZoomInButton>
-      <ZoomOutButton
-        size="sm"
-        kind="tertiary"
-        align="left"
-        label="Zoom out diagram"
-        aria-label="Zoom out diagram"
-        onClick={handleZoomOut}
-      >
-        <Subtract />
-      </ZoomOutButton>
-      {processDefinitionKey === undefined ? null : (
-        <DownloadBPMNDefinitionXML
-          processDefinitionKey={processDefinitionKey}
-        />
+    <ControlsContainer>
+      <ButtonsGroup>
+        <ControlButton
+          size="sm"
+          kind="tertiary"
+          align="top"
+          label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+          aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+          onClick={handleFullscreen}
+        >
+          {isFullscreen ? <Minimize /> : <Maximize />}
+        </ControlButton>
+        <MinimapButton
+          size="sm"
+          kind="tertiary"
+          align="top"
+          label={isMinimapOpen ? 'Hide minimap' : 'Show minimap'}
+          aria-label={isMinimapOpen ? 'Hide minimap' : 'Show minimap'}
+          onClick={handleMinimapToggle}
+          $isSelected={isMinimapOpen}
+        >
+          <Plan />
+        </MinimapButton>
+        <ControlButton
+          size="sm"
+          kind="tertiary"
+          align="top"
+          label="Reset diagram zoom"
+          aria-label="Reset diagram zoom"
+          onClick={handleZoomReset}
+        >
+          <CenterCircle />
+        </ControlButton>
+        <ControlButton
+          size="sm"
+          kind="tertiary"
+          align="top"
+          label="Zoom out diagram"
+          aria-label="Zoom out diagram"
+          onClick={handleZoomOut}
+        >
+          <Subtract />
+        </ControlButton>
+        <ControlButton
+          size="sm"
+          kind="tertiary"
+          align="top"
+          label="Zoom in diagram"
+          aria-label="Zoom in diagram"
+          onClick={handleZoomIn}
+        >
+          <Add />
+        </ControlButton>
+      </ButtonsGroup>
+      {processDefinitionKey !== undefined && (
+        <DownloadGroup>
+          <DownloadBPMNDefinitionXML
+            processDefinitionKey={processDefinitionKey}
+          />
+        </DownloadGroup>
       )}
-    </ButtonContainer>
+    </ControlsContainer>
   );
 };
 

--- a/operate/client/src/modules/components/Diagram/DiagramControlsNext/styled.ts
+++ b/operate/client/src/modules/components/Diagram/DiagramControlsNext/styled.ts
@@ -10,31 +10,68 @@ import {IconButton} from '@carbon/react';
 import styled, {css} from 'styled-components';
 import {DownloadBPMNDefinitionXML as BaseDownloadBPMNDefinitionXML} from 'modules/components/DownloadBPMNDefinitionXML';
 
-const ButtonContainer = styled.div`
+const ControlsContainer = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   position: absolute;
   right: var(--cds-spacing-05);
   bottom: var(--cds-spacing-05);
+  gap: var(--cds-spacing-03);
+  align-items: center;
+`;
+
+const ButtonsGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+  background-color: var(--cds-layer-01);
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+`;
+
+const DownloadGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+  background-color: var(--cds-layer-01);
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 `;
 
 const buttonStyles = css`
-  background-color: var(--cds-background);
+  background-color: transparent;
+  border: none;
+  color: inherit;
+
+  &:hover {
+    background-color: var(--cds-layer-hover);
+    color: inherit;
+  }
+
+  &:active {
+    background-color: var(--cds-layer-active);
+    color: inherit;
+  }
+
+  svg {
+    fill: currentColor;
+  }
 `;
 
-const ZoomResetButton = styled(IconButton)`
-  ${buttonStyles}
-  margin-bottom: var(--cds-spacing-02);
-`;
-
-const ZoomInButton = styled(IconButton)`
+const ControlButton = styled(IconButton)`
   ${buttonStyles}
 `;
 
-const ZoomOutButton = styled(IconButton)`
+type MinimapButtonProps = {
+  $isSelected?: boolean;
+};
+
+const MinimapButton = styled(IconButton)<MinimapButtonProps>`
   ${buttonStyles}
-  border-top: none;
-  margin-bottom: var(--cds-spacing-02);
+  ${({$isSelected}) =>
+    $isSelected
+      ? css`
+          background-color: var(--cds-layer-selected);
+        `
+      : ''}
 `;
 
 const DownloadBPMNDefinitionXML = styled(BaseDownloadBPMNDefinitionXML)`
@@ -42,9 +79,10 @@ const DownloadBPMNDefinitionXML = styled(BaseDownloadBPMNDefinitionXML)`
 `;
 
 export {
-  ButtonContainer,
-  ZoomResetButton,
-  ZoomInButton,
-  ZoomOutButton,
+  ControlsContainer,
+  ButtonsGroup,
+  DownloadGroup,
+  ControlButton,
+  MinimapButton,
   DownloadBPMNDefinitionXML,
 };

--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -52,6 +52,74 @@ type Props = {
   hasOuterBorderOnSelection?: boolean;
 };
 
+const useFullscreen = (
+  diagramRef: React.RefObject<HTMLDivElement | null>,
+  viewerRef: React.RefObject<BpmnJS | null>,
+) => {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const handleFullscreen = useCallback(() => {
+    const el = diagramRef.current;
+    if (el === null) {
+      return;
+    }
+
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+      return;
+    }
+
+    el.requestFullscreen();
+  }, [diagramRef]);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === diagramRef.current);
+
+      requestAnimationFrame(() => {
+        viewerRef.current?.notifyResize();
+        viewerRef.current?.zoomReset();
+      });
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
+  }, [diagramRef, viewerRef]);
+
+  return {isFullscreen, handleFullscreen};
+};
+
+const useMinimap = (
+  diagramCanvasRef: React.RefObject<HTMLDivElement | null>,
+  viewer: BpmnJS,
+  isDiagramRendered: boolean,
+) => {
+  const [isMinimapOpen, setIsMinimapOpen] = useState(false);
+
+  const resetMinimap = useCallback(() => {
+    setIsMinimapOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (isDiagramRendered && diagramCanvasRef.current) {
+      const minimap = diagramCanvasRef.current.querySelector('.djs-minimap');
+      if (minimap) {
+        minimap.setAttribute('aria-hidden', 'true');
+      }
+    }
+  }, [isDiagramRendered, diagramCanvasRef]);
+
+  const handleMinimapToggle = useCallback(() => {
+    viewer.toggleMinimap();
+    setIsMinimapOpen(viewer.isMinimapOpen());
+  }, [viewer]);
+
+  return {isMinimapOpen, handleMinimapToggle, resetMinimap};
+};
+
 const Diagram: React.FC<Props> = observer(
   ({
     xml,
@@ -73,8 +141,6 @@ const Diagram: React.FC<Props> = observer(
     const [isDiagramRendered, setIsDiagramRendered] = useState(false);
     const viewerRef = useRef<BpmnJS | null>(null);
     const [isViewboxChanging, setIsViewboxChanging] = useState(false);
-    const [isFullscreen, setIsFullscreen] = useState(false);
-    const [isMinimapOpen, setIsMinimapOpen] = useState(false);
 
     function getViewer() {
       if (viewerRef.current === null) {
@@ -83,6 +149,16 @@ const Diagram: React.FC<Props> = observer(
       return viewerRef.current;
     }
     const viewer = getViewer();
+
+    const {isFullscreen, handleFullscreen} = useFullscreen(
+      diagramRef,
+      viewerRef,
+    );
+    const {isMinimapOpen, handleMinimapToggle, resetMinimap} = useMinimap(
+      diagramCanvasRef,
+      viewer,
+      isDiagramRendered,
+    );
 
     useLayoutEffect(() => {
       async function renderDiagram() {
@@ -100,7 +176,7 @@ const Diagram: React.FC<Props> = observer(
             hasOuterBorderOnSelection,
           });
           setIsDiagramRendered(true);
-          setIsMinimapOpen(false);
+          resetMinimap();
         }
       }
       renderDiagram();
@@ -114,16 +190,8 @@ const Diagram: React.FC<Props> = observer(
       highlightedElementIds,
       nonSelectableNodeTooltipText,
       hasOuterBorderOnSelection,
+      resetMinimap,
     ]);
-
-    useEffect(() => {
-      if (isDiagramRendered && diagramCanvasRef.current) {
-        const minimap = diagramCanvasRef.current.querySelector('.djs-minimap');
-        if (minimap) {
-          minimap.setAttribute('aria-hidden', 'true');
-        }
-      }
-    }, [isDiagramRendered]);
 
     useEffect(() => {
       if (onElementSelection !== undefined) {
@@ -143,74 +211,6 @@ const Diagram: React.FC<Props> = observer(
         viewer.reset();
       };
     }, [viewer]);
-
-    const handleFullscreen = useCallback(() => {
-      const el = diagramRef.current;
-      if (el === null) {
-        return;
-      }
-
-      if (!document.fullscreenElement) {
-        if (el.requestFullscreen) {
-          el.requestFullscreen();
-        } else {
-          (
-            el as HTMLElement & {webkitRequestFullscreen?: () => void}
-          ).webkitRequestFullscreen?.();
-        }
-      } else {
-        if (document.exitFullscreen) {
-          document.exitFullscreen();
-        } else {
-          (
-            document as Document & {webkitExitFullscreen?: () => void}
-          ).webkitExitFullscreen?.();
-        }
-      }
-    }, []);
-
-    const handleMinimapToggle = useCallback(() => {
-      viewer.toggleMinimap();
-      setIsMinimapOpen(viewer.isMinimapOpen());
-    }, [viewer]);
-
-    useEffect(() => {
-      const handleFullscreenChange = () => {
-        const fullscreenElement =
-          document.fullscreenElement ??
-          (document as Document & {webkitFullscreenElement?: Element})
-            .webkitFullscreenElement ??
-          null;
-
-        const isCurrentlyFullscreen =
-          fullscreenElement !== null &&
-          fullscreenElement === diagramRef.current;
-
-        setIsFullscreen(isCurrentlyFullscreen);
-
-        requestAnimationFrame(() => {
-          viewerRef.current?.notifyResize();
-          viewerRef.current?.zoomReset();
-        });
-      };
-
-      document.addEventListener('fullscreenchange', handleFullscreenChange);
-      document.addEventListener(
-        'webkitfullscreenchange',
-        handleFullscreenChange,
-      );
-
-      return () => {
-        document.removeEventListener(
-          'fullscreenchange',
-          handleFullscreenChange,
-        );
-        document.removeEventListener(
-          'webkitfullscreenchange',
-          handleFullscreenChange,
-        );
-      };
-    }, []);
 
     return (
       <StyledDiagram

--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -6,7 +6,13 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import React, {useRef, useEffect, useLayoutEffect, useState} from 'react';
+import React, {
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useCallback,
+} from 'react';
 import {
   BpmnJS,
   type OnElementSelection,
@@ -63,9 +69,12 @@ const Diagram: React.FC<Props> = observer(
     hasOuterBorderOnSelection = true,
   }) => {
     const diagramCanvasRef = useRef<HTMLDivElement | null>(null);
+    const diagramRef = useRef<HTMLDivElement | null>(null);
     const [isDiagramRendered, setIsDiagramRendered] = useState(false);
     const viewerRef = useRef<BpmnJS | null>(null);
     const [isViewboxChanging, setIsViewboxChanging] = useState(false);
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const [isMinimapOpen, setIsMinimapOpen] = useState(false);
 
     function getViewer() {
       if (viewerRef.current === null) {
@@ -91,6 +100,7 @@ const Diagram: React.FC<Props> = observer(
             hasOuterBorderOnSelection,
           });
           setIsDiagramRendered(true);
+          setIsMinimapOpen(false);
         }
       }
       renderDiagram();
@@ -105,6 +115,15 @@ const Diagram: React.FC<Props> = observer(
       nonSelectableNodeTooltipText,
       hasOuterBorderOnSelection,
     ]);
+
+    useEffect(() => {
+      if (isDiagramRendered && diagramCanvasRef.current) {
+        const minimap = diagramCanvasRef.current.querySelector('.djs-minimap');
+        if (minimap) {
+          minimap.setAttribute('aria-hidden', 'true');
+        }
+      }
+    }, [isDiagramRendered]);
 
     useEffect(() => {
       if (onElementSelection !== undefined) {
@@ -125,9 +144,81 @@ const Diagram: React.FC<Props> = observer(
       };
     }, [viewer]);
 
+    const handleFullscreen = useCallback(() => {
+      const el = diagramRef.current;
+      if (el === null) {
+        return;
+      }
+
+      if (!document.fullscreenElement) {
+        if (el.requestFullscreen) {
+          el.requestFullscreen();
+        } else {
+          (
+            el as HTMLElement & {webkitRequestFullscreen?: () => void}
+          ).webkitRequestFullscreen?.();
+        }
+      } else {
+        if (document.exitFullscreen) {
+          document.exitFullscreen();
+        } else {
+          (
+            document as Document & {webkitExitFullscreen?: () => void}
+          ).webkitExitFullscreen?.();
+        }
+      }
+    }, []);
+
+    const handleMinimapToggle = useCallback(() => {
+      viewer.toggleMinimap();
+      setIsMinimapOpen(viewer.isMinimapOpen());
+    }, [viewer]);
+
+    useEffect(() => {
+      const handleFullscreenChange = () => {
+        const fullscreenElement =
+          document.fullscreenElement ??
+          (document as Document & {webkitFullscreenElement?: Element})
+            .webkitFullscreenElement ??
+          null;
+
+        const isCurrentlyFullscreen =
+          fullscreenElement !== null &&
+          fullscreenElement === diagramRef.current;
+
+        setIsFullscreen(isCurrentlyFullscreen);
+
+        requestAnimationFrame(() => {
+          viewerRef.current?.notifyResize();
+          viewerRef.current?.zoomReset();
+        });
+      };
+
+      document.addEventListener('fullscreenchange', handleFullscreenChange);
+      document.addEventListener(
+        'webkitfullscreenchange',
+        handleFullscreenChange,
+      );
+
+      return () => {
+        document.removeEventListener(
+          'fullscreenchange',
+          handleFullscreenChange,
+        );
+        document.removeEventListener(
+          'webkitfullscreenchange',
+          handleFullscreenChange,
+        );
+      };
+    }, []);
+
     return (
-      <StyledDiagram data-testid="diagram">
-        <DiagramCanvas ref={diagramCanvasRef} />
+      <StyledDiagram
+        data-testid="diagram"
+        ref={diagramRef}
+        $isFullscreen={isFullscreen}
+      >
+        <DiagramCanvas ref={diagramCanvasRef} data-testid="diagram-canvas" />
         {isDiagramRendered && (
           <>
             {IS_NEW_PROCESS_INSTANCE_PAGE ? (
@@ -135,6 +226,10 @@ const Diagram: React.FC<Props> = observer(
                 handleZoomIn={viewer.zoomIn}
                 handleZoomOut={viewer.zoomOut}
                 handleZoomReset={viewer.zoomReset}
+                handleFullscreen={handleFullscreen}
+                isFullscreen={isFullscreen}
+                handleMinimapToggle={handleMinimapToggle}
+                isMinimapOpen={isMinimapOpen}
                 processDefinitionKey={processDefinitionKey}
               />
             ) : (

--- a/operate/client/src/modules/components/Diagram/styled.ts
+++ b/operate/client/src/modules/components/Diagram/styled.ts
@@ -8,10 +8,17 @@
 
 import styled from 'styled-components';
 
-const Diagram = styled.div`
+const Diagram = styled.div<{$isFullscreen?: boolean}>`
   height: 100%;
   width: 100%;
   position: relative;
+
+  ${({$isFullscreen}) =>
+    $isFullscreen
+      ? `
+    background-color: var(--cds-layer-01);
+  `
+      : ''}
 `;
 
 const DiagramCanvas = styled.div`
@@ -20,6 +27,7 @@ const DiagramCanvas = styled.div`
   width: 100%;
   left: 0;
   top: 0;
+  min-height: 200px;
 
   .op-highlighted.djs-shape .djs-visual > :nth-child(1) {
     stroke: var(--cds-background-brand) !important;
@@ -45,6 +53,39 @@ const DiagramCanvas = styled.div`
     polygon {
       fill: var(--cds-highlight) !important;
     }
+  }
+
+  .djs-minimap {
+    top: auto !important;
+    bottom: calc(
+      var(--cds-spacing-05) + 48px + var(--cds-spacing-02)
+    ) !important;
+    right: var(--cds-spacing-05) !important;
+    z-index: 10;
+    background-color: var(--cds-layer-01) !important;
+    border-color: var(--cds-border-subtle-01) !important;
+  }
+
+  .djs-minimap .map {
+    width: 240px !important;
+    height: 135px !important;
+  }
+
+  .djs-minimap .toggle:before {
+    content: '' !important;
+  }
+
+  .djs-minimap:not(.open) .toggle {
+    display: none;
+  }
+
+  .djs-minimap.open .overlay {
+    background: var(--cds-layer-02) !important;
+    opacity: 0.2;
+  }
+
+  .djs-minimap .viewport-dom {
+    border-color: var(--cds-background-brand) !important;
   }
 `;
 

--- a/operate/client/src/modules/components/DownloadBPMNDefinitionXML/index.tsx
+++ b/operate/client/src/modules/components/DownloadBPMNDefinitionXML/index.tsx
@@ -61,7 +61,7 @@ const DownloadBPMNDefinitionXML: React.FC<Props> = ({
     <IconButton
       kind="tertiary"
       size="sm"
-      align="left"
+      align="top-right"
       disabled={isPending}
       onClick={() =>
         startTransition(async () => {

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,6 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_NEW_PROCESS_INSTANCE_PAGE = false;
+const IS_NEW_PROCESS_INSTANCE_PAGE = true;
 
 export {IS_NEW_PROCESS_INSTANCE_PAGE};

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,6 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_NEW_PROCESS_INSTANCE_PAGE = true;
+const IS_NEW_PROCESS_INSTANCE_PAGE = false;
 
 export {IS_NEW_PROCESS_INSTANCE_PAGE};

--- a/operate/client/src/modules/types/bpmn-js.d.ts
+++ b/operate/client/src/modules/types/bpmn-js.d.ts
@@ -184,6 +184,11 @@ declare module 'bpmn-js/lib/NavigatedViewer' {
     get(module: 'zoomScroll'): {
       stepZoom(step: number): void;
     };
+    get(module: 'minimap'): {
+      open(): void;
+      close(): void;
+      isOpen(): boolean;
+    };
 
     on: EventCallback;
     off: EventCallback;

--- a/operate/client/src/setupTests.tsx
+++ b/operate/client/src/setupTests.tsx
@@ -98,6 +98,8 @@ vi.mock('modules/stores/licenseTag', () => ({
 
 vi.mock('bpmn-js/lib/features/outline', () => ({default: () => {}}));
 
+vi.mock('diagram-js-minimap', () => ({default: () => {}}));
+
 vi.mock('@floating-ui/react-dom', async () => {
   const originalModule = await vi.importActual('@floating-ui/react-dom');
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -25,7 +25,7 @@ export class OperateDiagramPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.diagram = this.page.getByTestId('diagram');
+    this.diagram = this.page.getByTestId('diagram-canvas');
     this.popover = this.page.getByTestId('popover');
     this.popoverLink = (name: string | RegExp) =>
       this.popover.getByRole('link', {name});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -101,8 +101,8 @@ class OperateProcessInstancePage {
 
   constructor(page: Page) {
     this.page = page;
-    this.diagram = page.getByTestId('diagram');
-    this.drilldownButton = page.locator('.bjs-drilldown');
+    this.diagram = page.getByTestId('diagram-canvas');
+    this.drilldownButton = this.diagram.locator('.bjs-drilldown').first();
     this.completedIcon = page
       .getByTestId('instance-header')
       .getByTestId('COMPLETED-icon');
@@ -442,7 +442,11 @@ class OperateProcessInstancePage {
   }
 
   async clickFlowNode(flowNodeName: string) {
-    await this.diagram.getByText(flowNodeName).first().click({timeout: 20000});
+    await this.diagram
+      .locator('.djs-element[data-element-id]')
+      .filter({hasText: new RegExp(`${flowNodeName}`, 'i')})
+      .first()
+      .click({timeout: 20000});
   }
 
   async navigateToRootScope() {
@@ -529,12 +533,15 @@ class OperateProcessInstancePage {
     return {
       clickFlowNode: (flowNodeName: string) => {
         return this.diagram
-          .getByText(flowNodeName)
+          .locator('.djs-element[data-element-id]')
+          .filter({hasText: new RegExp(`${flowNodeName}`, 'i')})
           .first()
           .click({timeout: 20000});
       },
       getFlowNode: (flowNodeName: string) => {
-        return this.diagram.getByText(flowNodeName);
+        return this.diagram
+          .locator('.djs-element[data-element-id]')
+          .filter({hasText: new RegExp(`${flowNodeName}`, 'i')});
       },
       clickEvent: async (eventName: string) => {
         await this.diagram

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -222,7 +222,7 @@ test.describe('Process Instance', () => {
     operateProcessInstancePage,
     operateDiagramPage,
   }) => {
-    const {diagram} = operateProcessInstancePage;
+    const {diagramHelper} = operateProcessInstancePage;
 
     await test.step('Navigate to collapsed sub process instance', async () => {
       await operateProcessInstancePage.gotoProcessInstancePage({
@@ -240,7 +240,7 @@ test.describe('Process Instance', () => {
       await operateProcessInstancePage.clickTreeItem(/submit application/i);
 
       await expect(
-        diagram.getByText('submit application', {exact: false}),
+        diagramHelper.getFlowNode('submit application'),
       ).toBeVisible();
     });
 
@@ -248,7 +248,7 @@ test.describe('Process Instance', () => {
       await page.keyboard.press('ArrowRight');
       await operateProcessInstancePage.clickTreeItem(/fill form/i);
       await expect(
-        diagram.getByText('fill form', {exact: false}),
+        diagramHelper.getFlowNode('fill form'),
       ).toBeVisible();
       await operateProcessInstancePage.clickTreeItem(/fill form/i);
 
@@ -267,19 +267,21 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Click on collapsed sub process', async () => {
-      await diagram.getByText('collapsedSubProcess').click();
+      await operateProcessInstancePage.diagram
+        .getByText('collapsedSubProcess')
+        .click();
 
       await expect(
-        diagram.getByText('submit application', {exact: false}),
+        diagramHelper.getFlowNode('submit application'),
       ).toBeVisible();
-      await expect(diagram.getByText('fill form', {exact: false})).toBeHidden();
+      await expect(diagramHelper.getFlowNode('fill form')).toBeHidden();
     });
 
     await test.step('Navigate back to start event', async () => {
       await operateProcessInstancePage.clickTreeItem('startEvent', true);
 
       await expect(
-        diagram.getByText('submit application', {exact: false}),
+        diagramHelper.getFlowNode('submit application'),
       ).toBeVisible();
     });
 
@@ -287,7 +289,7 @@ test.describe('Process Instance', () => {
       await operateProcessInstancePage.drilldownButton.click();
 
       await expect(
-        diagram.getByText('fill form', {exact: false}),
+        diagramHelper.getFlowNode('fill form'),
       ).toBeVisible();
     });
   });


### PR DESCRIPTION
## Description

- Add `diagram-js-minimap`
- Add fullscreen mode and minimap toggle to the BPMN diagram viewer behind the `IS_NEW_PROCESS_INSTANCE_PAGE` feature flag                                                                                                                       
- Both controls are added to `DiagramControlsNext` only, the old `DiagramControls` component is untouched             
- Extends Diagram component with fullscreen/minimap state and handlers, fullscreenchange event listener, feature flag conditional rendering
- Add tests and mocks for test setup

> [!NOTE]
> The diagram-js-minimap plugin renders a full copy of all diagram SVG elements into the DOM as soon as it's registered. This happens regardless of whether the minimap is visually open. Playwright's getByText matches hidden elements, so any test using text-based locators to find diagram flow nodes would resolve to 2+ elements and fail with strict mode violations.                                                                                                                                                                                                  
> Implemented solution:                                                                                                                                                      
>  1. Use data-element-id selectors instead of text matching(as main diagram uses them, and minimap does not) +  `getFlowNodeById(elementId)` helper was added to the Diagram page object to suupport this update.
>  2. Added data-testid="diagram-canvas" to the canvas container(to help to scope locators)
  Note: the minimap is still a child of diagram-canvas (bpmn-js injects it into the same container), so this alone doesn't exclude minimap text, that's why data-element-id selectors are the primary fix.
> 3. Added aria-hidden="true" to the minimap container. As the minimap is more of a visual navigation aid, not interactive content, plus it helps if tests use role-based locators.

## Related issues

closes #47038
