### PR TITLE
fix: replace NULL with blank string to fix oracle handling

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
@@ -12,6 +12,7 @@ import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobEntity.JobKind;
 import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.entities.JobEntity.ListenerEventType;
+import java.util.Objects;
 
 public class JobEntityMapper {
 
@@ -19,7 +20,7 @@ public class JobEntityMapper {
     return new JobEntity.Builder()
         .jobKey(jobDbModel.jobKey())
         .type(jobDbModel.type())
-        .worker(jobDbModel.worker())
+        .worker(Objects.requireNonNullElse(jobDbModel.worker(), ""))
         .state(JobState.valueOf(jobDbModel.state().name()))
         .kind(JobKind.valueOf(jobDbModel.kind().name()))
         .listenerEventType(ListenerEventType.valueOf(jobDbModel.listenerEventType().name()))

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
@@ -103,7 +103,7 @@ public class JobEntityMapperTest {
     // Then
     assertThat(entity.jobKey()).isNotNull();
     assertThat(entity.type()).isNull();
-    assertThat(entity.worker()).isNull();
+    assertThat(entity.worker()).isEqualTo(""); // worker must be empty string
     assertThat(entity.state()).isNotNull();
     assertThat(entity.kind()).isNotNull();
     assertThat(entity.listenerEventType()).isNotNull();


### PR DESCRIPTION
## Description

Handles Oracles special empty string handling for `job.worker`. 

Background: Oracle treats any empty String value as `NULL`, but the API spec of the `job.worker` field is non-null and must at least be an empty String.

## Related issues

closes #46454