### PR TITLE
Track Business ID uniqueness across all process versions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -53,7 +53,7 @@ public class ProcessInstanceCreationHelper {
   private static final String ERROR_MESSAGE_NO_NONE_START_EVENT =
       "Expected to create instance of process with none start event, but there is no such event";
   private static final String ERROR_MESSAGE_BUSINESS_ID_ALREADY_EXISTS =
-      "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition key '%d'";
+      "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'";
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       Set.of(
           BpmnElementType.START_EVENT,
@@ -217,7 +217,9 @@ public class ProcessInstanceCreationHelper {
         .flatMap(
             valid ->
                 validateBusinessIdUniqueness(
-                    businessId, deployedProcess.getKey(), command.getTenantId()))
+                    businessId,
+                    bufferAsString(deployedProcess.getBpmnProcessId()),
+                    command.getTenantId()))
         .map(valid -> deployedProcess);
   }
 
@@ -415,7 +417,7 @@ public class ProcessInstanceCreationHelper {
   }
 
   private Either<Rejection, ?> validateBusinessIdUniqueness(
-      final String businessId, final long processDefinitionKey, final String tenantId) {
+      final String businessId, final String processDefinitionId, final String tenantId) {
     // If the uniqueness check is disabled or if no business id is provided, skip validation
     if (!businessIdUniquenessEnabled || businessId == null || businessId.isEmpty()) {
       return VALID;
@@ -423,12 +425,12 @@ public class ProcessInstanceCreationHelper {
 
     // Check if a process instance with this business id already exists
     if (elementInstanceState.hasActiveProcessInstanceWithBusinessId(
-        businessId, processDefinitionKey, tenantId, bannedInstanceState::isProcessInstanceBanned)) {
+        businessId, processDefinitionId, tenantId, bannedInstanceState::isProcessInstanceBanned)) {
       return Either.left(
           new Rejection(
               RejectionType.ALREADY_EXISTS,
               String.format(
-                  ERROR_MESSAGE_BUSINESS_ID_ALREADY_EXISTS, businessId, processDefinitionKey)));
+                  ERROR_MESSAGE_BUSINESS_ID_ALREADY_EXISTS, businessId, processDefinitionId)));
     }
 
     return VALID;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.engine.state.immutable.IncidentState.MISSING_INCI
 import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.AD_HOC_SUB_PROCESS_ELEMENTS;
 import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
 
+import com.google.common.base.Predicates;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
@@ -189,7 +190,11 @@ public class ProcessInstanceMigrationMigrateProcessor
         BufferUtil.bufferAsString(targetProcessDefinition.getBpmnProcessId()),
         elementInstanceState,
         businessIdUniquenessEnabled,
