### PR TITLE
fix: declare decision-instance.version as required field

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -290,6 +290,7 @@ components:
         - decisionDefinitionKey
         - decisionDefinitionName
         - decisionDefinitionType
+        - decisionDefinitionVersion
         - decisionEvaluationInstanceKey
         - decisionEvaluationKey
         - elementInstanceKey


### PR DESCRIPTION
## Description

Was missed in https://github.com/camunda/camunda/pull/47675

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #47649
