### PR TITLE
test: env vars in makefile were not properly escaped

### DIFF
--- a/load-tests/setup/cloud-default/Makefile
+++ b/load-tests/setup/cloud-default/Makefile
@@ -31,13 +31,13 @@ install-load-test:
 		--reuse-values \
 		--render-subchart-notes \
 		--set saas.enabled=true \
-		--set saas.credentials.clientId="$(ZEEBE_CLIENT_ID)" \
-		--set saas.credentials.clientSecret="$(ZEEBE_CLIENT_SECRET)" \
-		--set saas.credentials.zeebeRestAddress="$(ZEEBE_REST_ADDRESS)" \
-		--set saas.credentials.authServer="$(ZEEBE_AUTHORIZATION_SERVER_URL)" \
+		--set saas.credentials.clientId="$${ZEEBE_CLIENT_ID}" \
+		--set saas.credentials.clientSecret="$${ZEEBE_CLIENT_SECRET}" \
+		--set saas.credentials.zeebeRestAddress="$${ZEEBE_REST_ADDRESS}" \
+		--set saas.credentials.authServer="$${ZEEBE_AUTHORIZATION_SERVER_URL}" \
 		--set saas.credentials.authType="OAUTH" \
-		--set saas.credentials.zeebeGrpcAddress="$(ZEEBE_GRPC_ADDRESS)" \
-		--set saas.credentials.authorizationAudience="$(ZEEBE_TOKEN_AUDIENCE)" \
+		--set saas.credentials.zeebeGrpcAddress="$${ZEEBE_GRPC_ADDRESS}" \
+		--set saas.credentials.authorizationAudience="$${ZEEBE_TOKEN_AUDIENCE}" \
 		$(additional_load_test_configuration)
 
 .PHONY: clean


### PR DESCRIPTION
## Description
Environment variables need to be escaped with `$${ENV_VAR}` instead of `${ENV_VAR}` otherwise they are substituted inside `make` rather then in the shell.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
