### PR TITLE
feat: add azure document handling capabilities

### DIFF
--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -65,6 +65,10 @@
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
     </dependency>
 

--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -60,6 +60,15 @@
     </dependency>
 
     <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-blob</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStore.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.UserDelegationKey;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import io.camunda.document.api.DocumentContent;
+import io.camunda.document.api.DocumentCreationRequest;
+import io.camunda.document.api.DocumentError;
+import io.camunda.document.api.DocumentError.DocumentAlreadyExists;
+import io.camunda.document.api.DocumentError.DocumentNotFound;
+import io.camunda.document.api.DocumentError.InvalidInput;
+import io.camunda.document.api.DocumentError.UnknownDocumentError;
+import io.camunda.document.api.DocumentLink;
+import io.camunda.document.api.DocumentMetadataModel;
+import io.camunda.document.api.DocumentReference;
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.store.InputStreamHashCalculator;
+import io.camunda.zeebe.util.Either;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AzureBlobDocumentStore implements DocumentStore {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AzureBlobDocumentStore.class);
+
+  private static final String CONTENT_HASH_METADATA_KEY = "contentHash";
+  private static final String EXPIRES_AT_METADATA_KEY = "expiresAt";
+  private static final String FILENAME_METADATA_KEY = "fileName";
+  private static final String SIZE_METADATA_KEY = "size";
+  private static final String CONTENT_TYPE_METADATA_KEY = "contentType";
+  private static final String METADATA_PROCESS_DEFINITION_ID = "camundaProcessDefinitionId";
+  private static final String METADATA_PROCESS_INSTANCE_KEY = "camundaProcessInstanceKey";
+
+  private static final int HTTP_NOT_FOUND = 404;
+  private static final int HTTP_FORBIDDEN = 403;
+  private static final int HTTP_CONFLICT = 409;
+
+  private final String containerName;
+  private final String containerPath;
+  private final BlobContainerClient containerClient;
+  private final BlobServiceClient serviceClient;
+  private final ExecutorService executor;
+
+  public AzureBlobDocumentStore(
+      final String containerName,
+      final String containerPath,
+      final BlobContainerClient containerClient,
+      final BlobServiceClient serviceClient,
+      final ExecutorService executor) {
+    this.containerName = containerName;
+    this.containerPath = containerPath;
+    this.containerClient = containerClient;
+    this.serviceClient = serviceClient;
+    this.executor = executor;
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, DocumentReference>> createDocument(
+      final DocumentCreationRequest request) {
+    return CompletableFuture.supplyAsync(() -> createDocumentInternal(request), executor);
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, DocumentContent>> getDocument(
+      final String documentId) {
+    return CompletableFuture.supplyAsync(() -> getDocumentInternal(documentId), executor);
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, Void>> deleteDocument(final String documentId) {
+    return CompletableFuture.supplyAsync(() -> deleteDocumentInternal(documentId), executor);
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, DocumentLink>> createLink(
+      final String documentId, final long durationInMillis) {
+    return CompletableFuture.supplyAsync(
+        () -> createLinkInternal(documentId, durationInMillis), executor);
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, Void>> verifyContentHash(
+      final String documentId, final String contentHash) {
+    return CompletableFuture.supplyAsync(
+        () -> verifyContentHashInternal(documentId, contentHash), executor);
+  }
+
+  @Override
+  public void validateSetup() {
+    try {
+      if (containerClient.exists()) {
+        LOGGER.info("Successfully accessed container '{}'", containerName);
+      } else {
+        LOGGER.warn(
+            "Container '{}' does not exist. {}", containerName, SETUP_VALIDATION_FAILURE_MESSAGE);
+      }
+    } catch (final BlobStorageException e) {
+      if (e.getStatusCode() == HTTP_FORBIDDEN) {
+        LOGGER.warn(
+            "Access denied to container '{}'. Check that the connection string or credentials "
+                + "have the required permissions. {}",
+            containerName,
+            SETUP_VALIDATION_FAILURE_MESSAGE,
+            e);
+      } else if (e.getStatusCode() == HTTP_NOT_FOUND) {
+        LOGGER.warn(
+            "Container '{}' was not found. Check that the 'CONTAINER' property is correct. {}",
+            containerName,
+            SETUP_VALIDATION_FAILURE_MESSAGE,
+            e);
+      } else {
+        LOGGER.warn(
+            "Could not access container '{}' (HTTP {}). {}",
+            containerName,
+            e.getStatusCode(),
+            SETUP_VALIDATION_FAILURE_MESSAGE,
+            e);
+      }
+    } catch (final Exception e) {
+      LOGGER.warn(
+          "Unexpected error while accessing container '{}'. "
+              + "Check that the connection string or endpoint is valid. {}",
+          containerName,
+          SETUP_VALIDATION_FAILURE_MESSAGE,
+          e);
+    }
+  }
+
+  private Either<DocumentError, DocumentReference> createDocumentInternal(
+      final DocumentCreationRequest request) {
+    final String documentId =
+        Objects.requireNonNullElse(request.documentId(), UUID.randomUUID().toString());
+    try {
+      final String blobName = resolveBlobName(documentId);
+      final BlobClient blobClient = containerClient.getBlobClient(blobName);
+
+      if (blobClient.exists()) {
+        return Either.left(new DocumentAlreadyExists(documentId));
+      }
+
+      final String fileName = resolveFileName(request.metadata(), documentId);
+
+      final String hash;
+      try {
+        hash =
+            InputStreamHashCalculator.streamAndCalculateHash(
+                request.contentInputStream(),
+                stream -> blobClient.upload(stream, request.metadata().size(), false));
+      } catch (final Exception e) {
+        return Either.left(new UnknownDocumentError(e));
+      }
+
+      final Map<String, String> metadata = toBlobMetadata(request.metadata(), fileName, hash);
+      blobClient.setMetadata(metadata);
+
+      final BlobHttpHeaders headers = new BlobHttpHeaders();
+      if (request.metadata().contentType() != null) {
+        headers.setContentType(request.metadata().contentType());
+      }
+      headers.setContentDisposition("attachment; filename=" + fileName);
+      blobClient.setHttpHeaders(headers);
+
+      final var updatedMetadata =
+          new DocumentMetadataModel(
+              request.metadata().contentType(),
+              fileName,
+              request.metadata().expiresAt(),
+              request.metadata().size(),
+              request.metadata().processDefinitionId(),
+              request.metadata().processInstanceKey(),
+              request.metadata().customProperties());
+      return Either.right(new DocumentReference(documentId, hash, updatedMetadata));
+    } catch (final BlobStorageException e) {
+      return Either.left(mapBlobStorageError(documentId, e));
+    } catch (final Exception e) {
+      return Either.left(new UnknownDocumentError(e));
+    }
+  }
+
+  private Either<DocumentError, DocumentContent> getDocumentInternal(final String documentId) {
+    try {
+      final String blobName = resolveBlobName(documentId);
+      final BlobClient blobClient = containerClient.getBlobClient(blobName);
+
+      final BlobProperties properties = blobClient.getProperties();
+
+      if (isDocumentExpired(properties.getMetadata(), documentId)) {
+        return Either.left(new DocumentNotFound(documentId));
+      }
+
+      final InputStream inputStream = blobClient.openInputStream();
+      final String contentType = properties.getContentType();
+
+      return Either.right(new DocumentContent(inputStream, contentType));
+    } catch (final BlobStorageException e) {
+      return Either.left(mapBlobStorageError(documentId, e));
+    } catch (final Exception e) {
+      return Either.left(new UnknownDocumentError(e));
+    }
+  }
+
+  private Either<DocumentError, Void> deleteDocumentInternal(final String documentId) {
+    try {
+      final String blobName = resolveBlobName(documentId);
+      final BlobClient blobClient = containerClient.getBlobClient(blobName);
+      blobClient.delete();
+      return Either.right(null);
+    } catch (final BlobStorageException e) {
+      return Either.left(mapBlobStorageError(documentId, e));
+    } catch (final Exception e) {
+      return Either.left(new UnknownDocumentError(e));
+    }
+  }
+
+  private Either<DocumentError, DocumentLink> createLinkInternal(
+      final String documentId, final long durationInMillis) {
+    try {
+      if (durationInMillis <= 0) {
+        return Either.left(new InvalidInput("Duration must be greater than 0"));
+      }
+
+      final String blobName = resolveBlobName(documentId);
+      final BlobClient blobClient = containerClient.getBlobClient(blobName);
+
+      final BlobProperties properties;
+      try {
+        properties = blobClient.getProperties();
+      } catch (final BlobStorageException e) {
+        return Either.left(mapBlobStorageError(documentId, e));
+      }
+
+      if (isDocumentExpired(properties.getMetadata(), documentId)) {
+        return Either.left(new DocumentNotFound(documentId));
+      }
+
+      final OffsetDateTime expiryTime =
+          OffsetDateTime.now().plus(Duration.ofMillis(durationInMillis));
+      final BlobSasPermission permissions = new BlobSasPermission().setReadPermission(true);
+      final BlobServiceSasSignatureValues sasValues =
+          new BlobServiceSasSignatureValues(expiryTime, permissions);
+
+      String sasUrl;
+      try {
+        final UserDelegationKey userDelegationKey =
+            serviceClient.getUserDelegationKey(OffsetDateTime.now().minusMinutes(5), expiryTime);
+        final String sasToken = blobClient.generateUserDelegationSas(sasValues, userDelegationKey);
+        sasUrl = blobClient.getBlobUrl() + "?" + sasToken;
+      } catch (final Exception e) {
+        LOGGER.debug("User delegation SAS generation failed, falling back to service SAS", e);
+        final String sasToken = blobClient.generateSas(sasValues);
+        sasUrl = blobClient.getBlobUrl() + "?" + sasToken;
+      }
+
+      return Either.right(
+          new DocumentLink(sasUrl, OffsetDateTime.now().plus(Duration.ofMillis(durationInMillis))));
+    } catch (final BlobStorageException e) {
+      return Either.left(mapBlobStorageError(documentId, e));
+    } catch (final Exception e) {
+      return Either.left(new UnknownDocumentError(e));
+    }
+  }
+
+  private Either<DocumentError, Void> verifyContentHashInternal(
+      final String documentId, final String contentHashToVerify) {
+    try {
+      final String blobName = resolveBlobName(documentId);
+      final BlobClient blobClient = containerClient.getBlobClient(blobName);
+
+      final BlobProperties properties;
+      try {
+        properties = blobClient.getProperties();
+      } catch (final BlobStorageException e) {
+        return Either.left(mapBlobStorageError(documentId, e));
+      }
+
+      final Map<String, String> metadata = properties.getMetadata();
+      if (metadata == null) {
+        return Either.left(new InvalidInput("No metadata found for document"));
+      }
+
+      final String storedContentHash = metadata.get(CONTENT_HASH_METADATA_KEY);
+      if (storedContentHash == null) {
+        return Either.left(new InvalidInput("No content hash found for document"));
+      }
+
+      if (!storedContentHash.equals(contentHashToVerify)) {
+        return Either.left(new DocumentError.DocumentHashMismatch(documentId, contentHashToVerify));
+      }
+      return Either.right(null);
+    } catch (final BlobStorageException e) {
+      return Either.left(mapBlobStorageError(documentId, e));
+    } catch (final Exception e) {
+      return Either.left(new UnknownDocumentError(e));
+    }
+  }
+
+  private boolean isDocumentExpired(final Map<String, String> metadata, final String documentId) {
+    if (metadata != null) {
+      final String expiresAt = metadata.get(EXPIRES_AT_METADATA_KEY);
+
+      if (expiresAt != null && OffsetDateTime.parse(expiresAt).isBefore(OffsetDateTime.now())) {
+        deleteDocumentInternal(documentId);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Map<String, String> toBlobMetadata(
+      final DocumentMetadataModel metadata, final String fileName, final String contentHash) {
+    if (metadata == null) {
+      return Collections.emptyMap();
+    }
+
+    final Map<String, String> metadataMap = new HashMap<>();
+
+    putIfPresent(CONTENT_TYPE_METADATA_KEY, metadata.contentType(), metadataMap);
+    putIfPresent(SIZE_METADATA_KEY, metadata.size(), metadataMap);
+    putIfPresent(FILENAME_METADATA_KEY, fileName, metadataMap);
+    putIfPresent(EXPIRES_AT_METADATA_KEY, metadata.expiresAt(), metadataMap);
+
+    metadataMap.put(CONTENT_HASH_METADATA_KEY, contentHash);
+
+    if (metadata.customProperties() != null) {
+      metadata
+          .customProperties()
+          .forEach((key, value) -> metadataMap.put(key, String.valueOf(value)));
+    }
+
+    putIfPresent(METADATA_PROCESS_DEFINITION_ID, metadata.processDefinitionId(), metadataMap);
+    putIfPresent(METADATA_PROCESS_INSTANCE_KEY, metadata.processInstanceKey(), metadataMap);
+
+    return metadataMap;
+  }
+
+  private <T> void putIfPresent(
+      final String key, final T value, final Map<String, String> metadataMap) {
+    if (value != null) {
+      metadataMap.put(key, value.toString());
+    }
+  }
+
+  private static DocumentError mapBlobStorageError(
+      final String documentId, final BlobStorageException e) {
+    final int statusCode = e.getStatusCode();
+    if (statusCode == HTTP_NOT_FOUND) {
+      if (e.getErrorCode() != null && "ContainerNotFound".equals(e.getErrorCode().toString())) {
+        return new UnknownDocumentError(
+            "Azure Blob container not found. Check that the 'CONTAINER' property "
+                + "is correct and the container exists.",
+            e);
+      }
+      return new DocumentNotFound(documentId);
+    }
+    if (statusCode == HTTP_FORBIDDEN) {
+      return new UnknownDocumentError(
+          "Access denied to Azure Blob Storage. Check that the connection string "
+              + "or credentials have the required permissions.",
+          e);
+    }
+    if (statusCode == HTTP_CONFLICT) {
+      return new DocumentAlreadyExists(documentId);
+    }
+    return new UnknownDocumentError(
+        "Azure Blob Storage error (HTTP " + statusCode + "): " + e.getMessage(), e);
+  }
+
+  private String resolveBlobName(final String documentId) {
+    return containerPath + documentId;
+  }
+
+  private String resolveFileName(
+      final DocumentMetadataModel documentMetadata, final String documentId) {
+    return documentMetadata.fileName() != null ? documentMetadata.fileName() : documentId;
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStore.java
@@ -16,6 +16,8 @@ import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.UserDelegationKey;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.document.api.DocumentContent;
 import io.camunda.document.api.DocumentCreationRequest;
 import io.camunda.document.api.DocumentError;
@@ -62,6 +64,7 @@ public class AzureBlobDocumentStore implements DocumentStore {
   private final String containerPath;
   private final BlobContainerClient containerClient;
   private final BlobServiceClient serviceClient;
+  private final ObjectMapper objectMapper = new ObjectMapper();
   private final ExecutorService executor;
 
   public AzureBlobDocumentStore(
@@ -274,8 +277,7 @@ public class AzureBlobDocumentStore implements DocumentStore {
         sasUrl = blobClient.getBlobUrl() + "?" + sasToken;
       }
 
-      return Either.right(
-          new DocumentLink(sasUrl, OffsetDateTime.now().plus(Duration.ofMillis(durationInMillis))));
+      return Either.right(new DocumentLink(sasUrl, expiryTime));
     } catch (final BlobStorageException e) {
       return Either.left(mapBlobStorageError(documentId, e));
     } catch (final Exception e) {
@@ -330,7 +332,8 @@ public class AzureBlobDocumentStore implements DocumentStore {
   }
 
   private Map<String, String> toBlobMetadata(
-      final DocumentMetadataModel metadata, final String fileName, final String contentHash) {
+      final DocumentMetadataModel metadata, final String fileName, final String contentHash)
+      throws JsonProcessingException {
     if (metadata == null) {
       return Collections.emptyMap();
     }
@@ -344,10 +347,12 @@ public class AzureBlobDocumentStore implements DocumentStore {
 
     metadataMap.put(CONTENT_HASH_METADATA_KEY, contentHash);
 
-    if (metadata.customProperties() != null) {
-      metadata
-          .customProperties()
-          .forEach((key, value) -> metadataMap.put(key, String.valueOf(value)));
+    if (metadata.customProperties() != null && !metadata.customProperties().isEmpty()) {
+      for (final var key : metadata.customProperties().keySet()) {
+        final var value = metadata.customProperties().get(key);
+        final var valueAsString = objectMapper.writeValueAsString(value);
+        metadataMap.put(key, valueAsString);
+      }
     }
 
     putIfPresent(METADATA_PROCESS_DEFINITION_ID, metadata.processDefinitionId(), metadataMap);

--- a/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStoreFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.azure;
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import java.util.concurrent.ExecutorService;
+
+public class AzureBlobDocumentStoreFactory {
+
+  public static AzureBlobDocumentStore createWithDefaultCredential(
+      final String endpoint,
+      final String containerName,
+      final String containerPath,
+      final ExecutorService executor) {
+    final BlobServiceClient serviceClient =
+        new BlobServiceClientBuilder()
+            .endpoint(endpoint)
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildClient();
+    final BlobContainerClient containerClient = serviceClient.getBlobContainerClient(containerName);
+    return new AzureBlobDocumentStore(
+        containerName, containerPath, containerClient, serviceClient, executor);
+  }
+
+  public static AzureBlobDocumentStore createWithConnectionString(
+      final String connectionString,
+      final String containerName,
+      final String containerPath,
+      final ExecutorService executor) {
+    final BlobServiceClient serviceClient =
+        new BlobServiceClientBuilder().connectionString(connectionString).buildClient();
+    final BlobContainerClient containerClient = serviceClient.getBlobContainerClient(containerName);
+    return new AzureBlobDocumentStore(
+        containerName, containerPath, containerClient, serviceClient, executor);
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.azure;
+
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import io.camunda.document.api.DocumentStoreProvider;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
+
+public class AzureBlobDocumentStoreProvider implements DocumentStoreProvider {
+
+  private static final Pattern INVALID_CHARACTERS = Pattern.compile("[\\u0000-\\u001F\\\\]");
+
+  private static final String CONTAINER_PROPERTY = "CONTAINER";
+  private static final String CONTAINER_PATH = "CONTAINER_PATH";
+  private static final String CONNECTION_STRING = "CONNECTION_STRING";
+  private static final String ENDPOINT = "ENDPOINT";
+
+  @Override
+  public DocumentStore createDocumentStore(
+      final DocumentStoreConfigurationRecord configuration, final ExecutorService executorService) {
+    final String containerName =
+        Optional.ofNullable(configuration.properties().get(CONTAINER_PROPERTY))
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Failed to configure document store with id '"
+                            + configuration.id()
+                            + "': missing required property '"
+                            + CONTAINER_PROPERTY
+                            + "'"));
+
+    final String connectionString = configuration.properties().get(CONNECTION_STRING);
+    final String endpoint = configuration.properties().get(ENDPOINT);
+
+    if (connectionString == null && endpoint == null) {
+      throw new IllegalArgumentException(
+          "Failed to configure document store with id '"
+              + configuration.id()
+              + "': either '"
+              + CONNECTION_STRING
+              + "' or '"
+              + ENDPOINT
+              + "' must be set");
+    }
+
+    final String containerPath = getContainerPath(configuration);
+
+    if (connectionString != null) {
+      return AzureBlobDocumentStoreFactory.createWithConnectionString(
+          connectionString, containerName, containerPath, executorService);
+    } else {
+      return AzureBlobDocumentStoreFactory.createWithDefaultCredential(
+          endpoint, containerName, containerPath, executorService);
+    }
+  }
+
+  private static String getContainerPath(final DocumentStoreConfigurationRecord configuration) {
+    String containerPath =
+        Objects.requireNonNullElse(configuration.properties().get(CONTAINER_PATH), "");
+
+    if (INVALID_CHARACTERS.matcher(containerPath).find()) {
+      throw new IllegalArgumentException(
+          "Failed to configure document store with id '"
+              + configuration.id()
+              + "': '"
+              + CONTAINER_PATH
+              + " is invalid. Must not contain \\ character'");
+    }
+
+    if (!containerPath.isEmpty() && !containerPath.endsWith("/")) {
+      containerPath = containerPath + "/";
+    }
+
+    return containerPath;
+  }
+}

--- a/document/store/src/main/resources/META-INF/services/io.camunda.document.api.DocumentStoreProvider
+++ b/document/store/src/main/resources/META-INF/services/io.camunda.document.api.DocumentStoreProvider
@@ -9,3 +9,4 @@ io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider
 io.camunda.document.store.gcp.GcpDocumentStoreProvider
 io.camunda.document.store.aws.AwsDocumentStoreProvider
 io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider
+io.camunda.document.store.azure.AzureBlobDocumentStoreProvider

--- a/document/store/src/test/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/azure/AzureBlobDocumentStoreProviderTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import java.util.HashMap;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+
+class AzureBlobDocumentStoreProviderTest {
+
+  @Test
+  void shouldCreateDocumentStoreWithConnectionString() {
+    try (final var mockedFactory = mockStatic(AzureBlobDocumentStoreFactory.class)) {
+      // given
+      final String containerName = "test-container";
+      final String connectionString = "DefaultEndpointsProtocol=https;AccountName=test";
+      final AzureBlobDocumentStore mockDocumentStore = mock(AzureBlobDocumentStore.class);
+
+      mockedFactory
+          .when(
+              () ->
+                  AzureBlobDocumentStoreFactory.createWithConnectionString(
+                      eq(connectionString), eq(containerName), eq(""), any()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "azure", AzureBlobDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("CONTAINER", containerName);
+      configuration.properties().put("CONNECTION_STRING", connectionString);
+      final AzureBlobDocumentStoreProvider provider = new AzureBlobDocumentStoreProvider();
+
+      // when
+      final DocumentStore documentStore =
+          provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(documentStore).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldCreateDocumentStoreWithEndpoint() {
+    try (final var mockedFactory = mockStatic(AzureBlobDocumentStoreFactory.class)) {
+      // given
+      final String containerName = "test-container";
+      final String endpoint = "https://myaccount.blob.core.windows.net";
+      final AzureBlobDocumentStore mockDocumentStore = mock(AzureBlobDocumentStore.class);
+
+      mockedFactory
+          .when(
+              () ->
+                  AzureBlobDocumentStoreFactory.createWithDefaultCredential(
+                      eq(endpoint), eq(containerName), eq(""), any()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "azure", AzureBlobDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("CONTAINER", containerName);
+      configuration.properties().put("ENDPOINT", endpoint);
+      final AzureBlobDocumentStoreProvider provider = new AzureBlobDocumentStoreProvider();
+
+      // when
+      final DocumentStore documentStore =
+          provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(documentStore).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldThrowIfContainerNameMissing() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "my-azure", AzureBlobDocumentStoreProvider.class, new HashMap<>());
+    final AzureBlobDocumentStoreProvider provider = new AzureBlobDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to configure document store with id 'my-azure':"
+                + " missing required property 'CONTAINER'");
+  }
+
+  @Test
+  void shouldThrowIfNeitherEndpointNorConnectionStringProvided() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "azure", AzureBlobDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("CONTAINER", "test-container");
+    final AzureBlobDocumentStoreProvider provider = new AzureBlobDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to configure document store with id 'azure':"
+                + " either 'CONNECTION_STRING' or 'ENDPOINT' must be set");
+  }
+
+  @Test
+  void shouldThrowIfContainerPathInvalid() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "azure", AzureBlobDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("CONTAINER", "test-container");
+    configuration.properties().put("CONNECTION_STRING", "some-connection-string");
+    configuration.properties().put("CONTAINER_PATH", "test\\path");
+    final AzureBlobDocumentStoreProvider provider = new AzureBlobDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to configure document store with id 'azure':"
+                + " 'CONTAINER_PATH is invalid. Must not contain \\ character'");
+  }
+
+  @Test
+  void shouldAppendTrailingSlashToContainerPath() {
+    try (final var mockedFactory = mockStatic(AzureBlobDocumentStoreFactory.class)) {
+      // given
+      final String containerName = "test-container";
+      final String connectionString = "DefaultEndpointsProtocol=https;AccountName=test";
+      final AzureBlobDocumentStore mockDocumentStore = mock(AzureBlobDocumentStore.class);
+
+      mockedFactory
+          .when(
+              () ->
+                  AzureBlobDocumentStoreFactory.createWithConnectionString(
+                      eq(connectionString), eq(containerName), eq("documents/"), any()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "azure", AzureBlobDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("CONTAINER", containerName);
+      configuration.properties().put("CONNECTION_STRING", connectionString);
+      configuration.properties().put("CONTAINER_PATH", "documents");
+      final AzureBlobDocumentStoreProvider provider = new AzureBlobDocumentStoreProvider();
+
+      // when
+      final DocumentStore documentStore =
+          provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(documentStore).isNotNull();
+      mockedFactory.verify(
+          () ->
+              AzureBlobDocumentStoreFactory.createWithConnectionString(
+                  eq(connectionString), eq(containerName), eq("documents/"), any()));
+    }
+  }
+}

--- a/document/store/src/test/java/io/camunda/document/store/azure/AzureBlobDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/azure/AzureBlobDocumentStoreTest.java
@@ -1,0 +1,500 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.*;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.UserDelegationKey;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.blob.specialized.BlobInputStream;
+import io.camunda.document.api.DocumentContent;
+import io.camunda.document.api.DocumentCreationRequest;
+import io.camunda.document.api.DocumentError.DocumentAlreadyExists;
+import io.camunda.document.api.DocumentError.DocumentHashMismatch;
+import io.camunda.document.api.DocumentError.DocumentNotFound;
+import io.camunda.document.api.DocumentError.InvalidInput;
+import io.camunda.document.api.DocumentError.UnknownDocumentError;
+import io.camunda.document.api.DocumentLink;
+import io.camunda.document.api.DocumentMetadataModel;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AzureBlobDocumentStoreTest {
+
+  private static final String CONTAINER_NAME = "test-container";
+  private static final String CONTAINER_PATH = "test/";
+
+  @Mock private BlobContainerClient containerClient;
+  @Mock private BlobServiceClient serviceClient;
+  @Mock private BlobClient blobClient;
+
+  private AzureBlobDocumentStore documentStore;
+
+  @BeforeEach
+  void setUp() {
+    documentStore =
+        new AzureBlobDocumentStore(
+            CONTAINER_NAME,
+            CONTAINER_PATH,
+            containerClient,
+            serviceClient,
+            Executors.newSingleThreadExecutor());
+  }
+
+  @Test
+  void shouldCreateDocumentSuccessfully() {
+    // given
+    final var documentId = "test-document-id";
+    final var content = "test-content-random-bits\n.".getBytes();
+    final var inputStream = new ByteArrayInputStream(content);
+
+    final var metadata =
+        new DocumentMetadataModel(
+            "text/plain",
+            "test-file.txt",
+            null,
+            (long) content.length,
+            null,
+            null,
+            Collections.emptyMap());
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.exists()).thenReturn(false);
+    doAnswer(
+            invocation -> {
+              final InputStream stream = invocation.getArgument(0);
+              stream.transferTo(OutputStream.nullOutputStream());
+              return null;
+            })
+        .when(blobClient)
+        .upload(any(InputStream.class), anyLong(), eq(false));
+
+    final var request = new DocumentCreationRequest(documentId, inputStream, metadata);
+
+    // when
+    final var result = documentStore.createDocument(request).join();
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get().documentId()).isEqualTo(documentId);
+    assertThat(result.get().contentHash())
+        .isEqualTo("3635e7279b883d6bfd13cfe4d8815cc01b70c678afc8d278c0a4c1b0afbb87a8");
+
+    verify(blobClient).setMetadata(anyMap());
+    verify(blobClient).setHttpHeaders(any());
+  }
+
+  @Test
+  void shouldFailIfDocumentAlreadyExists() {
+    // given
+    final var documentId = "existing-document-id";
+    final var inputStream = new ByteArrayInputStream(new byte[0]);
+    final var metadata =
+        new DocumentMetadataModel(null, null, null, 0L, null, null, Collections.emptyMap());
+    final var request = new DocumentCreationRequest(documentId, inputStream, metadata);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.exists()).thenReturn(true);
+
+    // when
+    final var result = documentStore.createDocument(request).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentAlreadyExists.class);
+  }
+
+  @Test
+  void shouldFailForGeneralExceptionOnCreate() {
+    // given
+    final var documentId = "test-document-id";
+    final var inputStream = new ByteArrayInputStream(new byte[0]);
+    final var metadata =
+        new DocumentMetadataModel(null, null, null, 0L, null, null, Collections.emptyMap());
+    final var request = new DocumentCreationRequest(documentId, inputStream, metadata);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId))
+        .thenThrow(new RuntimeException("Something went wrong"));
+
+    // when
+    final var result = documentStore.createDocument(request).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(UnknownDocumentError.class);
+  }
+
+  @Test
+  void shouldGetDocumentSuccessfully() {
+    // given
+    final var documentId = "test-document-id";
+    final var blobInputStream = mock(BlobInputStream.class);
+    final var properties = mock(BlobProperties.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(Collections.emptyMap());
+    when(properties.getContentType()).thenReturn("text/plain");
+    when(blobClient.openInputStream()).thenReturn(blobInputStream);
+
+    // when
+    final var result = documentStore.getDocument(documentId).join();
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    final DocumentContent content = result.get();
+    assertThat(content.contentType()).isEqualTo("text/plain");
+  }
+
+  @Test
+  void shouldFailGetIfDocumentNotFound() {
+    // given
+    final var documentId = "test-document-id";
+    final var exception = mock(BlobStorageException.class);
+    when(exception.getStatusCode()).thenReturn(404);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenThrow(exception);
+
+    // when
+    final var result = documentStore.getDocument(documentId).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
+  }
+
+  @Test
+  void shouldFailGetIfDocumentExpired() {
+    // given
+    final var documentId = "test-document-id";
+    final var expiresAt = OffsetDateTime.now().minus(Duration.ofDays(10)).toString();
+    final var metadata = Map.of("expiresAt", expiresAt);
+    final var properties = mock(BlobProperties.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(metadata);
+
+    // when
+    final var result = documentStore.getDocument(documentId).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
+  }
+
+  @Test
+  void shouldDeleteDocumentSuccessfully() {
+    // given
+    final var documentId = "test-document-id";
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    doNothing().when(blobClient).delete();
+
+    // when
+    final var result = documentStore.deleteDocument(documentId).join();
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    verify(blobClient).delete();
+  }
+
+  @Test
+  void shouldFailDeleteIfDocumentNotFound() {
+    // given
+    final var documentId = "test-document-id";
+    final var exception = mock(BlobStorageException.class);
+    when(exception.getStatusCode()).thenReturn(404);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    doThrow(exception).when(blobClient).delete();
+
+    // when
+    final var result = documentStore.deleteDocument(documentId).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
+  }
+
+  @Test
+  void shouldVerifyContentHashSuccessfully() {
+    // given
+    final var documentId = "test-document-id";
+    final var contentHash = "randomhash";
+    final var metadata = Map.of("contentHash", contentHash);
+    final var properties = mock(BlobProperties.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(metadata);
+
+    // when
+    final var result = documentStore.verifyContentHash(documentId, contentHash).join();
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldFailVerifyForDifferentHash() {
+    // given
+    final var documentId = "test-document-id";
+    final var contentHash = "contentHash";
+    final var metadata = Map.of("contentHash", contentHash);
+    final var properties = mock(BlobProperties.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(metadata);
+
+    // when
+    final var result = documentStore.verifyContentHash(documentId, "wrongHash").join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentHashMismatch.class);
+  }
+
+  @Test
+  void shouldFailVerifyIfDocumentNotFound() {
+    // given
+    final var documentId = "test-document-id";
+    final var exception = mock(BlobStorageException.class);
+    when(exception.getStatusCode()).thenReturn(404);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenThrow(exception);
+
+    // when
+    final var result = documentStore.verifyContentHash(documentId, "hash").join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
+  }
+
+  @Test
+  void shouldFailVerifyIfNoMetadata() {
+    // given
+    final var documentId = "test-document-id";
+    final var properties = mock(BlobProperties.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(null);
+
+    // when
+    final var result = documentStore.verifyContentHash(documentId, "hash").join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(InvalidInput.class);
+  }
+
+  @Test
+  void shouldFailVerifyIfNoContentHash() {
+    // given
+    final var documentId = "test-document-id";
+    final var properties = mock(BlobProperties.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(Collections.emptyMap());
+
+    // when
+    final var result = documentStore.verifyContentHash(documentId, "hash").join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(InvalidInput.class);
+  }
+
+  @Test
+  void shouldFailVerifyForGeneralException() {
+    // given
+    final var documentId = "test-document-id";
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId))
+        .thenThrow(new RuntimeException());
+
+    // when
+    final var result = documentStore.verifyContentHash(documentId, "hash").join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(UnknownDocumentError.class);
+  }
+
+  @Test
+  void shouldCreateLinkSuccessfully() {
+    // given
+    final var documentId = "test-document-id";
+    final var durationInMillis = 10000L;
+    final var metadata = Map.of("expiresAt", OffsetDateTime.now().plusDays(1).toString());
+    final var properties = mock(BlobProperties.class);
+    final var userDelegationKey = mock(UserDelegationKey.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(metadata);
+    when(serviceClient.getUserDelegationKey(any(OffsetDateTime.class), any(OffsetDateTime.class)))
+        .thenReturn(userDelegationKey);
+    when(blobClient.generateUserDelegationSas(
+            any(BlobServiceSasSignatureValues.class), any(UserDelegationKey.class)))
+        .thenReturn("sastoken123");
+    when(blobClient.getBlobUrl())
+        .thenReturn("https://account.blob.core.windows.net/container/blob");
+
+    // when
+    final var result = documentStore.createLink(documentId, durationInMillis).join();
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    final DocumentLink link = result.get();
+    assertThat(link.link())
+        .isEqualTo("https://account.blob.core.windows.net/container/blob?sastoken123");
+    assertThat(link.expiresAt()).isNotNull();
+  }
+
+  @Test
+  void shouldFallBackToServiceSasWhenUserDelegationFails() {
+    // given
+    final var documentId = "test-document-id";
+    final var durationInMillis = 10000L;
+    final var metadata = Map.of("expiresAt", OffsetDateTime.now().plusDays(1).toString());
+    final var properties = mock(BlobProperties.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(metadata);
+    when(serviceClient.getUserDelegationKey(any(OffsetDateTime.class), any(OffsetDateTime.class)))
+        .thenThrow(new RuntimeException("User delegation not supported"));
+    when(blobClient.generateSas(any(BlobServiceSasSignatureValues.class)))
+        .thenReturn("servicesastoken");
+    when(blobClient.getBlobUrl())
+        .thenReturn("https://account.blob.core.windows.net/container/blob");
+
+    // when
+    final var result = documentStore.createLink(documentId, durationInMillis).join();
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    final DocumentLink link = result.get();
+    assertThat(link.link())
+        .isEqualTo("https://account.blob.core.windows.net/container/blob?servicesastoken");
+  }
+
+  @Test
+  void shouldFailCreateLinkForInvalidDuration() {
+    // given
+    final var documentId = "test-document-id";
+
+    // when
+    final var result = documentStore.createLink(documentId, -1L).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(InvalidInput.class);
+    assertThat(((InvalidInput) result.getLeft()).message())
+        .isEqualTo("Duration must be greater than 0");
+  }
+
+  @Test
+  void shouldFailCreateLinkForDocumentNotFound() {
+    // given
+    final var documentId = "test-document-id";
+    final var exception = mock(BlobStorageException.class);
+    when(exception.getStatusCode()).thenReturn(404);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenThrow(exception);
+
+    // when
+    final var result = documentStore.createLink(documentId, 10000L).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
+  }
+
+  @Test
+  void shouldFailCreateLinkForExpiredDocument() {
+    // given
+    final var documentId = "test-document-id";
+    final var metadata = Map.of("expiresAt", OffsetDateTime.now().minusDays(1).toString());
+    final var properties = mock(BlobProperties.class);
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId)).thenReturn(blobClient);
+    when(blobClient.getProperties()).thenReturn(properties);
+    when(properties.getMetadata()).thenReturn(metadata);
+
+    // when
+    final var result = documentStore.createLink(documentId, 10000L).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(DocumentNotFound.class);
+  }
+
+  @Test
+  void shouldHandleGeneralExceptionOnCreateLink() {
+    // given
+    final var documentId = "test-document-id";
+
+    when(containerClient.getBlobClient(CONTAINER_PATH + documentId))
+        .thenThrow(new RuntimeException("Unexpected error"));
+
+    // when
+    final var result = documentStore.createLink(documentId, 10000L).join();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isInstanceOf(UnknownDocumentError.class);
+  }
+
+  @Test
+  void shouldValidateSetupSuccessfully() {
+    // given
+    when(containerClient.exists()).thenReturn(true);
+
+    // when / then
+    assertThatNoException().isThrownBy(() -> documentStore.validateSetup());
+    verify(containerClient).exists();
+  }
+
+  @Test
+  void shouldHandleExceptionInValidateSetup() {
+    // given
+    when(containerClient.exists()).thenThrow(new RuntimeException("Unexpected error"));
+
+    // when / then
+    assertThatNoException().isThrownBy(() -> documentStore.validateSetup());
+    verify(containerClient).exists();
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -11,7 +11,7 @@ paths:
       description: |
         Upload a document to the Camunda 8 cluster.
 
-        Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
+        Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
       parameters:
         - name: storeId
           in: query
@@ -79,7 +79,7 @@ paths:
         each of which contains the file name of the document that failed to upload and the reason for the failure.
         The client can choose to retry the whole batch or individual documents based on the response.
 
-        Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
+        Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
       parameters:
         - name: storeId
           in: query
@@ -146,7 +146,7 @@ paths:
       description: |
         Download a document from the Camunda 8 cluster.
 
-        Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
+        Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
       parameters:
         - name: documentId
           in: path
@@ -195,7 +195,7 @@ paths:
       description: |
         Delete a document from the Camunda 8 cluster.
 
-        Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
+        Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
       parameters:
         - name: documentId
           in: path
@@ -231,7 +231,7 @@ paths:
       description: |
         Create a link to a document in the Camunda 8 cluster.
 
-        Note that this is currently supported for document stores of type: AWS, GCP
+        Note that this is currently supported for document stores of type: AWS, Azure, GCP
       parameters:
         - name: documentId
           in: path


### PR DESCRIPTION
## Description

Adds Azure Blob Storage as a supported document store backend for Self-Managed Camunda 8, alongside the existing AWS S3 and GCP implementations.

### What changed

- **`document/store/pom.xml`** — added `azure-storage-blob` and `azure-identity` dependencies (versions managed by `azure-sdk-bom` in parent)
- **`AzureBlobDocumentStore`** — full `DocumentStore` implementation: create, get, delete, create link (SAS token), verify content hash, validate setup
- **`AzureBlobDocumentStoreFactory`** — static factory for testability (mirrors `AwsDocumentStoreFactory`)
- **`AzureBlobDocumentStoreProvider`** — `DocumentStoreProvider` SPI implementation; reads config from env vars and validates required properties
- **SPI registration** — added to `META-INF/services/io.camunda.document.api.DocumentStoreProvider`
- **OpenAPI spec** (`documents.yaml`) — added Azure to the list of supported store types
- **Unit tests** — 22 tests for the store, 6 for the provider

### Configuration (environment variables)

| Variable | Required | Description |
|---|---|---|
| `DOCUMENT_STORE_AZURE_CLASS` | Yes | Must be `io.camunda.document.store.azure.AzureBlobDocumentStoreProvider` |
| `DOCUMENT_STORE_AZURE_CONTAINER` | Yes | Azure Blob container name |
| `DOCUMENT_STORE_AZURE_CONNECTION_STRING` | Conditional | Full Azure connection string (alternative to endpoint) |
| `DOCUMENT_STORE_AZURE_ENDPOINT` | Conditional | Storage account endpoint, e.g. `https://<account>.blob.core.windows.net` (used with `DefaultAzureCredential`) |
| `DOCUMENT_STORE_AZURE_CONTAINER_PATH` | No | Blob name prefix within the container (e.g. `documents/`) |

Either `CONNECTION_STRING` or `ENDPOINT` must be set. When using `ENDPOINT`, authentication is handled by `DefaultAzureCredential` (Managed Identity, Workload Identity, Azure CLI, service principal env vars).

### SAS token generation

User Delegation SAS is attempted first (works with `DefaultAzureCredential`); falls back to Service SAS if unavailable (e.g. when using a connection string).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47790
