### PR TITLE
[Backport stable/8.9] fix: support oracle 19c multiline insert syntax

### DIFF
--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -139,6 +139,15 @@
     </foreach>
   </insert>
 
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="permissionTypes" item="permissionType">
+      INTO ${prefix}AUTHORIZATIONS (AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, RESOURCE_PROPERTY_NAME, PERMISSION_TYPE)
+      VALUES (#{authorizationKey}, #{ownerId}, #{ownerType}, #{resourceType}, #{resourceMatcher}, #{resourceId}, #{resourcePropertyName}, #{permissionType})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel">
     DELETE
     FROM ${prefix}AUTHORIZATIONS

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -76,6 +76,17 @@
     </foreach>
   </insert>
 
+  <insert id="insertItems"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemsDto"
+    databaseId="oracle">
+    INSERT ALL
+    <foreach collection="items" item="item">
+      INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, STATE)
+      VALUES (#{batchOperationKey}, #{item.itemKey}, #{item.processInstanceKey}, #{item.rootProcessInstanceKey}, #{item.state})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <insert id="insertErrors"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationErrorDto">
     INSERT INTO ${prefix}BATCH_OPERATION_ERROR
@@ -84,6 +95,17 @@
     <foreach collection="errors" item="error" separator=",">
       (#{batchOperationKey}, #{error.partitionId}, #{error.type}, #{error.message})
     </foreach>
+  </insert>
+
+  <insert id="insertErrors"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationErrorDto"
+    databaseId="oracle">
+    INSERT ALL
+    <foreach collection="errors" item="error">
+      INTO ${prefix}BATCH_OPERATION_ERROR (BATCH_OPERATION_KEY, PARTITION_ID, TYPE, MESSAGE)
+      VALUES (#{batchOperationKey}, #{error.partitionId}, #{error.type}, #{error.message})
+    </foreach>
+    SELECT 1 FROM DUAL
   </insert>
 
   <update id="activate"

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -268,6 +268,15 @@
     </foreach>
   </insert>
 
+  <insert id="insertInput" parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="evaluatedInputs" item="item">
+      INTO ${prefix}DECISION_INSTANCE_INPUT (DECISION_INSTANCE_ID, INPUT_ID, INPUT_NAME, INPUT_VALUE)
+      VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <!-- create select statement for decision instance input -->
   <select id="loadInputs" parameterType="list"
     resultMap="io.camunda.db.rdbms.sql.DecisionInstanceMapper.evaluatedInputResultMap">
@@ -299,6 +308,17 @@
       (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId},
       #{item.ruleIndex})
     </foreach>
+  </insert>
+
+  <insert id="insertOutput"
+    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel"
+    databaseId="oracle">
+    INSERT ALL
+    <foreach collection="evaluatedOutputs" item="item">
+      INTO ${prefix}DECISION_INSTANCE_OUTPUT (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, OUTPUT_VALUE, RULE_ID, RULE_INDEX)
+      VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId}, #{item.ruleIndex})
+    </foreach>
+    SELECT 1 FROM DUAL
   </insert>
 
   <select id="loadOutputs" parameterType="list"

--- a/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
@@ -37,6 +37,14 @@
     </foreach>
   </insert>
 
+  <insert id="insertEventTypes" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="eventTypes" item="eventType">
+      INTO ${prefix}GLOBAL_LISTENER_EVENT_TYPE (GLOBAL_LISTENER_ID, EVENT_TYPE) VALUES (#{id}, #{eventType})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
     UPDATE ${prefix}GLOBAL_LISTENER
     SET LISTENER_ID = #{listenerId},

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -460,6 +460,14 @@
       </foreach>
   </insert>
 
+  <insert id="insertTags" parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="tags" item="tag">
+      INTO ${prefix}PROCESS_INSTANCE_TAG (PROCESS_INSTANCE_KEY, TAG_VALUE) VALUES (#{processInstanceKey}, #{tag})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}PROCESS_INSTANCE
     SET HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -35,6 +35,14 @@
     </foreach>
   </insert>
 
+  <insert id="insertCandidateUsers" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="candidateUsers" item="candidateUser">
+      INTO ${prefix}CANDIDATE_USER (USER_TASK_KEY, CANDIDATE_USER) VALUES (#{userTaskKey}, #{candidateUser})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <insert id="insertCandidateGroups" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     INSERT INTO ${prefix}CANDIDATE_GROUP (USER_TASK_KEY, CANDIDATE_GROUP)
     VALUES
@@ -43,12 +51,28 @@
     </foreach>
   </insert>
 
+  <insert id="insertCandidateGroups" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="candidateGroups" item="candidateGroup">
+      INTO ${prefix}CANDIDATE_GROUP (USER_TASK_KEY, CANDIDATE_GROUP) VALUES (#{userTaskKey}, #{candidateGroup})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
   <insert id="insertTags" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel">
     INSERT INTO ${prefix}USER_TASK_TAG (USER_TASK_KEY, TAG_VALUE)
     VALUES
     <foreach collection="tags" item="tag" separator=", ">
       (#{userTaskKey}, #{tag})
     </foreach>
+  </insert>
+
+  <insert id="insertTags" parameterType="io.camunda.db.rdbms.write.domain.UserTaskDbModel" databaseId="oracle">
+    INSERT ALL
+    <foreach collection="tags" item="tag">
+      INTO ${prefix}USER_TASK_TAG (USER_TASK_KEY, TAG_VALUE) VALUES (#{userTaskKey}, #{tag})
+    </foreach>
+    SELECT 1 FROM DUAL
   </insert>
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.UserTaskDbModel">


### PR DESCRIPTION
# Description
Backport of #47149 to `stable/8.9`.

relates to 