### PR TITLE
fix: lock was unlocked even if it was not acquired initially

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
@@ -30,17 +30,17 @@ public class EventDescription {
   public void status(final String status) {
     try {
       if (lock.tryLock(WRITE_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
-        // this cannot fail, try/finally is not needed
-        this.status = status;
-        position = 0;
-        intent = null;
-        valueType = null;
+        try {
+          this.status = status;
+          position = 0;
+          intent = null;
+          valueType = null;
+        } finally {
+          lock.unlock();
+        }
       }
     } catch (final InterruptedException e) {
-      // ignore it, it's just for reporting
       Thread.currentThread().interrupt();
-    } finally {
-      lock.unlock();
     }
   }
 
@@ -48,16 +48,17 @@ public class EventDescription {
       final String status, final long position, final Intent intent, final ValueType valueType) {
     try {
       if (lock.tryLock(WRITE_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
-        this.status = status;
-        this.position = position;
-        this.intent = intent;
-        this.valueType = valueType;
+        try {
+          this.status = status;
+          this.position = position;
+          this.intent = intent;
+          this.valueType = valueType;
+        } finally {
+          lock.unlock();
+        }
       }
     } catch (final InterruptedException e) {
-      // ignore it, it's just for reporting
       Thread.currentThread().interrupt();
-    } finally {
-      lock.unlock();
     }
   }
 
@@ -65,21 +66,22 @@ public class EventDescription {
   public String toString() {
     try {
       if (lock.tryLock(READ_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
-        if (position == 0) {
-          return status;
-        } else {
-          return String.format(
-              "%s @ position=%d, intent=%s, valueType=%s", status, position, intent, valueType);
+        try {
+          if (position == 0) {
+            return status;
+          } else {
+            return String.format(
+                "%s @ position=%d, intent=%s, valueType=%s", status, position, intent, valueType);
+          }
+        } finally {
+          lock.unlock();
         }
       } else {
         return FAILED_TO_ACQUIRE_LOCK;
       }
     } catch (final InterruptedException e) {
-      // ignore it, it's just for reporting
       Thread.currentThread().interrupt();
       return FAILED_TO_ACQUIRE_LOCK;
-    } finally {
-      lock.unlock();
     }
   }
 }


### PR DESCRIPTION
## Description
lock.unlock was called unconditionally even if the lock was not acquired by the tryLock.
The short WRITE_ACQUIRE_LOCK_TIMEOUT made this a possibility.
Found in a load test cluster:
```
java.lang.RuntimeException: Failed to replay batch at 'LoggedEvent [position=57041068, key=4503599656467884, timestamp=1772455831305, sourceEventPosition=57039524] RecordMetadata{recordType=EVENT, valueType=JOB, intent=CREATED, authorization={"format":"UNKNOWN","authData":"***","claims":"***"}}'
	at io.camunda.zeebe.stream.impl.ReplayStateMachine.lambda$replayNextEvent$4(ReplayStateMachine.java:171)
	at io.camunda.zeebe.scheduler.future.FutureContinuationRunnable.run(FutureContinuationRunnable.java:33)
	at io.camunda.zeebe.scheduler.ActorJob.invoke(ActorJob.java:86)
	at io.camunda.zeebe.scheduler.ActorJob.execute(ActorJob.java:43)
	at io.camunda.zeebe.scheduler.ActorTask.execute(ActorTask.java:125)
	at io.camunda.zeebe.scheduler.ActorThread.executeCurrentTask(ActorThread.java:127)
	at io.camunda.zeebe.scheduler.ActorThread.doWork(ActorThread.java:104)
	at io.camunda.zeebe.scheduler.ActorThread.run(ActorThread.java:224)
Caused by: java.lang.IllegalMonitorStateException
	at java.base/java.util.concurrent.locks.ReentrantLock$Sync.tryRelease(Unknown Source)
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.release(Unknown Source)
	at java.base/java.util.concurrent.locks.ReentrantLock.unlock(Unknown Source)
	at io.camunda.zeebe.stream.impl.EventDescription.status(EventDescription.java:43)
	at io.camunda.zeebe.stream.impl.ReplayStateMachine.onRecordReplayed(ReplayStateMachine.java:283)
	at io.camunda.zeebe.stream.impl.ReplayStateMachine.replayEvent(ReplayStateMachine.java:249)
	at java.base/java.util.Iterator.forEachRemaining(Unknown Source)
	at io.camunda.zeebe.stream.impl.ReplayStateMachine.lambda$tryToReplayBatch$5(ReplayStateMachine.java:212)
	at io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransaction.run(ZeebeTransaction.java:128)
	at io.camunda.zeebe.stream.impl.ReplayStateMachine.tryToReplayBatch(ReplayStateMachine.java:210)
	at io.camunda.zeebe.stream.impl.ReplayStateMachine.lambda$replayNextEvent$3(ReplayStateMachine.java:165)
	at io.camunda.zeebe.scheduler.retry.ActorRetryMechanism.run(ActorRetryMechanism.java:28)
	at io.camunda.zeebe.scheduler.retry.RecoverableRetryStrategy.run(RecoverableRetryStrategy.java:48)
	at io.camunda.zeebe.scheduler.ActorJob.invoke(ActorJob.java:84)
	... 5 more
``` 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #45558
