### PR TITLE
fix: switch load-test nodeSelectors from gke-nodepool to component label [8.8]

### DIFF
--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -82,7 +82,7 @@ orchestration:
       memory: 2Gi
 
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4
+    component: benchmark-n2-standard-4
 
   tolerations:
     - key: nodepool
@@ -229,7 +229,7 @@ elasticsearch:
         cpu: 3
         memory: 6Gi
     nodeSelector:
-      cloud.google.com/gke-nodepool: n2-standard-4
+      component: benchmark-n2-standard-4
     tolerations:
       - key: nodepool
         operator: Equal

--- a/zeebe/benchmarks/setup/default/values-preemptible.yaml
+++ b/zeebe/benchmarks/setup/default/values-preemptible.yaml
@@ -4,7 +4,7 @@ orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4
+    component: benchmark-n2-standard-4
 
   tolerations:
   - key: nodepool

--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -4,7 +4,7 @@ orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4-stable
+    component: benchmark-n2-standard-4-stable
 
   tolerations:
   - key: nodepool


### PR DESCRIPTION
## Description

Backport of #47583 to `stable/8.8`.

Migrates load-test Helm values to use the new `component` nodeSelector label (with `benchmark-` prefix) instead of `cloud.google.com/gke-nodepool`, enabling workload scheduling onto v2 nodepools.

Note: On this branch the files live in `zeebe/benchmarks/` instead of `load-tests/`.

**Changed files:**

- `zeebe/benchmarks/camunda-platform-values.yaml`
- `zeebe/benchmarks/setup/default/values-preemptible.yaml`
- `zeebe/benchmarks/setup/default/values-stable.yaml`

Related: camunda/team-infrastructure#829