### PR TITLE
fix: Move Archiver Reindexing to Bounded Threadpool

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -25,6 +25,7 @@ public class DocumentBasedHistory {
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
   private static final String DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "1h";
+  private static final int DEFAULT_HISTORY_MAX_PARALLEL_ARCHIVER_REINDEX_TASKS = 5;
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
           "process-instance-enabled",
@@ -70,6 +71,9 @@ public class DocumentBasedHistory {
 
   /** Maximum millisecond interval between archiver runs due to failure backoffs */
   private Duration maxDelayBetweenRuns = DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS;
+
+  /** Maximum archiver reindex tasks per partition (set `-1` for unlimited with caution) */
+  private int maxParallelArchiverReindexTasks = DEFAULT_HISTORY_MAX_PARALLEL_ARCHIVER_REINDEX_TASKS;
 
   /** Defines the name of the created and applied ILM policy. */
   private String policyName = DEFAULT_HISTORY_POLICY_NAME;
@@ -185,6 +189,14 @@ public class DocumentBasedHistory {
 
   public void setMaxDelayBetweenRuns(final Duration maxDelayBetweenRuns) {
     this.maxDelayBetweenRuns = maxDelayBetweenRuns;
+  }
+
+  public int getMaxParallelArchiverReindexTasks() {
+    return maxParallelArchiverReindexTasks;
+  }
+
+  public void setMaxParallelArchiverReindexTasks(final int maxParallelArchiverReindexTasks) {
+    this.maxParallelArchiverReindexTasks = maxParallelArchiverReindexTasks;
   }
 
   public String getPolicyName() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -151,6 +151,8 @@ public final class CamundaExporterConfigurationApplier {
     target.setRolloverInterval(source.getHistory().getRolloverInterval());
     target.setRolloverBatchSize(source.getHistory().getRolloverBatchSize());
     target.setWaitPeriodBeforeArchiving(source.getHistory().getWaitPeriodBeforeArchiving());
+    target.setMaxParallelArchiverReindexTasks(
+        source.getHistory().getMaxParallelArchiverReindexTasks());
     target.setDelayBetweenRuns(
         Math.toIntExact(source.getHistory().getDelayBetweenRuns().toMillis()));
     target.setMaxDelayBetweenRuns(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -230,6 +230,8 @@ public class ExporterConfiguration {
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
     private int maxDelayBetweenRuns = 60000;
+    // use `-1` for unlimited parallel archiver reindex tasks, use with caution
+    private int maxParallelArchiverReindexTasks = 5;
     private RetentionConfiguration retention = new RetentionConfiguration();
     private boolean trackArchivalMetricsForProcessInstance = true;
 
@@ -309,6 +311,14 @@ public class ExporterConfiguration {
       this.maxDelayBetweenRuns = maxDelayBetweenRuns;
     }
 
+    public int getMaxParallelArchiverReindexTasks() {
+      return maxParallelArchiverReindexTasks;
+    }
+
+    public void setMaxParallelArchiverReindexTasks(final int maxParallelArchiverReindexTasks) {
+      this.maxParallelArchiverReindexTasks = maxParallelArchiverReindexTasks;
+    }
+
     @Override
     public String toString() {
       return "ArchiverConfiguration{"
@@ -327,6 +337,8 @@ public class ExporterConfiguration {
           + delayBetweenRuns
           + ", maxDelayBetweenRuns="
           + maxDelayBetweenRuns
+          + ", maxParallelArchiverReindexTasks="
+          + maxParallelArchiverReindexTasks
           + ", retention="
           + retention
           + ", trackArchivalMetricsForProcessInstance="

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -99,6 +99,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   private final AtomicReference<Instant> lastFlushTime = new AtomicReference<>(Instant.now());
   private final AtomicInteger processInstancesAwaitingArchival = new AtomicInteger(0);
+  private final AtomicInteger archiverReindexTasksInFlight = new AtomicInteger(0);
 
   public CamundaExporterMetrics(final MeterRegistry meterRegistry) {
     this(meterRegistry, InstantSource.system());
@@ -285,6 +286,13 @@ public class CamundaExporterMetrics implements AutoCloseable {
             AtomicInteger::get)
         .description("Number of process instances awaiting archival (approximate)")
         .register(meterRegistry);
+
+    Gauge.builder(
+            meterName("archiver.reindex.tasks.inflight"),
+            archiverReindexTasksInFlight,
+            AtomicInteger::get)
+        .description("Number of archiver reindexing tasks inflight")
+        .register(meterRegistry);
   }
 
   public CloseableSilently measureFlushDuration() {
@@ -401,6 +409,14 @@ public class CamundaExporterMetrics implements AutoCloseable {
     processInstancesAwaitingArchival.set(count);
   }
 
+  public void beginArchiverReindexTask() {
+    archiverReindexTasksInFlight.incrementAndGet();
+  }
+
+  public void completeArchiverReindexTask() {
+    archiverReindexTasksInFlight.decrementAndGet();
+  }
+
   /**
    * For each record write timestamp, observes the export latency by subtracting the timestamp from
    * the current stream clock.
@@ -464,6 +480,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(meterName("since.last.flush.seconds"));
     removeGaugeIfExists(meterName("process.instances.awaiting.archival"));
+    removeGaugeIfExists(meterName("archiver.reindex.tasks.inflight"));
   }
 
   private void removeGaugeIfExists(final String meterName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -68,6 +68,7 @@ import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
@@ -84,6 +85,7 @@ public final class BackgroundTaskManagerFactory {
   private final ObjectMapper objectMapper;
 
   private ScheduledThreadPoolExecutor executor;
+  private Semaphore reindexSemaphore;
   private ArchiverRepository archiverRepository;
   private IncidentUpdateRepository incidentRepository;
   private BatchOperationUpdateRepository batchOperationUpdateRepository;
@@ -117,6 +119,7 @@ public final class BackgroundTaskManagerFactory {
 
   public BackgroundTaskManager build() {
     executor = buildExecutor();
+    reindexSemaphore = new Semaphore(getMaxParallelArchiverReindexTasks());
 
     // initialize all repositories based on connection type to reuse clients
     if (config.getConnect().getTypeEnum().isOpenSearch()) {
@@ -153,6 +156,22 @@ public final class BackgroundTaskManagerFactory {
         executor,
         tasks,
         Duration.ofSeconds(5));
+  }
+
+  private int getMaxParallelArchiverReindexTasks() {
+    if (config.getHistory().getMaxParallelArchiverReindexTasks() <= 0) {
+      logger.info(
+          "Creating a reindexing throttler with unlimited parallel execution permits. Use "
+              + "the `history.maxParallelArchiverReindexTasks` config property to set a lower "
+              + "number of parallel execution permits to reduce resource usage.");
+      return Integer.MAX_VALUE;
+    }
+
+    logger.debug(
+        "Creating reindexing throttler with {} parallel permits.",
+        config.getHistory().getMaxParallelArchiverReindexTasks());
+
+    return config.getHistory().getMaxParallelArchiverReindexTasks();
   }
 
   private OpensearchBatchOperationUpdateRepository createBatchOperationRepository(
@@ -408,7 +427,8 @@ public final class BackgroundTaskManagerFactory {
             dependantTemplates,
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildBatchOperationArchiverJob() {
@@ -425,7 +445,8 @@ public final class BackgroundTaskManagerFactory {
             dependantTemplates,
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildUsageMetricsArchiverJob() {
@@ -435,7 +456,8 @@ public final class BackgroundTaskManagerFactory {
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildUsageMetricsTUArchiverJob() {
@@ -445,7 +467,8 @@ public final class BackgroundTaskManagerFactory {
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildJobBatchMetricsArchiverJob() {
@@ -455,7 +478,8 @@ public final class BackgroundTaskManagerFactory {
             resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildStandaloneDecisionArchiverJob() {
@@ -472,6 +496,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
+            reindexSemaphore,
             dependantTemplates));
   }
 
@@ -516,7 +541,8 @@ public final class BackgroundTaskManagerFactory {
             resourceProvider.getIndexTemplateDescriptor(AuditLogTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ScheduledThreadPoolExecutor buildExecutor() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -17,6 +17,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 
@@ -27,10 +30,16 @@ import org.slf4j.Logger;
  */
 public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundTask {
 
+  // Virtual-thread executor used exclusively for blocking semaphore.acquire() calls.
+  // This prevent using main (platform-threaded) executor, avoiding thread starvation.
+  private static final ExecutorService SEMAPHORE_EXECUTOR =
+      Executors.newVirtualThreadPerTaskExecutor();
+
   private final ArchiverRepository archiverRepository;
   private final CamundaExporterMetrics exporterMetrics;
   private final Logger logger;
   private final Executor executor;
+  private final Semaphore reindexSemaphore;
 
   private final Consumer<Integer> recordArchivingMetric;
   private final Consumer<Integer> recordArchivedMetric;
@@ -40,12 +49,14 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
       final Executor executor,
+      final Semaphore reindexSemaphore,
       final Consumer<Integer> recordArchivingMetric,
       final Consumer<Integer> recordArchivedMetric) {
     this.archiverRepository = archiverRepository;
     this.exporterMetrics = exporterMetrics;
     this.logger = logger;
     this.executor = executor;
+    this.reindexSemaphore = reindexSemaphore;
     this.recordArchivingMetric = recordArchivingMetric;
     this.recordArchivedMetric = recordArchivedMetric;
   }
@@ -133,9 +144,16 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
     final var sourceIdxName = templateDescriptor.getFullQualifiedName();
     final var idsMap = createIdsByFieldMap(templateDescriptor, batch);
     final var finishDate = batch.finishDate();
-    return archiverRepository
-        .moveDocuments(sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor)
-        .thenApplyAsync(ok -> batch.size(), executor);
+
+    // Note: Acquire the semaphore on a virtual thread to avoid blocking the main executor threads
+    return CompletableFuture.supplyAsync(this::getReindexPermit, SEMAPHORE_EXECUTOR)
+        .thenComposeAsync(
+            ignored ->
+                archiverRepository.moveDocuments(
+                    sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor),
+            executor)
+        .whenCompleteAsync((result, error) -> releaseReindexPermit(), SEMAPHORE_EXECUTOR)
+        .thenApply(ok -> batch.size());
   }
 
   /**
@@ -149,4 +167,22 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
    */
   protected abstract Map<String, List<String>> createIdsByFieldMap(
       final IndexTemplateDescriptor templateDescriptor, final B batch);
+
+  private boolean getReindexPermit() {
+    try {
+      reindexSemaphore.acquire();
+      exporterMetrics.beginArchiverReindexTask();
+      return true;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.error(
+          "Archiver job interrupted while waiting for reindex permit: {}", e.getMessage(), e);
+      return false;
+    }
+  }
+
+  private void releaseReindexPermit() {
+    reindexSemaphore.release();
+    exporterMetrics.completeArchiverReindexTask();
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
@@ -28,12 +29,14 @@ public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
       final AuditLogTemplate auditLogTemplate,
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         archiverRepository,
         exporterMetrics,
         logger,
         executor,
+        reindexSemaphore,
         exporterMetrics::recordAuditLogsArchiving,
         exporterMetrics::recordAuditLogsArchived);
     this.repository = repository;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -31,12 +32,14 @@ public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArc
       final List<BatchOperationDependant> batchOperationDependants,
       final CamundaExporterMetrics metrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         metrics,
         logger,
         executor,
+        reindexSemaphore,
         metrics::recordBatchOperationsArchiving,
         metrics::recordBatchOperationsArchived);
     this.batchOperationTemplate = batchOperationTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -26,12 +27,14 @@ public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
       final JobMetricsBatchTemplate jobMetricsBatchTemplate,
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         exporterMetrics,
         logger,
         executor,
+        reindexSemaphore,
         exporterMetrics::recordJobBatchMetricsArchiving,
         exporterMetrics::recordJobBatchMetricsArchived);
     this.jobMetricsBatchTemplate = jobMetricsBatchTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 /**
@@ -37,12 +38,14 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
       final List<ProcessInstanceDependant> processInstanceDependants,
       final CamundaExporterMetrics metrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         metrics,
         logger,
         executor,
+        reindexSemaphore,
         metrics::recordProcessInstancesArchiving,
         metrics::recordProcessInstancesArchived);
     this.processInstanceTemplate = processInstanceTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -31,12 +32,14 @@ public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch
       final CamundaExporterMetrics metrics,
       final Logger logger,
       final Executor executor,
+      final Semaphore reindexSemaphore,
       final List<DecisionInstanceDependant> decisionInstanceDependants) {
     super(
         repository,
         metrics,
         logger,
         executor,
+        reindexSemaphore,
         metrics::recordStandaloneDecisionsArchiving,
         metrics::recordStandaloneDecisionsArchived);
     this.decisionInstanceTemplate = decisionInstanceTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -26,12 +27,14 @@ public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
       final UsageMetricTemplate usageMetricTemplate,
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         exporterMetrics,
         logger,
         executor,
+        reindexSemaphore,
         exporterMetrics::recordUsageMetricsArchiving,
         exporterMetrics::recordUsageMetricsArchived);
     this.usageMetricTemplate = usageMetricTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -25,12 +26,14 @@ public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArch
       final UsageMetricTUTemplate usageMetricTUTemplate,
       final CamundaExporterMetrics metrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         metrics,
         logger,
         executor,
+        reindexSemaphore,
         metrics::recordUsageMetricsTUArchiving,
         metrics::recordUsageMetricsTUArchived);
     this.usageMetricTUTemplate = usageMetricTUTemplate;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -125,6 +126,7 @@ final class ArchiverJobTest {
           exporterMetrics,
           logger,
           executor,
+          new Semaphore(Integer.MAX_VALUE),
           recordArchivingMetric,
           recordArchivedMetric);
       indexTemplateDescriptor = mock(IndexTemplateDescriptor.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
@@ -16,6 +16,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -26,6 +27,7 @@ public class AuditLogArchiverJobTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final NoopAuditLogArchiverRepository auditLogArchiverRepository =
       new NoopAuditLogArchiverRepository();
@@ -40,7 +42,8 @@ public class AuditLogArchiverJobTest {
           auditLogTemplate,
           metrics,
           LOGGER,
-          executor);
+          executor,
+          reindexSemaphore);
 
   @AfterEach
   void cleanUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -18,6 +18,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
   private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final BatchOperationTemplate batchOperationTemplate =
@@ -38,7 +40,13 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
 
   private final BatchOperationArchiverJob job =
       new BatchOperationArchiverJob(
-          repository, batchOperationTemplate, List.of(auditLogTemplate), metrics, LOGGER, executor);
+          repository,
+          batchOperationTemplate,
+          List.of(auditLogTemplate),
+          metrics,
+          LOGGER,
+          executor,
+          reindexSemaphore);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
       LoggerFactory.getLogger(JobBatchMetricsArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final JobMetricsBatchTemplate jobMetricsBatchTemplate =
@@ -38,7 +40,7 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
 
   private final JobBatchMetricsArchiverJob job =
       new JobBatchMetricsArchiverJob(
-          repository, jobMetricsBatchTemplate, metrics, LOGGER, executor);
+          repository, jobMetricsBatchTemplate, metrics, LOGGER, executor, reindexSemaphore);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
       LoggerFactory.getLogger(ProcessInstanceArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
@@ -50,7 +52,8 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
           List.of(decisionInstanceTemplate, sequenceFlowTemplate, auditLogTemplate),
           metrics,
           LOGGER,
-          executor);
+          executor,
+          reindexSemaphore);
 
   @BeforeEach
   void setUp() {
@@ -84,7 +87,13 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     // given
     final ProcessInstanceArchiverJob processInstanceJob =
         new ProcessInstanceArchiverJob(
-            repository, processInstanceTemplate, List.of(), metrics, LOGGER, executor);
+            repository,
+            processInstanceTemplate,
+            List.of(),
+            metrics,
+            LOGGER,
+            executor,
+            reindexSemaphore);
 
     // when
     final int count = processInstanceJob.execute().toCompletableFuture().join();
@@ -169,7 +178,13 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     final var dependant = new WeirdlyNamedDependant();
     final var job =
         new ProcessInstanceArchiverJob(
-            repository, processInstanceTemplate, List.of(dependant), metrics, LOGGER, executor);
+            repository,
+            processInstanceTemplate,
+            List.of(dependant),
+            metrics,
+            LOGGER,
+            executor,
+            reindexSemaphore);
     repository.batch = new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L), List.of());
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
       LoggerFactory.getLogger(StandaloneDecisionArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final DecisionInstanceTemplate decisionInstanceTemplate =
@@ -47,6 +49,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
           metrics,
           LOGGER,
           executor,
+          reindexSemaphore,
           List.of(auditLogTemplate));
 
   @BeforeEach
@@ -80,7 +83,13 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     // given
     final StandaloneDecisionArchiverJob standaloneDecisionArchiverJob =
         new StandaloneDecisionArchiverJob(
-            repository, decisionInstanceTemplate, metrics, LOGGER, executor, List.of());
+            repository,
+            decisionInstanceTemplate,
+            metrics,
+            LOGGER,
+            executor,
+            reindexSemaphore,
+            List.of());
 
     // when
     final int count = standaloneDecisionArchiverJob.execute().toCompletableFuture().join();
@@ -149,7 +158,13 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     final var dependant = new WeirdlyNamedDependant();
     final var job =
         new StandaloneDecisionArchiverJob(
-            repository, decisionInstanceTemplate, metrics, LOGGER, executor, List.of(dependant));
+            repository,
+            decisionInstanceTemplate,
+            metrics,
+            LOGGER,
+            executor,
+            reindexSemaphore,
+            List.of(dependant));
     repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2"));
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   private static final Logger LOGGER = LoggerFactory.getLogger(UsageMetricArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final UsageMetricTemplate usageMetricTemplate = new UsageMetricTemplate("", true);
@@ -35,7 +37,8 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
 
   private final UsageMetricArchiverJob job =
-      new UsageMetricArchiverJob(repository, usageMetricTemplate, metrics, LOGGER, executor);
+      new UsageMetricArchiverJob(
+          repository, usageMetricTemplate, metrics, LOGGER, executor, reindexSemaphore);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   private static final Logger LOGGER = LoggerFactory.getLogger(UsageMetricTUArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final UsageMetricTUTemplate usageMetricTUTemplate = new UsageMetricTUTemplate("", true);
@@ -34,7 +36,8 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
 
   private final UsageMetricTUArchiverJob job =
-      new UsageMetricTUArchiverJob(repository, usageMetricTUTemplate, metrics, LOGGER, executor);
+      new UsageMetricTUArchiverJob(
+          repository, usageMetricTUTemplate, metrics, LOGGER, executor, reindexSemaphore);
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION

## Description

We currently run archivers and the reindexing tasks from an unbounded Threadpool which means we will could be running a lot of tasks at a time. Especially when the PI archiver is running it spawns 13+ tasks in parallel.

This will use a special bounded threadpool to run the reindexing tasks so that we can control how many reindexing tasks we will run at the same time.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
