### PR TITLE
refactor: simplify IncidentHandler

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -81,17 +81,17 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
         .setId(ExporterUtil.toStringOrNull(incidentKey))
         .setKey(incidentKey)
         .setPartitionId(record.getPartitionId())
-        .setPosition(record.getPosition());
+        .setPosition(record.getPosition())
+        .setProcessInstanceKey(recordValue.getProcessInstanceKey())
+        .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
+        .setBpmnProcessId(recordValue.getBpmnProcessId())
+        .setFlowNodeInstanceKey(recordValue.getElementInstanceKey())
+        .setTreePath(buildTreePath(record));
+
     if (recordValue.getJobKey() > 0) {
       entity.setJobKey(recordValue.getJobKey());
     }
-    if (recordValue.getProcessInstanceKey() > 0) {
-      entity.setProcessInstanceKey(recordValue.getProcessInstanceKey());
-    }
-    if (recordValue.getProcessDefinitionKey() > 0) {
-      entity.setProcessDefinitionKey(recordValue.getProcessDefinitionKey());
-    }
-    entity.setBpmnProcessId(recordValue.getBpmnProcessId());
+
     final String errorMessage = ExporterUtil.trimWhitespace(recordValue.getErrorMessage());
     entity
         .setErrorMessage(errorMessage)
@@ -99,16 +99,11 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
             ErrorType.fromZeebeErrorType(
                 recordValue.getErrorType() == null ? null : recordValue.getErrorType().name()))
         .setFlowNodeId(recordValue.getElementId());
-    if (recordValue.getElementInstanceKey() > 0) {
-      entity.setFlowNodeInstanceKey(recordValue.getElementInstanceKey());
-    }
     entity
         .setState(IncidentState.PENDING)
         .setCreationTime(
             OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC))
         .setTenantId(ExporterUtil.tenantOrDefault(recordValue.getTenantId()));
-
-    entity.setTreePath(buildTreePath(record));
 
     final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {


### PR DESCRIPTION
## Description

Removal of redundant null-checks for processInstanceKey , elementInstanceKey or processDefinitionKey. These need to be present on all records.

See https://github.com/camunda/camunda/pull/47610#discussion_r2888722298

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

