### PR TITLE
Allow filtering and sorting by businessId in process instances search queries

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
@@ -186,6 +186,14 @@ public interface ProcessInstanceFilter extends ProcessInstanceFilterBase {
   @Override
   ProcessInstanceFilter incidentErrorHashCode(final Consumer<IntegerProperty> fn);
 
+  /** Filter by businessId */
+  @Override
+  ProcessInstanceFilter businessId(final String businessId);
+
+  /** Filter by businessId using {@link StringProperty} consumer */
+  @Override
+  ProcessInstanceFilter businessId(final Consumer<StringProperty> fn);
+
   /** Filter by or conjunction using {@link ProcessInstanceFilterBase} consumer */
   ProcessInstanceFilterBase orFilters(List<Consumer<ProcessInstanceFilterBase>> filters);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
@@ -155,4 +155,10 @@ public interface ProcessInstanceFilterBase extends SearchRequestFilter {
 
   /** Filter by tags */
   ProcessInstanceFilterBase tags(final String... tags);
+
+  /** Filter by businessId */
+  ProcessInstanceFilterBase businessId(final String businessId);
+
+  /** Filter by businessId using {@link StringProperty} consumer */
+  ProcessInstanceFilterBase businessId(final Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/ProcessInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/ProcessInstanceSort.java
@@ -44,4 +44,6 @@ public interface ProcessInstanceSort extends SearchRequestSort<ProcessInstanceSo
   ProcessInstanceSort hasIncident();
 
   ProcessInstanceSort tenantId();
+
+  ProcessInstanceSort businessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -330,6 +330,20 @@ public class ProcessInstanceFilterImpl
   }
 
   @Override
+  public ProcessInstanceFilter businessId(final String businessId) {
+    businessId(b -> b.eq(businessId));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilter businessId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBusinessId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public ProcessInstanceFilterBase orFilters(final List<Consumer<ProcessInstanceFilterBase>> fns) {
     for (final Consumer<ProcessInstanceFilterBase> fn : fns) {
       final ProcessInstanceFilterImpl orFilter = new ProcessInstanceFilterImpl();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/ProcessInstanceSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/ProcessInstanceSortImpl.java
@@ -87,6 +87,11 @@ public class ProcessInstanceSortImpl extends SearchRequestSortBase<ProcessInstan
   }
 
   @Override
+  public ProcessInstanceSort businessId() {
+    return field("businessId");
+  }
+
+  @Override
   protected ProcessInstanceSort self() {
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/util/ProcessInstanceFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/ProcessInstanceFilterMapper.java
@@ -55,6 +55,7 @@ public final class ProcessInstanceFilterMapper {
     target.setElementId(filter.getElementId());
     target.setHasElementInstanceIncident(filter.getHasElementInstanceIncident());
     target.setIncidentErrorHashCode(filter.getIncidentErrorHashCode());
+    target.setBusinessId(filter.getBusinessId());
 
     return target;
   }

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -105,7 +105,8 @@ public class QueryProcessInstanceTest extends ClientRestTest {
                     .elementId("elementId")
                     .elementInstanceState(ElementInstanceState.ACTIVE)
                     .hasElementInstanceIncident(true)
-                    .incidentErrorHashCode(123456789))
+                    .incidentErrorHashCode(123456789)
+                    .businessId("my-business-id"))
         .send()
         .join();
     // then
@@ -136,6 +137,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
         .isEqualTo(ElementInstanceStateEnum.ACTIVE);
     assertThat(filter.getHasElementInstanceIncident()).isEqualTo(true);
     assertThat(filter.getIncidentErrorHashCode().get$Eq()).isEqualTo(123456789);
+    assertThat(filter.getBusinessId().get$Eq()).isEqualTo("my-business-id");
   }
 
   @Test
@@ -193,6 +195,44 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     final StringFilterProperty processInstanceKey = filter.getProcessDefinitionId();
     assertThat(processInstanceKey).isNotNull();
     assertThat(processInstanceKey.get$Like()).isEqualTo("string");
+  }
+
+  @Test
+  void shouldSearchProcessInstanceByBusinessIdStringFilter() {
+    // when
+    client
+        .newProcessInstanceSearchRequest()
+        .filter(f -> f.businessId(b -> b.like("order-*")))
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceSearchQuery request =
+        gatewayService.getLastRequest(ProcessInstanceSearchQuery.class);
+    final ProcessInstanceFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    final StringFilterProperty businessId = filter.getBusinessId();
+    assertThat(businessId).isNotNull();
+    assertThat(businessId.get$Like()).isEqualTo("order-*");
+  }
+
+  @Test
+  void shouldSearchProcessInstanceByBusinessIdEqFilter() {
+    // when
+    client
+        .newProcessInstanceSearchRequest()
+        .filter(f -> f.businessId("my-business-id"))
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceSearchQuery request =
+        gatewayService.getLastRequest(ProcessInstanceSearchQuery.class);
+    final ProcessInstanceFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    final StringFilterProperty businessId = filter.getBusinessId();
+    assertThat(businessId).isNotNull();
+    assertThat(businessId.get$Eq()).isEqualTo("my-business-id");
   }
 
   @Test
@@ -269,6 +309,8 @@ public class QueryProcessInstanceTest extends ClientRestTest {
                     .hasIncident()
                     .desc()
                     .tenantId()
+                    .asc()
+                    .businessId()
                     .asc())
         .send()
         .join();
@@ -279,7 +321,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     final List<SearchRequestSort> sorts =
         SearchRequestSortMapper.fromProcessInstanceSearchQuerySortRequest(
             Objects.requireNonNull(request.getSort()));
-    assertThat(sorts).hasSize(13);
+    assertThat(sorts).hasSize(14);
     assertSort(sorts.get(0), "processInstanceKey", SortOrderEnum.ASC);
     assertSort(sorts.get(1), "processDefinitionId", SortOrderEnum.DESC);
     assertSort(sorts.get(2), "processDefinitionName", SortOrderEnum.ASC);
@@ -293,6 +335,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     assertSort(sorts.get(10), "state", SortOrderEnum.ASC);
     assertSort(sorts.get(11), "hasIncident", SortOrderEnum.DESC);
     assertSort(sorts.get(12), "tenantId", SortOrderEnum.ASC);
+    assertSort(sorts.get(13), "businessId", SortOrderEnum.ASC);
   }
 
   @Test

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ProcessInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ProcessInstanceSearchColumn.java
@@ -22,7 +22,8 @@ public enum ProcessInstanceSearchColumn implements SearchColumn<ProcessInstanceE
   TENANT_ID("tenantId"),
   PARENT_PROCESS_INSTANCE_KEY("parentProcessInstanceKey"),
   PARENT_ELEMENT_INSTANCE_KEY("parentFlowNodeInstanceKey"),
-  HAS_INCIDENT("hasIncident");
+  HAS_INCIDENT("hasIncident"),
+  BUSINESS_ID("businessId");
 
   private final String property;
 

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -350,6 +350,14 @@
         )
       </foreach>
     </if>
