### PR TITLE
feat: add JobErrorStatistics API

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -21,11 +21,13 @@ import io.camunda.db.rdbms.sql.columns.JobWorkerStatisticsColumn;
 import io.camunda.search.clients.reader.JobMetricsBatchReader;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
@@ -210,6 +212,12 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
             .toList();
 
     return timeSeriesStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
+  }
+
+  @Override
+  public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
+      final JobErrorStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException("Job error statistics is not yet implemented");
   }
 
   /** Inner reader for worker statistics to provide typed AbstractEntityReader methods. */

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -53,6 +53,7 @@ import io.camunda.search.filter.GlobalJobStatisticsFilter;
 import io.camunda.search.filter.GlobalListenerFilter;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.JobErrorStatisticsFilter;
 import io.camunda.search.filter.JobFilter;
 import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
 import io.camunda.search.filter.JobTypeStatisticsFilter;
@@ -501,6 +502,40 @@ public class SearchQueryFilterMapper {
 
     final var resolution = validateDuration(filter.getResolution(), "resolution", validationErrors);
     Optional.ofNullable(resolution).ifPresent(builder::resolution);
+
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
+  }
+
+  public static Either<List<String>, JobErrorStatisticsFilter> toJobErrorStatisticsFilter(
+      final io.camunda.gateway.protocol.model.JobErrorStatisticsFilter filter) {
+    final var builder = FilterBuilders.jobErrorStatistics();
+    final List<String> validationErrors = new ArrayList<>();
+
+    if (filter == null) {
+      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter"));
+      return Either.<List<String>, JobErrorStatisticsFilter>left(validationErrors);
+    }
+
+    final var from = validateDate(filter.getFrom(), "from", validationErrors);
+    Optional.ofNullable(from).ifPresent(builder::from);
+
+    final var to = validateDate(filter.getTo(), "to", validationErrors);
+    Optional.ofNullable(to).ifPresent(builder::to);
+
+    if (filter.getJobType() == null || filter.getJobType().isBlank()) {
+      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobType"));
+    } else {
+      builder.jobType(filter.getJobType());
+    }
+
+    Optional.ofNullable(filter.getErrorCode())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::errorCodeOperations);
+    Optional.ofNullable(filter.getErrorMessage())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::errorMessageOperations);
 
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -40,6 +40,7 @@ import io.camunda.search.query.GlobalListenerQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
@@ -155,6 +156,14 @@ public final class SearchQueryRequestMapper {
     final var filter = SearchQueryFilterMapper.toJobTimeSeriesStatisticsFilter(request.getFilter());
     return buildSearchQuery(
         filter, Either.right(null), page, SearchQueryBuilders::jobTimeSeriesStatisticsSearchQuery);
+  }
+
+  public static Either<ProblemDetail, JobErrorStatisticsQuery> toJobErrorStatisticsQuery(
+      final io.camunda.gateway.protocol.model.JobErrorStatisticsQuery request) {
+    final Either<List<String>, SearchQueryPage> page = toSearchQueryPage(request.getPage());
+    final var filter = SearchQueryFilterMapper.toJobErrorStatisticsFilter(request.getFilter());
+    return buildSearchQuery(
+        filter, Either.right(null), page, SearchQueryBuilders::jobErrorStatisticsSearchQuery);
   }
 
   public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -72,6 +72,8 @@ import io.camunda.gateway.protocol.model.IncidentProcessInstanceStatisticsByErro
 import io.camunda.gateway.protocol.model.IncidentResult;
 import io.camunda.gateway.protocol.model.IncidentSearchQueryResult;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
+import io.camunda.gateway.protocol.model.JobErrorStatisticsItem;
+import io.camunda.gateway.protocol.model.JobErrorStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobKindEnum;
 import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
