### PR TITLE
fix: switch load-test nodeSelectors from gke-nodepool to component label [8.9]

### DIFF
--- a/load-tests/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch.yaml
@@ -81,7 +81,7 @@ elasticsearch:
         cpu: 3000m
         memory: 6Gi
     nodeSelector:
-      cloud.google.com/gke-nodepool: n2-standard-4
+      component: benchmark-n2-standard-4
     tolerations:
       - key: nodepool
         operator: Equal

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -82,7 +82,7 @@ orchestration:
       memory: 2Gi
 
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4
+    component: benchmark-n2-standard-4
 
   tolerations:
     - key: nodepool

--- a/load-tests/secondary-storage-values-opensearch.yaml
+++ b/load-tests/secondary-storage-values-opensearch.yaml
@@ -46,7 +46,7 @@ persistence:
   storageClass: "ssd"
 
 nodeSelector:
-  cloud.google.com/gke-nodepool: n2-standard-4
+  component: benchmark-n2-standard-4
 
 tolerations:
   - key: nodepool

--- a/load-tests/secondary-storage-values-postgresql.yaml
+++ b/load-tests/secondary-storage-values-postgresql.yaml
@@ -18,7 +18,7 @@ primary:
       memory: 6Gi
 
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4
+    component: benchmark-n2-standard-4
 
   tolerations:
     - key: nodepool

--- a/load-tests/setup/default/values-preemptible.yaml
+++ b/load-tests/setup/default/values-preemptible.yaml
@@ -4,7 +4,7 @@ orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4
+    component: benchmark-n2-standard-4
 
   tolerations:
   - key: nodepool

--- a/load-tests/setup/default/values-stable.yaml
+++ b/load-tests/setup/default/values-stable.yaml
@@ -4,7 +4,7 @@ orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4-stable
+    component: benchmark-n2-standard-4-stable
 
   tolerations:
   - key: nodepool


### PR DESCRIPTION
## Description

Backport of #47583 to `stable/8.9`.

Migrates load-test Helm values to use the new `component` nodeSelector label (with `benchmark-` prefix) instead of `cloud.google.com/gke-nodepool`, enabling workload scheduling onto v2 nodepools.

**Changed files:**

- `load-tests/camunda-platform-values.yaml`
- `load-tests/camunda-platform-values-elasticsearch.yaml`
- `load-tests/secondary-storage-values-opensearch.yaml`
- `load-tests/secondary-storage-values-postgresql.yaml`
- `load-tests/setup/default/values-preemptible.yaml`
- `load-tests/setup/default/values-stable.yaml`

Related: camunda/team-infrastructure#829