### PR TITLE
fix: pin identity version for smoketest to prevent latest tag resolution

### DIFF
--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -137,7 +137,7 @@
     <profile>
       <id>add-license-key</id>
       <properties>
-        <exclude.from.config />
+        <exclude.from.config></exclude.from.config>
       </properties>
     </profile>
     <profile>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -51,6 +51,8 @@
     <zeebe.version>8.8.15</zeebe.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
+    <!-- Identity version used for CI smoketest docker-compose -->
+    <identity.version>8.8.9</identity.version>
 
     <!-- maven plugins -->
     <surefire-plugin.version>3.5.5</surefire-plugin.version>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -289,15 +289,15 @@
             <configuration>
               <skip>${skip.docker}</skip>
               <target description="Check whether ES is running" name="check-es-is-up">
-                <echo message="Check ES is running..." />
+                <echo message="Check ES is running..."></echo>
                 <waitfor checkevery="1" checkeveryunit="second" maxwait="30" maxwaitunit="second">
-                  <socket port="9200" server="localhost" />
+                  <socket port="9200" server="localhost"></socket>
                 </waitfor>
-                <echo message="ES http socket is open. Checking for ES cluster state..." />
+                <echo message="ES http socket is open. Checking for ES cluster state..."></echo>
                 <waitfor checkevery="1" checkeveryunit="second" maxwait="30" maxwaitunit="second">
-                  <http url="http://localhost:9200/_cluster/state" />
+                  <http url="http://localhost:9200/_cluster/state"></http>
                 </waitfor>
-                <echo message="ES is running." />
+                <echo message="ES is running."></echo>
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This is a temporary fix to unblock the 8.8.7 release build. The CI smoketest was failing because IDENTITY_VERSION was not being set, causing docker-compose to fall back to camunda/identity:latest (currently 8.9.0-alpha5), which is incompatible with the smoketest Keycloak setup. This pins the identity version to 8.8.9 to match what's defined in parent/pom.xml.

Follow-up: The underlying issue is that the workflow reads IDENTITY_VERSION from optimize/pom.xml via java-info-action, but the identity version property has never existed in that file — it lives in parent/pom.xml under a different property name (version.identity). A proper fix will update the workflow to extract the identity version directly from parent/pom.xml, removing the need for this duplicated property.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
