### PR TITLE
test: 8.9 improvements for nightly

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "97eddb8e91fcb83317bcd56ba252156de08e641c",
-    "generatedAt": "2026-03-03T10:12:17.756Z",
+    "commit": "7c620d8fa0860ad4ede95f19c51422b29e37c1c0",
+    "generatedAt": "2026-03-04T12:09:32.437Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "bccc59e0433930d48553b50ee54a8f09a97df50b3f430549e4082b5cecebcd49"
+    "specSha256": "085990d845643bb2efa49c584764d02f1f015eeb4c1a5e230e2a377a659db082"
   },
   "responses": [
     {
@@ -26,6 +26,12 @@
                 {
                   "name": "actorType",
                   "type": "string",
+                  "enumValues": [
+                    "ANONYMOUS",
+                    "CLIENT",
+                    "UNKNOWN",
+                    "USER"
+                  ],
                   "nullable": true
                 },
                 {
@@ -262,6 +268,12 @@
           {
             "name": "actorType",
             "type": "string",
+            "enumValues": [
+              "ANONYMOUS",
+              "CLIENT",
+              "UNKNOWN",
+              "USER"
+            ],
             "nullable": true
           },
           {
@@ -835,45 +847,14 @@
             "children": {
               "required": [
                 {
-                  "name": "errors",
-                  "type": "array<object>",
-                  "children": {
-                    "required": [],
-                    "optional": [
-                      {
-                        "name": "message",
-                        "type": "string"
-                      },
-                      {
-                        "name": "partitionId",
-                        "type": "number"
-                      },
-                      {
-                        "name": "type",
-                        "type": "string",
-                        "enumValues": [
-                          "QUERY_FAILED",
-                          "RESULT_BUFFER_SIZE_EXCEEDED"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              ],
-              "optional": [
-                {
                   "name": "actorId",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "actorType",
                   "type": "string",
-                  "enumValues": [
-                    "ANONYMOUS",
-                    "CLIENT",
-                    "UNKNOWN",
-                    "USER"
-                  ]
+                  "nullable": true
                 },
                 {
                   "name": "batchOperationKey",
@@ -899,9 +880,29 @@
                   "wrapper": true
                 },
                 {
-                  "name": "endDate",
-                  "type": "string",
-                  "nullable": true
+                  "name": "errors",
+                  "type": "array<object>",
+                  "children": {
+                    "required": [],
+                    "optional": [
+                      {
+                        "name": "message",
+                        "type": "string"
+                      },
+                      {
+                        "name": "partitionId",
+                        "type": "number"
+                      },
+                      {
+                        "name": "type",
+                        "type": "string",
+                        "enumValues": [
+                          "QUERY_FAILED",
+                          "RESULT_BUFFER_SIZE_EXCEEDED"
+                        ]
+                      }
+                    ]
+                  }
                 },
                 {
                   "name": "operationsCompletedCount",
@@ -916,11 +917,6 @@
                   "type": "number"
                 },
                 {
-                  "name": "startDate",
-                  "type": "string",
-                  "nullable": true
-                },
-                {
                   "name": "state",
                   "type": "string",
                   "enumValues": [
@@ -932,6 +928,18 @@
                     "PARTIALLY_COMPLETED",
                     "SUSPENDED"
                   ]
+                }
+              ],
+              "optional": [
+                {
+                  "name": "endDate",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "startDate",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -974,45 +982,14 @@
       "schema": {
         "required": [
           {
-            "name": "errors",
-            "type": "array<object>",
-            "children": {
-              "required": [],
-              "optional": [
-                {
-                  "name": "message",
-                  "type": "string"
-                },
-                {
-                  "name": "partitionId",
-                  "type": "number"
-                },
-                {
-                  "name": "type",
-                  "type": "string",
-                  "enumValues": [
-                    "QUERY_FAILED",
-                    "RESULT_BUFFER_SIZE_EXCEEDED"
-                  ]
-                }
-              ]
-            }
-          }
-        ],
-        "optional": [
-          {
             "name": "actorId",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "actorType",
             "type": "string",
-            "enumValues": [
-              "ANONYMOUS",
-              "CLIENT",
-              "UNKNOWN",
-              "USER"
-            ]
+            "nullable": true
           },
           {
             "name": "batchOperationKey",
@@ -1038,9 +1015,29 @@
             "wrapper": true
           },
           {
-            "name": "endDate",
-            "type": "string",
-            "nullable": true
+            "name": "errors",
+            "type": "array<object>",
+            "children": {
+              "required": [],
+              "optional": [
+                {
+                  "name": "message",
+                  "type": "string"
+                },
+                {
+                  "name": "partitionId",
+                  "type": "number"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "enumValues": [
+                    "QUERY_FAILED",
+                    "RESULT_BUFFER_SIZE_EXCEEDED"
+                  ]
+                }
+              ]
+            }
           },
           {
             "name": "operationsCompletedCount",
@@ -1055,11 +1052,6 @@
             "type": "number"
           },
           {
-            "name": "startDate",
-            "type": "string",
-            "nullable": true
-          },
-          {
             "name": "state",
             "type": "string",
             "enumValues": [
@@ -1071,6 +1063,18 @@
               "PARTIALLY_COMPLETED",
               "SUSPENDED"
             ]
+          }
+        ],
+        "optional": [
+          {
+            "name": "endDate",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "startDate",
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -2073,8 +2077,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "batchOperationKey",
             "type": "string"
@@ -2095,7 +2098,8 @@
               "UPDATE_VARIABLE"
             ]
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -2402,8 +2406,7 @@
       "method": "POST",
       "status": "201",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "camunda.document.type",
             "type": "string",
@@ -2413,7 +2416,8 @@
           },
           {
             "name": "contentHash",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "documentId",
@@ -2421,23 +2425,21 @@
           },
           {
             "name": "metadata",
-            "type": "metadata",
-            "rawRefName": "metadata",
+            "type": "object",
             "children": {
               "required": [
-                {
-                  "name": "customProperties",
-                  "type": "object"
-                }
-              ],
-              "optional": [
                 {
                   "name": "contentType",
                   "type": "string"
                 },
                 {
+                  "name": "customProperties",
+                  "type": "object"
+                },
+                {
                   "name": "expiresAt",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "fileName",
@@ -2445,24 +2447,28 @@
                 },
                 {
                   "name": "processDefinitionId",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "size",
                   "type": "number"
                 }
-              ]
+              ],
+              "optional": []
             }
           },
           {
             "name": "storeId",
             "type": "string"
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -2475,8 +2481,7 @@
             "name": "createdDocuments",
             "type": "array<schema>",
             "children": {
-              "required": [],
-              "optional": [
+              "required": [
                 {
                   "name": "camunda.document.type",
                   "type": "string",
@@ -2486,7 +2491,8 @@
                 },
                 {
                   "name": "contentHash",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "documentId",
@@ -2494,23 +2500,21 @@
                 },
                 {
                   "name": "metadata",
-                  "type": "metadata",
-                  "rawRefName": "metadata",
+                  "type": "object",
                   "children": {
                     "required": [
-                      {
-                        "name": "customProperties",
-                        "type": "object"
-                      }
-                    ],
-                    "optional": [
                       {
                         "name": "contentType",
                         "type": "string"
                       },
                       {
+                        "name": "customProperties",
+                        "type": "object"
+                      },
+                      {
                         "name": "expiresAt",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "fileName",
@@ -2518,24 +2522,28 @@
                       },
                       {
                         "name": "processDefinitionId",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "processInstanceKey",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "size",
                         "type": "number"
                       }
-                    ]
+                    ],
+                    "optional": []
                   }
                 },
                 {
                   "name": "storeId",
                   "type": "string"
                 }
-              ]
+              ],
+              "optional": []
             }
           },
           {
@@ -2577,8 +2585,7 @@
             "name": "createdDocuments",
             "type": "array<schema>",
             "children": {
-              "required": [],
-              "optional": [
+              "required": [
                 {
                   "name": "camunda.document.type",
                   "type": "string",
@@ -2588,7 +2595,8 @@
                 },
                 {
                   "name": "contentHash",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "documentId",
@@ -2596,23 +2604,21 @@
                 },
                 {
                   "name": "metadata",
-                  "type": "metadata",
-                  "rawRefName": "metadata",
+                  "type": "object",
                   "children": {
                     "required": [
-                      {
-                        "name": "customProperties",
-                        "type": "object"
-                      }
-                    ],
-                    "optional": [
                       {
                         "name": "contentType",
                         "type": "string"
                       },
                       {
+                        "name": "customProperties",
+                        "type": "object"
+                      },
+                      {
                         "name": "expiresAt",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "fileName",
@@ -2620,24 +2626,28 @@
                       },
                       {
                         "name": "processDefinitionId",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "processInstanceKey",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "size",
                         "type": "number"
                       }
-                    ]
+                    ],
+                    "optional": []
                   }
                 },
                 {
                   "name": "storeId",
                   "type": "string"
                 }
-              ]
+              ],
+              "optional": []
             }
           },
           {
@@ -2674,8 +2684,7 @@
       "method": "POST",
       "status": "201",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "expiresAt",
             "type": "string"
@@ -2684,7 +2693,8 @@
             "name": "url",
             "type": "string"
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -4802,8 +4812,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "messageKey",
             "type": "string"
@@ -4816,7 +4825,8 @@
             "name": "tenantId",
             "type": "string"
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -4824,8 +4834,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "messageKey",
             "type": "string"
@@ -4834,7 +4843,8 @@
             "name": "tenantId",
             "type": "string"
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -5297,8 +5307,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "batchOperationKey",
             "type": "string"
@@ -5319,7 +5328,8 @@
               "UPDATE_VARIABLE"
             ]
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -5327,8 +5337,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "batchOperationKey",
             "type": "string"
@@ -5349,7 +5358,8 @@
               "UPDATE_VARIABLE"
             ]
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -5357,8 +5367,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "batchOperationKey",
             "type": "string"
@@ -5379,7 +5388,8 @@
               "UPDATE_VARIABLE"
             ]
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -5387,8 +5397,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "batchOperationKey",
             "type": "string"
@@ -5409,7 +5418,8 @@
               "UPDATE_VARIABLE"
             ]
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -5417,8 +5427,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "batchOperationKey",
             "type": "string"
@@ -5439,7 +5448,8 @@
               "UPDATE_VARIABLE"
             ]
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -5672,8 +5682,7 @@
       "method": "POST",
       "status": "200",
       "schema": {
-        "required": [],
-        "optional": [
+        "required": [
           {
             "name": "batchOperationKey",
             "type": "string"
@@ -5694,7 +5703,8 @@
               "UPDATE_VARIABLE"
             ]
           }
-        ]
+        ],
+        "optional": []
       }
     },
     {
@@ -5964,8 +5974,7 @@
             "type": "schema",
             "nullable": true,
             "children": {
-              "required": [],
-              "optional": [
+              "required": [
                 {
                   "name": "batchOperationKey",
                   "type": "string"
@@ -5986,7 +5995,8 @@
                     "UPDATE_VARIABLE"
                   ]
                 }
-              ]
+              ],
+              "optional": []
             }
           }
         ]
@@ -7357,6 +7367,12 @@
                 {
                   "name": "actorType",
                   "type": "string",
+                  "enumValues": [
+                    "ANONYMOUS",
+                    "CLIENT",
+                    "UNKNOWN",
+                    "USER"
+                  ],
                   "nullable": true
                 },
                 {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "7c620d8fa0860ad4ede95f19c51422b29e37c1c0",
-    "generatedAt": "2026-03-04T12:09:32.437Z",
+    "commit": "bcbd1f318d761292601822f1ceb7ea46b163cd77",
+    "generatedAt": "2026-03-04T14:53:28.645Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "085990d845643bb2efa49c584764d02f1f015eeb4c1a5e230e2a377a659db082"
+    "specSha256": "32a3444594e48c55a72f08802ef18b1e7d451ed032b875b67e3881c2b43e7766"
   },
   "responses": [
     {
@@ -3029,7 +3029,8 @@
                     "ACTIVE",
                     "MIGRATED",
                     "PENDING",
-                    "RESOLVED"
+                    "RESOLVED",
+                    "UNKNOWN"
                   ]
                 }
               ]
@@ -3739,7 +3740,8 @@
                     "ACTIVE",
                     "MIGRATED",
                     "PENDING",
-                    "RESOLVED"
+                    "RESOLVED",
+                    "UNKNOWN"
                   ]
                 }
               ]
