### PR TITLE
feat: add JobTimeSeriesStatistics RDBMS implementation

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTimeSeriesStatisticsDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTimeSeriesStatisticsDbQuery.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.db.rdbms.sql.columns.JobMetricsBatchColumn;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record JobTimeSeriesStatisticsDbQuery(
+    JobTimeSeriesStatisticsFilter filter,
+    List<String> authorizedTenantIds,
+    long resolutionSeconds,
+    String timeBucketColumn,
+    DbQueryPage page,
+    DbQuerySorting<JobTimeSeriesStatisticsEntity> sort) {
+
+  public static JobTimeSeriesStatisticsDbQuery of(
+      final Function<
+              JobTimeSeriesStatisticsDbQuery.Builder, ObjectBuilder<JobTimeSeriesStatisticsDbQuery>>
+          fn) {
+    return fn.apply(new JobTimeSeriesStatisticsDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<JobTimeSeriesStatisticsDbQuery> {
+    private JobTimeSeriesStatisticsFilter filter;
+    private List<String> authorizedTenantIds;
+    private DbQueryPage page;
+    private DbQuerySorting<JobTimeSeriesStatisticsEntity> sort;
+
+    public Builder filter(final JobTimeSeriesStatisticsFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<
+                JobTimeSeriesStatisticsFilter.Builder, ObjectBuilder<JobTimeSeriesStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.jobTimeSeriesStatistics(fn));
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<JobTimeSeriesStatisticsEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    @Override
+    public JobTimeSeriesStatisticsDbQuery build() {
+      final var f = Objects.requireNonNull(filter, "filter must not be null");
+      final long resolutionSeconds = Math.max(1L, f.resolution().getSeconds());
+      return new JobTimeSeriesStatisticsDbQuery(
+          f,
+          Objects.requireNonNullElse(authorizedTenantIds, Collections.emptyList()),
+          resolutionSeconds,
+          JobMetricsBatchColumn.START_TIME.name(),
+          page,
+          sort);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTimeSeriesStatisticsDbResult.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTimeSeriesStatisticsDbResult.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import java.time.OffsetDateTime;
+
+public record JobTimeSeriesStatisticsDbResult(
+    OffsetDateTime bucketTime,
+    Long createdCount,
+    OffsetDateTime lastCreatedAt,
+    Long completedCount,
+    OffsetDateTime lastCompletedAt,
+    Long failedCount,
+    OffsetDateTime lastFailedAt) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -11,9 +11,11 @@ import static java.util.Optional.ofNullable;
 
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
+import io.camunda.db.rdbms.sql.columns.JobTimeSeriesStatisticsColumn;
 import io.camunda.db.rdbms.sql.columns.JobTypeStatisticsColumn;
 import io.camunda.db.rdbms.sql.columns.JobWorkerStatisticsColumn;
 import io.camunda.search.clients.reader.JobMetricsBatchReader;
@@ -28,6 +30,7 @@ import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.JobTimeSeriesStatisticsSort;
 import io.camunda.search.sort.JobTypeStatisticsSort;
 import io.camunda.search.sort.JobWorkerStatisticsSort;
 import io.camunda.security.reader.ResourceAccessChecks;
@@ -50,15 +53,21 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
   private static final JobWorkerStatisticsSort JOB_WORKER_STATS_FIXED_SORT =
       JobWorkerStatisticsSort.of(b -> b.worker().asc());
 
+  // Fixed sort: time asc
+  private static final JobTimeSeriesStatisticsSort JOB_TIME_SERIES_FIXED_SORT =
+      JobTimeSeriesStatisticsSort.of(b -> b.time().asc());
+
   private final JobMetricsBatchMapper jobMetricsBatchMapper;
 
   private final AbstractEntityReader<JobWorkerStatisticsEntity> workerStatsReader;
+  private final AbstractEntityReader<JobTimeSeriesStatisticsEntity> timeSeriesStatsReader;
 
   public JobMetricsBatchDbReader(
       final JobMetricsBatchMapper jobMetricsBatchMapper, final RdbmsReaderConfig readerConfig) {
     super(JobTypeStatisticsColumn.values(), readerConfig);
     this.jobMetricsBatchMapper = jobMetricsBatchMapper;
     workerStatsReader = new WorkerStatsReader(readerConfig);
+    timeSeriesStatsReader = new TimeSeriesStatsReader(readerConfig);
   }
 
   @Override
@@ -166,7 +175,41 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
   @Override
   public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
       final JobTimeSeriesStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException("Time series statistics are not implemented yet");
+    LOG.trace("[RDBMS DB] Search job time-series statistics with {}", query);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return EmptyResults.JOB_TIME_SERIES_STATISTICS;
+    }
+    final var dbSort = timeSeriesStatsReader.convertSort(JOB_TIME_SERIES_FIXED_SORT);
+    final var dbPage =
+        timeSeriesStatsReader.convertPaging(
+            dbSort, Optional.ofNullable(query.page()).orElse(SearchQueryPage.DEFAULT));
+
+    final var dbQuery =
+        JobTimeSeriesStatisticsDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(dbPage));
+
+    final var results = jobMetricsBatchMapper.jobTimeSeriesStatistics(dbQuery);
+    final var entities =
+        results.stream()
+            .map(
+                result ->
+                    new JobTimeSeriesStatisticsEntity(
+                        result.bucketTime(),
+                        new StatusMetric(
+                            ofNullable(result.createdCount()).orElse(0L), result.lastCreatedAt()),
+                        new StatusMetric(
+                            ofNullable(result.completedCount()).orElse(0L),
+                            result.lastCompletedAt()),
+                        new StatusMetric(
+                            ofNullable(result.failedCount()).orElse(0L), result.lastFailedAt())))
+            .toList();
+
+    return timeSeriesStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
   }
 
   /** Inner reader for worker statistics to provide typed AbstractEntityReader methods. */
@@ -178,12 +221,25 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
     }
   }
 