@@ -161,6 +163,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
@@ -1631,6 +1634,29 @@ public final class SearchQueryResponseMapper {
         .created(toStatusMetric(entity.created()))
         .completed(toStatusMetric(entity.completed()))
         .failed(toStatusMetric(entity.failed()));
+  }
+
+  public static JobErrorStatisticsQueryResult toJobErrorStatisticsQueryResult(
+      final SearchQueryResult<JobErrorStatisticsEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new JobErrorStatisticsQueryResult()
+        .page(page)
+        .items(
+            result.items().stream()
+                .map(SearchQueryResponseMapper::toJobErrorStatisticsItem)
+                .toList());
+  }
+
+  private static JobErrorStatisticsItem toJobErrorStatisticsItem(
+      final JobErrorStatisticsEntity entity) {
+    if (entity == null) {
+      return new JobErrorStatisticsItem();
+    }
+
+    return new JobErrorStatisticsItem()
+        .errorCode(entity.errorCode())
+        .errorMessage(entity.errorMessage())
+        .workers(entity.workers());
   }
 
   private static StatusMetric toStatusMetric(final GlobalJobStatisticsEntity.StatusMetric metric) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
@@ -13,10 +13,12 @@ import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobWorkerStatisticsAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
@@ -58,5 +60,11 @@ public class JobMetricsBatchDocumentReader extends DocumentBasedReader
       final JobTimeSeriesStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
     return aggregateToResult(
         query, JobTimeSeriesStatisticsAggregationResult.class, resourceAccessChecks);
+  }
+
+  @Override
+  public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
+      final JobErrorStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException("Job error statistics is not yet implemented");
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -121,6 +121,7 @@ import io.camunda.search.clients.transformers.filter.GlobalListenerFilterTransfo
 import io.camunda.search.clients.transformers.filter.GroupFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GroupMemberFilterTransformer;
 import io.camunda.search.clients.transformers.filter.IncidentFilterTransformer;
+import io.camunda.search.clients.transformers.filter.JobErrorStatisticsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.JobFilterTransformer;
 import io.camunda.search.clients.transformers.filter.JobTimeSeriesStatisticsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.JobTypeStatisticsFilterTransformer;
@@ -194,6 +195,7 @@ import io.camunda.search.filter.GlobalListenerFilter;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.GroupMemberFilter;
 import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.JobErrorStatisticsFilter;
 import io.camunda.search.filter.JobFilter;
 import io.camunda.search.filter.JobTimeSeriesStatisticsFilter;
 import io.camunda.search.filter.JobTypeStatisticsFilter;
@@ -633,6 +635,9 @@ public final class ServiceTransformers {
         SequenceFlowFilter.class,
         new SequenceFlowFilterTransformer(indexDescriptors.get(SequenceFlowTemplate.class)));
     mappers.put(JobFilter.class, new JobFilterTransformer(indexDescriptors.get(JobTemplate.class)));
