### PR TITLE
ci: run alwaysgreen tests on main as baseline

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -5,6 +5,9 @@
 name: Docker Build, Helm Deploy & E2E Tests (SaaS + Helm)
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
@@ -65,6 +68,7 @@ jobs:
     permissions: { }
     if: >
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
     steps:


### PR DESCRIPTION
## Description

We should run the Docker Build, Helm Deploy & E2E Tests also on a reliable branch like `main` where we expect them to be "alwaysgreen" (hence the initiative title). This allows us to establish a baseline of reliability metrics, unlike on PRs where it is never clear whether a failure was flakiness or broken code.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not for now, only targets main to not overwhelm Distro infra

## Related issues

None
