### PR TITLE
perf: optimize tree path calculation

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -198,12 +198,21 @@ public class FlowNodeInstanceFromProcessInstanceHandler
   private static void setTreePath(
       final Record<ProcessInstanceRecordValue> record, final FlowNodeInstanceEntity entity) {
     final var recordValue = record.getValue();
-    if (recordValue.getElementInstancePath() != null
-        && !recordValue.getElementInstancePath().isEmpty()) {
-
-      final List<String> treePathEntries =
-          recordValue.getElementInstancePath().getLast().stream().map(String::valueOf).toList();
-      final String treePath = String.join("/", treePathEntries);
+    final var elementInstancePath = recordValue.getElementInstancePath();
+    if (elementInstancePath != null && !elementInstancePath.isEmpty()) {
+      final var pathWithinProcessInstance = elementInstancePath.getLast();
+      // Keys are usually 16 characters + 1 for the '/' character
+      final var treePathEntries = pathWithinProcessInstance.size();
+      final var expectedPathLength = (16 + 1) * treePathEntries;
+      final var treePathBuilder = new StringBuilder(expectedPathLength);
+      for (int i = 0; i < treePathEntries; i++) {
+        final var pathEntry = pathWithinProcessInstance.get(i);
+        treePathBuilder.append((long) pathEntry);
+        if (i != treePathEntries - 1) {
+          treePathBuilder.append("/");
+        }
+      }
+      final String treePath = treePathBuilder.toString();
 
       // Apply truncation for extremely deep nesting scenarios
       if (treePath.length() > MAX_TREE_PATH_LENGTH) {
@@ -211,7 +220,7 @@ public class FlowNodeInstanceFromProcessInstanceHandler
       } else {
         entity.setTreePath(treePath);
       }
-      entity.setLevel(treePathEntries.size() - 1);
+      entity.setLevel(treePathEntries - 1);
     } else {
       LOGGER.warn(
           "No elementInstancePath is provided for flow node instance id: {}. TreePath will be set to default value.",

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -215,12 +215,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   @Override
   public List<List<Long>> getElementInstancePath() {
     final var elementInstancePath = new ArrayList<List<Long>>(elementInstancePathProp.size());
-    elementInstancePathProp.forEach(
-        pe -> {
-          final var pathEntry = new ArrayList<Long>(pe.size());
-          pe.forEach(e -> pathEntry.add(e.getValue()));
-          elementInstancePath.add(pathEntry);
-        });
+    for (final var pe : elementInstancePathProp) {
+      final var pathEntry = new ArrayList<Long>(pe.size());
+      for (final var e : pe) {
+        pathEntry.add(e.getValue());
+      }
+      elementInstancePath.add(pathEntry);
+    }
     return elementInstancePath;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -214,10 +214,10 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   @Override
   public List<List<Long>> getElementInstancePath() {
-    final var elementInstancePath = new ArrayList<List<Long>>();
+    final var elementInstancePath = new ArrayList<List<Long>>(elementInstancePathProp.size());
     elementInstancePathProp.forEach(
         pe -> {
-          final var pathEntry = new ArrayList<Long>();
+          final var pathEntry = new ArrayList<Long>(pe.size());
           pe.forEach(e -> pathEntry.add(e.getValue()));
           elementInstancePath.add(pathEntry);
         });


### PR DESCRIPTION
This optimizes how the exporter determines the element tree path.

Spotted here:
<img width="2278" height="1231" alt="image" src="https://github.com/user-attachments/assets/02f65ac0-793b-4e8e-b233-c853713307b1" />
