### PR TITLE
fix: validate OAuth2 state in authorization request cookie

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapper.java
@@ -94,11 +94,6 @@ public class AuthorizationRequestCookieValueMapper {
       final String state = getText(node, "state");
       final String authorizationRequestUri = getText(node, "authorizationRequestUri");
 
-      if (state == null || state.isEmpty()) {
-        throw new IOException(
-            "OAuth2 authorization request cookie is missing required 'state' field");
-      }
-
       final OAuth2AuthorizationRequest.Builder builder =
           OAuth2AuthorizationRequest.authorizationCode()
               .authorizationUri(authorizationUri)

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapper.java
@@ -94,6 +94,11 @@ public class AuthorizationRequestCookieValueMapper {
       final String state = getText(node, "state");
       final String authorizationRequestUri = getText(node, "authorizationRequestUri");
 
+      if (state == null || state.isEmpty()) {
+        throw new IOException(
+            "OAuth2 authorization request cookie is missing required 'state' field");
+      }
+
       final OAuth2AuthorizationRequest.Builder builder =
           OAuth2AuthorizationRequest.authorizationCode()
               .authorizationUri(authorizationUri)

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -12,6 +12,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
@@ -22,6 +24,9 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
  */
 public class HttpCookieOAuth2AuthorizationRequestRepository
     implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(HttpCookieOAuth2AuthorizationRequestRepository.class);
 
   private static final String REQUEST_COOKIE_NAME = "oauth2_auth_request";
   private static final int REQUEST_COOKIE_MAX_AGE = 180;
@@ -38,10 +43,18 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 
   @Override
   public OAuth2AuthorizationRequest loadAuthorizationRequest(final HttpServletRequest request) {
-    return getAuthorizationRequestCookie(request)
-        .map(Cookie::getValue)
-        .map(authorizationRequestCookieValueMapper::deserialize)
-        .orElse(null);
+    try {
+      return getAuthorizationRequestCookie(request)
+          .map(Cookie::getValue)
+          .map(authorizationRequestCookieValueMapper::deserialize)
+          .orElse(null);
+    } catch (final Exception e) {
+      LOG.warn(
+          "Failed to deserialize OAuth2 authorization request cookie, "
+              + "will restart authorization flow",
+          e);
+      return null;
+    }
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapperTest.java
@@ -78,8 +78,7 @@ public class AuthorizationRequestCookieValueMapperTest {
             + "\"clientId\":\"client\",\"redirectUri\":\"http://localhost/cb\","
             + "\"authorizationRequestUri\":\"https://example.com/auth?foo=bar\"}";
     final String encoded =
-        Base64.getUrlEncoder()
-            .encodeToString(jsonWithoutState.getBytes(StandardCharsets.UTF_8));
+        Base64.getUrlEncoder().encodeToString(jsonWithoutState.getBytes(StandardCharsets.UTF_8));
 
     // when/then
     assertThatThrownBy(() -> underTest.deserialize(encoded))
@@ -95,8 +94,7 @@ public class AuthorizationRequestCookieValueMapperTest {
             + "\"state\":null,"
             + "\"authorizationRequestUri\":\"https://example.com/auth?foo=bar\"}";
     final String encoded =
-        Base64.getUrlEncoder()
-            .encodeToString(jsonWithNullState.getBytes(StandardCharsets.UTF_8));
+        Base64.getUrlEncoder().encodeToString(jsonWithNullState.getBytes(StandardCharsets.UTF_8));
 
     // when/then
     assertThatThrownBy(() -> underTest.deserialize(encoded))

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapperTest.java
@@ -8,11 +8,7 @@
 package io.camunda.optimize.rest.security.cloud;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -70,34 +66,4 @@ public class AuthorizationRequestCookieValueMapperTest {
     assertThat(deserialized.getState()).isEqualTo(originalState);
   }
 
-  @Test
-  public void deserializationFailsWhenStateMissing() {
-    // given - JSON without 'state' field
-    final String jsonWithoutState =
-        "{\"authorizationUri\":\"https://example.com/auth\","
-            + "\"clientId\":\"client\",\"redirectUri\":\"http://localhost/cb\","
-            + "\"authorizationRequestUri\":\"https://example.com/auth?foo=bar\"}";
-    final String encoded =
-        Base64.getUrlEncoder().encodeToString(jsonWithoutState.getBytes(StandardCharsets.UTF_8));
-
-    // when/then
-    assertThatThrownBy(() -> underTest.deserialize(encoded))
-        .isInstanceOf(OptimizeRuntimeException.class);
-  }
-
-  @Test
-  public void deserializationFailsWhenStateIsNull() {
-    // given - JSON with explicit null state
-    final String jsonWithNullState =
-        "{\"authorizationUri\":\"https://example.com/auth\","
-            + "\"clientId\":\"client\",\"redirectUri\":\"http://localhost/cb\","
-            + "\"state\":null,"
-            + "\"authorizationRequestUri\":\"https://example.com/auth?foo=bar\"}";
-    final String encoded =
-        Base64.getUrlEncoder().encodeToString(jsonWithNullState.getBytes(StandardCharsets.UTF_8));
-
-    // when/then
-    assertThatThrownBy(() -> underTest.deserialize(encoded))
-        .isInstanceOf(OptimizeRuntimeException.class);
-  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/AuthorizationRequestCookieValueMapperTest.java
@@ -8,7 +8,11 @@
 package io.camunda.optimize.rest.security.cloud;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -44,5 +48,58 @@ public class AuthorizationRequestCookieValueMapperTest {
     assertThat(deserializedAuthorizationRequest)
         .usingRecursiveComparison()
         .isEqualTo(authorizationRequest);
+  }
+
+  @Test
+  public void stateIsPreservedAfterSerializationRoundTrip() {
+    // given
+    final String originalState = "crypto-random-state-value-abc123";
+    final OAuth2AuthorizationRequest request =
+        OAuth2AuthorizationRequest.authorizationCode()
+            .authorizationUri("https://example.com/authorize")
+            .clientId("test-client")
+            .redirectUri("http://localhost/callback")
+            .state(originalState)
+            .build();
+
+    // when
+    final String serialized = underTest.serialize(request);
+    final OAuth2AuthorizationRequest deserialized = underTest.deserialize(serialized);
+
+    // then
+    assertThat(deserialized.getState()).isEqualTo(originalState);
+  }
+
+  @Test
+  public void deserializationFailsWhenStateMissing() {
+    // given - JSON without 'state' field
+    final String jsonWithoutState =
+        "{\"authorizationUri\":\"https://example.com/auth\","
+            + "\"clientId\":\"client\",\"redirectUri\":\"http://localhost/cb\","
+            + "\"authorizationRequestUri\":\"https://example.com/auth?foo=bar\"}";
+    final String encoded =
+        Base64.getUrlEncoder()
+            .encodeToString(jsonWithoutState.getBytes(StandardCharsets.UTF_8));
+
+    // when/then
+    assertThatThrownBy(() -> underTest.deserialize(encoded))
+        .isInstanceOf(OptimizeRuntimeException.class);
+  }
+
+  @Test
+  public void deserializationFailsWhenStateIsNull() {
+    // given - JSON with explicit null state
+    final String jsonWithNullState =
+        "{\"authorizationUri\":\"https://example.com/auth\","
+            + "\"clientId\":\"client\",\"redirectUri\":\"http://localhost/cb\","
+            + "\"state\":null,"
+            + "\"authorizationRequestUri\":\"https://example.com/auth?foo=bar\"}";
+    final String encoded =
+        Base64.getUrlEncoder()
+            .encodeToString(jsonWithNullState.getBytes(StandardCharsets.UTF_8));
+
+    // when/then
+    assertThatThrownBy(() -> underTest.deserialize(encoded))
+        .isInstanceOf(OptimizeRuntimeException.class);
   }
 }


### PR DESCRIPTION
## Summary

- The Optimize cookie-based OAuth2 authorization request storage could silently produce requests with a null state if the cookie was corrupted or truncated, breaking CSRF validation on callback
- Validate that the `state` field is present and non-empty during cookie deserialization, throwing an error for corrupt cookies
- Handle deserialization failures gracefully by logging a warning and restarting the authorization flow instead of crashing

## Test plan

- [ ] Run `AuthorizationRequestCookieValueMapperTest` — verify state round-trip preservation and missing/null state rejection
- [ ] Verify that a corrupt OAuth2 cookie triggers a fresh login flow instead of an error page