### PR TITLE
[Backport stable/8.8] fix: correct FormResult.schema type from object to string in OpenAPI spec

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -45,6 +45,25 @@
           "code": "java.annotation.attributeValueChanged",
           "annotationType": "io.camunda.client.api.ExperimentalApi",
           "justification": "The ExperimentalApi annotation is used to mark methods as 'in-development'. It is okay to change value field"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChangedCovariantly",
+          "old": "method java.lang.Object io.camunda.client.protocol.rest.FormResult::getSchema()",
+          "new": "method java.lang.String io.camunda.client.protocol.rest.FormResult::getSchema()",
+          "justification": "This method was previously returning Object, which was a bug. Changing it to String is a more accurate return type and remains backward-compatible, as callers can still treat the returned value as an Object if needed."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.client.protocol.rest.FormResult io.camunda.client.protocol.rest.FormResult::schema(java.lang.Object)",
+          "justification": "This method was previously returning Object, which was a bug. Changing it to String is a more accurate return type and remains backward-compatible, as callers can still treat the returned value as an Object if needed."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method void io.camunda.client.protocol.rest.FormResult::setSchema(java.lang.Object)",
+          "justification": "This method was previously returning Object, which was a bug. Changing it to String is a more accurate return type and remains backward-compatible, as callers can still treat the returned value as an Object if needed."
         }
       ]
     }

--- a/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
@@ -10745,8 +10745,8 @@ components:
           description: The user-provided identifier of the form.
           type: string
         schema:
-          description: The form content.
-          type: object
+          description: The form schema as a JSON document serialized as a string.
+          type: string
         version:
           description: The version of the the deployed form.
           type: integer

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -11856,8 +11856,8 @@ components:
           allOf:
             - $ref: "#/components/schemas/FormId"
         schema:
-          description: The form content.
-          type: object
+          description: The form schema as a JSON document serialized as a string.
+          type: string
         version:
           description: The version of the the deployed form.
           type: integer


### PR DESCRIPTION
# Description
Backport of #47752 to `stable/8.8`.

relates to #47743