### PR TITLE
[Backport stable/8.9] test: ignore event types ordering in global listeners

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
@@ -170,6 +170,12 @@ public class GlobalListenerIT {
 
   private void assertDbModelEqualToEntity(
       final GlobalListenerDbModel dbModel, final GlobalListenerEntity entity) {
-    assertThat(entity).usingRecursiveComparison().isEqualTo(dbModel);
+    assertThat(entity)
+        .as("Expect retrieved entity to have the same field values as the db model")
+        .usingRecursiveComparison()
+        // ordering of event types is not significant for the equality of the entity and the db
+        // model, so ignore it in the comparison
+        .ignoringCollectionOrderInFields("eventTypes")
+        .isEqualTo(dbModel);
   }
 }


### PR DESCRIPTION
# Description
Backport of #47806 to `stable/8.9`.

relates to #47824