### PR TITLE
[Backport stable/8.9] fix: handle null state and errorType in SearchQueryResponseMapper.toIncident()

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/IncidentState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/IncidentState.java
@@ -20,5 +20,6 @@ public enum IncidentState {
   MIGRATED,
   RESOLVED,
   PENDING,
+  UNKNOWN,
   UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.client.impl.search.response;
 
+import static java.util.Optional.ofNullable;
+
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.Incident;
@@ -51,7 +53,9 @@ public class IncidentImpl implements Incident {
     elementId = item.getElementId();
     elementInstanceKey = ParseUtil.parseLongOrNull(item.getElementInstanceKey());
     creationTime = ParseUtil.parseOffsetDateTimeOrNull(item.getCreationTime());
-    state = EnumUtil.convert(item.getState(), IncidentState.class);
+    state =
+        ofNullable(EnumUtil.convert(item.getState(), IncidentState.class))
+            .orElse(IncidentState.UNKNOWN_ENUM_VALUE);
     jobKey = ParseUtil.parseLongOrNull(item.getJobKey());
     tenantId = item.getTenantId();
   }

--- a/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
+import io.camunda.client.impl.search.response.IncidentImpl;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -219,5 +220,31 @@ public class SearchIncidentTest extends ClientRestTest {
     assertThat(filter.getState().get$Eq()).isEqualTo(IncidentStateEnum.ACTIVE);
     assertThat(filter.getJobKey().get$Eq()).isEqualTo("5");
     assertThat(filter.getTenantId().get$Eq()).isEqualTo("tenant");
+  }
+
+  @Test
+  void shouldDefaultToUnknownEnumValueWhenStateIsNull() {
+    // given
+    final IncidentResult result =
+        new IncidentResult()
+            .incidentKey("1")
+            .processDefinitionKey("2")
+            .processDefinitionId("processId")
+            .processInstanceKey("3")
+            .rootProcessInstanceKey("4")
+            .errorType(IncidentErrorTypeEnum.JOB_NO_RETRIES)
+            .errorMessage("error")
+            .elementId("element")
+            .elementInstanceKey("5")
+            .creationTime(OffsetDateTime.now().toString())
+            .state(null)
+            .jobKey("6")
+            .tenantId("tenant");
+
+    // when
+    final IncidentImpl incident = new IncidentImpl(result);
+
+    // then
+    assertThat(incident.getState()).isEqualTo(IncidentState.UNKNOWN_ENUM_VALUE);
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1019,7 +1019,10 @@ public final class SearchQueryResponseMapper {
         .elementId(t.flowNodeId())
         .elementInstanceKey(KeyUtil.keyToString(t.flowNodeInstanceKey()))
         .creationTime(formatDate(t.creationTime()))
-        .state(IncidentStateEnum.fromValue(t.state().name()))
+        .state(
+            t.state() != null
+                ? IncidentStateEnum.fromValue(t.state().name())
+                : IncidentStateEnum.UNKNOWN)
         .jobKey(KeyUtil.keyToString(t.jobKey()))
         .tenantId(t.tenantId());
   }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
+import io.camunda.gateway.protocol.model.IncidentStateEnum;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
@@ -219,6 +220,32 @@ class SearchQueryResponseMapperTest {
 
     // then
     assertThat(response.getRootProcessInstanceKey()).isEqualTo("999");
+  }
+
+  @Test
+  void shouldHandleNullIncidentState() {
+    // given
+    final var entity =
+        new IncidentEntity(
+            123L, // incidentKey
+            456L, // processDefinitionKey
+            "processId", // processDefinitionId
+            789L, // processInstanceKey
+            999L, // rootProcessInstanceKey
+            ErrorType.JOB_NO_RETRIES, // errorType
+            "Error message", // errorMessage
+            "flowNodeId", // flowNodeId
+            111L, // flowNodeInstanceKey
+            OffsetDateTime.now(), // creationTime
+            null, // state
+            222L, // jobKey
+            "tenant"); // tenantId
+
+    // when
+    final var response = SearchQueryResponseMapper.toIncident(entity);
+
+    // then
+    assertThat(response.getState()).isEqualTo(IncidentStateEnum.UNKNOWN);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -129,6 +129,7 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
     updateFields.put(FLOW_NODE_ID, entity.getFlowNodeId());
     updateFields.put(POSITION, entity.getPosition());
     updateFields.put(TREE_PATH, entity.getTreePath());
+    updateFields.put(STATE, entity.getState());
     batchRequest.upsert(indexName, String.valueOf(entity.getKey()), entity, updateFields);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -154,7 +154,9 @@ public class IncidentHandlerTest {
                 "processDefinitionKey",
                 incidentRecordValue.getProcessDefinitionKey(),
                 "treePath",
-                incidentEntity.getTreePath()));
+                incidentEntity.getTreePath(),
+                "state",
+                incidentEntity.getState()));
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -360,6 +360,7 @@ components:
         - MIGRATED
         - PENDING
         - RESOLVED
+        - UNKNOWN
 
     IncidentSearchQuerySortRequest:
       type: object


### PR DESCRIPTION
# Description
Backport of #46706 to `stable/8.9`.

relates to #37288