### PR TITLE
Reject oversized businessId early at the gateway

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidator.java
@@ -12,6 +12,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_ONLY_ONE_FIELD;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateBusinessId;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateOperationReference;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateProcessDefinitionId;
@@ -67,6 +68,7 @@ public class ProcessInstanceRequestValidator {
           }
           validateKeyFormat(request.getProcessDefinitionKey(), "processDefinitionKey", violations);
           validateOperationReference(request.getOperationReference(), violations);
+          validateBusinessId(request.getBusinessId(), violations);
           validateTags(request.getTags(), violations);
         });
   }
@@ -82,6 +84,7 @@ public class ProcessInstanceRequestValidator {
           }
           validateProcessDefinitionId(request.getProcessDefinitionId(), violations);
           validateOperationReference(request.getOperationReference(), violations);
+          validateBusinessId(request.getBusinessId(), violations);
           validateTags(request.getTags(), violations);
         });
   }
@@ -117,6 +120,8 @@ public class ProcessInstanceRequestValidator {
             violations.add(
                 "processDefinitionVersion can only be set when using processDefinitionId");
           }
+
+          validateBusinessId(request.getBusinessId(), violations);
         });
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
@@ -12,6 +12,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_KEY_FORMAT;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
 
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
@@ -34,6 +35,9 @@ public final class RequestValidator {
   /** Compiled pattern for a valid BPMN process definition ID, matching the OpenAPI spec. */
   public static final Pattern PROCESS_DEFINITION_ID_PATTERN =
       Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_\\-.]*$");
+
+  /** Maximum allowed length for a business ID, matching the engine-side constraint. */
+  public static final int MAX_BUSINESS_ID_LENGTH = 256;
 
   public static Optional<ProblemDetail> createProblemDetail(final List<String> violations) {
     String problems = String.join(". ", violations);
@@ -128,6 +132,19 @@ public final class RequestValidator {
       violations.add(
           ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted(
               "processDefinitionId", PROCESS_DEFINITION_ID_PATTERN.pattern()));
+    }
+  }
+
+  /**
+   * Validates that a business ID does not exceed the maximum allowed length.
+   *
+   * @param businessId the business ID to validate (may be null; null is not validated)
+   * @param violations the list to add validation errors to
+   */
+  public static void validateBusinessId(final String businessId, final List<String> violations) {
+    if (businessId != null && businessId.length() > MAX_BUSINESS_ID_LENGTH) {
+      violations.add(
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("businessId", MAX_BUSINESS_ID_LENGTH));
     }
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/SimpleRequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/SimpleRequestMapperTest.java
@@ -232,5 +232,24 @@ class SimpleRequestMapperTest {
       assertThat(mapped.processDefinitionKey()).isEqualTo(123L);
       assertThat(mapped.businessId()).isEqualTo(businessId);
     }
+
+    @Test
+    void shouldRejectBusinessIdExceedingMaxLength() {
+      // given
+      final var request =
+          new ProcessInstanceCreationInstruction()
+              .processDefinitionKey("123")
+              .businessId("a".repeat(257));
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, false);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft().getStatus()).isEqualTo(400);
+      assertThat(result.getLeft().getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(result.getLeft().getDetail()).contains("businessId").contains("256");
+    }
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidatorTest.java
@@ -218,4 +218,92 @@ class ProcessInstanceRequestValidatorTest {
 
     assertThat(result).isEmpty();
   }
