### PR TITLE
feat: apply intent whitelist to ProcessingResult write rate limiting

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
@@ -85,7 +85,7 @@ final class RemoteJobStreamErrorHandler implements RemoteStreamErrorHandler<Acti
       final LogStreamWriter writer,
       final TaskResult result) {
     final var writeResult =
-        writer.tryWrite(WriteContext.processingResult(), result.getRecordBatch().entries());
+        writer.tryWrite(WriteContext.internal(), result.getRecordBatch().entries());
     if (writeResult.isLeft()) {
       FAILED_WRITER_LOGGER.warn(
           """

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.log.WriteContext.Internal;
+import io.camunda.zeebe.logstreams.log.WriteContext.ProcessingResult;
 import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
 import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -152,6 +153,9 @@ public final class FlowControl implements AppendListener {
         if (requestListener == null) {
           return Either.left(Rejection.RequestLimitExhausted);
         }
+      }
+      case ProcessingResult(final var intent) -> {
+        alwaysAllowed = WhiteListedCommands.isWhitelisted(intent);
       }
       default -> {}
     }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -31,6 +31,6 @@ public class WhiteListedCommands {
           CommandDistributionIntent.ACKNOWLEDGE);
 
   public static boolean isWhitelisted(final Intent intent) {
-    return WHITE_LISTED_COMMANDS.contains(intent);
+    return intent != null && WHITE_LISTED_COMMANDS.contains(intent);
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/WriteContext.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/WriteContext.java
@@ -14,8 +14,8 @@ public sealed interface WriteContext {
     return new UserCommand(intent);
   }
 
-  static WriteContext processingResult() {
-    return ProcessingResult.INSTANCE;
+  static WriteContext processingResult(final Intent intent) {
+    return new ProcessingResult(intent);
   }
 
   static WriteContext interPartition() {
@@ -32,9 +32,7 @@ public sealed interface WriteContext {
 
   record UserCommand(Intent intent) implements WriteContext {}
 
-  final class ProcessingResult implements WriteContext {
-    private static final ProcessingResult INSTANCE = new ProcessingResult();
-  }
+  record ProcessingResult(Intent intent) implements WriteContext {}
 
   final class InterPartition implements WriteContext {
     private static final InterPartition INSTANCE = new InterPartition();

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -83,6 +83,31 @@ public class FlowControlTest {
 
   @ParameterizedTest
   @MethodSource("intentClassesProvider")
+  public void shouldBlockProcessingResultsBasedOnSourceIntent(final Intent intent) {
+    // given
+    final var writeContext = WriteContext.processingResult(intent);
+
+    // when
+    final var permits = acquireMultiplePermits(writeContext, intent, ValueType.JOB, 10);
+
+    // then
+    assertThat(permits).first().satisfies(first -> EitherAssert.assertThat(first).isRight());
+    assertThat(permits.subList(1, permits.size()))
+        .allSatisfy(
+            permit -> {
+              if (WhiteListedCommands.isWhitelisted(intent)) {
+                EitherAssert.assertThat(permit).isRight();
+              } else {
+                EitherAssert.assertThat(permit)
+                    .isLeft()
+                    .left()
+                    .satisfies(r -> assertThat(r).isEqualTo(Rejection.WriteRateLimitExhausted));
+              }
+            });
+  }
+
+  @ParameterizedTest
+  @MethodSource("intentClassesProvider")
   public void shouldNeverBlockInternalCommands(final Intent intent) {
     // given
     final var writeContext = WriteContext.internal();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -623,7 +623,9 @@ public final class ProcessingStateMachine {
               () -> {
                 final var writeResult =
                     logStreamWriter.tryWrite(
-                        WriteContext.processingResult(), pendingWrites, sourceRecordPosition);
+                        WriteContext.processingResult(typedCommand.getIntent()),
+                        pendingWrites,
+                        sourceRecordPosition);
                 if (writeResult.isRight()) {
                   writtenPosition = writeResult.get();
                   return true;


### PR DESCRIPTION
## Description
Always allow a ProcessingResult that originated from a whitelisted intent to be written bypassing the write rate limits. This is consistent with how we handle user commands, as we always allow commands from a whitelisted intent.
Note that this measure was put in place to limit recursive/looping processes: this is still the case as only the first batch will bypass the write rate limit. All subsequent batches will honor the limits.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #
