### PR TITLE
fix: lock was unlocked even if it was not acquired initially

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>camunda-authentication</artifactId>

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>camunda-authentication</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,12 +8,12 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>4.0.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath></relativePath>
   </parent>
 
   <groupId>io.camunda</groupId>
   <artifactId>zeebe-bom</artifactId>
-  <version>8.6.37</version>
+  <version>8.6.38-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Zeebe BOM</name>
@@ -24,7 +24,7 @@
   <scm>
     <connection>scm:git:git@github.com:camunda/camunda.git</connection>
     <developerConnection>scm:git:git@github.com:camunda/camunda.git</developerConnection>
-    <tag>8.6.37</tag>
+    <tag>8.6.0</tag>
     <url>https://github.com/camunda/camunda</url>
   </scm>
 
@@ -187,7 +187,7 @@
           <configuration>
             <pom>
               <!-- https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#sortpom -->
-              <sortPom />
+              <sortPom></sortPom>
             </pom>
           </configuration>
         </plugin>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,12 +8,12 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>4.0.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath></relativePath>
+    <relativePath />
   </parent>
 
   <groupId>io.camunda</groupId>
   <artifactId>zeebe-bom</artifactId>
-  <version>8.6.37-SNAPSHOT</version>
+  <version>8.6.37</version>
   <packaging>pom</packaging>
 
   <name>Zeebe BOM</name>
@@ -24,7 +24,7 @@
   <scm>
     <connection>scm:git:git@github.com:camunda/camunda.git</connection>
     <developerConnection>scm:git:git@github.com:camunda/camunda.git</developerConnection>
-    <tag>8.6.0</tag>
+    <tag>8.6.37</tag>
     <url>https://github.com/camunda/camunda</url>
   </scm>
 
@@ -187,7 +187,7 @@
           <configuration>
             <pom>
               <!-- https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#sortpom -->
-              <sortPom></sortPom>
+              <sortPom />
             </pom>
           </configuration>
         </plugin>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,7 +7,7 @@
     <!-- We can't reference zeebe parent as parent otherwise we will have a circle dependency -->
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-bom</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../bom/pom.xml</relativePath>
   </parent>
   <artifactId>zeebe-build-tools</artifactId>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,7 +7,7 @@
     <!-- We can't reference zeebe parent as parent otherwise we will have a circle dependency -->
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-bom</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../bom/pom.xml</relativePath>
   </parent>
   <artifactId>zeebe-build-tools</artifactId>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -642,7 +642,7 @@
               <goal>assemble</goal>
             </goals>
             <phase>package</phase>
-            <configuration></configuration>
+            <configuration />
           </execution>
         </executions>
       </plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -642,7 +642,7 @@
               <goal>assemble</goal>
             </goals>
             <phase>package</phase>
-            <configuration />
+            <configuration></configuration>
           </execution>
         </executions>
       </plugin>

--- a/document/api/pom.xml
+++ b/document/api/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>document-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/document/api/pom.xml
+++ b/document/api/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>document-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/document/pom.xml
+++ b/document/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/document/pom.xml
+++ b/document/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>document-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>document-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/identity/client/pom.xml
+++ b/identity/client/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>identity-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>identity-webjar</artifactId>

--- a/identity/client/pom.xml
+++ b/identity/client/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>identity-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>identity-webjar</artifactId>

--- a/identity/migration/pom.xml
+++ b/identity/migration/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>identity-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
 
   <artifactId>identity-migration</artifactId>

--- a/identity/migration/pom.xml
+++ b/identity/migration/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>identity-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
 
   <artifactId>identity-migration</artifactId>

--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-archiver</artifactId>

--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-archiver</artifactId>

--- a/operate/client/pom.xml
+++ b/operate/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-webjar</artifactId>

--- a/operate/client/pom.xml
+++ b/operate/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-webjar</artifactId>

--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-common</artifactId>

--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-common</artifactId>

--- a/operate/data-generator/pom.xml
+++ b/operate/data-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-data-generator</artifactId>

--- a/operate/data-generator/pom.xml
+++ b/operate/data-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-data-generator</artifactId>

--- a/operate/importer-8_5/pom.xml
+++ b/operate/importer-8_5/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-8_5</artifactId>

--- a/operate/importer-8_5/pom.xml
+++ b/operate/importer-8_5/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-8_5</artifactId>

--- a/operate/importer-8_6/pom.xml
+++ b/operate/importer-8_6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-8_6</artifactId>

