### PR TITLE
feat: make job metrics config available to to the gateway layer

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/JobMetricsConfig.java
+++ b/configuration/src/main/java/io/camunda/configuration/JobMetricsConfig.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.time.Duration;
+import java.util.Set;
+
+public class JobMetricsConfig {
+
+  private static final String PREFIX = "camunda.monitoring.metrics.job-metrics";
+
+  private static final Duration DEFAULT_EXPORT_INTERVAL = Duration.ofMinutes(5);
+  private static final int DEFAULT_MAX_WORKER_NAME_LENGTH = 100;
+  private static final int DEFAULT_MAX_JOB_TYPE_LENGTH = 100;
+  private static final int DEFAULT_MAX_TENANT_ID_LENGTH = 30;
+  private static final int DEFAULT_MAX_UNIQUE_KEYS = 9500;
+  private static final boolean DEFAULT_ENABLED = true;
+
+  private static final Set<String> LEGACY_EXPORT_INTERVAL_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.jobMetrics.exportInterval");
+
+  private static final Set<String> LEGACY_MAX_WORKER_NAME_LENGTH_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.jobMetrics.maxWorkerNameLength");
+
+  private static final Set<String> LEGACY_MAX_JOB_TYPE_LENGTH_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.jobMetrics.maxJobTypeLength");
+
+  private static final Set<String> LEGACY_MAX_TENANT_ID_LENGTH_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.jobMetrics.maxTenantIdLength");
+
+  private static final Set<String> LEGACY_MAX_UNIQUE_KEYS_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.jobMetrics.maxUniqueKeys");
+
+  private static final Set<String> LEGACY_ENABLED_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.jobMetrics.enabled");
+
+  /** The interval at which job metrics are exported. */
+  private Duration exportInterval = DEFAULT_EXPORT_INTERVAL;
+
+  /** The maximum length of the worker name used in job metrics labels. */
+  private int maxWorkerNameLength = DEFAULT_MAX_WORKER_NAME_LENGTH;
+
+  /** The maximum length of the job type used in job metrics labels. */
+  private int maxJobTypeLength = DEFAULT_MAX_JOB_TYPE_LENGTH;
+
+  /** The maximum length of the tenant ID used in job metrics labels. */
+  private int maxTenantIdLength = DEFAULT_MAX_TENANT_ID_LENGTH;
+
+  /** The maximum number of unique metric keys tracked for job metrics. */
+  private int maxUniqueKeys = DEFAULT_MAX_UNIQUE_KEYS;
+
+  /** Whether job metrics export is enabled. */
+  private boolean enabled = DEFAULT_ENABLED;
+
+  public Duration getExportInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".export-interval",
+        exportInterval,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_EXPORT_INTERVAL_PROPERTIES);
+  }
+
+  public void setExportInterval(final Duration exportInterval) {
+    this.exportInterval = exportInterval;
+  }
+
+  public int getMaxWorkerNameLength() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-worker-name-length",
+        maxWorkerNameLength,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_WORKER_NAME_LENGTH_PROPERTIES);
+  }
+
+  public void setMaxWorkerNameLength(final int maxWorkerNameLength) {
+    this.maxWorkerNameLength = maxWorkerNameLength;
+  }
+
+  public int getMaxJobTypeLength() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-job-type-length",
+        maxJobTypeLength,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_JOB_TYPE_LENGTH_PROPERTIES);
+  }
+
+  public void setMaxJobTypeLength(final int maxJobTypeLength) {
+    this.maxJobTypeLength = maxJobTypeLength;
+  }
+
+  public int getMaxTenantIdLength() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-tenant-id-length",
+        maxTenantIdLength,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_TENANT_ID_LENGTH_PROPERTIES);
+  }
+
+  public void setMaxTenantIdLength(final int maxTenantIdLength) {
+    this.maxTenantIdLength = maxTenantIdLength;
+  }
+
+  public int getMaxUniqueKeys() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-unique-keys",
+        maxUniqueKeys,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_UNIQUE_KEYS_PROPERTIES);
+  }
+
+  public void setMaxUniqueKeys(final int maxUniqueKeys) {
+    this.maxUniqueKeys = maxUniqueKeys;
+  }
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enabled",
+        enabled,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ENABLED_PROPERTIES);
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Metrics.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metrics.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import java.util.Set;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Metrics {
 
@@ -24,6 +25,9 @@ public class Metrics {
 
   /** Enable exporter execution metrics */
   private boolean enableExporterExecutionMetrics;
+
+  /** Configure job metrics export settings */
+  @NestedConfigurationProperty private JobMetricsConfig jobMetrics = new JobMetricsConfig();
 
   public boolean isActor() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -49,5 +53,13 @@ public class Metrics {
 
   public void setEnableExporterExecutionMetrics(final boolean enableExporterExecutionMetrics) {
     this.enableExporterExecutionMetrics = enableExporterExecutionMetrics;
+  }
+
+  public JobMetricsConfig getJobMetrics() {
+    return jobMetrics;
+  }
+
+  public void setJobMetrics(final JobMetricsConfig jobMetrics) {
+    this.jobMetrics = jobMetrics;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1002,8 +1002,7 @@ public class BrokerBasedPropertiesOverride {
     override.getExperimental().getFeatures().setEnableActorMetrics(metrics.isActor());
     override.setExecutionMetricsExporterEnabled(metrics.isEnableExporterExecutionMetrics());
 
-    final var jobMetrics =
-        unifiedConfiguration.getCamunda().getMonitoring().getMetrics().getJobMetrics();
+    final var jobMetrics = metrics.getJobMetrics();
     final var jobMetricsCfg = override.getExperimental().getEngine().getJobMetrics();
     jobMetricsCfg.setExportInterval(jobMetrics.getExportInterval());
     jobMetricsCfg.setMaxWorkerNameLength(jobMetrics.getMaxWorkerNameLength());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1001,6 +1001,16 @@ public class BrokerBasedPropertiesOverride {
     final Metrics metrics = unifiedConfiguration.getCamunda().getMonitoring().getMetrics();
     override.getExperimental().getFeatures().setEnableActorMetrics(metrics.isActor());
     override.setExecutionMetricsExporterEnabled(metrics.isEnableExporterExecutionMetrics());
+
+    final var jobMetrics =
+        unifiedConfiguration.getCamunda().getMonitoring().getMetrics().getJobMetrics();
+    final var jobMetricsCfg = override.getExperimental().getEngine().getJobMetrics();
+    jobMetricsCfg.setExportInterval(jobMetrics.getExportInterval());
+    jobMetricsCfg.setMaxWorkerNameLength(jobMetrics.getMaxWorkerNameLength());
+    jobMetricsCfg.setMaxJobTypeLength(jobMetrics.getMaxJobTypeLength());
+    jobMetricsCfg.setMaxTenantIdLength(jobMetrics.getMaxTenantIdLength());
+    jobMetricsCfg.setMaxUniqueKeys(jobMetrics.getMaxUniqueKeys());
+    jobMetricsCfg.setEnabled(jobMetrics.isEnabled());
   }
 
   private void setArgIfNotNull(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -8,11 +8,13 @@
 package io.camunda.configuration.beanoverrides;
 
 import io.camunda.configuration.Executor;
+import io.camunda.configuration.JobMetricsConfig;
 import io.camunda.configuration.ProcessCache;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.GatewayRestProperties;
 import io.camunda.configuration.beans.LegacyGatewayRestProperties;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ApiExecutorConfiguration;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.JobMetricsConfiguration;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ProcessCacheConfiguration;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -44,6 +46,7 @@ public class GatewayRestPropertiesOverride {
 
     populateFromProcessCache(override);
     populateFromExecutor(override);
+    populateFromJobMetrics(override);
 
     return override;
   }
@@ -63,5 +66,17 @@ public class GatewayRestPropertiesOverride {
     apiExecutorConfiguration.setMaxPoolSizeMultiplier(executor.getMaxPoolSizeMultiplier());
     apiExecutorConfiguration.setKeepAliveSeconds(executor.getKeepAlive().getSeconds());
     apiExecutorConfiguration.setQueueCapacity(executor.getQueueCapacity());
+  }
+
+  private void populateFromJobMetrics(final GatewayRestProperties override) {
+    final JobMetricsConfig jobMetrics =
+        unifiedConfiguration.getCamunda().getMonitoring().getMetrics().getJobMetrics();
+    final JobMetricsConfiguration jobMetricsConfiguration = override.getJobMetrics();
+    jobMetricsConfiguration.setExportInterval(jobMetrics.getExportInterval());
+    jobMetricsConfiguration.setMaxWorkerNameLength(jobMetrics.getMaxWorkerNameLength());
+    jobMetricsConfiguration.setMaxJobTypeLength(jobMetrics.getMaxJobTypeLength());
+    jobMetricsConfiguration.setMaxTenantIdLength(jobMetrics.getMaxTenantIdLength());
+    jobMetricsConfiguration.setMaxUniqueKeys(jobMetrics.getMaxUniqueKeys());
+    jobMetricsConfiguration.setEnabled(jobMetrics.isEnabled());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestJobMetricsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestJobMetricsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayRestPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class ApiRestJobMetricsTest {
+
+  private static final Duration EXPECTED_EXPORT_INTERVAL = Duration.ofMinutes(10);
+  private static final int EXPECTED_MAX_WORKER_NAME_LENGTH = 50;
+  private static final int EXPECTED_MAX_JOB_TYPE_LENGTH = 75;
+  private static final int EXPECTED_MAX_TENANT_ID_LENGTH = 20;
+  private static final int EXPECTED_MAX_UNIQUE_KEYS = 5000;
+  private static final boolean EXPECTED_ENABLED = false;
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.monitoring.metrics.job-metrics.export-interval=10m",
+        "camunda.monitoring.metrics.job-metrics.max-worker-name-length="
+            + EXPECTED_MAX_WORKER_NAME_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-job-type-length="
+            + EXPECTED_MAX_JOB_TYPE_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-tenant-id-length="
+            + EXPECTED_MAX_TENANT_ID_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-unique-keys=" + EXPECTED_MAX_UNIQUE_KEYS,
+        "camunda.monitoring.metrics.job-metrics.enabled=" + EXPECTED_ENABLED,
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetJobMetrics() {
+      final var jobMetrics = gatewayRestProperties.getJobMetrics();
+      assertThat(jobMetrics.getExportInterval()).isEqualTo(EXPECTED_EXPORT_INTERVAL);
+      assertThat(jobMetrics.getMaxWorkerNameLength()).isEqualTo(EXPECTED_MAX_WORKER_NAME_LENGTH);
+      assertThat(jobMetrics.getMaxJobTypeLength()).isEqualTo(EXPECTED_MAX_JOB_TYPE_LENGTH);
+      assertThat(jobMetrics.getMaxTenantIdLength()).isEqualTo(EXPECTED_MAX_TENANT_ID_LENGTH);
+      assertThat(jobMetrics.getMaxUniqueKeys()).isEqualTo(EXPECTED_MAX_UNIQUE_KEYS);
+      assertThat(jobMetrics.isEnabled()).isEqualTo(EXPECTED_ENABLED);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.jobMetrics.exportInterval=10m",
+        "zeebe.broker.experimental.engine.jobMetrics.maxWorkerNameLength="
+            + EXPECTED_MAX_WORKER_NAME_LENGTH,
+        "zeebe.broker.experimental.engine.jobMetrics.maxJobTypeLength="
+            + EXPECTED_MAX_JOB_TYPE_LENGTH,
+        "zeebe.broker.experimental.engine.jobMetrics.maxTenantIdLength="
+            + EXPECTED_MAX_TENANT_ID_LENGTH,
+        "zeebe.broker.experimental.engine.jobMetrics.maxUniqueKeys=" + EXPECTED_MAX_UNIQUE_KEYS,
+        "zeebe.broker.experimental.engine.jobMetrics.enabled=" + EXPECTED_ENABLED,
+      })
+  class WithOnlyLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithOnlyLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetJobMetricsFromLegacy() {
+      final var jobMetrics = gatewayRestProperties.getJobMetrics();
+      assertThat(jobMetrics.getExportInterval()).isEqualTo(EXPECTED_EXPORT_INTERVAL);
+      assertThat(jobMetrics.getMaxWorkerNameLength()).isEqualTo(EXPECTED_MAX_WORKER_NAME_LENGTH);
+      assertThat(jobMetrics.getMaxJobTypeLength()).isEqualTo(EXPECTED_MAX_JOB_TYPE_LENGTH);
+      assertThat(jobMetrics.getMaxTenantIdLength()).isEqualTo(EXPECTED_MAX_TENANT_ID_LENGTH);
+      assertThat(jobMetrics.getMaxUniqueKeys()).isEqualTo(EXPECTED_MAX_UNIQUE_KEYS);
+      assertThat(jobMetrics.isEnabled()).isEqualTo(EXPECTED_ENABLED);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.monitoring.metrics.job-metrics.export-interval=10m",
+        "camunda.monitoring.metrics.job-metrics.max-worker-name-length="
+            + EXPECTED_MAX_WORKER_NAME_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-job-type-length="
+            + EXPECTED_MAX_JOB_TYPE_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-tenant-id-length="
+            + EXPECTED_MAX_TENANT_ID_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-unique-keys=" + EXPECTED_MAX_UNIQUE_KEYS,
+        "camunda.monitoring.metrics.job-metrics.enabled=" + EXPECTED_ENABLED,
+        // legacy (different values to ensure new config wins)
+        "zeebe.broker.experimental.engine.jobMetrics.exportInterval=1m",
+        "zeebe.broker.experimental.engine.jobMetrics.maxWorkerNameLength=10",
+        "zeebe.broker.experimental.engine.jobMetrics.maxJobTypeLength=10",
+        "zeebe.broker.experimental.engine.jobMetrics.maxTenantIdLength=10",
+        "zeebe.broker.experimental.engine.jobMetrics.maxUniqueKeys=10",
+        "zeebe.broker.experimental.engine.jobMetrics.enabled=true",
+      })
+  class WithNewAndLegacySet {
+    final GatewayRestProperties gatewayRestProperties;
+
+    WithNewAndLegacySet(@Autowired final GatewayRestProperties gatewayRestProperties) {
+      this.gatewayRestProperties = gatewayRestProperties;
+    }
+
+    @Test
+    void shouldSetJobMetrics() {
+      final var jobMetrics = gatewayRestProperties.getJobMetrics();
+      assertThat(jobMetrics.getExportInterval()).isEqualTo(EXPECTED_EXPORT_INTERVAL);
+      assertThat(jobMetrics.getMaxWorkerNameLength()).isEqualTo(EXPECTED_MAX_WORKER_NAME_LENGTH);
+      assertThat(jobMetrics.getMaxJobTypeLength()).isEqualTo(EXPECTED_MAX_JOB_TYPE_LENGTH);
+      assertThat(jobMetrics.getMaxTenantIdLength()).isEqualTo(EXPECTED_MAX_TENANT_ID_LENGTH);
+      assertThat(jobMetrics.getMaxUniqueKeys()).isEqualTo(EXPECTED_MAX_UNIQUE_KEYS);
+      assertThat(jobMetrics.isEnabled()).isEqualTo(EXPECTED_ENABLED);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/JobMetricsConfigTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/JobMetricsConfigTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class JobMetricsConfigTest {
+
+  private static final Duration EXPECTED_EXPORT_INTERVAL = Duration.ofMinutes(10);
+  private static final int EXPECTED_MAX_WORKER_NAME_LENGTH = 50;
+  private static final int EXPECTED_MAX_JOB_TYPE_LENGTH = 75;
+  private static final int EXPECTED_MAX_TENANT_ID_LENGTH = 20;
+  private static final int EXPECTED_MAX_UNIQUE_KEYS = 5000;
+  private static final boolean EXPECTED_ENABLED = false;
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.monitoring.metrics.job-metrics.export-interval=10m",
+        "camunda.monitoring.metrics.job-metrics.max-worker-name-length="
+            + EXPECTED_MAX_WORKER_NAME_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-job-type-length="
+            + EXPECTED_MAX_JOB_TYPE_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-tenant-id-length="
+            + EXPECTED_MAX_TENANT_ID_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-unique-keys=" + EXPECTED_MAX_UNIQUE_KEYS,
+        "camunda.monitoring.metrics.job-metrics.enabled=" + EXPECTED_ENABLED,
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetJobMetrics() {
+      final var jobMetrics = brokerCfg.getExperimental().getEngine().getJobMetrics();
+      assertThat(jobMetrics.getExportInterval()).isEqualTo(EXPECTED_EXPORT_INTERVAL);
+      assertThat(jobMetrics.getMaxWorkerNameLength()).isEqualTo(EXPECTED_MAX_WORKER_NAME_LENGTH);
+      assertThat(jobMetrics.getMaxJobTypeLength()).isEqualTo(EXPECTED_MAX_JOB_TYPE_LENGTH);
+      assertThat(jobMetrics.getMaxTenantIdLength()).isEqualTo(EXPECTED_MAX_TENANT_ID_LENGTH);
+      assertThat(jobMetrics.getMaxUniqueKeys()).isEqualTo(EXPECTED_MAX_UNIQUE_KEYS);
+      assertThat(jobMetrics.isEnabled()).isEqualTo(EXPECTED_ENABLED);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.jobMetrics.exportInterval=10m",
+        "zeebe.broker.experimental.engine.jobMetrics.maxWorkerNameLength="
+            + EXPECTED_MAX_WORKER_NAME_LENGTH,
+        "zeebe.broker.experimental.engine.jobMetrics.maxJobTypeLength="
+            + EXPECTED_MAX_JOB_TYPE_LENGTH,
+        "zeebe.broker.experimental.engine.jobMetrics.maxTenantIdLength="
+            + EXPECTED_MAX_TENANT_ID_LENGTH,
+        "zeebe.broker.experimental.engine.jobMetrics.maxUniqueKeys=" + EXPECTED_MAX_UNIQUE_KEYS,
+        "zeebe.broker.experimental.engine.jobMetrics.enabled=" + EXPECTED_ENABLED,
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetJobMetricsFromLegacy() {
+      final var jobMetrics = brokerCfg.getExperimental().getEngine().getJobMetrics();
+      assertThat(jobMetrics.getExportInterval()).isEqualTo(EXPECTED_EXPORT_INTERVAL);
+      assertThat(jobMetrics.getMaxWorkerNameLength()).isEqualTo(EXPECTED_MAX_WORKER_NAME_LENGTH);
+      assertThat(jobMetrics.getMaxJobTypeLength()).isEqualTo(EXPECTED_MAX_JOB_TYPE_LENGTH);
+      assertThat(jobMetrics.getMaxTenantIdLength()).isEqualTo(EXPECTED_MAX_TENANT_ID_LENGTH);
+      assertThat(jobMetrics.getMaxUniqueKeys()).isEqualTo(EXPECTED_MAX_UNIQUE_KEYS);
+      assertThat(jobMetrics.isEnabled()).isEqualTo(EXPECTED_ENABLED);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.monitoring.metrics.job-metrics.export-interval=10m",
+        "camunda.monitoring.metrics.job-metrics.max-worker-name-length="
+            + EXPECTED_MAX_WORKER_NAME_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-job-type-length="
+            + EXPECTED_MAX_JOB_TYPE_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-tenant-id-length="
+            + EXPECTED_MAX_TENANT_ID_LENGTH,
+        "camunda.monitoring.metrics.job-metrics.max-unique-keys=" + EXPECTED_MAX_UNIQUE_KEYS,
+        "camunda.monitoring.metrics.job-metrics.enabled=" + EXPECTED_ENABLED,
+        // legacy (different values to ensure new config wins)
+        "zeebe.broker.experimental.engine.jobMetrics.exportInterval=1m",
+        "zeebe.broker.experimental.engine.jobMetrics.maxWorkerNameLength=10",
+        "zeebe.broker.experimental.engine.jobMetrics.maxJobTypeLength=10",
+        "zeebe.broker.experimental.engine.jobMetrics.maxTenantIdLength=10",
+        "zeebe.broker.experimental.engine.jobMetrics.maxUniqueKeys=10",
+        "zeebe.broker.experimental.engine.jobMetrics.enabled=true",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetJobMetrics() {
+      final var jobMetrics = brokerCfg.getExperimental().getEngine().getJobMetrics();
+      assertThat(jobMetrics.getExportInterval()).isEqualTo(EXPECTED_EXPORT_INTERVAL);
+      assertThat(jobMetrics.getMaxWorkerNameLength()).isEqualTo(EXPECTED_MAX_WORKER_NAME_LENGTH);
+      assertThat(jobMetrics.getMaxJobTypeLength()).isEqualTo(EXPECTED_MAX_JOB_TYPE_LENGTH);
+      assertThat(jobMetrics.getMaxTenantIdLength()).isEqualTo(EXPECTED_MAX_TENANT_ID_LENGTH);
+      assertThat(jobMetrics.getMaxUniqueKeys()).isEqualTo(EXPECTED_MAX_UNIQUE_KEYS);
+      assertThat(jobMetrics.isEnabled()).isEqualTo(EXPECTED_ENABLED);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import java.time.Duration;
+
 public class GatewayRestConfiguration {
 
   private final ProcessCacheConfiguration processCache = new ProcessCacheConfiguration();
   private final ApiExecutorConfiguration apiExecutor = new ApiExecutorConfiguration();
+  private final JobMetricsConfiguration jobMetrics = new JobMetricsConfiguration();
 
   public ProcessCacheConfiguration getProcessCache() {
     return processCache;
@@ -18,6 +21,10 @@ public class GatewayRestConfiguration {
 
   public ApiExecutorConfiguration getApiExecutor() {
     return apiExecutor;
+  }
+
+  public JobMetricsConfiguration getJobMetrics() {
+    return jobMetrics;
   }
 
   public static class ProcessCacheConfiguration {
@@ -165,6 +172,83 @@ public class GatewayRestConfiguration {
         throw new IllegalArgumentException("queueCapacity must be > 0 (was " + queueCapacity + ")");
       }
       this.queueCapacity = queueCapacity;
+    }
+  }
+
+  /** Configuration for job metrics export settings. */
+  public static class JobMetricsConfiguration {
+
+    private static final Duration DEFAULT_EXPORT_INTERVAL = Duration.ofMinutes(5);
+    private static final int DEFAULT_MAX_WORKER_NAME_LENGTH = 100;
+    private static final int DEFAULT_MAX_JOB_TYPE_LENGTH = 100;
+    private static final int DEFAULT_MAX_TENANT_ID_LENGTH = 30;
+    private static final int DEFAULT_MAX_UNIQUE_KEYS = 9500;
+    private static final boolean DEFAULT_ENABLED = true;
+
+    /** The interval at which job metrics are exported. */
+    private Duration exportInterval = DEFAULT_EXPORT_INTERVAL;
+
+    /** The maximum length of the worker name used in job metrics labels. */
+    private int maxWorkerNameLength = DEFAULT_MAX_WORKER_NAME_LENGTH;
+
+    /** The maximum length of the job type used in job metrics labels. */
+    private int maxJobTypeLength = DEFAULT_MAX_JOB_TYPE_LENGTH;
+
+    /** The maximum length of the tenant ID used in job metrics labels. */
+    private int maxTenantIdLength = DEFAULT_MAX_TENANT_ID_LENGTH;
+
+    /** The maximum number of unique metric keys tracked for job metrics. */
+    private int maxUniqueKeys = DEFAULT_MAX_UNIQUE_KEYS;
+
+    /** Whether job metrics export is enabled. */
+    private boolean enabled = DEFAULT_ENABLED;
+
+    public Duration getExportInterval() {
+      return exportInterval;
+    }
+
+    public void setExportInterval(final Duration exportInterval) {
+      this.exportInterval = exportInterval;
+    }
+
+    public int getMaxWorkerNameLength() {
+      return maxWorkerNameLength;
+    }
+
+    public void setMaxWorkerNameLength(final int maxWorkerNameLength) {
+      this.maxWorkerNameLength = maxWorkerNameLength;
+    }
+
+    public int getMaxJobTypeLength() {
+      return maxJobTypeLength;
+    }
+
+    public void setMaxJobTypeLength(final int maxJobTypeLength) {
+      this.maxJobTypeLength = maxJobTypeLength;
+    }
+
+    public int getMaxTenantIdLength() {
+      return maxTenantIdLength;
+    }
+
+    public void setMaxTenantIdLength(final int maxTenantIdLength) {
+      this.maxTenantIdLength = maxTenantIdLength;
+    }
+
+    public int getMaxUniqueKeys() {
+      return maxUniqueKeys;
+    }
+
+    public void setMaxUniqueKeys(final int maxUniqueKeys) {
+      this.maxUniqueKeys = maxUniqueKeys;
+    }
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+      this.enabled = enabled;
     }
   }
 }


### PR DESCRIPTION
This pull request introduces a new configuration class for job metrics, integrates it into the unified configuration system, and ensures its values are correctly propagated throughout the broker and gateway REST configuration. It also adds comprehensive tests to validate both unified and legacy configuration properties for job metrics.

**Job Metrics Configuration Integration:**

* Added a new `JobMetricsConfig` class to encapsulate job metrics settings, including export interval, worker name length, job type length, tenant ID length, unique keys, and enabled flag, with support for both unified and legacy configuration properties.
* Integrated `JobMetricsConfig` into the main `Metrics` configuration class, providing getter and setter methods for easy access and configuration binding. [[1]](diffhunk://#diff-5b387240dbf2788af9b88f1fd0769df3ca9132d6d9127334802689ceb6907a01R29-R31) [[2]](diffhunk://#diff-5b387240dbf2788af9b88f1fd0769df3ca9132d6d9127334802689ceb6907a01R57-R64)

**Configuration Propagation:**

* Updated `BrokerBasedPropertiesOverride` to populate broker job metrics configuration from the unified configuration, ensuring all job metrics settings are correctly transferred.
* Updated `GatewayRestPropertiesOverride` and `GatewayRestConfiguration` to support job metrics configuration, including a new `JobMetricsConfiguration` class and propagation logic. [[1]](diffhunk://#diff-bf1731928da91c12a54b6b9f2a899d48c95bed95497b127285ca01da4e8d3e5bR11-R17) [[2]](diffhunk://#diff-bf1731928da91c12a54b6b9f2a899d48c95bed95497b127285ca01da4e8d3e5bR49) [[3]](diffhunk://#diff-bf1731928da91c12a54b6b9f2a899d48c95bed95497b127285ca01da4e8d3e5bR70-R81) [[4]](diffhunk://#diff-2c9ef6fb49f2322bc3e5df7f40460fbf925fa10cdea07b6c3d1d4d97f89c9d3eR10-R16) [[5]](diffhunk://#diff-2c9ef6fb49f2322bc3e5df7f40460fbf925fa10cdea07b6c3d1d4d97f89c9d3eR26-R29) [[6]](diffhunk://#diff-2c9ef6fb49f2322bc3e5df7f40460fbf925fa10cdea07b6c3d1d4d97f89c9d3eR177-R253)

**Testing:**

* Added `JobMetricsConfigTest` to verify that job metrics configuration is correctly set from unified, legacy, and mixed property sources, ensuring backward compatibility and correct precedence.