### PR TITLE
[Backport stable/8.8] deps: downgrade maven surefire plugin to 3.5.2

### DIFF
--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
@@ -52,7 +52,6 @@ public class ElasticsearchProcessDefinitionDaoTest {
     ReflectionTestUtils.setField(processDefinitionDao, "tenantAwareClient", tenantAwareClient);
     ReflectionTestUtils.setField(processDefinitionDao, "objectMapper", objectMapper);
     ReflectionTestUtils.setField(processDefinitionDao, "processIndex", processIndex);
-    when(processIndex.getAlias()).thenReturn("process-index");
   }
 
   @Test
@@ -93,6 +92,7 @@ public class ElasticsearchProcessDefinitionDaoTest {
   public void shouldExcludeBpmnXmlFromSearch() throws APIException, IOException {
     // given
     final Query<ProcessDefinition> query = new Query<>();
+    when(processIndex.getAlias()).thenReturn("process-index");
     mockSearchResponse();
 
     // when
@@ -119,6 +119,7 @@ public class ElasticsearchProcessDefinitionDaoTest {
             .setTenantId("<default>")
             .setVersion(2);
     final Query<ProcessDefinition> query = new Query<ProcessDefinition>().setFilter(filter);
+    when(processIndex.getAlias()).thenReturn("process-index");
     mockSearchResponse();
 
     // when
@@ -137,6 +138,7 @@ public class ElasticsearchProcessDefinitionDaoTest {
     // given - query with pagination parameters
     final Query<ProcessDefinition> query =
         new Query<ProcessDefinition>().setSize(100).setSearchAfter(new Object[] {50L});
+    when(processIndex.getAlias()).thenReturn("process-index");
     mockSearchResponse();
 
     // when
@@ -154,6 +156,7 @@ public class ElasticsearchProcessDefinitionDaoTest {
   public void shouldOnlyExcludeBpmnXmlAndNotOtherFields() throws APIException, IOException {
     // given - ensure only BPMN XML is excluded, not other process definition fields
     final Query<ProcessDefinition> query = new Query<>();
+    when(processIndex.getAlias()).thenReturn("process-index");
     mockSearchResponse();
 
     // when
@@ -188,6 +191,7 @@ public class ElasticsearchProcessDefinitionDaoTest {
             .setFilter(filter)
             .setSize(25)
             .setSort(Query.Sort.listOf(ProcessDefinition.VERSION, Query.Sort.Order.DESC));
+    when(processIndex.getAlias()).thenReturn("process-index");
     mockSearchResponse();
 
     // when
@@ -207,6 +211,7 @@ public class ElasticsearchProcessDefinitionDaoTest {
     final Query<ProcessDefinition> query =
         new Query<ProcessDefinition>()
             .setSort(Query.Sort.listOf(ProcessDefinition.NAME, Query.Sort.Order.ASC));
+    when(processIndex.getAlias()).thenReturn("process-index");
     mockSearchResponse();
 
     // when

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -226,7 +226,7 @@
     <plugin.version.shade>3.6.1</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.9.8.2</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.5</plugin.version.surefire>
+    <plugin.version.surefire>3.5.2</plugin.version.surefire>
     <plugin.version.versions>2.18.0</plugin.version.versions>
     <plugin.version.frontend-maven>1.15.1</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>


### PR DESCRIPTION
# Description
Backport of #47476 to `stable/8.8`.

relates to apache/maven-surefire#3203