+    <!-- Business ID filters -->
+    <if
+      test="filter.businessIdOperations != null and !filter.businessIdOperations.isEmpty()">
+      <foreach collection="filter.businessIdOperations" item="operation">
+        AND pi.BUSINESS_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.ProcessInstanceEntity">

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -655,6 +655,10 @@ public class SearchQueryFilterMapper {
         }
       }
 
+      ofNullable(filter.getBusinessId())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::businessIdOperations);
+
       if (!CollectionUtils.isEmpty(filter.getVariables())) {
         final Either<List<String>, List<VariableValueFilter>> either =
             toVariableValueFilters(filter.getVariables());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -374,6 +374,7 @@ public class SearchQuerySortRequestMapper {
         case STATE -> builder.state();
         case HAS_INCIDENT -> builder.hasIncident();
         case TENANT_ID -> builder.tenantId();
+        case BUSINESS_ID -> builder.businessId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
@@ -78,7 +78,8 @@ public class CustomMcpModelPropertiesTest {
                 "startDate",
                 "state",
                 "tags",
-                "variables")),
+                "variables",
+                "businessId")),
         Arguments.argumentSet(
             "VariableFilter",
             VariableFilter.class,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -13,6 +13,7 @@ import static io.camunda.client.api.search.enums.ProcessInstanceState.TERMINATED
 import static io.camunda.it.util.TestHelper.assertSorted;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.startProcessInstanceWithBusinessId;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitUntilJobWorkerHasFailedJob;
@@ -92,8 +93,12 @@ public class ProcessInstanceSearchIT {
     processInstanceWithIncidentKey = processInstanceWithIncident.getProcessInstanceKey();
     PROCESS_INSTANCES.add(processInstanceWithIncident);
     PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "parent_process_v1"));