--- a/operate/importer-8_6/pom.xml
+++ b/operate/importer-8_6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-8_6</artifactId>

--- a/operate/importer-common/pom.xml
+++ b/operate/importer-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-common</artifactId>

--- a/operate/importer-common/pom.xml
+++ b/operate/importer-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-common</artifactId>

--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer</artifactId>

--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer</artifactId>

--- a/operate/mvc-auth-commons/pom.xml
+++ b/operate/mvc-auth-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-mvc-auth-commons</artifactId>

--- a/operate/mvc-auth-commons/pom.xml
+++ b/operate/mvc-auth-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-mvc-auth-commons</artifactId>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/operate/qa/backup-restore-tests/pom.xml
+++ b/operate/qa/backup-restore-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-backup-restore-tests</artifactId>
 

--- a/operate/qa/backup-restore-tests/pom.xml
+++ b/operate/qa/backup-restore-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-backup-restore-tests</artifactId>
 

--- a/operate/qa/data-generator/pom.xml
+++ b/operate/qa/data-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-data-generator</artifactId>
 

--- a/operate/qa/data-generator/pom.xml
+++ b/operate/qa/data-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-data-generator</artifactId>
 

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-it-tests</artifactId>
 

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-it-tests</artifactId>
 

--- a/operate/qa/migration-performance-test/pom.xml
+++ b/operate/qa/migration-performance-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-performance-test</artifactId>
 

--- a/operate/qa/migration-performance-test/pom.xml
+++ b/operate/qa/migration-performance-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-performance-test</artifactId>
 

--- a/operate/qa/migration-tests/migration-test/pom.xml
+++ b/operate/qa/migration-tests/migration-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests</artifactId>
 

--- a/operate/qa/migration-tests/migration-test/pom.xml
+++ b/operate/qa/migration-tests/migration-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests</artifactId>
 

--- a/operate/qa/migration-tests/pom.xml
+++ b/operate/qa/migration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-parent</artifactId>
   <packaging>pom</packaging>

--- a/operate/qa/migration-tests/pom.xml
+++ b/operate/qa/migration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-parent</artifactId>
   <packaging>pom</packaging>

--- a/operate/qa/migration-tests/test-fixture-110/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-110/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-110</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-110/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-110/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-110</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-120/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-120/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-120</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-120/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-120/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-120</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-130/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-130/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-130</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-130/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-130/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-130</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-800/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-800/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-800</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-800/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-800/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-800</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-810/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-810/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-810</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-810/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-810/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-810</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-820/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-820/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-820</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-820/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-820/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-820</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-830/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-830/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-830</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-830/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-830/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-830</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-840/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-840/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-840</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-840/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-840/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-840</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-850/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-850/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-850</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-850/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-850/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-850</artifactId>
 

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-qa</artifactId>

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-qa</artifactId>

--- a/operate/qa/query-performance-tests/pom.xml
+++ b/operate/qa/query-performance-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-query-performance-tests</artifactId>
 

--- a/operate/qa/query-performance-tests/pom.xml
+++ b/operate/qa/query-performance-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-query-performance-tests</artifactId>
 

--- a/operate/qa/util/pom.xml
+++ b/operate/qa/util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-util</artifactId>
 

--- a/operate/qa/util/pom.xml
+++ b/operate/qa/util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>operate-qa-util</artifactId>
 

--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-schema</artifactId>

--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-schema</artifactId>

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-webapp</artifactId>

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-webapp</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-bom</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../bom/pom.xml</relativePath>
   </parent>
 
@@ -2350,7 +2350,7 @@
                 <goal>check</goal>
               </goals>
               <phase>validate</phase>
-              <configuration />
+              <configuration></configuration>
             </execution>
           </executions>
         </plugin>
@@ -2382,7 +2382,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter" />
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
             <skip>${skipUTs}</skip>
           </configuration>
           <dependencies>
@@ -2424,7 +2424,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter" />
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
             <skip>${skipITs}</skip>
           </configuration>
           <dependencies>
@@ -2515,7 +2515,7 @@
                   <argument>-classpath</argument>
                   <!-- automatically creates the classpath using all project dependencies,
                      also adding the project build directory -->
-                  <classpath />
+                  <classpath></classpath>
                   <argument>uk.co.real_logic.sbe.SbeTool</argument>
                 </arguments>
                 <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
@@ -2550,7 +2550,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore></ignore>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -2635,7 +2635,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions />
+                  <banDuplicatePomDependencyVersions></banDuplicatePomDependencyVersions>
                 </rules>
               </configuration>
             </execution>
