### PR TITLE
[Backport stable/8.7] fix: in LogStreamMetrics IN_FLIGHT_REQUESTS was incrementing `inFlightAppends`

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -82,7 +82,7 @@ public final class LogStreamMetrics {
     appendLatency = MicrometerUtil.buildTimer(WRITE_LATENCY).register(registry);
 
     registerGauge(INFLIGHT_APPENDS, inflightAppends);
-    registerGauge(INFLIGHT_REQUESTS, inflightAppends);
+    registerGauge(INFLIGHT_REQUESTS, inflightRequests);
     registerGauge(REQUEST_LIMIT, requestLimit);
     registerGauge(LAST_COMMITTED_POSITION, lastCommitted);
     registerGauge(LAST_WRITTEN_POSITION, lastWritten);


### PR DESCRIPTION
# Description
Backport of #47774 to `stable/8.7`.

relates to 