@@ -3859,7 +3861,8 @@
               "ACTIVE",
               "MIGRATED",
               "PENDING",
-              "RESOLVED"
+              "RESOLVED",
+              "UNKNOWN"
             ]
           }
         ]
@@ -5795,7 +5798,8 @@
                     "ACTIVE",
                     "MIGRATED",
                     "PENDING",
-                    "RESOLVED"
+                    "RESOLVED",
+                    "UNKNOWN"
                   ]
                 }
               ]

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/responses.json
@@ -2,7 +2,7 @@
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
     "commit": "bcbd1f318d761292601822f1ceb7ea46b163cd77",
-    "generatedAt": "2026-03-04T14:53:28.645Z",
+    "generatedAt": "2026-03-04T14:57:02.148Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
     "specSha256": "32a3444594e48c55a72f08802ef18b1e7d451ed032b875b67e3881c2b43e7766"
   },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
@@ -1636,9 +1636,9 @@
       "license": "Python-2.0"
     },
     "node_modules/assert-json-body": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/assert-json-body/-/assert-json-body-1.6.1.tgz",
-      "integrity": "sha512-AmIK3/lm/+GfZu9kyhsQQZRwKtI40FWPBODeYMZRqtFbl4nGsAcQ3DE6J4Ep71EBF3AX5345+psSnf6fWfoIOg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/assert-json-body/-/assert-json-body-1.6.2.tgz",
+      "integrity": "sha512-uARV5NLV/H3jp0d8sgnO2c7bIXTVytnDxiMuP41gL6wLi+6gv9BN2QmHpVY9HOIEht1Bq3f+01rFUdxJURMgMg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
@@ -21,7 +21,7 @@
         "@types/node": "^24.0.0",
         "@typescript-eslint/eslint-plugin": "8.56.1",
         "@typescript-eslint/parser": "8.56.1",
