### PR TITLE
feat: add JobErrorStatistics OS/ES implementation

### DIFF
--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -24,6 +24,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.TopHitsAggregate;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.json.JsonData;
 import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
 import io.camunda.search.clients.aggregator.SearchTopHitsAggregator;
 import io.camunda.search.clients.core.AggregationResult;
 import io.camunda.search.clients.core.AggregationResult.Builder;
@@ -47,7 +48,6 @@ public class SearchAggregationResultTransformer<T>
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SearchAggregationResultTransformer.class);
-  private static final String COMPOSITE_KEY_DELIMITER = "__";
   private final ElasticsearchTransformers transformers;
   private final List<SearchAggregator> aggregators;
 
@@ -144,9 +144,10 @@ public class SearchAggregationResultTransformer<T>
                       b.keyAsString() != null ? b.keyAsString() : String.valueOf(b.key());
                   case final DateHistogramBucket b -> String.valueOf(b.key());
                   case final CompositeBucket b ->
-                      b.key().values().stream()
-                          .map(SearchAggregationResultTransformer::fieldValueToString)
-                          .collect(Collectors.joining(COMPOSITE_KEY_DELIMITER));
+                      SearchCompositeAggregator.joinKeys(
+                          b.key().values().stream()
+                              .map(SearchAggregationResultTransformer::fieldValueToString)
+                              .toArray(String[]::new));
                   default ->
                       throw new IllegalStateException(
                           "Unsupported bucket type: " + bucket.getClass());

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.os.transformers.aggregator;
 
 import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
 import io.camunda.search.clients.aggregator.SearchTopHitsAggregator;
 import io.camunda.search.clients.core.AggregationResult;
 import io.camunda.search.clients.core.AggregationResult.Builder;
@@ -47,7 +48,6 @@ public class SearchAggregationResultTransformer<T>
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SearchAggregationResultTransformer.class);
-  private static final String COMPOSITE_KEY_DELIMITER = "__";
   private final OpensearchTransformers transformers;
   private final List<SearchAggregator> aggregators;
 
@@ -147,9 +147,10 @@ public class SearchAggregationResultTransformer<T>
                       b.keyAsString() != null ? b.keyAsString() : String.valueOf(b.key().signed());
                   case final DateHistogramBucket b -> String.valueOf(b.key());
                   case final CompositeBucket b ->
-                      b.key().values().stream()
-                          .map(SearchAggregationResultTransformer::fieldValueToString)
-                          .collect(Collectors.joining(COMPOSITE_KEY_DELIMITER));
+                      SearchCompositeAggregator.joinKeys(
+                          b.key().values().stream()
+                              .map(SearchAggregationResultTransformer::fieldValueToString)
+                              .toArray(String[]::new));
                   default ->
                       throw new IllegalStateException(
                           "Unsupported bucket type: " + bucket.getClass());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchCompositeAggregator.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchCompositeAggregator.java
