### PR TITLE
[Backport stable/8.9] fix: correct FormResult.schema type from object to string in OpenAPI spec

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -56,6 +56,13 @@
           "code": "java.method.removed",
           "old": "method io.camunda.client.api.search.filter.AuthorizationFilter io.camunda.client.api.search.filter.AuthorizationFilter::resourceIds(java.util.List<java.lang.String>)",
           "justification": "Updated the parameter type from List to Collection to make API more flexible. This remains backward-compatible for users, as any List already implements Collection and callers can continue passing the same arguments."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChangedCovariantly",
+          "old": "method java.lang.Object io.camunda.client.api.search.response.Form::getSchema()",
+          "new": "method java.lang.String io.camunda.client.api.search.response.Form::getSchema()",
+          "justification": "This method was previously returning Object, which was a bug. Changing it to String is a more accurate return type and remains backward-compatible, as callers can still treat the returned value as an Object if needed."
         }
       ]
     }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Form.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Form.java
@@ -36,7 +36,7 @@ public interface Form {
   /**
    * @return the schema of the form
    */
-  Object getSchema();
+  String getSchema();
 
   /**
    * @return the tenant identifier that owns this form

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/FormImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/FormImpl.java
@@ -23,7 +23,7 @@ public class FormImpl implements Form {
   private String formId;
   private Long version;
   private Long formKey;
-  private Object schema;
+  private String schema;
   private String tenantId;
 
   public FormImpl(final FormResult item) {
@@ -52,7 +52,7 @@ public class FormImpl implements Form {
   }
 
   @Override
-  public Object getSchema() {
+  public String getSchema() {
     return schema;
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/form-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/form-models.yaml
@@ -21,8 +21,8 @@ components:
           allOf:
             - $ref: "identifiers.yaml#/components/schemas/FormId"
         schema:
-          description: The form content.
-          type: object
+          description: The form schema as a JSON document serialized as a string.
+          type: string
         version:
           description: The version of the the deployed form.
           type: integer


### PR DESCRIPTION
# Description
Backport of #47752 to `stable/8.9`.

relates to #47743