### PR TITLE
ci: assign original author as reviewer of backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -49,6 +49,7 @@ jobs:
             relates to ${issue_refs}
 
           add_author_as_assignee: true
+          add_author_as_reviewer: true
           experimental: >
             {
               "conflict_resolution": "draft_commit_conflicts"


### PR DESCRIPTION
Makes use of https://github.com/korthout/backport-action/pull/564 to assign the original author as the reviewer for the backport PR as well.

This gives more visibility thanks to pending review reminders and _may_ reduce review noise caused by CODEOWNERS auto-assignment.