### PR TITLE
refactor: simplify health and webapps initializers

### DIFF
--- a/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
@@ -28,23 +28,8 @@ import org.springframework.core.env.Environment;
 public class HealthConfigurationInitializer
     implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-  private static final String INDICATOR_BROKER_READY = "brokerReady";
-  private static final String INDICATOR_NODE_ID_PROVIDER_READY = "nodeIdProviderReady";
   private static final String INDICATOR_GATEWAY_STARTED = "gatewayStarted";
-  private static final String INDICATOR_BROKER_STARTUP = "brokerStartup";
-  private static final String INDICATOR_OPERATE_INDICES_CHECK = "indicesCheck";
   private static final String INDICATOR_SPRING_READINESS_STATE = "readinessState";
-  private static final String INDICATOR_TASKLIST_SEARCH_ENGINE_CHECK = "searchEngineCheck";
-
-  private static final String SPRING_READINESS_PROPERTY =
-      "management.health.readinessstate.enabled";
-  private static final String SPRING_PROBES_PROPERTY = "management.endpoint.health.probes.enabled";
-  private static final String SPRING_READINESS_GROUP_PROPERTY =
-      "management.endpoint.health.group.readiness.include";
-  private static final String HEALTH_GROUP_STATUS_PROPERTY =
-      "management.endpoint.health.group.status.include";
-  private static final String HEALTH_GROUP_LIVENESS_PROPERTY =
-      "management.endpoint.health.group.liveness.include";
 
   @Value("camunda.mode")
   private String camundaMode;
@@ -63,13 +48,13 @@ public class HealthConfigurationInitializer
     final var propertyMap = new HashMap<String, Object>();
 
     // Enables readinessState
-    propertyMap.put(SPRING_READINESS_PROPERTY, enableReadinessState);
+    propertyMap.put("management.health.readinessstate.enabled", enableReadinessState);
 
     // Enables Kubernetes health groups
-    propertyMap.put(SPRING_PROBES_PROPERTY, enableProbes);
+    propertyMap.put("management.endpoint.health.probes.enabled", enableProbes);
 
     if (!healthIndicators.isEmpty()) {
-      propertyMap.put(SPRING_READINESS_GROUP_PROPERTY, healthIndicators);
+      propertyMap.put("management.endpoint.health.group.readiness.include", healthIndicators);
     }
 
     final Set<String> startupGroup = new HashSet<>();
@@ -85,7 +70,7 @@ public class HealthConfigurationInitializer
       livenessGroup.add("livenessGatewayClusterAwareness");
       livenessGroup.add("livenessGatewayPartitionLeaderAwareness");
       livenessGroup.add("livenessMemory");
-      propertyMap.put(HEALTH_GROUP_LIVENESS_PROPERTY, livenessGroup);
+      propertyMap.put("management.endpoint.health.group.liveness.include", livenessGroup);
       propertyMap.put("management.endpoint.health.group.liveness.show-details", "always");
 
       propertyMap.put(
@@ -105,12 +90,12 @@ public class HealthConfigurationInitializer
       propertyMap.put("management.endpoint.health.logging.slow-indicator-threshold", "10s");
 
       /* Configure broker status indicator */
-      propertyMap.put(HEALTH_GROUP_STATUS_PROPERTY, "brokerStatus");
+      propertyMap.put("management.endpoint.health.group.status.include", "brokerStatus");
       propertyMap.put("management.endpoint.health.group.status.show-components", "never");
       propertyMap.put("management.endpoint.health.group.status.show-details", "never");
 
       /* Configure startup health check */
-      startupGroup.add(INDICATOR_BROKER_STARTUP);
+      startupGroup.add("brokerStartup");
       propertyMap.put("management.endpoint.health.group.startup.show-components", "never");
       propertyMap.put("management.endpoint.health.group.startup.show-details", "never");
     }