+  /** Inner reader for time-series statistics to provide typed AbstractEntityReader methods. */
+  private static final class TimeSeriesStatsReader
+      extends AbstractEntityReader<JobTimeSeriesStatisticsEntity> {
+
+    TimeSeriesStatsReader(final RdbmsReaderConfig readerConfig) {
+      super(JobTimeSeriesStatisticsColumn.values(), readerConfig);
+    }
+  }
+
   private static final class EmptyResults {
     private static final SearchQueryResult<JobTypeStatisticsEntity> JOB_TYPE_STATISTICS =
         SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
 
     private static final SearchQueryResult<JobWorkerStatisticsEntity> JOB_WORKER_STATISTICS =
         SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
+
+    private static final SearchQueryResult<JobTimeSeriesStatisticsEntity>
+        JOB_TIME_SERIES_STATISTICS =
+            SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
 
     private static final GlobalJobStatisticsEntity GLOBAL_JOB_STATISTICS =
         new GlobalJobStatisticsEntity(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
@@ -9,6 +9,8 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbQuery;
@@ -26,6 +28,9 @@ public interface JobMetricsBatchMapper {
   List<JobTypeStatisticsDbResult> jobTypeStatistics(JobTypeStatisticsDbQuery query);
 
   List<JobWorkerStatisticsDbResult> jobWorkerStatistics(JobWorkerStatisticsDbQuery query);
+
+  List<JobTimeSeriesStatisticsDbResult> jobTimeSeriesStatistics(
+      JobTimeSeriesStatisticsDbQuery query);
 
   int cleanupMetrics(CleanupHistoryDto dto);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobMetricsBatchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobMetricsBatchColumn.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.JobMetricsBatchEntity;
+
+/**
+ * Maps every column of the {@code JOB_METRICS_BATCH} table to the corresponding field in {@link
+ * JobMetricsBatchEntity}.
+ *
+ * <p>The string passed to each constant is the exact Java property name on the record (used by
+ * {@link SearchColumn#getPropertyValue} via reflection to retrieve the value from an entity
+ * instance).
+ */
+public enum JobMetricsBatchColumn implements SearchColumn<JobMetricsBatchEntity> {
+  KEY("key"),
+  PARTITION_ID("partitionId"),
+  START_TIME("startTime"),
+  END_TIME("endTime"),
+  INCOMPLETE_BATCH("incompleteBatch"),
+  TENANT_ID("tenantId"),
+  FAILED_COUNT("failedCount"),
+  LAST_FAILED_AT("lastFailedAt"),
+  COMPLETED_COUNT("completedCount"),
+  LAST_COMPLETED_AT("lastCompletedAt"),
+  CREATED_COUNT("createdCount"),
+  LAST_CREATED_AT("lastCreatedAt"),
+  JOB_TYPE("jobType"),
+  WORKER("worker");
+
+  private final String property;
+
+  JobMetricsBatchColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<JobMetricsBatchEntity> getEntityClass() {
+    return JobMetricsBatchEntity.class;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobTimeSeriesStatisticsColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobTimeSeriesStatisticsColumn.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
+
+public enum JobTimeSeriesStatisticsColumn implements SearchColumn<JobTimeSeriesStatisticsEntity> {
+  BUCKET_TIME("time");
+
+  private final String property;
+
+  JobTimeSeriesStatisticsColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<JobTimeSeriesStatisticsEntity> getEntityClass() {
+    return JobTimeSeriesStatisticsEntity.class;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -287,6 +287,37 @@
     </include>
   </sql>
 
+  <!--
+    Vendor-specific SQL fragment that floors a timestamp column to the nearest bucket boundary.
+    Parameters injected from the enclosing query object:
+      ${timeBucketColumn}   - the column name (e.g. START_TIME), substituted at parse time
+      #{resolutionSeconds}  - the bucket size in seconds, bound at execution time
+    Default dialect: H2 (used in unit tests)
+  -->
+  <sql id="timeBucket">
+    TIMESTAMPADD('SECOND', FLOOR(DATEDIFF('SECOND', TIMESTAMP '1970-01-01 00:00:00', ${timeBucketColumn}) / #{resolutionSeconds}) * #{resolutionSeconds}, TIMESTAMP '1970-01-01 00:00:00')
+  </sql>
+
+  <sql id="timeBucket" databaseId="postgresql">
+    TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM ${timeBucketColumn}) / #{resolutionSeconds}) * #{resolutionSeconds})
+  </sql>
+
+  <sql id="timeBucket" databaseId="mysql">
+    FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(${timeBucketColumn}) / #{resolutionSeconds}) * #{resolutionSeconds})
+  </sql>
+
+  <sql id="timeBucket" databaseId="mariadb">
+    FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(${timeBucketColumn}) / #{resolutionSeconds}) * #{resolutionSeconds})
+  </sql>
+
+  <sql id="timeBucket" databaseId="mssql">
+    TODATETIMEOFFSET(DATEADD(SECOND, (DATEDIFF_BIG(SECOND, '1970-01-01', ${timeBucketColumn}) / #{resolutionSeconds}) * #{resolutionSeconds}, '1970-01-01'), 0)
+  </sql>
+
+  <sql id="timeBucket" databaseId="oracle">
+    TIMESTAMP '1970-01-01 00:00:00 UTC' + NUMTODSINTERVAL(FLOOR((EXTRACT(DAY FROM (SYS_EXTRACT_UTC(${timeBucketColumn}) - TIMESTAMP '1970-01-01 00:00:00')) * 86400 + EXTRACT(HOUR FROM (SYS_EXTRACT_UTC(${timeBucketColumn}) - TIMESTAMP '1970-01-01 00:00:00')) * 3600 + EXTRACT(MINUTE FROM (SYS_EXTRACT_UTC(${timeBucketColumn}) - TIMESTAMP '1970-01-01 00:00:00')) * 60 + EXTRACT(SECOND FROM (SYS_EXTRACT_UTC(${timeBucketColumn}) - TIMESTAMP '1970-01-01 00:00:00'))) / #{resolutionSeconds}) * #{resolutionSeconds}, 'SECOND')
+  </sql>
+
   <resultMap id="flowNodeStatisticsResultMap"
     type="io.camunda.search.entities.ProcessFlowNodeStatisticsEntity">
     <constructor>

--- a/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
@@ -177,6 +177,70 @@
     AND WORKER IS NOT NULL
   </sql>
 
+  <resultMap id="JobTimeSeriesStatisticsResultMap"
+    type="io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbResult">
+    <constructor>
+      <arg column="BUCKET_TIME" javaType="java.time.OffsetDateTime"/>
+      <arg column="CREATED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_CREATED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="COMPLETED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_COMPLETED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="FAILED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_FAILED_AT" javaType="java.time.OffsetDateTime"/>
+    </constructor>
+  </resultMap>
+
+  <select id="jobTimeSeriesStatistics"
+    parameterType="io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbQuery"
+    resultMap="JobTimeSeriesStatisticsResultMap"
+    statementType="PREPARED">
+    SELECT
+      BUCKET_TIME,
+      SUM(CREATED_COUNT)     AS CREATED_COUNT,
+      MAX(LAST_CREATED_AT)   AS LAST_CREATED_AT,
+      SUM(COMPLETED_COUNT)   AS COMPLETED_COUNT,
+      MAX(LAST_COMPLETED_AT) AS LAST_COMPLETED_AT,
+      SUM(FAILED_COUNT)      AS FAILED_COUNT,
+      MAX(LAST_FAILED_AT)    AS LAST_FAILED_AT
+    FROM (
+      SELECT
+        <include refid="io.camunda.db.rdbms.sql.Commons.timeBucket"/> AS BUCKET_TIME,
+        CREATED_COUNT, LAST_CREATED_AT,
+        COMPLETED_COUNT, LAST_COMPLETED_AT,
+        FAILED_COUNT, LAST_FAILED_AT
+      FROM ${prefix}JOB_METRICS_BATCH
+      <include refid="io.camunda.db.rdbms.sql.JobMetricsBatchMapper.jobTimeSeriesFilter"/>
+    ) BUCKETED
+    <trim prefix="WHERE" prefixOverrides="AND">
+      <trim prefix="AND" prefixOverrides="WHERE">
+        <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+      </trim>
+    </trim>
+    GROUP BY BUCKET_TIME
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="jobTimeSeriesFilter">
+    <where>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
+      <if test="filter.from != null">
+        AND START_TIME &gt;= #{filter.from}
+      </if>
+      <if test="filter.to != null">
+        AND END_TIME &lt;= #{filter.to}
+      </if>
+      <if test="filter.jobType != null">
+        AND JOB_TYPE = #{filter.jobType}
+      </if>
+    </where>
+  </sql>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel">
     INSERT INTO ${prefix}JOB_METRICS_BATCH (JOB_METRICS_BATCH_KEY,
                                             PARTITION_ID,

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
@@ -14,10 +14,12 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbResult;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.security.reader.AuthorizationCheck;
@@ -663,7 +665,7 @@ class JobMetricsBatchDbReaderTest {
   }
 
   @Test
-  void shouldReturnJobWorkerStatisticsForLongWorkerNames() {
+  void shouldReturnJobForLongWorkerNames() {
     // given
     final var now = OffsetDateTime.now();
     final var longWorkerName =
@@ -684,5 +686,155 @@ class JobMetricsBatchDbReaderTest {
 
     // then
     assertThat(result.items().getFirst().worker()).isEqualTo(longWorkerName);
+  }
+
+  // -----------------------------------------------------------------------
+  // getJobTimeSeriesStatistics
+  // -----------------------------------------------------------------------
+
+  @Test
+  void shouldReturnEmptyTimeSeriesWhenTenantCheckEnabledButNoTenants() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobTimeSeriesStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    // when
+    final var result =
+        jobMetricsBatchDbReader.getJobTimeSeriesStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+    verifyNoInteractions(jobMetricsBatchMapper);
+  }
+
+  @Test
+  void shouldReturnTimeSeriesFromMapper() {
+    // given
+    final var bucket1 = OffsetDateTime.parse("2024-07-28T00:00:00Z");
+    final var bucket2 = OffsetDateTime.parse("2024-07-28T01:00:00Z");
+    final var lastUpdatedAt = OffsetDateTime.now();
+
+    final var dbResult1 =
+        new JobTimeSeriesStatisticsDbResult(
+            bucket1, 10L, lastUpdatedAt, 8L, lastUpdatedAt, 2L, lastUpdatedAt);
+    final var dbResult2 =
+        new JobTimeSeriesStatisticsDbResult(
+            bucket2, 5L, lastUpdatedAt, 4L, lastUpdatedAt, 1L, lastUpdatedAt);
+
+    when(jobMetricsBatchMapper.jobTimeSeriesStatistics(any()))
+        .thenReturn(List.of(dbResult1, dbResult2));
+
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobTimeSeriesStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result =
+        jobMetricsBatchDbReader.getJobTimeSeriesStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(2L);
+    assertThat(result.items()).hasSize(2);
+
+    final var item1 = result.items().get(0);
+    assertThat(item1.time()).isEqualTo(bucket1);
+    assertThat(item1.created().count()).isEqualTo(10L);
+    assertThat(item1.completed().count()).isEqualTo(8L);
+    assertThat(item1.failed().count()).isEqualTo(2L);
+
+    final var item2 = result.items().get(1);
+    assertThat(item2.time()).isEqualTo(bucket2);
+    assertThat(item2.created().count()).isEqualTo(5L);
+    assertThat(item2.completed().count()).isEqualTo(4L);
+    assertThat(item2.failed().count()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldReturnTimeSeriesWithNullCountsDefaultingToZero() {
+    // given
+    final var bucket = OffsetDateTime.parse("2024-07-28T00:00:00Z");
+    final var dbResult =
+        new JobTimeSeriesStatisticsDbResult(bucket, null, null, null, null, null, null);
+    when(jobMetricsBatchMapper.jobTimeSeriesStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobTimeSeriesStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result =
+        jobMetricsBatchDbReader.getJobTimeSeriesStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final var item = result.items().getFirst();
+    assertThat(item.time()).isEqualTo(bucket);
+    assertThat(item.created().count()).isZero();
+    assertThat(item.created().lastUpdatedAt()).isNull();
+    assertThat(item.completed().count()).isZero();
+    assertThat(item.failed().count()).isZero();
+  }
+
+  @Test
+  void shouldReturnEmptyTimeSeriesWhenMapperReturnsEmptyList() {
+    // given
+    when(jobMetricsBatchMapper.jobTimeSeriesStatistics(any())).thenReturn(List.of());
+
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobTimeSeriesStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result =
+        jobMetricsBatchDbReader.getJobTimeSeriesStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnTimeSeriesWithTimestampsPreserved() {
+    // given
+    final var bucket = OffsetDateTime.parse("2024-07-28T12:00:00Z");
+    final var lastCreated = OffsetDateTime.parse("2024-07-28T12:30:00Z");
+    final var lastCompleted = OffsetDateTime.parse("2024-07-28T12:45:00Z");
+    final var lastFailed = OffsetDateTime.parse("2024-07-28T12:59:00Z");
+
+    final var dbResult =
+        new JobTimeSeriesStatisticsDbResult(
+            bucket, 100L, lastCreated, 90L, lastCompleted, 3L, lastFailed);
+    when(jobMetricsBatchMapper.jobTimeSeriesStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobTimeSeriesStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result =
+        jobMetricsBatchDbReader.getJobTimeSeriesStatistics(query, resourceAccessChecks);
+
+    // then
+    final var item = result.items().getFirst();
+    assertThat(item.created().lastUpdatedAt()).isEqualTo(lastCreated);
+    assertThat(item.completed().lastUpdatedAt()).isEqualTo(lastCompleted);
+    assertThat(item.failed().lastUpdatedAt()).isEqualTo(lastFailed);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobMetricsBatchFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobMetricsBatchFixtures.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel.Builder;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import java.time.OffsetDateTime;
@@ -246,6 +247,59 @@ public final class JobMetricsBatchFixtures extends CommonFixtures {
                 .orElseThrow());
     assertThat(stats.isIncomplete())
         .isEqualTo(metrics.stream().anyMatch(JobMetricsBatchDbModel::incompleteBatch));
+  }
+
+  /**
+   * Asserts that a {@link JobTimeSeriesStatisticsEntity} exactly matches the counts and timestamps
+   * of a single {@link JobMetricsBatchDbModel} (single bucket = single row).
+   *
+   * <p>Timestamps are compared after normalizing both sides to UTC.
+   */
+  public static void assertTimeSeriesStats(
+      final JobTimeSeriesStatisticsEntity stats, final JobMetricsBatchDbModel metric) {
+    assertThat(stats.created().count()).isEqualTo(metric.createdCount());
+    assertThat(stats.created().lastUpdatedAt()).isEqualTo(toUtc(metric.lastCreatedAt()));
+    assertThat(stats.completed().count()).isEqualTo(metric.completedCount());
+    assertThat(stats.completed().lastUpdatedAt()).isEqualTo(toUtc(metric.lastCompletedAt()));
+    assertThat(stats.failed().count()).isEqualTo(metric.failedCount());
+    assertThat(stats.failed().lastUpdatedAt()).isEqualTo(toUtc(metric.lastFailedAt()));
+  }
+
+  /**
+   * Asserts that a {@link JobTimeSeriesStatisticsEntity} matches the aggregated result of a list of
+   * {@link JobMetricsBatchDbModel}: counts are summed, timestamps are the MAX across all models.
+   *
+   * <p>Timestamps are compared after normalizing both sides to UTC.
+   */
+  public static void assertTimeSeriesStats(
+      final JobTimeSeriesStatisticsEntity stats, final List<JobMetricsBatchDbModel> metrics) {
+    assertThat(stats.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(stats.created().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCreatedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(stats.completed().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCompletedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+    assertThat(stats.failed().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastFailedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
   }
 
   private static OffsetDateTime toUtc(final OffsetDateTime timestamp) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.rdbms.db.jobmetrics;
 
 import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.NOW;
 import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.PARTITION_ID;
+import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.assertTimeSeriesStats;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,12 +28,15 @@ import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
+import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -335,7 +339,12 @@ public class JobMetricsBatchIT {
     // when - query for a different time range
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
-            GlobalJobStatisticsQuery.of(q -> q.filter(f -> f.from(NOW).to(NOW.plusMinutes(10)))),
+            GlobalJobStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.endTime().plusSeconds(10))
+                                .to(metric.endTime().plusMinutes(10)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
@@ -1120,8 +1129,8 @@ public class JobMetricsBatchIT {
                 q ->
                     q.filter(
                         f ->
-                            f.from(NOW.plusMinutes(1))
-                                .to(NOW.plusMinutes(10))
+                            f.from(metric.endTime().plusMinutes(1))
+                                .to(metric.endTime().plusMinutes(10))
                                 .jobType(JOB_TYPE_A))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
@@ -1238,5 +1247,389 @@ public class JobMetricsBatchIT {
     assertThat(actual.items()).hasSize(1);
     assertThat(actual.items().getFirst().worker()).isEqualTo(WORKER_1);
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metrics);
+  }
+
+  // -----------------------------------------------------------------------
+  // Time-series statistics
+  // -----------------------------------------------------------------------
+
+  @TestTemplate
+  public void shouldReturnSingleTimeBucketForSingleMetric() {
+    // given — one row with a resolution larger than the window so everything lands in one bucket
+    final var metric =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1).incompleteBatch(false));
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
+
+    // when — 1-hour resolution: all data lands in one bucket
+    final var actual =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusHours(1))
+                                .to(metric.endTime().plusHours(1))
+                                .jobType(JOB_TYPE_A)
+                                .resolution(Duration.ofHours(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then
+    assertThat(actual.items()).hasSize(1);
+    JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().getFirst(), metric);
+  }
+
+  @TestTemplate
+  public void shouldAggregateTwoBatchesIntoSameBucket() {
+    // given — two rows with the same start-hour, same jobType → both collapse into one bucket
+    final var base = NOW.truncatedTo(ChronoUnit.HOURS);
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base)
+                    .endTime(base.plusMinutes(10))
+                    .incompleteBatch(false));
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_2)
+                    .startTime(base.plusMinutes(30))
+                    .endTime(base.plusMinutes(45))
+                    .incompleteBatch(false));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metric1, metric2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when — 1-hour resolution
+    final var actual =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(base.minusMinutes(1))
+                                .to(base.plusHours(1))
+                                .jobType(JOB_TYPE_A)
+                                .resolution(Duration.ofHours(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then — aggregated into a single bucket
+    assertThat(actual.items()).hasSize(1);
+    JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().getFirst(), metrics);
+  }
+
+  @TestTemplate
+  public void shouldReturnTwoBucketsWhenMetricsSpanTwoHours() {
+    // given — two rows in different hours
+    final var base = NOW.truncatedTo(ChronoUnit.HOURS);
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base)
+                    .endTime(base.plusMinutes(30))
+                    .incompleteBatch(false));
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base.plusHours(1))
+                    .endTime(base.plusHours(1).plusMinutes(30))
+                    .incompleteBatch(false));
+
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, List.of(metric1, metric2));
+
+    // when — 1-hour resolution → 2 distinct buckets
+    final var actual =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(base.minusMinutes(1))
+                                .to(base.plusHours(2))
+                                .jobType(JOB_TYPE_A)
+                                .resolution(Duration.ofHours(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then — 2 buckets, ordered ascending by time
+    assertThat(actual.items()).hasSize(2);
+    assertThat(actual.items().get(0).time()).isBefore(actual.items().get(1).time());
+    JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().get(0), metric1);
+    JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().get(1), metric2);
+  }
+
+  @TestTemplate
+  public void shouldAggregateTwoBatchesIntoFirstBucketAndKeepThirdBucketSeparate() {
+    // given — metric1 and metric2 start within the same minute → same bucket
+    //         metric3 starts in a different minute → separate bucket
+    final var base = NOW.truncatedTo(ChronoUnit.MINUTES);
+
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base)
+                    .endTime(base.plusSeconds(30))
+                    .incompleteBatch(false));
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_2)
+                    .startTime(base.plusSeconds(25))
+                    .endTime(base.plusSeconds(59))
+                    .incompleteBatch(false));
+    // metric3 starts 1 minute later → falls into the next bucket
+    final var metric3 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base.plusMinutes(1))
+                    .endTime(base.plusMinutes(1).plusSeconds(30))
+                    .incompleteBatch(false));
+
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, List.of(metric1, metric2, metric3));
+
+    // when — 1-minute resolution
+    final var actual =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(base.minusSeconds(1))
+                                .to(base.plusMinutes(2))
+                                .jobType(JOB_TYPE_A)
+                                .resolution(Duration.ofMinutes(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then — exactly 2 buckets ordered ascending by time
+    assertThat(actual.items()).hasSize(2);
+    assertThat(actual.items().get(0).time()).isBefore(actual.items().get(1).time());
+
+    // first bucket aggregates metric1 + metric2
+    JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().get(0), List.of(metric1, metric2));
+
+    // second bucket contains only metric3
+    JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().get(1), metric3);
+  }
+
+  @TestTemplate
+  public void shouldRespectJobTypeFilterForTimeSeries() {
+    // given — two different job types in the same time range
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1).incompleteBatch(false));
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_B).worker(WORKER_1).incompleteBatch(false));
+    final List<JobMetricsBatchDbModel> allMetrics = List.of(metric1, metric2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, allMetrics);
+
+    // when — filter by JOB_TYPE_A only
+    final var actual =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(allMetrics).minusMinutes(1))
+                                .to(getMaxEndTime(allMetrics).plusMinutes(1))
+                                .jobType(JOB_TYPE_A)
+                                .resolution(Duration.ofHours(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then — only JOB_TYPE_A data
+    assertThat(actual.items()).hasSize(1);
+    assertTimeSeriesStats(actual.items().get(0), metric1);
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyTimeSeriesWhenNoDataInRange() {
+    // given — data outside the query window
+    final var metric =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1).incompleteBatch(false));
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
+
+    // when — query window does not overlap the metric
+    final var windowStart = metric.endTime().plusDays(1);
+    final var actual =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(windowStart)
+                                .to(windowStart.plusDays(1))
+                                .jobType(JOB_TYPE_A)
+                                .resolution(Duration.ofHours(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then
+    assertThat(actual.items()).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldReturnFirstPageOfTimeSeries() {
+    // given — 3 batches each in a distinct minute bucket
+    final var base = NOW.truncatedTo(ChronoUnit.MINUTES);
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base)
+                    .endTime(base.plusSeconds(30))
+                    .incompleteBatch(false));
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base.plusMinutes(1))
+                    .endTime(base.plusMinutes(1).plusSeconds(30))
+                    .incompleteBatch(false));
+    final var metric3 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base.plusMinutes(2))
+                    .endTime(base.plusMinutes(2).plusSeconds(30))
+                    .incompleteBatch(false));
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, List.of(metric1, metric2, metric3));
+
+    // when — request only the first 2 buckets
+    final var firstPage =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                            f ->
+                                f.from(base.minusSeconds(1))
+                                    .to(base.plusMinutes(3))
+                                    .jobType(JOB_TYPE_A)
+                                    .resolution(Duration.ofMinutes(1)))
+                        .page(p -> p.size(2))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then — only the first 2 buckets returned, ordered ascending
+    assertThat(firstPage.items()).hasSize(2);
+    assertThat(firstPage.endCursor()).isNotNull();
+    assertTimeSeriesStats(firstPage.items().get(0), metric1);
+    assertTimeSeriesStats(firstPage.items().get(1), metric2);
+  }
+
+  @TestTemplate
+  public void shouldReturnSecondPageOfTimeSeriesUsingCursor() {
+    // given — 3 batches each in a distinct minute bucket
+    final var base = NOW.truncatedTo(ChronoUnit.MINUTES);
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base)
+                    .endTime(base.plusSeconds(30))
+                    .incompleteBatch(false));
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base.plusMinutes(1))
+                    .endTime(base.plusMinutes(1).plusSeconds(30))
+                    .incompleteBatch(false));
+    final var metric3 =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(base.plusMinutes(2))
+                    .endTime(base.plusMinutes(2).plusSeconds(30))
+                    .incompleteBatch(false));
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, List.of(metric1, metric2, metric3));
+
+    final var filter =
+        JobTimeSeriesStatisticsQuery.of(
+            q ->
+                q.filter(
+                        f ->
+                            f.from(base.minusSeconds(1))
+                                .to(base.plusMinutes(3))
+                                .jobType(JOB_TYPE_A)
+                                .resolution(Duration.ofMinutes(1)))
+                    .page(p -> p.size(2)));
+
+    // get the first page to obtain the cursor
+    final var firstPage =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            filter, ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // when — fetch the second page using the end cursor
+    final var secondPage =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                            f ->
+                                f.from(base.minusSeconds(1))
+                                    .to(base.plusMinutes(3))
+                                    .jobType(JOB_TYPE_A)
+                                    .resolution(Duration.ofMinutes(1)))
+                        .page(p -> p.size(2).after(firstPage.endCursor()))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then — only the third bucket is returned
+    assertThat(secondPage.items()).hasSize(1);
+    assertTimeSeriesStats(secondPage.items().getFirst(), metric3);
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyTimeSeriesWhenTenantNotAuthorized() {
+    // given
+    final var metric =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1).incompleteBatch(false));
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
+
+    // when — authorized for TENANT2 only
+    final var actual =
+        jobMetricsBatchReader.getJobTimeSeriesStatistics(
+            JobTimeSeriesStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusMinutes(1))
+                                .to(metric.endTime().plusMinutes(1))
+                                .jobType(JOB_TYPE_A)
+                                .resolution(Duration.ofHours(1)))),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(TENANT2))));
+
+    // then
+    assertThat(actual.items()).isEmpty();
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobMetricsBatchEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobMetricsBatchEntity.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+
+/**
+ * Represents a single row in the {@code JOB_METRICS_BATCH} table.
+ *
+ * <p>Each row captures aggregated job-state counters (created / completed / failed) for a specific
+ * combination of job type, worker and tenant, within a time window defined by {@code startTime} and
+ * {@code endTime}.
+ *
+ * @param key unique identifier of the batch row
+ * @param partitionId Zeebe partition that produced the record
+ * @param startTime start of the batch time window (inclusive)
+ * @param endTime end of the batch time window (inclusive)
+ * @param incompleteBatch {@code true} if the record-size limit was exceeded during export
+ * @param tenantId tenant that owns this record
+ * @param failedCount number of job-failed events in the window
+ * @param lastFailedAt timestamp of the latest failed event, or {@code null} if none
+ * @param completedCount number of job-completed events in the window
+ * @param lastCompletedAt timestamp of the latest completed event, or {@code null} if none
+ * @param createdCount number of job-created events in the window
+ * @param lastCreatedAt timestamp of the latest created event, or {@code null} if none
+ * @param jobType job type name
+ * @param worker worker name, or {@code null} for anonymous workers
+ */
+public record JobMetricsBatchEntity(
+    String key,
+    Integer partitionId,
+    OffsetDateTime startTime,
+    OffsetDateTime endTime,
+    Boolean incompleteBatch,
+    String tenantId,
+    Integer failedCount,
+    OffsetDateTime lastFailedAt,
+    Integer completedCount,
+    OffsetDateTime lastCompletedAt,
+    Integer createdCount,
+    OffsetDateTime lastCreatedAt,
+    String jobType,
+    String worker)
+    implements TenantOwnedEntity {
+
+  public static class Builder implements ObjectBuilder<JobMetricsBatchEntity> {
+
+    private String key;
+    private Integer partitionId;
+    private OffsetDateTime startTime;
+    private OffsetDateTime endTime;
+    private Boolean incompleteBatch;
+    private String tenantId;
+    private Integer failedCount;
+    private OffsetDateTime lastFailedAt;
+    private Integer completedCount;
+    private OffsetDateTime lastCompletedAt;
+    private Integer createdCount;
+    private OffsetDateTime lastCreatedAt;
+    private String jobType;
+    private String worker;
+
+    public Builder key(final String key) {
+      this.key = key;
+      return this;
+    }
+
+    public Builder partitionId(final Integer partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    public Builder startTime(final OffsetDateTime startTime) {
+      this.startTime = startTime;
+      return this;
+    }
+
+    public Builder endTime(final OffsetDateTime endTime) {
+      this.endTime = endTime;
+      return this;
+    }
+
+    public Builder incompleteBatch(final Boolean incompleteBatch) {
+      this.incompleteBatch = incompleteBatch;
+      return this;
+    }
+
+    public Builder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public Builder failedCount(final Integer failedCount) {
+      this.failedCount = failedCount;
+      return this;
+    }
+
+    public Builder lastFailedAt(final OffsetDateTime lastFailedAt) {
+      this.lastFailedAt = lastFailedAt;
+      return this;
+    }
+
+    public Builder completedCount(final Integer completedCount) {
+      this.completedCount = completedCount;
+      return this;
+    }
+
+    public Builder lastCompletedAt(final OffsetDateTime lastCompletedAt) {
+      this.lastCompletedAt = lastCompletedAt;
+      return this;
+    }
+
+    public Builder createdCount(final Integer createdCount) {
+      this.createdCount = createdCount;
+      return this;
+    }
+
+    public Builder lastCreatedAt(final OffsetDateTime lastCreatedAt) {
+      this.lastCreatedAt = lastCreatedAt;
+      return this;
+    }
+
+    public Builder jobType(final String jobType) {
+      this.jobType = jobType;
+      return this;
+    }
+
+    public Builder worker(final String worker) {
+      this.worker = worker;
+      return this;
+    }
+
+    @Override
+    public JobMetricsBatchEntity build() {
+      return new JobMetricsBatchEntity(
+          key,
+          partitionId,
+          startTime,
+          endTime,
+          incompleteBatch,
+          tenantId,
+          failedCount,
+          lastFailedAt,
+          completedCount,
+          lastCompletedAt,
+          createdCount,
+          lastCreatedAt,
+          jobType,
+          worker);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/JobTimeSeriesStatisticsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/JobTimeSeriesStatisticsSort.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record JobTimeSeriesStatisticsSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static JobTimeSeriesStatisticsSort of(
+      final Function<
+              JobTimeSeriesStatisticsSort.Builder, ObjectBuilder<JobTimeSeriesStatisticsSort>>
+          fn) {
+    return SortOptionBuilders.jobTimeSeriesStatistics(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<JobTimeSeriesStatisticsSort.Builder>
+      implements ObjectBuilder<JobTimeSeriesStatisticsSort> {
+
+    public Builder time() {
+      currentOrdering = new FieldSorting("time", null);
+      return this;
+    }
+
+    @Override
+    protected JobTimeSeriesStatisticsSort.Builder self() {
+      return this;
+    }
+
+    @Override
+    public JobTimeSeriesStatisticsSort build() {
+      return new JobTimeSeriesStatisticsSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -290,6 +290,17 @@ public final class SortOptionBuilders {
     return fn.apply(jobWorkerStatistics()).build();
   }
 
+  public static JobTimeSeriesStatisticsSort.Builder jobTimeSeriesStatistics() {
+    return new JobTimeSeriesStatisticsSort.Builder();
+  }
+
+  public static JobTimeSeriesStatisticsSort jobTimeSeriesStatistics(
+      final Function<
+              JobTimeSeriesStatisticsSort.Builder, ObjectBuilder<JobTimeSeriesStatisticsSort>>
+          fn) {
+    return fn.apply(jobTimeSeriesStatistics()).build();
+  }
+
   public static CorrelatedMessageSubscriptionSort.Builder correlatedMessageSubscription() {
     return new CorrelatedMessageSubscriptionSort.Builder();
   }


### PR DESCRIPTION
## Description

This pull request implements support for querying job time-series statistics in the RDBMS batch metrics reader. It introduces new domain classes, query and result mapping, SQL, and integrates the new functionality into the service layer. Additionally, it adds time bucketing SQL expressions for all supported databases to enable grouping by time intervals.

**Job Time-Series Statistics Feature:**

* Added new domain classes: `JobTimeSeriesStatisticsDbQuery` and `JobTimeSeriesStatisticsDbResult` to encapsulate query parameters and results for time-series statistics. [[1]](diffhunk://#diff-e3a9059644b5026ed232ad3a178f4eda5387ab536bd585db18ebd76958d277f9R1-R82) [[2]](diffhunk://#diff-4ae780153e9e78056913573be6475c434ab699bfa8d8ee5e6f19214e48825b73R1-R19)
* Introduced a new enum `JobTimeSeriesStatisticsColumn` to support column mapping for time-series statistics entities.
* Implemented the `jobTimeSeriesStatistics` method in `JobMetricsBatchMapper` and mapped it in the MyBatis XML, including result mapping and SQL for aggregating job metrics by time bucket. [[1]](diffhunk://#diff-a4e0dee68facb952762b30e1eb6bd11a7fc75b15810b75258e90acd22a09f012R12-R13) [[2]](diffhunk://#diff-a4e0dee68facb952762b30e1eb6bd11a7fc75b15810b75258e90acd22a09f012R32-R34) [[3]](diffhunk://#diff-76bcc9d46c6f7e8b18ff6be8b66f8d6fed24f524445f0c27077b2d93ec2679a8R180-R243)
* Integrated the time-series statistics query into `JobMetricsBatchDbReader`, including a new inner reader, fixed sorting, and logic to map database results to entities. [[1]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R14-R18) [[2]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R33) [[3]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R56-R70) [[4]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289L169-R212) [[5]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R224-R243)

**Database Compatibility:**

* Added `timeBucket` SQL expressions for H2, MariaDB, MySQL, MSSQL, Oracle, and PostgreSQL in their respective properties files to enable time bucketing across all supported databases. [[1]](diffhunk://#diff-2f2a2611251558fbabbb58c33e0811c140d1d2785470a17829c71e7b9c1393cfR21) [[2]](diffhunk://#diff-f322a85d9f37f8da4f58777f3501822afcc47eee65e01d8e66a158aee3d6fb97R21) [[3]](diffhunk://#diff-926b403e05a21bd142b0d9ff8ba16457a181c9a554d3afd96bfcde9e363d9452R21) [[4]](diffhunk://#diff-b48c23ebfdd3096240c902fb02f754b31b900c1f2bef7a5e714a07908819bb5cR21) [[5]](diffhunk://#diff-455f627c81b817de3834a5a45a6baffd0a1cebd86e0050b3288c18bf7dde2d2aR22) [[6]](diffhunk://#diff-e6e2f0e8101ed9312d4f3632346958a56975369141d0bf64f0dcf0a158ca9746R22)

**Testing:**

* Updated test dependencies and imports to cover the new functionality. [[1]](diffhunk://#diff-cd39ec6e6acccdb0c3ec262a19eb7f63a0e0154aceb8fb7da2945ed486ce26e1R17-R22) [[2]](diffhunk://#diff-cd39ec6e6acccdb0c3ec262a19eb7f63a0e0154aceb8fb7da2945ed486ce26e1L666-R668)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43059
