### PR TITLE
fix: Correct FormResult.schema type from object to string in OpenAPI spec

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
@@ -10746,7 +10746,7 @@ components:
           type: string
         schema:
           description: The form content.
-          type: object
+          type: string
         version:
           description: The version of the the deployed form.
           type: integer

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -11856,8 +11856,8 @@ components:
           allOf:
             - $ref: "#/components/schemas/FormId"
         schema:
-          description: The form content.
-          type: object
+          description: The form content as a JSON string.
+          type: string
         version:
           description: The version of the the deployed form.
           type: integer


### PR DESCRIPTION
## Description

The schema field in FormResult was incorrectly specified as type: object, but the actual implementation has always serialized it as a JSON string. This change corrects the OpenAPI specification to match the runtime behavior.

Fixes issue where TypeScript SDK and other generated clients had incorrect type expectations for the schema field.

Backport of fix to stable/8.8

Relates to #47610
