### PR TITLE
Fix Swagger UI missing CSRF token and base64 encoding

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rest/HttpMessageConverterConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/HttpMessageConverterConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
@@ -38,6 +39,14 @@ public class HttpMessageConverterConfiguration {
     // objects to plain Strings.
     // This behavior (custom converters taking precedence) changed with Spring Boot 4.0
     return new StringHttpMessageConverter(StandardCharsets.UTF_8);
+  }
+
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE + 1)
+  public ByteArrayHttpMessageConverter byteHttpMessageConverter() {
+    // This converter is needed to properly handle byte arrays
+    // e.g. in the context of OpenAPI JSON schema generation
+    return new ByteArrayHttpMessageConverter();
   }
 
   @Bean

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -99,8 +99,8 @@ management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
 springdoc.swagger-ui.csrf.enabled=true
 springdoc.swagger-ui.csrf.header-name=X-CSRF-TOKEN
 springdoc.swagger-ui.csrf.session-storage-key=X-CSRF-TOKEN
-springdoc.swagger-ui.csrf.use-session-storage=false
-springdoc.swagger-ui.csrf.use-local-storage=true
+springdoc.swagger-ui.csrf.use-session-storage=true
+springdoc.swagger-ui.csrf.use-local-storage=false
 
 # Spring AI MCP integration - disabled by default
 spring.ai.mcp.server.enabled=false


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fixes the null CSRF token since it's now saved in session storage instead of local storage.

In addition to this, this PR also fixes the Swagger UI regression for Spring Boot 4 where the `ByteArrayHttpMessageConverter` is not present, resulting in the Swagger `api-docs` endpoints returning base64 encoded strings of the JSON payload rather than in its plaintext form. You can see more [details here](https://springdoc.org/#why-am-i-getting-an-error-swagger-ui-unable-to-render-definition-when-overriding-the-default-spring-registered-httpmessageconverter).


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44367
