### PR TITLE
[Backport stable/8.9] fix: declare decision-instance.version as required field

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -290,6 +290,7 @@ components:
         - decisionDefinitionKey
         - decisionDefinitionName
         - decisionDefinitionType
+        - decisionDefinitionVersion
         - decisionEvaluationInstanceKey
         - decisionEvaluationKey
         - elementInstanceKey


### PR DESCRIPTION
# Description
Backport of #47851 to `stable/8.9`.

relates to #47649