### PR TITLE
fix: Element instance IDs do not get updated after user task migration

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
@@ -48,14 +48,11 @@ public class ListViewFlowNodeFromJobHandler
 
   @Override
   public boolean handlesRecord(final Record<JobRecordValue> record) {
-    // do not handle record if the job is executed on a process instance instead of a flow node
-    // instance
     final var recordValue = record.getValue();
-    // only execute update if job is on a flownode (not on a process)
-    if (recordValue.getElementInstanceKey() == recordValue.getProcessInstanceKey()) {
-      return false;
-    }
-    return true;
+    // only execute update if job is on a flownode instance (not on a process instance)
+    // only execute update if it's not a job cancellation from a user task implementation migration
+    return recordValue.getElementInstanceKey() != recordValue.getProcessInstanceKey()
+        && !recordValue.isJobToUserTaskMigration();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
@@ -61,7 +61,7 @@ public class ListViewFlowNodeFromJobHandlerTest {
   }
 
   @Test
-  public void shouldNotHandlesRecord() {
+  public void shouldNotHandlesRecordOfProcessInstances() {
     // given
     final Record<JobRecordValue> jobRecord =
         factory.generateRecord(
@@ -72,6 +72,25 @@ public class ListViewFlowNodeFromJobHandlerTest {
                             .withProcessDefinitionKey(1L)
                             .withElementInstanceKey(111L)
                             .withProcessInstanceKey(111L)
+                            .build())
+                    .withKey(111L));
+    // when - then
+    assertThat(underTest.handlesRecord(jobRecord)).isFalse();
+  }
+
+  @Test
+  public void shouldNotHandlesRecordOfUserTaskImplementationMigration() {
+    // given
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            r ->
+                r.withValueType(ValueType.JOB)
+                    .withValue(
+                        ImmutableJobRecordValue.builder()
+                            .withProcessDefinitionKey(1L)
+                            .withElementInstanceKey(111L)
+                            .withProcessInstanceKey(222L)
+                            .withJobToUserTaskMigration(true)
                             .build())
                     .withKey(111L));
     // when - then


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes updated flownode entities getting overwritten by the canceled job record of a camunda user task migration.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/47609