-        "assert-json-body": "^1.6.1",
+        "assert-json-body": "^1.6.2",
         "eslint": "9.39.3",
         "eslint-config-prettier": "^10.0.2",
         "eslint-plugin-license-header": "0.9.0",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/package.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "8.56.1",
     "@typescript-eslint/parser": "8.56.1",
-    "assert-json-body": "^1.6.1",
+    "assert-json-body": "^1.6.2",
     "eslint": "9.39.3",
     "eslint-config-prettier": "^10.0.2",
     "eslint-plugin-license-header": "0.9.0",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -183,7 +183,7 @@ export class OperateDiagramPage {
       for (const text of expectedTexts) {
         await expect(
           this.metadataModal.getByText(text, {exact: false}),
-        ).toBeVisible({timeout: 15000});
+        ).toBeVisible({timeout: 30000});
       }
     }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskDetailsPage.ts
@@ -288,14 +288,35 @@ class TaskDetailsPageV1 {
         `No elements found for label "${label}" in the dynamic list`,
       );
     }
-
     for (const [index, element] of elements.entries()) {
-      const expectedValue = `${value}${index + 1}`;
-      await element.fill(expectedValue);
-
-      // Assert that the value was added correctly
-      await expect(element).toHaveValue(expectedValue);
+      await this.fillElementWithRetry(element, index, value);
     }