@@ -2910,7 +2910,7 @@
             <configuration>
               <groups>strace</groups>
               <!-- Reset <excludedGroups> as it take precedence over <groups> -->
-              <excludedGroups combine.self="override" />
+              <excludedGroups combine.self="override"></excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2928,7 +2928,7 @@
             <configuration>
               <groups>performance</groups>
               <!-- Reset <excludedGroups> as it take precedence over <groups> -->
-              <excludedGroups combine.self="override" />
+              <excludedGroups combine.self="override"></excludedGroups>
             </configuration>
           </plugin>
         </plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -233,7 +233,7 @@
     <extension.version.os-maven-plugin>1.7.1</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <backwards.compat.version>8.6.36</backwards.compat.version>
+    <backwards.compat.version>8.6.37</backwards.compat.version>
     <ignored.changes.file>ignored-changes.json</ignored.changes.file>
 
     <!--

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-bom</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../bom/pom.xml</relativePath>
   </parent>
 
@@ -2350,7 +2350,7 @@
                 <goal>check</goal>
               </goals>
               <phase>validate</phase>
-              <configuration></configuration>
+              <configuration />
             </execution>
           </executions>
         </plugin>
@@ -2382,7 +2382,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter" />
             <skip>${skipUTs}</skip>
           </configuration>
           <dependencies>
@@ -2424,7 +2424,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter" />
             <skip>${skipITs}</skip>
           </configuration>
           <dependencies>
@@ -2515,7 +2515,7 @@
                   <argument>-classpath</argument>
                   <!-- automatically creates the classpath using all project dependencies,
                      also adding the project build directory -->
-                  <classpath></classpath>
+                  <classpath />
                   <argument>uk.co.real_logic.sbe.SbeTool</argument>
                 </arguments>
                 <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
@@ -2550,7 +2550,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore />
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -2635,7 +2635,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions></banDuplicatePomDependencyVersions>
+                  <banDuplicatePomDependencyVersions />
                 </rules>
               </configuration>
             </execution>
@@ -2910,7 +2910,7 @@
             <configuration>
               <groups>strace</groups>
               <!-- Reset <excludedGroups> as it take precedence over <groups> -->
-              <excludedGroups combine.self="override"></excludedGroups>
+              <excludedGroups combine.self="override" />
             </configuration>
           </plugin>
         </plugins>
@@ -2928,7 +2928,7 @@
             <configuration>
               <groups>performance</groups>
               <!-- Reset <excludedGroups> as it take precedence over <groups> -->
-              <excludedGroups combine.self="override"></excludedGroups>
+              <excludedGroups combine.self="override" />
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
   <scm>
     <connection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git</connection>
     <developerConnection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git</developerConnection>
-    <tag>8.6.37</tag>
+    <tag>8.6.0</tag>
     <url>https://github.com/camunda/camunda</url>
   </scm>
 
@@ -72,7 +72,7 @@
               <exclude>.github/skills/**/*.md</exclude>
               <exclude>.github/agents/**/*.md</exclude>
             </excludes>
-            <flexmark />
+            <flexmark></flexmark>
           </markdown>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
   <scm>
     <connection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git</connection>
     <developerConnection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git</developerConnection>
-    <tag>8.6.0</tag>
+    <tag>8.6.37</tag>
     <url>https://github.com/camunda/camunda</url>
   </scm>
 
@@ -72,7 +72,7 @@
               <exclude>.github/skills/**/*.md</exclude>
               <exclude>.github/agents/**/*.md</exclude>
             </excludes>
-            <flexmark></flexmark>
+            <flexmark />
           </markdown>
         </configuration>
       </plugin>

--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
 
   <artifactId>camunda-archunit-tests</artifactId>

--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-archunit-tests</artifactId>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-qa-integration-tests</artifactId>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
 
   <artifactId>camunda-qa-integration-tests</artifactId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>camunda-search-client-connect</artifactId>

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>camunda-search-client-connect</artifactId>

--- a/search/search-client-elasticsearch/pom.xml
+++ b/search/search-client-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/search/search-client-elasticsearch/pom.xml
+++ b/search/search-client-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/search/search-client-opensearch/pom.xml
+++ b/search/search-client-opensearch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/search/search-client-opensearch/pom.xml
+++ b/search/search-client-opensearch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/search/search-client-plugin/pom.xml
+++ b/search/search-client-plugin/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>camunda-search-client-plugin</artifactId>
-  <version>8.6.37</version>
+  <version>8.6.38-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Camunda Search Client Plugin</name>

