### PR TITLE
refactor: add `jspecify` to `zeebe/logstreams` module

### DIFF
--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -97,6 +97,11 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -13,7 +13,9 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.CloseableSilently;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public interface LogStreamMetrics {
 
   void increaseInflightAppends();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsDoc.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsDoc.java
@@ -11,9 +11,11 @@ import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
+import org.jspecify.annotations.NullMarked;
 
 /** Flow control metrics for the log storage appender. */
 @SuppressWarnings("NullableProblems")
+@NullMarked
 public enum LogStreamMetricsDoc implements ExtendedMeterDocumentation {
   /** The count of records passing through the flow control, organized by context and outcome */
   FLOW_CONTROL_OUTCOME {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsImpl.java
@@ -49,7 +49,9 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.atomic.AtomicLong;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public final class LogStreamMetricsImpl implements LogStreamMetrics {
   private final AtomicLong inflightAppends = new AtomicLong();
   private final AtomicLong inflightRequests = new AtomicLong();
@@ -97,46 +99,57 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
         .register(registry);
   }
 
+  @Override
   public void increaseInflightAppends() {
     inflightAppends.incrementAndGet();
   }
 
+  @Override
   public void decreaseInflightAppends() {
     inflightAppends.decrementAndGet();
   }
 
+  @Override
   public void setInflightRequests(final int count) {
     inflightRequests.set(count);
   }
 
+  @Override
   public void setRequestLimit(final int limit) {
     requestLimit.set(limit);
   }
 
+  @Override
   public void increaseInflightRequests() {
     inflightRequests.incrementAndGet();
   }
 
+  @Override
   public void decreaseInflightRequests() {
     inflightRequests.decrementAndGet();
   }
 
+  @Override
   public CloseableSilently startWriteTimer() {
     return MicrometerUtil.timer(appendLatency, Timer.start(registry));
   }
 
+  @Override
   public CloseableSilently startCommitTimer() {
     return MicrometerUtil.timer(commitLatency, Timer.start(registry));
   }
 
+  @Override
   public void setLastWrittenPosition(final long position) {
     lastWritten.set(position);
   }
 
+  @Override
   public void setLastCommittedPosition(final long position) {
     lastCommitted.set(position);
   }
 
+  @Override
   public void recordAppendedEntry(
       final int amount,
       final RecordType recordType,
@@ -147,6 +160,7 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
         .increment(amount);
   }
 
+  @Override
   public void flowControlAccepted(final WriteContext context, final int size) {
     triedAppends.increment();
 
@@ -162,6 +176,7 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
         .increment(size);
   }
 
+  @Override
   public void flowControlRejected(
       final WriteContext context, final int size, final Rejection reason) {
     triedAppends.increment();
@@ -180,18 +195,22 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
         .increment(size);
   }
 
+  @Override
   public void setExportingRate(final long value) {
     exportingRate.set(value);
   }
 
+  @Override
   public void setWriteRateMaxLimit(final long value) {
     writeRateMaxLimit.set(value);
   }
 
+  @Override
   public void setPartitionLoad(final double load) {
     partitionLoad.set(Double.doubleToLongBits(load));
   }
 
+  @Override
   public void setWriteRateLimit(final double value) {
     writeRateLimit.set(Double.doubleToLongBits(value));
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/Loggers.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/Loggers.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.logstreams.impl;
 
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@NullMarked
 public final class Loggers {
 
   public static final Logger LOGSTREAMS_LOGGER =

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -85,7 +85,7 @@ public final class FlowControl implements AppendListener {
 
   private final LogStreamMetrics metrics;
   @Nullable private RateLimit writeRateLimit;
-  private Limit requestLimit;
+  @Nullable private Limit requestLimit;
   private Limiter<Intent> processingLimiter;
   @Nullable private RateLimiter writeRateLimiter;
   private final RateMeasurement exportingRate =
@@ -94,7 +94,7 @@ public final class FlowControl implements AppendListener {
   private final RateMeasurement writeRate =
       new RateMeasurement(
           ActorClock::currentTimeMillis, Duration.ofMinutes(5), Duration.ofSeconds(10));
-  private RateLimitThrottle writeRateThrottle;
+  @Nullable private RateLimitThrottle writeRateThrottle;
   private volatile long lastWrittenPosition = -1;
   private volatile long lastExportedPosition;
 
@@ -111,8 +111,8 @@ public final class FlowControl implements AppendListener {
 
   public FlowControl(
       final LogStreamMetrics metrics,
-      final Limit requestLimit,
-      final RateLimit writeRateLimit,
+      final @Nullable Limit requestLimit,
+      final @Nullable RateLimit writeRateLimit,
       final int inFlightCapacity) {
     this.metrics = metrics;
     inFlight = new RingBuffer(inFlightCapacity);
@@ -196,7 +196,10 @@ public final class FlowControl implements AppendListener {
     if (inFlightEntry != null) {
       inFlightEntry.onWrite();
     }
-    if (writeRate.observe(highestPosition) && writeRateLimit != null && writeRateLimit.enabled()) {
+    if (writeRate.observe(highestPosition)
+        && writeRateLimit != null
+        && writeRateLimit.enabled()
+        && writeRateLimiter != null) {
       metrics.setPartitionLoad(
           Math.min((float) (writeRate.rate() / writeRateLimiter.getRate() * 100L), 100));
     }
@@ -238,11 +241,11 @@ public final class FlowControl implements AppendListener {
     }
   }
 
-  public Limit getRequestLimit() {
+  public @Nullable Limit getRequestLimit() {
     return requestLimit;
   }
 
-  public void setRequestLimit(final Limit requestLimit) {
+  public void setRequestLimit(final @Nullable Limit requestLimit) {
     this.requestLimit = requestLimit;
     processingLimiter =
         requestLimit != null
@@ -250,11 +253,11 @@ public final class FlowControl implements AppendListener {
             : new NoopLimiter<>();
   }
 
-  public RateLimit getWriteRateLimit() {
+  public @Nullable RateLimit getWriteRateLimit() {
     return writeRateLimit;
   }
 
-  public void setWriteRateLimit(final RateLimit writeRateLimit) {
+  public void setWriteRateLimit(final @Nullable RateLimit writeRateLimit) {
     this.writeRateLimit = writeRateLimit;
     writeRateLimiter = writeRateLimit == null ? null : writeRateLimit.limiter();
     writeRateThrottle =

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -25,6 +25,8 @@ import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Maintains a view of in-flight entries as they are being appended, written, committed and finally
@@ -78,13 +80,14 @@ import java.util.List;
  * RateMeasurements to update the cluster load and the exporting rate metrics.
  */
 @SuppressWarnings("UnstableApiUsage")
+@NullMarked
 public final class FlowControl implements AppendListener {
 
   private final LogStreamMetrics metrics;
-  private RateLimit writeRateLimit;
+  @Nullable private RateLimit writeRateLimit;
   private Limit requestLimit;
   private Limiter<Intent> processingLimiter;
-  private RateLimiter writeRateLimiter;
+  @Nullable private RateLimiter writeRateLimiter;
   private final RateMeasurement exportingRate =
       new RateMeasurement(
           ActorClock::currentTimeMillis, Duration.ofMinutes(5), Duration.ofSeconds(10));

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlLimits.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlLimits.java
@@ -8,5 +8,9 @@
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
 import com.netflix.concurrency.limits.Limit;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-public record FlowControlLimits(Limit requestLimiter, RateLimit writeRateLimit) {}
+@NullMarked
+public record FlowControlLimits(
+    @Nullable Limit requestLimiter, @Nullable RateLimit writeRateLimit) {}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -13,10 +13,12 @@ import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import net.jcip.annotations.ThreadSafe;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
+@ThreadSafe
 public final class InFlightEntry {
   final LogStreamMetrics metrics;
   @Nullable LogAppendEntryMetadata entryMetadata;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -13,13 +13,16 @@ import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public final class InFlightEntry {
   final LogStreamMetrics metrics;
-  LogAppendEntryMetadata entryMetadata;
-  final AtomicReference<Listener> requestListener;
-  final AtomicReference<CloseableSilently> writeTimer;
-  final AtomicReference<CloseableSilently> commitTimer;
+  @Nullable LogAppendEntryMetadata entryMetadata;
+  final AtomicReference<@Nullable Listener> requestListener;
+  final AtomicReference<@Nullable CloseableSilently> writeTimer;
+  final AtomicReference<@Nullable CloseableSilently> commitTimer;
 
   /**
    * The position this entry was registered at in the ring buffer. Set by {@link RingBuffer#put}
@@ -38,7 +41,7 @@ public final class InFlightEntry {
   public InFlightEntry(
       final LogStreamMetrics metrics,
       final LogAppendEntryMetadata entryMetadata,
-      final Listener requestListener) {
+      @Nullable final Listener requestListener) {
     this.metrics = metrics;
     this.entryMetadata = entryMetadata;
     this.requestListener = new AtomicReference<>(requestListener);
@@ -80,7 +83,7 @@ public final class InFlightEntry {
     closeIfPossible(commitTimer);
   }
 
-  private void closeIfPossible(final AtomicReference<CloseableSilently> closeableRef) {
+  private void closeIfPossible(final AtomicReference<@Nullable CloseableSilently> closeableRef) {
     final var closeable = closeableRef.getAndSet(null);
     if (closeable != null) {
       closeable.close();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/NoopListener.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/NoopListener.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
 import com.netflix.concurrency.limits.Limiter.Listener;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 class NoopListener implements Listener {
   public static final NoopListener INSTANCE = new NoopListener();
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateLimit.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateLimit.java
@@ -10,8 +10,11 @@ package io.camunda.zeebe.logstreams.impl.flowcontrol;
 import com.google.common.util.concurrent.RateLimiter;
 import java.time.Duration;
 import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage")
+@NullMarked
 public record RateLimit(boolean enabled, int limit, Duration rampUp, Throttling throttling) {
   public RateLimit {
     Objects.requireNonNull(throttling, "throttling must not be null");
@@ -32,7 +35,7 @@ public record RateLimit(boolean enabled, int limit, Duration rampUp, Throttling 
     return new RateLimit(false, 0, Duration.ZERO, Throttling.disabled());
   }
 
-  public RateLimiter limiter() {
+  public @Nullable RateLimiter limiter() {
     if (!enabled) {
       return null;
     }
@@ -42,6 +45,7 @@ public record RateLimit(boolean enabled, int limit, Duration rampUp, Throttling 
     return RateLimiter.create(limit, rampUp);
   }
 
+  @NullMarked
   public record Throttling(
       boolean enabled, long acceptableBacklog, long minRate, Duration resolution) {
     public Throttling {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurement.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurement.java
@@ -11,9 +11,11 @@ import java.time.Duration;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.LongSupplier;
 import net.jcip.annotations.ThreadSafe;
+import org.jspecify.annotations.NullMarked;
 
 /** Measures the rate of change for monotonically increasing values. */
 @ThreadSafe
+@NullMarked
 public final class RateMeasurement {
   private final LongSupplier clock;
   private final LinkedBlockingDeque<Observation> observations;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.agrona.BitUtil;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,11 +30,12 @@ import org.slf4j.LoggerFactory;
  * position. This keeps all concurrency concerns (position stamping + volatile publication) inside
  * the ring buffer.
  */
+@NullMarked
 final class RingBuffer {
   private static final int DEFAULT_CAPACITY = 8 * 1024; // 8K slots
   private static final Logger LOGGER = LoggerFactory.getLogger(RingBuffer.class);
 
-  private final AtomicReferenceArray<InFlightEntry> buffer;
+  private final AtomicReferenceArray<@Nullable InFlightEntry> buffer;
   private final int mask;
   // NOTE: this field is not volatile
   private long lastWrittenPosition = -1;
@@ -85,7 +88,7 @@ final class RingBuffer {
    * Returns the entry at the given position, or null if the slot is empty or holds an entry for a
    * different position (i.e. the slot was overwritten by a wraparound).
    */
-  InFlightEntry get(final long position) {
+  @Nullable InFlightEntry get(final long position) {
     final var entry = buffer.get((int) (position & mask));
     return entry != null && entry.position == position ? entry : null;
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -15,7 +15,10 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public class WhiteListedCommands {
 
   private static final Set<? extends Intent> WHITE_LISTED_COMMANDS =
@@ -30,7 +33,7 @@ public class WhiteListedCommands {
           ScaleIntent.STATUS,
           CommandDistributionIntent.ACKNOWLEDGE);
 
-  public static boolean isWhitelisted(final Intent intent) {
+  public static boolean isWhitelisted(final @Nullable Intent intent) {
     return intent != null && WHITE_LISTED_COMMANDS.contains(intent);
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadata.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadata.java
@@ -12,7 +12,9 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.List;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public final class LogAppendEntryMetadata {
   private final short[] recordTypes;
   private final short[] valueTypes;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.logstreams.impl.log;
 
+import static java.util.Objects.requireNonNull;
+
 import com.netflix.concurrency.limits.Limit;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit;
 import io.camunda.zeebe.logstreams.log.LogStream;
@@ -14,19 +16,21 @@ import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
-import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public final class LogStreamBuilderImpl implements LogStreamBuilder {
   private static final int MINIMUM_FRAGMENT_SIZE = 4 * 1024;
   private int maxFragmentSize = 1024 * 1024 * 4;
   private int partitionId = -1;
-  private LogStorage logStorage;
-  private String logName;
-  private InstantSource clock;
-  private Limit requestLimit;
-  private RateLimit writeRateLimit;
+  @Nullable private LogStorage logStorage;
+  @Nullable private String logName;
+  @Nullable private InstantSource clock;
+  @Nullable private Limit requestLimit;
+  @Nullable private RateLimit writeRateLimit;
   private int inFlightCapacity;
-  private MeterRegistry meterRegistry;
+  @Nullable private MeterRegistry meterRegistry;
 
   @Override
   public LogStreamBuilder withMaxFragmentSize(final int maxFragmentSize) {
@@ -84,24 +88,6 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
 
   @Override
   public LogStream build() {
-    validate();
-
-    return new LogStreamImpl(
-        logName,
-        partitionId,
-        maxFragmentSize,
-        logStorage,
-        clock,
-        requestLimit,
-        writeRateLimit,
-        inFlightCapacity,
-        meterRegistry);
-  }
-
-  private void validate() {
-    Objects.requireNonNull(logStorage, "Must specify a log storage");
-    Objects.requireNonNull(clock, "Must specify a clock source");
-    Objects.requireNonNull(meterRegistry, "Must specify a meter registry");
 
     if (maxFragmentSize < MINIMUM_FRAGMENT_SIZE) {
       throw new IllegalArgumentException(
@@ -109,5 +95,16 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
               "Expected fragment size to be at least '%d', but was '%d'",
               MINIMUM_FRAGMENT_SIZE, maxFragmentSize));
     }
+
+    return new LogStreamImpl(
+        logName,
+        partitionId,
+        maxFragmentSize,
+        requireNonNull(logStorage, "Must specify a log storage"),
+        requireNonNull(clock, "Must specify a clock source"),
+        requestLimit,
+        writeRateLimit,
+        inFlightCapacity,
+        requireNonNull(meterRegistry, "Must specify a meter registry"));
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -22,8 +22,11 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
+@NullMarked
 public final class LogStreamImpl implements LogStream, CommitListener {
 
   private static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;
@@ -31,7 +34,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   private final Collection<LogStreamReader> readers = new CopyOnWriteArrayList<>();
   private final Collection<LogRecordAwaiter> recordAwaiters = new CopyOnWriteArrayList<>();
 
-  private final String logName;
+  private @Nullable final String logName;
   private final int partitionId;
   private final LogStorage logStorage;
   private final FlowControl flowControl;
@@ -39,13 +42,13 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   private volatile boolean closed;
 
   LogStreamImpl(
-      final String logName,
+      @Nullable final String logName,
       final int partitionId,
       final int maxFragmentSize,
       final LogStorage logStorage,
       final InstantSource clock,
-      final Limit requestLimit,
-      final RateLimit writeRateLimit,
+      @Nullable final Limit requestLimit,
+      @Nullable final RateLimit writeRateLimit,
       final int inFlightCapacity,
       final MeterRegistry meterRegistry) {
     this.logName = logName;
@@ -83,7 +86,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   }
 
   @Override
-  public String getLogName() {
+  public @Nullable String getLogName() {
     return logName;
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
@@ -13,7 +13,9 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.List;
 import java.util.Objects;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public record SequencedBatch(
     long timestamp,
     long firstPosition,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -24,6 +24,7 @@ import java.time.InstantSource;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * serializes them, assigning positions to all entries. Writes that are accepted are written
  * directly to the {@link LogStorage}.
  */
+@NullMarked
 final class Sequencer implements LogStreamWriter, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(Sequencer.class);
   private final int maxFragmentSize;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -16,7 +16,9 @@ import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 final class SequencerMetrics {
   private final DistributionSummary batchSize;
   private final DistributionSummary batchLengthBytes;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.logstreams.log;
 
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
 import io.camunda.zeebe.logstreams.impl.log.LogStreamBuilderImpl;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a stream of events. New events are append to the end of the log. With {@link
@@ -17,6 +19,7 @@ import io.camunda.zeebe.logstreams.impl.log.LogStreamBuilderImpl;
  *
  * <p>To read events, the {@link LogStream#newLogStreamReader()} ()} can be used.
  */
+@NullMarked
 public interface LogStream extends AutoCloseable {
 
   @Override
@@ -39,7 +42,7 @@ public interface LogStream extends AutoCloseable {
    *
    * @return the log stream name
    */
-  String getLogName();
+  @Nullable String getLogName();
 
   /**
    * @return a future, when successfully completed it returns a newly created log stream reader


### PR DESCRIPTION
## Description
Added `jspecify` to the `pom.xml`.
Added annotation for classes that I touched recently.
I try to not change much code, I just added a null check and moved the body of a function to help jspecify
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
