### PR TITLE
fix: prevent unauthenticated access when broker profile is not specified

### DIFF
--- a/dist/src/main/java/io/camunda/operate/OperateModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/operate/OperateModuleConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(
-    basePackages = "io.camunda.operate",
+    basePackages = {"io.camunda.operate", "io.camunda.authentication"},
     excludeFilters = {
       @ComponentScan.Filter(
           type = FilterType.REGEX,

--- a/dist/src/main/java/io/camunda/tasklist/TasklistModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/tasklist/TasklistModuleConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(
-    basePackages = "io.camunda.tasklist",
+    basePackages = {"io.camunda.tasklist", "io.camunda.authentication"},
     excludeFilters = {
       @ComponentScan.Filter(
           type = FilterType.REGEX,

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/security/DefaultWebSecurityConfig.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/security/DefaultWebSecurityConfig.java
@@ -10,6 +10,7 @@ package io.camunda.operate.archiver.security;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 @Configuration
 @Component("archiverWebSecurityConfig")
 @ConditionalOnMissingBean(name = {"webSecurityConfig", "importerWebSecurityConfig"})
+@Profile("!auth-basic")
 @Order(20)
 public class DefaultWebSecurityConfig {
 

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/security/DefaultWebSecurityConfig.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/security/DefaultWebSecurityConfig.java
@@ -10,6 +10,7 @@ package io.camunda.operate.zeebeimport.security;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 @Configuration
 @Component("importerWebSecurityConfig")
 @ConditionalOnMissingBean(name = "webSecurityConfig")
+@Profile("!auth-basic")
 @Order(10)
 public class DefaultWebSecurityConfig {
 

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/security/DefaultWebSecurityConfig.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/security/DefaultWebSecurityConfig.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.archiver.security;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -20,11 +21,12 @@ import org.springframework.stereotype.Component;
 @Configuration
 @Component("archiverWebSecurityConfig")
 @ConditionalOnMissingBean(name = {"webSecurityConfig", "importerWebSecurityConfig"})
+@Profile("!auth-basic")
 @Order(20)
 public class DefaultWebSecurityConfig {
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
     return http.csrf().disable().authorizeRequests().anyRequest().permitAll().and().build();
   }
 }

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/security/DefaultWebSecurityConfig.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/security/DefaultWebSecurityConfig.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.zeebeimport.security;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -20,11 +21,12 @@ import org.springframework.stereotype.Component;
 @Configuration
 @Component("importerWebSecurityConfig")
 @ConditionalOnMissingBean(name = "webSecurityConfig")
+@Profile("!auth-basic")
 @Order(10)
 public class DefaultWebSecurityConfig {
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
     return http.csrf().disable().authorizeRequests().anyRequest().permitAll().and().build();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The io.camunda.authentication package is only defined to be scanned in the `broker` profile. As a result, when running Camunda without the broker by specifying the profiles `operate, tasklist, standalone, auth-basic` results in the WebSecurityConfig not being loaded. 

Additionally, since this is not an auto-configuration class, @ConditionalOnMissingBean fails to load correctly. Since this is only necessary for the auth-basic profile, we add a profile check to prevent the loading of `DefaultWebSecurityConfig` for `auth-basic`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45220