--- a/search/search-client-plugin/pom.xml
+++ b/search/search-client-plugin/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>camunda-search-client-plugin</artifactId>
-  <version>8.6.37-SNAPSHOT</version>
+  <version>8.6.37</version>
   <packaging>jar</packaging>
 
   <name>Camunda Search Client Plugin</name>

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-search</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/tasklist/archiver/pom.xml
+++ b/tasklist/archiver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-archiver</artifactId>

--- a/tasklist/archiver/pom.xml
+++ b/tasklist/archiver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-archiver</artifactId>

--- a/tasklist/client/pom.xml
+++ b/tasklist/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tasklist/client/pom.xml
+++ b/tasklist/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-common</artifactId>

--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-common</artifactId>

--- a/tasklist/data-generator/pom.xml
+++ b/tasklist/data-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-data-generator</artifactId>

--- a/tasklist/data-generator/pom.xml
+++ b/tasklist/data-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-data-generator</artifactId>

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-els-schema</artifactId>

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-els-schema</artifactId>

--- a/tasklist/importer-850/pom.xml
+++ b/tasklist/importer-850/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-importer-850</artifactId>

--- a/tasklist/importer-850/pom.xml
+++ b/tasklist/importer-850/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-importer-850</artifactId>

--- a/tasklist/importer-860/pom.xml
+++ b/tasklist/importer-860/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-importer-860</artifactId>

--- a/tasklist/importer-860/pom.xml
+++ b/tasklist/importer-860/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-importer-860</artifactId>

--- a/tasklist/importer-common/pom.xml
+++ b/tasklist/importer-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-importer-common</artifactId>

--- a/tasklist/importer-common/pom.xml
+++ b/tasklist/importer-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-importer-common</artifactId>

--- a/tasklist/importer/pom.xml
+++ b/tasklist/importer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-importer</artifactId>

--- a/tasklist/importer/pom.xml
+++ b/tasklist/importer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-importer</artifactId>

--- a/tasklist/mvc-auth-commons/pom.xml
+++ b/tasklist/mvc-auth-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-mvc-auth-commons</artifactId>

--- a/tasklist/mvc-auth-commons/pom.xml
+++ b/tasklist/mvc-auth-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-mvc-auth-commons</artifactId>

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <groupId>io.camunda</groupId>

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <groupId>io.camunda</groupId>

--- a/tasklist/qa/backup-restore-tests/pom.xml
+++ b/tasklist/qa/backup-restore-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-backup-restore-tests</artifactId>
 

--- a/tasklist/qa/backup-restore-tests/pom.xml
+++ b/tasklist/qa/backup-restore-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-backup-restore-tests</artifactId>
 

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-it-tests</artifactId>
 

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-it-tests</artifactId>
 

--- a/tasklist/qa/migration-tests/migration-test/pom.xml
+++ b/tasklist/qa/migration-tests/migration-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests</artifactId>
 

--- a/tasklist/qa/migration-tests/migration-test/pom.xml
+++ b/tasklist/qa/migration-tests/migration-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests</artifactId>
 

--- a/tasklist/qa/migration-tests/pom.xml
+++ b/tasklist/qa/migration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-parent</artifactId>
   <packaging>pom</packaging>

--- a/tasklist/qa/migration-tests/pom.xml
+++ b/tasklist/qa/migration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-parent</artifactId>
   <packaging>pom</packaging>

--- a/tasklist/qa/migration-tests/test-fixture-810/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-810/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-810</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-810/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-810/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-810</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-820/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-820/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-820</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-820/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-820/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-820</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-830/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-830/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-830</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-830/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-830/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-830</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-840/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-840/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-840</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-840/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-840/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-840</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-850/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-850/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-850</artifactId>
 

--- a/tasklist/qa/migration-tests/test-fixture-850/pom.xml
+++ b/tasklist/qa/migration-tests/test-fixture-850/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa-migration-tests-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-migration-tests-test-fixture-850</artifactId>
 

--- a/tasklist/qa/pom.xml
+++ b/tasklist/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-qa</artifactId>

--- a/tasklist/qa/pom.xml
+++ b/tasklist/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-qa</artifactId>

--- a/tasklist/qa/util/pom.xml
+++ b/tasklist/qa/util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
   <artifactId>tasklist-qa-util</artifactId>
 

