### PR TITLE
[Backport stable/8.9] build: add dedicated Spring Boot 3 and 4 camunda-spring-boot-starter and test modules

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -126,6 +126,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-spring-boot-3</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-spring-4</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -102,6 +102,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-spring-boot-3-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-spring-boot-4-starter</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -81,6 +81,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
@@ -202,6 +207,14 @@
           <ignoredNonTestScopedDependencies>
             <dependency>*</dependency>
           </ignoredNonTestScopedDependencies>
+          <!--
+            spring-web is declared as a test dep to make Jackson2ObjectMapperBuilder available
+            for Jackson auto-configuration tests; it is not directly referenced in test source
+            but is required at runtime for JacksonAutoConfiguration to activate.
+          -->
+          <ignoredUnusedDeclaredDependencies>
+            <dependency>org.springframework:spring-web</dependency>
+          </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
 
@@ -304,9 +317,6 @@
             <!-- Low risk on those, given they are not tightly coupled to spring classes -->
             <exclude>**/configurationMetadata/AlignmentTest.java</exclude>
             <exclude>**/configurationMetadata/FormattingTest.java</exclude>
-            <!-- Exclude tests that use Jackson 3.x (tools.jackson.*) which is not available in Spring Boot 3.x -->
-            <exclude>**/CamundaObjectMapperTest.java</exclude>
-            <exclude>**/JsonMapperConfigurationTest.java</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-library-parent</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../../library-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-spring-boot-3-starter</artifactId>
+
+  <name>Camunda Spring Boot 3 Starter</name>
+  <description>Camunda Spring Boot Starter for Spring Boot 3.5.x</description>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <version.java>17</version.java>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
+    <!-- Override Spring Boot version for 3.x compatibility -->
+    <version.spring-boot>3.5.11</version.spring-boot>
+    <!-- Spring Framework 6.x is required for Spring Boot 3.x -->
+    <version.spring>6.2.16</version.spring>
+    <version.roaster>2.31.0.Final</version.roaster>
+    <version.aspectjweaver>1.9.25.1</version.aspectjweaver>
+    <generated.test.sources.path>${project.build.directory}/generated-test-sources/java</generated.test.sources.path>
+    <camunda-spring-boot-starter.sourcedir>${project.basedir}/../camunda-spring-boot-starter/src</camunda-spring-boot-starter.sourcedir>
+  </properties>
+
+  <dependencies>
+    <!-- Base Spring Boot starter - will be shaded -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.forge.roaster</groupId>
+      <artifactId>roaster-api</artifactId>
+      <version>${version.roaster}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+      <version>${version.aspectjweaver}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+          <testExcludes>
+            <!-- Exclude tests that use Jackson 3.x (tools.jackson.*) which is not available in Spring Boot 3.x -->
+            <exclude>io/camunda/client/impl/CamundaObjectMapperTest.java</exclude>
+            <exclude>io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java</exclude>
+          </testExcludes>
+        </configuration>
+      </plugin>
+
+      <!-- Shade plugin to include and relocate classes from camunda-spring-boot-starter -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <artifactSet>
+                <includes>
+                  <!-- Only include the base starter module in the shaded jar -->
+                  <include>io.camunda:camunda-spring-boot-starter</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>io.camunda:camunda-spring-boot-starter</artifact>
+                  <excludes>
+                    <!-- Exclude classes that we override with Spring Boot 3 versions -->
+                    <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.class</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.class</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.class</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.class</exclude>
+                    <!-- Exclude META-INF services that we override -->
+                    <exclude>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <!-- Merge service files -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <!-- Keep manifest entries -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <!--
+            Ignore all "used but undeclared" dependencies in this module.
+            This starter shades and reuses classes and tests from the base
+            camunda-spring-boot-starter module, which is where the actual
+            dependency declarations live. From the perspective of this POM,
+            many classes therefore appear as used but undeclared, even though
+            they are intentionally provided by the base module and by the
+            shaded artifact.
+          -->
+          <ignoredUsedUndeclaredDependencies>
+            <dependency>*</dependency>
+          </ignoredUsedUndeclaredDependencies>
+          <!-- Ignore any non-test scoped deps, likely false-positive -->
+          <ignoredNonTestScopedDependencies>
+            <dependency>*</dependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
+
+      <!-- Add test re-/sources from the base module -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-test-generator-source</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <sources>
+                <!-- Include test generator utility classes (compiled as main sources in base module) -->
+                <source>${camunda-spring-boot-starter.sourcedir}/test/test-source-generator</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-source</id>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <sources>
+                <source>${camunda-spring-boot-starter.sourcedir}/test/java</source>
+                <source>${generated.test.sources.path}</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-resources</id>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>${camunda-spring-boot-starter.sourcedir}/test/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <dependencies>
+          <!-- Needed for the roaster generator used -->
+          <dependency>
+            <groupId>org.jboss.forge.roaster</groupId>
+            <artifactId>roaster-jdt</artifactId>
+            <version>${version.roaster}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <!-- This executes the test generator classes -->
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <mainClass>io.camunda.client.spring.test.util.JobWorkerPermutationsGenerator</mainClass>
+              <arguments>
+                <argument>${generated.test.sources.path}</argument>
+              </arguments>
+              <classpathScope>provided</classpathScope>
+              <includePluginDependencies>true</includePluginDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <!-- As the test generator classes end up among main classes, they have to be excluded again -->
+          <excludes>
+            <exclude>**/test/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <!-- Run tests compiled from base module sources -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <!-- Exclude tests that require file system access to configuration metadata in JAR -->
+            <!-- Low risk on those, given they are not tightly coupled to spring classes -->
+            <exclude>**/configurationMetadata/AlignmentTest.java</exclude>
+            <exclude>**/configurationMetadata/FormattingTest.java</exclude>
+            <!-- Exclude tests that use Jackson 3.x (tools.jackson.*) which is not available in Spring Boot 3.x -->
+            <exclude>**/CamundaObjectMapperTest.java</exclude>
+            <exclude>**/JsonMapperConfigurationTest.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-library-parent</artifactId>
-    <version>8.10.0-SNAPSHOT</version>
+    <version>8.9.0-SNAPSHOT</version>
     <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 
