### PR TITLE
feat: add Camunda release load test workflow

### DIFF
--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -1,0 +1,171 @@
+# description: Create a Camunda load test for a given release.
+#              Abstraction layer of the actual load test creation process, to define a clear API between release process and the load test workflows.
+#              Public API - accepting inputs for test name and tag.
+#              To validate that load test creation works; we regularly run this workflow via schedule.
+#              The create load test (created by scheduled) is deleted after a fixed time (15 mins) to avoid unnecessary costs.
+# type: CI
+# owner @camunda/reliability-testing
+name: Camunda Release load test workflow
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Specifies the name of the load test'
+        type: string
+        required: true
+      tag:
+        description: 'Specifies the tag that should be used for the release load test'
+        type: string
+        required: true
+# This workflow is also scheduled to run daily with default values for the test name and tag, allowing for regular sanity check whether load testing creation works
+  schedule:
+    - cron: '0 4 * * *' # every day at 04:00
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+# Define environment variables for the workflow, allowing for default values (used on schedule) that can be overridden by workflow inputs
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+
+jobs:
+  sanitize-inputs:
+    name: Sanitize test inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      sanitized-name: c8-${{ steps.sanitize.outputs.branch_name }}
+      test-tag: ${{ steps.prepare_tag.outputs.test-tag }}
+    steps:
+      - id: sanitize
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@main
+        with:
+          branch: ${{ inputs.name || 'dry-run-release-8-8-x' }}
+          max_length: 50  # reduced to account for load-test prefix "c8-" and potential suffixes for uniqueness
+      # We prepare the tag to default to '8.8.3' if not provided, to ensure that the load test creation can proceed with a valid tag even in the case of missing input (e.g., during schedule runs)
+      - id: prepare_tag
+        run: echo "test-tag=${{ inputs.tag || '8.8.3' }}" >> "$GITHUB_OUTPUT"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  create-load-test:
+    name: Create release load test
+    needs: sanitize-inputs
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}
+      ref: ${{ needs.sanitize-inputs.outputs.test-tag }}
+      reuse-tag: ${{ needs.sanitize-inputs.outputs.test-tag }}
+      ttl: 60
+      use-official-docker-images: true
+      scenario: 'realistic'
+
+  await-load-test:
+    name: Await Load Test
+    needs: [sanitize-inputs, create-load-test]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Wait for load test to stabilize
+        run: sleep 900  # 15 minutes
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  delete-load-test:
+    name: Benchmark Cleanup
+    needs: [sanitize-inputs, await-load-test, create-load-test]
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 17.2.2
+
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+
+      - name: Delete benchmarks
+        run: |
+          kubectl delete ns "${{ needs.sanitize-inputs.outputs.sanitized-name }}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  notify-on-failure:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [sanitize-inputs, create-load-test, await-load-test, delete-load-test]
+    if: failure()
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v6
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *${{ github.event_name != 'workflow_dispatch' && '[Dry-run]:' || ':alarm:' }}Release load test creation failed:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@reliability-testing-team Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

* Adds a new abstraction layer - GitHub workflow to be the interface for the release process and our load test workflows
* Clearly define the API with just a name and a tag
* Adding dry run possibility via schedule to the workflow to make sure this workflow is working fine all the time

## Related issues

related to https://github.com/camunda/camunda/issues/47622 

But just the first stop of multiple - we need to validate whether this works and then backport this to the other branches, afterwards adjust the release process