--- a/tasklist/qa/util/pom.xml
+++ b/tasklist/qa/util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
   <artifactId>tasklist-qa-util</artifactId>
 

--- a/tasklist/test-coverage/pom.xml
+++ b/tasklist/test-coverage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tasklist/test-coverage/pom.xml
+++ b/tasklist/test-coverage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-webapp</artifactId>

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>tasklist-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>tasklist-webapp</artifactId>

--- a/testing/camunda-process-test-example/pom.xml
+++ b/testing/camunda-process-test-example/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/testing/camunda-process-test-example/pom.xml
+++ b/testing/camunda-process-test-example/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 

--- a/webapps-common/pom.xml
+++ b/webapps-common/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>webapps-common</artifactId>

--- a/webapps-common/pom.xml
+++ b/webapps-common/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>webapps-common</artifactId>

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -13,12 +13,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>webapps-schema</artifactId>
   <name>Webapps Schema</name>
 
-  <dependencies />
+  <dependencies></dependencies>
 
 </project>

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -13,12 +13,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>webapps-schema</artifactId>
   <name>Webapps Schema</name>
 
-  <dependencies></dependencies>
+  <dependencies />
 
 </project>

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-atomix-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
 
   <artifactId>zeebe-atomix-cluster</artifactId>

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-atomix-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-atomix-cluster</artifactId>

--- a/zeebe/atomix/pom.xml
+++ b/zeebe/atomix/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/atomix/pom.xml
+++ b/zeebe/atomix/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/atomix/utils/pom.xml
+++ b/zeebe/atomix/utils/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-atomix-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-atomix-utils</artifactId>

--- a/zeebe/atomix/utils/pom.xml
+++ b/zeebe/atomix/utils/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-atomix-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
 
   <artifactId>zeebe-atomix-utils</artifactId>

--- a/zeebe/auth/pom.xml
+++ b/zeebe/auth/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/auth/pom.xml
+++ b/zeebe/auth/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/azure/pom.xml
+++ b/zeebe/backup-stores/azure/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/azure/pom.xml
+++ b/zeebe/backup-stores/azure/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/common/pom.xml
+++ b/zeebe/backup-stores/common/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/common/pom.xml
+++ b/zeebe/backup-stores/common/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/filesystem/pom.xml
+++ b/zeebe/backup-stores/filesystem/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/filesystem/pom.xml
+++ b/zeebe/backup-stores/filesystem/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/s3/pom.xml
+++ b/zeebe/backup-stores/s3/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/s3/pom.xml
+++ b/zeebe/backup-stores/s3/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/testkit/pom.xml
+++ b/zeebe/backup-stores/testkit/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup-stores/testkit/pom.xml
+++ b/zeebe/backup-stores/testkit/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/bpmn-model/pom.xml
+++ b/zeebe/bpmn-model/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/bpmn-model/pom.xml
+++ b/zeebe/bpmn-model/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/broker-client/pom.xml
+++ b/zeebe/broker-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/broker-client/pom.xml
+++ b/zeebe/broker-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/dmn/pom.xml
+++ b/zeebe/dmn/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/dmn/pom.xml
+++ b/zeebe/dmn/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporter-api/pom.xml
+++ b/zeebe/exporter-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporter-api/pom.xml
+++ b/zeebe/exporter-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporter-test/pom.xml
+++ b/zeebe/exporter-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporter-test/pom.xml
+++ b/zeebe/exporter-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/expression-language/pom.xml
+++ b/zeebe/expression-language/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/expression-language/pom.xml
+++ b/zeebe/expression-language/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/feel/pom.xml
+++ b/zeebe/feel/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/feel/pom.xml
+++ b/zeebe/feel/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/gateway-protocol-impl/pom.xml
+++ b/zeebe/gateway-protocol-impl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
   <artifactId>zeebe-gateway-protocol-impl</artifactId>

--- a/zeebe/gateway-protocol-impl/pom.xml
+++ b/zeebe/gateway-protocol-impl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
   <artifactId>zeebe-gateway-protocol-impl</artifactId>

--- a/zeebe/gateway-protocol/pom.xml
+++ b/zeebe/gateway-protocol/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/gateway-protocol/pom.xml
+++ b/zeebe/gateway-protocol/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
   <artifactId>zeebe-gateway-rest</artifactId>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
   <artifactId>zeebe-gateway-rest</artifactId>

