### PR TITLE
[Backport stable/8.7] deps: downgrade maven surefire plugin to 3.5.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -222,7 +222,7 @@
     <plugin.version.shade>3.6.1</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.8.6.7</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.5</plugin.version.surefire>
+    <plugin.version.surefire>3.5.2</plugin.version.surefire>
     <plugin.version.versions>2.17.1</plugin.version.versions>
     <plugin.version.frontend-maven>1.15.4</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>


### PR DESCRIPTION
# Description
Backport of #47476 to `stable/8.7`.

relates to apache/maven-surefire#3203