-        bannedInstanceState::isProcessInstanceBanned);
+        Predicates.or(
+            // ignore the current instance as we expect it to be active during version migration
+            Predicates.equalTo(processInstanceKey),
+            // ignore banned instances as well, as we don't consider them active
+            key -> key != null && bannedInstanceState.isProcessInstanceBanned(key)));
     requireReferredElementsExist(
         sourceProcessDefinition, targetProcessDefinition, mappingInstructions, processInstanceKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -186,6 +186,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireNoBusinessIdConflictForTargetProcess(
         processInstance,
         targetProcessDefinitionKey,
+        BufferUtil.bufferAsString(targetProcessDefinition.getBpmnProcessId()),
         elementInstanceState,
         businessIdUniquenessEnabled,
         bannedInstanceState::isProcessInstanceBanned);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -310,6 +310,7 @@ public final class ProcessInstanceMigrationPreconditions {
    *
    * @param processInstance the process instance being migrated
    * @param targetProcessDefinitionKey the key of the target process definition
+   * @param targetProcessDefinitionId the BPMN process id of the target process definition
    * @param elementInstanceState the element instance state to query for active instances
    * @param businessIdUniquenessEnabled whether business id uniqueness checking is enabled
    * @param ignoreWhen a predicate to ignore certain process instances (e.g. banned ones)
@@ -317,6 +318,7 @@ public final class ProcessInstanceMigrationPreconditions {
   public static void requireNoBusinessIdConflictForTargetProcess(
       final ElementInstance processInstance,
       final long targetProcessDefinitionKey,
+      final String targetProcessDefinitionId,
       final ElementInstanceState elementInstanceState,
       final boolean businessIdUniquenessEnabled,
       final Predicate<Long> ignoreWhen) {
@@ -332,7 +334,7 @@ public final class ProcessInstanceMigrationPreconditions {
 
     final String tenantId = processInstanceRecord.getTenantId();
     if (elementInstanceState.hasActiveProcessInstanceWithBusinessId(
-        businessId, targetProcessDefinitionKey, tenantId, ignoreWhen)) {
+        businessId, targetProcessDefinitionId, tenantId, ignoreWhen)) {
       final String reason =
           String.format(
               ERROR_BUSINESS_ID_ALREADY_EXISTS_FOR_TARGET,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV3Applier.java
@@ -324,16 +324,13 @@ final class ProcessInstanceElementActivatingV3Applier
 
   /**
    * Inserts the business id index for root process instances. This maps the business id to the
-   * process instance key, scoped by process definition key and tenant id.
+   * process instance key, scoped by process definition id and tenant id.
    */
   private void insertBusinessIdIndex(final ProcessInstanceRecord value) {
     final var businessId = value.getBusinessId();
     if (!businessId.isEmpty()) {
       elementInstanceState.insertProcessInstanceKeyByBusinessId(
-          businessId,
-          value.getProcessDefinitionKey(),
-          value.getTenantId(),
-          value.getProcessInstanceKey());
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedV2Applier.java
@@ -140,10 +140,7 @@ final class ProcessInstanceElementCompletedV2Applier
     final String businessId = value.getBusinessId();
     if (!businessId.isEmpty()) {
       elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
-          businessId,
-          value.getProcessDefinitionKey(),
-          value.getTenantId(),
-          value.getProcessInstanceKey());
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV3Applier.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.DirectBuffer;
@@ -120,6 +121,11 @@ final class ProcessInstanceElementMigratedV3Applier
       return;
     }
     if (value.hasParentProcessInstance()) {
+      return;
+    }
+    if (Objects.equals(previousProcessDefinitionId, value.getBpmnProcessId())) {
+      // no need to update the business id index if the process definition id didn't change
+      // note that the business id, the tenant id, and the instance key never change on migration
       return;
     }
     elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV3Applier.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.DirectBuffer;
 
 /** Applies state changes for `ProcessInstance:Element_Migrated` */
@@ -43,10 +44,12 @@ final class ProcessInstanceElementMigratedV3Applier
     }
 
     final var previousProcessDefinitionKey = new AtomicLong();
+    final var previousProcessDefinitionId = new AtomicReference<String>();
     elementInstanceState.updateInstance(
         elementInstanceKey,
         elementInstance -> {
           previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          previousProcessDefinitionId.set(elementInstance.getValue().getBpmnProcessId());
           elementInstance
               .getValue()
               .setProcessDefinitionKey(value.getProcessDefinitionKey())
@@ -62,7 +65,7 @@ final class ProcessInstanceElementMigratedV3Applier
       elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
           value.getProcessInstanceKey(), value.getProcessDefinitionKey());
 
-      migrateBusinessIdIndex(value, previousProcessDefinitionKey.get());
+      migrateBusinessIdIndex(value, previousProcessDefinitionId.get());
     }
   }
 
@@ -111,7 +114,7 @@ final class ProcessInstanceElementMigratedV3Applier
   }
 
   private void migrateBusinessIdIndex(
-      final ProcessInstanceRecord value, final long previousProcessDefinitionKey) {
+      final ProcessInstanceRecord value, final String previousProcessDefinitionId) {
     final String businessId = value.getBusinessId();
     if (businessId.isEmpty()) {
       return;
@@ -121,13 +124,10 @@ final class ProcessInstanceElementMigratedV3Applier
     }
     elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
         businessId,
-        previousProcessDefinitionKey,
+        previousProcessDefinitionId,
         value.getTenantId(),
         value.getProcessInstanceKey());
     elementInstanceState.insertProcessInstanceKeyByBusinessId(
-        businessId,
-        value.getProcessDefinitionKey(),
-        value.getTenantId(),
-        value.getProcessInstanceKey());
+        businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedV2Applier.java
@@ -76,10 +76,7 @@ final class ProcessInstanceElementTerminatedV2Applier
     final String businessId = value.getBusinessId();
     if (!businessId.isEmpty()) {
       elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
-          businessId,
-          value.getProcessDefinitionKey(),
-          value.getTenantId(),
-          value.getProcessInstanceKey());
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -148,14 +148,18 @@ public interface ElementInstanceState {
 
   /**
    * Verifies if there is an active process instance with the given business id. This method is used
-   * to enforce uniqueness of business id per process definition (scoped by tenant).
+   * to enforce uniqueness of business id per process definition (scoped by tenant, across
+   * versions).
+   *
+   * <p>Note that it uses process definition id rather than key to find an active process instance
+   * across all versions of the process definition.
    *
    * <p>The {@code ignoreWhen} predicate can be used to exclude certain process instances from the
    * check, for example banned process instances. This allows the caller to handle edge cases where
    * a process instance should not be considered as active.
    *
    * @param businessId the business id to look up
-   * @param processDefinitionKey the process definition key
+   * @param processDefinitionId the id of the process definition to scope the search
    * @param tenantId the tenant id
    * @param ignoreWhen a predicate that takes a process instance key and returns true if the process
    *     instance should be ignored (e.g. because it is banned), and false otherwise
@@ -163,7 +167,7 @@ public interface ElementInstanceState {
    */
   boolean hasActiveProcessInstanceWithBusinessId(
       String businessId,
-      long processDefinitionKey,
+      String processDefinitionId,
       String tenantId,
       final Predicate<Long> ignoreWhen);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -79,8 +79,9 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   private final RuntimeInstructions runtimeInstructions;
   private final ColumnFamily<DbLong, RuntimeInstructions> runtimeInstructionsByProcessInstanceKey;
 
-  // Business ID index: [businessId | processDefinitionKey | tenantId | processInstanceKey] => NIL
+  // Business ID index: [businessId | processDefinitionId | tenantId | processInstanceKey] => NIL
   private final DbString businessId = new DbString();
+  private final DbString processDefinitionId = new DbString();
   private final DbString tenantId = new DbString();
   private final DbLong processInstanceKey = new DbLong();
   private final BusinessIdIndexKey businessIdIndexKey;
@@ -158,7 +159,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
             elementInstanceKey,
             runtimeInstructions);
 
-    businessIdIndexKey = new BusinessIdIndexKey(businessId, processDefinitionKey, tenantId);
+    businessIdIndexKey = new BusinessIdIndexKey(businessId, processDefinitionId, tenantId);
     processInstanceByBusinessIdIndexKey =
         new ProcessInstanceByBusinessIdIndexKey(businessIdIndexKey, processInstanceKey);
     processInstanceByBusinessIdIndexKeyColumnFamily =
@@ -360,11 +361,11 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   @Override
   public void insertProcessInstanceKeyByBusinessId(
       final String businessId,
-      final long processDefinitionKey,
+      final String processDefinitionId,
       final String tenantId,
       final long processInstanceKey) {
     this.businessId.wrapString(businessId);
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    this.processDefinitionId.wrapString(processDefinitionId);
     this.tenantId.wrapString(tenantId);
     this.processInstanceKey.wrapLong(processInstanceKey);
 
@@ -375,11 +376,11 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   @Override
   public void deleteProcessInstanceKeyMappingByBusinessId(
       final String businessId,
-      final long processDefinitionKey,
+      final String processDefinitionId,
       final String tenantId,
       final long processInstanceKey) {
     this.businessId.wrapString(businessId);
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    this.processDefinitionId.wrapString(processDefinitionId);
     this.tenantId.wrapString(tenantId);
     this.processInstanceKey.wrapLong(processInstanceKey);
 
@@ -577,11 +578,11 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   @Override
   public boolean hasActiveProcessInstanceWithBusinessId(
       final String businessId,
-      final long processDefinitionKey,
+      final String processDefinitionId,
       final String tenantId,
       final Predicate<Long> ignoreWhen) {
     this.businessId.wrapString(businessId);
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    this.processDefinitionId.wrapString(processDefinitionId);
     this.tenantId.wrapString(tenantId);
     final var exists = new AtomicBoolean(false);
     processInstanceByBusinessIdIndexKeyColumnFamily.whileEqualPrefix(
@@ -614,23 +615,23 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     }
   }
 
-  private static class BusinessIdAndProcessDefinitionKey extends DbCompositeKey<DbString, DbLong> {
-    public BusinessIdAndProcessDefinitionKey(
-        final DbString businessId, final DbLong processDefinitionKey) {
-      super(businessId, processDefinitionKey);
+  private static class BusinessIdAndProcessDefinitionId extends DbCompositeKey<DbString, DbString> {
+    public BusinessIdAndProcessDefinitionId(
+        final DbString businessId, final DbString processDefinitionId) {
+      super(businessId, processDefinitionId);
     }
   }
 
   private static class BusinessIdIndexKey
-      extends KeyWithTenantId<BusinessIdAndProcessDefinitionKey> {
+      extends KeyWithTenantId<BusinessIdAndProcessDefinitionId> {
     public BusinessIdIndexKey(
-        final DbString businessId, final DbLong processDefinitionKey, final DbString tenantId) {
-      super(new BusinessIdAndProcessDefinitionKey(businessId, processDefinitionKey), tenantId);
+        final DbString businessId, final DbString processDefinitionId, final DbString tenantId) {
+      super(new BusinessIdAndProcessDefinitionId(businessId, processDefinitionId), tenantId);
     }
   }
 
   private static class ProcessInstanceByBusinessIdIndexKey
-      extends DbCompositeKey<KeyWithTenantId<BusinessIdAndProcessDefinitionKey>, DbLong> {
+      extends DbCompositeKey<KeyWithTenantId<BusinessIdAndProcessDefinitionId>, DbLong> {
 
     public ProcessInstanceByBusinessIdIndexKey(
         final BusinessIdIndexKey businessIdIndexKey, final DbLong processInstanceKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -114,25 +114,25 @@ public interface MutableElementInstanceState extends ElementInstanceState {
 
   /**
    * Inserts a mapping from business id to process instance key. This is used to enforce uniqueness
-   * of business id per process definition (scoped by tenant).
+   * of business id per process definition (scoped by tenant, across versions).
    *
    * @param businessId the business id
-   * @param processDefinitionKey the process definition key
+   * @param processDefinitionId the process definition id
    * @param tenantId the tenant id
    * @param processInstanceKey the process instance key
    */
   void insertProcessInstanceKeyByBusinessId(
-      String businessId, long processDefinitionKey, String tenantId, long processInstanceKey);
+      String businessId, String processDefinitionId, String tenantId, long processInstanceKey);
 
   /**
    * Deletes the mapping from business id to process instance key. This is used to enforce
-   * uniqueness of business id per process definition (scoped by tenant).
+   * uniqueness of business id per process definition (scoped by tenant, across versions).
    *
    * @param businessId the business id
-   * @param processDefinitionKey the process definition key
+   * @param processDefinitionId the process definition id
    * @param tenantId the tenant id
    * @param processInstanceKey the process instance key
    */
   void deleteProcessInstanceKeyMappingByBusinessId(
-      String businessId, long processDefinitionKey, String tenantId, long processInstanceKey);
+      String businessId, String processDefinitionId, String tenantId, long processInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -810,4 +810,83 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             but an instance with this business id already exists for process definition '%s'"""
                 .formatted(businessId, processId));
   }
+
+  @Test
+  public void shouldRejectVersionMigrationWhenAnotherInstanceOfSameProcessHasSameBusinessId() {
+    final String processId = helper.getBpmnProcessId();
+    final String businessId = "biz-123";
+
+    // given - deploy version 1 and version 2 of the same process
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+    final long v2ProcessDefinitionKey =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                    .userTask("another_task", AbstractUserTaskBuilder::zeebeUserTask)
+                    .endEvent()
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst()
+            .getProcessDefinitionKey();
+
+    // and - restart the engine with uniqueness disabled so we can create two instances with the
+    // same business id for the same process definition
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+    ENGINE.start();
+
+    final var v1ProcessInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVersion(1)
+            .withBusinessId(businessId)
+            .create();
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVersion(2)
+        .withBusinessId(businessId)
+        .create();
+
+    // and - restart the engine with uniqueness re-enabled
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    ENGINE.start();
+
+    // when - try to migrate the v1 instance to v2
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(v1ProcessInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(v2ProcessDefinitionKey)
+            .addMappingInstruction("task", "task")
+            .expectRejection()
+            .migrate();
+
+    // then - should be rejected because the v2 instance already holds the business id
+    // for the same process definition
+    assertThat(rejection)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            """
+            Expected to migrate instance '%s' with business id '%s' to process definition key '%s', \
+            but an active instance with this business id already exists for the target process definition"""
+                .formatted(v1ProcessInstanceKey, businessId, v2ProcessDefinitionKey));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -90,6 +90,66 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
   }
 
   @Test
+  public void shouldRejectCreateProcessInstanceWithBusinessIdInUseByOtherVersion() {
+    final String processId = helper.getBpmnProcessId();
+    final String businessId = "biz-123";
+
+    // given - deploy version 1 and create an instance with a business id
+    final var processDefinitionKey =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                    .endEvent()
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst()
+            .getProcessDefinitionKey();
+    ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+
+    // and - deploy version 2 of the same process
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .userTask("another_task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when - try to create an instance with the same business id for version 2
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVersion(2)
+        .withBusinessId(businessId)
+        .withTags("secondInstance")
+        .expectRejection()
+        .create();
+
+    // then - should be rejected because version 1 already has an active instance with this
+    // business id, and uniqueness is enforced across all versions of the same process definition
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .onlyCommandRejections()
+                .withTags("secondInstance")
+                .withBpmnProcessId(processId)
+                .getFirst())
+        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionReason(
+            """
+            Expected to create instance of process with business id '%s', \
+            but an instance with this business id already exists for process definition key '%s'"""
+                .formatted(businessId, processDefinitionKey));
+  }
+
+  @Test
   public void shouldCreateProcessInstanceWithBusinessIdInUseForOtherTenant() {
     final String processId = helper.getBpmnProcessId();
     final String businessId = "biz-123";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -49,20 +49,15 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
     final String businessId = "biz-123";
 
     // given
-    final var processDefinitionKey =
-        ENGINE
-            .deployment()
-            .withXmlResource(
-                Bpmn.createExecutableProcess(processId)
-                    .startEvent()
-                    .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
-                    .endEvent()
-                    .done())
-            .deploy()
-            .getValue()
-            .getProcessesMetadata()
-            .getFirst()
-            .getProcessDefinitionKey();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
     ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
 
     // when
@@ -85,8 +80,8 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .hasRejectionReason(
             """
             Expected to create instance of process with business id '%s', \
-            but an instance with this business id already exists for process definition key '%s'"""
-                .formatted(businessId, processDefinitionKey));
+            but an instance with this business id already exists for process definition '%s'"""
+                .formatted(businessId, processId));
   }
 
   @Test
@@ -95,20 +90,15 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
     final String businessId = "biz-123";
 
     // given - deploy version 1 and create an instance with a business id
-    final var processDefinitionKey =
-        ENGINE
-            .deployment()
-            .withXmlResource(
-                Bpmn.createExecutableProcess(processId)
-                    .startEvent()
-                    .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
-                    .endEvent()
-                    .done())
-            .deploy()
-            .getValue()
-            .getProcessesMetadata()
-            .getFirst()
-            .getProcessDefinitionKey();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
     ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
 
     // and - deploy version 2 of the same process
@@ -145,8 +135,8 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .hasRejectionReason(
             """
             Expected to create instance of process with business id '%s', \
-            but an instance with this business id already exists for process definition key '%s'"""
-                .formatted(businessId, processDefinitionKey));
+            but an instance with this business id already exists for process definition '%s'"""
+                .formatted(businessId, processId));
   }
 
   @Test
@@ -678,8 +668,8 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .hasRejectionReason(
             """
             Expected to create instance of process with business id '%s', \
-            but an instance with this business id already exists for process definition key '%s'"""
-                .formatted(businessId, targetProcessDefinitionKey));
+            but an instance with this business id already exists for process definition '%s'"""
+                .formatted(businessId, targetProcessId));
   }
 
   @Test
@@ -817,7 +807,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .hasRejectionReason(
             """
             Expected to create instance of process with business id '%s', \
-            but an instance with this business id already exists for process definition key '%s'"""
-                .formatted(businessId, targetProcessDefinitionKey));
+            but an instance with this business id already exists for process definition '%s'"""
+                .formatted(businessId, processId));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -746,4 +746,78 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             but an active instance with this business id already exists for the target process definition"""
                 .formatted(processInstanceKey, businessId, targetProcessDefinitionKey));
   }
+
+  @Test
+  public void shouldRejectCreateProcessInstanceWithBusinessIdOfOldVersionAfterVersionMigration() {
+    final String processId = helper.getBpmnProcessId();
+    final String businessId = "biz-123";
+
+    // given - deploy version 1 and create a process instance with a business id
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+
+    // and - deploy version 2 of the same process
+    final long targetProcessDefinitionKey =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                    .userTask("another_task", AbstractUserTaskBuilder::zeebeUserTask)
+                    .endEvent()
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst()
+            .getProcessDefinitionKey();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("task")
+        .await();
+
+    // when - migrate the process instance to version 2
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task", "task")
+        .migrate();
+
+    // then - creating an instance of version 1 with the same business id should be rejected because
+    // uniqueness is checked across all versions of a process definition.
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVersion(1)
+        .withBusinessId(businessId)
+        .withTags("rejectedInstance")
+        .expectRejection()
+        .create();
+
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .onlyCommandRejections()
+                .withTags("rejectedInstance")
+                .withBpmnProcessId(processId)
+                .getFirst())
+        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionReason(
+            """
+            Expected to create instance of process with business id '%s', \
+            but an instance with this business id already exists for process definition key '%s'"""
+                .formatted(businessId, targetProcessDefinitionKey));
+  }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v3.golden
@@ -324,16 +324,13 @@ final class ProcessInstanceElementActivatingV3Applier
 
   /**
    * Inserts the business id index for root process instances. This maps the business id to the
-   * process instance key, scoped by process definition key and tenant id.
+   * process instance key, scoped by process definition id and tenant id.
    */
   private void insertBusinessIdIndex(final ProcessInstanceRecord value) {
     final var businessId = value.getBusinessId();
     if (!businessId.isEmpty()) {
       elementInstanceState.insertProcessInstanceKeyByBusinessId(
-          businessId,
-          value.getProcessDefinitionKey(),
-          value.getTenantId(),
-          value.getProcessInstanceKey());
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
     }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_COMPLETED_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_COMPLETED_v2.golden
@@ -140,10 +140,7 @@ final class ProcessInstanceElementCompletedV2Applier
     final String businessId = value.getBusinessId();
     if (!businessId.isEmpty()) {
       elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
-          businessId,
-          value.getProcessDefinitionKey(),
-          value.getTenantId(),
-          value.getProcessInstanceKey());
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
     }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v3.golden
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.DirectBuffer;
@@ -120,6 +121,11 @@ final class ProcessInstanceElementMigratedV3Applier
       return;
     }
     if (value.hasParentProcessInstance()) {
+      return;
+    }
+    if (Objects.equals(previousProcessDefinitionId, value.getBpmnProcessId())) {
+      // no need to update the business id index if the process definition id didn't change
+      // note that the business id, the tenant id, and the instance key never change on migration
       return;
     }
     elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v3.golden
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.DirectBuffer;
 
 /** Applies state changes for `ProcessInstance:Element_Migrated` */
@@ -43,10 +44,12 @@ final class ProcessInstanceElementMigratedV3Applier
     }
 
     final var previousProcessDefinitionKey = new AtomicLong();
+    final var previousProcessDefinitionId = new AtomicReference<String>();
     elementInstanceState.updateInstance(
         elementInstanceKey,
         elementInstance -> {
           previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          previousProcessDefinitionId.set(elementInstance.getValue().getBpmnProcessId());
           elementInstance
               .getValue()
               .setProcessDefinitionKey(value.getProcessDefinitionKey())
@@ -62,7 +65,7 @@ final class ProcessInstanceElementMigratedV3Applier
       elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
           value.getProcessInstanceKey(), value.getProcessDefinitionKey());
 
-      migrateBusinessIdIndex(value, previousProcessDefinitionKey.get());
+      migrateBusinessIdIndex(value, previousProcessDefinitionId.get());
     }
   }
 
@@ -111,7 +114,7 @@ final class ProcessInstanceElementMigratedV3Applier
   }
 
   private void migrateBusinessIdIndex(
-      final ProcessInstanceRecord value, final long previousProcessDefinitionKey) {
+      final ProcessInstanceRecord value, final String previousProcessDefinitionId) {
     final String businessId = value.getBusinessId();
     if (businessId.isEmpty()) {
       return;
@@ -121,13 +124,10 @@ final class ProcessInstanceElementMigratedV3Applier
     }
     elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
         businessId,
-        previousProcessDefinitionKey,
+        previousProcessDefinitionId,
         value.getTenantId(),
         value.getProcessInstanceKey());
     elementInstanceState.insertProcessInstanceKeyByBusinessId(
-        businessId,
-        value.getProcessDefinitionKey(),
-        value.getTenantId(),
-        value.getProcessInstanceKey());
+        businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_TERMINATED_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_TERMINATED_v2.golden
@@ -76,10 +76,7 @@ final class ProcessInstanceElementTerminatedV2Applier
     final String businessId = value.getBusinessId();
     if (!businessId.isEmpty()) {
       elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
-          businessId,
-          value.getProcessDefinitionKey(),
-          value.getTenantId(),
-          value.getProcessInstanceKey());
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
     }
   }
 }


### PR DESCRIPTION
## Description

Change Business ID uniqueness tracking from per process definition key (version-specific) to per process definition ID (shared across all versions of a process). This prevents accidental business domain duplicates when creating a new instance of a newer/older version.

Previously, Business ID uniqueness was enforced per process definition key, meaning each version of a process had its own uniqueness scope. This allowed a Business ID to be reused across versions of the same process, which could break business identity guarantees — especially after migrating a process instance to a new version, as the old version's scope would become available for reuse.

### What changed

- **Data schema**: The Business ID index mapping now stores entries by process definition ID instead of process definition key. The process definition ID remains the same across all versions of a process, so uniqueness is now enforced across all versions.
- **Migration handling**: When migrating a process instance (with a Business ID) to another version of the same process, the migrating instance is excluded from the uniqueness check to avoid self-conflicts. This is implemented using `Predicates.or` for composable and well-documented predicate logic.
- **Rejection messages**: Updated to reflect the new scope of the uniqueness constraint.
- **Event applier golden files**: Updated to match the new data schema. This is safe because the affected event applier versions have not yet been included in any stable release.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47372