### PR TITLE
[Backport stable/8.9] fix: remove writing agent to es/os exporter records

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -159,6 +159,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jeasy</groupId>
+      <artifactId>easy-random-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-jackson</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -78,6 +78,7 @@ final class BulkIndexRequest {
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
+  private static final String RECORD_AGENT_PROPERTY = "agent";
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
@@ -195,7 +196,7 @@ final class BulkIndexRequest {
   record IndexOperation(BulkIndexAction metadata, byte[] source) {}
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
-  @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY})
+  @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY, RECORD_AGENT_PROPERTY})
   private static final class RecordSequenceMixin {}
 
   @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -53,15 +53,6 @@
         },
         "batchOperationReference": {
           "type": "long"
-        },
-        "agent": {
-          "type": "object",
-          "properties": {
-            "elementId": {
-              "type": "keyword",
-              "index": false
-            }
-          }
         }
       }
     }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -34,7 +34,6 @@ import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -92,6 +91,7 @@ final class BulkIndexRequestTest {
     // Elasticsearch exporter. We need to do the same in the test to get the correct memory usage.
     recordAsMap.put("sequence", recordSequence.sequence());
     recordAsMap.remove("authorizations");
+    recordAsMap.remove("agent");
     return MAPPER.writeValueAsBytes(recordAsMap).length;
   }
 
@@ -175,7 +175,7 @@ final class BulkIndexRequestTest {
   final class SerializationTest {
     @Test
     void shouldIndexRecordSerialized() {
-      // given - use an empty authorization for comparison, since the bulk request will remove it
+      // given
       final var record =
           recordFactory.generateRecord(
               b -> b.withAuthorizations(Map.of()).withBrokerVersion(VersionUtil.getVersion()));
@@ -184,12 +184,18 @@ final class BulkIndexRequestTest {
       // when
       request.index(action, record, new RecordSequence(PARTITION_ID, 1));
 
-      // then
+      // then - verify the record was serialized with expected properties
       final var operations = request.bulkOperations();
-      assertThat(operations)
-          .hasSize(1)
-          .map(IndexOperation::metadata, this::deserializeSource)
-          .containsExactly(Tuple.tuple(action, record));
+      assertThat(operations).hasSize(1);
+
+      final var deserialized = deserializeSource(operations.getFirst());
+      // Verify key record properties are serialized correctly
+      assertThat(deserialized.getPartitionId()).isEqualTo(record.getPartitionId());
+      assertThat(deserialized.getPosition()).isEqualTo(record.getPosition());
+      assertThat(deserialized.getKey()).isEqualTo(record.getKey());
+      // Verify excluded fields are null/empty
+      assertThat(deserialized.getAuthorizations()).isEmpty();
+      assertThat(deserialized.getAgent()).isNull();
     }
 
     @Test
@@ -223,7 +229,7 @@ final class BulkIndexRequestTest {
     }
 
     @Test
-    void shouldIndexRecordWithoutAuthorizations() {
+    void shouldIndexRecordWithoutAuthorizationsAndAgent() {
       // given
       final var records =
           recordFactory
@@ -242,6 +248,12 @@ final class BulkIndexRequestTest {
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("authorizations"))
           .describedAs("Expect that the records are NOT serialized with authorizations")
+          .containsExactly(new Object[] {null});
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("agent"))
+          .describedAs("Expect that the records are NOT serialized with agent")
           .containsExactly(new Object[] {null});
     }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -76,8 +76,10 @@ final class ElasticsearchExporterIT {
   private static TestClient testClient;
   private static ExporterTestContext exporterTestContext;
   private static String previousTestMethod = null;
-  // omit authorizations since they are removed from the records during serialization
-  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+  // omit authorizations and agent since they are removed from the records during serialization
+  private final ProtocolFactory factory =
+      new ProtocolFactory(b -> b.withAuthorizations(Map.of()))
+          .registerRandomizer(field -> "agent".equals(field.getName()), random -> null);
 
   @BeforeEach
   public void beforeEach(final TestInfo testInfo) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
@@ -31,8 +31,10 @@ final class FaultToleranceIT {
 
   private final ElasticsearchExporterConfiguration config =
       new ElasticsearchExporterConfiguration();
-  // omit authorizations since they are removed from the records during serialization
-  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+  // omit authorizations and agent since they are removed from the records during serialization
+  private final ProtocolFactory factory =
+      new ProtocolFactory(b -> b.withAuthorizations(Map.of()))
+          .registerRandomizer(field -> "agent".equals(field.getName()), random -> null);
   private final ExporterTestController controller = new ExporterTestController();
   private final ElasticsearchExporter exporter = new ElasticsearchExporter();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -184,6 +184,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jeasy</groupId>
+      <artifactId>easy-random-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -85,6 +85,7 @@ final class BulkIndexRequest {
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
+  private static final String RECORD_AGENT_PROPERTY = "agent";
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
@@ -217,7 +218,7 @@ final class BulkIndexRequest {
   }
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
-  @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY})
+  @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY, RECORD_AGENT_PROPERTY})
   private static final class RecordSequenceMixin {}
 
   @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -59,15 +59,6 @@
         },
         "batchOperationReference": {
           "type": "long"
-        },
-        "agent": {
-          "type": "object",
-          "properties": {
-            "elementId": {
-              "type": "keyword",
-              "index": false
-            }
-          }
         }
       }
     }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -89,6 +89,7 @@ final class BulkIndexRequestTest {
     // Opensearch exporter. We need to do the same in the test to get the correct memory usage.
     recordAsMap.put("sequence", recordSequence.sequence());
     recordAsMap.remove("authorizations");
+    recordAsMap.remove("agent");
     return MAPPER.writeValueAsBytes(recordAsMap).length;
   }
 
