### PR TITLE
[Backport stable/8.9] chore: fixing the required properties in the cluster variable yaml

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -368,6 +368,8 @@ components:
           description: The new value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
     ClusterVariableResult:
       type: object
+      required:
+        - value
       allOf:
         - $ref: '#/components/schemas/ClusterVariableResultBase'
       properties:
@@ -377,6 +379,9 @@ components:
     ClusterVariableSearchResult:
       description: Cluster variable search response item.
       type: object
+      required:
+        - value
+        - isTruncated
       allOf:
         - $ref: '#/components/schemas/ClusterVariableResultBase'
       properties:
@@ -392,6 +397,7 @@ components:
       required:
         - name
         - scope
+        - tenantId
       properties:
         name:
           type: string


### PR DESCRIPTION
# Description
Backport of #47463 to `stable/8.9`.

relates to 