### PR TITLE
feat: add restructured instance headers

### DIFF
--- a/operate/client/src/App/DecisionInstance/HeaderNext/index.tsx
+++ b/operate/client/src/App/DecisionInstance/HeaderNext/index.tsx
@@ -17,7 +17,6 @@ import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
 import type {DrdPanelState} from 'modules/queries/decisionInstances/useDrdPanelState';
 import {getClientConfig} from 'modules/utils/getClientConfig';
-import {useNavigate} from 'react-router-dom';
 
 const getHeaderColumns = (isMultiTenancyEnabled: boolean = false) => {
   return [
@@ -57,7 +56,6 @@ const Header: React.FC<HeaderProps> = ({
   decisionEvaluationInstanceKey,
   onChangeDrdPanelState,
 }) => {
-  const navigate = useNavigate();
   const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
   const headerColumns = getHeaderColumns(isMultiTenancyEnabled);
   const tenantsById = useAvailableTenants();
@@ -66,13 +64,7 @@ const Header: React.FC<HeaderProps> = ({
   );
 
   if (status === 'pending') {
-    return (
-      <Skeleton
-        backButtonLabel="Back"
-        onBackClick={() => navigate(-1)}
-        headerColumns={headerColumns}
-      />
-    );
+    return <Skeleton headerColumns={headerColumns} />;
   }
 
   if (status === 'success' && decisionInstance !== null) {
@@ -89,8 +81,6 @@ const Header: React.FC<HeaderProps> = ({
         state={decisionInstance.state}
         instanceName={decisionInstance.decisionDefinitionName}
         incidentsCount={decisionInstance.state === 'FAILED' ? 1 : 0}
-        backButtonLabel="Back"
-        onBackClick={() => navigate(-1)}
         headerColumns={headerColumns.map(({name}) => name)}
         bodyColumns={[
           {

--- a/operate/client/src/App/DecisionInstance/HeaderNext/index.tsx
+++ b/operate/client/src/App/DecisionInstance/HeaderNext/index.tsx
@@ -66,7 +66,13 @@ const Header: React.FC<HeaderProps> = ({
   );
 
   if (status === 'pending') {
-    return <Skeleton headerColumns={headerColumns} />;
+    return (
+      <Skeleton
+        backButtonLabel="Back"
+        onBackClick={() => navigate(-1)}
+        headerColumns={headerColumns}
+      />
+    );
   }
 
   if (status === 'success' && decisionInstance !== null) {

--- a/operate/client/src/App/DecisionInstance/HeaderNext/index.tsx
+++ b/operate/client/src/App/DecisionInstance/HeaderNext/index.tsx
@@ -17,13 +17,10 @@ import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
 import type {DrdPanelState} from 'modules/queries/decisionInstances/useDrdPanelState';
 import {getClientConfig} from 'modules/utils/getClientConfig';
+import {useNavigate} from 'react-router-dom';
 
 const getHeaderColumns = (isMultiTenancyEnabled: boolean = false) => {
   return [
-    {
-      name: 'Decision Name',
-      skeletonWidth: '136px',
-    },
     {
       name: 'Decision Instance Key',
       skeletonWidth: '137px',
@@ -60,6 +57,7 @@ const Header: React.FC<HeaderProps> = ({
   decisionEvaluationInstanceKey,
   onChangeDrdPanelState,
 }) => {
+  const navigate = useNavigate();
   const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
   const headerColumns = getHeaderColumns(isMultiTenancyEnabled);
   const tenantsById = useAvailableTenants();
@@ -83,12 +81,12 @@ const Header: React.FC<HeaderProps> = ({
     return (
       <InstanceHeader
         state={decisionInstance.state}
+        instanceName={decisionInstance.decisionDefinitionName}
+        incidentsCount={decisionInstance.state === 'FAILED' ? 1 : 0}
+        backButtonLabel="Back"
+        onBackClick={() => navigate(-1)}
         headerColumns={headerColumns.map(({name}) => name)}
         bodyColumns={[
-          {
-            title: decisionInstance.decisionDefinitionName,
-            content: decisionInstance.decisionDefinitionName,
-          },
           {
             title: decisionInstance.decisionEvaluationInstanceKey,
             content: decisionInstance.decisionEvaluationInstanceKey,
@@ -131,7 +129,7 @@ const Header: React.FC<HeaderProps> = ({
               ]
             : []),
           {
-            title: formatDate(decisionInstance.evaluationDate) ?? '--',
+            title: formatDate(decisionInstance.evaluationDate),
             content: formatDate(decisionInstance.evaluationDate),
           },
           {

--- a/operate/client/src/App/DecisionInstance/HeaderNext/tests/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/HeaderNext/tests/index.test.tsx
@@ -71,10 +71,10 @@ describe('<Header />', () => {
 
     expect(await screen.findByTestId('EVALUATED-icon')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {name: /open decision requirements diagram/i}),
+      screen.getByText(invoiceClassification.decisionDefinitionName),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('columnheader', {name: /^decision name$/i}),
+      screen.getByRole('button', {name: /open decision requirements diagram/i}),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('columnheader', {name: /decision instance key/i}),
@@ -87,11 +87,6 @@ describe('<Header />', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('columnheader', {name: /process instance key/i}),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole('cell', {
-        name: invoiceClassification.decisionDefinitionName,
-      }),
     ).toBeInTheDocument();
     expect(
       await screen.findByRole('cell', {
@@ -115,5 +110,27 @@ describe('<Header />', () => {
         description: `View process instance ${invoiceClassification.processInstanceKey}`,
       }),
     ).toBeInTheDocument();
+  });
+
+  it('should display a failed evaluation state', async () => {
+    const failedInstance = {
+      ...invoiceClassification,
+      state: 'FAILED',
+    } satisfies typeof invoiceClassification;
+    mockFetchDecisionInstance().withSuccess(failedInstance);
+
+    render(
+      <Header
+        decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID}
+        onChangeDrdPanelState={() => void 0}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(await screen.findByTestId('FAILED-icon')).toBeInTheDocument();
+    expect(
+      screen.getByText(invoiceClassification.decisionDefinitionName),
+    ).toBeInTheDocument();
+    expect(screen.getByText('1 Incident')).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
@@ -53,10 +53,6 @@ const skeletonColumns: {
     skeletonWidth: '142px',
   },
   {
-    name: 'End Date',
-    skeletonWidth: '142px',
-  },
-  {
     name: 'Called Instances',
     skeletonWidth: '142px',
   },
@@ -93,7 +89,13 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   });
 
   if (processInstance === null || isPending) {
-    return <Skeleton headerColumns={skeletonColumns} />;
+    return (
+      <Skeleton
+        backButtonLabel="Back"
+        onBackClick={() => navigate(-1)}
+        headerColumns={skeletonColumns}
+      />
+    );
   }
 
   const versionColumnTitle = `View process "${getProcessDefinitionName(

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
@@ -24,7 +24,6 @@ import {hasCalledProcessInstances} from 'modules/bpmn-js/utils/hasCalledProcessI
 import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.9';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {getClientConfig} from 'modules/utils/getClientConfig';
-import {useNavigate} from 'react-router-dom';
 
 const headerColumns = [
   'Process Instance Key',
@@ -74,7 +73,6 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
     hasIncident,
     processDefinitionId,
   } = processInstance;
-  const navigate = useNavigate();
   const tenantsById = useAvailableTenants();
   const tenantName = tenantsById[tenantId] ?? tenantId;
 
@@ -89,13 +87,7 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   });
 
   if (processInstance === null || isPending) {
-    return (
-      <Skeleton
-        backButtonLabel="Back"
-        onBackClick={() => navigate(-1)}
-        headerColumns={skeletonColumns}
-      />
-    );
+    return <Skeleton headerColumns={skeletonColumns} />;
   }
 
   const versionColumnTitle = `View process "${getProcessDefinitionName(
@@ -111,8 +103,6 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
       state={processInstanceState}
       instanceName={getProcessDefinitionName(processInstance)}
       incidentsCount={incidentsCount}
-      backButtonLabel="Back"
-      onBackClick={() => navigate(-1)}
       headerColumns={headerColumns.filter((name) => {
         if (name === 'Tenant') {
           return isMultiTenancyEnabled;

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/index.tsx
@@ -11,7 +11,7 @@ import {formatDate} from 'modules/utils/date';
 import {ProcessInstanceOperations} from './ProcessInstanceOperations';
 import {getProcessDefinitionName} from 'modules/utils/instance';
 import {Link} from 'modules/components/Link';
-import {Locations, Paths} from 'modules/Routes';
+import {Locations} from 'modules/Routes';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {tracking} from 'modules/tracking';
 import {InstanceHeader} from 'modules/components/InstanceHeaderNext';
@@ -19,31 +19,27 @@ import {Skeleton} from 'modules/components/InstanceHeaderNext/Skeleton';
 import {VersionTag} from './styled';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/useProcessInstanceIncidentsCount';
 import {hasCalledProcessInstances} from 'modules/bpmn-js/utils/hasCalledProcessInstances';
 import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.9';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {getClientConfig} from 'modules/utils/getClientConfig';
+import {useNavigate} from 'react-router-dom';
 
 const headerColumns = [
-  'Process Name',
   'Process Instance Key',
   'Version',
   'Version Tag',
   'Tenant',
   'Start Date',
   'End Date',
-  'Parent Process Instance Key',
-  'Called Process Instances',
+  'Called Instances',
 ] as const;
 
 const skeletonColumns: {
   name: (typeof headerColumns)[number];
   skeletonWidth: string;
 }[] = [
-  {
-    name: 'Process Name',
-    skeletonWidth: '94px',
-  },
   {
     name: 'Process Instance Key',
     skeletonWidth: '136px',
@@ -61,11 +57,7 @@ const skeletonColumns: {
     skeletonWidth: '142px',
   },
   {
-    name: 'Parent Process Instance Key',
-    skeletonWidth: '142px',
-  },
-  {
-    name: 'Called Process Instances',
+    name: 'Called Instances',
     skeletonWidth: '142px',
   },
 ] as const;
@@ -82,11 +74,11 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
     tenantId,
     startDate,
     endDate,
-    parentProcessInstanceKey,
     state,
     hasIncident,
     processDefinitionId,
   } = processInstance;
+  const navigate = useNavigate();
   const tenantsById = useAvailableTenants();
   const tenantName = tenantsById[tenantId] ?? tenantId;
 
@@ -95,6 +87,9 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   const processDefinitionKey = useProcessDefinitionKeyContext();
   const {isPending, data: processInstanceXmlData} = useProcessInstanceXml({
     processDefinitionKey,
+  });
+  const incidentsCount = useProcessInstanceIncidentsCount(processInstanceKey, {
+    enabled: hasIncident,
   });
 
   if (processInstance === null || isPending) {
@@ -112,7 +107,10 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   return (
     <InstanceHeader
       state={processInstanceState}
-      hideBottomBorder={hasIncident}
+      instanceName={getProcessDefinitionName(processInstance)}
+      incidentsCount={incidentsCount}
+      backButtonLabel="Back"
+      onBackClick={() => navigate(-1)}
       headerColumns={headerColumns.filter((name) => {
         if (name === 'Tenant') {
           return isMultiTenancyEnabled;
@@ -120,13 +118,12 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
         if (name === 'Version Tag') {
           return hasVersionTag;
         }
+        if (name === 'End Date') {
+          return endDate !== null;
+        }
         return true;
       })}
       bodyColumns={[
-        {
-          title: getProcessDefinitionName(processInstance),
-          content: getProcessDefinitionName(processInstance),
-        },
         {title: processInstanceKey, content: processInstanceKey},
         {
           hideOverflowingContent: false,
@@ -177,40 +174,20 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
             ]
           : []),
         {
-          title: formatDate(startDate) ?? '--',
+          title: formatDate(startDate),
           content: formatDate(startDate),
           dataTestId: 'start-date',
         },
-        {
-          title: formatDate(endDate ?? null) ?? '--',
-          content: formatDate(endDate ?? null),
-          dataTestId: 'end-date',
-        },
-        {
-          title: parentProcessInstanceKey ?? 'None',
-          hideOverflowingContent: false,
-          content: (
-            <>
-              {parentProcessInstanceKey ? (
-                <Link
-                  to={Paths.processInstance(parentProcessInstanceKey)}
-                  title={`View parent instance ${parentProcessInstanceKey}`}
-                  aria-label={`View parent instance ${parentProcessInstanceKey}`}
-                  onClick={() => {
-                    tracking.track({
-                      eventName: 'navigation',
-                      link: 'process-details-parent-details',
-                    });
-                  }}
-                >
-                  {parentProcessInstanceKey}
-                </Link>
-              ) : (
-                'None'
-              )}
-            </>
-          ),
-        },
+        ...(endDate !== null
+          ? [
+              {
+                title: formatDate(endDate),
+                content: formatDate(endDate),
+                dataTestId: 'end-date',
+              },
+            ]
+          : []),
+
         {
           hideOverflowingContent: false,
           content: (

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/tests/index.test.tsx
@@ -14,16 +14,13 @@ import {
 } from 'modules/testing-library';
 import {getProcessDefinitionName} from 'modules/utils/instance';
 import {ProcessInstanceHeader} from '../index';
-import {
-  mockInstance,
-  mockInstanceWithParentInstance,
-  Wrapper,
-} from './index.setup';
+import {mockInstance, Wrapper} from './index.setup';
 
 import {
   createUser,
   mockCallActivityProcessXML,
   mockProcessXML,
+  searchResult,
 } from 'modules/testUtils';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {notificationsStore} from 'modules/stores/notifications';
@@ -34,6 +31,8 @@ import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mo
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {mockDeleteProcessInstance} from 'modules/mocks/api/v2/processInstances/deleteProcessInstance';
+import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
+import {mockIncidents} from 'App/ProcessInstance/IncidentsWrapper/tests/mocks';
 
 vi.mock('modules/stores/notifications', () => ({
   notificationsStore: {
@@ -82,22 +81,62 @@ describe('InstanceHeader', () => {
         }" instances`,
       }),
     ).toHaveTextContent(mockInstance.processDefinitionVersion.toString());
-    expect(screen.getByText(mockInstance.endDate ?? '--')).toBeInTheDocument();
-    expect(screen.getByText('--')).toBeInTheDocument();
     expect(
       screen.getByTestId(`${mockInstance.state}-icon`),
     ).toBeInTheDocument();
-    expect(screen.getByText('Process Name')).toBeInTheDocument();
     expect(screen.getByText('Process Instance Key')).toBeInTheDocument();
     expect(screen.getByText('Version')).toBeInTheDocument();
     expect(screen.getByText('Start Date')).toBeInTheDocument();
-    expect(screen.getByText('End Date')).toBeInTheDocument();
-    expect(screen.getByText('Parent Process Instance Key')).toBeInTheDocument();
-    expect(screen.getByText('Called Process Instances')).toBeInTheDocument();
-    expect(screen.getAllByText('None').length).toBe(2);
+    expect(screen.queryByText('End Date')).not.toBeInTheDocument();
+    expect(screen.getByText('Called Instances')).toBeInTheDocument();
+    expect(screen.getAllByText('None').length).toBe(1);
     expect(
       screen.queryByRole('link', {name: /view all/i}),
     ).not.toBeInTheDocument();
+  });
+
+  it('should render an end date for finished process instances', async () => {
+    const finishedInstance = {
+      ...mockInstance,
+      state: 'COMPLETED',
+      endDate: '2020-06-21 00:00:00',
+    } satisfies typeof mockInstance;
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+
+    render(<ProcessInstanceHeader processInstance={finishedInstance} />, {
+      wrapper: Wrapper,
+    });
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('instance-header-skeleton'),
+    );
+
+    expect(screen.getByText('End Date')).toBeInTheDocument();
+    expect(screen.getByText(finishedInstance.endDate)).toBeInTheDocument();
+  });
+
+  it('should render an incidents count for process instances with incidents', async () => {
+    const finishedInstance = {
+      ...mockInstance,
+      state: 'ACTIVE',
+      hasIncident: true,
+    } satisfies typeof mockInstance;
+    mockSearchIncidentsByProcessInstance(
+      finishedInstance.processInstanceKey,
+    ).withSuccess(mockIncidents);
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+
+    render(<ProcessInstanceHeader processInstance={finishedInstance} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(await screen.findByText('2 Incidents')).toBeInTheDocument();
+    expect(screen.getByTestId(`INCIDENT-icon`)).toBeInTheDocument();
+    expect(
+      screen.getByText(finishedInstance.processDefinitionName),
+    ).toBeInTheDocument();
   });
 
   it('should render "View All" link for call activity process', async () => {
@@ -157,41 +196,6 @@ describe('InstanceHeader', () => {
 
     expect(screen.getByTestId('pathname')).toHaveTextContent(/^\/processes$/);
     expect(panelStatesStore.state.isFiltersCollapsed).toBe(false);
-  });
-
-  it('should render parent Process Instance Key', async () => {
-    mockQueryBatchOperationItems().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
-
-    render(
-      <ProcessInstanceHeader
-        processInstance={{
-          ...mockInstance,
-          parentProcessInstanceKey: '8724390842390124',
-        }}
-      />,
-      {
-        wrapper: Wrapper,
-      },
-    );
-
-    await waitForElementToBeRemoved(
-      screen.queryByTestId('instance-header-skeleton'),
-    );
-
-    expect(
-      screen.getByRole('link', {
-        description: `View parent instance ${mockInstanceWithParentInstance.parentProcessInstanceKey}`,
-      }),
-    ).toBeInTheDocument();
   });
 
   it('should show spinner when instance has active operations', async () => {

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeaderNext/tests/index.test.tsx
@@ -117,25 +117,25 @@ describe('InstanceHeader', () => {
   });
 
   it('should render an incidents count for process instances with incidents', async () => {
-    const finishedInstance = {
+    const failedInstance = {
       ...mockInstance,
       state: 'ACTIVE',
       hasIncident: true,
     } satisfies typeof mockInstance;
     mockSearchIncidentsByProcessInstance(
-      finishedInstance.processInstanceKey,
+      failedInstance.processInstanceKey,
     ).withSuccess(mockIncidents);
     mockQueryBatchOperationItems().withSuccess(searchResult([]));
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
 
-    render(<ProcessInstanceHeader processInstance={finishedInstance} />, {
+    render(<ProcessInstanceHeader processInstance={failedInstance} />, {
       wrapper: Wrapper,
     });
 
     expect(await screen.findByText('2 Incidents')).toBeInTheDocument();
     expect(screen.getByTestId(`INCIDENT-icon`)).toBeInTheDocument();
     expect(
-      screen.getByText(finishedInstance.processDefinitionName),
+      screen.getByText(failedInstance.processDefinitionName),
     ).toBeInTheDocument();
   });
 

--- a/operate/client/src/modules/components/InstanceHeaderNext/Skeleton.tsx
+++ b/operate/client/src/modules/components/InstanceHeaderNext/Skeleton.tsx
@@ -6,38 +6,27 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Button} from '@carbon/react';
-import {ArrowLeft} from '@carbon/react/icons';
-import {Container, Table, Th, Td, SkeletonText, SkeletonIcon} from './styled';
+import {
+  Container,
+  Table,
+  Th,
+  Td,
+  SkeletonText,
+  SkeletonIcon,
+  NameContainer,
+} from './styled';
 
 type Props = {
   headerColumns: {name: string; skeletonWidth: string}[];
-  backButtonLabel?: string;
-  onBackClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
-const Skeleton: React.FC<Props> = ({
-  headerColumns,
-  backButtonLabel = 'Back',
-  onBackClick,
-}) => {
+const Skeleton: React.FC<Props> = ({headerColumns}) => {
   return (
     <Container data-testid="instance-header-skeleton">
-      {onBackClick && (
-        <Button
-          kind="ghost"
-          size="sm"
-          renderIcon={ArrowLeft}
-          hasIconOnly
-          iconDescription={backButtonLabel}
-          aria-label={backButtonLabel}
-          tooltipPosition="bottom"
-          tooltipAlignment="start"
-          onClick={onBackClick}
-        />
-      )}
       <SkeletonIcon />
-      <SkeletonText width="128px" />
+      <NameContainer>
+        <SkeletonText width="128px" />
+      </NameContainer>
       <Table>
         <thead>
           <tr>
@@ -56,7 +45,6 @@ const Skeleton: React.FC<Props> = ({
           </tr>
         </tbody>
       </Table>
-      <SkeletonText width={'78px'} />
     </Container>
   );
 };

--- a/operate/client/src/modules/components/InstanceHeaderNext/Skeleton.tsx
+++ b/operate/client/src/modules/components/InstanceHeaderNext/Skeleton.tsx
@@ -6,16 +6,38 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {Button} from '@carbon/react';
+import {ArrowLeft} from '@carbon/react/icons';
 import {Container, Table, Th, Td, SkeletonText, SkeletonIcon} from './styled';
 
 type Props = {
   headerColumns: {name: string; skeletonWidth: string}[];
+  backButtonLabel?: string;
+  onBackClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
-const Skeleton: React.FC<Props> = ({headerColumns}) => {
+const Skeleton: React.FC<Props> = ({
+  headerColumns,
+  backButtonLabel = 'Back',
+  onBackClick,
+}) => {
   return (
     <Container data-testid="instance-header-skeleton">
+      {onBackClick && (
+        <Button
+          kind="ghost"
+          size="sm"
+          renderIcon={ArrowLeft}
+          hasIconOnly
+          iconDescription={backButtonLabel}
+          aria-label={backButtonLabel}
+          tooltipPosition="bottom"
+          tooltipAlignment="start"
+          onClick={onBackClick}
+        />
+      )}
       <SkeletonIcon />
+      <SkeletonText width="128px" />
       <Table>
         <thead>
           <tr>

--- a/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
+++ b/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
@@ -15,6 +15,7 @@ import {
   NameContainer,
   InstanceName,
   IncidentCount,
+  AdditionalContent,
 } from './styled';
 import {StateIcon} from 'modules/components/StateIcon';
 import {ArrowLeft} from '@carbon/react/icons';
@@ -105,7 +106,7 @@ const InstanceHeader: React.FC<Props> = ({
           </tr>
         </tbody>
       </Table>
-      {additionalContent}
+      <AdditionalContent>{additionalContent}</AdditionalContent>
     </Container>
   );
 };

--- a/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
+++ b/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
@@ -6,8 +6,19 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Container, Table, Th, Td} from './styled';
+import {Button} from '@carbon/react';
+import {
+  Container,
+  Table,
+  Th,
+  Td,
+  NameContainer,
+  InstanceName,
+  IncidentCount,
+} from './styled';
 import {StateIcon} from 'modules/components/StateIcon';
+import {ArrowLeft} from '@carbon/react/icons';
+import pluralSuffix from 'modules/utils/pluralSuffix';
 
 type Column = {
   title?: string;
@@ -18,26 +29,55 @@ type Column = {
 
 type Props = {
   state: React.ComponentProps<typeof StateIcon>['state'];
+  instanceName: string;
+  incidentsCount?: number;
   headerColumns: string[];
   bodyColumns: Column[];
   additionalContent?: React.ReactNode;
   hideBottomBorder?: boolean;
+  backButtonLabel?: string;
+  onBackClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 const InstanceHeader: React.FC<Props> = ({
   state,
   headerColumns,
   bodyColumns,
+  instanceName,
+  incidentsCount = 0,
   additionalContent,
   hideBottomBorder = false,
+  backButtonLabel = 'Back',
+  onBackClick,
 }) => {
   return (
     <Container
       data-testid="instance-header"
       $hideBottomBorder={hideBottomBorder}
     >
+      {onBackClick && (
+        <Button
+          kind="ghost"
+          size="sm"
+          renderIcon={ArrowLeft}
+          hasIconOnly
+          iconDescription={backButtonLabel}
+          aria-label={backButtonLabel}
+          tooltipPosition="bottom"
+          tooltipAlignment="start"
+          onClick={onBackClick}
+        />
+      )}
       <StateIcon state={state} size={24} data-testid={`${state}-icon`} />
 
+      <NameContainer>
+        <InstanceName>{instanceName}</InstanceName>
+        {incidentsCount > 0 && (
+          <IncidentCount>
+            {pluralSuffix(incidentsCount, 'Incident')}
+          </IncidentCount>
+        )}
+      </NameContainer>
       <Table>
         <thead>
           <tr>

--- a/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
+++ b/operate/client/src/modules/components/InstanceHeaderNext/index.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Button} from '@carbon/react';
 import {
   Container,
   Table,
@@ -18,7 +17,6 @@ import {
   AdditionalContent,
 } from './styled';
 import {StateIcon} from 'modules/components/StateIcon';
-import {ArrowLeft} from '@carbon/react/icons';
 import pluralSuffix from 'modules/utils/pluralSuffix';
 
 type Column = {
@@ -36,8 +34,6 @@ type Props = {
   bodyColumns: Column[];
   additionalContent?: React.ReactNode;
   hideBottomBorder?: boolean;
-  backButtonLabel?: string;
-  onBackClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 const InstanceHeader: React.FC<Props> = ({
@@ -48,27 +44,12 @@ const InstanceHeader: React.FC<Props> = ({
   incidentsCount = 0,
   additionalContent,
   hideBottomBorder = false,
-  backButtonLabel = 'Back',
-  onBackClick,
 }) => {
   return (
     <Container
       data-testid="instance-header"
       $hideBottomBorder={hideBottomBorder}
     >
-      {onBackClick && (
-        <Button
-          kind="ghost"
-          size="sm"
-          renderIcon={ArrowLeft}
-          hasIconOnly
-          iconDescription={backButtonLabel}
-          aria-label={backButtonLabel}
-          tooltipPosition="bottom"
-          tooltipAlignment="start"
-          onClick={onBackClick}
-        />
-      )}
       <StateIcon state={state} size={24} data-testid={`${state}-icon`} />
 
       <NameContainer>

--- a/operate/client/src/modules/components/InstanceHeaderNext/styled.ts
+++ b/operate/client/src/modules/components/InstanceHeaderNext/styled.ts
@@ -14,12 +14,15 @@ import {
 } from '@carbon/react';
 
 const Table = styled.table`
-  width: 100%;
-  padding-left: var(--cds-spacing-05);
   table-layout: fixed;
   border-collapse: separate;
-  border-spacing: var(--cds-spacing-01);
+  border-spacing: 0 var(--cds-spacing-01);
   color: var(--cds-text-secondary);
+
+  th:not(:first-child),
+  td:not(:first-child) {
+    padding-left: var(--cds-spacing-07);
+  }
 `;
 
 const Th = styled.th`
@@ -57,6 +60,7 @@ const Container = styled.header<ContainerProps>`
     return css`
       display: flex;
       align-items: center;
+      gap: var(--cds-spacing-05);
       background-color: var(--cds-layer-01);
       padding: var(--cds-spacing-02) var(--cds-spacing-05);
       border-bottom: 1px solid var(--cds-border-subtle-01);
@@ -64,8 +68,39 @@ const Container = styled.header<ContainerProps>`
       css`
         border-bottom: none;
       `}
+
+      & > :last-child {
+        margin-left: auto;
+      }
     `;
   }}
+`;
+
+const NameContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-01);
+  margin-right: var(--cds-spacing-05);
+`;
+
+const InstanceName = styled.span`
+  ${styles.label02};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  color: var(--cds-text-secondary);
+
+  &:has(+ span) {
+    ${styles.label01};
+  }
+`;
+
+const IncidentCount = styled.span`
+  ${styles.label02};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  color: var(--cds-support-error);
 `;
 
 const SkeletonText = styled(BaseSkeletonText)`
@@ -77,4 +112,14 @@ const SkeletonIcon = styled(BaseSkeletonIcon)`
   height: var(--cds-spacing-06);
 `;
 
-export {Table, Td, Th, Container, SkeletonText, SkeletonIcon};
+export {
+  Table,
+  Td,
+  Th,
+  Container,
+  SkeletonText,
+  SkeletonIcon,
+  NameContainer,
+  InstanceName,
+  IncidentCount,
+};

--- a/operate/client/src/modules/components/InstanceHeaderNext/styled.ts
+++ b/operate/client/src/modules/components/InstanceHeaderNext/styled.ts
@@ -68,12 +68,12 @@ const Container = styled.header<ContainerProps>`
       css`
         border-bottom: none;
       `}
-
-      & > :last-child {
-        margin-left: auto;
-      }
     `;
   }}
+`;
+
+const AdditionalContent = styled.div`
+  margin-left: auto;
 `;
 
 const NameContainer = styled.div`
@@ -117,6 +117,7 @@ export {
   Td,
   Th,
   Container,
+  AdditionalContent,
   SkeletonText,
   SkeletonIcon,
   NameContainer,

--- a/operate/client/src/modules/utils/date/__mocks__/formatDate.ts
+++ b/operate/client/src/modules/utils/date/__mocks__/formatDate.ts
@@ -10,8 +10,8 @@ const MOCK_TIMESTAMP = '2018-12-12 00:00:00';
 
 function formatDate(
   dateString: Date | string | null,
-  placeholder: string | null = '--',
-) {
+  placeholder = '--',
+): string {
   return dateString ? MOCK_TIMESTAMP : placeholder;
 }
 

--- a/operate/client/src/modules/utils/date/formatDate.test.ts
+++ b/operate/client/src/modules/utils/date/formatDate.test.ts
@@ -38,6 +38,6 @@ describe('formatDate', () => {
     const givenDate = new Date('2019-11-06T14:24:15.422');
     const expectedDate = '2019-11-06 14:24:15';
 
-    expect(formatDate(givenDate, null)).toEqual(expectedDate);
+    expect(formatDate(givenDate, 'custom')).toEqual(expectedDate);
   });
 });

--- a/operate/client/src/modules/utils/date/formatDate.ts
+++ b/operate/client/src/modules/utils/date/formatDate.ts
@@ -14,8 +14,8 @@ function parseDate(dateString: string | Date) {
 
 function formatDate(
   dateString: string | Date | null,
-  placeholder: string | null = '--',
-) {
+  placeholder = '--',
+): string {
   return dateString
     ? format(parseDate(dateString), 'yyyy-MM-dd HH:mm:ss')
     : placeholder;


### PR DESCRIPTION
## Description

Updates the decision- & process- instance headers with the changes from the design mockup. After [aligning on the original back button](https://camunda.slack.com/archives/C09QVGEG3SS/p1773057071602189?thread_ts=1772617035.990459&cid=C09QVGEG3SS) in the prototype, the back button has been removed in this implementation.

## Related issues

closes #47036
