### PR TITLE
test: 8.7 fix nightly

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -173,6 +173,8 @@ class TaskDetailsPage {
     await this.clickAddVariableButton();
     await this.getNthVariableNameInput(1).fill(name);
     await this.getNthVariableValueInput(1).fill(value);
+    await expect(this.getNthVariableNameInput(1)).toHaveValue(name);
+    await expect(this.getNthVariableValueInput(1)).toHaveValue(value);
   }
 
   async fillNumber(number: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -141,6 +141,14 @@ class TaskDetailsPage {
       },
       onFailure: async () => {
         console.log('Task completed banner not visible, retrying...');
+        await this.page.reload();
+        await sleep(1000);
+        if (
+          (await this.completeTaskButton.isVisible()) &&
+          (await this.completeTaskButton.isEnabled())
+        ) {
+          await expect(this.completeTaskButton).toBeVisible({timeout: 60000});
+        }
       },
     });
   }
@@ -175,6 +183,7 @@ class TaskDetailsPage {
     await this.getNthVariableValueInput(1).fill(value);
     await expect(this.getNthVariableNameInput(1)).toHaveValue(name);
     await expect(this.getNthVariableValueInput(1)).toHaveValue(value);
+    await sleep(200);
   }
 
   async fillNumber(number: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -195,8 +195,13 @@ test.describe('task details page', () => {
       timeout: 120000,
     });
     await taskDetailsPage.clickAssignToMeButton();
-    await expect(page.getByText('zeebeVar', {exact: true})).toBeVisible({
-      timeout: 60000,
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(page.getByText('zeebeVar', {exact: true})).toBeVisible();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
     });
     await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
     await taskDetailsPage.addVariable({
@@ -209,8 +214,13 @@ test.describe('task details page', () => {
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.assertCompletedHeadingVisible();
     await taskPanelPage.openTask('Zeebe_user_task');
-    await expect(page.getByText('zeebeVar', {exact: true})).toBeVisible({
-      timeout: 60000,
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(page.getByText('zeebeVar', {exact: true})).toBeVisible();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
     });
     await expect(taskDetailsPage.assignToMeButton).toBeHidden();
     await expect(taskDetailsPage.unassignButton).toBeHidden();


### PR DESCRIPTION
## Description

Added retries for zeebe/job worker variable test.

[Successful run](https://github.com/camunda/camunda/actions/runs/22722540321) ✅ 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