+  }
+
+  private async fillElementWithRetry(
+    locator: Locator,
+    index: number,
+    value: string,
+  ): Promise<void> {
+    let retryCount = 0;
+    const maxRetries = 3;
+    while (retryCount < maxRetries) {
+      try {
+        const expectedValue = `${value}${index + 1}`;
+        await locator.fill(expectedValue);
+        await expect(locator).toHaveValue(expectedValue);
+        return;
+      } catch {
+        retryCount++;
+        console.log(`Attempt ${retryCount} failed. Retrying...`);
+        await sleep(1000);
+        await locator.click();
+        await locator.clear();
+      }
+    }
+    throw new Error(
+      `${locator} could not be filled with value "${value}" after ${maxRetries} attempts.`,
+    );
   }
 
   async getDynamicListValues(label: string): Promise<string[]> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskPanelPage.ts
@@ -9,6 +9,7 @@
 import {Page, Locator} from '@playwright/test';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {expect} from '@playwright/test';
+import {sleep} from '../../utils/sleep';
 
 class TaskPanelPageV1 {
   readonly availableTasks: Locator;
@@ -54,21 +55,38 @@ class TaskPanelPageV1 {
       | 'Completed'
       | 'Custom',
   ) {
-    await this.expandSidePanelButton.click();
-    await this.page.getByRole('link', {name: option, exact: true}).click();
+    let retryCount = 0;
+    const maxRetries = 5;
+    while (retryCount < maxRetries) {
+      try {
+        const link = this.page.getByRole('link', {name: option, exact: true});
+        if (!(await link.isVisible())) {
+          await expect(this.expandSidePanelButton).toBeVisible();
+          await this.expandSidePanelButton.click();
+        }
+        await expect(link).toBeVisible({timeout: 10000});
+        await link.click();
 
-    const expectedSegment =
-      option === 'All open tasks'
-        ? 'all-open'
-        : option === 'Assigned to me'
-          ? 'assigned-to-me'
-          : option.toLowerCase().replace(/\s+/g, '-');
+        const expectedSegment =
+          option === 'All open tasks'
+            ? 'all-open'
+            : option === 'Assigned to me'
+              ? 'assigned-to-me'
+              : option.toLowerCase().replace(/\s+/g, '-');
 
-    await expect(this.page).toHaveURL(new RegExp(`${expectedSegment}`), {
-      timeout: 15000,
-    });
-
-    await this.collapseSidePanelButton.click();
+        await expect(this.page).toHaveURL(new RegExp(`${expectedSegment}`), {
+          timeout: 15000,
+        });
+        await this.collapseSidePanelButton.click();
+        return;
+      } catch (error) {
+        retryCount++;
+        console.log(`Attempt ${retryCount} failed. Retrying...`, error);
+      }
+    }
+    throw new Error(
+      `Failed to apply filter "${option}" after ${maxRetries} attempts.`,
+    );
   }
 
   async clickCollapseFilter(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -320,8 +320,8 @@ test.describe.parallel('Document API Tests', () => {
   test('Create Multiple Documents', async ({request}) => {
     const name = await generateRandomStringAsync(10);
     const payload = CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(name, 2);
-    const expectedFile1 = CREATE_TXT_DOC_RESPONSE_BODY(`${name}1`, 22);
-    const expectedFile2 = CREATE_TXT_DOC_RESPONSE_BODY(`${name}2`, 22);
+    const expectedFile1 = CREATE_TXT_DOC_RESPONSE_BODY(`${name}1`, 24);
+    const expectedFile2 = CREATE_TXT_DOC_RESPONSE_BODY(`${name}2`, 24);
     let json: Serializable = {};
 
     await test.step('Create Multiple Documents 201', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -191,7 +191,7 @@ test.describe('Identity User Flows', () => {
     });
 
     await test.step(`Verify Tasklist access`, async () => {
-      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist`);
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist/login`);
       await loginPage.login(testUser!.username, testUser!.password);
       await expect(page).toHaveURL(new RegExp(`tasklist`));
       await verifyAccess(page, true, 'tasklist');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -181,6 +181,7 @@ test.describe('Identity User Flows', () => {
 
     await test.step(`Login with the new user and verify Identity access`, async () => {
       await identityHeader.logout();
+      await sleep(200);
       await loginPage.login(testUser!.username, testUser!.password);
       await expect(page).toHaveURL(new RegExp(`admin`));
       await verifyAccess(page);
@@ -191,7 +192,7 @@ test.describe('Identity User Flows', () => {
     });
 
     await test.step(`Verify Tasklist access`, async () => {
-      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist/login`);
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist`);
       await loginPage.login(testUser!.username, testUser!.password);
       await expect(page).toHaveURL(new RegExp(`tasklist`));
       await verifyAccess(page, true, 'tasklist');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -8,11 +8,19 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {deploy, createInstances} from 'utils/zeebeClient';
+import {
+  deploy,
+  createInstances,
+  cancelProcessInstance,
+} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {waitForAssertion} from 'utils/waitForAssertion';
+import {
+  CreateProcessInstanceResponse,
+  DeployResourceResponse,
+} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 
 const PROCESS_INSTANCE_COUNT = 10;
 const AUTO_MIGRATION_INSTANCE_COUNT = 6;
@@ -30,6 +38,7 @@ type TestProcesses = {
 };
 
 let testProcesses: TestProcesses;
+let processes: CreateProcessInstanceResponse[][] = [];
 
 test.beforeAll(async () => {
   await deploy(['./resources/orderProcessMigration_v_1.bpmn']);
@@ -38,7 +47,7 @@ test.beforeAll(async () => {
     version: 1,
   };
 
-  await Promise.all(
+  processes = await Promise.all(
     [...new Array(PROCESS_INSTANCE_COUNT)].map((_, index) =>
       createInstances(processV1.bpmnProcessId, processV1.version, 1, {
         key1: 'myFirstCorrelationKey',
@@ -48,16 +57,21 @@ test.beforeAll(async () => {
     ),
   );
 
-  await deploy(['./resources/orderProcessMigration_v_2.bpmn']);
+  const newProcessMigrationV2: DeployResourceResponse = await deploy([
+    './resources/orderProcessMigration_v_2.bpmn',
+  ]);
   const processV2: ProcessDeployment = {
     bpmnProcessId: 'orderProcessMigration',
-    version: 2,
+    version: newProcessMigrationV2.processes[0].processDefinitionVersion,
   };
+  const newProcessMigrationV3: DeployResourceResponse = await deploy([
+    './resources/orderProcessMigration_v_3.bpmn',
+  ]);
+  expect(processV2.version).toBeGreaterThan(processV1.version);
 
-  await deploy(['./resources/orderProcessMigration_v_3.bpmn']);
   const processV3: ProcessDeployment = {
     bpmnProcessId: 'newOrderProcessMigration',
-    version: 1,
+    version: newProcessMigrationV3.processes[0].processDefinitionVersion,
   };
 
   testProcesses = {
@@ -68,9 +82,15 @@ test.beforeAll(async () => {
   await sleep(2000);
 });
 
-test.describe.serial('Process Instance Migration', () => {
-  test.describe.configure({retries: 0});
+test.afterAll(async () => {
+  for (const process of processes) {
+    for (const instance of process) {
+      await cancelProcessInstance(instance.processInstanceKey as string);
+    }
+  }
+});
 
+test.describe.serial('Process Instance Migration', () => {
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
@@ -122,6 +142,10 @@ test.describe.serial('Process Instance Migration', () => {
     });
 
     await test.step('Verify target process is preselected with auto-mapping and Complete Migration', async () => {
+      await operateProcessMigrationModePage.targetProcessCombobox.click();
+      await operateProcessMigrationModePage
+        .getOptionByName(targetBpmnProcessId)
+        .click();
       await expect(
         operateProcessMigrationModePage.targetProcessCombobox,
       ).toHaveValue(targetBpmnProcessId);
@@ -676,7 +700,6 @@ test.describe.serial('Process Instance Migration', () => {
   });
 
   test('Migrated message events', async ({
-    page,
     operateFiltersPanelPage,
     operateProcessesPage,
     operateDiagramPage,
@@ -738,7 +761,6 @@ test.describe.serial('Process Instance Migration', () => {
   });
 
   test('Migrated gateways', async ({
-    page,
     operateFiltersPanelPage,
     operateProcessesPage,
     operateDiagramPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -216,6 +216,7 @@ test.describe('task details page', () => {
     await taskDetailsPage.fillDatetimeField('Invoice Date', '1/1/3000');
     await taskDetailsPage.fillDatetimeField('Due Date', '1/2/3000');
     await taskDetailsPage.fillTextInput('Invoice Number*', '123');
+    await sleep(200);
 
     await taskDetailsPage.selectDropdownOption(
       'USD - United States Dollar',
@@ -226,6 +227,7 @@ test.describe('task details page', () => {
     await taskDetailsPage.fillDynamicList('Item Name*', 'Laptop');
     await taskDetailsPage.fillDynamicList('Unit Price*', '1');
     await taskDetailsPage.fillDynamicList('Quantity*', '2');
+    await sleep(200);
 
     await expect(taskDetailsPage.form).toContainText('EUR 231');
     await expect(taskDetailsPage.form).toContainText('EUR 264');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
@@ -165,7 +165,6 @@ test.describe('process page', () => {
     );
     await taskDetailsPageV1.fillTextInput('Invoice Number*', '123');
     await taskDetailsPageV1.addDynamicListRow();
-    await sleep(200);
 
     await taskDetailsPageV1.fillDynamicList('Item Name*', 'Laptop');
     await taskDetailsPageV1.fillDynamicList('Unit Price*', '1');
@@ -174,7 +173,6 @@ test.describe('process page', () => {
     await expect(page.getByText('EUR 231')).toBeVisible();
     await expect(page.getByText('EUR 264')).toBeVisible();
     await expect(page.getByText('Total: EUR 544.5')).toBeVisible();
-    await sleep(200);
     await tasklistProcessesPageV1.clickStartProcessSubButton();
 
     await tasklistHeaderV1.clickTasksTab();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
@@ -122,7 +122,7 @@ test.describe('process page', () => {
         ).toBeVisible();
       },
       onFailure: async () => {
-        page.reload();
+        await page.reload();
       },
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
@@ -174,6 +174,7 @@ test.describe('process page', () => {
     await expect(page.getByText('EUR 231')).toBeVisible();
     await expect(page.getByText('EUR 264')).toBeVisible();
     await expect(page.getByText('Total: EUR 544.5')).toBeVisible();
+    await sleep(200);
     await tasklistProcessesPageV1.clickStartProcessSubButton();
 
     await tasklistHeaderV1.clickTasksTab();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
@@ -165,6 +165,7 @@ test.describe('process page', () => {
     );
     await taskDetailsPageV1.fillTextInput('Invoice Number*', '123');
     await taskDetailsPageV1.addDynamicListRow();
+    await sleep(200);
 
     await taskDetailsPageV1.fillDynamicList('Item Name*', 'Laptop');
     await taskDetailsPageV1.fillDynamicList('Unit Price*', '1');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
@@ -446,6 +446,7 @@ test.describe('task details page', () => {
     await taskDetailsPageV1.assertFieldValue('Number', '2');
     await taskDetailsPageV1.clickDecrementButton();
     await taskDetailsPageV1.assertFieldValue('Number', '1');
+    await sleep(200);
     await taskDetailsPageV1.clickCompleteTaskButton();
     await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/accessVerification.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/accessVerification.ts
@@ -15,7 +15,10 @@ export async function verifyAccess(
   appName?: string,
 ) {
   if (appName) {
-    await page.goto(`${process.env.CORE_APPLICATION_URL}/${appName}/`);
+    await page.goto(`${process.env.CORE_APPLICATION_URL}/${appName}/`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60000,
+    });
   }
 
   if (shouldHaveAccess) {


### PR DESCRIPTION
## Description

- Updated API spec for documents batch endpoint and to use latest version 1.6.2
- Wait for the page load to navigate the page
- Added retries for clicking 
- Changed migration test to be retriable
- Added small sleeps 200ms since adding new varaible was too quick

Run: https://github.com/camunda/camunda/actions/runs/22706932102
⚠️ Two API tests failed. Team is implementing a fix, it is in [this PR](https://camunda.slack.com/archives/C08MRKHJ0CD/p1772638949033889?thread_ts=1772638867.816619&cid=C08MRKHJ0CD)


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