--- a/zeebe/gateway/pom.xml
+++ b/zeebe/gateway/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/gateway/pom.xml
+++ b/zeebe/gateway/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/journal/pom.xml
+++ b/zeebe/journal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/journal/pom.xml
+++ b/zeebe/journal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/msgpack-core/pom.xml
+++ b/zeebe/msgpack-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/msgpack-core/pom.xml
+++ b/zeebe/msgpack-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/msgpack-value/pom.xml
+++ b/zeebe/msgpack-value/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/msgpack-value/pom.xml
+++ b/zeebe/msgpack-value/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol-asserts/pom.xml
+++ b/zeebe/protocol-asserts/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol-asserts/pom.xml
+++ b/zeebe/protocol-asserts/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol-impl/pom.xml
+++ b/zeebe/protocol-impl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol-impl/pom.xml
+++ b/zeebe/protocol-impl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol-jackson/pom.xml
+++ b/zeebe/protocol-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol-jackson/pom.xml
+++ b/zeebe/protocol-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol-test-util/pom.xml
+++ b/zeebe/protocol-test-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol-test-util/pom.xml
+++ b/zeebe/protocol-test-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-qa-integration-tests</artifactId>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
   </parent>
 
   <artifactId>zeebe-qa-integration-tests</artifactId>

--- a/zeebe/qa/pom.xml
+++ b/zeebe/qa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/qa/pom.xml
+++ b/zeebe/qa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/qa/update-tests/pom.xml
+++ b/zeebe/qa/update-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/zeebe/qa/update-tests/pom.xml
+++ b/zeebe/qa/update-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-qa</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-qa</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/scheduler/pom.xml
+++ b/zeebe/scheduler/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/scheduler/pom.xml
+++ b/zeebe/scheduler/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/snapshot/pom.xml
+++ b/zeebe/snapshot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/snapshot/pom.xml
+++ b/zeebe/snapshot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
@@ -30,17 +30,17 @@ public class EventDescription {
   public void status(final String status) {
     try {
       if (lock.tryLock(WRITE_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
-        // this cannot fail, try/finally is not needed
-        this.status = status;
-        position = 0;
-        intent = null;
-        valueType = null;
+        try {
+          this.status = status;
+          position = 0;
+          intent = null;
+          valueType = null;
+        } finally {
+          lock.unlock();
+        }
       }
     } catch (final InterruptedException e) {
-      // ignore it, it's just for reporting
       Thread.currentThread().interrupt();
-    } finally {
-      lock.unlock();
     }
   }
 
@@ -48,16 +48,17 @@ public class EventDescription {
       final String status, final long position, final Intent intent, final ValueType valueType) {
     try {
       if (lock.tryLock(WRITE_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
-        this.status = status;
-        this.position = position;
-        this.intent = intent;
-        this.valueType = valueType;
+        try {
+          this.status = status;
+          this.position = position;
+          this.intent = intent;
+          this.valueType = valueType;
+        } finally {
+          lock.unlock();
+        }
       }
     } catch (final InterruptedException e) {
-      // ignore it, it's just for reporting
       Thread.currentThread().interrupt();
-    } finally {
-      lock.unlock();
     }
   }
 
@@ -65,21 +66,22 @@ public class EventDescription {
   public String toString() {
     try {
       if (lock.tryLock(READ_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
-        if (position == 0) {
-          return status;
-        } else {
-          return String.format(
-              "%s @ position=%d, intent=%s, valueType=%s", status, position, intent, valueType);
+        try {
+          if (position == 0) {
+            return status;
+          } else {
+            return String.format(
+                "%s @ position=%d, intent=%s, valueType=%s", status, position, intent, valueType);
+          }
+        } finally {
+          lock.unlock();
         }
       } else {
         return FAILED_TO_ACQUIRE_LOCK;
       }
     } catch (final InterruptedException e) {
-      // ignore it, it's just for reporting
       Thread.currentThread().interrupt();
       return FAILED_TO_ACQUIRE_LOCK;
-    } finally {
-      lock.unlock();
     }
   }
 }

--- a/zeebe/test-util/pom.xml
+++ b/zeebe/test-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/test-util/pom.xml
+++ b/zeebe/test-util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/transport/pom.xml
+++ b/zeebe/transport/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/transport/pom.xml
+++ b/zeebe/transport/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/zb-db/pom.xml
+++ b/zeebe/zb-db/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37</version>
+    <version>8.6.38-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/zb-db/pom.xml
+++ b/zeebe/zb-db/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.6.37-SNAPSHOT</version>
+    <version>8.6.37</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION

## Description
Backport of PR #47686 to release-8.6.37

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
