### PR TITLE
fix: in LogStreamMetrics IN_FLIGHT_REQUESTS was incrementing `inFlightAppends`

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -82,7 +82,7 @@ public final class LogStreamMetrics {
     appendLatency = MicrometerUtil.buildTimer(WRITE_LATENCY).register(registry);
 
     registerGauge(INFLIGHT_APPENDS, inflightAppends);
-    registerGauge(INFLIGHT_REQUESTS, inflightAppends);
+    registerGauge(INFLIGHT_REQUESTS, inflightRequests);
     registerGauge(REQUEST_LIMIT, requestLimit);
     registerGauge(LAST_COMMITTED_POSITION, lastCommitted);
     registerGauge(LAST_WRITTEN_POSITION, lastWritten);


### PR DESCRIPTION
## Description
Metric was incrementing the wrong counter

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