@@ -19,6 +19,26 @@ public record SearchCompositeAggregator(
     List<SearchAggregator> sources)
     implements SearchAggregator {
 
+  public static final String COMPOSITE_KEY_DELIMITER = "__";
+
+  /** Joins multiple composite source values into a single bucket map key. */
+  public static String joinKeys(final String... parts) {
+    return String.join(COMPOSITE_KEY_DELIMITER, parts);
+  }
+
+  /**
+   * Splits a composite bucket key back into its parts.
+   *
+   * <p>Uses a bounded split so that the last part can itself contain the delimiter.
+   *
+   * @param key the composite key (e.g. {@code "errorCode__errorMessage"})
+   * @param expectedParts the number of parts expected (i.e. number of composite sources)
+   * @return an array of length {@code expectedParts}
+   */
+  public static String[] splitKey(final String key, final int expectedParts) {
+    return key.split(COMPOSITE_KEY_DELIMITER, expectedParts);
+  }
+
   @Override
   public String getName() {
     return name;

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
+import io.camunda.search.aggregation.result.JobErrorStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobTimeSeriesStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobWorkerStatisticsAggregationResult;
@@ -65,6 +66,7 @@ public class JobMetricsBatchDocumentReader extends DocumentBasedReader
   @Override
   public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
       final JobErrorStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException("Job error statistics is not yet implemented");
+    return aggregateToResult(
+        query, JobErrorStatisticsAggregationResult.class, resourceAccessChecks);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -12,6 +12,7 @@ import io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation;
 import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
+import io.camunda.search.aggregation.JobErrorStatisticsAggregation;
 import io.camunda.search.aggregation.JobTimeSeriesStatisticsAggregation;
 import io.camunda.search.aggregation.JobTypeStatisticsAggregation;
 import io.camunda.search.aggregation.JobWorkerStatisticsAggregation;
@@ -28,6 +29,7 @@ import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggre
 import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
+import io.camunda.search.aggregation.result.JobErrorStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobTimeSeriesStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.JobWorkerStatisticsAggregationResult;
@@ -48,6 +50,7 @@ import io.camunda.search.clients.transformers.aggregation.DecisionDefinitionLate
 import io.camunda.search.clients.transformers.aggregation.GlobalJobStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByErrorAggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.JobErrorStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.JobTimeSeriesStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.JobTypeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.JobWorkerStatisticsAggregationTransformer;
@@ -64,6 +67,7 @@ import io.camunda.search.clients.transformers.aggregation.result.DecisionDefinit
 import io.camunda.search.clients.transformers.aggregation.result.GlobalJobStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.JobErrorStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.JobTimeSeriesStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.JobTypeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.JobWorkerStatisticsAggregationResultTransformer;
@@ -236,6 +240,7 @@ import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
@@ -456,6 +461,7 @@ public final class ServiceTransformers {
             JobTypeStatisticsQuery.class,
             JobWorkerStatisticsQuery.class,
             JobTimeSeriesStatisticsQuery.class,
+            JobErrorStatisticsQuery.class,
             GlobalListenerQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
@@ -700,6 +706,8 @@ public final class ServiceTransformers {
     mappers.put(
         JobTimeSeriesStatisticsAggregation.class,
         new JobTimeSeriesStatisticsAggregationTransformer());
+    mappers.put(
+        JobErrorStatisticsAggregation.class, new JobErrorStatisticsAggregationTransformer());
 
     // aggregation result
     mappers.put(
@@ -745,5 +753,8 @@ public final class ServiceTransformers {
     mappers.put(
         JobTimeSeriesStatisticsAggregationResult.class,
         new JobTimeSeriesStatisticsAggregationResultTransformer());
+    mappers.put(
+        JobErrorStatisticsAggregationResult.class,
+        new JobErrorStatisticsAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/JobErrorStatisticsAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/JobErrorStatisticsAggregationTransformer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_BY_ERROR;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_COMPOSITE_SIZE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_SOURCE_NAME_ERROR_CODE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_SOURCE_NAME_ERROR_MESSAGE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_WORKERS;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.FIELD_ERROR_CODE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.FIELD_ERROR_MESSAGE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.FIELD_WORKER;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.cardinality;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.composite;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+
+import io.camunda.search.aggregation.JobErrorStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import java.util.Optional;
+
+public class JobErrorStatisticsAggregationTransformer
+    implements AggregationTransformer<JobErrorStatisticsAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<JobErrorStatisticsAggregation, ServiceTransformers> value) {
+
+    final var aggregation = value.getLeft();
+
+    // Cardinality sub-aggregation to count distinct workers per (errorCode, errorMessage) bucket
+    final var workersAgg = cardinality(AGGREGATION_WORKERS, FIELD_WORKER);
+
+    // Two terms sources to composite-bucket by (errorCode, errorMessage)
+    final var byErrorCodeSource =
+        terms().name(AGGREGATION_SOURCE_NAME_ERROR_CODE).field(FIELD_ERROR_CODE).build();
+    final var byErrorMessageSource =
+        terms().name(AGGREGATION_SOURCE_NAME_ERROR_MESSAGE).field(FIELD_ERROR_MESSAGE).build();
+
+    // Composite aggregation for pagination support
+    final var page = aggregation.page();
+    final var byErrorAgg =
+        composite()
+            .name(AGGREGATION_BY_ERROR)
+            .size(
+                Optional.ofNullable(page)
+                    .map(SearchQueryPage::size)
+                    .orElse(AGGREGATION_COMPOSITE_SIZE))
+            .after(Optional.ofNullable(page).map(SearchQueryPage::after).orElse(null))
+            .sources(List.of(byErrorCodeSource, byErrorMessageSource))
+            .aggregations(workersAgg)
+            .build();
+
+    return List.of(byErrorAgg);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/JobErrorStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/JobErrorStatisticsAggregationResultTransformer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_BY_ERROR;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_WORKERS;
+
+import io.camunda.search.aggregation.result.JobErrorStatisticsAggregationResult;
+import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class JobErrorStatisticsAggregationResultTransformer
+    implements AggregationResultTransformer<JobErrorStatisticsAggregationResult> {
+
+  @Override
+  public JobErrorStatisticsAggregationResult apply(
+      final Map<String, AggregationResult> aggregations) {
+
+    final var byErrorAgg = aggregations.get(AGGREGATION_BY_ERROR);
+    if (byErrorAgg == null || byErrorAgg.aggregations() == null) {
+      return new JobErrorStatisticsAggregationResult(Collections.emptyList(), null);
+    }
+
+    final var perErrorBuckets = byErrorAgg.aggregations();
+
+    final List<JobErrorStatisticsEntity> items =
+        perErrorBuckets.entrySet().stream()
+            .map(
+                entry -> {
+                  final String compositeKey = entry.getKey();
+                  final var agg = entry.getValue();
+                  if (agg == null) {
+                    return null;
+                  }
+
+                  // Composite key is "errorCode__errorMessage"
+                  final String[] parts = SearchCompositeAggregator.splitKey(compositeKey, 2);
+                  final String errorCode = parts[0];
+                  final String errorMessage = parts.length > 1 ? parts[1] : null;
+
+                  final int workers = extractCardinality(agg.aggregations());
+
+                  return new JobErrorStatisticsEntity(errorCode, errorMessage, workers);
+                })
+            .filter(Objects::nonNull)
+            .toList();
+
+    return new JobErrorStatisticsAggregationResult(items, byErrorAgg.endCursor());
+  }
+
+  private int extractCardinality(final Map<String, AggregationResult> aggregations) {
+    if (aggregations == null) {
+      return 0;
+    }
+    final var agg = aggregations.get(AGGREGATION_WORKERS);
+    if (agg != null && agg.docCount() != null) {
+      return agg.docCount().intValue();
+    }
+    return 0;
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/JobErrorStatisticsAggregationTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/JobErrorStatisticsAggregationTransformerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_BY_ERROR;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_COMPOSITE_SIZE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_SOURCE_NAME_ERROR_CODE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_SOURCE_NAME_ERROR_MESSAGE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_WORKERS;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.FIELD_ERROR_CODE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.FIELD_ERROR_MESSAGE;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.FIELD_WORKER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.aggregation.JobErrorStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
+import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.aggregator.SearchTermsAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JobErrorStatisticsAggregationTransformerTest {
+
+  private final JobErrorStatisticsAggregationTransformer transformer =
+      new JobErrorStatisticsAggregationTransformer();
+
+  private final ServiceTransformers transformers =
+      ServiceTransformers.newInstance(new IndexDescriptors("", true));
+
+  @Test
+  void shouldBuildExpectedAggregationStructure() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(50).after("cursor123"));
+    final var aggregation = new JobErrorStatisticsAggregation(page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    assertThat(aggregations).hasSize(1);
+
+    assertThat(aggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchCompositeAggregator.class,
+            compositeAgg -> {
+              assertThat(compositeAgg.name()).isEqualTo(AGGREGATION_BY_ERROR);
+              assertThat(compositeAgg.size()).isEqualTo(50);
+              assertThat(compositeAgg.after()).isEqualTo("cursor123");
+
+              // Two terms sources: errorCode and errorMessage
+              assertThat(compositeAgg.sources()).hasSize(2);
+              assertThat(compositeAgg.sources().get(0))
+                  .isInstanceOfSatisfying(
+                      SearchTermsAggregator.class,
+                      termsAgg -> {
+                        assertThat(termsAgg.getName())
+                            .isEqualTo(AGGREGATION_SOURCE_NAME_ERROR_CODE);
+                        assertThat(termsAgg.field()).isEqualTo(FIELD_ERROR_CODE);
+                      });
+              assertThat(compositeAgg.sources().get(1))
+                  .isInstanceOfSatisfying(
+                      SearchTermsAggregator.class,
+                      termsAgg -> {
+                        assertThat(termsAgg.getName())
+                            .isEqualTo(AGGREGATION_SOURCE_NAME_ERROR_MESSAGE);
+                        assertThat(termsAgg.field()).isEqualTo(FIELD_ERROR_MESSAGE);
+                      });
+
+              // One cardinality sub-aggregation for workers
+              assertThat(compositeAgg.aggregations()).hasSize(1);
+              assertThat(compositeAgg.aggregations().get(0))
+                  .isInstanceOfSatisfying(
+                      SearchCardinalityAggregator.class,
+                      cardAgg -> {
+                        assertThat(cardAgg.getName()).isEqualTo(AGGREGATION_WORKERS);
+                        assertThat(cardAgg.field()).isEqualTo(FIELD_WORKER);
+                      });
+            });
+  }
+
+  @Test
+  void shouldUseDefaultSizeWhenPageIsNull() {
+    // given
+    final var aggregation = new JobErrorStatisticsAggregation(null);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    assertThat(aggregations).hasSize(1);
+    assertThat(aggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchCompositeAggregator.class,
+            compositeAgg -> {
+              assertThat(compositeAgg.size()).isEqualTo(AGGREGATION_COMPOSITE_SIZE);
+              assertThat(compositeAgg.after()).isNull();
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/JobErrorStatisticsAggregationResultTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/JobErrorStatisticsAggregationResultTransformerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_BY_ERROR;
+import static io.camunda.search.aggregation.JobErrorStatisticsAggregation.AGGREGATION_WORKERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.core.AggregationResult;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class JobErrorStatisticsAggregationResultTransformerTest {
+
+  private final JobErrorStatisticsAggregationResultTransformer transformer =
+      new JobErrorStatisticsAggregationResultTransformer();
+
+  @Test
+  void shouldReturnEmptyListWhenAggregationsEmpty() {
+    // when
+    final var result = transformer.apply(Map.of());
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.endCursor()).isNull();
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenByErrorAggIsNull() {
+    // given
+    final Map<String, AggregationResult> input = Map.of();
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.endCursor()).isNull();
+  }
+
+  @Test
+  void shouldTransformSingleErrorBucket() {
+    // given
+    final long workerCount = 7L;
+    final String endCursor = "cursorABC";
+
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_ERROR,
+            byErrorBucket(
+                Map.of("UNHANDLED_ERROR_EVENT__Something went wrong", workersBucket(workerCount)),
+                endCursor));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.endCursor()).isEqualTo(endCursor);
+
+    final var entity = result.items().get(0);
+    assertThat(entity.errorCode()).isEqualTo("UNHANDLED_ERROR_EVENT");
+    assertThat(entity.errorMessage()).isEqualTo("Something went wrong");
+    assertThat(entity.workers()).isEqualTo((int) workerCount);
+  }
+
+  @Test
+  void shouldTransformMultipleErrorBuckets() {
+    // given
+    final Map<String, AggregationResult> buckets = new LinkedHashMap<>();
+    buckets.put("IO_ERROR__Disk full", workersBucket(3L));
+    buckets.put("TIMEOUT__Connection timed out", workersBucket(12L));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_BY_ERROR, byErrorBucket(buckets, null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.endCursor()).isNull();
+
+    assertThat(result.items())
+        .anySatisfy(
+            e -> {
+              assertThat(e.errorCode()).isEqualTo("IO_ERROR");
+              assertThat(e.errorMessage()).isEqualTo("Disk full");
+              assertThat(e.workers()).isEqualTo(3);
+            });
+    assertThat(result.items())
+        .anySatisfy(
+            e -> {
+              assertThat(e.errorCode()).isEqualTo("TIMEOUT");
+              assertThat(e.errorMessage()).isEqualTo("Connection timed out");
+              assertThat(e.workers()).isEqualTo(12);
+            });
+  }
+
+  @Test
+  void shouldHandleMissingWorkersSubAggregation() {
+    // given
+    final Map<String, AggregationResult> buckets = Map.of("NO_WORKERS_ERROR__msg", emptyBucket());
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_BY_ERROR, byErrorBucket(buckets, null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).workers()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldHandleBucketWithErrorCodeOnly() {
+    // given — composite key has errorCode but an empty errorMessage
+    final Map<String, AggregationResult> buckets = Map.of("IO_ERROR__", workersBucket(5L));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_BY_ERROR, byErrorBucket(buckets, null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final var entity = result.items().getFirst();
+    assertThat(entity.errorCode()).isEqualTo("IO_ERROR");
+    assertThat(entity.errorMessage()).isEmpty();
+    assertThat(entity.workers()).isEqualTo(5);
+  }
+
+  // ---------- helpers ----------
+
+  private static AggregationResult byErrorBucket(
+      final Map<String, AggregationResult> buckets, final String endCursor) {
+    return new AggregationResult.Builder().aggregations(buckets).endCursor(endCursor).build();
+  }
+
+  private static AggregationResult workersBucket(final long count) {
+    return new AggregationResult.Builder()
+        .aggregations(
+            Map.of(AGGREGATION_WORKERS, new AggregationResult.Builder().docCount(count).build()))
+        .build();
+  }
+
+  private static AggregationResult emptyBucket() {
+    return new AggregationResult.Builder().aggregations(Collections.emptyMap()).build();
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces support for job error statistics aggregation and refines composite key handling in aggregation result transformers. The main themes are the implementation of job error statistics aggregation, integration of new transformers, and improvements to composite key management.

**Job Error Statistics Aggregation Support:**

* Implemented the `JobErrorStatisticsAggregationTransformer` to support aggregating job errors by error code and error message, including counting distinct workers per error.
* Added the `JobErrorStatisticsAggregationResultTransformer` to convert aggregation results into `JobErrorStatisticsAggregationResult` entities, parsing composite keys and extracting worker counts.
* Enabled the `JobMetricsBatchDocumentReader` to handle `JobErrorStatisticsQuery` and return results using the new aggregation and result transformers.

**Integration and Registration of Transformers:**

* Registered `JobErrorStatisticsAggregation`, its result, and associated transformers in `ServiceTransformers`, ensuring correct mapping and transformation for queries and results. [[1]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R15) [[2]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R32) [[3]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R53) [[4]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R70) [[5]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R243) [[6]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R464) [[7]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R709-R710) [[8]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R756-R758)

**Composite Key Handling Improvements:**

* Refactored composite key joining and splitting logic into static methods (`joinKeys` and `splitKey`) within `SearchCompositeAggregator`, and updated Elasticsearch and OpenSearch result transformers to use these methods for consistent key management. [[1]](diffhunk://#diff-77c581d8193fb0cbe3d247401246f59e4a4b7b077bc4e3c8220df8f4d042d4afR22-R41) [[2]](diffhunk://#diff-94c46f968e4dd355de4ecb06fe2856786e47cd2ba3bfc7d41a8b8df98d5de5bbR27) [[3]](diffhunk://#diff-94c46f968e4dd355de4ecb06fe2856786e47cd2ba3bfc7d41a8b8df98d5de5bbL50) [[4]](diffhunk://#diff-94c46f968e4dd355de4ecb06fe2856786e47cd2ba3bfc7d41a8b8df98d5de5bbR147-R150) [[5]](diffhunk://#diff-c4991e7b556bf18f2f29858e87fd27a635491dea74c5ebb0d54d8ca7ad041062R11) [[6]](diffhunk://#diff-c4991e7b556bf18f2f29858e87fd27a635491dea74c5ebb0d54d8ca7ad041062L50) [[7]](diffhunk://#diff-c4991e7b556bf18f2f29858e87fd27a635491dea74c5ebb0d54d8ca7ad041062R150-R153)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43051
