### PR TITLE
fix: Cleanup AWS OS Old Indexes Before Run

### DIFF
--- a/.github/actions/setup-aws-opensearch-env/README.md
+++ b/.github/actions/setup-aws-opensearch-env/README.md
@@ -1,0 +1,38 @@
+# Setup AWS OpenSearch env
+
+Imports AWS OpenSearch endpoint secrets from Vault, resolves the endpoint URL for a selected
+OpenSearch version, exports required environment variables, and configures AWS credentials
+for subsequent steps.
+
+## Inputs
+
+|        Input         |                    Description                    | Required |
+|----------------------|---------------------------------------------------|----------|
+| `vault-address`      | Vault URL to retrieve secrets from                | Yes      |
+| `vault-role-id`      | Vault Role ID to use                              | Yes      |
+| `vault-secret-id`    | Vault Secret ID to use                            | Yes      |
+| `opensearch-version` | OpenSearch version to configure (`2.19` or `3.3`) | Yes      |
+
+## Outputs
+
+|      Output      |                        Description                        |
+|------------------|-----------------------------------------------------------|
+| `opensearch-url` | Resolved OpenSearch endpoint URL for the selected version |
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - name: Setup AWS OpenSearch
+    uses: ./.github/actions/setup-aws-opensearch-env
+    with:
+      vault-address: ${{ secrets.VAULT_ADDR }}
+      vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+      vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      opensearch-version: "2.19"
+
+  - name: Use OpenSearch URL
+    run: echo "${{ env.OPENSEARCH_URL }}"
+```
+

--- a/.github/actions/setup-aws-opensearch-env/action.yml
+++ b/.github/actions/setup-aws-opensearch-env/action.yml
@@ -1,0 +1,77 @@
+---
+name: Setup AWS OpenSearch env
+
+# owner: @camunda/data-layer
+
+description: |
+  Imports OpenSearch endpoints from Vault, resolves OS URL for a selected 
+  version, and configures AWS credentials.
+
+inputs:
+  vault-address:
+    description: Vault URL to retrieve secrets from
+    required: true
+  vault-role-id:
+    description: Vault Role ID to use
+    required: true
+  vault-secret-id:
+    description: Vault Secret ID to use
+    required: true
+  opensearch-version:
+    description: OpenSearch version to configure (2.19 or 3.3)
+    required: true
+
+outputs:
+  opensearch-url:
+    description: Resolved OpenSearch endpoint URL for the selected version
+    value: ${{ steps.resolve-os-url.outputs.opensearch-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Import secrets from Vault
+      id: secrets
+      uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      with:
+        url: ${{ inputs.vault-address }}
+        method: approle
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
+        secrets: |
+          secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_2_19_URL;
+          secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_3_3_URL;
+
+    - name: Resolve OpenSearch URL and export env
+      id: resolve-os-url
+      shell: bash
+      run: |
+        {
+          echo "AWS_REGION=$AWS_REGION"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "AWS_ROLE_ARN=$AWS_ROLE_ARN"
+          echo "AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE"
+          echo "AWS_STS_REGIONAL_ENDPOINTS=$AWS_STS_REGIONAL_ENDPOINTS"
+        } >> "$GITHUB_ENV"
+
+        if [[ "${{ inputs.opensearch-version }}" = "2.19" ]]
+        then
+          echo "Using OS 2.19"
+          OS_URL="https://${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_2_19_URL }}"
+        elif [[ "${{ inputs.opensearch-version }}" = "3.3" ]]
+        then
+          echo "Using OS 3.3"
+          OS_URL="https://${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_3_3_URL }}"
+        else
+          echo "Unsupported OpenSearch version"
+          exit 1
+        fi
+
+        echo "OPENSEARCH_URL=$OS_URL" >> "$GITHUB_ENV"
+        echo "opensearch-url=$OS_URL" >> "$GITHUB_OUTPUT"
+
+    - name: Pre-login to AWS
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-region: ${{ env.AWS_REGION }}
+        web-identity-token-file: ${{ env.AWS_WEB_IDENTITY_TOKEN_FILE }}
+        role-to-assume: ${{ env.AWS_ROLE_ARN }}

--- a/.github/scripts/clean-up-aws-opensearch-indices.py
+++ b/.github/scripts/clean-up-aws-opensearch-indices.py
@@ -1,28 +1,36 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-: "${OPENSEARCH_URL:?OPENSEARCH_URL is required}"
-DRY_RUN="${DRY_RUN:-true}"
-AGE_HOURS="${AGE_HOURS:-6}"
-
-# Install runtime deps into the same interpreter used below.
-# boto3 is required for AWS credential resolution used by AWSV4SignerAuth.
-# opensearch-py is the official OpenSearch Python client with built-in AWS SigV4 auth support
-python3 -m pip install -q --disable-pip-version-check \
-  "boto3" \
-  "opensearch-py==3.1.0"
-
-python3 - <<'PYTHON_SCRIPT'
-import os, sys, time
+#!/usr/bin/env python3
+import os
+import sys
+import time
 from urllib.parse import urlparse
 
 import boto3
 from opensearchpy import OpenSearch, NotFoundError, RequestsHttpConnection, AWSV4SignerAuth
 
-OPENSEARCH_URL = os.environ["OPENSEARCH_URL"].rstrip("/")
+# Validate and normalize environment variables first.
+opensearch_url = os.environ.get("OPENSEARCH_URL", "").strip()
+if not opensearch_url:
+    print("ERROR: OPENSEARCH_URL is required")
+    sys.exit(1)
+OPENSEARCH_URL = opensearch_url.rstrip("/")
+
+dry_run = os.environ.get("DRY_RUN", "true").strip().lower()
+if dry_run not in {"true", "false"}:
+    print("ERROR: DRY_RUN must be 'true' or 'false'")
+    sys.exit(1)
+DRY_RUN = dry_run == "true"
+
+age_hours = os.environ.get("AGE_HOURS", "6").strip()
+try:
+    AGE_HOURS = int(age_hours)
+except ValueError:
+    print("ERROR: AGE_HOURS must be an integer")
+    sys.exit(1)
+if AGE_HOURS < 0:
+    print("ERROR: AGE_HOURS must be >= 0")
+    sys.exit(1)
+
 REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
-DRY_RUN = os.environ.get("DRY_RUN", "true").lower() == "true"
-AGE_HOURS = int(os.environ.get("AGE_HOURS", "6"))
 THRESHOLD = AGE_HOURS * 3600
 
 raw_creds = boto3.Session().get_credentials()
@@ -30,9 +38,12 @@ if raw_creds is None:
     print("ERROR: No AWS credentials found. Ensure the runner has a configured IAM role or credentials.")
     sys.exit(1)
 
-awsauth = AWSV4SignerAuth(raw_creds, REGION, "es")
-
 parsed = urlparse(OPENSEARCH_URL)
+if not parsed.hostname:
+    print("ERROR: OPENSEARCH_URL must be a valid URL with hostname")
+    sys.exit(1)
+
+awsauth = AWSV4SignerAuth(raw_creds, REGION, "es")
 client = OpenSearch(
     hosts=[{"host": parsed.hostname, "port": parsed.port or (443 if parsed.scheme == "https" else 80)}],
     http_auth=awsauth,
@@ -43,10 +54,11 @@ client = OpenSearch(
 
 try:
     all_indices = client.cat.indices(h="index,creation.date", format="json")
-except Exception as e:
-    print(f"ERROR: Failed to list indices: {e}")
+except Exception as exc:
+    print(f"Failed to list indices: {exc}")
     sys.exit(1)
-indices = [idx for idx in all_indices if not idx["index"].startswith(".")]
+
+indices = [idx for idx in all_indices if not idx.get("index", "").startswith(".")]
 if not indices:
     print("INFO: No user indices found, nothing to delete.")
     sys.exit(0)
@@ -55,13 +67,19 @@ now = int(time.time())
 deleted = skipped_young = skipped_already_gone = skipped_error = 0
 
 for idx in indices:
-    idx_name = idx["index"]
+    idx_name = idx.get("index", "<unknown>")
     creation_date = idx.get("creation.date")
     if creation_date is None:
         skipped_error += 1
         print(f"  WARN: Missing creation date for {idx_name}, skipping.")
         continue
-    age_seconds = now - (int(creation_date) // 1000)
+
+    try:
+        age_seconds = now - (int(creation_date) // 1000)
+    except (TypeError, ValueError):
+        skipped_error += 1
+        print(f"  WARN: Invalid creation date for {idx_name}, skipping.")
+        continue
 
     if age_seconds <= THRESHOLD:
         skipped_young += 1
@@ -76,10 +94,17 @@ for idx in indices:
             deleted += 1
         except NotFoundError:
             skipped_already_gone += 1
-        except Exception as e:
+        except Exception as exc:
             skipped_error += 1
-            print(f"  WARN: Failed to delete {idx_name}: {e}")
+            print(f"  WARN: Failed to delete {idx_name}: {exc}")
 
 prefix = "[DRY RUN] " if DRY_RUN else ""
-print(f"\n{prefix}Summary: {len(indices)} indices found | {deleted} deleted | {skipped_young} too young | {skipped_already_gone} already gone | {skipped_error} errors")
-PYTHON_SCRIPT
+print(
+    f"\n{prefix}Summary:"
+    f"\n{prefix}indices_found={len(indices)}"
+    f"\n{prefix}deleted={deleted}"
+    f"\n{prefix}too_young={skipped_young}"
+    f"\n{prefix}already_gone={skipped_already_gone}"
+    f"\n{prefix}errors={skipped_error}"
+)
+sys.exit(0)

--- a/.github/scripts/clean-up-aws-opensearch-indices.sh
+++ b/.github/scripts/clean-up-aws-opensearch-indices.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OPENSEARCH_URL:?OPENSEARCH_URL is required}"
+DRY_RUN="${DRY_RUN:-true}"
+AGE_HOURS="${AGE_HOURS:-6}"
+
+# Install runtime deps into the same interpreter used below.
+# boto3 is required for AWS credential resolution used by AWSV4SignerAuth.
+# opensearch-py is the official OpenSearch Python client with built-in AWS SigV4 auth support
+python3 -m pip install -q --disable-pip-version-check \
+  "boto3" \
+  "opensearch-py==3.1.0"
+
+python3 - <<'PYTHON_SCRIPT'
+import os, sys, time
+from urllib.parse import urlparse
+
+import boto3
+from opensearchpy import OpenSearch, NotFoundError, RequestsHttpConnection, AWSV4SignerAuth
+
+OPENSEARCH_URL = os.environ["OPENSEARCH_URL"].rstrip("/")
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+DRY_RUN = os.environ.get("DRY_RUN", "true").lower() == "true"
+AGE_HOURS = int(os.environ.get("AGE_HOURS", "6"))
+THRESHOLD = AGE_HOURS * 3600
+
+raw_creds = boto3.Session().get_credentials()
+if raw_creds is None:
+    print("ERROR: No AWS credentials found. Ensure the runner has a configured IAM role or credentials.")
+    sys.exit(1)
+
+awsauth = AWSV4SignerAuth(raw_creds, REGION, "es")
+
+parsed = urlparse(OPENSEARCH_URL)
+client = OpenSearch(
+    hosts=[{"host": parsed.hostname, "port": parsed.port or (443 if parsed.scheme == "https" else 80)}],
+    http_auth=awsauth,
+    use_ssl=parsed.scheme == "https",
+    verify_certs=True,
+    connection_class=RequestsHttpConnection,
+)
+
+try:
+    all_indices = client.cat.indices(h="index,creation.date", format="json")
+except Exception as e:
+    print(f"ERROR: Failed to list indices: {e}")
+    sys.exit(1)
+indices = [idx for idx in all_indices if not idx["index"].startswith(".")]
+if not indices:
+    print("INFO: No user indices found, nothing to delete.")
+    sys.exit(0)
+
+now = int(time.time())
+deleted = skipped_young = skipped_already_gone = skipped_error = 0
+
+for idx in indices:
+    idx_name = idx["index"]
+    creation_date = idx.get("creation.date")
+    if creation_date is None:
+        skipped_error += 1
+        print(f"  WARN: Missing creation date for {idx_name}, skipping.")
+        continue
+    age_seconds = now - (int(creation_date) // 1000)
+
+    if age_seconds <= THRESHOLD:
+        skipped_young += 1
+        continue
+
+    if DRY_RUN:
+        deleted += 1
+        print(f"  [DRY RUN] Would delete: {idx_name} (age: {age_seconds // 3600}h {(age_seconds % 3600) // 60}m)")
+    else:
+        try:
+            client.indices.delete(index=idx_name)
+            deleted += 1
+        except NotFoundError:
+            skipped_already_gone += 1
+        except Exception as e:
+            skipped_error += 1
+            print(f"  WARN: Failed to delete {idx_name}: {e}")
+
+prefix = "[DRY RUN] " if DRY_RUN else ""
+print(f"\n{prefix}Summary: {len(indices)} indices found | {deleted} deleted | {skipped_young} too young | {skipped_already_gone} already gone | {skipped_error} errors")
+PYTHON_SCRIPT

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -1,5 +1,9 @@
 # description: Runs Integration tests on different versions of AWS OS
-# test location: /zeebe/exporters/opensearch-exporter, /search/search-client-connect, /zeebe/exporters/camunda-exporter, /qa/acceptance-tests
+# test locations:
+#  - /qa/acceptance-tests
+#  - /search/search-client-opensearch,
+#  - /zeebe/exporters/camunda-exporter,
+#  - /zeebe/exporters/zeebe-opensearch-exporter,
 # type: CI
 # owner: @camunda/core-features, @camunda/data-layer
 name: AWS OpenSearch Manual/Scheduled Run Integration Tests
@@ -7,8 +11,8 @@ name: AWS OpenSearch Manual/Scheduled Run Integration Tests
 on:
   workflow_dispatch:
     inputs:
-      os_version:
-        description: Version of AWS OS
+      opensearch-version:
+        description: Version of AWS OpenSearch
         type: choice
         options:
           - "2.19"
@@ -23,8 +27,52 @@ defaults:
     shell: bash
 
 jobs:
+  cleanup-opensearch-indices:
+    name: "[PRE] Cleanup old AWS OpenSearch indices. OS ver.${{ matrix.os_version }}"
+    permissions:
+      contents: read
+      actions: write
+    timeout-minutes: 30
+    runs-on: aws-core-8-default
+    strategy:
+      fail-fast: false
+      matrix:
+        os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.3"')) }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup AWS OpenSearch
+        uses: ./.github/actions/setup-aws-opensearch-env
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          opensearch-version: ${{ matrix.os_version }}
+      - name: Python setup
+        if: always()
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Delete old aws opensearch indices
+        env:
+          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
+          DRY_RUN: "false"
+          AGE_HOURS: "2"
+        run: bash .github/scripts/clean-up-aws-opensearch-indices.sh
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "cleanup-opensearch-indices/${{ matrix.os_version }}"
+          build_status: ${{ job.status }}
+          user_description: "General"
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   integration-tests:
     name: "[IT] ${{ matrix.name }}. OS ver.${{ matrix.os_version }}"
+    needs: cleanup-opensearch-indices
     permissions:
       contents: read
       actions: write
@@ -33,34 +81,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_version: ${{ fromJSON(format('[{0}]', inputs.os_version || '"2.19", "3.3"')) }}
+        os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.3"')) }}
         group:
-        - os-exporter
-        - search-client-os
-        - camunda-exporter
         - camunda-qa-acceptance-tests
+        - search-client-opensearch
+        - camunda-exporter
+        - zeebe-opensearch-exporter
         include:
-          - group: os-exporter
-            name: "Zeebe OS Exporter Integration Tests"
-            maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
-            maven-build-threads: 2
-            maven-test-fork-count: 7
-            runs-on: aws-core-8-default
-            owner: "Data Layer"
-          - group: search-client-os
-            name: "Search Client AWS OS Integration Tests"
-            maven-modules: "'io.camunda:camunda-search-client-connect'"
-            maven-build-threads: 2
-            maven-test-fork-count: 7
-            runs-on: aws-core-8-default
-            owner: "Core Features"
-          - group: camunda-exporter
-            name: "Camunda Exporter AWS OS Integration Tests"
-            maven-modules: "'io.camunda:camunda-exporter'"
-            maven-build-threads: 2
-            maven-test-fork-count: 7
-            runs-on: aws-core-8-default
-            owner: "Data Layer"
           - group: camunda-qa-acceptance-tests
             name: "Camunda QA Integration Module"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
@@ -68,49 +95,36 @@ jobs:
             maven-test-fork-count: 7
             runs-on: aws-core-8-default
             owner: "General"
+          - group: search-client-opensearch
+            name: "Search Client OpenSearch ITs"
+            maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+            runs-on: aws-core-8-default
+            owner: "Core Features"
+          - group: camunda-exporter
+            name: "Camunda Exporter ITs"
+            maven-modules: "'io.camunda:camunda-exporter'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+            runs-on: aws-core-8-default
+            owner: "Data Layer"
+          - group: zeebe-opensearch-exporter
+            name: "Zeebe OpenSearch Exporter ITs"
+            maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+            runs-on: aws-core-8-default
+            owner: "Data Layer"
     steps:
       - uses: actions/checkout@v6
-      - name: Import secrets from Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Setup AWS OpenSearch
+        uses: ./.github/actions/setup-aws-opensearch-env
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_2_19_URL;
-            secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_3_3_URL;
-      - name: Set temp GH envs
-        id: temp-vars
-        run: |
-          {
-            echo "AWS_REGION=$AWS_REGION"
-            echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
-            echo "AWS_ROLE_ARN=$AWS_ROLE_ARN"
-            echo "AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE"
-            echo "AWS_STS_REGIONAL_ENDPOINTS=$AWS_STS_REGIONAL_ENDPOINTS"
-          } >> "$GITHUB_ENV"
-
-          if [[ "${{ matrix.os_version }}" = "2.19" ]]
-          then
-            echo "Using OS 2.19"
-            OS_URL="https://"${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_2_19_URL }};
-          elif [[ "${{ matrix.os_version }}" = "3.3" ]]
-          then
-            echo "Using OS 3.3"
-            OS_URL="https://"${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_3_3_URL }};
-          else
-            echo "Incorrect on usupported version of OpenSearch"
-            exit 1
-          fi
-          echo "OS_URL=$OS_URL" >> "$GITHUB_ENV"
-      - uses: aws-actions/configure-aws-credentials@v6
-        name: Pre-login to AWS
-        with:
-          aws-region: ${{ env.AWS_REGION }}
-          web-identity-token-file: ${{ env.AWS_WEB_IDENTITY_TOKEN_FILE }}
-          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          opensearch-version: ${{ matrix.os_version }}
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: it-${{ matrix.group }}
@@ -131,7 +145,7 @@ jobs:
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D flaky.test.reportDir=failsafe-reports
-          -D test.integration.opensearch.aws.url="${{ env.OS_URL }}"
+          -D test.integration.opensearch.aws.url="${{ env.OPENSEARCH_URL }}"
           -D test.integration.camunda.database.type=AWS_OS
           -D test.integration.opensearch.aws.timeout.seconds=180
           -P parallel-tests,extract-flaky-tests,multi-db-test

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -3,7 +3,7 @@
 #  - /qa/acceptance-tests
 #  - /search/search-client-opensearch,
 #  - /zeebe/exporters/camunda-exporter,
-#  - /zeebe/exporters/zeebe-opensearch-exporter,
+#  - /zeebe/exporters/opensearch-exporter,
 # type: CI
 # owner: @camunda/core-features, @camunda/data-layer
 name: AWS OpenSearch Manual/Scheduled Run Integration Tests
@@ -31,7 +31,6 @@ jobs:
     name: "[PRE] Cleanup old AWS OpenSearch indices. OS ver.${{ matrix.os_version }}"
     permissions:
       contents: read
-      actions: write
     timeout-minutes: 30
     runs-on: aws-core-8-default
     strategy:
@@ -48,16 +47,18 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           opensearch-version: ${{ matrix.os_version }}
       - name: Python setup
-        if: always()
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
       - name: Delete old aws opensearch indices
         env:
           OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
           DRY_RUN: "false"
           AGE_HOURS: "2"
-        run: bash .github/scripts/clean-up-aws-opensearch-indices.sh
+        run: python3 .github/scripts/clean-up-aws-opensearch-indices.py
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION

## Description

We see test failures due to not being able to clean older indexes and OpenSearch running out of available shards to create new indexes needed by tests.

This mainly adds a script to go through older indexes and clean them before running the tests. However, this script also needed AWS setup, and as a result, moved that to be a reusable action.

The script uses the official AWS boto and OpenSearch python lib to get auth and make calls to delete indexes. We only delete indexes that are older than 2 hours so that this won't interfere with any ongoing tests.

Couple of other changes/refactoring to tidy it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