+
+  @Test
+  @DisplayName("Should reject businessId exceeding max length when creating by key")
+  void shouldRejectBusinessIdExceedingMaxLengthByKey() {
+    final var request = new ProcessInstanceCreationInstructionByKey();
+    request.setProcessDefinitionKey("123456789");
+    request.setBusinessId("a".repeat(257));
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("businessId").contains("256");
+  }
+
+  @Test
+  @DisplayName("Should reject businessId exceeding max length when creating by id")
+  void shouldRejectBusinessIdExceedingMaxLengthById() {
+    final var request = new ProcessInstanceCreationInstructionById();
+    request.setProcessDefinitionId("process-id");
+    request.setBusinessId("a".repeat(257));
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("businessId").contains("256");
+  }
+
+  @Test
+  @DisplayName("Should reject businessId exceeding max length in simple API")
+  void shouldRejectBusinessIdExceedingMaxLengthSimpleApi() {
+    final var request =
+        new io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationInstruction();
+    request.setProcessDefinitionId("process-id");
+    request.setBusinessId("a".repeat(257));
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateSimpleCreateProcessInstanceRequest(request);
+
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("businessId").contains("256");
+  }
+
+  @Test
+  @DisplayName("Should accept businessId with exactly max length")
+  void shouldAcceptBusinessIdWithMaxLength() {
+    final var request = new ProcessInstanceCreationInstructionByKey();
+    request.setProcessDefinitionKey("123456789");
+    request.setBusinessId("a".repeat(256));
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should accept null businessId")
+  void shouldAcceptNullBusinessId() {
+    final var request = new ProcessInstanceCreationInstructionByKey();
+    request.setProcessDefinitionKey("123456789");
+    request.setBusinessId(null);
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should accept empty businessId")
+  void shouldAcceptEmptyBusinessId() {
+    final var request = new ProcessInstanceCreationInstructionByKey();
+    request.setProcessDefinitionKey("123456789");
+    request.setBusinessId("");
+
+    final Optional<ProblemDetail> result =
+        ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest(request);
+
+    assertThat(result).isEmpty();
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
@@ -11,8 +11,10 @@ import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.waitForProcessInstance;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.Process;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -222,5 +224,25 @@ public class ProcessInstanceCreateIT {
     assertThat(result.getProcessInstanceKey())
         .isEqualTo(processInstanceCreation.getProcessInstanceKey());
     assertThat(result.getBusinessId()).isEqualTo(BUSINESS_ID + "-with-result");
+  }
+
+  @Test
+  void shouldRejectProcessInstanceCreationWithBusinessIdExceedingMaxLength() {
+    // given
+    final String tooLongBusinessId = "a".repeat(257);
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateInstanceCommand()
+                    .bpmnProcessId("process")
+                    .latestVersion()
+                    .businessId(tooLongBusinessId)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("businessId")
+        .hasMessageContaining("256");
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.camunda.zeebe.gateway.cmd.InvalidBusinessIdException;
 import io.camunda.zeebe.gateway.cmd.InvalidTenantRequestException;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerBroadcastSignalRequest;
@@ -76,6 +77,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class RequestMapper extends RequestUtil {
 
   private static final Pattern TENANT_ID_MASK = Pattern.compile("^[\\w\\.-]{1,31}$");
+  private static final int MAX_BUSINESS_ID_LENGTH = 256;
   private static boolean isMultiTenancyEnabled = false;
 
   /**
@@ -264,7 +266,7 @@ public final class RequestMapper extends RequestUtil {
         .setVariables(ensureJsonSet(grpcRequest.getVariables()))
         .setStartInstructions(grpcRequest.getStartInstructionsList())
         .setTags(Set.copyOf(grpcRequest.getTagsList()))
-        .setBusinessId(grpcRequest.hasBusinessId() ? grpcRequest.getBusinessId() : "");
+        .setBusinessId(ensureBusinessIdValid(grpcRequest.getBusinessId()));
 
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
@@ -279,6 +281,7 @@ public final class RequestMapper extends RequestUtil {
     final var brokerRequest = new BrokerCreateProcessInstanceWithResultRequest();
 
     final var request = grpcRequest.getRequest();
+
     brokerRequest
         .setBpmnProcessId(request.getBpmnProcessId())
         .setKey(request.getProcessDefinitionKey())
@@ -288,7 +291,7 @@ public final class RequestMapper extends RequestUtil {
         .setStartInstructions(request.getStartInstructionsList())
         .setTags(Set.copyOf(request.getTagsList()))
         .setFetchVariables(grpcRequest.getFetchVariablesList())
-        .setBusinessId(request.getBusinessId());
+        .setBusinessId(ensureBusinessIdValid(request.getBusinessId()));
 
     if (request.hasOperationReference()) {
       brokerRequest.setOperationReference(request.getOperationReference());
@@ -467,6 +470,15 @@ public final class RequestMapper extends RequestUtil {
         .setClaims(claims);
 
     return jobActivationProperties;
+  }
+
+  public static String ensureBusinessIdValid(final String businessId) {
+    if (businessId != null && businessId.length() > MAX_BUSINESS_ID_LENGTH) {
+      throw new InvalidBusinessIdException(
+          businessId,
+          "business id exceeds the limit of %d characters".formatted(MAX_BUSINESS_ID_LENGTH));
+    }
+    return businessId;
   }
 
   public static String ensureTenantIdSet(final String commandName, final String tenantId) {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.cmd.IllegalTenantRequestException;
+import io.camunda.zeebe.gateway.cmd.InvalidBusinessIdException;
 import io.camunda.zeebe.gateway.cmd.InvalidTenantRequestException;
 import io.camunda.zeebe.msgpack.MsgpackPropertyException;
 import io.grpc.StatusRuntimeException;
@@ -83,6 +84,10 @@ public final class GrpcErrorMapper {
         logger.debug("Expected to handle gRPC request, but JSON property was invalid", rootError);
       }
       case final InvalidTenantRequestException ignored -> {
+        builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
+        logger.debug(error.getMessage(), rootError);
+      }
+      case final InvalidBusinessIdException ignored -> {
         builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
         logger.debug(error.getMessage(), rootError);
       }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -11,7 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import io.camunda.zeebe.gateway.cmd.InvalidBusinessIdException;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeleteResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
@@ -567,6 +570,148 @@ public class RequestMapperTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("Unrecognized tenantFilter option")
           .hasMessageContaining("expected one of ASSIGNED or PROVIDED");
+    }
+  }
+
+  @Nested
+  class CreateProcessInstanceRequestBusinessIdTest {
+
+    @Test
+    public void shouldAcceptValidBusinessId() {
+      // given
+      final var grpcRequest =
+          CreateProcessInstanceRequest.newBuilder()
+              .setBpmnProcessId("process")
+              .setBusinessId("order-12345")
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCreateProcessInstanceRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEqualTo("order-12345");
+    }
+
+    @Test
+    public void shouldAcceptBusinessIdAtMaxLength() {
+      // given
+      final String maxLengthBusinessId = "a".repeat(256);
+      final var grpcRequest =
+          CreateProcessInstanceRequest.newBuilder()
+              .setBpmnProcessId("process")
+              .setBusinessId(maxLengthBusinessId)
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCreateProcessInstanceRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEqualTo(maxLengthBusinessId);
+    }
+
+    @Test
+    public void shouldRejectBusinessIdExceedingMaxLength() {
+      // given
+      final String tooLongBusinessId = "a".repeat(257);
+      final var grpcRequest =
+          CreateProcessInstanceRequest.newBuilder()
+              .setBpmnProcessId("process")
+              .setBusinessId(tooLongBusinessId)
+              .build();
+
+      // when/then
+      assertThatThrownBy(() -> RequestMapper.toCreateProcessInstanceRequest(grpcRequest))
+          .isInstanceOf(InvalidBusinessIdException.class)
+          .hasMessageContaining("business id")
+          .hasMessageContaining("256");
+    }
+
+    @Test
+    public void shouldAcceptEmptyBusinessId() {
+      // given
+      final var grpcRequest =
+          CreateProcessInstanceRequest.newBuilder().setBpmnProcessId("process").build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCreateProcessInstanceRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEmpty();
+    }
+  }
+
+  @Nested
+  class CreateProcessInstanceWithResultRequestBusinessIdTest {
+
+    @Test
+    public void shouldAcceptValidBusinessId() {
+      // given
+      final var grpcRequest =
+          CreateProcessInstanceWithResultRequest.newBuilder()
+              .setRequest(
+                  CreateProcessInstanceRequest.newBuilder()
+                      .setBpmnProcessId("process")
+                      .setBusinessId("order-12345"))
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCreateProcessInstanceWithResultRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEqualTo("order-12345");
+    }
+
+    @Test
+    public void shouldAcceptBusinessIdAtMaxLength() {
+      // given
+      final String maxLengthBusinessId = "a".repeat(256);
+      final var grpcRequest =
+          CreateProcessInstanceWithResultRequest.newBuilder()
+              .setRequest(
+                  CreateProcessInstanceRequest.newBuilder()
+                      .setBpmnProcessId("process")
+                      .setBusinessId(maxLengthBusinessId))
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCreateProcessInstanceWithResultRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEqualTo(maxLengthBusinessId);
+    }
+
+    @Test
+    public void shouldRejectBusinessIdExceedingMaxLength() {
+      // given
+      final String tooLongBusinessId = "a".repeat(257);
+      final var grpcRequest =
+          CreateProcessInstanceWithResultRequest.newBuilder()
+              .setRequest(
+                  CreateProcessInstanceRequest.newBuilder()
+                      .setBpmnProcessId("process")
+                      .setBusinessId(tooLongBusinessId))
+              .build();
+
+      // when/then
+      assertThatThrownBy(() -> RequestMapper.toCreateProcessInstanceWithResultRequest(grpcRequest))
+          .isInstanceOf(InvalidBusinessIdException.class)
+          .hasMessageContaining("business id")
+          .hasMessageContaining("256");
+    }
+
+    @Test
+    public void shouldAcceptEmptyBusinessId() {
+      // given
+      final var grpcRequest =
+          CreateProcessInstanceWithResultRequest.newBuilder()
+              .setRequest(CreateProcessInstanceRequest.newBuilder().setBpmnProcessId("process"))
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCreateProcessInstanceWithResultRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEmpty();
     }
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperBusinessIdTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperBusinessIdTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.zeebe.gateway.RequestMapper;
+import io.camunda.zeebe.gateway.cmd.InvalidBusinessIdException;
+import io.camunda.zeebe.test.util.logging.RecordingAppender;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import java.util.UUID;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.slf4j.Log4jLogger;
+import org.apache.logging.slf4j.Log4jMarkerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GrpcErrorMapperBusinessIdTest {
+
+  private final RecordingAppender recorder = new RecordingAppender();
+  private final GrpcErrorMapper errorMapper = new GrpcErrorMapper();
+
+  private Logger log;
+  private Log4jLogger logger;
+
+  @BeforeEach
+  void beforeEach() {
+    log = (Logger) LogManager.getLogger(UUID.randomUUID().toString());
+    logger = new Log4jLogger(new Log4jMarkerFactory(), log, log.getName());
+
+    recorder.start();
+    log.addAppender(recorder);
+  }
+
+  @AfterEach
+  void tearDown() {
+    recorder.stop();
+    log.removeAppender(recorder);
+  }
+
+  @Test
+  void shouldMapInvalidBusinessIdExceptionToInvalidArgument() {
+    // given
+    final String tooLongBusinessId = "a".repeat(257);
+    try {
+      RequestMapper.ensureBusinessIdValid(tooLongBusinessId);
+      fail("Expected to throw exception");
+    } catch (final RuntimeException exception) {
+      assertThat(exception)
+          .isInstanceOf(InvalidBusinessIdException.class)
+          .hasMessageContaining("exceeds the limit of 256 characters");
+
+      // when
+      log.setLevel(Level.DEBUG);
+      final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+      // then
+      assertThat(statusException.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+      assertThat(recorder.getAppendedEvents()).hasSize(1);
+      final LogEvent event = recorder.getAppendedEvents().get(0);
+      assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+      assertThat(event.getMessage().getFormattedMessage()).contains("business id").contains("256");
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -3005,4 +3005,80 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
   }
+
+  @Test
+  void shouldRejectCreateProcessInstanceByIdWithBusinessIdExceedingMaxLength() {
+    // given — businessId exceeds 256 characters
+    final var tooLongBusinessId = "a".repeat(257);
+    final var request =
+        """
+            {
+                "processDefinitionId": "bpmnProcessId",
+                "businessId": "%s"
+            }"""
+            .formatted(tooLongBusinessId);
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"The provided businessId exceeds the limit of 256 characters.",
+                "instance":"/v2/process-instances"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCreateProcessInstanceByKeyWithBusinessIdExceedingMaxLength() {
+    // given — businessId exceeds 256 characters
+    final var tooLongBusinessId = "a".repeat(257);
+    final var request =
+        """
+            {
+                "processDefinitionKey": "123",
+                "businessId": "%s"
+            }"""
+            .formatted(tooLongBusinessId);
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"The provided businessId exceeds the limit of 256 characters.",
+                "instance":"/v2/process-instances"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/cmd/InvalidBusinessIdException.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/cmd/InvalidBusinessIdException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.cmd;
+
+public class InvalidBusinessIdException extends ClientException {
+
+  private static final String MESSAGE_FORMAT =
+      "Expected to handle request with business id '%s', but %s";
+
+  private final String businessId;
+  private final String reason;
+
+  public InvalidBusinessIdException(final String businessId, final String reason) {
+    super(String.format(MESSAGE_FORMAT, businessId, reason));
+
+    this.businessId = businessId;
+    this.reason = reason;
+  }
+
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+}


### PR DESCRIPTION
## Description

Requests with a businessId longer than 256 characters could bypass REST schema validation when arriving through MCP or other non-REST gateway paths, only to be rejected later by the engine.

Validate the length in the shared request-validation layer so all entry points fail fast with a clear 400 error.

> [!Note]
>**For the gRPC gateway**: There are no dedicated validator classes, no validate* methods for process instances, jobs, messages, etc. The gRPC gateway relies on:
>- Protobuf schema for basic type enforcement (required fields, types)
 >- Engine-side rejection: invalid requests that pass through the gRPC gateway are caught by the engine's command processors, which return `RejectionType.INVALID_ARGUMENT` rejections back to the client

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47604
