### PR TITLE
test: use new Operate v2 APIs

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
@@ -66,23 +66,23 @@ export async function waitForProcessInstances(
   await expect
     .poll(
       async () => {
-        const response = await request.post('/api/process-instances', {
-          ...requestHeaders,
-          data: {
-            query: {
-              active: true,
-              running: true,
-              incidents: true,
-              completed: true,
-              finished: true,
-              canceled: true,
-              ids: instanceIds,
+        let total = 0;
+
+        for (const id of instanceIds) {
+          const response = await request.post('/v2/process-instances/search', {
+            ...requestHeaders,
+            data: {
+              filter: {
+                processInstanceKey: id, // single ID per request
+              },
             },
-            pageSize: 50,
-          },
-        });
-        const instances = await response.json();
-        return instances.totalCount;
+          });
+
+          const result = await response.json();
+          total += result.page?.totalItems ?? 0;
+        }
+
+        return total;
       },
       {timeout},
     )

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
@@ -52,16 +52,19 @@ export async function createDemoOperations(
     .poll(
       async () => {
         const response = await request.post(
-          `${credentials.baseUrl}/api/batch-operations`,
+          `${credentials.baseUrl}/v2/batch-operations/search`,
           {
             ...requestHeaders,
             data: {
-              pageSize: count,
+              filter: {
+                operationType: 'RESOLVE_INCIDENT',
+              },
             },
           },
         );
-        const operations = await response.json();
-        return operations.length;
+        expect(response.status()).toBe(200);
+        const body = await response.json();
+        return body.items.length;
       },
       {timeout: 30000},
     )


### PR DESCRIPTION
## Description

The tests were using Operate v1 APIs. I updated them to use the v2 endpoints.

Run: https://github.com/camunda/camunda/actions/runs/22628710222

- RDBMS tests expected to fail
- One test (`Process Instance Migration › Migrated tasks `) failed for v2, I will check it in a separate PR

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
