### PR TITLE
[Backport stable/8.8] fix: no markdown formatting should be contained in descriptions

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientAuthProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientAuthProperties.java
@@ -26,21 +26,22 @@ public class CamundaClientAuthProperties {
 
   /**
    * The authentication method to use. If not set, it is detected based on the presence of a
-   * username, password, client ID, and client secret. A default is set by `camunda.client.mode:
-   * saas`.
+   * username, password, client ID, and client secret. A default is set by <code>
+   * camunda.client.mode: saas</code>.
    */
   private AuthMethod method;
 
   // basic auth
   /**
-   * The username to use for basic authentication. A default is set by `camunda.client.auth.method:
-   * basic`.
+   * The username to use for basic authentication. A default is set by <code>
+   * camunda.client.auth.method:
+   * basic </code>.
    */
   private String username;
 
   /**
-   * The password to be use for basic authentication. A default is set by
-   * `camunda.client.auth.method: basic`.
+   * The password to be use for basic authentication. A default is set by <code>
+   * camunda.client.auth.method: basic </code>.
    */
   private String password;
 
@@ -54,14 +55,14 @@ public class CamundaClientAuthProperties {
   private String clientSecret;
 
   /**
-   * The authorization server URL from which to request the access token. A default is set by
-   * `camunda.client.mode: saas` and `camunda.client.auth.method: oidc`.
+   * The authorization server URL from which to request the access token. A default is set by <code>
+   * camunda.client.mode: saas</code> and <code>camunda.client.auth.method: oidc</code>.
    */
   private URI tokenUrl;
 
   /**
-   * The resource for which the access token must be valid. A default is set by
-   * `camunda.client.mode: saas` and `camunda.client.auth.method: oidc`.
+   * The resource for which the access token must be valid. A default is set by <code>
+   * camunda.client.mode: saas</code> and <code>camunda.client.auth.method: oidc</code>.
    */
   private String audience;
 

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientDeploymentProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientDeploymentProperties.java
@@ -17,7 +17,7 @@ package io.camunda.client.spring.properties;
 
 public class CamundaClientDeploymentProperties {
 
-  /** Indicates if deployment uses the `@Deployment` annotation. */
+  /** Indicates if the <code>@Deployment</code> annotation is processed. */
   private boolean enabled = true;
 
   public boolean isEnabled() {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientJobWorkerProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientJobWorkerProperties.java
@@ -31,8 +31,8 @@ public class CamundaClientJobWorkerProperties {
   private String type;
 
   /**
-   * The name of the worker owner. If set to default, it is generated as
-   * `${beanName}#${methodName}`.
+   * The name of the worker owner. If set to default, it is generated as <code>
+   * ${beanName}#${methodName}</code>.
    */
   private String name;
 
@@ -68,7 +68,7 @@ public class CamundaClientJobWorkerProperties {
    */
   private List<String> tenantIds;
 
-  /** Sets whether all variables are fetched. Overrides `fetch-variables`. */
+  /** Sets whether all variables are fetched. Overrides <code>fetch-variables</code>. */
   private Boolean forceFetchAllVariables;
 
   /**

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
@@ -32,8 +32,8 @@ public class CamundaClientProperties {
   private boolean enabled = true;
 
   /**
-   * The client mode to use. If not set, `saas` mode is detected based on the presence of a
-   * `camunda.client.cloud.cluster-id`.
+   * The client mode to use. If not set, <code>saas</code> mode is detected based on the presence of
+   * a <code>camunda.client.cloud.cluster-id</code>.
    */
   private ClientMode mode;
 
@@ -50,14 +50,14 @@ public class CamundaClientProperties {
   private Duration messageTimeToLive = DEFAULT_MESSAGE_TTL;
 
   /**
-   * A custom `maxMessageSize` sets the maximum inbound message size the client can receive from
-   * Camunda. It specifies the `maxInboundMessageSize` of the gRPC channel.
+   * A custom <code>maxMessageSize</code> sets the maximum inbound message size the client can
+   * receive from Camunda. It specifies the <code>maxInboundMessageSize</code> of the gRPC channel.
    */
   private DataSize maxMessageSize = DataSize.ofBytes(DEFAULT_MAX_MESSAGE_SIZE);
 
   /**
-   * A custom `maxMetadataSize` sets the maximum inbound metadata size the client can receive from
-   * Camunda. It specifies the `maxInboundMetadataSize` of the gRPC channel.
+   * A custom <code>maxMetadataSize</code> sets the maximum inbound metadata size the client can
+   * receive from Camunda. It specifies the <code>maxInboundMetadataSize</code> of the gRPC channel.
    */
   private DataSize maxMetadataSize = DataSize.ofBytes(DEFAULT_MAX_METADATA_SIZE);
 
@@ -79,19 +79,20 @@ public class CamundaClientProperties {
   @NestedConfigurationProperty
   private CamundaClientWorkerProperties worker = new CamundaClientWorkerProperties();
 
-  /** If `true`, prefers REST over gRPC for operations supported by both protocols. */
+  /** If <code>true</code>, prefers REST over gRPC for operations supported by both protocols. */
   private boolean preferRestOverGrpc = DEFAULT_PREFER_REST_OVER_GRPC;
 
   /**
    * The gRPC address of Camunda that the client can connect to. The address must be an absolute
-   * URL, including the scheme. An alternative default is set by both `camunda.client.mode`.
+   * URL, including the scheme. An alternative default is set by both <code>camunda.client.mode
+   * </code>.
    */
   private URI grpcAddress = DEFAULT_GRPC_ADDRESS;
 
   /**
    * The REST API address of the Camunda instance that the client can connect to. The address must
-   * be an absolute URL, including the scheme. An alternative default is set by
-   * both`camunda.client.mode`.
+   * be an absolute URL, including the scheme. An alternative default is set by both <code>
+   * camunda.client.mode</code>.
    */
   private URI restAddress = DEFAULT_REST_ADDRESS;
 

--- a/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "camunda.client.cloud",
-      "description": "Properties for connecting the Camunda client to SaaS. These are used to compose default connection details when the client is configured to `camunda.client.mode: saas`."
+      "description": "Properties for connecting the Camunda client to SaaS. These are used to compose default connection details when the client is configured to <code>camunda.client.mode: saas</code>."
     },
     {
       "name": "camunda.client.worker",
@@ -46,7 +46,7 @@
     {
       "name": "camunda.client.zeebe.override",
       "type": "java.util.Map",
-      "description": "Properties for overriding individual job workers registered to the Camunda client. Replaced by `camunda.client.worker.override`."
+      "description": "Properties for overriding individual job workers registered to the Camunda client. Replaced by <code>camunda.client.worker.override</code>."
     },
     {
       "name": "camunda.client.identity",
@@ -105,7 +105,7 @@
     {
       "name": "zeebe.client.worker.override",
       "type": "java.util.Map",
-      "description": "Properties to override the individual job workers registered with the Camunda client. Replaced by `camunda.client.worker.override`."
+      "description": "Properties to override the individual job workers registered with the Camunda client. Replaced by <code>camunda.client.worker.override</code>."
     }
   ],
   "properties": [
@@ -396,7 +396,7 @@
     {
       "name": "zeebe.client.connection-mode",
       "type": "java.lang.String",
-      "description": "Connection mode can be set to \"CLOUD\" (connect to SaaS with properties), or \"ADDRESS\" (to use a manually set address to the broker) If not set, \"CLOUD\" is used if a `zeebe.client.cloud.cluster-id` property is set, \"ADDRESS\" otherwise.",
+      "description": "Connection mode can be set to \"CLOUD\" (connect to SaaS with properties), or \"ADDRESS\" (to use a manually set address to the broker) If not set, \"CLOUD\" is used if a <code>zeebe.client.cloud.cluster-id</code> property is set, \"ADDRESS\" otherwise.",
       "sourceType": "io.camunda.spring.client.properties.ZeebeClientConfigurationProperties",
       "deprecation": {
         "reason": "Client modes are now available.",

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/FormattingTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/FormattingTest.java
@@ -54,6 +54,7 @@ public class FormattingTest {
                           assertThat(property.has("description")).isTrue();
                           final String description = property.get("description").asText();
                           assertThat(description).endsWith(".");
+                          assertThat(description).doesNotContain("`", "**", "_");
                         })));
   }
 
@@ -74,6 +75,7 @@ public class FormattingTest {
                           assertThat(group.has("description")).isTrue();
                           final String description = group.get("description").asText();
                           assertThat(description).endsWith(".");
+                          assertThat(description).doesNotContain("`", "**", "_");
                         })));
   }
 }


### PR DESCRIPTION
# Description
Backport of #47510 to `stable/8.8`.

relates to 