### PR TITLE
feat: add JobErrorStatistics RDBMS implementation

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobErrorStatisticsDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobErrorStatisticsDbQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.JobErrorStatisticsEntity;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobErrorStatisticsFilter;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record JobErrorStatisticsDbQuery(
+    JobErrorStatisticsFilter filter,
+    List<String> authorizedTenantIds,
+    DbQueryPage page,
+    DbQuerySorting<JobErrorStatisticsEntity> sort) {
+
+  public static JobErrorStatisticsDbQuery of(
+      final Function<JobErrorStatisticsDbQuery.Builder, ObjectBuilder<JobErrorStatisticsDbQuery>>
+          fn) {
+    return fn.apply(new JobErrorStatisticsDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<JobErrorStatisticsDbQuery> {
+    private JobErrorStatisticsFilter filter;
+    private List<String> authorizedTenantIds;
+    private DbQueryPage page;
+    private DbQuerySorting<JobErrorStatisticsEntity> sort;
+
+    public Builder filter(final JobErrorStatisticsFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<JobErrorStatisticsFilter.Builder, ObjectBuilder<JobErrorStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.jobErrorStatistics(fn));
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<JobErrorStatisticsEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    @Override
+    public JobErrorStatisticsDbQuery build() {
+      return new JobErrorStatisticsDbQuery(
+          Objects.requireNonNull(filter, "filter must not be null"),
+          Objects.requireNonNullElse(authorizedTenantIds, Collections.emptyList()),
+          page,
+          sort);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobErrorStatisticsDbResult.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobErrorStatisticsDbResult.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+public record JobErrorStatisticsDbResult(String errorCode, String errorMessage, Integer workers) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -11,10 +11,12 @@ import static java.util.Optional.ofNullable;
 
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobErrorStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
+import io.camunda.db.rdbms.sql.columns.JobErrorStatisticsColumn;
 import io.camunda.db.rdbms.sql.columns.JobTimeSeriesStatisticsColumn;
 import io.camunda.db.rdbms.sql.columns.JobTypeStatisticsColumn;
 import io.camunda.db.rdbms.sql.columns.JobWorkerStatisticsColumn;
@@ -32,6 +34,7 @@ import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.JobErrorStatisticsSort;
 import io.camunda.search.sort.JobTimeSeriesStatisticsSort;
 import io.camunda.search.sort.JobTypeStatisticsSort;
 import io.camunda.search.sort.JobWorkerStatisticsSort;
@@ -59,10 +62,15 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
   private static final JobTimeSeriesStatisticsSort JOB_TIME_SERIES_FIXED_SORT =
       JobTimeSeriesStatisticsSort.of(b -> b.time().asc());
 
+  // Fixed sort: errorCode asc, errorMessage asc
+  private static final JobErrorStatisticsSort JOB_ERROR_STATS_FIXED_SORT =
+      JobErrorStatisticsSort.of(b -> b.errorCode().asc());
+
   private final JobMetricsBatchMapper jobMetricsBatchMapper;
 
   private final AbstractEntityReader<JobWorkerStatisticsEntity> workerStatsReader;
   private final AbstractEntityReader<JobTimeSeriesStatisticsEntity> timeSeriesStatsReader;
+  private final AbstractEntityReader<JobErrorStatisticsEntity> errorStatsReader;
 
   public JobMetricsBatchDbReader(
       final JobMetricsBatchMapper jobMetricsBatchMapper, final RdbmsReaderConfig readerConfig) {
@@ -70,6 +78,7 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
     this.jobMetricsBatchMapper = jobMetricsBatchMapper;
     workerStatsReader = new WorkerStatsReader(readerConfig);
     timeSeriesStatsReader = new TimeSeriesStatsReader(readerConfig);
+    errorStatsReader = new ErrorStatsReader(readerConfig);
   }
 
   @Override
@@ -217,7 +226,37 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
   @Override
   public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
       final JobErrorStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException("Job error statistics is not yet implemented");
+    LOG.trace("[RDBMS DB] Search job error statistics with {}", query);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return EmptyResults.JOB_ERROR_STATISTICS;
+    }
+
+    final var dbSort = errorStatsReader.convertSort(JOB_ERROR_STATS_FIXED_SORT);
+    final var dbPage =
+        errorStatsReader.convertPaging(
+            dbSort, Optional.ofNullable(query.page()).orElse(SearchQueryPage.DEFAULT));
+
+    final var dbQuery =
+        JobErrorStatisticsDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(dbPage));
+
+    final var results = jobMetricsBatchMapper.jobErrorStatistics(dbQuery);
+    final var entities =
+        results.stream()
+            .map(
+                result ->
+                    new JobErrorStatisticsEntity(
+                        result.errorCode(),
+                        result.errorMessage(),
+                        ofNullable(result.workers()).orElse(0)))
+            .toList();
+
+    return errorStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
   }
 
   /** Inner reader for worker statistics to provide typed AbstractEntityReader methods. */
@@ -238,6 +277,15 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
     }
   }
 
