### PR TITLE
fix: ensure node versions are updated in swim

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
@@ -44,12 +44,12 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import oracle.net.nt.Clock;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -206,7 +206,33 @@ public class DynamicNodeIdIT {
     }
   }
 
+  @Test
+  // configure timeout less than the nodeIdprovider.readinessCheckTimeout to ensure the
+  // test fails if the node does not become ready with in time.
+  @Timeout(100)
+  void shouldBecomeReadyAfterRestartingWithExpiredLease() {
+    final var broker = testCluster.brokers().values().iterator().next();
+    final int nodeIdBeforeRestart =
+        broker.bean(BrokerBasedProperties.class).getCluster().getNodeId();
+    final var leaseBeforeRestart = awaitValidLease(nodeIdBeforeRestart);
+
+    broker.stop();
+
+    // Create a fake "expired" lease in S3
+    expireLease(nodeIdBeforeRestart);
+
+    // when - then
+    broker.start().await(TestHealthProbe.READY);
+    testCluster.awaitCompleteTopology();
+
+    final Lease leaseAfterRestart = awaitValidLease(nodeIdBeforeRestart);
+    assertThat(leaseAfterRestart.nodeInstance().id()).isEqualTo(nodeIdBeforeRestart);
+    assertThat(leaseAfterRestart.nodeInstance().version().version())
+        .isGreaterThan(leaseBeforeRestart.nodeInstance().version().version());
+  }
+
   @ParameterizedTest
+  @Timeout(120)
   @ValueSource(booleans = {true, false})
   public void shouldCreateNewVersionedFolderAfterRestartWithHardLinks(
       final boolean gracefulShutdown) throws IOException {
@@ -242,22 +268,7 @@ public class DynamicNodeIdIT {
 
       if (!gracefulShutdown) {
         // Create a fake "expired" lease in S3 for each broker
-        final var expiredLease =
-            new Lease(
-                "fake-object",
-                Clock.currentTimeMillis() - LEASE_DURATION.toMillis() * 2,
-                new NodeInstance(nodeId, Version.of(1L)),
-                VersionMappings.empty());
-        final var body = RequestBody.fromBytes(expiredLease.toJsonBytes(OBJECT_MAPPER));
-        final var metadata = Metadata.fromLease(expiredLease);
-        final var request =
-            PutObjectRequest.builder()
-                .bucket(BUCKET_NAME)
-                .key(S3NodeIdRepository.objectKey(nodeId))
-                .metadata(metadata.asMap())
-                .contentType("application/json")
-                .build();
-        s3Client.putObject(request, body);
+        expireLease(nodeId);
       }
     }
 
@@ -314,6 +325,25 @@ public class DynamicNodeIdIT {
                 assertThat(completedJobs.size()).isEqualTo(startedProcesses);
               });
     }
