### PR TITLE
[Backport stable/8.9] Add required response properties to message publish and correlation endpoint

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -167,6 +167,10 @@ components:
         The message key of the correlated message, as well as the first process instance key it
         correlated with.
       type: object
+      required:
+        - tenantId
+        - messageKey
+        - processInstanceKey
       properties:
         tenantId:
           description: The tenant ID of the correlated message
@@ -217,6 +221,9 @@ components:
     MessagePublicationResult:
       description: The message key of the published message.
       type: object
+      required:
+        - tenantId
+        - messageKey
       properties:
         tenantId:
           description: The tenant ID of the message.


### PR DESCRIPTION
# Description
Backport of #47498 to `stable/8.9`.

relates to #47302