+  /** Inner reader for error statistics to provide typed AbstractEntityReader methods. */
+  private static final class ErrorStatsReader
+      extends AbstractEntityReader<JobErrorStatisticsEntity> {
+
+    ErrorStatsReader(final RdbmsReaderConfig readerConfig) {
+      super(JobErrorStatisticsColumn.values(), readerConfig);
+    }
+  }
+
   private static final class EmptyResults {
     private static final SearchQueryResult<JobTypeStatisticsEntity> JOB_TYPE_STATISTICS =
         SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
@@ -248,6 +296,9 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
     private static final SearchQueryResult<JobTimeSeriesStatisticsEntity>
         JOB_TIME_SERIES_STATISTICS =
             SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
+
+    private static final SearchQueryResult<JobErrorStatisticsEntity> JOB_ERROR_STATISTICS =
+        SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
 
     private static final GlobalJobStatisticsEntity GLOBAL_JOB_STATISTICS =
         new GlobalJobStatisticsEntity(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
@@ -9,6 +9,8 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobErrorStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobErrorStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
@@ -31,6 +33,8 @@ public interface JobMetricsBatchMapper {
 
   List<JobTimeSeriesStatisticsDbResult> jobTimeSeriesStatistics(
       JobTimeSeriesStatisticsDbQuery query);
+
+  List<JobErrorStatisticsDbResult> jobErrorStatistics(JobErrorStatisticsDbQuery query);
 
   int cleanupMetrics(CleanupHistoryDto dto);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobErrorStatisticsColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobErrorStatisticsColumn.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.JobErrorStatisticsEntity;
+
+public enum JobErrorStatisticsColumn implements SearchColumn<JobErrorStatisticsEntity> {
+  ERROR_CODE("errorCode"),
+  ERROR_MESSAGE("errorMessage");
+
+  private final String property;
+
+  JobErrorStatisticsColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<JobErrorStatisticsEntity> getEntityClass() {
+    return JobErrorStatisticsEntity.class;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
@@ -241,6 +241,64 @@
     </where>
   </sql>
 
+  <resultMap id="JobErrorStatisticsResultMap"
+    type="io.camunda.db.rdbms.read.domain.JobErrorStatisticsDbResult">
+    <constructor>
+      <arg column="ERROR_CODE"    javaType="java.lang.String"/>
+      <arg column="ERROR_MESSAGE" javaType="java.lang.String"/>
+      <arg column="WORKERS"       javaType="java.lang.Integer"/>
+    </constructor>
+  </resultMap>
+
+  <select id="jobErrorStatistics"
+    parameterType="io.camunda.db.rdbms.read.domain.JobErrorStatisticsDbQuery"
+    resultMap="JobErrorStatisticsResultMap"
+    statementType="PREPARED">
+    SELECT
+      ERROR_CODE,
+      ERROR_MESSAGE,
+      COUNT(DISTINCT WORKER) AS WORKERS
+    FROM ${prefix}JOB
+    <include refid="io.camunda.db.rdbms.sql.JobMetricsBatchMapper.jobErrorStatisticsFilter"/>
+    <trim prefix="AND" prefixOverrides="WHERE">
+      <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    </trim>
+    GROUP BY ERROR_CODE, ERROR_MESSAGE
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="jobErrorStatisticsFilter">
+    WHERE ERROR_CODE IS NOT NULL
+    <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+      AND TENANT_ID IN
+      <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+        #{tenantId}
+      </foreach>
+    </if>
+    <if test="filter.from != null">
+      AND CREATION_TIME &gt;= #{filter.from}
+    </if>
+    <if test="filter.to != null">
+      AND CREATION_TIME &lt;= #{filter.to}
+    </if>
+    <if test="filter.jobType != null">
+      AND TYPE = #{filter.jobType}
+    </if>
+    <if test="filter.errorCodeOperations != null and !filter.errorCodeOperations.isEmpty()">
+      <foreach collection="filter.errorCodeOperations" item="operation">
+        AND ERROR_CODE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
+      <foreach collection="filter.errorMessageOperations" item="operation">
+        AND ERROR_MESSAGE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+  </sql>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel">
     INSERT INTO ${prefix}JOB_METRICS_BATCH (JOB_METRICS_BATCH_KEY,
                                             PARTITION_ID,

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
@@ -14,11 +14,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobErrorStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobTimeSeriesStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbResult;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
@@ -836,5 +838,99 @@ class JobMetricsBatchDbReaderTest {
     assertThat(item.created().lastUpdatedAt()).isEqualTo(lastCreated);
     assertThat(item.completed().lastUpdatedAt()).isEqualTo(lastCompleted);
     assertThat(item.failed().lastUpdatedAt()).isEqualTo(lastFailed);
+  }
+
+  // -----------------------------------------------------------------------
+  // getJobErrorStatistics
+  // -----------------------------------------------------------------------
+
+  @Test
+  void shouldReturnEmptyErrorStatisticsWhenTenantCheckEnabledButNoTenants() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobErrorStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobErrorStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+    verifyNoInteractions(jobMetricsBatchMapper);
+  }
+
+  @Test
+  void shouldReturnErrorStatisticsFromMapper() {
+    // given
+    final var dbResult1 = new JobErrorStatisticsDbResult("IO_ERROR", "Disk full", 3);
+    final var dbResult2 = new JobErrorStatisticsDbResult("TIMEOUT", "Connection timed out", 7);
+    when(jobMetricsBatchMapper.jobErrorStatistics(any())).thenReturn(List.of(dbResult1, dbResult2));
+
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobErrorStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobErrorStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(2L);
+    assertThat(result.items()).hasSize(2);
+
+    assertThat(result.items().get(0).errorCode()).isEqualTo("IO_ERROR");
+    assertThat(result.items().get(0).errorMessage()).isEqualTo("Disk full");
+    assertThat(result.items().get(0).workers()).isEqualTo(3);
+
+    assertThat(result.items().get(1).errorCode()).isEqualTo("TIMEOUT");
+    assertThat(result.items().get(1).errorMessage()).isEqualTo("Connection timed out");
+    assertThat(result.items().get(1).workers()).isEqualTo(7);
+  }
+
+  @Test
+  void shouldReturnErrorStatisticsWithNullWorkersDefaultingToZero() {
+    // given
+    final var dbResult = new JobErrorStatisticsDbResult("IO_ERROR", "msg", null);
+    when(jobMetricsBatchMapper.jobErrorStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobErrorStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobErrorStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().workers()).isZero();
+  }
+
+  @Test
+  void shouldReturnEmptyErrorStatisticsWhenMapperReturnsEmptyList() {
+    // given
+    when(jobMetricsBatchMapper.jobErrorStatistics(any())).thenReturn(List.of());
+
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobErrorStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobErrorStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobMetricsBatchFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobMetricsBatchFixtures.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel.Builder;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.JobErrorStatisticsEntity;
 import io.camunda.search.entities.JobTimeSeriesStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
@@ -300,6 +301,20 @@ public final class JobMetricsBatchFixtures extends CommonFixtures {
                 .max(OffsetDateTime::compareTo)
                 .map(JobMetricsBatchFixtures::toUtc)
                 .orElseThrow());
+  }
+
+  /**
+   * Asserts that a {@link JobErrorStatisticsEntity} matches the expected errorCode, errorMessage
+   * and distinct worker count derived from a list of {@link JobMetricsBatchDbModel}.
+   */
+  public static void assertErrorStats(
+      final JobErrorStatisticsEntity stats,
+      final String expectedErrorCode,
+      final String expectedErrorMessage,
+      final int expectedWorkers) {
+    assertThat(stats.errorCode()).isEqualTo(expectedErrorCode);
+    assertThat(stats.errorMessage()).isEqualTo(expectedErrorMessage);
+    assertThat(stats.workers()).isEqualTo(expectedWorkers);
   }
 
   private static OffsetDateTime toUtc(final OffsetDateTime timestamp) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.rdbms.db.jobmetrics;
 
 import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.NOW;
 import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.PARTITION_ID;
+import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.assertErrorStats;
 import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.assertTimeSeriesStats;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,6 +20,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
 import io.camunda.db.rdbms.write.service.JobMetricsBatchWriter;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
+import io.camunda.it.rdbms.db.fixtures.JobFixtures;
 import io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
@@ -28,6 +30,7 @@ import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobErrorStatisticsQuery;
 import io.camunda.search.query.JobTimeSeriesStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
@@ -1631,5 +1634,296 @@ public class JobMetricsBatchIT {
 
     // then
     assertThat(actual.items()).isEmpty();
+  }
+
+  // -----------------------------------------------------------------------
+  // getJobErrorStatistics
+  // -----------------------------------------------------------------------
+
+  @TestTemplate
+  public void shouldReturnErrorStatisticsGroupedByErrorCodeAndMessage() {
+    // given — two jobs with the same error, one job with a different error
+    final var uniqueTenant = "error-tenant-" + CommonFixtures.generateRandomString(8);
+    final var now = NOW;
+    final var jobType = "error-job-type-" + CommonFixtures.generateRandomString(6);
+
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("IO_ERROR")
+                .errorMessage("Disk full")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(30)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("IO_ERROR")
+                .errorMessage("Disk full")
+                .worker("worker-2")
+                .creationTime(now.minusMinutes(20)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("TIMEOUT")
+                .errorMessage("Connection timed out")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(10)));
+
+    // when
+    final var result =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f -> f.from(now.minusHours(1)).to(now.plusMinutes(1)).jobType(jobType))),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(uniqueTenant))));
+
+    // then
+    assertThat(result.items()).hasSize(2);
+
+    final var ioError =
+        result.items().stream()
+            .filter(e -> "IO_ERROR".equals(e.errorCode()))
+            .findFirst()
+            .orElseThrow();
+    assertErrorStats(ioError, "IO_ERROR", "Disk full", 2);
+
+    final var timeout =
+        result.items().stream()
+            .filter(e -> "TIMEOUT".equals(e.errorCode()))
+            .findFirst()
+            .orElseThrow();
+    assertErrorStats(timeout, "TIMEOUT", "Connection timed out", 1);
+  }
+
+  @TestTemplate
+  public void shouldFilterErrorStatisticsByErrorCodePrefix() {
+    // given
+    final var uniqueTenant = "error-tenant-" + CommonFixtures.generateRandomString(8);
+    final var now = NOW;
+    final var jobType = "filter-error-job-" + CommonFixtures.generateRandomString(6);
+
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("IO_ERROR")
+                .errorMessage("Disk full")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(30)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("UNHANDLED_EXCEPTION")
+                .errorMessage("NPE")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(20)));
+
+    // when — filter to IO_ERROR only
+    final var result =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(now.minusHours(1))
+                                .to(now.plusMinutes(1))
+                                .jobType(jobType)
+                                .errorCodeOperations(Operation.eq("IO_ERROR")))),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(uniqueTenant))));
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertErrorStats(result.items().getFirst(), "IO_ERROR", "Disk full", 1);
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyErrorStatisticsWhenTenantNotAuthorized() {
+    // given
+    final var now = NOW;
+    final var jobType = "tenant-error-job-" + CommonFixtures.generateRandomString(6);
+
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(TENANT1)
+                .errorCode("IO_ERROR")
+                .errorMessage("msg")
+                .worker("w1")
+                .creationTime(now.minusMinutes(10)));
+
+    // when — authorized for TENANT2 only
+    final var result =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f -> f.from(now.minusHours(1)).to(now.plusMinutes(1)).jobType(jobType))),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(TENANT2))));
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldOnlyCountJobsFromAuthorizedTenants() {
+    // given — one job on TENANT1 (authorized), one on TENANT2 (not authorized), same error
+    final var now = NOW;
+    final var jobType = "multi-tenant-error-job-" + CommonFixtures.generateRandomString(6);
+
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(TENANT1)
+                .errorCode("IO_ERROR")
+                .errorMessage("Disk full")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(20)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(TENANT2)
+                .errorCode("IO_ERROR")
+                .errorMessage("Disk full")
+                .worker("worker-2")
+                .creationTime(now.minusMinutes(10)));
+
+    // when — authorized for TENANT1 only
+    final var result =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f -> f.from(now.minusHours(1)).to(now.plusMinutes(1)).jobType(jobType))),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(TENANT1))));
+
+    // then — only the TENANT1 job is visible: 1 bucket, 1 worker
+    assertThat(result.items()).hasSize(1);
+    assertErrorStats(result.items().getFirst(), "IO_ERROR", "Disk full", 1);
+  }
+
+  @TestTemplate
+  public void shouldExcludeJobsWithoutErrorCode() {
+    // given — one job with an error code, one job without
+    final var now = NOW;
+    final var uniqueTenant = "no-error-tenant-" + CommonFixtures.generateRandomString(8);
+    final var jobType = "no-error-job-" + CommonFixtures.generateRandomString(6);
+
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("IO_ERROR")
+                .errorMessage("Disk full")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(20)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode(null)
+                .errorMessage(null)
+                .worker("worker-2")
+                .creationTime(now.minusMinutes(10)));
+
+    // when
+    final var result =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f -> f.from(now.minusHours(1)).to(now.plusMinutes(1)).jobType(jobType))),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(uniqueTenant))));
+
+    // then — only the job with an error code is returned
+    assertThat(result.items()).hasSize(1);
+    assertErrorStats(result.items().getFirst(), "IO_ERROR", "Disk full", 1);
+  }
+
+  @TestTemplate
+  public void shouldReturnSecondPageOfErrorStatisticsUsingCursor() {
+    // given — 3 jobs each with a distinct errorCode so each forms its own bucket
+    // errorCodes are chosen so alphabetical order is: ERR_A < ERR_B < ERR_C
+    final var now = NOW;
+    final var uniqueTenant = "paging-error-tenant-" + CommonFixtures.generateRandomString(8);
+    final var jobType = "paging-error-job-" + CommonFixtures.generateRandomString(6);
+
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("ERR_A")
+                .errorMessage("msg-a")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(30)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("ERR_B")
+                .errorMessage("msg-b")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(20)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .errorCode("ERR_C")
+                .errorMessage("msg-c")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(10)));
+
+    final var accessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(uniqueTenant)));
+
+    // fetch first page (size=2) — should return ERR_A and ERR_B
+    final var firstPage =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(f -> f.from(now.minusHours(1)).to(now.plusMinutes(1)).jobType(jobType))
+                        .page(p -> p.size(2))),
+            accessChecks);
+
+    assertThat(firstPage.items()).hasSize(2);
+    assertThat(firstPage.items().get(0).errorCode()).isEqualTo("ERR_A");
+    assertThat(firstPage.items().get(1).errorCode()).isEqualTo("ERR_B");
+    assertThat(firstPage.endCursor()).isNotNull();
+
+    // when — fetch second page using the end cursor
+    final var secondPage =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(f -> f.from(now.minusHours(1)).to(now.plusMinutes(1)).jobType(jobType))
+                        .page(p -> p.size(2).after(firstPage.endCursor()))),
+            accessChecks);
+
+    // then — only ERR_C is returned on the second page
+    assertThat(secondPage.items()).hasSize(1);
+    assertErrorStats(secondPage.items().getFirst(), "ERR_C", "msg-c", 1);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/JobErrorStatisticsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/JobErrorStatisticsSort.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record JobErrorStatisticsSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static JobErrorStatisticsSort of(
+      final Function<JobErrorStatisticsSort.Builder, ObjectBuilder<JobErrorStatisticsSort>> fn) {
+    return SortOptionBuilders.jobErrorStatistics(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<JobErrorStatisticsSort.Builder>
+      implements ObjectBuilder<JobErrorStatisticsSort> {
+
+    public Builder errorCode() {
+      currentOrdering = new FieldSorting("errorCode", null);
+      return this;
+    }
+
+    public Builder errorMessage() {
+      currentOrdering = new FieldSorting("errorMessage", null);
+      return this;
+    }
+
+    @Override
+    protected JobErrorStatisticsSort.Builder self() {
+      return this;
+    }
+
+    @Override
+    public JobErrorStatisticsSort build() {
+      return new JobErrorStatisticsSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -362,4 +362,13 @@ public final class SortOptionBuilders {
       final Function<GlobalListenerSort.Builder, ObjectBuilder<GlobalListenerSort>> fn) {
     return fn.apply(globalListener()).build();
   }
+
+  public static JobErrorStatisticsSort.Builder jobErrorStatistics() {
+    return new JobErrorStatisticsSort.Builder();
+  }
+
+  public static JobErrorStatisticsSort jobErrorStatistics(
+      final Function<JobErrorStatisticsSort.Builder, ObjectBuilder<JobErrorStatisticsSort>> fn) {
+    return fn.apply(jobErrorStatistics()).build();
+  }
 }


### PR DESCRIPTION
## Description

This pull request adds support for retrieving job error statistics from the RDBMS backend, including new query, result, and mapping classes, as well as integration in the service layer and corresponding tests. The main focus is enabling queries that aggregate job errors by error code and message, along with the count of distinct workers for each error.

**Key changes:**

**Job Error Statistics Feature Implementation:**
- Added new domain classes: `JobErrorStatisticsDbQuery` and `JobErrorStatisticsDbResult` to represent the query and result structures for job error statistics. [[1]](diffhunk://#diff-ce2cb860cfdb45dee317909aa5bda88cc992996b74eda054a7d1adfb22aa05f5R1-R72) [[2]](diffhunk://#diff-52b55a971d31e60635d59aa44968757b3f2fa3accf7e24182ea3c7fa766241e2R1-R10)
- Implemented the SQL mapping and result map for job error statistics in `JobMetricsBatchMapper.xml`, including filtering, grouping, and paging logic.
- Introduced `JobErrorStatisticsColumn` enum for mapping error statistics columns.
- Extended the `JobMetricsBatchMapper` interface and its implementation to support fetching job error statistics. [[1]](diffhunk://#diff-a4e0dee68facb952762b30e1eb6bd11a7fc75b15810b75258e90acd22a09f012R12-R13) [[2]](diffhunk://#diff-a4e0dee68facb952762b30e1eb6bd11a7fc75b15810b75258e90acd22a09f012R37-R38)

**Service Layer Integration:**
- Updated `JobMetricsBatchDbReader` to support the new job error statistics query, including a fixed sort order, a dedicated reader, and logic to transform database results into entities. [[1]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R14-R19) [[2]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R37) [[3]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R65-R81) [[4]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289L220-R259) [[5]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R280-R288) [[6]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R300-R302)

**Testing:**
- Added comprehensive unit tests to `JobMetricsBatchDbReaderTest` to verify correct behavior for various scenarios, including empty results, correct mapping, and handling of null values. [[1]](diffhunk://#diff-cd39ec6e6acccdb0c3ec262a19eb7f63a0e0154aceb8fb7da2945ed486ce26e1R17-R23) [[2]](diffhunk://#diff-cd39ec6e6acccdb0c3ec262a19eb7f63a0e0154aceb8fb7da2945ed486ce26e1R842-R935)
- Added an assertion helper method for error statistics in acceptance test fixtures.
- Integrated the new assertion in acceptance tests. [[1]](diffhunk://#diff-5a16e579d6e97b1487ee12cc834246ad9ca849181c9282f723ca42fd07be4ae1R12) [[2]](diffhunk://#diff-5a16e579d6e97b1487ee12cc834246ad9ca849181c9282f723ca42fd07be4ae1R23)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43052