### PR TITLE
test: migrate dashboard.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
@@ -15,6 +15,23 @@ export class OperateDashboardPage {
   readonly totalInstancesLink: Locator;
   readonly activeInstancesLink: Locator;
   readonly incidentInstancesLink: Locator;
+  readonly instancesByProcess: Locator;
+  readonly incidentsByError: Locator;
+  readonly instancesByProcessItem: (index: number) => Locator;
+  readonly incidentsByErrorItem: (index: number) => Locator;
+  readonly activeInstancesBadge: Locator;
+  readonly incidentInstancesBadge: Locator;
+  readonly processInstancesHeading: (
+    count: string | number,
+    isPlural?: boolean,
+  ) => Locator;
+  readonly incidentLinkByType: (type: string | RegExp) => Locator;
+  readonly viewInstanceLink: () => Locator;
+  readonly expandRowButton: () => Locator;
+  readonly incidentBadgeFromItem: (item: Locator) => Locator;
+  readonly activeBadgeFromItem: (item: Locator) => Locator;
+  readonly expandRowButtonFromItem: (item: Locator) => Locator;
+  readonly firstLinkFromItem: (item: Locator) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -25,6 +42,55 @@ export class OperateDashboardPage {
     this.totalInstancesLink = page.getByTestId('total-instances-link');
     this.activeInstancesLink = page.getByTestId('active-instances-link');
     this.incidentInstancesLink = page.getByTestId('incident-instances-link');
+    this.instancesByProcess = page.getByTestId('instances-by-process');
+    this.incidentsByError = page.getByTestId('incident-byError');
+
+    this.instancesByProcessItem = (index: number) =>
+      page.getByTestId(`instances-by-process-${index}`);
+
+    this.incidentsByErrorItem = (index: number) =>
+      page.getByTestId(`incident-byError-${index}`);
+
+    this.activeInstancesBadge = page
+      .getByTestId('active-instances-badge')
+      .nth(0);
+
+    this.incidentInstancesBadge = page
+      .getByTestId('incident-instances-badge')
+      .nth(0);
+
+    this.processInstancesHeading = (count, isPlural = true) =>
+      page.getByRole('heading', {
+        name: `Process Instances - ${count} result${isPlural ? 's' : ''}`,
+      });
+
+    this.incidentLinkByType = (type) =>
+      page.getByRole('link', {
+        name: type,
+      });
+
+    this.viewInstanceLink = () =>
+      page.getByRole('link', {
+        name: /view instance/i,
+      });
+
+    this.expandRowButton = () =>
+      page.getByRole('button', {
+        name: 'Expand current row',
+      });
+
+    this.incidentBadgeFromItem = (item) =>
+      item.getByTestId('incident-instances-badge');
+
+    this.activeBadgeFromItem = (item) =>
+      item.getByTestId('active-instances-badge');
+
+    this.expandRowButtonFromItem = (item) =>
+      item.getByRole('button', {
+        name: 'Expand current row',
+      });
+
+    this.firstLinkFromItem = (item) => item.getByRole('link').nth(0);
   }
 
   async gotoDashboardPage(
@@ -42,5 +108,25 @@ export class OperateDashboardPage {
 
   async clickIncidentInstancesLink(): Promise<void> {
     await this.incidentInstancesLink.click();
+  }
+
+  async clickIncidentByType(type: string | RegExp): Promise<void> {
+    await this.incidentLinkByType(type).click();
+  }
+
+  async clickViewInstanceLink(): Promise<void> {
+    await this.viewInstanceLink().click();
+  }
+
+  async clickItem(item: Locator): Promise<void> {
+    await item.click();
+  }
+
+  async expandItem(item: Locator): Promise<void> {
+    await this.expandRowButtonFromItem(item).click();
+  }
+
+  async clickFirstLinkInItem(item: Locator): Promise<void> {
+    await this.firstLinkFromItem(item).click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -44,6 +44,7 @@ class OperateProcessInstancePage {
   readonly processInstanceKeyCell: Locator;
   readonly viewAllCalledInstancesLink: Locator;
   readonly viewParentInstanceLink: Locator;
+  readonly variableCellByName: (name: string | RegExp) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -96,6 +97,8 @@ class OperateProcessInstancePage {
     this.viewAllCalledInstancesLink = page.getByRole('link', {
       name: /view all called instances/i,
     });
+    this.variableCellByName = (name) =>
+      this.variablesList.getByRole('cell', {name});
     this.viewParentInstanceLink = this.instanceHeader.getByRole('link', {
       name: /view parent instance/i,
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/incidentGeneratorProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/incidentGeneratorProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0lj6gqo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="incidentGeneratorProcess" name="Incident Generator Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_13hjtls</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_13hjtls" sourceRef="StartEvent_1" targetRef="IncidentGenerator" />
+    <bpmn:endEvent id="Event_11zx0y4">
+      <bpmn:incoming>Flow_1nrs4lg</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1nrs4lg" sourceRef="IncidentGenerator" targetRef="Event_11zx0y4" />
+    <bpmn:serviceTask id="IncidentGenerator" name="Incident Generator">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="incidentGenerator" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13hjtls</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nrs4lg</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="incidentGeneratorProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11zx0y4_di" bpmnElement="Event_11zx0y4">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05iptua_di" bpmnElement="IncidentGenerator">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13hjtls_di" bpmnElement="Flow_13hjtls">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nrs4lg_di" bpmnElement="Flow_1nrs4lg">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/onlyIncidentsProcess_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/onlyIncidentsProcess_v_2.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="onlyIncidentsProcess" name="Only Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_01kuijd</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_1ker6z2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="alwaysFails2" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_01kuijd</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1ker6z2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_01kuijd" sourceRef="alwaysFails" targetRef="alwaysFails2" />
+    <bpmn:sequenceFlow id="SequenceFlow_1ker6z2" sourceRef="alwaysFails2" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="onlyIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0s7aueh_di" bpmnElement="alwaysFails2">
+        <dc:Bounds x="600" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_01kuijd_di" bpmnElement="SequenceFlow_01kuijd">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="600" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ker6z2_di" bpmnElement="SequenceFlow_1ker6z2">
+        <di:waypoint x="700" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutIncidentsProcess_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutIncidentsProcess_v_1.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="withoutIncidentsProcess" name="Without Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverFails" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="neverFails" targetRef="end" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverFails" name="Never fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="withoutIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="502" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint x="602" y="120" />
+        <di:waypoint x="867" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverFails">
+        <dc:Bounds x="502" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutIncidentsProcess_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutIncidentsProcess_v_2.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="withoutIncidentsProcess" name="Without Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverFails" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_0g2buaw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverFails" name="Never fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0v10lat</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="neverFails2" name="Never fails again">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverFails2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0v10lat</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0g2buaw</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0v10lat" sourceRef="neverFails" targetRef="neverFails2" />
+    <bpmn:sequenceFlow id="SequenceFlow_0g2buaw" sourceRef="neverFails2" targetRef="end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="withoutIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="374" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverFails">
+        <dc:Bounds x="374" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1j8pmi5_di" bpmnElement="neverFails2">
+        <dc:Bounds x="602" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0v10lat_di" bpmnElement="SequenceFlow_0v10lat">
+        <di:waypoint x="474" y="120" />
+        <di:waypoint x="602" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0g2buaw_di" bpmnElement="SequenceFlow_0g2buaw">
+        <di:waypoint x="702" y="120" />
+        <di:waypoint x="867" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutInstancesProcess_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutInstancesProcess_v_1.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="noInstancesProcess" name="Without Instances Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverExecuted" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="neverExecuted" targetRef="end" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverExecuted" name="Never executed">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverExecuted" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="noInstancesProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="502" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint x="602" y="120" />
+        <di:waypoint x="867" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverExecuted">
+        <dc:Bounds x="502" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutInstancesProcess_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutInstancesProcess_v_2.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="noInstancesProcess" name="Without Instances Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverExecuted" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="neverExecuted" targetRef="neverExecuted2" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1uidxur</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverExecuted" name="Never executed">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverExecuted" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="neverExecuted2" name="Never executed again">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverExecuted2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1uidxur</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1uidxur" sourceRef="neverExecuted2" targetRef="end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="noInstancesProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="363" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint x="463" y="120" />
+        <di:waypoint x="606" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverExecuted">
+        <dc:Bounds x="363" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1j5fcpc_di" bpmnElement="neverExecuted2">
+        <dc:Bounds x="606" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1uidxur_di" bpmnElement="SequenceFlow_1uidxur">
+        <di:waypoint x="706" y="120" />
+        <di:waypoint x="867" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -47,6 +47,7 @@ test.describe('Process Instance Batch Modification', () => {
     operateDiagramPage,
     operateProcessModificationModePage,
     operateFiltersPanelPage,
+    operateOperationPanelPage,
   }) => {
     await test.step('Navigate to processes page with filters', async () => {
       await gotoProcessesPage(page, {
@@ -126,6 +127,7 @@ test.describe('Process Instance Batch Modification', () => {
     });
 
     await test.step('Filter and verify modified instances', async () => {
+      await operateOperationPanelPage.collapseOperationsPanel();
       await operateDiagramPage.clickFlowNode('shipArticles');
       await operateFiltersPanelPage.clickCanceledInstancesCheckbox();
       await waitForAssertion({
@@ -135,7 +137,8 @@ test.describe('Process Instance Batch Modification', () => {
           ).toBeVisible();
         },
         onFailure: async () => {
-          await page.reload();
+          await operateOperationPanelPage.collapseOperationsPanel();
+          await operateDiagramPage.clickFlowNode('shipArticles');
         },
       });
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -1,0 +1,266 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {
+  deploy,
+  createInstances,
+  createSingleInstance,
+  createWorker,
+} from 'utils/zeebeClient';
+import {waitForProcessInstances, waitForIncidents} from 'utils/incidentsHelper';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {waitForAssertion} from '../../utils/waitForAssertion';
+
+let instanceIds: string[] = [];
+
+test.beforeAll(async ({request}) => {
+  test.setTimeout(180000);
+
+  await deploy([
+    './resources/withoutInstancesProcess_v_1.bpmn',
+    './resources/withoutIncidentsProcess_v_1.bpmn',
+    './resources/onlyIncidentsProcess_v_1.bpmn',
+    './resources/orderProcess_v_1.bpmn',
+    './resources/processWithAnIncident.bpmn',
+    './resources/incidentGeneratorProcess.bpmn',
+  ]);
+
+  await deploy([
+    './resources/withoutInstancesProcess_v_2.bpmn',
+    './resources/withoutIncidentsProcess_v_2.bpmn',
+    './resources/onlyIncidentsProcess_v_2.bpmn',
+  ]);
+
+  createWorker('incidentGenerator', true, {}, (job) => {
+    const BASE_ERROR_MESSAGE =
+      'This is an error message for testing purposes. This error message is very long to ensure it is truncated in the UI.';
+    if (job.variables.incidentType === 'Incident Type A') {
+      return job.fail(`${BASE_ERROR_MESSAGE} Type A`);
+    } else {
+      return job.fail(`${BASE_ERROR_MESSAGE} Type B`);
+    }
+  });
+
+  const instancesList = await Promise.all([
+    createInstances('withoutIncidentsProcess', 1, 4),
+    createInstances('withoutIncidentsProcess', 2, 8),
+    createInstances('onlyIncidentsProcess', 1, 10),
+    createInstances('onlyIncidentsProcess', 2, 5),
+    createInstances('orderProcess', 1, 10),
+    createSingleInstance('processWithAnIncident', 1),
+    createSingleInstance('incidentGeneratorProcess', 1, {
+      incidentType: 'Incident Type A',
+    }),
+    createSingleInstance('incidentGeneratorProcess', 1, {
+      incidentType: 'Incident Type B',
+    }),
+  ]);
+
+  const allInstances = instancesList.flatMap((instances) => instances);
+  instanceIds = allInstances.map((instance) => instance.processInstanceKey);
+
+  const incidentTypeAKey = instancesList[6].processInstanceKey;
+  const incidentTypeBKey = instancesList[7].processInstanceKey;
+
+  // Wait for all 40 instances to be indexed
+  await waitForProcessInstances(request, instanceIds, 40);
+
+  // Wait for Type A and Type B incidents to be indexed before tests run
+  await Promise.all([
+    waitForIncidents(request, incidentTypeAKey),
+    waitForIncidents(request, incidentTypeBKey),
+  ]);
+});
+
+test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+  await navigateToApp(page, 'operate');
+  await loginPage.login('demo', 'demo');
+  await expect(operateHomePage.operateBanner).toBeVisible();
+});
+
+test.afterEach(async ({page}, testInfo) => {
+  await captureScreenshot(page, testInfo);
+  await captureFailureVideo(page, testInfo);
+});
+
+test.describe('Dashboard', () => {
+  test('Statistics', async ({operateDashboardPage}) => {
+    await test.step('Verify total count equals sum of active and incident instances', async () => {
+      const incidentInstancesCount = Number(
+        await operateDashboardPage.incidentInstancesBadge.innerText(),
+      );
+      const activeProcessInstancesCount = Number(
+        await operateDashboardPage.activeInstancesBadge.innerText(),
+      );
+      const totalInstancesCount = operateDashboardPage.totalInstancesLink;
+
+      await expect(totalInstancesCount).toHaveText(
+        `${
+          incidentInstancesCount + activeProcessInstancesCount
+        } Running Process Instances in total`,
+      );
+    });
+  });
+
+  test('Navigation to Processes View', async ({operateDashboardPage}) => {
+    await test.step('Navigate to active instances and verify count', async () => {
+      const activeProcessInstancesCount =
+        await operateDashboardPage.activeInstancesBadge.innerText();
+
+      await operateDashboardPage.clickActiveInstancesLink();
+
+      await expect(
+        operateDashboardPage.processInstancesHeading(
+          activeProcessInstancesCount,
+          Number(activeProcessInstancesCount) > 1,
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to incident instances and verify count', async () => {
+      await operateDashboardPage.gotoDashboardPage();
+
+      const instancesWithIncidentCount =
+        await operateDashboardPage.incidentInstancesBadge.innerText();
+
+      await operateDashboardPage.clickIncidentInstancesLink();
+
+      await expect(
+        operateDashboardPage.processInstancesHeading(
+          instancesWithIncidentCount,
+          Number(instancesWithIncidentCount) > 1,
+        ),
+      ).toBeVisible();
+    });
+  });
+
+  test('Navigate to processes view (same truncated error message)', async ({
+    operateDashboardPage,
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Select incident type A and verify details', async () => {
+      await operateDashboardPage.clickIncidentByType(/type a/i);
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateDashboardPage.processInstancesHeading(1, false),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          console.log(
+            'Process instances heading not visible yet, retrying assertion...',
+          );
+        },
+      });
+
+      await operateDashboardPage.clickViewInstanceLink();
+      await expect(
+        operateProcessInstancePage.variableCellByName(/incident type a/i),
+      ).toBeVisible();
+    });
+
+    await test.step('Select incident type B and verify details', async () => {
+      await operateDashboardPage.gotoDashboardPage();
+      await operateDashboardPage.clickIncidentByType(/type b/i);
+      await expect(
+        operateDashboardPage.processInstancesHeading(1, false),
+      ).toBeVisible();
+
+      await operateDashboardPage.clickViewInstanceLink();
+      await expect(
+        operateProcessInstancePage.variableCellByName(/incident type b/i),
+      ).toBeVisible();
+    });
+  });
+
+  test('Select process instances by name', async ({operateDashboardPage}) => {
+    await test.step('Select first process and verify total count', async () => {
+      await expect(operateDashboardPage.instancesByProcess).toBeVisible();
+
+      const firstInstanceByProcess =
+        operateDashboardPage.instancesByProcessItem(0);
+
+      const incidentCount = Number(
+        await operateDashboardPage
+          .incidentBadgeFromItem(firstInstanceByProcess)
+          .innerText(),
+      );
+
+      const runningInstanceCount = Number(
+        await operateDashboardPage
+          .activeBadgeFromItem(firstInstanceByProcess)
+          .innerText(),
+      );
+
+      const totalInstanceCount = incidentCount + runningInstanceCount;
+
+      await operateDashboardPage.clickItem(firstInstanceByProcess);
+
+      await expect(
+        operateDashboardPage.processInstancesHeading(
+          totalInstanceCount,
+          Number(totalInstanceCount) > 1,
+        ),
+      ).toBeVisible();
+    });
+  });
+
+  test('Select process instances by error message', async ({
+    operateDashboardPage,
+  }) => {
+    await test.step('Select first error and verify incident count', async () => {
+      await expect(operateDashboardPage.incidentsByError).toBeVisible();
+
+      const firstInstanceByError = operateDashboardPage.incidentsByErrorItem(0);
+
+      const incidentCount = Number(
+        await operateDashboardPage
+          .incidentBadgeFromItem(firstInstanceByError)
+          .innerText(),
+      );
+
+      await operateDashboardPage.clickItem(firstInstanceByError);
+
+      await expect(
+        operateDashboardPage.processInstancesHeading(
+          incidentCount,
+          Number(incidentCount) > 1,
+        ),
+      ).toBeVisible();
+    });
+  });
+
+  test('Select process instances by error message (expanded)', async ({
+    operateDashboardPage,
+  }) => {
+    await test.step('Expand first error and navigate to verify incident count', async () => {
+      await expect(operateDashboardPage.incidentsByError).toBeVisible();
+
+      const firstInstanceByError = operateDashboardPage.incidentsByErrorItem(0);
+
+      const incidentCount = Number(
+        await operateDashboardPage
+          .incidentBadgeFromItem(firstInstanceByError)
+          .innerText(),
+      );
+
+      await operateDashboardPage.expandItem(firstInstanceByError);
+      await operateDashboardPage.clickFirstLinkInItem(firstInstanceByError);
+
+      await expect(
+        operateDashboardPage.processInstancesHeading(
+          incidentCount,
+          Number(incidentCount) > 1,
+        ),
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, request, type APIRequestContext} from '@playwright/test';
+import {sleep} from './sleep';
+
+export async function waitForIncidents(
+  _request: APIRequestContext,
+  processInstanceKey: string,
+  timeout = 120000,
+): Promise<void> {
+  const baseURL =
+    process.env.CORE_APPLICATION_OPERATE_URL ?? 'http://localhost:8081';
+  const username = process.env.TEST_USERNAME || 'demo';
+  const password = process.env.TEST_PASSWORD || 'demo';
+
+  const apiContext = await request.newContext({baseURL});
+  await apiContext.post('/api/login', {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    form: {username, password},
+  });
+
+  try {
+    await expect
+      .poll(
+        async () => {
+          const response = await apiContext.post('/v1/incidents/search', {
+            data: {
+              filter: {
+                processInstanceKey: parseInt(processInstanceKey),
+              },
+            },
+          });
+          const incidents: {items: {state: string}[]; total: number} =
+            await response.json();
+          return (
+            incidents.total > 0 &&
+            incidents.items.filter(({state}) => state === 'PENDING').length ===
+              0
+          );
+        },
+        {timeout},
+      )
+      .toBeTruthy();
+  } finally {
+    await apiContext.dispose();
+  }
+
+  await sleep(2000);
+}
+
+export async function waitForProcessInstances(
+  _request: APIRequestContext,
+  instanceIds: string[],
+  expectedCount: number,
+  timeout = 120000,
+): Promise<void> {
+  const baseURL =
+    process.env.CORE_APPLICATION_OPERATE_URL ?? 'http://localhost:8081';
+  const username = process.env.TEST_USERNAME || 'demo';
+  const password = process.env.TEST_PASSWORD || 'demo';
+
+  const apiContext = await request.newContext({baseURL});
+  await apiContext.post('/api/login', {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    form: {username, password},
+  });
+
+  try {
+    await expect
+      .poll(
+        async () => {
+          const response = await apiContext.post('/api/process-instances', {
+            data: {
+              query: {
+                active: true,
+                running: true,
+                incidents: true,
+                completed: true,
+                finished: true,
+                canceled: true,
+                ids: instanceIds,
+              },
+              pageSize: 50,
+            },
+          });
+          const instances = await response.json();
+          return instances.totalCount;
+        },
+        {timeout},
+      )
+      .toBe(expectedCount);
+  } finally {
+    await apiContext.dispose();
+  }
+
+  await sleep(2000);
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -9,7 +9,8 @@
 import {Camunda8} from '@camunda8/sdk';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types';
 
-const c8 = new Camunda8({
+// REST client – uses BASIC auth from env
+const c8Rest = new Camunda8({
   CAMUNDA_AUTH_STRATEGY: process.env.CAMUNDA_AUTH_STRATEGY as
     | 'BASIC'
     | 'OAUTH'
@@ -22,7 +23,54 @@ const c8 = new Camunda8({
   ZEEBE_REST_ADDRESS: process.env.ZEEBE_REST_ADDRESS,
 });
 
-const zeebe = c8.getCamundaRestClient();
+// gRPC client – no auth, no TLS.
+// CAMUNDA_AUTH_STRATEGY is set explicitly to NONE to prevent
+// the SDK from picking up CAMUNDA_AUTH_STRATEGY=BASIC from the env.
+// In SDK >=8.7, the grpc:// scheme in ZEEBE_GRPC_ADDRESS signals an insecure
+// (non-TLS) connection. grpcs:// signals TLS. ZEEBE_INSECURE_CONNECTION is
+// deprecated and ignored when ZEEBE_GRPC_ADDRESS is set.
+const rawGrpcAddress =
+  process.env.ZEEBE_GRPC_ADDRESS ?? 'grpc://localhost:26500';
+const c8Grpc = new Camunda8({
+  CAMUNDA_OAUTH_DISABLED: true,
+  CAMUNDA_AUTH_STRATEGY: 'NONE',
+  // Ensure the address always has the grpc:// scheme so the SDK treats it as insecure.
+  ZEEBE_GRPC_ADDRESS: rawGrpcAddress.startsWith('grpcs://')
+    ? rawGrpcAddress
+    : `grpc://${rawGrpcAddress.replace(/^grpcs?:\/\//, '')}`,
+});
+
+const zeebe = c8Rest.getCamundaRestClient();
+const zeebeGrpc = c8Grpc.getZeebeGrpcApiClient();
+zeebeGrpc.onConnectionError = () =>
+  console.error(
+    '[zeebeGrpc] gRPC connection error – check ZEEBE_GRPC_ADDRESS and TLS settings.',
+  );
+
+const createWorker = (
+  taskType: string,
+  shouldFail = false,
+  variables: JSONDoc = {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler?: (job: any) => any,
+  timeout?: number,
+) => {
+  return zeebeGrpc.createWorker({
+    taskType,
+    taskHandler:
+      handler ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ((job: any) => {
+        if (shouldFail) {
+          return job.fail('Task failed for testing purposes');
+        }
+        return job.complete(variables);
+      }),
+    pollInterval: 300,
+    ...(timeout ? {timeout} : {}),
+  });
+};
+
 const deploy = async (processFilePaths: string[]) => {
   try {
     const results = await zeebe.deployResourcesFromFiles(processFilePaths);
@@ -39,13 +87,15 @@ const createInstances = async (
   numberOfInstances: number,
   variables?: JSONDoc,
 ) => {
+  const instances = [];
   for (let i = 0; i < numberOfInstances; i++) {
-    await zeebe.createProcessInstance({
+    const instance = await zeebe.createProcessInstance({
       processDefinitionId,
-      processDefinitionVersion,
       variables: variables ?? {},
     });
+    instances.push(instance);
   }
+  return instances;
 };
 
 const createSingleInstance = async (
@@ -55,7 +105,6 @@ const createSingleInstance = async (
 ) => {
   const result = await zeebe.createProcessInstance({
     processDefinitionId,
-    processDefinitionVersion,
     variables: variables ?? {},
   });
   return result;
@@ -116,6 +165,7 @@ export {
   deploy,
   createInstances,
   createSingleInstance,
+  createWorker,
   publishMessage,
   generateManyVariables,
   cancelProcessInstance,


### PR DESCRIPTION
## Description

Migrates `dashboard.spec.ts` from the Operate component folder to the `c8-orchestration-cluster-e2e-test-suite`, following the suite's POM patterns.

### Changes

- **`tests/operate/dashboard.spec.ts`** — migrated test covering running/active/incident instance counts, version filtering, and navigation.
- **`pages/OperateDashboardPage.ts`** — new page object for dashboard locators and interactions.
- **`utils/incidentsHelper.ts`** — utility for generating incidents via a worker for test data setup.
- **New BPMN resources** — versioned process variants and an incident generator process required by `beforeAll`.
- **`zeebeClient.ts`** — split into REST (BASIC auth) and gRPC (no auth/TLS) clients; uses `grpc://` scheme to fix `CAMUNDA_SECURE_CONNECTION is deprecated` / `ZEEBE_INSECURE_CONNECTION is deprecated` warnings from SDK ≥ 8.7.
- **`batchMoveModification.spec.ts`** — fixed a race in the `onFailure` retry: re-collapse the Operations panel before re-clicking the flow node, since the panel can re-expand as operations complete.
- **`OperateProcessesPage.ts` / `OperateProcessInstancePage.ts`** — promoted inline locators to `readonly` class properties.


🧪 [Test run](https://github.com/camunda/camunda/actions/runs/22757019146)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34119
