### PR TITLE
test: ignore event types ordering in global listeners

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
@@ -170,6 +170,12 @@ public class GlobalListenerIT {
 
   private void assertDbModelEqualToEntity(
       final GlobalListenerDbModel dbModel, final GlobalListenerEntity entity) {
-    assertThat(entity).usingRecursiveComparison().isEqualTo(dbModel);
+    assertThat(entity)
+        .as("Expect retrieved entity to have the same field values as the db model")
+        .usingRecursiveComparison()
+        // ordering of event types is not significant for the equality of the entity and the db
+        // model, so ignore it in the comparison
+        .ignoringCollectionOrderInFields("eventTypes")
+        .isEqualTo(dbModel);
   }
 }


### PR DESCRIPTION
## Description

When using RDBMS as secondary storage, the event types handled by a global listener are stored in a different table than the listeners themselves. When a listener and its linked event types are retrieved, the query does not explicitly sort the event types, so their ordering is not guaranteed.

The ordering is not important from a business logic perspective, so the tests should not check the ordering either.

#### Additional notes
The tests started failing after the introduction of the Oracle-specific `INSERT ALL` statement to add the event types in #47149. Using the `INSERT INTO` statement does seem to keep the correct insertion order, ensuring deterministic ordering in the result of the `SELECT` statement.
Interestingly, only the `GlobalListenerIT#shouldCreateAndGetGlobalListenerByListenerIdAndListenerType` test failed and not the similar `GlobalListenerIT#shouldUpdateGlobalListener` test for which the ordering was not changed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47824