+    PROCESS_INSTANCES.add(
+        startProcessInstanceWithBusinessId(camundaClient, "manual_process", "order-001"));
+    PROCESS_INSTANCES.add(
+        startProcessInstanceWithBusinessId(camundaClient, "manual_process", "order-002"));
 
-    waitForProcessInstancesToStart(camundaClient, 8);
+    waitForProcessInstancesToStart(camundaClient, 10);
     waitUntilProcessInstanceHasIncidents(camundaClient, 2);
   }
 
@@ -695,7 +700,7 @@ public class ProcessInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(3);
+    assertThat(result.items().size()).isEqualTo(5);
     assertThat(result.items()).extracting("state").doesNotContain(ProcessInstanceState.ACTIVE);
   }
 
@@ -714,11 +719,15 @@ public class ProcessInstanceSearchIT {
                       .join();
 
               // then
-              assertThat(result.items().size()).isEqualTo(3);
+              assertThat(result.items().size()).isEqualTo(5);
               assertThat(
                       result.items().stream().map(ProcessInstance::getProcessDefinitionId).toList())
                   .containsExactlyInAnyOrder(
-                      "parent_process_v1", "child_process_v1", "manual_process");
+                      "parent_process_v1",
+                      "child_process_v1",
+                      "manual_process",
+                      "manual_process",
+                      "manual_process");
             });
   }
 
@@ -782,7 +791,7 @@ public class ProcessInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(8);
+    assertThat(result.items().size()).isEqualTo(expectedBpmnProcessIds.size());
     assertThat(result.items().stream().map(ProcessInstance::getProcessDefinitionId).toList())
         .containsExactlyElementsOf(expectedBpmnProcessIds);
   }
