### PR TITLE
fix: guard MicrometerMetricsRecorder bean on MeterRegistry bean presence

### DIFF
--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -154,6 +154,7 @@
                     <!-- Exclude classes that we override with Spring Boot 4 versions -->
                     <exclude>io/camunda/zeebe/spring/client/actuator/ZeebeClientHealthIndicator.class</exclude>
                     <exclude>io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.class</exclude>
+                    <exclude>io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.class</exclude>
                     <exclude>io/camunda/zeebe/spring/client/configuration/CamundaAutoConfiguration.class</exclude>
                     <!-- Exclude META-INF services that we override -->
                     <exclude>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</exclude>

--- a/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
+++ b/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -43,6 +44,7 @@ import org.springframework.context.annotation.Lazy;
 public class ZeebeActuatorConfiguration {
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnBean(MeterRegistry.class)
   public MetricsRecorder micrometerMetricsRecorder(@Lazy final MeterRegistry meterRegistry) {
     return new MicrometerMetricsRecorder(meterRegistry);
   }

--- a/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
+++ b/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.configuration;
+
+import io.camunda.zeebe.client.CredentialsProvider;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.impl.ZeebeClientImpl;
+import io.camunda.zeebe.client.impl.util.ExecutorResource;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.camunda.zeebe.spring.client.configuration.condition.ConditionalOnCamundaClientEnabled;
+import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
+import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
+import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Spring Boot 4 compatible version of {@code ZeebeClientProdAutoConfiguration}. Adds {@link
+ * MetricsDefaultConfiguration} to the imports so that a {@code DefaultNoopMetricsRecorder} fallback
+ * is available when {@link ZeebeActuatorConfiguration} skips the {@code MicrometerMetricsRecorder}
+ * bean (e.g. because no {@code MeterRegistry} bean exists in Spring Boot 4, where {@code
+ * MetricsAutoConfiguration} was removed from {@code spring-boot-actuator-autoconfigure}).
+ *
+ * <p>All configurations that will only be used in production code - meaning NO TEST cases.
+ */
+@ConditionalOnCamundaClientEnabled
+@ConditionalOnMissingBean(SpringZeebeTestContext.class)
+@ImportAutoConfiguration({
+  ExecutorServiceConfiguration.class,
+  ZeebeActuatorConfiguration.class,
+  MetricsDefaultConfiguration.class,
+  JsonMapperConfiguration.class,
+  CredentialsProviderConfiguration.class,
+})
+@AutoConfigureBefore(ZeebeClientAllAutoConfiguration.class)
+@EnableConfigurationProperties({CamundaClientProperties.class})
+public class ZeebeClientProdAutoConfiguration {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZeebeClientProdAutoConfiguration.class);
+
+  @Bean
+  public ZeebeClientConfigurationImpl zeebeClientConfiguration(
+      final CamundaClientProperties camundaClientProperties,
+      final JsonMapper jsonMapper,
+      final List<ClientInterceptor> interceptors,
+      final List<AsyncExecChainHandler> chainHandlers,
+      final ZeebeClientExecutorService zeebeClientExecutorService,
+      final CredentialsProvider credentialsProvider) {
+    return new ZeebeClientConfigurationImpl(
+        camundaClientProperties,
+        jsonMapper,
+        interceptors,
+        chainHandlers,
+        zeebeClientExecutorService,
+        credentialsProvider);
+  }
+
+  @Bean(destroyMethod = "close")
+  public ZeebeClient zeebeClient(final ZeebeClientConfigurationImpl configuration) {
+    LOG.info("Creating ZeebeClient using ZeebeClientConfigurationImpl [" + configuration + "]");
+    final ScheduledExecutorService jobWorkerExecutor = configuration.jobWorkerExecutor();
+    if (jobWorkerExecutor != null) {
+      final ManagedChannel managedChannel = ZeebeClientImpl.buildChannel(configuration);
+      final GatewayGrpc.GatewayStub gatewayStub =
+          ZeebeClientImpl.buildGatewayStub(managedChannel, configuration);
+      final ExecutorResource executorResource =
+          new ExecutorResource(jobWorkerExecutor, configuration.ownsJobWorkerExecutor());
+      return new ZeebeClientImpl(configuration, managedChannel, gatewayStub, executorResource);
+    } else {
+      return new ZeebeClientImpl(configuration);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add @ConditionalOnBean(MeterRegistry.class) to the micrometerMetricsRecorder
bean definition in ZeebeActuatorConfiguration for the Spring Boot 4 starter.
This prevents the bean from being created when no MeterRegistry is available,
which happens in Spring Boot 4 where MetricsAutoConfiguration was removed
from spring-boot-actuator-autoconfigure.

Without this guard, the @Lazy MeterRegistry proxy is created at startup but
fails with NoSuchBeanDefinitionException on first use (e.g. jobActivated),
silently breaking job workers via an unobserved CompletableFuture.

Also override ZeebeClientProdAutoConfiguration in the Spring Boot 4 starter
to import MetricsDefaultConfiguration, ensuring a DefaultNoopMetricsRecorder
fallback is available when the Micrometer recorder is skipped.

Tested with https://github.com/camunda-community-hub/camunda-8-examples/pull/1102 , without this fix it silently fails not completing jobs as the metrics recording prevents job handling invocation.

On 8.8 this does not happen as there we have a default registry setup since https://github.com/camunda/zeebe-process-test/commit/d27f095d25731217d2b4b6341ff26f74cf9c1665

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