@@ -154,8 +139,8 @@ public class HealthConfigurationInitializer
     final boolean secondaryStorageEnabled = DatabaseTypeUtils.isSecondaryStorageEnabled(env);
 
     if (activeProfiles.contains(Profile.BROKER.getId())) {
-      healthIndicators.add(INDICATOR_BROKER_READY);
-      healthIndicators.add(INDICATOR_NODE_ID_PROVIDER_READY);
+      healthIndicators.add("brokerReady");
+      healthIndicators.add("nodeIdProviderReady");
     }
 
     if (activeProfiles.contains(Profile.GATEWAY.getId())) {
@@ -165,14 +150,14 @@ public class HealthConfigurationInitializer
     if (secondaryStorageEnabled && activeProfiles.contains(Profile.OPERATE.getId())) {
       healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
       if (DatabaseTypeUtils.isRdbmsDisabled(env)) {
-        healthIndicators.add(INDICATOR_OPERATE_INDICES_CHECK);
+        healthIndicators.add("indicesCheck");
       }
     }
 
     if (secondaryStorageEnabled
         && activeProfiles.contains(Profile.TASKLIST.getId())
         && DatabaseTypeUtils.isRdbmsDisabled(env)) {
-      healthIndicators.add(INDICATOR_TASKLIST_SEARCH_ENGINE_CHECK);
+      healthIndicators.add("searchEngineCheck");
     }
 
     if (secondaryStorageEnabled

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -29,6 +29,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 public class WebappsConfigurationInitializer
     implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
+  public static final String CAMUNDA_WEBAPPS_ENABLED_PROPERTY = "camunda.webapps.enabled";
   private static final Set<String> WEBAPPS_PROFILES =
       Set.of(OPERATE.getId(), TASKLIST.getId(), IDENTITY.getId(), ADMIN.getId());
   private static final String DEFAULT_RESOURCES_LOCATION = "classpath:/META-INF/resources/";
@@ -45,7 +46,7 @@ public class WebappsConfigurationInitializer
     final var propertyMap = new HashMap<String, Object>();
 
     if (activeProfiles.stream().anyMatch(WEBAPPS_PROFILES::contains)) {
-      propertyMap.put("camunda.webapps.enabled", true);
+      propertyMap.put(CAMUNDA_WEBAPPS_ENABLED_PROPERTY, true);
 
       propertyMap.put("spring.web.resources.add-mappings", true);
       propertyMap.put("spring.thymeleaf.check-template-location", true);

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -29,15 +29,8 @@ import org.springframework.context.ConfigurableApplicationContext;
 public class WebappsConfigurationInitializer
     implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-  public static final String CAMUNDA_WEBAPPS_ENABLED_PROPERTY = "camunda.webapps.enabled";
-  private static final String CAMUNDA_WEBAPPS_DEFAULT_APP_PROPERTY = "camunda.webapps.default-app";
-  private static final String CAMUNDA_WEBAPPS_LOGIN_DELEGATED_PROPERTY =
-      "camunda.webapps.login-delegated";
-  private static final String SERVER_SERVLET_SESSION_COOKIE_NAME_PROPERTY =
-      "server.servlet.session.cookie.name";
   private static final Set<String> WEBAPPS_PROFILES =
       Set.of(OPERATE.getId(), TASKLIST.getId(), IDENTITY.getId(), ADMIN.getId());
-  private static final String RESOURCES_LOCATION_PROPERTY = "spring.web.resources.static-locations";
   private static final String DEFAULT_RESOURCES_LOCATION = "classpath:/META-INF/resources/";
   private static final String AUTHORIZATIONS_ENABLED_PROPERTY =
       "camunda.security.authorizations.enabled";
@@ -52,15 +45,14 @@ public class WebappsConfigurationInitializer
     final var propertyMap = new HashMap<String, Object>();
 
     if (activeProfiles.stream().anyMatch(WEBAPPS_PROFILES::contains)) {
-      propertyMap.put(CAMUNDA_WEBAPPS_ENABLED_PROPERTY, true);
+      propertyMap.put("camunda.webapps.enabled", true);
 
       propertyMap.put("spring.web.resources.add-mappings", true);
       propertyMap.put("spring.thymeleaf.check-template-location", true);
       propertyMap.put("spring.thymeleaf.prefix", DEFAULT_RESOURCES_LOCATION);
 
-      propertyMap.put(CAMUNDA_WEBAPPS_LOGIN_DELEGATED_PROPERTY, isLoginDelegated(context));
-      propertyMap.put(
-          SERVER_SERVLET_SESSION_COOKIE_NAME_PROPERTY, WebSecurityConfig.SESSION_COOKIE);
+      propertyMap.put("camunda.webapps.login-delegated", isLoginDelegated(context));
+      propertyMap.put("server.servlet.session.cookie.name", WebSecurityConfig.SESSION_COOKIE);
     }
 
     // locations and home page
@@ -120,9 +112,9 @@ public class WebappsConfigurationInitializer
 
     // Store locations, default homepage and merge everything
 
-    propertyMap.put(RESOURCES_LOCATION_PROPERTY, locations);
+    propertyMap.put("spring.web.resources.static-locations", locations);
     if (defaultWebapp != null) {
-      propertyMap.put(CAMUNDA_WEBAPPS_DEFAULT_APP_PROPERTY, defaultWebapp);
+      propertyMap.put("camunda.webapps.default-app", defaultWebapp);
     }
     DefaultPropertiesPropertySource.addOrMerge(propertyMap, propertySources);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR makes a set of small simplification to improve code readability and maintainability in the config initializers.
It mostly removes constants when they are used only once.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
