### PR TITLE
test: migrate callActivities.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -240,4 +240,12 @@ export class OperateDiagramPage {
       );
     }
   }
+
+  getPopoverText(pattern: RegExp | string): Locator {
+    return this.popover.getByText(pattern);
+  }
+
+  async clickPopoverLink(pattern: RegExp | string): Promise<void> {
+    await this.popover.getByRole('link', {name: pattern}).click();
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -40,6 +40,8 @@ class OperateProcessInstancePage {
   readonly variableValueInput: Locator;
   readonly variableAddedBanner: Locator;
   readonly migratedTag: Locator;
+  readonly instanceHeaderSkeleton: Locator;
+  readonly processInstanceKeyCell: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -84,6 +86,11 @@ class OperateProcessInstancePage {
     this.migratedTag = page.locator('.cds--tag.cds--tag--green', {
       hasText: /^Migrated/,
     });
+    this.instanceHeaderSkeleton = page.getByTestId('instance-header-skeleton');
+    this.processInstanceKeyCell = page
+      .getByTestId('instance-header')
+      .locator('td')
+      .nth(1);
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -94,8 +101,22 @@ class OperateProcessInstancePage {
     return this.page.getByTestId(variableName).locator('td').last();
   }
 
-  async navigateToProcessInstance({id}: {id: string}): Promise<void> {
-    await this.page.goto(`/operate/processes/instances/${id}`);
+  async navigateToProcessInstance(id: string): Promise<void> {
+    const base =
+      process.env.CORE_APPLICATION_OPERATE_URL ?? 'http://localhost:8081';
+    await this.page.goto(`${base}/operate/processes/${id}`);
+  }
+
+  async clickViewAllCalledInstances(): Promise<void> {
+    await this.page
+      .getByRole('link', {name: /view all called instances/i})
+      .click();
+  }
+
+  async clickViewParentInstance(): Promise<void> {
+    await this.instanceHeader
+      .getByRole('link', {name: /view parent instance/i})
+      .click();
   }
 
   async getProcessInstanceKey(): Promise<string> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -42,6 +42,8 @@ class OperateProcessInstancePage {
   readonly migratedTag: Locator;
   readonly instanceHeaderSkeleton: Locator;
   readonly processInstanceKeyCell: Locator;
+  readonly viewAllCalledInstancesLink: Locator;
+  readonly viewParentInstanceLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -91,6 +93,12 @@ class OperateProcessInstancePage {
       .getByTestId('instance-header')
       .locator('td')
       .nth(1);
+    this.viewAllCalledInstancesLink = page.getByRole('link', {
+      name: /view all called instances/i,
+    });
+    this.viewParentInstanceLink = this.instanceHeader.getByRole('link', {
+      name: /view parent instance/i,
+    });
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -108,15 +116,11 @@ class OperateProcessInstancePage {
   }
 
   async clickViewAllCalledInstances(): Promise<void> {
-    await this.page
-      .getByRole('link', {name: /view all called instances/i})
-      .click();
+    await this.viewAllCalledInstancesLink.click();
   }
 
   async clickViewParentInstance(): Promise<void> {
-    await this.instanceHeader
-      .getByRole('link', {name: /view parent instance/i})
-      .click();
+    await this.viewParentInstanceLink.click();
   }
 
   async getProcessInstanceKey(): Promise<string> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -375,6 +375,20 @@ class OperateProcessesPage {
       );
     }
   }
+
+  calledInstanceCell(): Locator {
+    return this.page
+      .getByTestId('data-list')
+      .getByTestId('cell-processInstanceKey')
+      .first();
+  }
+
+  async clickViewParentInstanceFromList(): Promise<void> {
+    await this.page
+      .getByTestId('data-list')
+      .getByRole('link', {name: /view parent instance/i})
+      .click();
+  }
 }
 
 export {OperateProcessesPage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -50,6 +50,8 @@ class OperateProcessesPage {
   readonly expandOperationsButton: Locator;
   readonly inProgressBar: Locator;
   readonly resultsText: Locator;
+  readonly viewParentInstanceLink: Locator;
+  readonly calledInstanceCell: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -146,6 +148,13 @@ class OperateProcessesPage {
       '[role="progressbar"][aria-busy="true"]',
     );
     this.resultsText = page.getByText('results');
+    this.viewParentInstanceLink = page
+      .getByTestId('data-list')
+      .getByRole('link', {name: /view parent instance/i});
+    this.calledInstanceCell = page
+      .getByTestId('data-list')
+      .getByTestId('cell-processInstanceKey')
+      .first();
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -376,18 +385,8 @@ class OperateProcessesPage {
     }
   }
 
-  calledInstanceCell(): Locator {
-    return this.page
-      .getByTestId('data-list')
-      .getByTestId('cell-processInstanceKey')
-      .first();
-  }
-
   async clickViewParentInstanceFromList(): Promise<void> {
-    await this.page
-      .getByTestId('data-list')
-      .getByRole('link', {name: /view parent instance/i})
-      .click();
+    await this.viewParentInstanceLink.click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/callActivityNavigationProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/callActivityNavigationProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13gwn7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="CallActivityNavigationProcess" name="Call Activity Navigation Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1a3emhl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1a3emhl" sourceRef="StartEvent_1" targetRef="Activity_13otele" />
+    <bpmn:callActivity id="Activity_13otele" name="Call Activity">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="CalledProcess" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1a3emhl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1j9hrgw</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1p0nsc7">
+      <bpmn:incoming>Flow_1j9hrgw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1j9hrgw" sourceRef="Activity_13otele" targetRef="Event_1p0nsc7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CallActivityNavigationProcess">
+      <bpmndi:BPMNEdge id="Flow_1a3emhl_di" bpmnElement="Flow_1a3emhl">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j9hrgw_di" bpmnElement="Flow_1j9hrgw">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1jff16t_di" bpmnElement="Activity_13otele">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p0nsc7_di" bpmnElement="Event_1p0nsc7">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -25,7 +25,7 @@ test.beforeAll(async () => {
   await deploy(['./resources/orderProcessBatchMod_v_1.bpmn']);
   await createInstances('orderProcessBatchMod', 1, NUM_PROCESS_INSTANCES);
 
-  await sleep(3000);
+  await sleep(5000);
 });
 
 test.describe('Process Instance Batch Modification', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -37,8 +37,6 @@ test.beforeAll(async () => {
 });
 
 test.describe('Call Activities', () => {
-  test.describe.configure({retries: 0});
-
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
@@ -67,7 +65,9 @@ test.describe('Call Activities', () => {
       await expect(
         operateProcessInstancePage.instanceHeaderSkeleton,
       ).toBeHidden();
-      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible({
+        timeout: 60000,
+      });
       await expect(
         operateProcessInstancePage.processInstanceKeyCell,
       ).toHaveText(processInstanceKey);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {leep, sleep} from 'utils/sleep';
+
+type ProcessDeployment = {
+  readonly processInstanceKey: string;
+};
+
+let callActivityProcessInstance: ProcessDeployment;
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/callActivityNavigationProcess.bpmn',
+    './resources/calledProcess.bpmn',
+  ]);
+
+  const instance = await createSingleInstance(
+    'CallActivityNavigationProcess',
+    1,
+  );
+  callActivityProcessInstance = {
+    processInstanceKey: instance.processInstanceKey,
+  };
+
+  await sleep(3000);
+});
+
+test.describe('Call Activities', () => {
+  test.describe.configure({retries: 0});
+
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Navigate to called and parent process instances', async ({
+    operateProcessInstancePage,
+    operateProcessesPage,
+    operateDiagramPage,
+  }) => {
+    test.slow();
+    const processInstanceKey = callActivityProcessInstance.processInstanceKey;
+
+    await test.step('Navigate to the call activity process instance', async () => {
+      await operateProcessInstancePage.navigateToProcessInstance(
+        processInstanceKey,
+      );
+
+      await expect(
+        operateProcessInstancePage.instanceHeaderSkeleton,
+      ).toBeHidden();
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+      await expect(
+        operateProcessInstancePage.processInstanceKeyCell,
+      ).toHaveText(processInstanceKey);
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Navigation Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('View all called instances', async () => {
+      await operateProcessInstancePage.clickViewAllCalledInstances();
+
+      await expect(operateProcessesPage.processInstancesTable).toHaveCount(1);
+      await expect(
+        operateProcessesPage.processInstancesTable.getByText('Called Process'),
+      ).toBeVisible();
+    });
+
+    let calledProcessInstanceId: string;
+
+    await test.step('Get called process instance ID', async () => {
+      calledProcessInstanceId = await operateProcessesPage
+        .calledInstanceCell()
+        .innerText();
+    });
+
+    await test.step('Navigate back to parent instance from list', async () => {
+      await operateProcessesPage.clickViewParentInstanceFromList();
+
+      await expect(
+        operateProcessInstancePage.processInstanceKeyCell,
+      ).toHaveText(processInstanceKey);
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Navigation Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify instance history on parent process', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText(
+          'Call Activity Navigation Process',
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('StartEvent_1'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Call Activity', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_1p0nsc7'),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify diagram shows call activity', async () => {
+      await expect(
+        operateDiagramPage.getFlowNode('Activity_13otele'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to called process instance via diagram', async () => {
+      await operateDiagramPage.clickFlowNode('Activity_13otele');
+
+      await expect(
+        operateDiagramPage.getPopoverText(/Called Process Instance/),
+      ).toBeVisible();
+
+      await operateDiagramPage.clickPopoverLink(
+        /view called process instance/i,
+      );
+    });
+
+    await test.step('Verify called process instance header and history', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          calledProcessInstanceId,
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText('Called Process', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Called Process', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Process started'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_0y6k56d'),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify called process diagram', async () => {
+      await expect(
+        operateDiagramPage.getFlowNode('StartEvent_1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate back to parent instance from header', async () => {
+      await operateProcessInstancePage.clickViewParentInstance();
+
+      await expect(
+        operateProcessInstancePage.processInstanceKeyCell,
+      ).toHaveText(processInstanceKey);
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Navigation Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify parent process instance history and diagram again', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText(
+          'Call Activity Navigation Process',
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('StartEvent_1'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Call Activity', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_1p0nsc7'),
+      ).toBeVisible();
+
+      await expect(
+        operateDiagramPage.getFlowNode('Activity_13otele'),
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -11,7 +11,7 @@ import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
-import {leep, sleep} from 'utils/sleep';
+import {sleep} from 'utils/sleep';
 
 type ProcessDeployment = {
   readonly processInstanceKey: string;
@@ -90,9 +90,8 @@ test.describe('Call Activities', () => {
     let calledProcessInstanceId: string;
 
     await test.step('Get called process instance ID', async () => {
-      calledProcessInstanceId = await operateProcessesPage
-        .calledInstanceCell()
-        .innerText();
+      calledProcessInstanceId =
+        await operateProcessesPage.calledInstanceCell.innerText();
     });
 
     await test.step('Navigate back to parent instance from list', async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR migrates the callActivities test from the operate component folder to the OC e2e test suite, consolidating test coverage for call activities functionality.

## Changes:
- **Migrated** `callActivities.spec.ts` to OC test suite with comprehensive call activity navigation tests
- **Enhanced** page objects (`OperateDiagramPage`, `OperateProcessInstancePage`, `OperateProcessesPage`) with methods needed for call activity interactions  
- **Fixed** flaky checkbox assertion issues by updating `OperateFiltersPanelPage` locators to use proper `getByRole('checkbox')` instead of label selectors


🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/22714477856/job/65860715922)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34120