@@ -1049,7 +1058,7 @@ public class ProcessInstanceSearchIT {
             .send()
             .join();
 
-    assertThat(resultAfter.items().size()).isEqualTo(6);
+    assertThat(resultAfter.items().size()).isEqualTo(8);
     final var keyAfter = resultAfter.items().getFirst().getProcessInstanceKey();
     // apply searchBefore
     final var resultBefore =
@@ -1457,5 +1466,132 @@ public class ProcessInstanceSearchIT {
             .join();
 
     assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByBusinessIdEqual() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.businessId("order-001"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getBusinessId()).isEqualTo("order-001");
+    assertThat(result.items().getFirst().getProcessDefinitionId()).isEqualTo("manual_process");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByBusinessIdLike() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items())
+        .extracting("businessId")
+        .containsExactlyInAnyOrder("order-001", "order-002");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByBusinessIdIn() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.businessId(b -> b.in("order-001", "order-002", "non-existent")))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items())
+        .extracting("businessId")
+        .containsExactlyInAnyOrder("order-001", "order-002");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByBusinessIdNeq() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.businessId(b -> b.neq("order-001").exists(true)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getBusinessId()).isEqualTo("order-002");
+  }
+
+  @Test
+  void shouldReturnNoResultsForNonExistentBusinessId() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.businessId("does-not-exist"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSortProcessInstancesByBusinessId() {
+    // when
+    final var resultAsc =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .sort(s -> s.businessId().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .sort(s -> s.businessId().desc())
+            .send()
+            .join();
+
+    // then
+    assertThat(resultAsc.items()).hasSize(2);
+    assertThat(resultDesc.items()).hasSize(2);
+    assertThat(resultAsc.items().getFirst().getBusinessId()).isEqualTo("order-001");
+    assertThat(resultAsc.items().getLast().getBusinessId()).isEqualTo("order-002");
+    assertThat(resultDesc.items().getFirst().getBusinessId()).isEqualTo("order-002");
+    assertThat(resultDesc.items().getLast().getBusinessId()).isEqualTo("order-001");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByBusinessIdWithOrConditions() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.orFilters(
+                        List.of(
+                            f1 -> f1.businessId("order-001"), f2 -> f2.businessId("order-002"))))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items())
+        .extracting("businessId")
+        .containsExactlyInAnyOrder("order-001", "order-002");
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
@@ -35,7 +35,8 @@ public final class ProcessInstanceFixtures extends CommonFixtures {
             .endDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
             .version(RANDOM.nextInt(10000))
             .tenantId("tenant-" + RANDOM.nextInt(10000))
-            .partitionId(RANDOM.nextInt(10000));
+            .partitionId(RANDOM.nextInt(10000))
+            .businessId("business-" + RANDOM.nextInt(10000));
 
     return builderFunction.apply(builder).build();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -65,7 +65,8 @@ public class ProcessInstanceIT {
                     .startDate(NOW)
                     .parentProcessInstanceKey(-1L)
                     .parentElementInstanceKey(-1L)
-                    .version(1)));
+                    .version(1)
+                    .businessId("test-business-id")));
 
     final var instance = processInstanceReader.findOne(processInstanceKey).orElse(null);
 
@@ -81,6 +82,7 @@ public class ProcessInstanceIT {
     assertThat(instance.parentFlowNodeInstanceKey()).isEqualTo(-1L);
     assertThat(instance.processDefinitionVersion()).isEqualTo(1);
     assertThat(instance.hasIncident()).isFalse();
+    assertThat(instance.businessId()).isEqualTo("test-business-id");
   }
 
   @TestTemplate
@@ -303,7 +305,8 @@ public class ProcessInstanceIT {
                     .parentProcessInstanceKey(-1L)
                     .parentElementInstanceKey(-1L)
                     .version(1)
-                    .partitionId(123456)));
+                    .partitionId(123456)
+                    .businessId("test-business-id-full-filter")));
 
     final var searchResult =
         processInstanceReader.search(
@@ -317,7 +320,8 @@ public class ProcessInstanceIT {
                                     .states(ProcessInstanceState.ACTIVE.name())
                                     .parentProcessInstanceKeys(-1L)
                                     .parentFlowNodeInstanceKeys(-1L)
-                                    .partitionId(123456))
+                                    .partitionId(123456)
+                                    .businessIds("test-business-id-full-filter"))
                         .sort(s -> s)
                         .page(p -> p.from(0).size(5))));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
@@ -130,6 +130,25 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(p -> p.state().name()));
   }
 
