### PR TITLE
fix: switch load-test nodeSelectors from gke-nodepool to component label [8.6]

### DIFF
--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -167,7 +167,7 @@ zeebe:
       memory: 4Gi
 
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4
+    component: benchmark-n2-standard-4
 
   tolerations:
     - key: nodepool
@@ -276,7 +276,7 @@ elasticsearch:
         cpu: 2
         memory: 6Gi
     nodeSelector:
-      cloud.google.com/gke-nodepool: n2-standard-2
+      component: benchmark-n2-standard-2
     tolerations:
       - key: nodepool
         operator: Equal

--- a/zeebe/benchmarks/setup/default/values-preemptible.yaml
+++ b/zeebe/benchmarks/setup/default/values-preemptible.yaml
@@ -2,7 +2,7 @@
 zeebe:
   # Require n2-standard-4 to ensure the broker is the only application running on its node
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4
+    component: benchmark-n2-standard-4
 
   tolerations:
   - key: nodepool

--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -2,7 +2,7 @@
 zeebe:
   # Require n2-standard-4-stable to ensure the broker is the only application running on its node
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4-stable
+    component: benchmark-n2-standard-4-stable
 
   tolerations:
   - key: nodepool


### PR DESCRIPTION
## Description

Backport of #47583 to `stable/8.6`.

Migrates load-test Helm values to use the new `component` nodeSelector label (with `benchmark-` prefix) instead of `cloud.google.com/gke-nodepool`, enabling workload scheduling onto v2 nodepools.

Note: On this branch the files live in `zeebe/benchmarks/` and use `zeebe` instead of `orchestration` as the top-level key.

**Changed files:**

- `zeebe/benchmarks/camunda-platform-values.yaml`
- `zeebe/benchmarks/setup/default/values-preemptible.yaml`
- `zeebe/benchmarks/setup/default/values-stable.yaml`