@@ -38,6 +38,14 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-spring-boot-starter</artifactId>
+      <exclusions>
+        <!-- spring-boot-health is a Spring Boot 4.x-only module; in 3.5.x the health
+             classes live inside spring-boot-actuator. Exclude to prevent 4.x leaking. -->
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-health</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/clients/camunda-spring-boot-3-starter/src/main/java/io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java
+++ b/clients/camunda-spring-boot-3-starter/src/main/java/io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.actuator;
+
+import io.camunda.client.health.HealthCheck;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+
+/**
+ * Spring Boot 3 compatible health indicator for Camunda Client. Uses the package location for
+ * health classes in Spring Boot 3.x.
+ */
+public class CamundaClientHealthIndicator extends AbstractHealthIndicator {
+
+  private final HealthCheck healthCheck;
+
+  public CamundaClientHealthIndicator(final HealthCheck healthCheck) {
+    this.healthCheck = healthCheck;
+  }
+
+  @Override
+  protected void doHealthCheck(final Health.Builder builder) {
+    switch (healthCheck.health()) {
+      case UP -> builder.up();
+      case DOWN -> builder.down();
+      default -> throw new IllegalStateException("Unexpected value: " + healthCheck.health());
+    }
+  }
+}

--- a/clients/camunda-spring-boot-3-starter/src/main/java/io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java
+++ b/clients/camunda-spring-boot-3-starter/src/main/java/io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.health.HealthCheck;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.metrics.JobWorkerMetricsFactory;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.metrics.MicrometerJobWorkerMetricsFactory;
+import io.camunda.client.metrics.MicrometerMetricsRecorder;
+import io.camunda.client.spring.actuator.CamundaClientHealthIndicator;
+import io.camunda.client.spring.actuator.JobWorkerController;
+import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Spring Boot 3 compatible actuator configuration. Uses the package location for HealthIndicator in
+ * Spring Boot 3.x.
+ */
+@AutoConfigureBefore(MetricsDefaultConfiguration.class)
+@ConditionalOnCamundaClientEnabled
+@ConditionalOnClass({
+  EndpointAutoConfiguration.class,
+  MeterRegistry.class
+}) // only if actuator is on classpath
+public class CamundaActuatorConfiguration {
+
+  @Bean
+  public JobWorkerController jobWorkerController(final JobWorkerManager jobWorkerManager) {
+    return new JobWorkerController(jobWorkerManager);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public MetricsRecorder micrometerMetricsRecorder(@Lazy final MeterRegistry meterRegistry) {
+    return new MicrometerMetricsRecorder(meterRegistry);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public JobWorkerMetricsFactory jobWorkerMetricsFactory(@Lazy final MeterRegistry meterRegistry) {
+    return new MicrometerJobWorkerMetricsFactory(meterRegistry);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public HealthCheck camundaHealthCheck(final CamundaClient client) {
+    return new HealthCheck(client);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "management.health.camunda",
+      name = "enabled",
+      matchIfMissing = true)
+  @ConditionalOnClass(HealthIndicator.class)
+  @ConditionalOnMissingBean(name = "camundaClientHealthIndicator")
+  public CamundaClientHealthIndicator camundaClientHealthIndicator(final HealthCheck healthCheck) {
+    return new CamundaClientHealthIndicator(healthCheck);
+  }
+}

--- a/clients/camunda-spring-boot-3-starter/src/main/java/io/camunda/client/spring/configuration/CamundaAutoConfiguration.java
+++ b/clients/camunda-spring-boot-3-starter/src/main/java/io/camunda/client/spring/configuration/CamundaAutoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
+import io.camunda.client.spring.event.CamundaLifecycleEventProducer;
+import io.camunda.client.spring.testsupport.CamundaSpringProcessTestContext;
+import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Boot 3 compatible auto-configuration. Uses the package location for
+ * JacksonAutoConfiguration in Spring Boot 3.x and omits Jackson 3.x specific configurations.
+ *
+ * <p>Enabled by META-INF of Spring Boot Starter to provide beans for Camunda Clients
+ */
+@Configuration
+@ConditionalOnCamundaClientEnabled
+@ImportAutoConfiguration({
+  CamundaClientProdAutoConfiguration.class,
+  CamundaClientAllAutoConfiguration.class,
+  CamundaActuatorConfiguration.class,
+  MetricsDefaultConfiguration.class,
+  JsonMapperConfiguration.class,
+  ZeebeClientProdAutoConfiguration.class
+})
+@AutoConfigureAfter(JacksonAutoConfiguration.class)
+public class CamundaAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(
+      CamundaSpringProcessTestContext
+          .class) // only run if we are not running in a test case - as otherwise the lifecycle
+  // is controlled by the test
+  public CamundaLifecycleEventProducer camundaLifecycleEventProducer(
+      final CamundaClient client, final ApplicationEventPublisher publisher) {
+    return new CamundaLifecycleEventProducer(client, publisher);
+  }
+}

--- a/clients/camunda-spring-boot-3-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.java
+++ b/clients/camunda-spring-boot-3-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.annotation.customizer.JobWorkerValueCustomizer;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.worker.BackoffSupplier;
+import io.camunda.client.impl.worker.JobWorkerBuilderImpl;
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.DefaultCommandExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.DefaultJobExceptionHandlerSupplier;
+import io.camunda.client.jobhandling.JobExceptionHandlerSupplier;
+import io.camunda.client.jobhandling.JobWorkerFactory;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.jobhandling.parameter.DefaultParameterResolverStrategy;
+import io.camunda.client.jobhandling.parameter.ParameterResolverStrategy;
+import io.camunda.client.jobhandling.result.DefaultDocumentResultProcessorFailureHandlingStrategy;
+import io.camunda.client.jobhandling.result.DefaultResultProcessorStrategy;
+import io.camunda.client.jobhandling.result.DocumentResultProcessorFailureHandlingStrategy;
+import io.camunda.client.jobhandling.result.ResultProcessorStrategy;
+import io.camunda.client.metrics.JobWorkerMetricsFactory;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
+import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.camunda.client.spring.properties.PropertyBasedJobWorkerValueCustomizer;
+import io.camunda.zeebe.client.ZeebeClient;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Spring Boot 3 compatible configuration. Omits Jackson 3.x specific configurations which are not
+ * available in Spring Boot 3.x.
+ */
+@ConditionalOnCamundaClientEnabled
+@Import({
+  AnnotationProcessorConfiguration.class,
+  JsonMapperConfiguration.class,
+  CamundaBeanPostProcessorConfiguration.class
+})
+@EnableConfigurationProperties({CamundaClientProperties.class})
+public class CamundaClientAllAutoConfiguration {
+
+  private final CamundaClientProperties camundaClientProperties;
+
+  public CamundaClientAllAutoConfiguration(final CamundaClientProperties camundaClientProperties) {
+    this.camundaClientProperties = camundaClientProperties;
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public CamundaClientExecutorService camundaClientExecutorService() {
+    return CamundaClientExecutorService.createDefault(
+        camundaClientProperties.getExecutionThreads());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public CommandExceptionHandlingStrategy commandExceptionHandlingStrategy(
+      final BackoffSupplier backoffSupplier,
+      final CamundaClientExecutorService scheduledExecutorService) {
+    return new DefaultCommandExceptionHandlingStrategy(
+        backoffSupplier, scheduledExecutorService.getScheduledExecutor());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ParameterResolverStrategy parameterResolverStrategy(
+      final JsonMapper jsonMapper, @Autowired(required = false) final ZeebeClient zeebeClient) {
+    return new DefaultParameterResolverStrategy(jsonMapper, zeebeClient);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public DocumentResultProcessorFailureHandlingStrategy
+      documentResultProcessorFailureHandlingStrategy() {
+    return new DefaultDocumentResultProcessorFailureHandlingStrategy();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public JobExceptionHandlerSupplier jobExceptionHandlingSupplier(
+      final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+      final MetricsRecorder metricsRecorder) {
+    return new DefaultJobExceptionHandlerSupplier(
+        commandExceptionHandlingStrategy, metricsRecorder);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ResultProcessorStrategy resultProcessorStrategy(
+      final DocumentResultProcessorFailureHandlingStrategy
+          documentResultProcessorFailureHandlingStrategy) {
+    return new DefaultResultProcessorStrategy(documentResultProcessorFailureHandlingStrategy);
+  }
+
+  @Bean
+  public JobWorkerFactory jobWorkerFactory(
+      final BackoffSupplier backoffSupplier,
+      final BackoffSupplier streamNoJobsBackoffSupplier,
+      final JobWorkerMetricsFactory jobWorkerMetricsFactory,
+      final JobExceptionHandlerSupplier jobExceptionHandlerSupplier) {
+    return new JobWorkerFactory(
+        backoffSupplier,
+        streamNoJobsBackoffSupplier,
+        jobExceptionHandlerSupplier,
+        jobWorkerMetricsFactory);
+  }
+
+  @Bean
+  public JobWorkerManager jobWorkerManager(
+      final List<JobWorkerValueCustomizer> jobWorkerValueCustomizers,
+      final JobWorkerFactory jobWorkerFactory) {
+    return new JobWorkerManager(jobWorkerValueCustomizers, jobWorkerFactory);
+  }
+
+  @Bean("backoffSupplier")
+  @ConditionalOnMissingBean(name = "backoffSupplier")
+  public BackoffSupplier backoffSupplier() {
+    return JobWorkerBuilderImpl.DEFAULT_BACKOFF_SUPPLIER;
+  }
+
+  @Bean("streamNoJobsBackoffSupplier")
+  @ConditionalOnMissingBean(name = "streamNoJobsBackoffSupplier")
+  public BackoffSupplier streamNoJobsBackoffSupplier() {
+    return JobWorkerBuilderImpl.DEFAULT_STREAM_NO_JOBS_BACKOFF_SUPPLIER;
+  }
+
+  @Bean("propertyBasedJobWorkerValueCustomizer")
+  @ConditionalOnMissingBean(name = "propertyBasedJobWorkerValueCustomizer")
+  public JobWorkerValueCustomizer propertyBasedJobWorkerValueCustomizer() {
+    return new PropertyBasedJobWorkerValueCustomizer(camundaClientProperties);
+  }
+}

--- a/clients/camunda-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/clients/camunda-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.camunda.client.spring.configuration.CamundaAutoConfiguration

--- a/clients/camunda-spring-boot-3-starter/src/test/java/io/camunda/client/impl/CamundaJackson2ObjectMapperTest.java
+++ b/clients/camunda-spring-boot-3-starter/src/test/java/io/camunda/client/impl/CamundaJackson2ObjectMapperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Spring Boot 3 compatible equivalent of CamundaObjectMapperTest. Tests the Jackson 2
+ * (com.fasterxml.jackson) based CamundaObjectMapper instead of CamundaJackson3ObjectMapper.
+ */
+public class CamundaJackson2ObjectMapperTest {
+
+  @Test
+  public void shouldReturnEmptyObject() {
+    // Given
+    final CamundaObjectMapper camundaObjectMapper = new CamundaObjectMapper();
+    final TestObject testObject = new TestObject();
+    testObject.setObject(new Object());
+    // When
+    final String actual = camundaObjectMapper.toJson(testObject);
+    // Then
+    assertThat(actual).isEqualTo("{\"object\":{}}");
+  }
+
+  public static final class TestObject {
+    private Object object;
+
+    public Object getObject() {
+      return object;
+    }
+
+    public void setObject(final Object object) {
+      this.object = object;
+    }
+  }
+}

--- a/clients/camunda-spring-boot-3-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperJackson2ConfigurationTest.java
+++ b/clients/camunda-spring-boot-3-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperJackson2ConfigurationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.client.spring.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.spring.configuration.JsonMapperJackson2ConfigurationTest.OverrideObjectMapper.JacksonConfiguration;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Boot 3 compatible equivalent of JsonMapperConfigurationTest. Only covers the Jackson 2
+ * (com.fasterxml.jackson) test cases. Jackson 3 (tools.jackson) test cases are omitted because
+ * tools.jackson is not available in Spring Boot 3.x.
+ */
+public class JsonMapperJackson2ConfigurationTest {
+
+  @Nested
+  @SpringBootTest(classes = {JacksonAutoConfiguration.class, JsonMapperConfiguration.class})
+  class JacksonSpringBoot {
+    @Autowired com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+    @Autowired JsonMapper jsonMapper;
+
+    @Test
+    void shouldUseAutoConfiguredObjectMapper() {
+      assertThat(objectMapper).isNotNull();
+    }
+
+    @Test
+    void shouldUseCamundaObjectMapper() {
+      assertThat(jsonMapper).isInstanceOf(CamundaObjectMapper.class);
+    }
+  }
+
+  @Nested
+  @SpringBootTest(classes = {DefaultJsonMapperConfiguration.class})
+  class DefaultSpringBoot {
+    @Autowired JsonMapper jsonMapper;
+
+    @Test
+    void shouldUseCamundaObjectMapper() {
+      assertThat(jsonMapper).isInstanceOf(CamundaObjectMapper.class);
+    }
+  }
+
+  @Nested
+  @SpringBootTest(classes = {JacksonConfiguration.class, JsonMapperConfiguration.class})
+  class OverrideObjectMapper {
+    @Autowired ObjectMapper defaultObjectMapper;
+    @Autowired JsonMapper camundaJsonMapper;
+
+    @Test
+    public void shouldSerializeNullValuesInJson() throws Exception {
+      // given
+      final Map<String, Object> map = new HashMap<>();
+      map.put("key", null);
+      map.put("key2", "value2");
+      // when
+
+      final String json = camundaJsonMapper.toJson(map);
+      final JsonNode camundaJsonNode = new ObjectMapper().readTree(json);
+
+      // then
+      assertThat(camundaJsonNode.get("key").isNull()).isTrue();
+      assertThat(camundaJsonNode.get("key2").asText()).isEqualTo("value2");
+    }
+
+    @Test
+    public void shouldNotChangeDefaultObjectMapper() {
+      // verify that creating camunda object mapper does not change config of default object mapper
+      assertThat(defaultObjectMapper.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES))
+          .isTrue();
+    }
+
+    @Configuration
+    protected static class JacksonConfiguration {
+      @Bean
+      public ObjectMapper objectMapper() {
+        // default object mapper config
+        return new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+      }
+    }
+  }
+}

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-spring-boot-4-starter</artifactId>
+
+  <name>Camunda Spring Boot 4 Starter</name>
+  <description>Camunda Spring Boot Starter for Spring Boot 4.x (alias for camunda-spring-boot-starter).</description>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <distributionManagement>
+    <relocation>
+      <artifactId>camunda-spring-boot-starter</artifactId>
+      <message>camunda-spring-boot-4-starter is an alias for camunda-spring-boot-starter (Spring Boot 4.x).
+        Use camunda-spring-boot-3-starter for Spring Boot 3.5.x compatibility.</message>
+    </relocation>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <pomElements>
+            <distributionManagement/>
+          </pomElements>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.10.0-SNAPSHOT</version>
+    <version>8.9.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
     <module>clients/java</module>
     <module>clients/java-deprecated</module>
     <module>clients/camunda-spring-boot-starter</module>
+    <module>clients/camunda-spring-boot-3-starter</module>
+    <module>clients/camunda-spring-boot-4-starter</module>
     <module>clients/camunda-spring-boot-starter-virtual-threads</module>
     <module>clients/spring-boot-starter-camunda-sdk-deprecated</module>
     <module>testing</module>

--- a/testing/camunda-process-test-spring-boot-3/pom.xml
+++ b/testing/camunda-process-test-spring-boot-3/pom.xml
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-testing</artifactId>
+    <version>8.9.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-process-test-spring-boot-3</artifactId>
+
+  <name>Camunda Process Test Spring Boot 3</name>
+  <description>Camunda's testing library for processes and process applications with Spring Boot 3.5.x support</description>
+
+  <properties>
+    <version.java>17</version.java>
+    <!-- Override Spring Boot version for 3.x compatibility -->
+    <version.spring-boot>3.5.11</version.spring-boot>
+    <!-- Spring Framework 6.x is required for Spring Boot 3.x -->
+    <version.spring>6.2.16</version.spring>
+  </properties>
+
+  <dependencies>
+
+    <!-- Base module - will be shaded -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <!-- this dependency will be shaded into this artifact -->
+      <optional>true</optional>
+      <exclusions>
+        <!-- Exclude Spring Boot 4.x starter - we use 3.x version -->
+        <exclusion>
+          <groupId>io.camunda</groupId>
+          <artifactId>camunda-spring-boot-starter</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Use Spring Boot 3 starter instead -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-boot-3-starter</artifactId>
+    </dependency>
+
+    <!--
+      Original dependencies of the shaded module, except `camunda-spring-boot-starter`.
+      This is done as the shaded module is declared as optional
+      and we cannot use the shade plugin's feature to promoteTransitiveDependencies
+      as this would reintroduce the dependency on `camunda-spring-boot-starter`.
+    -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-json-test-cases</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <!-- Shade plugin to include and relocate classes from camunda-process-test-spring -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createSourcesJar>true</createSourcesJar>
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+              <artifactSet>
+                <includes>
+                  <!-- Only include the base module in the shaded jar -->
+                  <include>io.camunda:camunda-process-test-spring</include>
+                </includes>
+              </artifactSet>
+              <transformers>
+                <!-- Merge service files -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <!-- Keep manifest entries -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <!-- Ignore any non-test scoped deps, we only have test source here -->
+          <ignoredNonTestScopedDependencies>
+            <dependency>*</dependency>
+          </ignoredNonTestScopedDependencies>
+          <!-- Ignore all unused/undeclared, we duplicate all from the base module -->
+          <ignoredUsedUndeclaredDependencies>
+            <dependency>*</dependency>
+          </ignoredUsedUndeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <dependency>*</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+
+      <!-- Add test re-/sources from the base module -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-test-source</id>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <sources>
+                <source>${project.basedir}/../camunda-process-test-spring/src/test/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-resource</id>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/../camunda-process-test-spring/src/test/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Run tests compiled from base module sources -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>central-sonatype-publish</id>
+      <!--
+        This profile is typically activated during release builds refer to
+        org.camunda:camunda-release-parent
+      -->
+      <build>
+        <plugins>
+          <!--
+            Unpack javadoc from base module and repackage them, this is required to ensure we have
+            javadoc available, given this module is a shade of camunda-process-test-spring,
+            we lack them otherwise.
+          -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-javadoc</id>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>io.camunda</groupId>
+                      <artifactId>camunda-process-test-spring</artifactId>
+                      <version>${project.version}</version>
+                      <classifier>javadoc</classifier>
+                      <type>jar</type>
+                      <outputDirectory>${project.build.directory}/apidocs</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>javadoc-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <classesDirectory>${project.build.directory}/apidocs</classesDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -23,6 +23,7 @@
   <modules>
     <module>camunda-process-test-java</module>
     <module>camunda-process-test-spring</module>
+    <module>camunda-process-test-spring-boot-3</module>
     <module>camunda-process-test-example</module>
     <module>camunda-process-test-json-test-cases</module>
   </modules>


### PR DESCRIPTION
# Description
Backport of #47474 to `stable/8.9`.

relates to #45523 camunda/camunda#45523