+  @TestTemplate
+  public void shouldSortByBusinessIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.businessId().asc(),
+        Comparator.comparing(
+            ProcessInstanceEntity::businessId, Comparator.nullsFirst(Comparator.naturalOrder())));
+  }
+
+  @TestTemplate
+  public void shouldSortByBusinessIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.businessId().desc(),
+        Comparator.comparing(
+                ProcessInstanceEntity::businessId, Comparator.nullsFirst(Comparator.naturalOrder()))
+            .reversed());
+  }
+
   private void testSorting(
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<ProcessInstanceSort>> sortBuilder,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
@@ -91,7 +91,8 @@ public class ProcessInstanceSpecificFilterIT {
                     .endDate(NOW)
                     .parentProcessInstanceKey(-1L)
                     .parentElementInstanceKey(-1L)
-                    .version(1)));
+                    .version(1)
+                    .businessId("test-business-id-42")));
     final var searchResult =
         processInstanceReader.search(
             ProcessInstanceQuery.of(
@@ -147,6 +148,11 @@ public class ProcessInstanceSpecificFilterIT {
             List.of(42L)),
         Arguments.of(
             new ProcessInstanceFilter.Builder().processDefinitionVersionTags("Version 1").build(),
+            1,
+            1,
+            List.of(42L)),
+        Arguments.of(
+            new ProcessInstanceFilter.Builder().businessIds("test-business-id-42").build(),
             1,
             1,
             List.of(42L)),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -281,6 +281,16 @@ public final class TestHelper {
         .execute();
   }
 
+  public static ProcessInstanceEvent startProcessInstanceWithBusinessId(
+      final CamundaClient camundaClient, final String bpmnProcessId, final String businessId) {
+    return camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(bpmnProcessId)
+        .latestVersion()
+        .businessId(businessId)
+        .execute();
+  }
+
   public static ProcessInstanceEvent startProcessInstance(
       final CamundaClient camundaClient, final String bpmnProcessId, final String payload) {
     final CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep3

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -15,6 +15,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.AC
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITY_STATE;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.BATCH_OPERATION_IDS;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.BUSINESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.END_DATE;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ERROR_MSG;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.INCIDENT;
@@ -104,6 +105,8 @@ public final class ProcessInstanceFilterTransformer
     if (filter.tags() != null && !filter.tags().isEmpty()) {
       queries.add(and(filter.tags().stream().map(tag -> term(TAGS, tag)).toList()));
     }
+
+    queries.addAll(stringOperations(BUSINESS_ID, filter.businessIdOperations()));
 
     return queries;
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/ProcessInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/ProcessInstanceFieldSortingTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.sort;
 
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.BUSINESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.END_DATE;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.INCIDENT;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.KEY;
@@ -39,6 +40,7 @@ public class ProcessInstanceFieldSortingTransformer implements FieldSortingTrans
       case "state" -> STATE;
       case "hasIncident" -> INCIDENT;
       case "tenantId" -> TENANT_ID;
+      case "businessId" -> BUSINESS_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
@@ -610,6 +610,29 @@ public final class ProcessInstanceQueryTransformerTest extends AbstractTransform
     assertThat(processInstanceFilter.hasIncident()).isNull();
     assertThat(processInstanceFilter.tenantIdOperations()).isEmpty();
     assertThat(processInstanceFilter.errorMessageOperations()).isEmpty();
+    assertThat(processInstanceFilter.businessIdOperations()).isEmpty();
+  }
+
+  @Test
+  public void shouldQueryByBusinessId() {
+    // given
+    final var processInstanceFilter =
+        FilterBuilders.processInstance(f -> f.businessIds("order-123"));
+
+    // when
+    final var searchRequest = transformQuery(processInstanceFilter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(2);
+
+    assertIsSearchTermQuery(
+        ((SearchBoolQuery) queryVariant).must().get(0).queryOption(),
+        "joinRelation",
+        "processInstance");
+    assertIsSearchTermQuery(
+        ((SearchBoolQuery) queryVariant).must().get(1).queryOption(), "businessId", "order-123");
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/ProcessInstanceSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/ProcessInstanceSortTest.java
@@ -48,7 +48,9 @@ public class ProcessInstanceSortTest extends AbstractSortTransformerTest {
         new ProcessInstanceSortTest.TestArguments(
             "incident", SortOrder.DESC, s -> s.hasIncident().desc()),
         new ProcessInstanceSortTest.TestArguments(
-            "tenantId", SortOrder.ASC, s -> s.tenantId().asc()));
+            "tenantId", SortOrder.ASC, s -> s.tenantId().asc()),
+        new ProcessInstanceSortTest.TestArguments(
+            "businessId", SortOrder.ASC, s -> s.businessId().asc()));
   }
 
   @ParameterizedTest

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -43,6 +43,7 @@ public record ProcessInstanceFilter(
     List<Operation<Integer>> incidentErrorHashCodeOperations,
     Integer partitionId,
     Set<String> tags,
+    List<Operation<String>> businessIdOperations,
     List<ProcessInstanceFilter> orFilters)
     implements FilterBase {
 
@@ -71,6 +72,7 @@ public record ProcessInstanceFilter(
         .incidentErrorHashCodeOperations(incidentErrorHashCodeOperations)
         .partitionId(partitionId)
         .tags(tags)
+        .businessIdOperations(businessIdOperations)
         .orFilters(orFilters);
   }
 
@@ -99,6 +101,7 @@ public record ProcessInstanceFilter(
     private List<Operation<Integer>> incidentErrorHashCodeOperations;
     private Integer partitionId;
     private Set<String> tags;
+    private List<Operation<String>> businessIdOperations;
     private List<ProcessInstanceFilter> orFilters;
 
     public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
@@ -391,6 +394,21 @@ public record ProcessInstanceFilter(
       return this;
     }
 
+    public Builder businessIdOperations(final List<Operation<String>> operations) {
+      businessIdOperations = addValuesToList(businessIdOperations, operations);
+      return this;
+    }
+
+    public Builder businessIds(final String value, final String... values) {
+      return businessIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder businessIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return businessIdOperations(collectValues(operation, operations));
+    }
+
     public Builder addOrOperation(final ProcessInstanceFilter orOperation) {
       if (orFilters == null) {
         orFilters = new ArrayList<>();
@@ -431,6 +449,7 @@ public record ProcessInstanceFilter(
           Objects.requireNonNullElse(incidentErrorHashCodeOperations, Collections.emptyList()),
           partitionId,
           Objects.requireNonNullElse(tags, Collections.emptySet()),
+          Objects.requireNonNullElse(businessIdOperations, Collections.emptyList()),
           orFilters);
     }
   }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/ProcessInstanceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/ProcessInstanceSort.java
@@ -91,6 +91,11 @@ public record ProcessInstanceSort(List<FieldSorting> orderings) implements SortO
       return this;
     }
 
+    public Builder businessId() {
+      currentOrdering = new FieldSorting("businessId", null);
+      return this;
+    }
+
     @Override
     protected Builder self() {
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -978,6 +978,7 @@ components:
             - state
             - hasIncident
             - tenantId
+            - businessId
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
@@ -1068,6 +1069,10 @@ components:
           description: The incident error hash code, associated with this process.
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+        businessId:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: The business id associated with the process instance.
 
     ProcessDefinitionStatisticsFilter:
       description: Process definition statistics search filter.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -491,7 +491,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                   "type": "about:blank",
                   "title": "Bad Request",
                   "status": 400,
-                  "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [processInstanceKey, processDefinitionId, processDefinitionName, processDefinitionVersion, processDefinitionVersionTag, processDefinitionKey, parentProcessInstanceKey, parentElementInstanceKey, startDate, endDate, state, hasIncident, tenantId]",
+                  "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [processInstanceKey, processDefinitionId, processDefinitionName, processDefinitionVersion, processDefinitionVersionTag, processDefinitionKey, parentProcessInstanceKey, parentElementInstanceKey, startDate, endDate, state, hasIncident, tenantId, businessId]",
                   "instance": "%s"
                 }""",
             PROCESS_INSTANCES_SEARCH_URL);


### PR DESCRIPTION
## Description

Until now, the process instance search API had no way to query by `businessId`. 
This PR makes `businessId` a first-class filter and sort field in the process instance search query. It is supported as a full string-filter property (`$eq`, `$neq`, `$like`, `$in`, `$exists`) and as a sort criterion (ascending/descending), giving users the same level of query flexibility they already have for fields like `processDefinitionId` or `state`.

The change is wired end-to-end: REST API contract → gateway → search domain & query transformers → Elasticsearch/OpenSearch / RDBMS, as well as the Java client SDK. 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47246
