### PR TITLE
test: fix flaky ActivateJobsTest timeouts

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
@@ -72,25 +72,17 @@ class ActivateJobsTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void shouldReturnEmptyListOnUserDefinedGlobalRequestTimeout(final boolean useRest) {
-    // when
-    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(1)).build();
-    final var actual =
-        getCommand(client, useRest).jobType("notExisting").maxJobsToActivate(1).send().join();
-
-    // then
-    assertThat(actual.getJobs()).isEmpty();
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
   public void shouldReturnEmptyListOnUserDefinedCommandRequestTimeout(final boolean useRest) {
-    // when
+    // given - high global timeout
+    client.close();
+    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofMinutes(5)).build();
+
+    // when - low command timeout
     final var actual =
         getCommand(client, useRest)
             .jobType("notExisting")
             .maxJobsToActivate(1)
-            .requestTimeout(Duration.ofSeconds(1))
+            .requestTimeout(Duration.ofMillis(500))
             .send()
             .join();
 


### PR DESCRIPTION
## Description

- Removed redundant user-defined global request timeout test.
- Updated test to distinguish between global and command-specific timeouts.

## Related issues

closes https://github.com/camunda/camunda/issues/47658