+  }
+
+  private static void expireLease(final int nodeId) {
+    final var expiredLease =
+        new Lease(
+            "fake-object",
+            System.currentTimeMillis() - LEASE_DURATION.toMillis() * 2,
+            new NodeInstance(nodeId, Version.of(1L)),
+            VersionMappings.empty());
+    final var body = RequestBody.fromBytes(expiredLease.toJsonBytes(OBJECT_MAPPER));
+    final var metadata = Metadata.fromLease(expiredLease);
+    final var request =
+        PutObjectRequest.builder()
+            .bucket(BUCKET_NAME)
+            .key(S3NodeIdRepository.objectKey(nodeId))
+            .metadata(metadata.asMap())
+            .contentType("application/json")
+            .build();
+    s3Client.putObject(request, body);
   }
 
   private Path getDataDirectoryPath(final TestStandaloneBroker broker) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -295,7 +295,8 @@ public class SwimMembershipProtocol
         // lower incarnation number.
         || member.nodeVersion() > swimMember.nodeVersion()) {
       // If the member's version has changed, remove the old member and add the new member.
-      if (!Objects.equals(member.version(), swimMember.version())) {
+      if (!Objects.equals(member.version(), swimMember.version())
+          || member.nodeVersion() > swimMember.nodeVersion()) {
         members.remove(member.id());
         randomMembers.remove(swimMember);
         post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, swimMember.copy()));
@@ -595,21 +596,25 @@ public class SwimMembershipProtocol
     PROBE_LOGGER.trace(
         "{} - Received probe {} from {}", this.localMember.id(), localMember, remoteMember);
 
-    if (localMember.nodeVersion() < this.localMember.nodeVersion()) {
-      LOGGER.debug(
-          "Detected lower version for member {} (local: {}, remote: {}). Ignoring the probe.",
-          this.localMember.id(),
-          this.localMember.nodeVersion(),
-          localMember.nodeVersion());
-      return this.localMember.copy();
-    } else if (localMember.nodeVersion() > this.localMember.nodeVersion()) {
-      LOGGER.debug(
-          "Detected higher version for member {} (local: {}, remote: {}). Leaving the cluster.",
-          this.localMember.id(),
-          this.localMember.nodeVersion(),
-          localMember.nodeVersion());
-      leave(this.localMember);
-      return this.localMember.copy();
+    if (localMember.id().equals(this.localMember.id())) {
+      // id can be just the host address if the probe uses the configured initial contact points. In
+      // that case do not compare nodeVersion as it will be always 0.
+      if (localMember.nodeVersion() < this.localMember.nodeVersion()) {
+        LOGGER.debug(
+            "Detected lower version for member {} (local: {}, remote: {}). Ignoring the probe.",
+            this.localMember.id(),
+            this.localMember.nodeVersion(),
+            localMember.nodeVersion());
+        return this.localMember.copy();
+      } else if (localMember.nodeVersion() > this.localMember.nodeVersion()) {
+        LOGGER.debug(
+            "Detected higher version for member {} (local: {}, remote: {}). Leaving the cluster.",
+            this.localMember.id(),
+            this.localMember.nodeVersion(),
+            localMember.nodeVersion());
+        leave(this.localMember);
+        return this.localMember.copy();
+      }
     }
 
     // If the probe indicates a term greater than the local term, update the local term, increment

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -294,7 +294,8 @@ public class SwimMembershipProtocol
         // Although this would not happen, we handle the case where the higher node version has a
         // lower incarnation number.
         || member.nodeVersion() > swimMember.nodeVersion()) {
-      // If the member's version has changed, remove the old member and add the new member.
+      // If the member's software version or nodeVersion has changed, remove the old member and add
+      // the new member.
       if (!Objects.equals(member.version(), swimMember.version())
           || member.nodeVersion() > swimMember.nodeVersion()) {
         members.remove(member.id());

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -320,6 +320,51 @@ public class SwimProtocolTest extends ConcurrentTestCase {
   }
 
   @Test
+  public void shouldRemoveOldMemberNodeIdVersionWhenNoPropertyChanged()
+      throws InterruptedException {
+    // given
+    reset(true);
+    startProtocol(member1, member1.id().toString());
+    startProtocol(member2, member2.id().toString());
+
+    awaitMembers(member2, member1, member2);
+    awaitMembers(member1, member1, member2);
+
+    clearEvents(member1, member2);
+
+    // when - starting a member with new node version but all other properties unchanged
+    final var currentVersion = versions.get(member2.id().id());
+    // version can be null
+    final var nextVersion = currentVersion != null ? currentVersion + 1 : 0;
+    final var member2NewVersion =
+        member(
+            member2.id().id(),
+            nextVersion, // only update the node id version
+            member2.address().host(),
+            member2.address().port(),
+            version1 // use the same software version
+            );
+    startProtocol(member2NewVersion, "member2-" + member2.id().id());
+
+    // then
+    Awaitility.await("Member 2 old node version removed")
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> checkEvent(member1, MEMBER_REMOVED, member2));
+    checkEvent(member1, MEMBER_ADDED, member2NewVersion);
+
+    // verify that all members have only the new version of member2
+    for (final var entry : protocols.entrySet()) {
+      final var id = entry.getKey();
+      if (!id.equals(member2NewVersion.id())) {
+        final var memberView = ((SwimMember) entry.getValue().getMember(member2NewVersion.id()));
+        assertThat(memberView.nodeVersion())
+            .describedAs("Member %s has new version of member 2", id)
+            .isEqualTo(nextVersion);
+      }
+    }
+  }
+
+  @Test
   public void oldVersionShouldLeaveWhenNewVersionIsDetected() throws InterruptedException {
     // given
     reset(true);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -48,7 +48,10 @@ public final class ClusterConfigFactory {
     final var advertisedAddress =
         Address.from(network.getAdvertisedHost(), network.getAdvertisedPort());
 
-    return new MemberConfig().setAddress(advertisedAddress).setId(String.valueOf(nodeId));
+    return new MemberConfig()
+        .setAddress(advertisedAddress)
+        .setId(String.valueOf(nodeId))
+        .setNodeVersion(nodeVersion);
   }
 
   private SwimMembershipProtocolConfig membershipConfig(final MembershipCfg config) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -300,6 +300,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
             .map(m -> Map.entry(Integer.parseInt(m.id().id()), Version.of(m.nodeVersion())))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     knownVersionMappings = new VersionMappings(nodeInstances);
+    LOG.trace("Updating known version mappings to {}", knownVersionMappings);
   }
 
   private boolean isBroker(final MemberId memberId) {


### PR DESCRIPTION
## Description

The `knownVersionMappings` in the lease objects were observed to be always 0. There were two main bugs related to it.

1. `nodeVersion` from `NodeIdProvider` was not set in the atomix member when building it. As a result, SWIM always saw version 0.
2. SWIM member did not always update the local state when it receives an update from a remote member with a new nodeVersion. If the node restarts quickly before other nodes marked it as dead, then the next swim update was not updating the nodeVersion in the local state. As a result this member always uses the old nodeVersion of the node. To fix this we detect the change in nodeVersion and re-add the swim member so that it has the uptodate state.

In addition, the probe where generating unnecessary log because it detects lower version when ever a probe request using the address instead of the node id is received. This would not result in any issues, but the logs can be misleading. This is fixed by comparing the ids.

Existing test in DynamicNodeIT passed because the nodes become eventually ready after the configured `readinessCheckTimeout`. To detect this in future, a timeout is added to the test. Another test that can reproduce this bug is also added. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #40166 
