### PR TITLE
[Backport stable/8.9] fix: anchor cross-minor no-op bridge plan at X.Y.0 to prevent silent registry override

### DIFF
--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/CurrentVersionNoOperationUpgradePlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/CurrentVersionNoOperationUpgradePlanFactory.java
@@ -18,7 +18,7 @@ public class CurrentVersionNoOperationUpgradePlanFactory implements UpgradePlanF
   public UpgradePlan createUpgradePlan() {
     return UpgradePlanBuilder.createUpgradePlan()
         .fromVersion(PreviousVersion.PREVIOUS_VERSION_MAJOR_MINOR)
-        .toVersion(Version.VERSION)
+        .toVersion(Version.getMajorAndMinor(Version.VERSION) + ".0")
         .build();
   }
 

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/main/UpgradeProcedureIT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/main/UpgradeProcedureIT.java
@@ -54,8 +54,8 @@ public class UpgradeProcedureIT extends AbstractUpgradeIT {
             String.format(
                 "Schema version saved in Metadata [%s] must be one of [%s, %s]",
                 metadataIndexVersion,
-                PreviousVersion.PREVIOUS_VERSION_MAJOR_MINOR,
-                Version.VERSION));
+                previousVersionMajorMinorUpgradePlan.getFromVersion().getValue(),
+                previousVersionMajorMinorUpgradePlan.getToVersion().getValue()));
 
     assertThat(getMetadataVersion()).isEqualTo(metadataIndexVersion);
   }
@@ -70,7 +70,8 @@ public class UpgradeProcedureIT extends AbstractUpgradeIT {
         .isThrownBy(() -> upgradeProcedure.performUpgrade(previousVersionMajorMinorUpgradePlan));
 
     // then
-    assertThat(getMetadataVersion()).isEqualTo(Version.VERSION);
+    assertThat(getMetadataVersion())
+        .isEqualTo(previousVersionMajorMinorUpgradePlan.getToVersion().getValue());
   }
 
   @Test
@@ -83,7 +84,8 @@ public class UpgradeProcedureIT extends AbstractUpgradeIT {
         .isThrownBy(() -> upgradeProcedure.performUpgrade(previousVersionMajorMinorUpgradePlan));
 
     // then
-    assertThat(getMetadataVersion()).isEqualTo(Version.VERSION);
+    assertThat(getMetadataVersion())
+        .isEqualTo(previousVersionMajorMinorUpgradePlan.getToVersion().getValue());
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #47456 to `stable/8.9`.

relates to #47166 #46523 #40258