### PR TITLE
Add active PI metrics

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -233,8 +233,8 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 2,
-            "w": 9,
+            "h": 3,
+            "w": 3,
             "x": 8,
             "y": 1
           },
@@ -271,6 +271,80 @@
             }
           ],
           "title": "Banned instances",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Shows the count of active process instances in the partition.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "index": 0,
+                      "text": "None"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 11,
+            "y": 1
+          },
+          "id": 709,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max(zeebe_active_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (partition)",
+              "legendFormat": "Partition-{{partition}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Active instances",
           "type": "stat"
         },
         {
@@ -418,7 +492,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 4,
+            "h": 3,
             "w": 9,
             "x": 8,
             "y": 3

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -141,13 +141,13 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
     }
   },
 
-  /** Number of currently active root process instances */
-  ACTIVE_ROOT_PROCESS_INSTANCES {
+  /** Number of currently active process instances */
+  ACTIVE_PROCESS_INSTANCES {
     private static final KeyName[] KEY_NAMES = new KeyName[] {EngineKeyNames.ORGANIZATION_ID};
 
     @Override
     public String getDescription() {
-      return "Number of currently active root process instances";
+      return "Number of currently active process instances";
     }
 
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -141,6 +141,36 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
     }
   },
 
+  /** Number of currently active root process instances */
+  ACTIVE_ROOT_PROCESS_INSTANCES {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {EngineKeyNames.ORGANIZATION_ID};
+
+    @Override
+    public String getDescription() {
+      return "Number of currently active root process instances";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.active.instances.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
   /** Number of banned instances */
   BANNED_INSTANCES {
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -36,13 +36,13 @@ public final class ProcessEngineMetrics {
       Map3D.ofEnum(EngineAction.class, BpmnElementType.class, BpmnEventType.class, Counter[]::new);
   private final Map<EngineAction, Counter> executedEvents = new EnumMap<>(EngineAction.class);
   private final Map<EngineAction, Counter> evaluatedDmnElements = new EnumMap<>(EngineAction.class);
-  private final AtomicLong activeRootProcessInstances = new AtomicLong(0);
-  private boolean isActiveRootProcessInstanceGaugeRegistered = false;
+  private final AtomicLong activeProcessInstances = new AtomicLong(0);
+  private boolean isActiveProcessInstanceGaugeRegistered = false;
 
   public ProcessEngineMetrics(
       final MeterRegistry registry, final long initialActiveRootProcessInstances) {
     this.registry = Objects.requireNonNull(registry, "must specify a registry");
-    activeRootProcessInstances.set(initialActiveRootProcessInstances);
+    activeProcessInstances.set(initialActiveRootProcessInstances);
   }
 
   public void processInstanceCreated(final ProcessInstanceCreationRecord instanceCreationRecord) {
@@ -62,9 +62,12 @@ public final class ProcessEngineMetrics {
     final var eventTypeName = extractEventTypeName(eventType);
     elementInstanceEvent(EngineAction.ACTIVATED, elementType, eventTypeName);
 
+    if (isProcessInstance(elementType)) {
+      increaseActiveProcessInstances();
+    }
+
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
       increaseRootProcessInstance(EngineAction.ACTIVATED);
-      increaseActiveRootProcessInstances();
     }
   }
 
@@ -74,9 +77,12 @@ public final class ProcessEngineMetrics {
     final var eventTypeName = extractEventTypeName(eventType);
     elementInstanceEvent(EngineAction.COMPLETED, elementType, eventTypeName);
 
+    if (isProcessInstance(elementType)) {
+      decreaseActiveRootProcessInstances();
+    }
+
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
       increaseRootProcessInstance(EngineAction.COMPLETED);
-      decreaseActiveRootProcessInstances();
     }
   }
 
@@ -86,9 +92,12 @@ public final class ProcessEngineMetrics {
     final var eventTypeName = extractEventTypeName(eventType);
     elementInstanceEvent(EngineAction.TERMINATED, elementType, eventTypeName);
 
+    if (isProcessInstance(elementType)) {
+      decreaseActiveRootProcessInstances();
+    }
+
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
       increaseRootProcessInstance(EngineAction.TERMINATED);
-      decreaseActiveRootProcessInstances();
     }
   }
 
@@ -107,14 +116,14 @@ public final class ProcessEngineMetrics {
         .increment();
   }
 
-  private void increaseActiveRootProcessInstances() {
-    registerActiveRootProcessInstanceGaugeIfNeeded();
-    activeRootProcessInstances.incrementAndGet();
+  private void increaseActiveProcessInstances() {
+    registerActiveProcessInstanceGaugeIfNeeded();
+    activeProcessInstances.incrementAndGet();
   }
 
   private void decreaseActiveRootProcessInstances() {
-    registerActiveRootProcessInstanceGaugeIfNeeded();
-    activeRootProcessInstances.decrementAndGet();
+    registerActiveProcessInstanceGaugeIfNeeded();
+    activeProcessInstances.decrementAndGet();
   }
 
   private void increaseRootProcessInstance(final EngineAction action) {
@@ -181,14 +190,14 @@ public final class ProcessEngineMetrics {
         .register(registry);
   }
 
-  private void registerActiveRootProcessInstanceGaugeIfNeeded() {
-    if (!isActiveRootProcessInstanceGaugeRegistered) {
-      final var meterDoc = EngineMetricsDoc.ACTIVE_ROOT_PROCESS_INSTANCES;
-      Gauge.builder(meterDoc.getName(), activeRootProcessInstances, AtomicLong::get)
+  private void registerActiveProcessInstanceGaugeIfNeeded() {
+    if (!isActiveProcessInstanceGaugeRegistered) {
+      final var meterDoc = EngineMetricsDoc.ACTIVE_PROCESS_INSTANCES;
+      Gauge.builder(meterDoc.getName(), activeProcessInstances, AtomicLong::get)
           .description(meterDoc.getDescription())
           .tag(EngineKeyNames.ORGANIZATION_ID.asString(), ORGANIZATION_ID)
           .register(registry);
-      isActiveRootProcessInstanceGaugeRegistered = true;
+      isActiveProcessInstanceGaugeRegistered = true;
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -16,10 +16,12 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.util.collection.Map3D;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class ProcessEngineMetrics {
 
@@ -34,9 +36,13 @@ public final class ProcessEngineMetrics {
       Map3D.ofEnum(EngineAction.class, BpmnElementType.class, BpmnEventType.class, Counter[]::new);
   private final Map<EngineAction, Counter> executedEvents = new EnumMap<>(EngineAction.class);
   private final Map<EngineAction, Counter> evaluatedDmnElements = new EnumMap<>(EngineAction.class);
+  private final AtomicLong activeRootProcessInstances = new AtomicLong(0);
+  private boolean isActiveRootProcessInstanceGaugeRegistered = false;
 
-  public ProcessEngineMetrics(final MeterRegistry registry) {
+  public ProcessEngineMetrics(
+      final MeterRegistry registry, final long initialActiveRootProcessInstances) {
     this.registry = Objects.requireNonNull(registry, "must specify a registry");
+    activeRootProcessInstances.set(initialActiveRootProcessInstances);
   }
 
   public void processInstanceCreated(final ProcessInstanceCreationRecord instanceCreationRecord) {
@@ -58,6 +64,7 @@ public final class ProcessEngineMetrics {
 
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
       increaseRootProcessInstance(EngineAction.ACTIVATED);
+      increaseActiveRootProcessInstances();
     }
   }
 
@@ -69,6 +76,7 @@ public final class ProcessEngineMetrics {
 
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
       increaseRootProcessInstance(EngineAction.COMPLETED);
+      decreaseActiveRootProcessInstances();
     }
   }
 
@@ -80,6 +88,7 @@ public final class ProcessEngineMetrics {
 
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
       increaseRootProcessInstance(EngineAction.TERMINATED);
+      decreaseActiveRootProcessInstances();
     }
   }
 
@@ -96,6 +105,16 @@ public final class ProcessEngineMetrics {
     elementInstanceEvents
         .computeIfAbsent(action, elementType, eventType, this::registerElementInstanceEventCounter)
         .increment();
+  }
+
+  private void increaseActiveRootProcessInstances() {
+    registerActiveRootProcessInstanceGaugeIfNeeded();
+    activeRootProcessInstances.incrementAndGet();
+  }
+
+  private void decreaseActiveRootProcessInstances() {
+    registerActiveRootProcessInstanceGaugeIfNeeded();
+    activeRootProcessInstances.decrementAndGet();
   }
 
   private void increaseRootProcessInstance(final EngineAction action) {
@@ -160,5 +179,16 @@ public final class ProcessEngineMetrics {
         .tag(EngineKeyNames.ACTION.asString(), engineAction.toString())
         .tag(EngineKeyNames.ORGANIZATION_ID.asString(), ORGANIZATION_ID)
         .register(registry);
+  }
+
+  private void registerActiveRootProcessInstanceGaugeIfNeeded() {
+    if (!isActiveRootProcessInstanceGaugeRegistered) {
+      final var meterDoc = EngineMetricsDoc.ACTIVE_ROOT_PROCESS_INSTANCES;
+      Gauge.builder(meterDoc.getName(), activeRootProcessInstances, AtomicLong::get)
+          .description(meterDoc.getDescription())
+          .tag(EngineKeyNames.ORGANIZATION_ID.asString(), ORGANIZATION_ID)
+          .register(registry);
+      isActiveRootProcessInstanceGaugeRegistered = true;
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -128,7 +128,7 @@ public final class EngineProcessors {
     final var processEngineMetrics =
         new ProcessEngineMetrics(
             typedRecordProcessorContext.getMeterRegistry(),
-            processingState.getElementInstanceState().getActiveRootProcessInstanceCount());
+            processingState.getElementInstanceState().getActiveProcessInstanceCount());
     final var distributionMetrics =
         new DistributionMetrics(typedRecordProcessorContext.getMeterRegistry());
     final var batchOperationMetrics =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -126,7 +126,9 @@ public final class EngineProcessors {
 
     final var jobMetrics = new JobProcessingMetrics(typedRecordProcessorContext.getMeterRegistry());
     final var processEngineMetrics =
-        new ProcessEngineMetrics(typedRecordProcessorContext.getMeterRegistry());
+        new ProcessEngineMetrics(
+            typedRecordProcessorContext.getMeterRegistry(),
+            processingState.getElementInstanceState().getActiveRootProcessInstanceCount());
     final var distributionMetrics =
         new DistributionMetrics(typedRecordProcessorContext.getMeterRegistry());
     final var batchOperationMetrics =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -171,6 +171,16 @@ public interface ElementInstanceState {
       String tenantId,
       final Predicate<Long> ignoreWhen);
 
+  /**
+   * Returns the number of active root process instances. This includes all root process instances
+   * that are currently active, regardless of their process definition. This method is useful for
+   * monitoring and metrics purposes, as it provides insight into the overall number of active root
+   * process instances in the system.
+   *
+   * @return the number of active root process instances.
+   */
+  long getActiveRootProcessInstanceCount();
+
   @FunctionalInterface
   interface TakenSequenceFlowVisitor {
     void visit(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -172,14 +172,14 @@ public interface ElementInstanceState {
       final Predicate<Long> ignoreWhen);
 
   /**
-   * Returns the number of active root process instances. This includes all root process instances
-   * that are currently active, regardless of their process definition. This method is useful for
-   * monitoring and metrics purposes, as it provides insight into the overall number of active root
-   * process instances in the system.
+   * Returns the number of active process instances. This includes all process instances that are
+   * currently active, regardless of their process definition. This method is useful for monitoring
+   * and metrics purposes, as it provides insight into the overall number of active process
+   * instances in the system.
    *
-   * @return the number of active root process instances.
+   * @return the number of active process instances.
    */
-  long getActiveRootProcessInstanceCount();
+  long getActiveProcessInstanceCount();
 
   @FunctionalInterface
   interface TakenSequenceFlowVisitor {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -639,7 +639,9 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
   @Override
   public long getActiveProcessInstanceCount() {
-    return activeProcessInstanceCounterColumnFamily.get(activeProcessInstanceCounterKey).getValue();
+    final var counter =
+        activeProcessInstanceCounterColumnFamily.get(activeProcessInstanceCounterKey);
+    return counter != null ? counter.getValue() : 0L;
   }
 
   private void removeNumberOfTakenSequenceFlows(final long flowScopeKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -222,13 +222,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     variableState.removeScope(key);
     awaitProcessInstanceResultMetadataColumnFamily.deleteIfExists(elementInstanceKey);
     removeNumberOfTakenSequenceFlows(key);
-    decrementActiveProcessInstanceCount();
 
     final var recordValue = instance.getValue();
     if (recordValue.getBpmnElementType() == BpmnElementType.PROCESS) {
       processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
       processInstanceKeyByProcessDefinitionKeyColumnFamily.deleteExisting(
           processInstanceKeyByProcessDefinitionKey);
+      decrementActiveProcessInstanceCount();
     }
 
     if (parent > 0) {
@@ -252,13 +252,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     elementInstanceColumnFamily.insert(elementInstanceKey, instance);
     parentChildColumnFamily.insert(parentChildKey, DbNil.INSTANCE);
     variableState.createScope(elementInstanceKey.getValue(), parentKey.inner().getValue());
-    incrementActiveProcessInstanceCount();
 
     final var recordValue = instance.getValue();
     if (recordValue.getBpmnElementType() == BpmnElementType.PROCESS) {
       processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
       processInstanceKeyByProcessDefinitionKeyColumnFamily.insert(
           processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
+      incrementActiveProcessInstanceCount();
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -40,19 +40,18 @@ import org.agrona.collections.MutableInteger;
 
 public final class DbElementInstanceState implements MutableElementInstanceState {
 
+  // Root process instance counter
+  private static final long ROOT_PROCESS_INSTANCE_COUNTER_KEY = 1L;
   private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>>, DbNil>
       parentChildColumnFamily;
   private final DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>> parentChildKey;
   private final DbForeignKey<DbLong> parentKey;
-
   private final DbLong elementInstanceKey;
   private final ElementInstance elementInstance;
   private final ColumnFamily<DbLong, ElementInstance> elementInstanceColumnFamily;
-
   private final AwaitProcessInstanceResultMetadata awaitResultMetadata;
   private final ColumnFamily<DbLong, AwaitProcessInstanceResultMetadata>
       awaitProcessInstanceResultMetadataColumnFamily;
-
   private final DbLong flowScopeKey = new DbLong();
   private final DbString gatewayElementId = new DbString();
   private final DbString sequenceFlowElementId = new DbString();
@@ -68,7 +67,6 @@ public final class DbElementInstanceState implements MutableElementInstanceState
       numberOfTakenSequenceFlowsColumnFamily;
 
   private final MutableVariableState variableState;
-
   private final DbLong processDefinitionKey;
   private final DbCompositeKey<DbLong, DbLong> processInstanceKeyByProcessDefinitionKey;
 
@@ -88,6 +86,9 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   private final ProcessInstanceByBusinessIdIndexKey processInstanceByBusinessIdIndexKey;
   private final ColumnFamily<ProcessInstanceByBusinessIdIndexKey, DbNil>
       processInstanceByBusinessIdIndexKeyColumnFamily;
+  private final DbLong rootProcessInstanceCounterKey;
+  private final DbLong rootProcessInstanceCounterValue;
+  private final ColumnFamily<DbLong, DbLong> rootProcessInstanceCounterColumnFamily;
 
   public DbElementInstanceState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -168,6 +169,18 @@ public final class DbElementInstanceState implements MutableElementInstanceState
             transactionContext,
             processInstanceByBusinessIdIndexKey,
             DbNil.INSTANCE);
+
+    rootProcessInstanceCounterKey = new DbLong();
+    rootProcessInstanceCounterKey.wrapLong(ROOT_PROCESS_INSTANCE_COUNTER_KEY);
+    rootProcessInstanceCounterValue = new DbLong();
+    rootProcessInstanceCounterColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.ROOT_PROCESS_INSTANCE_COUNT,
+            transactionContext,
+            rootProcessInstanceCounterKey,
+            rootProcessInstanceCounterValue);
+    // only relevant after a migration
+    initializeRootProcessInstanceCounterIfNeeded();
   }
 
   @Override
@@ -215,6 +228,11 @@ public final class DbElementInstanceState implements MutableElementInstanceState
       processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
       processInstanceKeyByProcessDefinitionKeyColumnFamily.deleteExisting(
           processInstanceKeyByProcessDefinitionKey);
+
+      // Decrement the root process instance counter for root instances (no parent)
+      if (parent == -1) {
+        decrementActiveRootProcessInstanceCount();
+      }
     }
 
     if (parent > 0) {
@@ -244,6 +262,11 @@ public final class DbElementInstanceState implements MutableElementInstanceState
       processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
       processInstanceKeyByProcessDefinitionKeyColumnFamily.insert(
           processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
+
+      // Increment the root process instance counter for root instances (no parent)
+      if (instance.getParentKey() == -1) {
+        incrementActiveRootProcessInstanceCount();
+      }
     }
   }
 
@@ -386,6 +409,50 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
     processInstanceByBusinessIdIndexKeyColumnFamily.deleteExisting(
         processInstanceByBusinessIdIndexKey);
+  }
+
+  private void incrementActiveRootProcessInstanceCount() {
+    final var currentValue =
+        rootProcessInstanceCounterColumnFamily.get(rootProcessInstanceCounterKey);
+
+    final long newValue = currentValue.getValue() + 1;
+
+    rootProcessInstanceCounterValue.wrapLong(newValue);
+    rootProcessInstanceCounterColumnFamily.update(
+        rootProcessInstanceCounterKey, rootProcessInstanceCounterValue);
+  }
+
+  private void decrementActiveRootProcessInstanceCount() {
+    final var currentValue =
+        rootProcessInstanceCounterColumnFamily.get(rootProcessInstanceCounterKey);
+
+    rootProcessInstanceCounterValue.wrapLong(currentValue.getValue() - 1);
+    rootProcessInstanceCounterColumnFamily.update(
+        rootProcessInstanceCounterKey, rootProcessInstanceCounterValue);
+  }
+
+  /**
+   * Initializes the root process instance counter if it hasn't been initialized yet. This handles
+   * the migration scenario where the counter column family is new and doesn't have a value yet. In
+   * this case, we count the existing root process instances and initialize the counter with that
+   * value.
+   */
+  private void initializeRootProcessInstanceCounterIfNeeded() {
+    final var currentValue =
+        rootProcessInstanceCounterColumnFamily.get(rootProcessInstanceCounterKey);
+
+    if (currentValue == null) {
+      // We won't have a value if the cluster is new or after a migration. If it is a migration we
+      // need to count the existing root process instances and initialize the counter with that
+      // value. If it is a new cluster, the count will be 0.
+      // We only count instances with no parent, meaning root PIs (parentKey == -1).
+      parentKey.inner().wrapLong(-1L);
+      final long count = parentChildColumnFamily.countEqualPrefix(parentKey);
+
+      rootProcessInstanceCounterValue.wrapLong(count);
+      rootProcessInstanceCounterColumnFamily.insert(
+          rootProcessInstanceCounterKey, rootProcessInstanceCounterValue);
+    }
   }
 
   @Override
@@ -589,6 +656,11 @@ public final class DbElementInstanceState implements MutableElementInstanceState
           return false;
         });
     return exists.get();
+  }
+
+  @Override
+  public long getActiveRootProcessInstanceCount() {
+    return rootProcessInstanceCounterColumnFamily.get(rootProcessInstanceCounterKey).getValue();
   }
 
   private void removeNumberOfTakenSequenceFlows(final long flowScopeKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -179,7 +179,6 @@ public final class DbElementInstanceState implements MutableElementInstanceState
             transactionContext,
             activeProcessInstanceCounterKey,
             activeProcessInstanceCounterValue);
-    // only relevant after a migration
     initializeActiveProcessInstanceCounterIfNeeded();
   }
 
@@ -423,22 +422,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
         activeProcessInstanceCounterKey, activeProcessInstanceCounterValue);
   }
 
-  /**
-   * Initializes the root process instance counter if it hasn't been initialized yet. This handles
-   * the migration scenario where the counter column family is new and doesn't have a value yet. In
-   * this case, we count the existing process instances and initialize the counter with that value.
-   */
+  /** Initializes the root process instance counter if it hasn't been initialized yet. */
   private void initializeActiveProcessInstanceCounterIfNeeded() {
     final var currentValue =
         activeProcessInstanceCounterColumnFamily.get(activeProcessInstanceCounterKey);
 
     if (currentValue == null) {
-      // We won't have a value if the cluster is new or after a migration. If it is a migration we
-      // need to count the existing process instances and initialize the counter with that
-      // value. If it is a new cluster, the count will be 0.
-      final long count = parentChildColumnFamily.count();
-
-      activeProcessInstanceCounterValue.wrapLong(count);
+      activeProcessInstanceCounterValue.wrapLong(0);
       activeProcessInstanceCounterColumnFamily.insert(
           activeProcessInstanceCounterKey, activeProcessInstanceCounterValue);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -40,8 +40,8 @@ import org.agrona.collections.MutableInteger;
 
 public final class DbElementInstanceState implements MutableElementInstanceState {
 
-  // Root process instance counter
-  private static final long ROOT_PROCESS_INSTANCE_COUNTER_KEY = 1L;
+  // active process instance counter
+  private static final long ACTIVE_PROCESS_INSTANCE_COUNTER_KEY = 1L;
   private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>>, DbNil>
       parentChildColumnFamily;
   private final DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>> parentChildKey;
@@ -86,9 +86,9 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   private final ProcessInstanceByBusinessIdIndexKey processInstanceByBusinessIdIndexKey;
   private final ColumnFamily<ProcessInstanceByBusinessIdIndexKey, DbNil>
       processInstanceByBusinessIdIndexKeyColumnFamily;
-  private final DbLong rootProcessInstanceCounterKey;
-  private final DbLong rootProcessInstanceCounterValue;
-  private final ColumnFamily<DbLong, DbLong> rootProcessInstanceCounterColumnFamily;
+  private final DbLong activeProcessInstanceCounterKey;
+  private final DbLong activeProcessInstanceCounterValue;
+  private final ColumnFamily<DbLong, DbLong> activeProcessInstanceCounterColumnFamily;
 
   public DbElementInstanceState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -170,17 +170,17 @@ public final class DbElementInstanceState implements MutableElementInstanceState
             processInstanceByBusinessIdIndexKey,
             DbNil.INSTANCE);
 
-    rootProcessInstanceCounterKey = new DbLong();
-    rootProcessInstanceCounterKey.wrapLong(ROOT_PROCESS_INSTANCE_COUNTER_KEY);
-    rootProcessInstanceCounterValue = new DbLong();
-    rootProcessInstanceCounterColumnFamily =
+    activeProcessInstanceCounterKey = new DbLong();
+    activeProcessInstanceCounterKey.wrapLong(ACTIVE_PROCESS_INSTANCE_COUNTER_KEY);
+    activeProcessInstanceCounterValue = new DbLong();
+    activeProcessInstanceCounterColumnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.ROOT_PROCESS_INSTANCE_COUNT,
+            ZbColumnFamilies.ACTIVE_PROCESS_INSTANCE_COUNT,
             transactionContext,
-            rootProcessInstanceCounterKey,
-            rootProcessInstanceCounterValue);
+            activeProcessInstanceCounterKey,
+            activeProcessInstanceCounterValue);
     // only relevant after a migration
-    initializeRootProcessInstanceCounterIfNeeded();
+    initializeActiveProcessInstanceCounterIfNeeded();
   }
 
   @Override
@@ -222,17 +222,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     variableState.removeScope(key);
     awaitProcessInstanceResultMetadataColumnFamily.deleteIfExists(elementInstanceKey);
     removeNumberOfTakenSequenceFlows(key);
+    decrementActiveProcessInstanceCount();
 
     final var recordValue = instance.getValue();
     if (recordValue.getBpmnElementType() == BpmnElementType.PROCESS) {
       processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
       processInstanceKeyByProcessDefinitionKeyColumnFamily.deleteExisting(
           processInstanceKeyByProcessDefinitionKey);
-
-      // Decrement the root process instance counter for root instances (no parent)
-      if (parent == -1) {
-        decrementActiveRootProcessInstanceCount();
-      }
     }
 
     if (parent > 0) {
@@ -256,17 +252,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     elementInstanceColumnFamily.insert(elementInstanceKey, instance);
     parentChildColumnFamily.insert(parentChildKey, DbNil.INSTANCE);
     variableState.createScope(elementInstanceKey.getValue(), parentKey.inner().getValue());
+    incrementActiveProcessInstanceCount();
 
     final var recordValue = instance.getValue();
     if (recordValue.getBpmnElementType() == BpmnElementType.PROCESS) {
       processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
       processInstanceKeyByProcessDefinitionKeyColumnFamily.insert(
           processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
-
-      // Increment the root process instance counter for root instances (no parent)
-      if (instance.getParentKey() == -1) {
-        incrementActiveRootProcessInstanceCount();
-      }
     }
   }
 
@@ -411,47 +403,44 @@ public final class DbElementInstanceState implements MutableElementInstanceState
         processInstanceByBusinessIdIndexKey);
   }
 
-  private void incrementActiveRootProcessInstanceCount() {
+  private void incrementActiveProcessInstanceCount() {
     final var currentValue =
-        rootProcessInstanceCounterColumnFamily.get(rootProcessInstanceCounterKey);
+        activeProcessInstanceCounterColumnFamily.get(activeProcessInstanceCounterKey);
 
     final long newValue = currentValue.getValue() + 1;
 
-    rootProcessInstanceCounterValue.wrapLong(newValue);
-    rootProcessInstanceCounterColumnFamily.update(
-        rootProcessInstanceCounterKey, rootProcessInstanceCounterValue);
+    activeProcessInstanceCounterValue.wrapLong(newValue);
+    activeProcessInstanceCounterColumnFamily.update(
+        activeProcessInstanceCounterKey, activeProcessInstanceCounterValue);
   }
 
-  private void decrementActiveRootProcessInstanceCount() {
+  private void decrementActiveProcessInstanceCount() {
     final var currentValue =
-        rootProcessInstanceCounterColumnFamily.get(rootProcessInstanceCounterKey);
+        activeProcessInstanceCounterColumnFamily.get(activeProcessInstanceCounterKey);
 
-    rootProcessInstanceCounterValue.wrapLong(currentValue.getValue() - 1);
-    rootProcessInstanceCounterColumnFamily.update(
-        rootProcessInstanceCounterKey, rootProcessInstanceCounterValue);
+    activeProcessInstanceCounterValue.wrapLong(currentValue.getValue() - 1);
+    activeProcessInstanceCounterColumnFamily.update(
+        activeProcessInstanceCounterKey, activeProcessInstanceCounterValue);
   }
 
   /**
    * Initializes the root process instance counter if it hasn't been initialized yet. This handles
    * the migration scenario where the counter column family is new and doesn't have a value yet. In
-   * this case, we count the existing root process instances and initialize the counter with that
-   * value.
+   * this case, we count the existing process instances and initialize the counter with that value.
    */
-  private void initializeRootProcessInstanceCounterIfNeeded() {
+  private void initializeActiveProcessInstanceCounterIfNeeded() {
     final var currentValue =
-        rootProcessInstanceCounterColumnFamily.get(rootProcessInstanceCounterKey);
+        activeProcessInstanceCounterColumnFamily.get(activeProcessInstanceCounterKey);
 
     if (currentValue == null) {
       // We won't have a value if the cluster is new or after a migration. If it is a migration we
-      // need to count the existing root process instances and initialize the counter with that
+      // need to count the existing process instances and initialize the counter with that
       // value. If it is a new cluster, the count will be 0.
-      // We only count instances with no parent, meaning root PIs (parentKey == -1).
-      parentKey.inner().wrapLong(-1L);
-      final long count = parentChildColumnFamily.countEqualPrefix(parentKey);
+      final long count = parentChildColumnFamily.count();
 
-      rootProcessInstanceCounterValue.wrapLong(count);
-      rootProcessInstanceCounterColumnFamily.insert(
-          rootProcessInstanceCounterKey, rootProcessInstanceCounterValue);
+      activeProcessInstanceCounterValue.wrapLong(count);
+      activeProcessInstanceCounterColumnFamily.insert(
+          activeProcessInstanceCounterKey, activeProcessInstanceCounterValue);
     }
   }
 
@@ -659,8 +648,8 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public long getActiveRootProcessInstanceCount() {
-    return rootProcessInstanceCounterColumnFamily.get(rootProcessInstanceCounterKey).getValue();
+  public long getActiveProcessInstanceCount() {
+    return activeProcessInstanceCounterColumnFamily.get(activeProcessInstanceCounterKey).getValue();
   }
 
   private void removeNumberOfTakenSequenceFlows(final long flowScopeKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
@@ -236,18 +236,9 @@ public class ProcessEngineMetricsTest {
     final long processInstanceKey3 = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // Wait for all process instances to reach the user task
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey1)
-        .withElementType(BpmnElementType.USER_TASK)
-        .await();
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey2)
-        .withElementType(BpmnElementType.USER_TASK)
-        .await();
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey3)
-        .withElementType(BpmnElementType.USER_TASK)
-        .await();
+    awaitUserTaskActivated(processInstanceKey1);
+    awaitUserTaskActivated(processInstanceKey2);
+    awaitUserTaskActivated(processInstanceKey3);
 
     // Verify gauge shows 3 active instances before restart
     assertThat(activeRootProcessInstanceGauge()).isNotNull().isEqualTo(3);
@@ -260,12 +251,17 @@ public class ProcessEngineMetricsTest {
 
     // we create a new pi to register the metric
     final long processInstanceKey4 = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    awaitUserTaskActivated(processInstanceKey4);
+
+    // then
+    assertThat(activeRootProcessInstanceGauge()).isNotNull().isEqualTo(4);
+  }
+
+  private void awaitUserTaskActivated(final long processInstanceKey) {
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey4)
+        .withProcessInstanceKey(processInstanceKey)
         .withElementType(BpmnElementType.USER_TASK)
         .await();
-
-    assertThat(activeRootProcessInstanceGauge()).isNotNull().isEqualTo(4);
   }
 
   private Double activatedProcessInstanceMetric() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
@@ -258,7 +258,14 @@ public class ProcessEngineMetricsTest {
     engine.stop();
     engine.start();
 
-    assertThat(activeRootProcessInstanceGauge()).isNotNull().isEqualTo(3);
+    // we create a new pi to register the metric
+    final long processInstanceKey4 = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey4)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+
+    assertThat(activeRootProcessInstanceGauge()).isNotNull().isEqualTo(4);
   }
 
   private Double activatedProcessInstanceMetric() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
@@ -179,7 +179,7 @@ public class ProcessEngineMetricsTest {
   }
 
   @Test
-  public void shouldTrackActiveRootProcessInstanceGauge() {
+  public void shouldTrackActiveProcessInstanceGauge() {
     // given
     engine
         .deployment()
@@ -218,7 +218,7 @@ public class ProcessEngineMetricsTest {
   }
 
   @Test
-  public void shouldInitializeActiveRootProcessInstanceGaugeAfterRecovery() {
+  public void shouldInitializeActiveProcessInstanceGaugeAfterRecovery() {
     // given - deploy process and create instances
     engine
         .deployment()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
@@ -95,6 +95,8 @@ public class ProcessEngineMetricsTest {
         .withProcessInstanceKey(processInstanceKey)
         .await();
 
+    assertThat(activeRootProcessInstanceGauge()).isNotNull().isOne();
+
     engine.processInstance().withInstanceKey(processInstanceKey).cancel();
 
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
@@ -104,6 +106,7 @@ public class ProcessEngineMetricsTest {
 
     assertThat(activatedProcessInstanceMetric()).isNotNull().isOne();
     assertThat(terminatedProcessInstanceMetric()).isNotNull().isOne();
+    assertThat(activeRootProcessInstanceGauge()).isNotNull().isZero();
 
     assertThat(failedEvaluatedDmnElementsMetric())
         .isNotNull()
@@ -175,6 +178,89 @@ public class ProcessEngineMetricsTest {
     assertThat(processInstanceCreationsMetric("creation_at_given_element")).isOne();
   }
 
+  @Test
+  public void shouldTrackActiveRootProcessInstanceGauge() {
+    // given
+    engine
+        .deployment()
+        .withXmlClasspathResource(DMN_RESOURCE)
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("waitTask")
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // Wait for the user task to be created
+    // Wait for the process to reach the user task
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+
+    // then: gauge should be 1 while process is active
+    assertThat(activeRootProcessInstanceGauge()).isNotNull().isOne();
+
+    // terminate process instance
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // Wait for process completion
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.TERMINATE_ELEMENT)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then: gauge should be 0 after completion
+    assertThat(activeRootProcessInstanceGauge()).isNotNull().isZero();
+  }
+
+  @Test
+  public void shouldInitializeActiveRootProcessInstanceGaugeAfterRecovery() {
+    // given - deploy process and create instances
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("waitTask")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // Create 3 process instances
+    final long processInstanceKey1 = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long processInstanceKey2 = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long processInstanceKey3 = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // Wait for all process instances to reach the user task
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey1)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey2)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey3)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+
+    // Verify gauge shows 3 active instances before restart
+    assertThat(activeRootProcessInstanceGauge()).isNotNull().isEqualTo(3);
+
+    // when - take a snapshot and restart the engine
+    // Snapshot is required to preserve state - without it, the runtime folder is deleted on stop
+    engine.snapshot();
+    engine.stop();
+    engine.start();
+
+    assertThat(activeRootProcessInstanceGauge()).isNotNull().isEqualTo(3);
+  }
+
   private Double activatedProcessInstanceMetric() {
     return executedProcessInstanceMetric("activated");
   }
@@ -207,6 +293,10 @@ public class ProcessEngineMetricsTest {
         .tag("creation_mode", creationMode)
         .counter()
         .count();
+  }
+
+  private Double activeRootProcessInstanceGauge() {
+    return engine.getMeterRegistry().get("zeebe.active.instances.count").gauge().value();
   }
 
   private Double succeededEvaluatedDmnElementsMetric() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -61,7 +61,8 @@ public final class ProcessExecutionCleanStateTest {
           ZbColumnFamilies.JOB_METRICS_META,
           ZbColumnFamilies.JOB_METRICS_STRING_ENCODING,
           ZbColumnFamilies.JOB_METRICS,
-          ZbColumnFamilies.GLOBAL_LISTENER_CURRENT_CONFIG);
+          ZbColumnFamilies.GLOBAL_LISTENER_CURRENT_CONFIG,
+          ZbColumnFamilies.ACTIVE_PROCESS_INSTANCE_COUNT);
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -512,6 +512,93 @@ public final class ElementInstanceStateTest {
     assertThat(metadata.getRequestStreamId()).isEqualTo(streamId);
   }
 
+  @Test
+  public void shouldReturnZeroWhenNoRootProcessInstances() {
+    // when
+    long count = elementInstanceState.getActiveRootProcessInstanceCount();
+    // then
+    assertThat(count).isEqualTo(0);
+
+    // when we create a PI
+    final ProcessInstanceRecord processInstanceRecord =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+    elementInstanceState.newInstance(
+        200, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // then we should return one
+    count = elementInstanceState.getActiveRootProcessInstanceCount();
+    assertThat(count).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCountMultipleRootProcessInstances() {
+    // given
+    final ProcessInstanceRecord processInstanceRecord1 =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+    final ProcessInstanceRecord processInstanceRecord2 =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+
+    elementInstanceState.newInstance(
+        201, processInstanceRecord1, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    elementInstanceState.newInstance(
+        202, processInstanceRecord2, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    // when
+    final long count = elementInstanceState.getActiveRootProcessInstanceCount();
+    // then
+    assertThat(count).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldDecreaseCountWhenRootProcessInstanceRemoved() {
+    // given
+    final ProcessInstanceRecord processInstanceRecord1 =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+    final ProcessInstanceRecord processInstanceRecord2 =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+    elementInstanceState.newInstance(
+        203, processInstanceRecord1, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    elementInstanceState.newInstance(
+        204, processInstanceRecord2, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    // when
+    elementInstanceState.removeInstance(203);
+    final long count = elementInstanceState.getActiveRootProcessInstanceCount();
+    // then the count should be one
+    assertThat(count).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotCountChildInstancesAsRootProcessInstances() {
+    // given
+    final ProcessInstanceRecord rootRecord =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+    final long rootKey1 = 300L;
+    final long rootKey2 = 301L;
+    final ElementInstance rootInstance1 =
+        elementInstanceState.newInstance(
+            rootKey1, rootRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    final ElementInstance rootInstance2 =
+        elementInstanceState.newInstance(
+            rootKey2, rootRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // add child instances to rootInstance1
+    final ProcessInstanceRecord childRecord =
+        createProcessInstanceRecord().setElementId("subProcess");
+    elementInstanceState.newInstance(
+        rootInstance1, 400L, childRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    elementInstanceState.newInstance(
+        rootInstance1, 401L, childRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+    // add child instance to rootInstance2
+    elementInstanceState.newInstance(
+        rootInstance2, 402L, childRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+    // when
+    final long count = elementInstanceState.getActiveRootProcessInstanceCount();
+
+    // then we should still only have 2 root instances, not counting the child instances.
+    assertThat(count).isEqualTo(2);
+  }
+
   private void assertElementInstance(final ElementInstance elementInstance, final int childCount) {
     Assertions.assertThat(elementInstance.getKey()).isEqualTo(100);
     Assertions.assertThat(elementInstance.getState())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -513,9 +513,9 @@ public final class ElementInstanceStateTest {
   }
 
   @Test
-  public void shouldReturnZeroWhenNoRootProcessInstances() {
+  public void shouldReturnZeroWhenNoProcessInstances() {
     // when
-    long count = elementInstanceState.getActiveRootProcessInstanceCount();
+    long count = elementInstanceState.getActiveProcessInstanceCount();
     // then
     assertThat(count).isEqualTo(0);
 
@@ -526,12 +526,12 @@ public final class ElementInstanceStateTest {
         200, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
     // then we should return one
-    count = elementInstanceState.getActiveRootProcessInstanceCount();
+    count = elementInstanceState.getActiveProcessInstanceCount();
     assertThat(count).isEqualTo(1);
   }
 
   @Test
-  public void shouldCountMultipleRootProcessInstances() {
+  public void shouldCountMultipleProcessInstances() {
     // given
     final ProcessInstanceRecord processInstanceRecord1 =
         createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
@@ -543,7 +543,7 @@ public final class ElementInstanceStateTest {
     elementInstanceState.newInstance(
         202, processInstanceRecord2, ProcessInstanceIntent.ELEMENT_ACTIVATED);
     // when
-    final long count = elementInstanceState.getActiveRootProcessInstanceCount();
+    final long count = elementInstanceState.getActiveProcessInstanceCount();
     // then
     assertThat(count).isEqualTo(2);
   }
@@ -561,13 +561,13 @@ public final class ElementInstanceStateTest {
         204, processInstanceRecord2, ProcessInstanceIntent.ELEMENT_ACTIVATED);
     // when
     elementInstanceState.removeInstance(203);
-    final long count = elementInstanceState.getActiveRootProcessInstanceCount();
+    final long count = elementInstanceState.getActiveProcessInstanceCount();
     // then the count should be one
     assertThat(count).isEqualTo(1);
   }
 
   @Test
-  public void shouldNotCountChildInstancesAsRootProcessInstances() {
+  public void shouldCountChildInstancesProcessInstances() {
     // given
     final ProcessInstanceRecord rootRecord =
         createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
@@ -593,10 +593,10 @@ public final class ElementInstanceStateTest {
         rootInstance2, 402L, childRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
 
     // when
-    final long count = elementInstanceState.getActiveRootProcessInstanceCount();
+    final long count = elementInstanceState.getActiveProcessInstanceCount();
 
-    // then we should still only have 2 root instances, not counting the child instances.
-    assertThat(count).isEqualTo(2);
+    // then we should still only have 2 root instances, and 3 child instances.
+    assertThat(count).isEqualTo(5);
   }
 
   private void assertElementInstance(final ElementInstance elementInstance, final int childCount) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -434,6 +434,8 @@ public final class ElementInstanceStateTest {
     final var nonEmptyColumns =
         Arrays.stream(ZbColumnFamilies.values())
             .filter(not(ZbColumnFamilies.KEY::equals))
+            // ACTIVE_PROCESS_INSTANCE_COUNT tracks the count of active process instances
+            .filter(not(ZbColumnFamilies.ACTIVE_PROCESS_INSTANCE_COUNT::equals))
             .filter(not(processingState::isEmpty))
             .collect(Collectors.toList());
 
@@ -580,23 +582,21 @@ public final class ElementInstanceStateTest {
         elementInstanceState.newInstance(
             rootKey2, rootRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
-    // add child instances to rootInstance1
-    final ProcessInstanceRecord childRecord =
-        createProcessInstanceRecord().setElementId("subProcess");
+    // add child process instances started via call activities
+    final ProcessInstanceRecord childProcessRecord =
+        createProcessInstanceRecord()
+            .setElementId("childProcess")
+            .setBpmnElementType(BpmnElementType.PROCESS);
     elementInstanceState.newInstance(
-        rootInstance1, 400L, childRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+        rootInstance1, 500L, childProcessRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
     elementInstanceState.newInstance(
-        rootInstance1, 401L, childRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
-
-    // add child instance to rootInstance2
-    elementInstanceState.newInstance(
-        rootInstance2, 402L, childRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+        rootInstance2, 501L, childProcessRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
 
     // when
     final long count = elementInstanceState.getActiveProcessInstanceCount();
 
-    // then we should still only have 2 root instances, and 3 child instances.
-    assertThat(count).isEqualTo(5);
+    // then we should have 2 root process instances + 2 child process instances
+    assertThat(count).isEqualTo(4);
   }
 
   private void assertElementInstance(final ElementInstance elementInstance, final int childCount) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -273,7 +273,10 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
 
   // backup range tracking
   CHECKPOINTS(140, PARTITION_LOCAL),
-  BACKUP_RANGES(141, PARTITION_LOCAL);
+  BACKUP_RANGES(141, PARTITION_LOCAL),
+
+  // root process instance counter
+  ROOT_PROCESS_INSTANCE_COUNT(142, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -276,7 +276,7 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   BACKUP_RANGES(141, PARTITION_LOCAL),
 
   // root process instance counter
-  ROOT_PROCESS_INSTANCE_COUNT(142, PARTITION_LOCAL);
+  ACTIVE_PROCESS_INSTANCE_COUNT(142, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

<img width="2335" height="571" alt="image" src="https://github.com/user-attachments/assets/5d67388b-d6ff-4679-a7a5-25df4b0ff509" />

This pr adds a new small visualization for the number of active root process instances per partition.
The PR adds a new metric zeebe_active_instances_total.

The way we count the number of active root instances is by increasing the gauge with elementInstanceActivated events, and decrementing on elementInstanceCompleted and elementInstanceTerminated events.

Since this is a gauge, this value gets reset upon broker restart, so we add an active instance counter to the state that reuses existing events.

Tested the metric with load test to make sure the values were correct, including restarting all the pods at the same time and observing if the active instances were the same. `c8-rl-dashboard-test-2`
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/47606, https://github.com/camunda/camunda/issues/47605
