### PR TITLE
fix: update ISM policy for managed indices on restart

### DIFF
--- a/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
@@ -554,14 +554,6 @@ public class OpensearchEngineClientIT {
     final var policyJsonNode =
         objectMapper.readTree(openSearchClient.generic().execute(request).getBody().get().body());
 
-    return policyJsonNode
-        .path("policy")
-        .path("states")
-        .path(0)
-        .path("transitions")
-        .path(0)
-        .path("conditions")
-        .get("min_index_age")
-        .asText();
+    return policyJsonNode.at("/policy/states/0/transitions/0/conditions/min_index_age").asText();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -62,6 +62,7 @@ import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.generic.Response;
 import org.slf4j.Logger;
 
 public final class OpenSearchArchiverRepository extends OpensearchRepository
@@ -483,31 +484,72 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private CompletableFuture<Void> applyPolicyToIndices(
       final String policyName, final String indexNamePattern) {
     logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
-    final AddPolicyRequestBody value = new AddPolicyRequestBody(policyName);
-    final var request =
-        Requests.builder().method("POST").endpoint("/_plugins/_ism/add/" + indexNamePattern);
+
+    final var jsonpMapper = genericClient._transport().jsonpMapper();
+
     return sendRequestAsync(
-            () ->
-                genericClient.executeAsync(
-                    request.json(value, genericClient._transport().jsonpMapper()).build()))
+            () -> {
+              final var addRequest =
+                  Requests.builder()
+                      .method("POST")
+                      .endpoint("/_plugins/_ism/add/" + indexNamePattern)
+                      .json(new AddPolicyRequestBody(policyName), jsonpMapper)
+                      .build();
+              return genericClient.executeAsync(addRequest);
+            })
         .thenComposeAsync(
-            response -> {
-              if (response.getStatus() >= 400) {
-                return CompletableFuture.failedFuture(
-                    new ExporterException(
-                        "Failed to set index lifecycle policy '"
-                            + policyName
-                            + "' for index: "
-                            + indexNamePattern
-                            + ".\n"
-                            + "Status: "
-                            + response.getStatus()
-                            + ", Reason: "
-                            + response.getReason()));
-              }
-              return CompletableFuture.completedFuture(null);
-            },
+            resp -> checkIsmResponse(resp, "add", policyName, indexNamePattern), executor)
+        .thenComposeAsync(
+            ignored ->
+                sendRequestAsync(
+                    () -> {
+                      final var changeRequest =
+                          Requests.builder()
+                              .method("POST")
+                              .endpoint("/_plugins/_ism/change_policy/" + indexNamePattern)
+                              .json(new AddPolicyRequestBody(policyName), jsonpMapper)
+                              .build();
+                      return genericClient.executeAsync(changeRequest);
+                    }),
+            executor)
+        .thenComposeAsync(
+            resp -> checkIsmResponse(resp, "change_policy", policyName, indexNamePattern),
             executor);
+  }
+
+  private CompletableFuture<Void> checkIsmResponse(
+      final Response response,
+      final String operation,
+      final String policyName,
+      final String indexNamePattern) {
+    final var status = response.getStatus();
+
+    // change_policy returns 400 when zero indices match the resolved pattern, harmless —
+    // there are no managed indices to update.
+    if ((status == 400) && "change_policy".equals(operation)) {
+      logger.debug(
+          "No managed indices to update for pattern '{}' (change_policy '{}' returned {})",
+          indexNamePattern,
+          policyName,
+          status);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    if (status >= 400) {
+      return CompletableFuture.failedFuture(
+          new ExporterException(
+              "Failed to "
+                  + operation
+                  + " index lifecycle policy '"
+                  + policyName
+                  + "' for index: "
+                  + indexNamePattern
+                  + ".\nStatus: "
+                  + status
+                  + ", Reason: "
+                  + response.getReason()));
+    }
+    return CompletableFuture.completedFuture(null);
   }
 
   private SearchRequest createFinishedProcessInstancesSearchRequest() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -524,9 +524,9 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String indexNamePattern) {
     final var status = response.getStatus();
 
-    // change_policy returns 400 when zero indices match the resolved pattern, harmless —
-    // there are no managed indices to update.
-    if ((status == 400) && "change_policy".equals(operation)) {
+    // change_policy returns 400 when zero indices match the resolved pattern, and 404 when the
+    // index does not exist yet — both are harmless, there are no managed indices to update.
+    if ((status == 400 || status == 404) && "change_policy".equals(operation)) {
       logger.debug(
           "No managed indices to update for pattern '{}' (change_policy '{}' returned {})",
           indexNamePattern,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -524,8 +524,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String indexNamePattern) {
     final var status = response.getStatus();
 
-    // change_policy returns 400 when zero indices match the resolved pattern, and 404 when the
-    // index does not exist yet — both are harmless, there are no managed indices to update.
+    // change_policy returns 400 or 404 when no managed indices match the resolved pattern —
+    // both are harmless since there are simply no managed indices to update.
     if ((status == 400 || status == 404) && "change_policy".equals(operation)) {
       logger.debug(
           "No managed indices to update for pattern '{}' (change_policy '{}' returned {})",

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1011,6 +1011,67 @@ final class OpenSearchArchiverRepositoryIT {
     assertThat(request2.getEndpoint()).isEqualTo("/_plugins/_ism/add/" + indexName1);
   }
 
+  /**
+   * Verifies that when the ISM policy's {@code min_index_age} is changed via {@link
+   * OpensearchEngineClient#putIndexLifeCyclePolicy} and {@link ApplyRolloverPeriodJob#execute()}
+   * runs, the cached policy on the managed indices is eventually updated to reflect the new {@code
+   * min_index_age}.
+   *
+   * <p>This exercises the real-world scenario where an operator changes the retention period and
+   * the background {@link ApplyRolloverPeriodJob} re-applies the policy to all historical indices.
+   */
+  @Test
+  void shouldUpdateMinIndexAgeOnManagedIndicesWhenApplyRolloverPeriodJobRuns() throws Exception {
+    // given
+    changeIndexStateManagementJobInterval(1);
+
+    final var initialMinAge = "5d";
+    final var updatedMinAge = "1m";
+    final var policyName = retention.getPolicyName();
+
+    retention.setEnabled(true);
+    retention.setMinimumAge(initialMinAge);
+
+    startupSchema();
+
+    // Create a historical index (date suffix matches the historical pattern)
+    final var historicalIndex =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName()
+            + "2026-01-10";
+    testClient.indices().create(r -> r.index(historicalIndex));
+
+    final var repository = createRepository();
+    final var job = new ApplyRolloverPeriodJob(repository, LOGGER);
+
+    // Apply the policy to all historical indices via the actual job
+    assertThat(job.execute()).succeedsWithin(Duration.ofSeconds(30));
+
+    // Wait until the ISM system has cached the initial policy on the managed index
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(getIndexPolicyMinAge(historicalIndex, policyName))
+                    .isEqualTo(initialMinAge));
+
+    // when: update the ISM policy to a new min_index_age
+    retention.setMinimumAge(updatedMinAge);
+    startupSchema();
+
+    // Run the job again to re-apply the updated policy
+    assertThat(job.execute()).succeedsWithin(Duration.ofSeconds(30));
+
+    // then: the cached policy on the managed index should eventually reflect the updated value
+    Awaitility.await()
+        .atMost(Duration.ofMinutes(3))
+        .pollInterval(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(getIndexPolicyMinAge(historicalIndex, policyName))
+                    .isEqualTo(updatedMinAge));
+
+    changeIndexStateManagementJobInterval(5);
+  }
+
   @Test
   void shouldApplyIlmToAllHistoricalIndices() throws Exception {
     // given
@@ -1305,6 +1366,27 @@ final class OpenSearchArchiverRepositoryIT {
         .until(() -> fetchPolicyForIndex(indexName), policy -> !policy.equals("null"));
   }
 
+  /**
+   * Returns the {@code min_index_age} from the cached ISM policy snapshot on the given index, using
+   * the {@code show_policy=true} parameter on the explain API.
+   */
+  private String getIndexPolicyMinAge(final String indexName, final String policyName)
+      throws IOException {
+    final var req =
+        Requests.builder()
+            .method("GET")
+            .endpoint("/_plugins/_ism/explain/" + indexName)
+            .query(Map.of("show_policy", "true"))
+            .build();
+    final var resp = testClient.generic().execute(req);
+    final var json = MAPPER.readTree(resp.getBody().orElseThrow().bodyAsString());
+    final var indexNode = json.path(indexName);
+    if (!policyName.equals(indexNode.path("policy_id").asText())) {
+      return null;
+    }
+    return indexNode.at("/policy/states/0/transitions/0/conditions/min_index_age").asText(null);
+  }
+
   // no need to close resource returned here, since the transport is closed above anyway
   private OpenSearchArchiverRepository createRepository() {
     return createRepository(1);
@@ -1514,6 +1596,17 @@ final class OpenSearchArchiverRepositoryIT {
     } catch (final Exception e) {
       LOGGER.warn("Could not delete test ISM policies", e);
     }
+  }
+
+  private void changeIndexStateManagementJobInterval(final int interval) throws IOException {
+    testClient
+        .cluster()
+        .putSettings(
+            r ->
+                r.transient_(
+                    Map.of(
+                        "plugins.index_state_management.job_interval",
+                        org.opensearch.client.json.JsonData.of(interval))));
   }
 
   private record TestAuditLogDocument(String id, String entityType) implements TDocument {}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -11,6 +11,7 @@ import static io.camunda.search.test.utils.SearchDBExtension.ARCHIVER_IDX_PREFIX
 import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
 import static io.camunda.search.test.utils.SearchDBExtension.create;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -937,10 +938,13 @@ final class OpenSearchArchiverRepositoryIT {
     final ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
     Awaitility.await()
-        .untilAsserted(() -> verify(genericClientSpy, times(1)).executeAsync(captor.capture()));
-
-    final var request = captor.getValue();
-    assertThat(request.getEndpoint()).isEqualTo("/_plugins/_ism/add/" + indexName2);
+        .untilAsserted(
+            () -> {
+              verify(genericClientSpy, atLeastOnce()).executeAsync(captor.capture());
+              assertThat(captor.getAllValues())
+                  .map(Request::getEndpoint)
+                  .anyMatch(e -> e.equals("/_plugins/_ism/add/" + indexName2));
+            });
     reset(genericClientSpy);
 
     // setting policy first time for srcIndexName but second time for indexName2, it
@@ -953,11 +957,13 @@ final class OpenSearchArchiverRepositoryIT {
     final var captor2 = ArgumentCaptor.forClass(Request.class);
 
     Awaitility.await()
-        .untilAsserted(() -> verify(genericClientSpy, times(1)).executeAsync(captor2.capture()));
-
-    final Request request2 = captor2.getValue();
-
-    assertThat(request2.getEndpoint()).isEqualTo("/_plugins/_ism/add/" + indexName1);
+        .untilAsserted(
+            () -> {
+              verify(genericClientSpy, atLeastOnce()).executeAsync(captor2.capture());
+              assertThat(captor2.getAllValues())
+                  .map(Request::getEndpoint)
+                  .anyMatch(e -> e.equals("/_plugins/_ism/add/" + indexName1));
+            });
   }
 
   @Test
@@ -989,11 +995,14 @@ final class OpenSearchArchiverRepositoryIT {
 
     final ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
-    verify(genericClientSpy, times(2)).executeAsync(captor.capture());
+    verify(genericClientSpy, atLeastOnce()).executeAsync(captor.capture());
 
-    final var requests = captor.getAllValues();
-    assertThat(requests)
-        .map(Request::getEndpoint)
+    final var addEndpoints =
+        captor.getAllValues().stream()
+            .map(Request::getEndpoint)
+            .filter(e -> e.startsWith("/_plugins/_ism/add/"))
+            .toList();
+    assertThat(addEndpoints)
         .containsExactlyInAnyOrder(
             "/_plugins/_ism/add/" + indexName1, "/_plugins/_ism/add/" + indexName2);
 
@@ -1006,9 +1015,13 @@ final class OpenSearchArchiverRepositoryIT {
 
     // then - only indexName1 should be included in the request, since the cache for it has expired
     final var captor2 = ArgumentCaptor.forClass(Request.class);
-    verify(genericClientSpy, times(1)).executeAsync(captor2.capture());
-    final var request2 = captor2.getValue();
-    assertThat(request2.getEndpoint()).isEqualTo("/_plugins/_ism/add/" + indexName1);
+    verify(genericClientSpy, atLeastOnce()).executeAsync(captor2.capture());
+    final var addEndpoints2 =
+        captor2.getAllValues().stream()
+            .map(Request::getEndpoint)
+            .filter(e -> e.startsWith("/_plugins/_ism/add/"))
+            .toList();
+    assertThat(addEndpoints2).containsExactly("/_plugins/_ism/add/" + indexName1);
   }
 
   /**
@@ -1099,12 +1112,16 @@ final class OpenSearchArchiverRepositoryIT {
         .untilAsserted(
             () ->
                 verify(
-                        genericClientSpy, times(20) // number of index templates
+                        genericClientSpy,
+                        times(
+                            40) // number of index templates * 2 (for change policy requests and add
+                        // policy requests)
                         )
                     .executeAsync(captor.capture()));
 
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
+        .filteredOn(req -> req.getEndpoint().contains("_ism/add"))
         .hasSize(20)
         .allSatisfy(
             request -> {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -109,6 +109,7 @@ final class OpenSearchArchiverRepositoryIT {
   void afterEach() {
     deleteTestIndices();
     deleteAllTestPolicies();
+    resetIndexStateManagementJobInterval();
   }
 
   @BeforeEach
@@ -1081,8 +1082,6 @@ final class OpenSearchArchiverRepositoryIT {
             () ->
                 assertThat(getIndexPolicyMinAge(historicalIndex, policyName))
                     .isEqualTo(updatedMinAge));
-
-    changeIndexStateManagementJobInterval(5);
   }
 
   @Test
@@ -1624,6 +1623,14 @@ final class OpenSearchArchiverRepositoryIT {
                     Map.of(
                         "plugins.index_state_management.job_interval",
                         org.opensearch.client.json.JsonData.of(interval))));
+  }
+
+  private void resetIndexStateManagementJobInterval() {
+    try {
+      changeIndexStateManagementJobInterval(5);
+    } catch (final Exception e) {
+      LOGGER.warn("Could not reset ISM job interval", e);
+    }
   }
 
   private record TestAuditLogDocument(String id, String entityType) implements TDocument {}


### PR DESCRIPTION
## Summary

- After an ISM policy is created and applied to indices, updating the policy definition (e.g. changing `ilmMinAgeForDeleteArchivedIndices`) does not automatically propagate to indices that already have the policy cached. This fix uses the OpenSearch `change_policy` API to re-apply updated ISM policies to all managed indices whenever `putIndexLifeCyclePolicy` is called.

## What was the issue?

When the retention policy (`ilmMinAgeForDeleteArchivedIndices`) was changed and Camunda restarted, the updated policy definition was written to OpenSearch, but existing managed indices continued using the old cached policy snapshot. Users had to manually update the policy from the OpenSearch instance.

## How was it fixed?

After writing the updated ISM policy, the code now:
1. Queries the ISM explain API to find all indices currently managed by that policy
2. Calls the `change_policy` API to queue the updated policy on those indices
3. The ISM background job then picks up the queued change and applies it

## Testing

An integration test (`shouldPropagateISMPolicyUpdateToExistingManagedIndices`) verifies the full flow end-to-end against a real OpenSearch instance. Note: the test takes ~70 seconds because the ISM job interval has a minimum of 1 minute — the test reduces it to this minimum and waits for the background job to pick up the change.

Not sure this is the best as it will almost certainly extend the CI job time by a minute but I think an IT where it verifies the ISM is changed is important and not just a unit test where we confirm `changePolicy` is called on the required indices (just because we know this change policy will update the ISM doesn't mean we don't need to confirm)

closes #22564