### PR TITLE
feat: add ttl input for weekly load test recreation

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -10,6 +10,11 @@ on:
         type: string
         default: ""
         required: false
+      ttl:
+        description: 'Specifies after how many days the weekly load test namespace should be deleted. Useful to adjust if we recreate the weekly tests.'
+        type: number
+        default: 28
+        required: false
   schedule:
     # Runs at 1am every monday https://crontab.guru/#0_1_*_*_1
     - cron: 0 1 * * 1
@@ -52,7 +57,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-typical
-      ttl: 28
+      ttl: ${{ inputs.ttl || 28 }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: typical
       build-frontend: true
@@ -64,7 +69,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-rdbms-realistic
-      ttl: 28
+      ttl: ${{ inputs.ttl || 28 }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       secondary-storage-type: 'postgresql'
       build-frontend: true
@@ -77,7 +82,7 @@ jobs:
       - test-data
     with:
       name: ${{ needs.test-data.outputs.test }}-realistic
-      ttl: 28
+      ttl: ${{ inputs.ttl || 28 }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: realistic
       build-frontend: true
@@ -89,7 +94,7 @@ jobs:
       - test-data
     with:
       name: ${{ needs.test-data.outputs.test }}-latency
-      ttl: 28
+      ttl: ${{ inputs.ttl || 28 }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: latency
       build-frontend: true


### PR DESCRIPTION
## Description

* We have sometimes the use case to recreate weekly load tests
* We do not want to run them for four weeks in this case
* Instead we want to adjust the execution time 
* For this we have an new input value to override the default of 28 days
<!-- Describe the goal and purpose of this PR. -->


## Related issues

This will be useful when we migrate our weekly load tests to the new infra