### PR TITLE
[CPT] I can add a custom containers to the runtime

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -18,6 +18,7 @@ package io.camunda.process.test.api;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.api.testCases.TestCaseRunner;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
@@ -660,6 +661,32 @@ public class CamundaProcessTestExtension
   public CamundaProcessTestExtension withJsonMapper(
       final io.camunda.zeebe.client.api.JsonMapper jsonMapper) {
     zeebeJsonMapper = jsonMapper;
+    return this;
+  }
+
+  /**
+   * Add a custom container via the given provider to the runtime. The container will be started
+   * together with the runtime and stopped when the runtime is closed.
+   *
+   * @param containerProvider the provider of the custom container
+   * @return the extension builder
+   */
+  public CamundaProcessTestExtension withContainerProvider(
+      final CamundaProcessTestContainerProvider containerProvider) {
+    runtimeBuilder.withContainerProvider(containerProvider);
+    return this;
+  }
+
+  /**
+   * Enable or disable the loading of custom container providers via the Java ServiceLoader. By
+   * default, the ServiceLoader is enabled.
+   *
+   * @param enabled whether to load container providers via the Java ServiceLoader or not
+   * @return the extension builder
+   */
+  public CamundaProcessTestExtension withContainerProvidersServiceLoaderEnabled(
+      final boolean enabled) {
+    runtimeBuilder.withContainerProvidersServiceLoaderEnabled(enabled);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/runtime/CamundaProcessTestContainerContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/runtime/CamundaProcessTestContainerContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.runtime;
+
+import java.util.Collection;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+
+/**
+ * Context of the Camunda process test runtime for container providers. The context provides
+ * information about the runtime, such as the network and the containers included in the runtime.
+ */
+public interface CamundaProcessTestContainerContext {
+
+  /**
+   * Returns the network used by the containers in the Camunda process test runtime.
+   *
+   * @return the network used by the containers
+   */
+  Network getNetwork();
+
+  /**
+   * Returns the collection of containers included in the Camunda process test runtime.
+   *
+   * @return the collection of containers included in the runtime
+   */
+  Collection<GenericContainer<?>> getContainers();
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/runtime/CamundaProcessTestContainerProvider.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/runtime/CamundaProcessTestContainerProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.runtime;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Provides a container for the managed Camunda process test runtime based on Testcontainers. The
+ * container is added to the runtime and included in the runtime's lifecycle. The runtime starts the
+ * container before executing any tests and stops it after all tests have been executed.
+ */
+public interface CamundaProcessTestContainerProvider {
+
+  /**
+   * Creates a container for the Camunda process test runtime. Use the provided context to retrieve
+   * information about the runtime.
+   *
+   * @param context the context of the Camunda process test runtime, which can be used to retrieve
+   *     information
+   * @return the container to be included in the Camunda process test runtime
+   */
+  GenericContainer<?> createContainer(final CamundaProcessTestContainerContext context);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/runtime/CamundaProcessTestContainerProvider.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/runtime/CamundaProcessTestContainerProvider.java
@@ -18,9 +18,9 @@ package io.camunda.process.test.api.runtime;
 import org.testcontainers.containers.GenericContainer;
 
 /**
- * Provides a container for the managed Camunda process test runtime based on Testcontainers. The
- * container is added to the runtime and included in the runtime's lifecycle. The runtime starts the
- * container before executing any tests and stops it after all tests have been executed.
+ * Provides a container for the managed/shared Camunda process test runtime based on Testcontainers.
+ * The container is added to the runtime and included in the runtime's lifecycle. The runtime starts
+ * the container before executing any tests and stops it after all tests have been executed.
  */
 public interface CamundaProcessTestContainerProvider {
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -311,7 +311,7 @@ public class CamundaProcessTestContainerRuntime
 
     @Override
     public Collection<GenericContainer<?>> getContainers() {
-      return containers;
+      return Collections.unmodifiableCollection(containers);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.runtime;
 
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerContext;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.CamundaContainer.MultiTenancyConfiguration;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
@@ -28,6 +29,8 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -73,6 +76,7 @@ public class CamundaProcessTestContainerRuntime
   private final boolean isMultiTenancyEnabled;
   private final boolean connectorsEnabled;
 
+  private final List<GenericContainer<?>> containers = new ArrayList<>();
   private boolean isStarted = false;
 
   public CamundaProcessTestContainerRuntime(
@@ -84,8 +88,16 @@ public class CamundaProcessTestContainerRuntime
     connectorsEnabled = builder.isConnectorsEnabled();
 
     network = Network.newNetwork();
+
     camundaContainer = createCamundaContainer(network, builder);
+    containers.add(camundaContainer);
+
     connectorsContainer = createConnectorsContainer(network, builder);
+    if (connectorsEnabled) {
+      containers.add(connectorsContainer);
+    }
+
+    createAdditionalContainers(builder);
 
     if (isMultiTenancyEnabled) {
       LOGGER.debug(
@@ -94,6 +106,18 @@ public class CamundaProcessTestContainerRuntime
           MultiTenancyConfiguration.MULTITENANCY_USER_USERNAME,
           MultiTenancyConfiguration.MULTITENANCY_USER_PASSWORD);
     }
+  }
+
+  private void createAdditionalContainers(final CamundaProcessTestRuntimeBuilder builder) {
+    final ContainerContext containerContext = new ContainerContext(network, containers);
+    builder
+        .getContainerProviders()
+        .forEach(
+            containerProvider -> {
+              final GenericContainer<?> container =
+                  containerProvider.createContainer(containerContext).withNetwork(network);
+              containers.add(container);
+            });
   }
 
   /*
@@ -170,12 +194,6 @@ public class CamundaProcessTestContainerRuntime
 
   @Override
   public void start() {
-    final List<GenericContainer<?>> containers = new ArrayList<>();
-    containers.add(camundaContainer);
-    if (connectorsEnabled) {
-      containers.add(connectorsContainer);
-    }
-
     LOGGER.info(
         "Starting Camunda container runtime [{}]",
         containers.stream()
@@ -238,16 +256,18 @@ public class CamundaProcessTestContainerRuntime
     LOGGER.info("Stopping Camunda container runtime");
     final Instant startTime = Instant.now();
 
-    if (connectorsEnabled) {
-      connectorsContainer.stop();
-    }
+    // Stop containers in reverse order to ensure dependencies are stopped after the containers
+    // depending on them have been stopped
+    Collections.reverse(containers);
+    containers.forEach(GenericContainer::stop);
 
-    camundaContainer.stop();
     network.close();
 
     final Instant endTime = Instant.now();
     final Duration shutdownTime = Duration.between(startTime, endTime);
     LOGGER.info("Camunda container runtime stopped in {}", shutdownTime);
+
+    containers.clear();
   }
 
   public boolean isStarted() {
@@ -271,5 +291,27 @@ public class CamundaProcessTestContainerRuntime
 
   public static CamundaProcessTestRuntime newDefaultRuntime() {
     return newBuilder().build();
+  }
+
+  private static final class ContainerContext implements CamundaProcessTestContainerContext {
+
+    private final Network network;
+    private final Collection<GenericContainer<?>> containers;
+
+    public ContainerContext(
+        final Network network, final Collection<GenericContainer<?>> containers) {
+      this.network = network;
+      this.containers = containers;
+    }
+
+    @Override
+    public Network getNetwork() {
+      return network;
+    }
+
+    @Override
+    public Collection<GenericContainer<?>> getContainers() {
+      return containers;
+    }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -291,7 +291,8 @@ public class CamundaProcessTestRuntimeBuilder {
   // ============ Build =================
 
   private void loadContainerProvidersFromServiceLoader() {
-    if (containerProvidersServiceLoaderEnabled) {
+    if (containerProvidersServiceLoaderEnabled
+        && runtimeMode != CamundaProcessTestRuntimeMode.REMOTE) {
       ServiceLoader.load(CamundaProcessTestContainerProvider.class)
           .forEach(
               containerProvider -> {
@@ -305,9 +306,10 @@ public class CamundaProcessTestRuntimeBuilder {
   }
 
   public CamundaProcessTestRuntime build() {
+    loadContainerProvidersFromServiceLoader();
+
     switch (runtimeMode) {
       case MANAGED:
-        loadContainerProvidersFromServiceLoader();
         return new CamundaProcessTestContainerRuntime(this, containerFactory);
       case REMOTE:
         return new CamundaProcessTestRemoteRuntime(this);

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -19,6 +19,7 @@ import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.impl.containers.CamundaContainer.MultiTenancyConfiguration;
 import io.camunda.process.test.impl.containers.ContainerFactory;
 import java.net.URI;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,6 +75,9 @@ public class CamundaProcessTestRuntimeBuilder {
   private boolean connectorsEnabled = CamundaProcessTestRuntimeDefaults.CONNECTORS_ENABLED;
   private final Map<String, String> connectorsSecrets =
       new HashMap<>(CamundaProcessTestRuntimeDefaults.CONNECTORS_SECRETS);
+
+  private final List<CamundaProcessTestContainerProvider> containerProviders = new ArrayList<>();
+  private boolean containerProvidersServiceLoaderEnabled = true;
 
   private CamundaProcessTestRuntimeMode runtimeMode =
       CamundaProcessTestRuntimeDefaults.RUNTIME_MODE;
@@ -271,11 +276,38 @@ public class CamundaProcessTestRuntimeBuilder {
     return this;
   }
 
+  public CamundaProcessTestRuntimeBuilder withContainerProvider(
+      final CamundaProcessTestContainerProvider containerProvider) {
+    containerProviders.add(containerProvider);
+    return this;
+  }
+
+  public CamundaProcessTestRuntimeBuilder withContainerProvidersServiceLoaderEnabled(
+      final boolean enabled) {
+    containerProvidersServiceLoaderEnabled = enabled;
+    return this;
+  }
+
   // ============ Build =================
+
+  private void loadContainerProvidersFromServiceLoader() {
+    if (containerProvidersServiceLoaderEnabled) {
+      ServiceLoader.load(CamundaProcessTestContainerProvider.class)
+          .forEach(
+              containerProvider -> {
+                LOGGER.debug(
+                    "Loaded container provider from service loader: {}",
+                    containerProvider.getClass().getName());
+
+                containerProviders.add(containerProvider);
+              });
+    }
+  }
 
   public CamundaProcessTestRuntime build() {
     switch (runtimeMode) {
       case MANAGED:
+        loadContainerProvidersFromServiceLoader();
         return new CamundaProcessTestContainerRuntime(this, containerFactory);
       case REMOTE:
         return new CamundaProcessTestRemoteRuntime(this);
@@ -401,5 +433,13 @@ public class CamundaProcessTestRuntimeBuilder {
       camundaClientOverrides.accept(clientBuilder);
       return clientBuilder;
     };
+  }
+
+  public List<CamundaProcessTestContainerProvider> getContainerProviders() {
+    return containerProviders;
+  }
+
+  public boolean isContainerProvidersServiceLoaderEnabled() {
+    return containerProvidersServiceLoaderEnabled;
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.api.testCases.TestCaseRunner;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.coverage.ProcessCoverage;
@@ -72,6 +73,7 @@ public class JunitExtensionTest {
   @Mock private CamundaProcessTestContainerRuntime camundaContainerRuntime;
   @Mock private CamundaManagementClient camundaManagementClient;
   @Mock private CamundaProcessTestResultCollector camundaProcessTestResultCollector;
+  @Mock private CamundaProcessTestContainerProvider containerProvider;
 
   @Mock private ExtensionContext extensionContext;
   @Mock private TestInstances testInstances;
@@ -441,6 +443,23 @@ public class JunitExtensionTest {
 
     // then
     verify(camundaManagementClient).purgeCluster();
+  }
+
+  @Test
+  void shouldAddCustomContainerProviders() throws Exception {
+    // given
+    final CamundaProcessTestExtension extension =
+        new CamundaProcessTestExtension(camundaRuntimeBuilder, processCoverageBuilder, NOOP)
+            .withContainerProvider(containerProvider)
+            .withContainerProvidersServiceLoaderEnabled(true);
+
+    // when
+    extension.beforeAll(extensionContext);
+    extension.beforeEach(extensionContext);
+
+    // then
+    verify(camundaRuntimeBuilder).withContainerProvider(containerProvider);
+    verify(camundaRuntimeBuilder).withContainerProvidersServiceLoaderEnabled(true);
   }
 
   private void setManagementClientDummy(final CamundaProcessTestExtension extension) {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerContext;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
 import io.camunda.process.test.impl.containers.ContainerFactory;
@@ -31,8 +33,11 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.containers.GenericContainer;
 
 @ExtendWith(MockitoExtension.class)
 public class CamundaProcessTestContainerRuntimeTest {
@@ -58,6 +63,14 @@ public class CamundaProcessTestContainerRuntimeTest {
 
   @Mock(answer = Answers.RETURNS_SELF)
   private ConnectorsContainer connectorsContainer;
+
+  @Mock private CamundaProcessTestContainerProvider containerProvider;
+
+  @SuppressWarnings("rawtypes")
+  @Mock(answer = Answers.RETURNS_SELF)
+  private GenericContainer customContainer;
+
+  @Captor private ArgumentCaptor<CamundaProcessTestContainerContext> containerProviderContext;
 
   @BeforeEach
   void configureMocks() {
@@ -245,5 +258,52 @@ public class CamundaProcessTestContainerRuntimeTest {
 
     // then
     verify(camundaContainer).withMultiTenancy();
+  }
+
+  @Test
+  void shouldAddCustomContainers() throws Exception {
+    // given
+    //noinspection unchecked
+    when(containerProvider.createContainer(any())).thenReturn(customContainer);
+    when(customContainer.getDockerImageName()).thenReturn("custom-container");
+
+    final CamundaProcessTestContainerRuntime runtime =
+        (CamundaProcessTestContainerRuntime)
+            CamundaProcessTestContainerRuntime.newBuilder()
+                .withContainerFactory(containerFactory)
+                .withContainerProvider(containerProvider)
+                .build();
+
+    // when
+    runtime.start();
+
+    // then
+    verify(customContainer).withNetwork(any());
+    verify(customContainer).start();
+
+    // and when
+    runtime.close();
+
+    // then
+    verify(customContainer).stop();
+  }
+
+  @Test
+  void shouldProvideContainerContext() throws Exception {
+    // given
+    //noinspection unchecked
+    when(containerProvider.createContainer(containerProviderContext.capture()))
+        .thenReturn(customContainer);
+
+    // when
+    CamundaProcessTestContainerRuntime.newBuilder()
+        .withContainerFactory(containerFactory)
+        .withContainerProvider(containerProvider)
+        .build();
+
+    // then
+    final CamundaProcessTestContainerContext containerContext = containerProviderContext.getValue();
+    assertThat(containerContext.getNetwork()).isNotNull();
+    assertThat(containerContext.getContainers()).contains(camundaContainer);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilderTest.java
@@ -16,17 +16,23 @@
 package io.camunda.process.test.impl.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.containers.GenericContainer;
 
 @ExtendWith(MockitoExtension.class)
 public class CamundaProcessTestRuntimeBuilderTest {
@@ -35,6 +41,12 @@ public class CamundaProcessTestRuntimeBuilderTest {
 
   @Spy private CamundaClientBuilder clientBuilder = CamundaClient.newClientBuilder();
 
+  @Mock private CamundaProcessTestContainerProvider containerProvider;
+
+  @SuppressWarnings("rawtypes")
+  @Mock(answer = Answers.RETURNS_SELF)
+  private GenericContainer customContainer;
+
   @BeforeEach
   public void setup() {
     runtimeBuilder =
@@ -42,7 +54,7 @@ public class CamundaProcessTestRuntimeBuilderTest {
   }
 
   @Test
-  public void shouldOverrideCamundaClientBuilderConfiguration() {
+  void shouldOverrideCamundaClientBuilderConfiguration() {
     // given
     final String tenantId = "customTenant";
     final Duration requestTimeout = Duration.ofHours(1);
@@ -62,5 +74,52 @@ public class CamundaProcessTestRuntimeBuilderTest {
 
     assertThat(client.getDefaultRequestTimeout()).isEqualTo(requestTimeout);
     assertThat(client.getDefaultTenantId()).isEqualTo(tenantId);
+  }
+
+  @Test
+  void shouldLoadContainerProvidersViaServiceLoaderByDefault() {
+    // given: the DummyContainerProvider is registered in the service loader file
+
+    // when
+    runtimeBuilder.build();
+
+    // then
+    assertThat(runtimeBuilder.isContainerProvidersServiceLoaderEnabled()).isTrue();
+
+    assertThat(runtimeBuilder.getContainerProviders())
+        .hasSize(1)
+        .first()
+        .isInstanceOf(DummyContainerProvider.class);
+  }
+
+  @Test
+  void shouldDisableLoadContainerProvider() {
+    // given
+    runtimeBuilder.withContainerProvidersServiceLoaderEnabled(false);
+
+    // when
+    runtimeBuilder.build();
+
+    // then
+    assertThat(runtimeBuilder.isContainerProvidersServiceLoaderEnabled()).isFalse();
+    assertThat(runtimeBuilder.getContainerProviders()).isEmpty();
+  }
+
+  @Test
+  void shouldAddCustomContainersFromProviders() {
+    // given
+    //noinspection unchecked
+    when(containerProvider.createContainer(any())).thenReturn(customContainer);
+
+    runtimeBuilder.withContainerProvider(containerProvider);
+
+    // when
+    runtimeBuilder.build();
+
+    // then
+    assertThat(runtimeBuilder.getContainerProviders())
+        .hasSize(2)
+        .contains(containerProvider)
+        .hasAtLeastOneElementOfType(DummyContainerProvider.class);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
+import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,6 +80,7 @@ public class CamundaProcessTestRuntimeBuilderTest {
   @Test
   void shouldLoadContainerProvidersViaServiceLoaderByDefault() {
     // given: the DummyContainerProvider is registered in the service loader file
+    runtimeBuilder.withRuntimeMode(CamundaProcessTestRuntimeMode.MANAGED);
 
     // when
     runtimeBuilder.build();
@@ -121,5 +123,22 @@ public class CamundaProcessTestRuntimeBuilderTest {
         .hasSize(2)
         .contains(containerProvider)
         .hasAtLeastOneElementOfType(DummyContainerProvider.class);
+  }
+
+  @Test
+  void shouldLoadContainerProvidersViaServiceLoaderForSharedRuntime() {
+    // given: the DummyContainerProvider is registered in the service loader file
+    runtimeBuilder.withRuntimeMode(CamundaProcessTestRuntimeMode.SHARED);
+
+    // when
+    runtimeBuilder.build();
+
+    // then
+    assertThat(runtimeBuilder.isContainerProvidersServiceLoaderEnabled()).isTrue();
+
+    assertThat(runtimeBuilder.getContainerProviders())
+        .hasSize(1)
+        .first()
+        .isInstanceOf(DummyContainerProvider.class);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CustomContainerIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CustomContainerIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaProcessTestExtension;
+import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * This test verifies that we can add a custom container to the Camunda process test runtime. The
+ * custom container is used to mock the HTTP endpoint of the outbound connector in the process. We
+ * assert the invocation of the custom container by checking the process instance variables and the
+ * completion of the connector task.
+ */
+public class CustomContainerIT {
+
+  @RegisterExtension
+  private static final CamundaProcessTestExtension EXTENSION =
+      new CamundaProcessTestExtension()
+          .withRuntimeMode(CamundaProcessTestRuntimeMode.MANAGED)
+          .withConnectorsEnabled(true)
+          // Bind the connector's HTTP endpoint to the Wiremock container
+          .withConnectorsSecret("BASE_URL", "http://wiremock:8080")
+          .withContainerProvider(containerContext -> new WireMockContainer());
+
+  private CamundaClient client;
+
+  @Test
+  void shouldInvokeCustomContainer() {
+    // given
+    client
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("connector-outbound-process.bpmn")
+        .send()
+        .join();
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("outbound-connector-process")
+            .latestVersion()
+            .send()
+            .join();
+
+    // then
+    CamundaAssert.assertThatProcessInstance(processInstance)
+        .hasCompletedElements(byName("Mocked Outbound Connector"))
+        .hasVariable("status", "okay")
+        .isCompleted();
+  }
+
+  private static final class WireMockContainer extends GenericContainer<WireMockContainer> {
+    public WireMockContainer() {
+      super("wiremock/wiremock:3.13.0");
+      withNetworkAliases("wiremock")
+          .withExposedPorts(8080)
+          .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("tc.wiremock"), true))
+          .waitingFor(
+              Wait.forHttp("/__admin/mappings").forPort(8080).withMethod("GET").forStatusCode(200))
+          .withCopyFileToContainer(
+              // Copy the WireMock mapping file to the container
+              MountableFile.forClasspathResource("/customContainerIT/wiremock-mapping.json"),
+              "/home/wiremock/mappings/wiremock-mapping.json");
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/DummyContainerProvider.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/DummyContainerProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerContext;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
+import org.testcontainers.containers.GenericContainer;
+
+/** A dummy container provider for testing purposes. */
+public class DummyContainerProvider implements CamundaProcessTestContainerProvider {
+
+  @Override
+  public GenericContainer<?> createContainer(final CamundaProcessTestContainerContext context) {
+    // Use the "hello world" container as a dummy container for testing.
+    return new GenericContainer<>("testcontainers/helloworld");
+  }
+}

--- a/testing/camunda-process-test-java/src/test/resources/META-INF/services/io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider
+++ b/testing/camunda-process-test-java/src/test/resources/META-INF/services/io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider
@@ -1,0 +1,1 @@
+io.camunda.process.test.impl.runtime.DummyContainerProvider

--- a/testing/camunda-process-test-java/src/test/resources/customContainerIT/wiremock-mapping.json
+++ b/testing/camunda-process-test-java/src/test/resources/customContainerIT/wiremock-mapping.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/test"
+  },
+  "response": {
+    "status": 202,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "jsonBody": {
+      "status":"okay"
+    }
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -330,11 +330,11 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
     final CamundaClientProperties clientProperties =
         testContext.getApplicationContext().getBean(CamundaClientProperties.class);
 
-    final Map<String, CamundaProcessTestContainerProvider> containerProvider =
+    final Map<String, CamundaProcessTestContainerProvider> containerProviders =
         testContext
             .getApplicationContext()
             .getBeansOfType(CamundaProcessTestContainerProvider.class);
-    containerProvider.values().forEach(containerRuntimeBuilder::withContainerProvider);
+    containerProviders.values().forEach(containerRuntimeBuilder::withContainerProvider);
 
     return CamundaSpringProcessTestRuntimeBuilder.buildRuntime(
         containerRuntimeBuilder, runtimeConfiguration, clientProperties);

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.spring.event.CamundaClientClosingSpringEvent;
 import io.camunda.client.spring.event.CamundaClientCreatedSpringEvent;
 import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
@@ -48,6 +49,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -327,6 +329,12 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
 
     final CamundaClientProperties clientProperties =
         testContext.getApplicationContext().getBean(CamundaClientProperties.class);
+
+    final Map<String, CamundaProcessTestContainerProvider> containerProvider =
+        testContext
+            .getApplicationContext()
+            .getBeansOfType(CamundaProcessTestContainerProvider.class);
+    containerProvider.values().forEach(containerRuntimeBuilder::withContainerProvider);
 
     return CamundaSpringProcessTestRuntimeBuilder.buildRuntime(
         containerRuntimeBuilder, runtimeConfiguration, clientProperties);

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.spring.event.CamundaClientClosingSpringEvent;
 import io.camunda.client.spring.event.CamundaClientCreatedSpringEvent;
 import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.api.testCases.TestCaseRunner;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
@@ -48,6 +49,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -107,6 +109,9 @@ public class ExecutionListenerTest {
 
   @Captor private ArgumentCaptor<ZeebeClientCreatedEvent> zeebeClientCreatedEventArgumentCaptor;
   @Captor private ArgumentCaptor<ZeebeClientClosingEvent> zeebeClientClosingEventArgumentCaptor;
+
+  @Mock private CamundaProcessTestContainerProvider containerProvider;
+  @Mock private CamundaProcessTestContainerProvider anotherContainerProvider;
 
   @BeforeEach
   void configureMocks() {
@@ -454,6 +459,25 @@ public class ExecutionListenerTest {
     // then
     verify(processCoverageBuilder).reportDirectory(reportDirectory);
     verify(processCoverageBuilder).excludeProcessDefinitionIds(excludedProcesses);
+  }
+
+  @Test
+  void shouldAddCustomContainers() {
+    // given
+    when(applicationContext.getBeansOfType(CamundaProcessTestContainerProvider.class))
+        .thenReturn(Map.of("mock1", containerProvider, "mock2", anotherContainerProvider));
+
+    final CamundaProcessTestExecutionListener listener =
+        new CamundaProcessTestExecutionListener(
+            camundaRuntimeBuilder, processCoverageBuilder, NOOP);
+
+    // when
+    listener.beforeTestClass(testContext);
+    listener.beforeTestMethod(testContext);
+
+    // then
+    verify(camundaRuntimeBuilder).withContainerProvider(containerProvider);
+    verify(camundaRuntimeBuilder).withContainerProvider(anotherContainerProvider);
   }
 
   private void setManagementClientDummy(final CamundaProcessTestExecutionListener listener) {

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringCustomContainerIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringCustomContainerIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * This test verifies that we can add a custom container to the Camunda process test runtime. The
+ * custom container is used to mock the HTTP endpoint of the outbound connector in the process. We
+ * assert the invocation of the custom container by checking the process instance variables and the
+ * completion of the connector task.
+ */
+@SpringBootTest(
+    classes = {SpringCustomContainerIT.class, SpringCustomContainerIT.TestConfig.class},
+    properties = {
+      "camunda.process-test.connectors-enabled=true",
+      "camunda.process-test.connectors-secrets.BASE_URL=http://wiremock:8080"
+    })
+@CamundaSpringProcessTest
+public class SpringCustomContainerIT {
+
+  @Autowired private CamundaClient client;
+
+  @Test
+  void shouldInvokeCustomContainer() {
+    // given
+    client
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("connector-outbound-process.bpmn")
+        .send()
+        .join();
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("outbound-connector-process")
+            .latestVersion()
+            .send()
+            .join();
+
+    // then
+    CamundaAssert.assertThatProcessInstance(processInstance)
+        .hasCompletedElements(byName("Mocked Outbound Connector"))
+        .hasVariable("status", "okay")
+        .isCompleted();
+  }
+
+  @Configuration
+  static class TestConfig {
+
+    @Bean
+    public CamundaProcessTestContainerProvider wireMockProvider() {
+      return containerContext -> new WireMockContainer();
+    }
+  }
+
+  private static final class WireMockContainer extends GenericContainer<WireMockContainer> {
+    public WireMockContainer() {
+      super("wiremock/wiremock:3.13.0");
+      withNetworkAliases("wiremock")
+          .withExposedPorts(8080)
+          .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("tc.wiremock"), true))
+          .waitingFor(
+              Wait.forHttp("/__admin/mappings").forPort(8080).withMethod("GET").forStatusCode(200))
+          .withCopyFileToContainer(
+              // Copy the WireMock mapping file to the container
+              MountableFile.forClasspathResource("/customContainerIT/wiremock-mapping.json"),
+              "/home/wiremock/mappings/wiremock-mapping.json");
+    }
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/resources/customContainerIT/wiremock-mapping.json
+++ b/testing/camunda-process-test-spring/src/test/resources/customContainerIT/wiremock-mapping.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/test"
+  },
+  "response": {
+    "status": 202,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "jsonBody": {
+      "status":"okay"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the ability to add custom Testcontainers to the managed/shared runtime by implementing the new `CamundaProcessTestContainerProvider` interface. The custom containers are added to the network and started/stopped by the runtime. The provider gets a context with runtime information about the network and the created containers. This context is not required, but could enable more complex scenarios, for example, if a database needs to modify the Camunda/Connector container config. 

In Java:
- via JUnit extension `new CamundaProcessTestExtension().withContainerProvider(..)`
- via Java service loader file `/META-INF/services/io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider`, suitable for a shared runtime

In Spring:
- via bean definition of the type `CamundaProcessTestContainerProvider`. The interface doesn't feel very intuitive for Spring, but a better interface would require managing the whole runtime in Spring. We can improve it in further versions.

---

```java
  @Configuration
  public class ProcessTestConfig {

    @Bean
    public CamundaProcessTestContainerProvider wireMockProvider() {
      return containerContext -> new WireMockContainer();
    }
  }

  public final class WireMockContainer extends GenericContainer<WireMockContainer> {
    public WireMockContainer() {
      super("wiremock/wiremock:3.13.0");
      withNetworkAliases("wiremock")
          .withExposedPorts(8080)
          .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("tc.wiremock"), true))
          .waitingFor(
              Wait.forHttp("/__admin/mappings").forPort(8080).withMethod("GET").forStatusCode(200))
          .withCopyFileToContainer(
              // Copy the WireMock mapping file to the container
              MountableFile.forClasspathResource("/customContainerIT/wiremock-mapping.json"),
              "/home/wiremock/mappings/wiremock-mapping.json");
    }
  }
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/23158