+    mappers.put(
+        JobErrorStatisticsFilter.class,
+        new JobErrorStatisticsFilterTransformer(indexDescriptors.get(JobTemplate.class)));
     mappers.put(
         MessageSubscriptionFilter.class,
         new MessageSubscriptionFilterTransformer(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobErrorStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobErrorStatisticsFilterTransformer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.CREATION_TIME;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_CODE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_MESSAGE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_TYPE;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.JobErrorStatisticsFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JobErrorStatisticsFilterTransformer
+    extends IndexFilterTransformer<JobErrorStatisticsFilter> {
+
+  public JobErrorStatisticsFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final JobErrorStatisticsFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+
+    if (filter.from() != null) {
+      queries.addAll(dateTimeOperations(CREATION_TIME, List.of(Operation.gte(filter.from()))));
+    }
+
+    if (filter.to() != null) {
+      queries.addAll(dateTimeOperations(CREATION_TIME, List.of(Operation.lte(filter.to()))));
+    }
+
+    if (filter.jobType() != null) {
+      queries.add(term(JOB_TYPE, filter.jobType()));
+    }
+
+    if (!filter.errorCodeOperations().isEmpty()) {
+      queries.addAll(stringOperations(ERROR_CODE, filter.errorCodeOperations()));
+    }
+
+    if (!filter.errorMessageOperations().isEmpty()) {
+      queries.addAll(stringOperations(ERROR_MESSAGE, filter.errorMessageOperations()));
+    }
+
+    return queries.isEmpty() ? matchAll() : and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return matchAll();
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchReader.java
@@ -8,10 +8,12 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
@@ -31,4 +33,7 @@ public interface JobMetricsBatchReader extends SearchClientReader {
 
   SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
       JobTimeSeriesStatisticsQuery query, ResourceAccessChecks resourceAccessChecks);
+
+  SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
+      JobErrorStatisticsQuery query, ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -34,6 +34,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
@@ -80,6 +81,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
@@ -411,6 +413,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final JobTimeSeriesStatisticsQuery query) {
     return doReadWithResourceAccessController(
         access -> readers.jobMetricsBatchReader().getJobTimeSeriesStatistics(query, access));
+  }
+
+  @Override
+  public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
+      final JobErrorStatisticsQuery query) {
+    return doReadWithResourceAccessController(
+        access -> readers.jobMetricsBatchReader().getJobErrorStatistics(query, access));
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
@@ -9,10 +9,12 @@ package io.camunda.search.clients;
 
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
@@ -33,6 +35,8 @@ public interface JobSearchClient {
 
   SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
       JobTimeSeriesStatisticsQuery query);
+
+  SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(JobErrorStatisticsQuery query);
 
   JobSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -28,6 +28,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
@@ -69,6 +70,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
@@ -426,6 +428,12 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
       final JobTimeSeriesStatisticsQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
+      final JobErrorStatisticsQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -30,6 +30,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
@@ -70,6 +71,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
@@ -428,7 +430,13 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
       final JobTimeSeriesStatisticsQuery query) {
-    throw new UnsupportedOperationException("Job time-series statistics is not yet implemented");
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
+      final JobErrorStatisticsQuery query) {
+    return SearchQueryResult.empty();
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/JobErrorStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/JobErrorStatisticsAggregation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AggregationPaginated;
+
+public record JobErrorStatisticsAggregation(SearchQueryPage page)
+    implements AggregationBase, AggregationPaginated {
+
+  // Composite aggregation name
+  public static final String AGGREGATION_BY_ERROR = "byError";
+
+  // Composite aggregation source names
+  public static final String AGGREGATION_SOURCE_NAME_ERROR_CODE = "errorCode";
+  public static final String AGGREGATION_SOURCE_NAME_ERROR_MESSAGE = "errorMessage";
+
+  // Sub-aggregation name: count distinct workers
+  public static final String AGGREGATION_WORKERS = "workers";
+
+  // Default size for composite aggregation
+  public static final int AGGREGATION_COMPOSITE_SIZE = 10_000;
+
+  // Field names
+  public static final String FIELD_ERROR_CODE = "errorCode";
+  public static final String FIELD_ERROR_MESSAGE = "errorMessage";
+  public static final String FIELD_WORKER = "worker";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/JobErrorStatisticsAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/JobErrorStatisticsAggregationResult.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+import io.camunda.search.entities.JobErrorStatisticsEntity;
+import java.util.List;
+
+public record JobErrorStatisticsAggregationResult(
+    List<JobErrorStatisticsEntity> items, String endCursor)
+    implements CursorForwardPaginatedAggregationResult<JobErrorStatisticsEntity> {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobErrorStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobErrorStatisticsEntity.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+/**
+ * Represents aggregated job error statistics for a specific error type and message combination.
+ *
+ * @param errorCode the error code identifier
+ * @param errorMessage the error message
+ * @param workers the number of distinct workers that encountered this error
+ */
+public record JobErrorStatisticsEntity(String errorCode, String errorMessage, int workers) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -378,6 +378,16 @@ public final class FilterBuilders {
     return fn.apply(jobTimeSeriesStatistics()).build();
   }
 
+  public static JobErrorStatisticsFilter.Builder jobErrorStatistics() {
+    return new JobErrorStatisticsFilter.Builder();
+  }
+
+  public static JobErrorStatisticsFilter jobErrorStatistics(
+      final Function<JobErrorStatisticsFilter.Builder, ObjectBuilder<JobErrorStatisticsFilter>>
+          fn) {
+    return fn.apply(jobErrorStatistics()).build();
+  }
+
   public static GlobalListenerFilter.Builder globalListener() {
     return new GlobalListenerFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/JobErrorStatisticsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/JobErrorStatisticsFilter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Filter for job error statistics queries. Queries the job index to aggregate per-error metrics.
+ *
+ * @param from start of the time window (inclusive) to filter by job creation time
+ * @param to end of the time window (inclusive) to filter by job creation time
+ * @param jobType job type to return error metrics for (required)
+ * @param errorCodeOperations optional filter on error code
+ * @param errorMessageOperations optional filter on error message
+ */
+public record JobErrorStatisticsFilter(
+    OffsetDateTime from,
+    OffsetDateTime to,
+    String jobType,
+    List<Operation<String>> errorCodeOperations,
+    List<Operation<String>> errorMessageOperations)
+    implements FilterBase {
+
+  public static JobErrorStatisticsFilter of(
+      final Function<Builder, ObjectBuilder<JobErrorStatisticsFilter>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<JobErrorStatisticsFilter> {
+    private OffsetDateTime from;
+    private OffsetDateTime to;
+    private String jobType;
+    private List<Operation<String>> errorCodeOperations;
+    private List<Operation<String>> errorMessageOperations;
+
+    public Builder from(final OffsetDateTime from) {
+      this.from = from;
+      return this;
+    }
+
+    public Builder to(final OffsetDateTime to) {
+      this.to = to;
+      return this;
+    }
+
+    public Builder jobType(final String jobType) {
+      this.jobType = jobType;
+      return this;
+    }
+
+    public Builder errorCodeOperations(final List<Operation<String>> operations) {
+      errorCodeOperations = addValuesToList(errorCodeOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder errorCodeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return errorCodeOperations(collectValues(operation, operations));
+    }
+
+    public Builder errorMessageOperations(final List<Operation<String>> operations) {
+      errorMessageOperations = addValuesToList(errorMessageOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder errorMessageOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return errorMessageOperations(collectValues(operation, operations));
+    }
+
+    @Override
+    public JobErrorStatisticsFilter build() {
+      return new JobErrorStatisticsFilter(
+          Objects.requireNonNull(from, "from must not be null"),
+          Objects.requireNonNull(to, "to must not be null"),
+          Objects.requireNonNull(jobType, "jobType must not be null"),
+          Objects.requireNonNullElse(errorCodeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(errorMessageOperations, Collections.emptyList()));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/JobErrorStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/JobErrorStatisticsQuery.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.aggregation.JobErrorStatisticsAggregation;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobErrorStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Query for retrieving per-error statistics aggregated over jobs.
+ *
+ * @param filter the filter criteria
+ * @param page pagination parameters
+ */
+public record JobErrorStatisticsQuery(JobErrorStatisticsFilter filter, SearchQueryPage page)
+    implements TypedSearchAggregationQuery<
+        JobErrorStatisticsFilter, NoSort, JobErrorStatisticsAggregation> {
+
+  public static JobErrorStatisticsQuery of(
+      final Function<Builder, ObjectBuilder<JobErrorStatisticsQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public NoSort sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
+  public JobErrorStatisticsAggregation aggregation() {
+    return new JobErrorStatisticsAggregation(page);
+  }
+
+  @Override
+  public SearchQueryPage page() {
+    return page;
+  }
+
+  public static final class Builder
+      extends SearchQueryBase.AbstractQueryBuilder<JobErrorStatisticsQuery.Builder>
+      implements TypedSearchQueryBuilder<
+          JobErrorStatisticsQuery,
+          JobErrorStatisticsQuery.Builder,
+          JobErrorStatisticsFilter,
+          NoSort> {
+
+    private JobErrorStatisticsFilter filter;
+    private SearchQueryPage page;
+
+    @Override
+    public Builder filter(final JobErrorStatisticsFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final NoSort value) {
+      return this;
+    }
+
+    public Builder filter(
+        final Function<JobErrorStatisticsFilter.Builder, ObjectBuilder<JobErrorStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.jobErrorStatistics(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public Builder page(final SearchQueryPage page) {
+      this.page = page;
+      return this;
+    }
+
+    @Override
+    public Builder page(
+        final Function<SearchQueryPage.Builder, ObjectBuilder<SearchQueryPage>> fn) {
+      return page(SearchQueryPage.of(fn));
+    }
+
+    @Override
+    public JobErrorStatisticsQuery build() {
+      return new JobErrorStatisticsQuery(
+          Objects.requireNonNull(filter, "filter must not be null"), page);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -52,6 +52,10 @@ public final class SearchQueryBuilders {
     return new JobTimeSeriesStatisticsQuery.Builder();
   }
 
+  public static JobErrorStatisticsQuery.Builder jobErrorStatisticsSearchQuery() {
+    return new JobErrorStatisticsQuery.Builder();
+  }
+
   public static ProcessInstanceQuery processInstanceSearchQuery(
       final Function<ProcessInstanceQuery.Builder, ObjectBuilder<ProcessInstanceQuery>> fn) {
     return fn.apply(processInstanceSearchQuery()).build();

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -12,10 +12,12 @@ import static io.camunda.service.authorization.Authorizations.JOB_READ_AUTHORIZA
 import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
@@ -189,6 +191,17 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
                     securityContextProvider.provideSecurityContext(
                         authentication, Authorization.of(a -> a.system().readJobMetric())))
                 .getJobTimeSeriesStatistics(query));
+  }
+
+  public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
+      final JobErrorStatisticsQuery query) {
+    return executeSearchRequest(
+        () ->
+            jobSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, JOB_READ_AUTHORIZATION))
+                .getJobErrorStatistics(query));
   }
 
   public record ActivateJobsRequest(

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -147,6 +147,37 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 
+  /jobs/statistics/errors:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Job
+      operationId: getJobErrorStatistics
+      summary: Get error metrics for a job type
+      description: |
+        Returns aggregated metrics per error for the given jobType.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobErrorStatisticsQuery'
+      responses:
+        "200":
+          description: The job error statistics result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobErrorStatisticsQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+
 ## Schema definitions
 
 components:
@@ -422,3 +453,85 @@ components:
         failed:
           $ref: '#/components/schemas/StatusMetric'
 
+    JobErrorStatisticsQuery:
+      description: Job error statistics query.
+      type: object
+      required:
+        - filter
+      properties:
+        filter:
+          $ref: '#/components/schemas/JobErrorStatisticsFilter'
+        page:
+          description: Search cursor pagination.
+          allOf:
+            - $ref: 'search-models.yaml#/components/schemas/CursorForwardPagination'
+
+    JobErrorStatisticsFilter:
+      description: Job error statistics search filter.
+      type: object
+      required:
+        - from
+        - to
+        - jobType
+      properties:
+        from:
+          description: |
+            Start of the time window to filter metrics. ISO 8601 date-time format.
+          type: string
+          format: date-time
+          example: "2024-07-28T15:51:28.071Z"
+        to:
+          description: |
+            End of the time window to filter metrics. ISO 8601 date-time format.
+          type: string
+          format: date-time
+          example: "2024-07-29T15:51:28.071Z"
+        jobType:
+          description: Job type to return error metrics for.
+          type: string
+          example: "fetch-customer-data"
+        errorCode:
+          description: Optional error code filter with advanced search capabilities.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+        errorMessage:
+          description: Optional error message filter with advanced search capabilities.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+
+    JobErrorStatisticsQueryResult:
+      description: Job error statistics query result.
+      type: object
+      required:
+        - items
+        - page
+      allOf:
+        - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The list of per-error statistics items.
+          type: array
+          items:
+            $ref: '#/components/schemas/JobErrorStatisticsItem'
+
+    JobErrorStatisticsItem:
+      description: Aggregated error metrics for a single error type and message combination.
+      type: object
+      required:
+        - errorCode
+        - errorMessage
+        - workers
+      properties:
+        errorCode:
+          description: The error code identifier.
+          type: string
+          example: "UNHANDLED_ERROR_EVENT"
+        errorMessage:
+          description: The error message.
+          type: string
+          example: "An unexpected error occurred."
+        workers:
+          description: Number of distinct workers that encountered this error.
+          type: integer
+          format: int32
+          example: 15

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -243,6 +243,8 @@ paths:
     $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1by-workers'
   /jobs/statistics/time-series:
     $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1time-series'
+  /jobs/statistics/errors:
+    $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1errors'
 
   # License endpoints
   /license:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -21,6 +21,8 @@ import io.camunda.gateway.protocol.model.JobActivationRequest;
 import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.gateway.protocol.model.JobCompletionRequest;
 import io.camunda.gateway.protocol.model.JobErrorRequest;
+import io.camunda.gateway.protocol.model.JobErrorStatisticsQuery;
+import io.camunda.gateway.protocol.model.JobErrorStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobFailRequest;
 import io.camunda.gateway.protocol.model.JobSearchQuery;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
@@ -148,6 +150,14 @@ public class JobController {
         .fold(RestErrorMapper::mapProblemToResponse, this::getTimeSeriesStatistics);
   }
 
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/statistics/errors")
+  public ResponseEntity<JobErrorStatisticsQueryResult> getJobErrorStatistics(
+      @RequestBody final JobErrorStatisticsQuery request) {
+    return SearchQueryRequestMapper.toJobErrorStatisticsQuery(request)
+        .fold(RestErrorMapper::mapProblemToResponse, this::getErrorStatistics);
+  }
+
   private CompletableFuture<ResponseEntity<Object>> activateJobs(
       final ActivateJobsRequest activationRequest) {
     final var result = new CompletableFuture<ResponseEntity<Object>>();
@@ -272,6 +282,19 @@ public class JobController {
               .getJobTimeSeriesStatistics(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toJobTimeSeriesStatisticsQueryResult(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private ResponseEntity<JobErrorStatisticsQueryResult> getErrorStatistics(
+      final io.camunda.search.query.JobErrorStatisticsQuery query) {
+    try {
+      final var result =
+          jobServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .getJobErrorStatistics(query);
+      return ResponseEntity.ok(SearchQueryResponseMapper.toJobErrorStatisticsQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
@@ -2147,6 +2148,249 @@ public class JobControllerTest extends RestControllerTest {
     webClient
         .post()
         .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  // -------------------------------------------------------------------------
+  // /statistics/errors tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldGetJobErrorStatistics() {
+    // given
+    final var entity1 =
+        new JobErrorStatisticsEntity("UNHANDLED_ERROR_EVENT", "An unexpected error occurred.", 15);
+    final var entity2 =
+        new JobErrorStatisticsEntity("IO_ERROR", "Failed to read from remote server.", 3);
+
+    final var searchResult =
+        new SearchQueryResult.Builder<JobErrorStatisticsEntity>()
+            .total(2L, true)
+            .items(List.of(entity1, entity2))
+            .endCursor("endCursor")
+            .build();
+
+    when(jobServices.getJobErrorStatistics(any())).thenReturn(searchResult);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    final var expectedResponse =
+        """
+            {
+              "items": [
+                {
+                  "errorCode": "UNHANDLED_ERROR_EVENT",
+                  "errorMessage": "An unexpected error occurred.",
+                  "workers": 15
+                },
+                {
+                  "errorCode": "IO_ERROR",
+                  "errorMessage": "Failed to read from remote server.",
+                  "workers": 3
+                }
+              ],
+              "page": {
+                "totalItems": 2,
+                "startCursor": null,
+                "endCursor": "endCursor",
+                "hasMoreTotalItems": true
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/errors")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldGetJobErrorStatisticsWithOptionalFilters() {
+    // given
+    final var entity =
+        new JobErrorStatisticsEntity("UNHANDLED_ERROR_EVENT", "An unexpected error.", 5);
+
+    final var searchResult =
+        new SearchQueryResult.Builder<JobErrorStatisticsEntity>()
+            .total(1L)
+            .items(List.of(entity))
+            .build();
+
+    when(jobServices.getJobErrorStatistics(any())).thenReturn(searchResult);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data",
+                "errorCode": { "$like": "UNHANDLED_*" },
+                "errorMessage": { "$like": "unexpected*" }
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/errors")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("$.items[0].errorCode")
+        .isEqualTo("UNHANDLED_ERROR_EVENT")
+        .jsonPath("$.items[0].workers")
+        .isEqualTo(5);
+  }
+
+  @Test
+  void shouldRejectJobErrorStatisticsWithMissingBody() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "Bad Request",
+              "detail": "Required request body is missing",
+              "instance": "%s"
+            }"""
+            .formatted(JOBS_BASE_URL + "/statistics/errors");
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/errors")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobErrorStatisticsWithMissingFilter() {
+    // given
+    final var request = "{}";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/errors")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobErrorStatisticsWithMissingFrom() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/errors")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobErrorStatisticsWithMissingTo() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/errors")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobErrorStatisticsWithMissingJobType() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/errors")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)


### PR DESCRIPTION
## Description

This pull request introduces support for querying time-bucketed job metrics (time series statistics) for a specific job type in the Java client. It adds a new API for building and executing these requests, as well as the corresponding response types and implementation logic.

New API for job time-series statistics:

* Added a new method `newJobTimeSeriesStatisticsRequest` to the `CamundaClient` interface and its implementation, allowing users to build requests for fetching time-bucketed job metrics by job type. [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR1046-R1063) [[2]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R957-R963)
* Introduced the `JobTimeSeriesStatisticsRequest` interface for configuring and sending time series statistics queries, including support for specifying time ranges, job type, resolution, and pagination.
* Implemented the request logic in `JobTimeSeriesStatisticsRequestImpl`, handling request construction, parameter mapping, and HTTP invocation.

Response types and mapping:

* Added `JobTimeSeriesStatistics` and `JobTimeSeriesStatisticsItem` interfaces to represent the response structure, including time buckets and job status metrics. [[1]](diffhunk://#diff-a20ae9bfe9538bbdaedd178d64855b87de75a11619bd1aeca2fcc65b07cd0d71R1-R21) [[2]](diffhunk://#diff-dd0f70412d08de3ee9496518d4c948583ee9b080c3a4c394f8d61acee4132a55R1-R50)
* Implemented concrete response classes (`JobTimeSeriesStatisticsImpl`, `JobTimeSeriesStatisticsItemImpl`) and extended `StatisticsResponseMapper` to map protocol responses to these types. [[1]](diffhunk://#diff-b305776dede60abf8f55381eeece3fd7aadbbe8345fb0a2837a539e16a78a484R1-R66) [[2]](diffhunk://#diff-4fd6c6bdb78ad38bf92d42e3c3e18aba1ea8aec9ec66e8657d40da7e804e8e82R1-R94) [[3]](diffhunk://#diff-15258458de0c634b01308a375c589bbbcbeae4ccab4250fdddfc742090a5eafdR231-R250)

Supporting code changes:

* Updated imports and registration throughout the client and implementation classes to support the new request and response types. [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR183) [[2]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R194) [[3]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R370) [[4]](diffhunk://#diff-15258458de0c634b01308a375c589bbbcbeae4ccab4250fdddfc742090a5eafdR27-R28) [[5]](diffhunk://#diff-15258458de0c634b01308a375c589bbbcbeae4ccab4250fdddfc742090a5eafdR44)

These changes enable users of the Java client to efficiently query and analyze job metrics over time for specific job types, supporting advanced monitoring and reporting use cases.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43050
