### PR TITLE
refacor: rename flowNode to element in app folder

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/editVariable.test.tsx
@@ -554,7 +554,7 @@ describe('Edit variable', () => {
         type: 'token',
         payload: {
           operation: 'ADD_TOKEN',
-          element: {id: 'flow_node_0', name: 'flow node 0'},
+          element: {id: 'element_0', name: 'element 0'},
           scopeId: 'random-scope-id-0',
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
@@ -624,7 +624,7 @@ describe('Edit variable', () => {
         type: 'token',
         payload: {
           operation: 'ADD_TOKEN',
-          element: {id: 'flow_node_0', name: 'flow node 0'},
+          element: {id: 'element_0', name: 'element 0'},
           scopeId: 'random-scope-id-0',
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
@@ -742,7 +742,7 @@ describe('Edit variable', () => {
         type: 'token',
         payload: {
           operation: 'ADD_TOKEN',
-          element: {id: 'flow_node_0', name: 'flow node 0'},
+          element: {id: 'element_0', name: 'element 0'},
           scopeId: 'random-scope-id-0',
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
@@ -46,12 +46,12 @@ const TestSelectionControls: React.FC = () => {
         type="button"
         onClick={() =>
           selectElementInstance({
-            elementId: 'TEST_FLOW_NODE',
+            elementId: 'TEST_ELEMENT',
             elementInstanceKey: '2',
           })
         }
       >
-        select test flow node
+        select test element
       </button>
       <button
         type="button"
@@ -109,7 +109,7 @@ const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
 describe('VariablePanel', () => {
   const statistics = [
     {
-      elementId: 'TEST_FLOW_NODE',
+      elementId: 'TEST_ELEMENT',
       active: 0,
       canceled: 0,
       incidents: 0,
@@ -412,7 +412,7 @@ describe('VariablePanel', () => {
 
     mockFetchElementInstance('2').withSuccess({
       elementInstanceKey: '2',
-      elementId: 'TEST_FLOW_NODE',
+      elementId: 'TEST_ELEMENT',
       elementName: 'Test Flow Node',
       type: 'SERVICE_TASK',
       state: 'ACTIVE',
@@ -428,7 +428,7 @@ describe('VariablePanel', () => {
     });
 
     await user.click(
-      screen.getByRole('button', {name: /select test flow node/i}),
+      screen.getByRole('button', {name: /select test element/i}),
     );
 
     expect(
@@ -523,7 +523,7 @@ describe('VariablePanel', () => {
     );
   });
 
-  it('should select correct tab when navigating between flow nodes', async () => {
+  it('should select correct tab when navigating between elements', async () => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockSearchVariables().withSuccess({
       items: [createVariable()],

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
@@ -413,7 +413,7 @@ describe('VariablePanel', () => {
     mockFetchElementInstance('2').withSuccess({
       elementInstanceKey: '2',
       elementId: 'TEST_ELEMENT',
-      elementName: 'Test Flow Node',
+      elementName: 'Test Element',
       type: 'SERVICE_TASK',
       state: 'ACTIVE',
       startDate: '2018-06-21',

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
@@ -53,7 +53,7 @@ describe('VariablePanel readonly', () => {
 
     const statistics = [
       {
-        elementId: 'TEST_FLOW_NODE',
+        elementId: 'TEST_ELEMENT',
         active: 0,
         canceled: 0,
         incidents: 0,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/spinner.test.tsx
@@ -43,12 +43,12 @@ const TestSelectionControls: React.FC = () => {
         type="button"
         onClick={() =>
           selectElementInstance({
-            elementId: 'TEST_FLOW_NODE',
+            elementId: 'TEST_ELEMENT',
             elementInstanceKey: '2',
           })
         }
       >
-        select flow node instance
+        select element instance
       </button>
       <button
         type="button"
@@ -83,8 +83,8 @@ const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
 
 const selectedElementInstance: ElementInstance = {
   elementInstanceKey: '2',
-  elementId: 'TEST_FLOW_NODE',
-  elementName: 'Test Flow Node',
+  elementId: 'TEST_ELEMENT',
+  elementName: 'Test Element',
   type: 'SERVICE_TASK',
   state: 'ACTIVE',
   startDate: '2018-06-21',
@@ -104,7 +104,7 @@ describe('VariablePanel spinner', () => {
 
     const statistics = [
       {
-        elementId: 'TEST_FLOW_NODE',
+        elementId: 'TEST_ELEMENT',
         active: 0,
         canceled: 0,
         incidents: 0,
@@ -178,7 +178,7 @@ describe('VariablePanel spinner', () => {
     });
 
     await user.click(
-      screen.getByRole('button', {name: /select flow node instance/i}),
+      screen.getByRole('button', {name: /select element instance/i}),
     );
 
     expect(await screen.findByTestId('variables-spinner')).toBeInTheDocument();
@@ -234,7 +234,7 @@ describe('VariablePanel spinner', () => {
 
     mockFetchElementInstance('2').withSuccess(selectedElementInstance);
     await user.click(
-      screen.getByRole('button', {name: /select flow node instance/i}),
+      screen.getByRole('button', {name: /select element instance/i}),
     );
 
     expect(screen.getByTestId('variables-spinner')).toBeInTheDocument();

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/undoFromDifferentScope.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/undoFromDifferentScope.test.tsx
@@ -197,7 +197,7 @@ describe('Undo variable modifications from different scope', () => {
     mockFetchElementInstance('different_instance_id').withSuccess({
       elementInstanceKey: 'different_instance_id',
       elementId: 'different_element',
-      elementName: 'Different Flow Node',
+      elementName: 'Different Element',
       type: 'SERVICE_TASK',
       state: 'ACTIVE',
       startDate: '2018-06-21',
@@ -321,7 +321,7 @@ describe('Undo variable modifications from different scope', () => {
     mockFetchElementInstance('different_instance_id').withSuccess({
       elementInstanceKey: 'different_instance_id',
       elementId: 'different_element',
-      elementName: 'Different Flow Node',
+      elementName: 'Different Element',
       type: 'SERVICE_TASK',
       state: 'ACTIVE',
       startDate: '2018-06-21',

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/undoFromDifferentScope.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/undoFromDifferentScope.test.tsx
@@ -27,8 +27,8 @@ const INITIAL_ADD_MODIFICATION: ElementModification = {
   payload: {
     affectedTokenCount: 1,
     element: {
-      id: 'flow_node_0',
-      name: 'flow node 0',
+      id: 'element_0',
+      name: 'element 0',
     },
     operation: 'ADD_TOKEN',
     parentScopeIds: {},
@@ -89,7 +89,7 @@ const TestSelectionControls: React.FC = () => {
         type="button"
         onClick={() =>
           selectElementInstance({
-            elementId: 'different_flow_node',
+            elementId: 'different_element',
             elementInstanceKey: 'different_instance_id',
           })
         }
@@ -196,7 +196,7 @@ describe('Undo variable modifications from different scope', () => {
 
     mockFetchElementInstance('different_instance_id').withSuccess({
       elementInstanceKey: 'different_instance_id',
-      elementId: 'different_flow_node',
+      elementId: 'different_element',
       elementName: 'Different Flow Node',
       type: 'SERVICE_TASK',
       state: 'ACTIVE',
@@ -320,7 +320,7 @@ describe('Undo variable modifications from different scope', () => {
 
     mockFetchElementInstance('different_instance_id').withSuccess({
       elementInstanceKey: 'different_instance_id',
-      elementId: 'different_flow_node',
+      elementId: 'different_element',
       elementName: 'Different Flow Node',
       type: 'SERVICE_TASK',
       state: 'ACTIVE',

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Name.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Name.tsx
@@ -79,7 +79,7 @@ const Name: React.FC<Props> = ({variableName, scopeId}) => {
                 id: currentId,
                 name: currentName,
                 value: currentValue,
-                selectedFlowNodeName: selectedElementName,
+                selectedElementName,
               });
             }}
           />

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Value.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Value.tsx
@@ -79,7 +79,7 @@ const Value: React.FC<Props> = ({variableName, scopeId}) => {
                 id: currentId,
                 name: currentName,
                 value: currentValue,
-                selectedFlowNodeName: selectedElementName,
+                selectedElementName,
               });
             }}
           />
@@ -107,7 +107,7 @@ const Value: React.FC<Props> = ({variableName, scopeId}) => {
                 id: currentId,
                 name: currentName,
                 value: value,
-                selectedFlowNodeName: selectedElementName,
+                selectedElementName,
               });
             }
           }}

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/createModification.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/createModification.ts
@@ -14,14 +14,14 @@ const createModification = ({
   id,
   name,
   value,
-  selectedFlowNodeName,
+  selectedElementName,
 }: {
   scopeId: string | null;
   areFormFieldsValid: boolean;
   id: string;
   name: string;
   value: string;
-  selectedFlowNodeName: string;
+  selectedElementName: string;
 }) => {
   if (scopeId === null || !areFormFieldsValid || name === '' || value === '') {
     return;
@@ -44,7 +44,7 @@ const createModification = ({
         operation: 'ADD_VARIABLE',
         scopeId,
         id,
-        elementName: selectedFlowNodeName,
+        elementName: selectedElementName,
         name,
         newValue: value,
       },

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.test.tsx
@@ -252,7 +252,7 @@ describe('ElementInstanceLog', () => {
     vi.useRealTimers();
   });
 
-  it('should render flow node instances tree', async () => {
+  it('should render element instances tree', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
 
     mockFetchProcessDefinitionXml().withSuccess('');

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.tsx
@@ -69,12 +69,12 @@ const ModificationSummaryModal: React.FC<StateProps> = observer(
     const willAllElementsBeCanceled = useWillAllElementsBeCanceled();
     const modificationsByElement = useModificationsByElement();
     const {data: processInstance} = useProcessInstance();
-    const flowNodeModificationsTableRef = useRef<HTMLDivElement>(null);
+    const elementModificationsTableRef = useRef<HTMLDivElement>(null);
     const variableModificationsTableRef = useRef<HTMLDivElement>(null);
 
     useLayoutEffect(() => {
       if (
-        flowNodeModificationsTableRef.current === null ||
+        elementModificationsTableRef.current === null ||
         variableModificationsTableRef.current === null
       ) {
         return;
@@ -83,18 +83,18 @@ const ModificationSummaryModal: React.FC<StateProps> = observer(
       const variableModificationsTableScrollWidth =
         variableModificationsTableRef.current.offsetWidth -
         variableModificationsTableRef.current.scrollWidth;
-      const flowNodeModificationsTableScrollWidth =
-        flowNodeModificationsTableRef.current.offsetWidth -
-        flowNodeModificationsTableRef.current.scrollWidth;
+      const elementModificationsTableScrollWidth =
+        elementModificationsTableRef.current.offsetWidth -
+        elementModificationsTableRef.current.scrollWidth;
 
       if (
         variableModificationsTableScrollWidth !==
-        flowNodeModificationsTableScrollWidth
+        elementModificationsTableScrollWidth
       ) {
-        flowNodeModificationsTableRef.current.style.paddingRight = `${variableModificationsTableScrollWidth}px`;
-        variableModificationsTableRef.current.style.paddingRight = `${flowNodeModificationsTableScrollWidth}px`;
+        elementModificationsTableRef.current.style.paddingRight = `${variableModificationsTableScrollWidth}px`;
+        variableModificationsTableRef.current.style.paddingRight = `${elementModificationsTableScrollWidth}px`;
       } else {
-        flowNodeModificationsTableRef.current.style.paddingRight = '0px';
+        elementModificationsTableRef.current.style.paddingRight = '0px';
         variableModificationsTableRef.current.style.paddingRight = '0px';
       }
     });
@@ -190,7 +190,7 @@ const ModificationSummaryModal: React.FC<StateProps> = observer(
           <EmptyMessage>No planned element modifications</EmptyMessage>
         ) : (
           <DataTable
-            ref={flowNodeModificationsTableRef}
+            ref={elementModificationsTableRef}
             columnsWithNoContentPadding={['delete']}
             headers={[
               {header: ' ', key: 'emptyCell'},
@@ -222,7 +222,7 @@ const ModificationSummaryModal: React.FC<StateProps> = observer(
             ]}
             rows={modificationsStore.elementModifications.map(
               (modification, index) => {
-                const flowNodeId =
+                const elementId =
                   modification.operation === 'MOVE_TOKEN'
                     ? modification.targetElement.id
                     : modification.element.id;
@@ -265,7 +265,7 @@ const ModificationSummaryModal: React.FC<StateProps> = observer(
                     <span data-testid="affected-token-count">
                       {modification.operation === 'CANCEL_TOKEN'
                         ? modification.visibleAffectedTokenCount +
-                          (modificationsByElement[flowNodeId]
+                          (modificationsByElement[elementId]
                             ?.cancelledChildTokens ?? 0)
                         : modification.affectedTokenCount}
                     </span>

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/ModificationHelperModal/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/ModificationHelperModal/index.tsx
@@ -46,7 +46,7 @@ const ModificationHelperModal: React.FC<Props> = observer(
             modifications on a process instance.
           </p>
           <p>
-            By clicking on a flow node, you can select one of following
+            By clicking on an element, you can select one of following
             modifications if applicable:
           </p>
           <Modifications>
@@ -54,25 +54,25 @@ const ModificationHelperModal: React.FC<Props> = observer(
               <ModificationType>
                 Add <AddIcon />
               </ModificationType>
-              a single flow node instance
+              a single element instance
             </Modification>
             <Modification>
               <ModificationType>
                 Cancel <CancelIcon />
               </ModificationType>
-              all running flow node instances
+              all running element instances
             </Modification>
             <Modification>
               <ModificationType>
                 Move <MoveIcon />
               </ModificationType>
-              all the running instances to a different target flow node in the
+              all the running instances to a different target element in the
               diagram
             </Modification>
           </Modifications>
           <p>
-            Additionally, you add/edit variables by selecting the flow node
-            scope in the Instance History panel.
+            Additionally, you add/edit variables by selecting the element scope
+            in the Instance History panel.
           </p>
           <p>
             A summary of all planned modifications will be shown after clicking

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
@@ -149,7 +149,7 @@ describe('MetadataPopover', () => {
     vi.useRealTimers();
   });
 
-  it('should render meta data for completed flow node', async () => {
+  it('should render meta data for completed element', async () => {
     mockFetchProcessDefinitionXml().withSuccess(mockCallActivityProcessXML);
     mockFetchProcessInstanceV2().withSuccess(
       createProcessInstance({

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
@@ -10,11 +10,11 @@ import {screen, waitFor} from 'modules/testing-library';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {labels, renderPopover} from './mocks';
 import {
-  CALL_ACTIVITY_FLOW_NODE_ID,
+  CALL_ACTIVITY_ELEMENT_ID,
   PROCESS_INSTANCE_ID,
-  FLOW_NODE_ID,
-  USER_TASK_FLOW_NODE_ID,
-  BUSINESS_RULE_FLOW_NODE_ID,
+  ELEMENT_ID,
+  USER_TASK_ELEMENT_ID,
+  BUSINESS_RULE_ELEMENT_ID,
   calledDecisionInstanceMetadata,
 } from 'modules/mocks/metadata';
 import {metadataDemoProcess} from 'modules/mocks/metadataDemoProcess';
@@ -41,7 +41,7 @@ import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscr
 
 const mockElementInstance = {
   elementInstanceKey: '2251799813699889',
-  elementId: BUSINESS_RULE_FLOW_NODE_ID,
+  elementId: BUSINESS_RULE_ELEMENT_ID,
   elementName: 'Business Rule Task',
   type: 'BUSINESS_RULE_TASK',
   state: 'COMPLETED',
@@ -84,7 +84,7 @@ const mockIncident = {
   processDefinitionId: 'someKey',
   processDefinitionKey: '2',
   processInstanceKey: PROCESS_INSTANCE_ID,
-  elementId: BUSINESS_RULE_FLOW_NODE_ID,
+  elementId: BUSINESS_RULE_ELEMENT_ID,
   elementInstanceKey: '2251799813699889',
   jobKey: '',
   tenantId: '<default>',
@@ -106,21 +106,21 @@ describe('MetadataPopover', () => {
     mockFetchElementInstancesStatistics().withSuccess({
       items: [
         {
-          elementId: FLOW_NODE_ID,
+          elementId: ELEMENT_ID,
           active: 1,
           completed: 0,
           canceled: 0,
           incidents: 0,
         },
         {
-          elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+          elementId: CALL_ACTIVITY_ELEMENT_ID,
           active: 1,
           completed: 0,
           canceled: 0,
           incidents: 0,
         },
         {
-          elementId: USER_TASK_FLOW_NODE_ID,
+          elementId: USER_TASK_ELEMENT_ID,
           active: 1,
           completed: 0,
           canceled: 0,
@@ -159,7 +159,7 @@ describe('MetadataPopover', () => {
 
     const mockCallActivityElementInstance: ElementInstance = {
       ...mockElementInstance,
-      elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+      elementId: CALL_ACTIVITY_ELEMENT_ID,
       elementName: 'Call Activity',
       type: 'CALL_ACTIVITY',
     };
@@ -181,7 +181,7 @@ describe('MetadataPopover', () => {
     );
 
     renderPopover({
-      elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+      elementId: CALL_ACTIVITY_ELEMENT_ID,
     });
 
     expect(
@@ -207,7 +207,7 @@ describe('MetadataPopover', () => {
   it('should render completed decision', async () => {
     const mockBusinessRuleElementInstance: ElementInstance = {
       ...mockElementInstance,
-      elementId: BUSINESS_RULE_FLOW_NODE_ID,
+      elementId: BUSINESS_RULE_ELEMENT_ID,
       type: 'BUSINESS_RULE_TASK',
     };
 
@@ -230,7 +230,7 @@ describe('MetadataPopover', () => {
     );
 
     const {user} = renderPopover({
-      elementId: BUSINESS_RULE_FLOW_NODE_ID,
+      elementId: BUSINESS_RULE_ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
     expect(
@@ -261,7 +261,7 @@ describe('MetadataPopover', () => {
   it('should render failed decision', async () => {
     const mockBusinessRuleElementInstance: ElementInstance = {
       ...mockElementInstance,
-      elementId: BUSINESS_RULE_FLOW_NODE_ID,
+      elementId: BUSINESS_RULE_ELEMENT_ID,
       type: 'BUSINESS_RULE_TASK',
       hasIncident: true,
     };
@@ -296,7 +296,7 @@ describe('MetadataPopover', () => {
     );
 
     const {user} = renderPopover({
-      elementId: BUSINESS_RULE_FLOW_NODE_ID,
+      elementId: BUSINESS_RULE_ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
@@ -8,10 +8,10 @@
 
 import {screen} from 'modules/testing-library';
 import {
-  CALL_ACTIVITY_FLOW_NODE_ID,
+  CALL_ACTIVITY_ELEMENT_ID,
   PROCESS_INSTANCE_ID,
-  FLOW_NODE_ID,
-  USER_TASK_FLOW_NODE_ID,
+  ELEMENT_ID,
+  USER_TASK_ELEMENT_ID,
   jobMetadata,
   calledDecisionInstanceMetadata,
 } from 'modules/mocks/metadata';
@@ -120,21 +120,21 @@ describe('MetadataPopover', () => {
     mockFetchElementInstancesStatistics().withSuccess({
       items: [
         {
-          elementId: FLOW_NODE_ID,
+          elementId: ELEMENT_ID,
           active: 1,
           completed: 0,
           canceled: 0,
           incidents: 0,
         },
         {
-          elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+          elementId: CALL_ACTIVITY_ELEMENT_ID,
           active: 1,
           completed: 0,
           canceled: 0,
           incidents: 0,
         },
         {
-          elementId: USER_TASK_FLOW_NODE_ID,
+          elementId: USER_TASK_ELEMENT_ID,
           active: 1,
           completed: 0,
           canceled: 0,
@@ -164,7 +164,7 @@ describe('MetadataPopover', () => {
 
   it('should not show unrelated data', async () => {
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -205,7 +205,7 @@ describe('MetadataPopover', () => {
     );
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -242,7 +242,7 @@ describe('MetadataPopover', () => {
     mockSearchJobs().withSuccess(searchResult([jobMetadata]));
 
     const {user} = renderPopover({
-      elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+      elementId: CALL_ACTIVITY_ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -310,7 +310,7 @@ describe('MetadataPopover', () => {
     mockFetchElementInstancesStatistics().withSuccess({
       items: [
         {
-          elementId: FLOW_NODE_ID,
+          elementId: ELEMENT_ID,
           active: 7,
           completed: 0,
           canceled: 0,
@@ -325,7 +325,7 @@ describe('MetadataPopover', () => {
           processDefinitionId: 'invoice',
           errorType: 'CALLED_ELEMENT_ERROR',
           errorMessage: 'Multi-instance incident 1',
-          elementId: FLOW_NODE_ID,
+          elementId: ELEMENT_ID,
           creationTime: '2022-02-03T16:44:06.981+0000',
           state: 'PENDING',
           tenantId: '<default>',
@@ -340,7 +340,7 @@ describe('MetadataPopover', () => {
           processDefinitionId: 'invoice',
           errorType: 'JOB_NO_RETRIES',
           errorMessage: 'Multi-instance incident 2',
-          elementId: FLOW_NODE_ID,
+          elementId: ELEMENT_ID,
           creationTime: '2022-02-03T16:45:06.981+0000',
           state: 'PENDING',
           tenantId: '<default>',
@@ -355,7 +355,7 @@ describe('MetadataPopover', () => {
           processDefinitionId: 'invoice',
           errorType: 'IO_MAPPING_ERROR',
           errorMessage: 'Multi-instance incident 3',
-          elementId: FLOW_NODE_ID,
+          elementId: ELEMENT_ID,
           creationTime: '2022-02-03T16:46:06.981+0000',
           state: 'PENDING',
           tenantId: '<default>',
@@ -370,7 +370,7 @@ describe('MetadataPopover', () => {
     );
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
     });
 
     await waitFor(() => {
@@ -395,7 +395,7 @@ describe('MetadataPopover', () => {
 
   it('should not render called instances for multi instance call activities', async () => {
     renderPopover({
-      elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+      elementId: CALL_ACTIVITY_ELEMENT_ID,
     });
 
     expect(
@@ -419,7 +419,7 @@ describe('MetadataPopover', () => {
       type: 'USER_TASK',
     });
     renderPopover({
-      elementId: USER_TASK_FLOW_NODE_ID,
+      elementId: USER_TASK_ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -432,7 +432,7 @@ describe('MetadataPopover', () => {
     mockSearchJobs().withSuccess(searchResult([jobMetadata]));
 
     renderPopover({
-      elementId: USER_TASK_FLOW_NODE_ID,
+      elementId: USER_TASK_ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -446,7 +446,7 @@ describe('MetadataPopover', () => {
     );
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -460,7 +460,7 @@ describe('MetadataPopover', () => {
     mockFetchElementInstancesStatistics().withSuccess({
       items: [
         {
-          elementId: FLOW_NODE_ID,
+          elementId: ELEMENT_ID,
           active: 1,
           completed: 0,
           canceled: 0,
@@ -473,7 +473,7 @@ describe('MetadataPopover', () => {
     );
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
     });
 
     expect(
@@ -486,7 +486,7 @@ describe('MetadataPopover', () => {
     mockSearchElementInstances().withNetworkError();
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
     });
 
     expect(
@@ -498,7 +498,7 @@ describe('MetadataPopover', () => {
     mockFetchElementInstance('invalid-key').withNetworkError();
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
       elementInstanceKey: 'invalid-key',
     });
 
@@ -546,7 +546,7 @@ describe('MetadataPopover', () => {
     });
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -570,7 +570,7 @@ describe('MetadataPopover', () => {
     mockSearchDecisionInstances().withSuccess(searchResult([]));
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -594,7 +594,7 @@ describe('MetadataPopover', () => {
     mockSearchDecisionInstances().withNetworkError();
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
       elementInstanceKey: '2251799813699889',
     });
 
@@ -614,7 +614,7 @@ describe('MetadataPopover', () => {
     mockFetchElementInstancesStatistics().withSuccess({
       items: [
         {
-          elementId: FLOW_NODE_ID,
+          elementId: ELEMENT_ID,
           active: 3,
           completed: 0,
           canceled: 0,
@@ -624,7 +624,7 @@ describe('MetadataPopover', () => {
     });
 
     renderPopover({
-      elementId: FLOW_NODE_ID,
+      elementId: ELEMENT_ID,
       isMultiInstanceBody: 'true',
     });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -65,7 +65,7 @@ const ModificationDropdown: React.FC<Props> = observer(
       useTotalRunningInstancesForElement(selectedElementId ?? undefined);
     const {data: totalRunningInstancesVisible} =
       useTotalRunningInstancesVisibleForElement(selectedElementId ?? undefined);
-    const {data: totalRunningInstancesByFlowNode} =
+    const {data: totalRunningInstancesByElement} =
       useTotalRunningInstancesByElement();
 
     // true if an element instance is selected from the element history tree
@@ -177,7 +177,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                             if (
                               hasMultipleScopes(
                                 parentElement,
-                                totalRunningInstancesByFlowNode,
+                                totalRunningInstancesByElement,
                               )
                             ) {
                               modificationsStore.startAddingToken(

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -98,8 +98,8 @@ const TopPanel: React.FC = observer(() => {
   const [isInTransition, setIsInTransition] = useState(false);
   const {data: statistics} = useElementStatistics();
   const {data: selectableElements} = useSelectableElements();
-  const {data: executedFlowNodes} = useExecutedElements();
-  const {data: totalRunningInstancesByFlowNode} =
+  const {data: executedElements} = useExecutedElements();
+  const {data: totalRunningInstancesByElement} =
     useTotalRunningInstancesByElement();
   const {data: businessObjects} = useBusinessObjects();
   const {data: totalMoveOperationRunningInstances} =
@@ -190,7 +190,7 @@ const TopPanel: React.FC = observer(() => {
       .filter(isCompensationAssociation)
       .filter(({targetRef}) => {
         // check if the target element for the association was executed
-        return executedFlowNodes?.find(({elementId, completed}) => {
+        return executedElements?.find(({elementId, completed}) => {
           return targetRef?.id === elementId && completed > 0;
         });
       })
@@ -200,17 +200,13 @@ const TopPanel: React.FC = observer(() => {
       ...(processedSequenceFlowsFromHook || []),
       ...compensationAssociationIds,
     ];
-  }, [
-    processedSequenceFlowsFromHook,
-    processDefinitionData,
-    executedFlowNodes,
-  ]);
+  }, [processedSequenceFlowsFromHook, processDefinitionData, executedElements]);
 
   const highlightedSequenceFlowIds = useMemo(() => {
-    return executedFlowNodes?.map(({elementId}) => elementId);
-  }, [executedFlowNodes]);
+    return executedElements?.map(({elementId}) => elementId);
+  }, [executedElements]);
 
-  const modificationBadgesPerFlowNode = computed(() =>
+  const modificationBadgesPerElement = computed(() =>
     Object.entries(modificationsByElement).reduce<
       {
         elementId: string;
@@ -345,7 +341,7 @@ const TopPanel: React.FC = observer(() => {
                       businessObjects,
                       sourceElementIdForMoveOperation ?? '',
                       elementId ?? '',
-                      totalRunningInstancesByFlowNode,
+                      totalRunningInstancesByElement,
                     );
 
                     clearSelection();
@@ -374,7 +370,7 @@ const TopPanel: React.FC = observer(() => {
                   isModificationModeEnabled
                     ? [
                         ...(elementStateOverlays ?? []),
-                        ...modificationBadgesPerFlowNode.get(),
+                        ...modificationBadgesPerElement.get(),
                       ]
                     : elementStateOverlays
                 }

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
@@ -40,12 +40,12 @@ const BatchModificationNotification: React.FC<Props> = observer(
       sourceElementId,
     );
 
-    const sourceFlowNodeName = getElementName({
+    const sourceElementName = getElementName({
       businessObjects: processDefinitionData?.diagramModel.elementsById,
       elementId: sourceElementId,
     });
 
-    const targetFlowNodeName = getElementName({
+    const targetElementName = getElementName({
       businessObjects: processDefinitionData?.diagramModel.elementsById,
       elementId: targetElementId,
     });
@@ -58,12 +58,12 @@ const BatchModificationNotification: React.FC<Props> = observer(
           kind="info"
           title=""
           subtitle={
-            sourceFlowNodeName === '' || targetFlowNodeName === ''
+            sourceElementName === '' || targetElementName === ''
               ? 'Please select where you want to move the selected instances on the diagram.'
               : `Modification scheduled: Move ${pluralSuffix(
                   instancesCount,
                   'instance',
-                )} from “${sourceFlowNodeName}” to “${targetFlowNodeName}”. Press “Review Modification” button to confirm.`
+                )} from “${sourceElementName}” to “${targetElementName}”. Press “Review Modification” button to confirm.`
           }
         />
         {targetElementId && onUndoClick && (

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -95,7 +95,7 @@ const DiagramPanel: React.FC = observer(() => {
     processDefinitionKey: selectedDefinitionKey,
   });
   const selectableIds = processDefinitionXML?.selectableFlowNodes.map(
-    (flowNode) => flowNode.id,
+    (element) => element.id,
   );
 
   const {data: businessObjects} = useBusinessObjects();
@@ -125,16 +125,16 @@ const DiagramPanel: React.FC = observer(() => {
     batchModificationStore.state.isEnabled,
   );
 
-  const flowNodeIdsWithIncidents = processInstanceOverlayData
+  const elementIdsWithIncidents = processInstanceOverlayData
     ?.filter(({type}) => type === 'statistics-incidents')
     ?.map((overlay) => overlay.elementId);
 
-  const selectableFlowNodesWithIncidents = flowNodeIdsWithIncidents?.map(
-    (flowNodeId) => businessObjects?.[flowNodeId],
+  const selectableElementsWithIncidents = elementIdsWithIncidents?.map(
+    (elementId) => businessObjects?.[elementId],
   );
 
   const subprocessOverlays = getSubprocessOverlayFromIncidentElements(
-    selectableFlowNodesWithIncidents,
+    selectableElementsWithIncidents,
     'statistics-incidents',
   );
 
@@ -172,20 +172,20 @@ const DiagramPanel: React.FC = observer(() => {
       return selectableIds;
     }
 
-    return selectableIds?.filter((selectedFlowNodeId) => {
-      if (selectedFlowNodeId === flowNodeId) {
+    return selectableIds?.filter((selectedElementId) => {
+      if (selectedElementId === flowNodeId) {
         return false;
       }
-      if (selectedFlowNodeId === undefined) {
+      if (selectedElementId === undefined) {
         return false;
       }
 
-      const flowNode = getElement({
+      const element = getElement({
         businessObjects: processDefinitionXML?.diagramModel.elementsById,
-        elementId: selectedFlowNodeId,
+        elementId: selectedElementId,
       });
 
-      return isMoveModificationTarget(flowNode);
+      return isMoveModificationTarget(element);
     });
   };
 
@@ -200,15 +200,15 @@ const DiagramPanel: React.FC = observer(() => {
   };
 
   const handleElementSelection = (
-    selectedFlowNodeId: string | null | undefined,
+    selectedElementId: string | null | undefined,
   ) => {
     if (batchModificationStore.state.isEnabled) {
       return batchModificationStore.selectTargetElement(
-        selectedFlowNodeId ?? null,
+        selectedElementId ?? null,
       );
     }
 
-    if (selectedFlowNodeId === null || selectedFlowNodeId === undefined) {
+    if (selectedElementId === null || selectedElementId === undefined) {
       setSearchParams((p) => {
         p.delete('flowNodeId');
         return p;
@@ -217,7 +217,7 @@ const DiagramPanel: React.FC = observer(() => {
     }
 
     setSearchParams((p) => {
-      p.set('flowNodeId', selectedFlowNodeId);
+      p.set('flowNodeId', selectedElementId);
       return p;
     });
   };

--- a/operate/client/src/App/Processes/ListView/Filters/tests/batchModificationMode.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/batchModificationMode.test.tsx
@@ -15,7 +15,7 @@ import {
 } from 'modules/testUtils';
 import {Filters} from '../index';
 import {
-  selectFlowNode,
+  selectElement,
   selectProcess,
 } from 'modules/testUtils/selectComboBoxOption';
 import {Paths} from 'modules/Routes';
@@ -80,7 +80,7 @@ describe('Filters', () => {
     );
 
     await selectProcess({user, option: 'Big variable process'});
-    await selectFlowNode({user, option: 'Start Event 1'});
+    await selectElement({user, option: 'Start Event 1'});
 
     expect(screen.getByRole('combobox', {name: /version/i})).toBeEnabled();
     expect(screen.getByRole('combobox', {name: /element/i})).toBeEnabled();

--- a/operate/client/src/App/Processes/ListView/Filters/tests/fieldinteractions.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/fieldinteractions.test.tsx
@@ -16,7 +16,7 @@ import {
   searchResult,
 } from 'modules/testUtils';
 import {
-  selectFlowNode,
+  selectElement,
   selectProcess,
   selectProcessVersion,
 } from 'modules/testUtils/selectComboBoxOption';
@@ -181,7 +181,7 @@ describe('Interaction with other fields during validation', () => {
 
     expect(screen.getByText(ERRORS.ids)).toBeInTheDocument();
 
-    await selectFlowNode({user, option: 'Service Task 1'});
+    await selectElement({user, option: 'Service Task 1'});
 
     expect(screen.getByText(ERRORS.ids)).toBeInTheDocument();
   });

--- a/operate/client/src/App/Processes/ListView/Filters/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/index.test.tsx
@@ -17,7 +17,7 @@ import {
 import {Filters} from '../index';
 import {pickDateTimeRange} from 'modules/testUtils/dateTimeRange';
 import {
-  selectFlowNode,
+  selectElement,
   selectProcess,
   selectProcessVersion,
 } from 'modules/testUtils/selectComboBoxOption';
@@ -265,7 +265,7 @@ describe('Filters', () => {
       MOCK_VALUES.errorMessage,
     );
 
-    await selectFlowNode({user, option: 'Service Task 1'});
+    await selectElement({user, option: 'Service Task 1'});
 
     await user.click(screen.getByRole('button', {name: 'More Filters'}));
     await user.click(screen.getByText('Variable'));

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
@@ -42,12 +42,12 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
       processDefinitionKey: process?.processDefinitionKey,
     });
 
-    const sourceFlowNodeName = getElementName({
+    const sourceElementName = getElementName({
       businessObjects: processDefinitionData?.diagramModel.elementsById,
       elementId: sourceElementId,
     });
 
-    const targetFlowNodeName = getElementName({
+    const targetElementName = getElementName({
       businessObjects: processDefinitionData?.diagramModel.elementsById,
       elementId: selectedTargetElementId ?? undefined,
     });
@@ -86,7 +86,7 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
       {
         id: 'batchMove',
         operation: 'Batch move',
-        element: `${sourceFlowNodeName} --> ${targetFlowNodeName}`,
+        element: `${sourceElementName} --> ${targetElementName}`,
         affectedInstances: instancesCount,
       },
     ];

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/index.tsx
@@ -43,12 +43,12 @@ const onTransition = ({
 };
 
 const BatchModificationFooter: React.FC = observer(() => {
-  const isTargetFlowNodeSelected =
+  const isTargetElementSelected =
     batchModificationStore.state.selectedTargetElementId !== null;
 
   const isButtonDisabled =
     processInstancesSelectionStore.selectedProcessInstanceCount < 1 ||
-    !isTargetFlowNodeSelected;
+    !isTargetElementSelected;
 
   const {isNavigationInterrupted, confirmNavigation, cancelNavigation} =
     useCallbackPrompt({
@@ -108,9 +108,9 @@ const BatchModificationFooter: React.FC = observer(() => {
             // store in the next tick, which is fine.
             setTimeout(batchModificationStore.reset, 0);
           }}
-          danger={isTargetFlowNodeSelected}
+          danger={isTargetElementSelected}
         >
-          {isTargetFlowNodeSelected ? (
+          {isTargetElementSelected ? (
             <>
               <p>About to discard all added modifications</p>
               <p>Click “Exit” to proceed.</p>

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/index.tsx
@@ -33,7 +33,7 @@ const localStorageKey = 'hideMoveModificationHelperModal';
 
 const MoveAction: React.FC = observer(() => {
   const location = useLocation();
-  const {flowNodeId} = getProcessInstanceFilters(location.search);
+  const {flowNodeId: elementId} = getProcessInstanceFilters(location.search);
 
   const {hasSelectedRunningInstances} = processInstancesSelectionStore;
 
@@ -42,10 +42,10 @@ const MoveAction: React.FC = observer(() => {
     processDefinitionKey,
   });
 
-  const businessObject: BusinessObject | null = flowNodeId
+  const businessObject: BusinessObject | null = elementId
     ? (getElement({
         businessObjects: processDefinitionData?.diagramModel.elementsById,
-        elementId: flowNodeId,
+        elementId,
       }) ?? null)
     : null;
 
@@ -60,7 +60,7 @@ const MoveAction: React.FC = observer(() => {
   const isDisabled =
     batchModificationStore.state.isEnabled ||
     isNil(businessObject) ||
-    flowNodeId === undefined ||
+    elementId === undefined ||
     !isTypeSupported(businessObject) ||
     !hasSelectedRunningInstances ||
     isWithinMultiInstance(businessObject) ||
@@ -71,7 +71,7 @@ const MoveAction: React.FC = observer(() => {
       return undefined;
     }
 
-    if (flowNodeId === undefined || isNil(businessObject)) {
+    if (elementId === undefined || isNil(businessObject)) {
       return 'Please select an element from the diagram first.';
     }
     if (!isTypeSupported(businessObject)) {

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
@@ -87,9 +87,9 @@ const targetDefinition = createProcessDefinition({
 /**
  * Returns a custom matcher function which ignores all option elements from comboboxes.
  */
-const getMatcherFunction = (flowNodeName: string): MatcherFunction => {
+const getMatcherFunction = (elementName: string): MatcherFunction => {
   return (content, element) => {
-    return content === flowNodeName && element?.tagName !== 'OPTION';
+    return content === elementName && element?.tagName !== 'OPTION';
   };
 };
 

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
@@ -104,7 +104,7 @@ describe('MigrationView/BottomPanel', () => {
     processInstanceMigrationStore.setSourceProcessDefinition(sourceDefinition);
     processInstanceMigrationStore.setTargetProcessDefinition(targetDefinition);
   });
-  it('should render source flow nodes', async () => {
+  it('should render source elements', async () => {
     mockFetchProcessDefinitionXml().withSuccess(open('instanceMigration.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(open('instanceMigration.bpmn'));
 
@@ -328,7 +328,7 @@ describe('MigrationView/BottomPanel', () => {
     },
   );
 
-  it('should auto-map flow nodes', async () => {
+  it('should auto-map elements', async () => {
     // source process definition
     mockFetchProcessDefinitionXml({
       processDefinitionKey: SOURCE_PROCESS_DEFINITION_KEY,
@@ -487,7 +487,7 @@ describe('MigrationView/BottomPanel', () => {
       MultiInstanceSubProcess.id,
     );
 
-    // Expect no auto-mapping (flow node does not exist in target)
+    // Expect no auto-mapping (element does not exist in target)
     expect(comboboxShippingSubProcess).toHaveValue('');
 
     expect(comboboxMessageNonInterrupting).toHaveValue('');
@@ -506,7 +506,7 @@ describe('MigrationView/BottomPanel', () => {
     expect(comboboxTaskY).toBeEnabled();
   });
 
-  it('should add tags for unmapped flow nodes', async () => {
+  it('should add tags for unmapped elements', async () => {
     // source process definition
     mockFetchProcessDefinitionXml({
       processDefinitionKey: SOURCE_PROCESS_DEFINITION_KEY,
@@ -680,7 +680,7 @@ describe('MigrationView/BottomPanel', () => {
     ).toBeInTheDocument();
   }, 10000);
 
-  it('should hide mapped flow nodes', async () => {
+  it('should hide mapped elements', async () => {
     mockFetchProcessDefinitionXml({
       processDefinitionKey: SOURCE_PROCESS_DEFINITION_KEY,
     }).withSuccess(open('instanceMigration.bpmn'));
@@ -702,7 +702,7 @@ describe('MigrationView/BottomPanel', () => {
       HEADER_ROW_COUNT + CONTENT_ROW_COUNT,
     );
 
-    // Toggle on unmapped flow nodes
+    // Toggle on unmapped elements
     await user.click(screen.getByLabelText(/show only not mapped/i));
 
     // Expect the following rows to be hidden (because they're mapped)
@@ -811,7 +811,7 @@ describe('MigrationView/BottomPanel', () => {
     expect(screen.getByLabelText(/show only not mapped/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/show only not mapped/i)).toBeVisible();
 
-    // Toggle off unmapped flow nodes
+    // Toggle off unmapped elements
     await user.click(screen.getByLabelText(/show only not mapped/i));
 
     // Expect all rows to be visible again

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
@@ -37,8 +37,8 @@ const TOGGLE_LABEL = 'Show only not mapped';
 const BottomPanel: React.FC = observer(() => {
   const {selectedSourceElementIds} = processInstanceMigrationStore;
 
-  const handleCheckIsRowSelected = (selectedSourceFlowNodes?: string[]) => {
-    return (rowId: string) => selectedSourceFlowNodes?.includes(rowId) ?? false;
+  const handleCheckIsRowSelected = (selectedSourceElements?: string[]) => {
+    return (rowId: string) => selectedSourceElements?.includes(rowId) ?? false;
   };
 
   const {
@@ -76,7 +76,7 @@ const BottomPanel: React.FC = observer(() => {
       targetData?.selectableSequenceFlows,
     ) ?? [];
 
-  const filteredSourceFlowNodes = [
+  const filteredSourceElements = [
     ...mappableElements,
     ...mappableSequenceFlows,
   ].filter(({sourceElement}) => {
@@ -118,17 +118,17 @@ const BottomPanel: React.FC = observer(() => {
   }, [sourceData, targetData]);
 
   /**
-   * Returns true if an element with flowNodeId is auto-mappable
+   * Returns true if an element with elementId is auto-mappable
    */
-  const isAutoMappable = (flowNodeId: string) => {
+  const isAutoMappable = (elementId: string) => {
     return (
       autoMappableElements.find(({id}) => {
-        return flowNodeId === id;
+        return elementId === id;
       }) !== undefined
     );
   };
 
-  const hasSelectableSourceFlowNodes =
+  const hasSelectableSourceElements =
     sourceData?.selectableFlowNodes &&
     sourceData.selectableFlowNodes.length > 0;
 
@@ -182,7 +182,7 @@ const BottomPanel: React.FC = observer(() => {
 
   return (
     <BottomSection>
-      {!hasSelectableSourceFlowNodes && !hasSelectableSourceSequenceFlows ? (
+      {!hasSelectableSourceElements && !hasSelectableSourceSequenceFlows ? (
         <ErrorMessageContainer>
           <ErrorMessage
             message="There are no mappable flow nodes or sequence flows."
@@ -224,7 +224,7 @@ const BottomPanel: React.FC = observer(() => {
             checkIsRowSelected={handleCheckIsRowSelected(
               selectedSourceElementIds,
             )}
-            rows={filteredSourceFlowNodes.map(
+            rows={filteredSourceElements.map(
               ({sourceElement, selectableTargetElement}) => {
                 const isMapped = elementMapping[sourceElement.id] !== undefined;
 

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
@@ -86,7 +86,7 @@ const BottomPanel: React.FC = observer(() => {
   });
 
   /**
-   * Elements (flow nodes and sequence flows) which are contained in both source diagram and target diagram.
+   * Elements (elements and sequence flows) which are contained in both source diagram and target diagram.
    *
    * An element is auto-mappable when
    * - the element id is contained in source and target diagram
@@ -185,7 +185,7 @@ const BottomPanel: React.FC = observer(() => {
       {!hasSelectableSourceElements && !hasSelectableSourceSequenceFlows ? (
         <ErrorMessageContainer>
           <ErrorMessage
-            message="There are no mappable flow nodes or sequence flows."
+            message="There are no mappable elements or sequence flows."
             additionalInfo="Exit migration to select a different process"
           />
         </ErrorMessageContainer>

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/tests/sequenceFlows.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/tests/sequenceFlows.test.tsx
@@ -175,7 +175,7 @@ describe('BottomPanel - sequence flow mappings', () => {
       }),
     ).toBeVisible();
 
-    // Toggle on unmapped flow nodes
+    // Toggle on unmapped elements
     await user.click(screen.getByText(/show only not mapped/i));
 
     // Expect not mapped items to be visible

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.tsx
@@ -82,7 +82,7 @@ const SourceDiagram: React.FC = observer(() => {
             selectableElements={[
               ...migrationSourceData.selectableFlowNodes,
               ...migrationSourceData.selectableSequenceFlows,
-            ].map((flowNode) => flowNode.id)}
+            ].map((element) => element.id)}
             selectedElementIds={selectedSourceElementIds}
             onElementSelection={(elementId) => {
               processInstanceMigrationStore.selectSourceElement(elementId);

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.test.tsx
@@ -243,7 +243,7 @@ describe('Target Diagram', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render flow node overlays', async () => {
+  it('should render element overlays', async () => {
     mockSearchProcessDefinitions().withSuccess(searchResult([]));
     mockSearchProcessDefinitions().withSuccess(searchResult([]));
     mockSearchProcessDefinitions().withSuccess(searchResult([]));

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.tsx
@@ -40,7 +40,7 @@ const TargetDiagram: React.FC = observer(() => {
     processDefinitionId: targetProcessDefinition?.processDefinitionId,
   });
 
-  const {data: flowNodeData} = useProcessInstancesElementStates(
+  const {data: elementData} = useProcessInstancesElementStates(
     {
       filter: {
         processInstanceKey: getMigrationProcessInstancesFilter(),
@@ -63,15 +63,15 @@ const TargetDiagram: React.FC = observer(() => {
     return 'content';
   };
 
-  const getFlowNodeCountByTargetId = () => {
+  const getElementCountByTargetId = () => {
     return Object.entries(
       processInstanceMigrationStore.state.elementMapping,
     ).reduce<{
       [targetElementId: string]: number;
     }>((mappingByTarget, [sourceElementId, targetElementId]) => {
       const previousCount = mappingByTarget[targetElementId];
-      const newCount = flowNodeData
-        ? flowNodeData
+      const newCount = elementData
+        ? elementData
             .filter((state) => {
               return (
                 state.elementId === sourceElementId &&
@@ -113,7 +113,7 @@ const TargetDiagram: React.FC = observer(() => {
             selectableElements={[
               ...data.selectableFlowNodes,
               ...data.selectableSequenceFlows,
-            ].map((flowNode) => flowNode.id)}
+            ].map((element) => element.id)}
             selectedElementIds={
               processInstanceMigrationStore.selectedTargetElementId
                 ? [processInstanceMigrationStore.selectedTargetElementId]
@@ -124,7 +124,7 @@ const TargetDiagram: React.FC = observer(() => {
             }
             overlaysData={
               isSummaryStep
-                ? Object.entries(getFlowNodeCountByTargetId()).map(
+                ? Object.entries(getElementCountByTargetId()).map(
                     ([targetId, count]) => ({
                       payload: {count},
                       type: OVERLAY_TYPE,

--- a/operate/client/src/modules/mocks/metadata.ts
+++ b/operate/client/src/modules/mocks/metadata.ts
@@ -8,17 +8,17 @@
 
 import type {Job} from '@camunda/camunda-api-zod-schemas/8.9';
 
-const FLOW_NODE_ID = 'StartEvent_1'; // this need to match the id from mockProcessXML
-const CALL_ACTIVITY_FLOW_NODE_ID = 'Activity_0zqism7'; // this need to match the id from mockCallActivityProcessXML
-const USER_TASK_FLOW_NODE_ID = 'UserTask';
-const FLOW_NODE_INSTANCE_ID = '2251799813699889';
+const ELEMENT_ID = 'StartEvent_1'; // this need to match the id from mockProcessXML
+const CALL_ACTIVITY_ELEMENT_ID = 'Activity_0zqism7'; // this need to match the id from mockCallActivityProcessXML
+const USER_TASK_ELEMENT_ID = 'UserTask';
+const ELEMENT_INSTANCE_ID = '2251799813699889';
 const PROCESS_INSTANCE_ID = '2251799813685591';
-const BUSINESS_RULE_FLOW_NODE_ID = 'BusinessRuleTask';
+const BUSINESS_RULE_ELEMENT_ID = 'BusinessRuleTask';
 
 const jobMetadata: Job = {
   customHeaders: {},
   elementId: 'Activity_0dex012',
-  elementInstanceKey: FLOW_NODE_INSTANCE_ID,
+  elementInstanceKey: ELEMENT_INSTANCE_ID,
   deadline: '2018-12-12 00:00:00',
   endTime: '2025-07-23T10:14:48.597Z',
   errorCode: '',
@@ -67,8 +67,8 @@ export {
   jobMetadata,
   calledDecisionInstanceMetadata,
   PROCESS_INSTANCE_ID,
-  CALL_ACTIVITY_FLOW_NODE_ID,
-  FLOW_NODE_ID,
-  USER_TASK_FLOW_NODE_ID,
-  BUSINESS_RULE_FLOW_NODE_ID,
+  CALL_ACTIVITY_ELEMENT_ID,
+  ELEMENT_ID,
+  USER_TASK_ELEMENT_ID,
+  BUSINESS_RULE_ELEMENT_ID,
 };

--- a/operate/client/src/modules/testUtils/selectComboBoxOption.ts
+++ b/operate/client/src/modules/testUtils/selectComboBoxOption.ts
@@ -44,7 +44,7 @@ const selectTenant = async ({user, option}: SelectProps) => {
   await user.click(screen.getByRole('option', {name: option}));
 };
 
-const selectFlowNode = ({user, option}: SelectProps) => {
+const selectElement = ({user, option}: SelectProps) => {
   return selectComboBoxOption({
     user,
     option,
@@ -91,7 +91,7 @@ export {
   selectProcess,
   selectProcessVersion,
   selectTenant,
-  selectFlowNode,
+  selectElement,
   selectDecision,
   selectDecisionVersion,
   clearComboBox,


### PR DESCRIPTION
## Description

Update `flowNode` with `element` in the App folder

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46865 