@@ -208,6 +209,7 @@ final class BulkIndexRequestTest {
       assertThat(doc.get("position")).isEqualTo(record.getPosition());
       assertThat(doc.get("sequence")).isEqualTo(2251799813685249L);
       assertThat(doc.get("authorizations")).isNull();
+      assertThat(doc.get("agent")).isNull();
     }
 
     @Test
@@ -247,7 +249,7 @@ final class BulkIndexRequestTest {
     }
 
     @Test
-    void shouldIndexRecordWithoutAuthorizations() throws IOException {
+    void shouldIndexRecordWithoutAuthorizationsAndAgent() throws IOException {
       // given
       final var records =
           recordFactory
@@ -266,6 +268,9 @@ final class BulkIndexRequestTest {
       final var doc = getDocumentAsMap(request.bulkOperations().getFirst());
       assertThat(doc.get("authorizations"))
           .describedAs("Expect that the records are NOT serialized with authorizations")
+          .isNull();
+      assertThat(doc.get("agent"))
+          .describedAs("Expect that the records are NOT serialized with agent")
           .isNull();
     }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/FaultToleranceIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/FaultToleranceIT.java
@@ -30,8 +30,10 @@ import org.testcontainers.containers.SocatContainer;
 final class FaultToleranceIT {
 
   private final OpensearchExporterConfiguration config = new OpensearchExporterConfiguration();
-  // omit authorizations since they are removed from the records during serialization
-  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+  // omit authorizations and agent since they are removed from the records during serialization
+  private final ProtocolFactory factory =
+      new ProtocolFactory(b -> b.withAuthorizations(Map.of()))
+          .registerRandomizer(field -> "agent".equals(field.getName()), random -> null);
   private final ExporterTestController controller = new ExporterTestController();
   private final OpensearchExporter exporter = new OpensearchExporter();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -76,8 +76,10 @@ final class OpensearchExporterIT {
   private static TestClient testClient;
   private static ExporterTestContext exporterTestContext;
   private static String previousTestMethod = null;
-  // omit authorizations since they are removed from the records during serialization
-  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+  // omit authorizations and agent since they are removed from the records during serialization
+  private final ProtocolFactory factory =
+      new ProtocolFactory(b -> b.withAuthorizations(Map.of()))
+          .registerRandomizer(field -> "agent".equals(field.getName()), random -> null);
 
   @BeforeEach
   public void beforeEach(final TestInfo testInfo) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TemplateReaderTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TemplateReaderTest.java
@@ -92,16 +92,7 @@ final class TemplateReaderTest {
                 Property.builder().long_(LongNumberProperty.builder().build()).build()),
             Map.entry(
                 "batchOperationReference",
-                Property.builder().long_(LongNumberProperty.builder().build()).build()),
-            Map.entry(
-                "agent",
-                Property.builder()
-                    .object(
-                        o ->
-                            o.properties(
-                                "elementId",
-                                Property.builder().keyword(k -> k.index(false)).build()))
-                    .build()));
+                Property.builder().long_(LongNumberProperty.builder().build()).build()));
 
     assertThat(request.template().mappings())
         .as("component template should have mappings with properties")


### PR DESCRIPTION
# Description
Backport of #47162 to `stable/8.9`.

relates to #47155