### PR TITLE
Fix: Not all IN_PROGRESS backups are FAILED on re-election / restart

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -302,11 +302,13 @@ final class BackupServiceImpl {
               backupStore
                   .list(
                       new BackupIdentifierWildcardImpl(
-                          Optional.empty(),
-                          Optional.of(partitionId),
-                          CheckpointPattern.of(lastCheckpointId)))
+                          Optional.empty(), Optional.of(partitionId), CheckpointPattern.any()))
                   .thenAcceptAsync(
-                      backups -> backups.forEach(b -> failInProgressBackup(b, executor)), executor)
+                      backups ->
+                          backups.stream()
+                              .filter(b -> b.id().checkpointId() <= lastCheckpointId)
+                              .forEach(b -> failInProgressBackup(b, executor)),
+                      executor)
                   .exceptionallyAsync(
                       failure -> {
                         LOG.warn("Failed to list backups that should be marked as failed", failure);

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -326,6 +326,58 @@ class BackupServiceImplTest {
   }
 
   @Test
+  void shouldOnlyMarkBackupsAsFailedWithCheckpointIdLessThanOrEqualToLastCheckpointId() {
+    // given
+    final long lastCheckpointId = 10;
+    final var backupWithLowerCheckpointId = new BackupIdentifierImpl(1, 1, 5);
+    final var backupWithEqualCheckpointId = new BackupIdentifierImpl(2, 1, 10);
+    final var backupWithHigherCheckpointId = new BackupIdentifierImpl(3, 1, 15);
+
+    final var lowerCheckpointStatus =
+        new BackupStatusImpl(
+            backupWithLowerCheckpointId,
+            Optional.empty(),
+            BackupStatusCode.IN_PROGRESS,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var equalCheckpointStatus =
+        new BackupStatusImpl(
+            backupWithEqualCheckpointId,
+            Optional.empty(),
+            BackupStatusCode.IN_PROGRESS,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var higherCheckpointStatus =
+        new BackupStatusImpl(
+            backupWithHigherCheckpointId,
+            Optional.empty(),
+            BackupStatusCode.IN_PROGRESS,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
+    when(backupStore.list(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(lowerCheckpointStatus, equalCheckpointStatus, higherCheckpointStatus)));
+    when(backupStore.markFailed(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(BackupStatusCode.FAILED));
+
+    // when
+    backupService.failInProgressBackups(1, lastCheckpointId, concurrencyControl);
+
+    // then
+    final var expectedFailureReason = "Backup is cancelled due to leader change.";
+    verify(backupStore, timeout(1000))
+        .markFailed(backupWithLowerCheckpointId, expectedFailureReason);
+    verify(backupStore, timeout(1000))
+        .markFailed(backupWithEqualCheckpointId, expectedFailureReason);
+    verify(backupStore, never()).markFailed(backupWithHigherCheckpointId, expectedFailureReason);
+  }
+
+  @Test
   void shouldNotTakeNewBackupIfBackupAlreadyCompleted() {
     // given
     final ControllableInProgressBackup inProgressBackup = new ControllableInProgressBackup();


### PR DESCRIPTION
## Description

The fix implemented in this PR is to list all the backups in the partition and to faild all the backups have a checkpoint equal or older than the one provided. 

This operation should not add significant latency since the average amount of backputs per partition tends not to be too high. In SaaS, the standard is to keep only the last [3 successful backups. ](https://docs.camunda.io/docs/next/components/console/manage-clusters/create-backups/#create-a-scheduled-backup), while in SM it seems that we no longer provide the defaults with the config, and the customer must set them themselves: https://github.com/camunda/camunda-platform-helm/pull/5153. There is a greater chance of more backups per partition in SM, but since this works with a rolling window, these numbers should remain stable. 
We also use the same [wildcard](https://github.com/camunda/camunda/blob/3760b90d1c144a9601e9cf2bf9917d36513a25bc/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java#L199-L200) in the list call in `BackupRetention` when retrieving backups.
  
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/41200
