### PR TITLE
fix: prevent batch operation document overwrite in multi-partition clusters

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -79,11 +79,15 @@ public class BatchOperationChunkCreatedHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    // also set the endDate to null to ensure that the batch operation is processed again by the
-    // BatchOperationUpdateTask
-    batchRequest.updateWithScript(
+    // Use upsertWithScript to be resilient against cross-partition ordering: if the batch operation
+    // document has not been created yet (e.g., a slow partition's CREATED event export), the upsert
+    // creates a minimal document from the entity. The script then atomically increments the total
+    // count and resets endDate to null so that the BatchOperationUpdateTask will re-process this
+    // batch operation to update all counts.
+    batchRequest.upsertWithScript(
         indexName,
         entity.getId(),
+        entity,
         """
             ctx._source.operationsTotalCount = ctx._source.operationsTotalCount + params.operationsTotalCount;
             ctx._source.endDate = null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.exporter.utils.ExporterUtil.map;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
@@ -24,13 +25,26 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Handles the creation of a batch operation by inserting the corresponding {@link
+ * Handles the creation of a batch operation by upserting the corresponding {@link
  * BatchOperationEntity} with the batch operation details. This handler is responsible for
  * initializing the batch operation state and type, and updating the local cache for immediate
  * access.
+ *
+ * <p>This handler uses an upsert operation instead of an index (full overwrite) operation because
+ * the CREATED event is distributed to all partitions in the cluster. In a multi-partition
+ * environment, each partition's exporter independently processes its own CREATED event and writes
+ * to the same batch operation document in the search index. If a full index operation were used, a
+ * late write from a slow partition's exporter could overwrite updates already applied by other
+ * partitions (e.g., operationsTotalCount increments from CHUNK_CREATED events or state transitions
+ * from COMPLETED lifecycle events), causing the batch operation to appear permanently stuck in the
+ * ACTIVE state.
+ *
+ * @see <a href="https://github.com/camunda/camunda/issues/46466">#46466</a>
  */
 public class BatchOperationCreatedHandler
     implements ExportHandler<BatchOperationEntity, BatchOperationCreationRecordValue> {
@@ -92,7 +106,18 @@ public class BatchOperationCreatedHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    // Use upsert instead of add (index) to prevent cross-partition document overwrites.
+    // The CREATED event is distributed to all partitions, so each partition's exporter writes to
+    // the same document. An index operation would fully replace the document, potentially
+    // overwriting operationsTotalCount increments or state transitions applied by other partitions.
+    // With upsert: if the document does not yet exist, it is created from the entity; if it
+    // already exists, only the specified fields are updated without affecting other fields.
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(BatchOperationTemplate.TYPE, entity.getType());
+    updateFields.put(BatchOperationTemplate.STATE, entity.getState());
+    updateFields.put(BatchOperationTemplate.ACTOR_TYPE, entity.getActorType());
+    updateFields.put(BatchOperationTemplate.ACTOR_ID, entity.getActorId());
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -116,7 +116,7 @@ class BatchOperationChunkCreatedHandlerTest {
   }
 
   @Test
-  void shouldUpdateEntityOnFlush() throws PersistenceException {
+  void shouldUpsertWithScriptEntityOnFlush() throws PersistenceException {
     // given
     final var entity =
         new BatchOperationEntity().setId("123").setOperationsTotalCount(123).setEndDate(null);
@@ -131,8 +131,12 @@ class BatchOperationChunkCreatedHandlerTest {
     // then
     final var scriptCaptor = ArgumentCaptor.forClass(String.class);
     verify(mockRequest, times(1))
-        .updateWithScript(
-            eq(indexName), eq(entity.getId()), scriptCaptor.capture(), eq(updateFields));
+        .upsertWithScript(
+            eq(indexName),
+            eq(entity.getId()),
+            eq(entity),
+            scriptCaptor.capture(),
+            eq(updateFields));
 
     final var script = scriptCaptor.getValue();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -206,7 +206,7 @@ class BatchOperationCreatedHandlerTest {
   }
 
   @Test
-  void shouldAddEntityOnFlush() throws PersistenceException {
+  void shouldUpsertEntityOnFlush() throws PersistenceException {
     // given
     final var entity = new BatchOperationEntity().setId("123");
     final var mockRequest = mock(BatchRequest.class);
@@ -214,7 +214,7 @@ class BatchOperationCreatedHandlerTest {
     // when
     underTest.flush(entity, mockRequest);
 
-    // then
-    verify(mockRequest, times(1)).add(indexName, entity);
+    // then - should use upsert instead of add to prevent cross-partition document overwrites
+    verify(mockRequest, times(1)).upsert(eq(indexName), eq("123"), eq(entity), any(Map.class));
   }
 }


### PR DESCRIPTION
## Summary

Fixes the "Operate incident retry button spinner does not stop after retry" bug (#46466) that occurs in multi-partition SaaS clusters.

### Root Cause

The CREATED event for batch operations is distributed to **all partitions** in the cluster. Each partition's exporter independently writes to the same batch operation document in the search index. Using ES `INDEX` (full overwrite) operations in `BatchOperationCreatedHandler.flush()` allowed a late write from a slow partition's exporter to **overwrite** `operationsTotalCount` increments and state transitions already applied by other partitions, causing the batch operation to appear permanently stuck in ACTIVE state with `operationsTotalCount=0`.

This race condition is **latent in both 8.9 and 8.10** (the batch operation code is identical), but manifests probabilistically in multi-partition environments. Single-partition self-managed deployments are unaffected because there's only one exporter processing events sequentially.

### Changes

- **`BatchOperationCreatedHandler`**: Changed `flush()` from `batchRequest.add()` (INDEX = full overwrite) to `batchRequest.upsert()` (create-if-missing, partial-update-if-exists). When the document already exists, only `type`, `state`, `actorType`, `actorId` are updated without touching `operationsTotalCount` or lifecycle state.
- **`BatchOperationChunkCreatedHandler`**: Changed `flush()` from `batchRequest.updateWithScript()` to `batchRequest.upsertWithScript()`. This makes it resilient to the edge case where a CHUNK_CREATED event is exported before the batch operation document exists (`updateWithScript` would fail with `document_missing_exception`; `upsertWithScript` creates a minimal document from the entity instead).
- Updated corresponding unit tests.

### Backport

This fix should be backported to `stable/8.9` via the backporting bot.