### PR TITLE
fix: request more process instances at one for availability metric

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -156,6 +156,7 @@ public class Starter extends App {
                       .newProcessInstanceSearchRequest()
                       .filter((f) -> f.processInstanceKey(key -> key.in(listOfStartedInstances)))
                       .sort(ProcessInstanceSort::startDate)
+                      .page(p -> p.limit(Math.max(1, Math.min(600, listOfStartedInstances.size()))))
                       .send();
 
               return send.thenApply(


### PR DESCRIPTION
otherwise if the requests themselves are too slow we might struggle to keep up.