### PR TITLE
feat: add new process instance page deep linkable tab content routes

### DIFF
--- a/operate/client/src/App/OperationsLog/InstancesTable/Cell/CellActor.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/Cell/CellActor.tsx
@@ -43,7 +43,7 @@ const CellActor: React.FC<Props> = ({item}) => {
     <OperationLogName>
       {ActorIcon && (
         <Tooltip
-          align="bottom-left"
+          align="bottom-start"
           description={getTooltipActorContent(item.actorType)}
         >
           <ActorIcon />
@@ -51,7 +51,7 @@ const CellActor: React.FC<Props> = ({item}) => {
       )}
       {item.agentElementId && (
         <Tooltip
-          align="bottom-left"
+          align="bottom-start"
           description={getTooltipActorContent('AGENT')}
         >
           <AiAgentIcon />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputMappingsTab.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputMappingsTab.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {InputOutputMappings} from './InputOutputMappings';
+
+const InputMappingsTab: React.FC = () => {
+  const {selectedElementId} = useProcessInstanceElementSelection();
+
+  if (selectedElementId === null) {
+    return null;
+  }
+
+  return <InputOutputMappings type="Input" elementId={selectedElementId} />;
+};
+
+export {InputMappingsTab};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/IOMappingInfoBanner.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/IOMappingInfoBanner.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ActionableNotification} from '@carbon/react';
+import {storeStateLocally} from 'modules/utils/localStorage';
+
+type Props = {
+  type: 'Input' | 'Output';
+  text: string;
+  onClose: () => void;
+};
+
+const IOMappingInfoBanner: React.FC<Props> = ({type, text, onClose}) => {
+  return (
+    <ActionableNotification
+      kind="info"
+      inline
+      lowContrast
+      subtitle={text}
+      hasFocus={false}
+      actionButtonLabel="Learn more"
+      onActionButtonClick={() => {
+        window.open(
+          'https://docs.camunda.io/docs/components/concepts/variables/#inputoutput-variable-mappings',
+          '_blank',
+        );
+      }}
+      onClose={() => {
+        onClose();
+        storeStateLocally({[`hide${type}MappingsHelperBanner`]: true});
+      }}
+    />
+  );
+};
+
+export {IOMappingInfoBanner};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/index.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {InputOutputMappings} from './index';
+import {render, screen} from 'modules/testing-library';
+import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+
+const Wrapper = ({children}: {children?: React.ReactNode}) => {
+  return (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <ProcessDefinitionKeyContext.Provider value="123">
+        {children}
+      </ProcessDefinitionKeyContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+describe('Input Mappings', () => {
+  beforeEach(() =>
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    ),
+  );
+
+  it('should display input mappings', async () => {
+    const {rerender} = render(
+      <InputOutputMappings type="Input" elementId="Event_0bonl61" />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
+
+    rerender(<InputOutputMappings type="Input" elementId="Activity_0qtp1k6" />);
+
+    expect(await screen.findByText(/local variable name/i)).toBeInTheDocument();
+    expect(screen.getByText(/variable assignment value/i)).toBeInTheDocument();
+    expect(screen.getByText(/localVariable1/i)).toBeInTheDocument();
+    expect(screen.getByText(/= "test1"/i)).toBeInTheDocument();
+    expect(screen.getByText(/localVariable2/i)).toBeInTheDocument();
+    expect(screen.getByText(/= "test2"/i)).toBeInTheDocument();
+  });
+
+  it('should display output mappings', async () => {
+    const {rerender} = render(
+      <InputOutputMappings type="Input" elementId="Event_0bonl61" />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
+
+    rerender(
+      <InputOutputMappings type="Output" elementId="Activity_0qtp1k6" />,
+    );
+    expect(
+      await screen.findByText(/process variable name/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/variable assignment value/i)).toBeInTheDocument();
+    expect(screen.getByText(/outputTest/i)).toBeInTheDocument();
+    expect(screen.getByText(/= 2/i)).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      type: 'Input',
+      message:
+        'Input mappings are defined while modelling the diagram. They are used to create new local variables inside the element scope with the specified assignment.',
+    },
+    {
+      type: 'Output',
+      message:
+        'Output mappings are defined while modelling the diagram. They are used to control the variable propagation from the element scope. Process variables in the parent scopes are created/updated with the specified assignment.',
+    },
+  ] as const)(
+    'should display/hide information banner for input/output mappings',
+    async ({type, message}) => {
+      const {user, rerender} = render(
+        <InputOutputMappings type={type} elementId="Activity_0qtp1k6" />,
+        {
+          wrapper: Wrapper,
+        },
+      );
+      expect(screen.getByText(message)).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', {name: /close/}));
+
+      expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+      mockFetchProcessDefinitionXml().withSuccess(
+        mockProcessWithInputOutputMappingsXML,
+      );
+      rerender(
+        <InputOutputMappings type={type} elementId="Activity_0qtp1k6" />,
+      );
+      expect(screen.queryByText(message)).not.toBeInTheDocument();
+    },
+  );
+
+  it('should not move focus to the info banner on render', () => {
+    render(<InputOutputMappings type="Input" elementId="Activity_0qtp1k6" />, {
+      wrapper: Wrapper,
+    });
+
+    expect(document.activeElement).toBe(document.body);
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/index.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getMappings} from 'modules/bpmn-js/utils/getInputOutputMappings';
+import {Content, EmptyMessage} from './styled';
+import {IOMappingInfoBanner} from './IOMappingInfoBanner';
+import {useState} from 'react';
+import {getStateLocally} from 'modules/utils/localStorage';
+import {StructuredList} from 'modules/components/StructuredList';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+
+const INFORMATION_TEXT = {
+  Input:
+    'Input mappings are defined while modelling the diagram. They are used to create new local variables inside the element scope with the specified assignment.',
+  Output:
+    'Output mappings are defined while modelling the diagram. They are used to control the variable propagation from the element scope. Process variables in the parent scopes are created/updated with the specified assignment.',
+};
+
+type Props = {
+  type: 'Input' | 'Output';
+  elementId: string;
+};
+
+const InputOutputMappings: React.FC<Props> = ({type, elementId}) => {
+  const [isInfoBannerVisible, setIsInfoBannerVisible] = useState(
+    !getStateLocally()?.[`hide${type}MappingsHelperBanner`],
+  );
+
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const {data} = useProcessInstanceXml({processDefinitionKey});
+  const businessObject = data?.businessObjects[elementId];
+
+  const mappings =
+    businessObject === undefined ? [] : getMappings(businessObject, type);
+
+  return (
+    <Content $isInfoBannerVisible={isInfoBannerVisible}>
+      {isInfoBannerVisible && (
+        <IOMappingInfoBanner
+          type={type}
+          text={INFORMATION_TEXT[type]}
+          onClose={() => {
+            setIsInfoBannerVisible(false);
+          }}
+        />
+      )}
+      {mappings.length === 0 ? (
+        <EmptyMessage message={`No ${type} Mappings defined`} />
+      ) : (
+        <StructuredList
+          label="Input Mappings"
+          headerSize="sm"
+          headerColumns={[
+            {
+              cellContent:
+                type === 'Input'
+                  ? 'Local Variable Name'
+                  : 'Process Variable Name',
+            },
+            {
+              cellContent: 'Variable Assignment Value',
+            },
+          ]}
+          rows={mappings.map(({source, target}) => {
+            return {
+              id: target,
+              key: source,
+              columns: [
+                {
+                  id: 'target',
+                  cellContent: target,
+                  isBold: true,
+                },
+                {id: 'source', cellContent: source},
+              ],
+            };
+          })}
+        />
+      )}
+    </Content>
+  );
+};
+
+export {InputOutputMappings};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/index.tsx
@@ -54,7 +54,7 @@ const InputOutputMappings: React.FC<Props> = ({type, elementId}) => {
         <EmptyMessage message={`No ${type} Mappings defined`} />
       ) : (
         <StructuredList
-          label="Input Mappings"
+          label={`${type} Mappings`}
           headerSize="sm"
           headerColumns={[
             {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/styled.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled, {css} from 'styled-components';
+import {EmptyMessage as BaseEmptyMessage} from 'modules/components/EmptyMessage';
+
+type ContentProps = {
+  $isInfoBannerVisible: boolean;
+};
+
+const Content = styled.div<ContentProps>`
+  ${({$isInfoBannerVisible}) => {
+    return css`
+      height: 100%;
+      overflow: hidden;
+      display: grid;
+      grid-template-rows: ${$isInfoBannerVisible ? 'auto 1fr' : '1fr'};
+      ${$isInfoBannerVisible &&
+      css`
+        grid-gap: var(--cds-spacing-05);
+      `}
+    `;
+  }}
+`;
+
+const EmptyMessage = styled(BaseEmptyMessage)`
+  align-self: center;
+  margin: auto;
+`;
+
+export {Content, EmptyMessage};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {Layer} from '@carbon/react';
+
+import {EmptyMessage} from 'modules/components/EmptyMessage';
+import {spaceAndCapitalize} from 'modules/utils/spaceAndCapitalize';
+import {formatDate} from 'modules/utils/date';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useElementSelectionInstanceKey} from 'modules/hooks/useElementSelectionInstanceKey';
+import {useJobs} from 'modules/queries/jobs/useJobs';
+
+import {
+  CellContainer,
+  Content,
+  StructuredList,
+  WarningFilled,
+  Dropdown,
+  EmptyMessageWrapper,
+  Stack,
+} from './styled';
+
+type ListenerTypeFilter = 'EXECUTION_LISTENER' | 'TASK_LISTENER';
+
+const FilterLabelMapping = {
+  'All listeners': 'ALL_LISTENERS',
+  'Execution listeners': 'EXECUTION_LISTENER',
+  'User task listeners': 'TASK_LISTENER',
+} as const satisfies Record<string, ListenerTypeFilter | 'ALL_LISTENERS'>;
+
+type FilterLabelMappingType = typeof FilterLabelMapping;
+type FilterLabelMappingKeys = keyof FilterLabelMappingType;
+
+type SelectedItem = {
+  selectedItem: FilterLabelMappingKeys;
+};
+
+const ListenersTab: React.FC = () => {
+  const {processInstanceId = ''} = useProcessInstancePageParams();
+  const {resolvedElementInstance, selectedElementId} =
+    useProcessInstanceElementSelection();
+  const resolvedElementInstanceKey = useElementSelectionInstanceKey();
+
+  const hasUserTaskSelected = resolvedElementInstance?.type === 'USER_TASK';
+
+  const [listenerTypeFilter, setListenerTypeFilter] =
+    useState<ListenerTypeFilter>();
+  const [selectedOption, setSelectedOption] =
+    useState<FilterLabelMappingKeys>('All listeners');
+
+  const {
+    data: jobs,
+    fetchNextPage,
+    fetchPreviousPage,
+    hasNextPage,
+    hasPreviousPage,
+  } = useJobs({
+    payload: {
+      filter: {
+        processInstanceKey: processInstanceId,
+        elementId: selectedElementId ?? undefined,
+        elementInstanceKey: resolvedElementInstanceKey ?? undefined,
+        kind: listenerTypeFilter,
+      },
+    },
+    select: (data) => data.pages?.flatMap((page) => page.items),
+  });
+
+  const listeners = jobs ?? [];
+
+  const handleEmptyMessages = () => {
+    if (hasUserTaskSelected) {
+      if (selectedOption === 'All listeners') {
+        return 'This element has no execution listeners nor user task listeners';
+      }
+
+      if (selectedOption === 'User task listeners') {
+        return 'This element has no user task listeners';
+      }
+    }
+
+    return 'This element has no execution listeners';
+  };
+
+  return (
+    <Content>
+      {hasUserTaskSelected && (
+        <Dropdown
+          id="listenerTypeFilter"
+          data-testid="listener-type-filter"
+          titleText="Listener type"
+          label="All listeners"
+          hideLabel
+          onChange={async ({selectedItem}: SelectedItem) => {
+            if (selectedItem !== selectedOption) {
+              setSelectedOption(selectedItem);
+
+              if (FilterLabelMapping[selectedItem] !== 'ALL_LISTENERS') {
+                setListenerTypeFilter(FilterLabelMapping[selectedItem]);
+              } else {
+                setListenerTypeFilter(undefined);
+              }
+            }
+          }}
+          items={Object.keys(FilterLabelMapping)}
+          size="sm"
+          selectedItem={selectedOption}
+          disabled={
+            selectedOption === 'All listeners' && listeners?.length === 0
+          }
+        />
+      )}
+      <Stack as={Layer}>
+        {listeners?.length > 0 ? (
+          <StructuredList
+            dataTestId="listeners-list"
+            headerColumns={[
+              {cellContent: 'Listener type', width: '20%'},
+              {cellContent: 'Listener key', width: '20%'},
+              {cellContent: 'State', width: '10%'},
+              {cellContent: 'Job type', width: '15%'},
+              {cellContent: 'Event', width: '15%'},
+              {cellContent: 'Time', width: '20%'},
+            ]}
+            headerSize="sm"
+            verticalCellPadding="var(--cds-spacing-02)"
+            label="Listeners List"
+            onVerticalScrollStartReach={() => {
+              if (hasPreviousPage) {
+                fetchPreviousPage();
+              }
+            }}
+            onVerticalScrollEndReach={() => {
+              if (hasNextPage) {
+                fetchNextPage();
+              }
+            }}
+            rows={listeners?.map(
+              ({kind, jobKey, state, type, listenerEventType, endTime}) => {
+                return {
+                  key: jobKey,
+                  dataTestId: jobKey,
+                  columns: [
+                    {
+                      cellContent: (
+                        <CellContainer orientation="horizontal" gap={3}>
+                          {spaceAndCapitalize(kind)}
+                          {state === 'FAILED' && <WarningFilled />}
+                        </CellContainer>
+                      ),
+                    },
+                    {cellContent: <CellContainer>{jobKey}</CellContainer>},
+                    {
+                      cellContent: (
+                        <CellContainer>
+                          {spaceAndCapitalize(state)}
+                        </CellContainer>
+                      ),
+                    },
+                    {
+                      cellContent: <CellContainer>{type}</CellContainer>,
+                    },
+                    {
+                      cellContent: (
+                        <CellContainer>
+                          {spaceAndCapitalize(listenerEventType)}
+                        </CellContainer>
+                      ),
+                    },
+                    {
+                      cellContent: (
+                        <CellContainer>{formatDate(endTime)}</CellContainer>
+                      ),
+                    },
+                  ],
+                };
+              },
+            )}
+          />
+        ) : (
+          <EmptyMessageWrapper>
+            <EmptyMessage message={handleEmptyMessages()} />
+          </EmptyMessageWrapper>
+        )}
+      </Stack>
+    </Content>
+  );
+};
+
+export {ListenersTab};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/styled.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {StructuredList as BaseStructuredList} from 'modules/components/StructuredList';
+import {WarningFilled as BaseWarningFilled} from '@carbon/react/icons';
+import {supportError, spacing01, spacing03} from '@carbon/elements';
+import styled from 'styled-components';
+import {Stack as BaseStack, Dropdown as BaseDropdown} from '@carbon/react';
+
+const Content = styled.div`
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: var(--cds-spacing-03) var(--cds-spacing-05);
+
+  .cds--loading-overlay {
+    position: absolute;
+  }
+`;
+
+const StructuredList = styled(BaseStructuredList)`
+  [role='table'] {
+    table-layout: fixed;
+  }
+`;
+
+const CellContainer = styled(BaseStack)`
+  padding: ${spacing03} ${spacing01};
+`;
+
+const WarningFilled = styled(BaseWarningFilled)`
+  fill: ${supportError};
+  margin-top: ${spacing01};
+`;
+
+const Dropdown = styled(BaseDropdown)`
+  width: 200px;
+  margin-bottom: ${spacing03};
+`;
+
+const EmptyMessageWrapper = styled.div`
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+
+  > div {
+    max-width: 475px;
+  }
+`;
+
+const Stack = styled(BaseStack)`
+  height: 100%;
+  overflow-y: auto;
+`;
+
+export {
+  Content,
+  StructuredList,
+  CellContainer,
+  WarningFilled,
+  Dropdown,
+  EmptyMessageWrapper,
+  Stack,
+};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/Filters/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/Filters/index.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Filters} from './index';
+import {render, screen} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+
+function getWrapper(initialPath = '/processes/123') {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>
+            <Route path="/processes/123" element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+
+  return Wrapper;
+}
+
+describe('Process Instance OperationsLog Filters', () => {
+  it('should render operation type field', async () => {
+    render(<Filters />, {
+      wrapper: getWrapper(),
+    });
+
+    expect(screen.getByText('Operation type')).toBeInTheDocument();
+  });
+
+  it('should render entity type field', async () => {
+    render(<Filters />, {
+      wrapper: getWrapper(),
+    });
+
+    expect(screen.getByText('Entity type')).toBeInTheDocument();
+  });
+
+  it('should parse filters from URL search params', async () => {
+    render(<Filters />, {
+      wrapper: getWrapper('/processes/123?operationType=ASSIGN'),
+    });
+
+    expect(screen.getByText(/Total items selected:\s+1/)).toBeInTheDocument();
+  });
+
+  it('should submit filters when form values change', async () => {
+    const {user} = render(<Filters />, {
+      wrapper: getWrapper(),
+    });
+
+    const [firstComboBox] = screen.getAllByRole('combobox');
+    await user.click(firstComboBox);
+
+    const [firstCheckbox] = screen.getAllByRole('checkbox');
+    await user.click(firstCheckbox);
+
+    expect(screen.getByText(/Total items selected:\s+1/)).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/Filters/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/Filters/index.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Form} from 'react-final-form';
+import {
+  PROCESS_INSTANCE_AUDIT_LOG_FILTER_FIELDS,
+  type ProcessInstanceOperationsLogFilterField,
+  type ProcessInstanceOperationsLogFilters,
+} from '../operationsLogFilters';
+import {updateFiltersSearchString} from 'modules/utils/filter';
+import {useLocation, useNavigate} from 'react-router-dom';
+import {AutoSubmit} from 'modules/components/AutoSubmit';
+import {Stack} from '@carbon/react';
+import {FilterMultiselect} from 'modules/components/FilterMultiSelect';
+import {
+  auditLogEntityTypeSchema,
+  auditLogOperationTypeSchema,
+} from '@camunda/camunda-api-zod-schemas/8.9';
+import {getFilters} from 'modules/utils/filter/getProcessInstanceFilters';
+import {FiltersForm} from './styled';
+
+const Filters: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const filterValues = getFilters<
+    ProcessInstanceOperationsLogFilterField,
+    ProcessInstanceOperationsLogFilters
+  >(location.search, PROCESS_INSTANCE_AUDIT_LOG_FILTER_FIELDS, []);
+
+  const setFilters = (filters: ProcessInstanceOperationsLogFilters) => {
+    navigate({
+      search: updateFiltersSearchString<ProcessInstanceOperationsLogFilters>(
+        new URLSearchParams(location.search),
+        filters,
+        PROCESS_INSTANCE_AUDIT_LOG_FILTER_FIELDS,
+        [],
+      ),
+    });
+  };
+
+  return (
+    <Form<ProcessInstanceOperationsLogFilters>
+      onSubmit={setFilters}
+      initialValues={filterValues}
+    >
+      {({handleSubmit}) => (
+        <FiltersForm onSubmit={handleSubmit}>
+          <AutoSubmit fieldsToSkipTimeout={['operationType', 'entityType']} />
+          <Stack orientation="horizontal" gap={5}>
+            <FilterMultiselect
+              name="operationType"
+              titleText="Operation type"
+              items={auditLogOperationTypeSchema.options}
+            />
+            <FilterMultiselect
+              name="entityType"
+              titleText="Entity type"
+              items={auditLogEntityTypeSchema.options}
+            />
+          </Stack>
+        </FiltersForm>
+      )}
+    </Form>
+  );
+};
+
+export {Filters};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/Filters/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/Filters/styled.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const FiltersForm = styled('form')`
+  padding: var(--cds-spacing-03) var(--cds-spacing-05);
+`;
+
+export {FiltersForm};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/index.test.tsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {OperationsLogTab} from './index';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {mockQueryAuditLogs} from 'modules/mocks/api/v2/auditLogs/queryAuditLogs';
+import {notificationsStore} from 'modules/stores/notifications';
+import {Paths} from 'modules/Routes';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockProcessInstance} from 'modules/mocks/api/v2/mocks/processInstance';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const getWrapper = (searchParams?: Record<string, string>) => {
+  const params = new URLSearchParams(searchParams);
+  const Wrapper = ({children}: {children?: React.ReactNode}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter
+        initialEntries={[
+          `${Paths.processInstance(mockProcessInstance.processInstanceKey)}?${params.toString()}`,
+        ]}
+      >
+        <Routes>
+          <Route path={Paths.processInstance()} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+describe('OperationsLogTab', () => {
+  it('should show skeleton state when data undefined', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockQueryAuditLogs().withServerError();
+
+    render(<OperationsLogTab />, {
+      wrapper: getWrapper(),
+    });
+
+    expect(screen.getByTestId('data-table-skeleton')).toBeInTheDocument();
+  });
+
+  it('should render empty state when no items are present', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockQueryAuditLogs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<OperationsLogTab />, {
+      wrapper: getWrapper(),
+    });
+
+    expect(
+      await screen.findByText('No operations found for this instance'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render rows when data is present', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockQueryAuditLogs().withSuccess({
+      items: [
+        {
+          auditLogKey: '123',
+          entityKey: '1',
+          operationType: 'UPDATE',
+          entityType: 'VARIABLE',
+          result: 'SUCCESS',
+          actorId: 'user1',
+          timestamp: '2024-01-01T00:00:00.000Z',
+          annotation: 'Updated variable',
+          actorType: 'USER',
+          category: 'USER_TASKS',
+          entityDescription: 'variableValue',
+          batchOperationKey: null,
+          batchOperationType: null,
+          relatedEntityType: null,
+          resourceKey: null,
+          jobKey: null,
+          elementInstanceKey: '123',
+          tenantId: '<default>',
+          decisionRequirementsId: null,
+          decisionEvaluationKey: null,
+          deploymentKey: null,
+          decisionRequirementsKey: null,
+          processDefinitionId: null,
+          relatedEntityKey: null,
+          processDefinitionKey: null,
+          processInstanceKey: null,
+          rootProcessInstanceKey: null,
+          decisionDefinitionId: null,
+          decisionDefinitionKey: null,
+          userTaskKey: null,
+          formKey: null,
+          agentElementId: null,
+        },
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<OperationsLogTab />, {
+      wrapper: getWrapper(),
+    });
+
+    expect(
+      screen.getByRole('columnheader', {name: /operation type/i}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: /entity type/i}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: /entity key/i}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: /actor/i}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: /date/i}),
+    ).toBeInTheDocument();
+
+    expect(await screen.findByTestId('SUCCESS-icon')).toBeInTheDocument();
+    expect(await screen.findByText('Update')).toBeInTheDocument();
+    expect(await screen.findByText('Variable')).toBeInTheDocument();
+    expect(screen.getByText('variableValue')).toBeInTheDocument();
+    expect(screen.getAllByText('user1').at(0)).toBeInTheDocument();
+    expect(screen.getByText('2024-01-01 00:00:00')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /open details/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should handle error state', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockQueryAuditLogs().withNetworkError();
+
+    render(<OperationsLogTab />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        isDismissable: true,
+        kind: 'error',
+        title: 'Audit logs could not be fetched',
+      }),
+    );
+  });
+
+  it('should show a warning if multiple element instances are selected', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchElementInstances().withSuccess({
+      items: [],
+      page: {
+        totalItems: 2,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<OperationsLogTab />, {
+      wrapper: getWrapper({elementId: 'Activity_1'}),
+    });
+
+    expect(
+      await screen.findByText(
+        'To view the Operations Log, select a single Element Instance in the Instance History.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/index.tsx
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect, useMemo, useState} from 'react';
+import {observer} from 'mobx-react';
+import {formatDate} from 'modules/utils/date';
+import {useAuditLogs} from 'modules/queries/auditLog/useAuditLogs';
+import {
+  type AuditLog,
+  type QueryAuditLogsRequestBody,
+  auditLogSortFieldEnum,
+} from '@camunda/camunda-api-zod-schemas/8.9/audit-log';
+import {Container, EmptyMessageContainer} from './styled';
+import {PaginatedSortableTable} from 'modules/components/PaginatedSortableTable';
+import {getSortParams} from 'modules/utils/filter';
+import {useLocation} from 'react-router-dom';
+import {Information} from '@carbon/react/icons';
+import {Button} from '@carbon/react';
+import {notificationsStore} from 'modules/stores/notifications';
+import {logger} from 'modules/logger';
+import {tracking} from 'modules/tracking';
+import {spaceAndCapitalize} from 'modules/utils/spaceAndCapitalize';
+import {
+  DetailsModal,
+  type DetailsModalState,
+} from 'modules/components/OperationsLogDetailsModal';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {EmptyMessage} from 'modules/components/EmptyMessage';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {CellResult} from 'App/OperationsLog/InstancesTable/Cell/CellResult';
+import {CellActor} from 'App/OperationsLog/InstancesTable/Cell/CellActor';
+import {CellEntityKey} from 'App/OperationsLog/InstancesTable/Cell/CellEntityKey';
+import {Filters} from './Filters';
+import {
+  auditLogEntityTypeSchema,
+  auditLogOperationTypeSchema,
+} from '@camunda/camunda-api-zod-schemas/8.9';
+import {getFilters} from 'modules/utils/filter/getProcessInstanceFilters';
+import {
+  PROCESS_INSTANCE_AUDIT_LOG_FILTER_FIELDS,
+  type ProcessInstanceOperationsLogFilterField,
+  type ProcessInstanceOperationsLogFilters,
+} from './operationsLogFilters';
+
+const headerColumns = [
+  {
+    header: '',
+    key: 'result',
+  },
+  {
+    header: 'Operation Type',
+    key: 'operationType',
+    sortKey: 'operationType',
+  },
+  {
+    header: 'Entity Type',
+    key: 'entityType',
+    sortKey: 'entityType',
+  },
+  {
+    header: 'Entity Key',
+    key: 'entityKey',
+    sortKey: 'entityKey',
+  },
+  {
+    header: 'Actor',
+    key: 'user',
+    sortKey: 'actorId',
+  },
+  {
+    header: 'Date',
+    key: 'timestamp',
+    sortKey: 'timestamp',
+  },
+  {
+    header: '',
+    key: 'comment',
+    isDisabled: true,
+  },
+];
+
+const OperationsLogTab: React.FC = observer(() => {
+  const location = useLocation();
+  const sortParams = getSortParams(location.search) || {
+    sortBy: 'timestamp',
+    sortOrder: 'desc',
+  };
+  const sortByParsed = auditLogSortFieldEnum.safeParse(sortParams.sortBy);
+  const sortBy = sortByParsed.success ? sortByParsed.data : 'timestamp';
+  const {processInstanceId: processInstanceKey} =
+    useProcessInstancePageParams();
+  const {resolvedElementInstance, isFetchingElement, hasSelection} =
+    useProcessInstanceElementSelection();
+  const elementInstanceKey = resolvedElementInstance?.elementInstanceKey;
+  const hasMultipleInstances =
+    resolvedElementInstance?.elementInstanceKey === undefined && hasSelection;
+
+  const filterValues = getFilters<
+    ProcessInstanceOperationsLogFilterField,
+    ProcessInstanceOperationsLogFilters
+  >(location.search, PROCESS_INSTANCE_AUDIT_LOG_FILTER_FIELDS, []);
+
+  const request = useMemo(
+    (): QueryAuditLogsRequestBody => ({
+      sort: [
+        {
+          field: sortBy,
+          order: sortParams.sortOrder,
+        },
+      ],
+      filter: {
+        category: {$neq: 'ADMIN'},
+        processInstanceKey,
+        elementInstanceKey: elementInstanceKey ?? undefined,
+        operationType: filterValues.operationType
+          ? {
+              $in: filterValues.operationType
+                .split(',')
+                .map((v) => auditLogOperationTypeSchema.parse(v)),
+            }
+          : undefined,
+        entityType: filterValues.entityType
+          ? {
+              $in: filterValues.entityType
+                .split(',')
+                .map((v) => auditLogEntityTypeSchema.parse(v)),
+            }
+          : undefined,
+      },
+    }),
+    [
+      sortBy,
+      sortParams.sortOrder,
+      processInstanceKey,
+      elementInstanceKey,
+      filterValues.operationType,
+      filterValues.entityType,
+    ],
+  );
+
+  const {
+    isPending,
+    data,
+    isLoading,
+    error,
+    isFetchingPreviousPage,
+    hasPreviousPage,
+    fetchPreviousPage,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useAuditLogs(request, {
+    enabled: !isFetchingElement && !hasMultipleInstances,
+    select: (data) => {
+      tracking.track({
+        eventName: 'audit-logs-loaded',
+        filters: Object.keys(request.filter ?? {}),
+        sort: request.sort,
+      });
+      return {
+        auditLogs: data.pages.flatMap((page) => page.items),
+        totalCount: data.pages.at(0)?.page.totalItems ?? 0,
+      };
+    },
+  });
+
+  const [detailsModal, setDetailsModal] = useState<DetailsModalState>({
+    isOpen: false,
+  });
+
+  useEffect(() => {
+    if (error !== null) {
+      tracking.track({
+        eventName: 'audit-logs-fetch-failed',
+      });
+      notificationsStore.displayNotification({
+        isDismissable: true,
+        kind: 'error',
+        title: 'Audit logs could not be fetched',
+      });
+      logger.error(error);
+    }
+  }, [error]);
+
+  const rows = useMemo(
+    () =>
+      data?.auditLogs.map((item: AuditLog) => ({
+        id: item.auditLogKey,
+        result: <CellResult item={item} />,
+        operationType: spaceAndCapitalize(item.operationType.toString()),
+        entityType: spaceAndCapitalize(item.entityType.toString()),
+        entityKey: <CellEntityKey item={item} />,
+        user: <CellActor item={item} />,
+        timestamp: formatDate(item.timestamp),
+        comment: (
+          <Button
+            kind="ghost"
+            size="sm"
+            tooltipPosition="left"
+            iconDescription="Open details"
+            aria-label="Open details"
+            onClick={() => setDetailsModal({isOpen: true, auditLog: item})}
+            hasIconOnly
+            renderIcon={Information}
+          />
+        ),
+      })) || [],
+    [data],
+  );
+
+  const getTableState = () => {
+    if (isPending) {
+      return 'skeleton';
+    }
+
+    if (isLoading) {
+      return 'loading';
+    }
+
+    if (error) {
+      return 'error';
+    }
+
+    if (rows.length === 0) {
+      return 'empty';
+    }
+    return 'content';
+  };
+
+  if (hasMultipleInstances) {
+    return (
+      <Container>
+        <EmptyMessageContainer>
+          <EmptyMessage message="To view the Operations Log, select a single Element Instance in the Instance History." />
+        </EmptyMessageContainer>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <Filters />
+      <PaginatedSortableTable
+        state={getTableState()}
+        rows={rows}
+        emptyMessage={{
+          message: 'No operations found for this instance',
+        }}
+        headerColumns={headerColumns}
+        pagination={{
+          hasPreviousPage,
+          hasNextPage,
+          isFetchingPreviousPage,
+          isFetchingNextPage,
+          fetchPreviousPage,
+          fetchNextPage,
+        }}
+        stickyHeader
+      />
+      {detailsModal.auditLog && (
+        <DetailsModal
+          isOpen={detailsModal.isOpen}
+          onClose={() => setDetailsModal({isOpen: false})}
+          auditLog={detailsModal.auditLog}
+        />
+      )}
+    </Container>
+  );
+});
+
+export {OperationsLogTab};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/operationsLogFilters.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/operationsLogFilters.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+type ProcessInstanceOperationsLogFilters = {
+  operationType?: string;
+  entityType?: string;
+};
+
+type ProcessInstanceOperationsLogFilterField =
+  keyof ProcessInstanceOperationsLogFilters;
+
+const PROCESS_INSTANCE_AUDIT_LOG_FILTER_FIELDS: ProcessInstanceOperationsLogFilterField[] =
+  ['operationType', 'entityType'];
+
+export type {
+  ProcessInstanceOperationsLogFilters,
+  ProcessInstanceOperationsLogFilterField,
+};
+export {PROCESS_INSTANCE_AUDIT_LOG_FILTER_FIELDS};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/styled.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const Container = styled.section`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const EmptyMessageContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+
+export {Container, EmptyMessageContainer};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OutputMappingsTab.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OutputMappingsTab.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {InputOutputMappings} from './InputOutputMappings';
+
+const OutputMappingsTab: React.FC = () => {
+  const {selectedElementId} = useProcessInstanceElementSelection();
+
+  if (selectedElementId === null) {
+    return null;
+  }
+
+  return <InputOutputMappings type="Output" elementId={selectedElementId} />;
+};
+
+export {OutputMappingsTab};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/EditButtons.styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/EditButtons.styled.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {Loading as BaseLoading} from '@carbon/react';
+
+const Loading = styled(BaseLoading)`
+  align-self: center;
+  justify-self: center;
+`;
+
+export {Loading};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/EditButtons.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/EditButtons.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useForm, useFormState} from 'react-final-form';
+import {getError} from './getError';
+import {useFieldError} from 'modules/hooks/useFieldError';
+import {Button} from '@carbon/react';
+import {Checkmark, Close} from '@carbon/react/icons';
+import {Loading} from './EditButtons.styled';
+
+const EditButtons: React.FC = () => {
+  const form = useForm();
+  const {values, initialValues, validating, hasValidationErrors} =
+    useFormState();
+
+  const nameError = useFieldError('name');
+  const valueError = useFieldError('value');
+  const errorMessage = getError(
+    initialValues?.name === '' ? nameError : undefined,
+    valueError,
+  );
+
+  return (
+    <>
+      <Button
+        kind="ghost"
+        size="sm"
+        iconDescription="Exit edit mode"
+        aria-label="Exit edit mode"
+        tooltipPosition="left"
+        onClick={() => {
+          form.reset({});
+        }}
+        hasIconOnly
+        renderIcon={Close}
+        disabled={form.getState().submitting}
+      />
+
+      {form.getState().submitting ? (
+        <Loading small withOverlay={false} data-testid="full-variable-loader" />
+      ) : (
+        <Button
+          kind="ghost"
+          size="sm"
+          iconDescription="Save variable"
+          aria-label="Save variable"
+          tooltipPosition="left"
+          disabled={
+            initialValues?.value === values?.value ||
+            validating ||
+            hasValidationErrors ||
+            errorMessage !== undefined
+          }
+          onClick={() => form.submit()}
+          hasIconOnly
+          renderIcon={Checkmark}
+        />
+      )}
+    </>
+  );
+};
+
+export {EditButtons};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ExistingVariableValue.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ExistingVariableValue.tsx
@@ -1,0 +1,247 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  validateValueComplete,
+  validateValueNotEmpty,
+  validateValueValid,
+} from './validators';
+import {Field, useField, useForm, useFormState} from 'react-final-form';
+import {useEffect, useState} from 'react';
+import {JSONEditorModal} from 'modules/components/JSONEditorModal';
+import {tracking} from 'modules/tracking';
+import {observer} from 'mobx-react';
+import {modificationsStore} from 'modules/stores/modifications';
+import {createVariableFieldName} from './createVariableFieldName';
+import {mergeValidators} from 'modules/utils/validators/mergeValidators';
+import {Maximize} from '@carbon/react/icons';
+import {LoadingTextfield} from './LoadingTextField';
+import {Layer} from '@carbon/react';
+import {useSelectedElementName} from 'modules/hooks/elementSelection';
+import type {Variable} from '@camunda/camunda-api-zod-schemas/8.9';
+import {useVariable} from 'modules/queries/variables/useVariable';
+import {notificationsStore} from 'modules/stores/notifications';
+import {useVariableScopeKey} from 'modules/hooks/variables';
+
+type Props = {
+  id?: string;
+  variableName: string;
+  variableValue: string;
+  isPreview?: boolean;
+};
+
+const createModification = ({
+  scopeId,
+  isValid,
+  isDirty,
+  name,
+  oldValue,
+  newValue,
+  selectedElementName,
+}: {
+  scopeId: string | null;
+  isValid: boolean;
+  isDirty: boolean;
+  name: string;
+  oldValue: string;
+  newValue: string;
+  selectedElementName: string;
+}) => {
+  if (
+    !modificationsStore.isModificationModeEnabled ||
+    scopeId === null ||
+    !isValid ||
+    newValue === ''
+  ) {
+    return;
+  }
+
+  const lastEditModification = modificationsStore.getLastVariableModification(
+    scopeId,
+    name,
+    'EDIT_VARIABLE',
+  );
+
+  if (
+    lastEditModification?.newValue !== newValue &&
+    (isDirty ||
+      (lastEditModification !== undefined &&
+        lastEditModification.newValue !== newValue))
+  ) {
+    modificationsStore.addModification({
+      type: 'variable',
+      payload: {
+        operation: 'EDIT_VARIABLE',
+        id: name,
+        scopeId,
+        elementName: selectedElementName,
+        name,
+        oldValue,
+        newValue,
+      },
+    });
+  }
+};
+
+const ExistingVariableValue: React.FC<Props> = observer(
+  ({id, variableName, variableValue, isPreview}) => {
+    const {isModificationModeEnabled} = modificationsStore;
+    const formState = useFormState();
+    const selectedElementName = useSelectedElementName() || '';
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const form = useForm();
+    const {
+      data: variable,
+      isLoading,
+      error,
+    } = useVariable(id!, {
+      enabled: isPreview && id !== undefined,
+    });
+    const variableScopeKey = useVariableScopeKey();
+
+    useEffect(() => {
+      if (error) {
+        notificationsStore.displayNotification({
+          kind: 'error',
+          title: 'Variable could not be fetched',
+          isDismissable: true,
+        });
+      }
+    }, [error]);
+
+    const fieldName = isModificationModeEnabled
+      ? createVariableFieldName(variableName)
+      : 'value';
+
+    const {
+      meta: {validating, valid},
+    } = useField(fieldName);
+
+    const isValid = !validating && valid;
+
+    const pendingEditModification =
+      isModificationModeEnabled && variableScopeKey !== null
+        ? modificationsStore.getLastVariableModification(
+            variableScopeKey,
+            variableName,
+            'EDIT_VARIABLE',
+          )
+        : undefined;
+
+    const getInitialValue = (variable?: Variable) => {
+      if (pendingEditModification !== undefined) {
+        return pendingEditModification.newValue;
+      }
+      return variable?.value ?? variableValue;
+    };
+
+    const isVariableValueUndefined = variable?.value === undefined;
+    const pauseValidation = isPreview && isVariableValueUndefined;
+
+    return (
+      <Layer>
+        <Field
+          name={fieldName}
+          initialValue={getInitialValue(variable)}
+          validate={
+            pauseValidation
+              ? () => undefined
+              : mergeValidators(
+                  validateValueComplete,
+                  validateValueValid,
+                  validateValueNotEmpty,
+                )
+          }
+          parse={(value) => value}
+        >
+          {({input, meta}) => (
+            <LoadingTextfield
+              {...input}
+              size="sm"
+              type="text"
+              id={fieldName}
+              hideLabel
+              disabled={formState.submitting}
+              labelText="Value"
+              placeholder="Value"
+              data-testid="edit-variable-value"
+              buttonLabel="Open JSON editor"
+              tooltipPosition="left"
+              onIconClick={() => {
+                if (formState.submitting) {
+                  return;
+                }
+
+                setIsModalVisible(true);
+                tracking.track({
+                  eventName: 'json-editor-opened',
+                  variant: 'edit-variable',
+                });
+              }}
+              Icon={Maximize}
+              autoFocus={!isModificationModeEnabled || meta.active}
+              isLoading={isLoading}
+              onFocus={(event) => {
+                if (!meta.active) {
+                  input.onFocus(event);
+                }
+              }}
+              onBlur={(event) => {
+                createModification({
+                  scopeId: variableScopeKey,
+                  name: variableName,
+                  oldValue: getInitialValue(variable),
+                  newValue: input.value ?? '',
+                  isDirty: getInitialValue(variable) !== input.value,
+                  isValid: isValid ?? false,
+                  selectedElementName,
+                });
+
+                input.onBlur(event);
+              }}
+            />
+          )}
+        </Field>
+        {isModalVisible && (
+          <JSONEditorModal
+            isVisible={isModalVisible}
+            title={`Edit Variable "${variableName}"`}
+            value={formState.values?.[fieldName]}
+            onClose={() => {
+              setIsModalVisible(false);
+              tracking.track({
+                eventName: 'json-editor-closed',
+                variant: 'edit-variable',
+              });
+            }}
+            onApply={(value) => {
+              form.change(fieldName, value);
+              setIsModalVisible(false);
+              tracking.track({
+                eventName: 'json-editor-saved',
+                variant: 'edit-variable',
+              });
+
+              createModification({
+                scopeId: variableScopeKey,
+                name: variableName,
+                oldValue: getInitialValue(variable),
+                newValue: value ?? '',
+                isDirty: getInitialValue(variable) !== value,
+                isValid: isValid ?? false,
+                selectedElementName,
+              });
+            }}
+          />
+        )}
+      </Layer>
+    );
+  },
+);
+
+export {ExistingVariableValue};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/AddVariableButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/AddVariableButton.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Button} from '@carbon/react';
+import {Add} from '@carbon/react/icons';
+
+type Props = {
+  disabled?: boolean;
+  onClick: () => void;
+  className?: string;
+};
+
+const AddVariableButton: React.FC<Props> = ({
+  disabled = false,
+  onClick,
+  className,
+}) => {
+  return (
+    <Button
+      kind="ghost"
+      size="md"
+      onClick={onClick}
+      disabled={disabled}
+      className={className}
+      renderIcon={Add}
+    >
+      Add Variable
+    </Button>
+  );
+};
+
+export {AddVariableButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/CopyVariablesButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/CopyVariablesButton.test.tsx
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {CopyVariablesButton} from './CopyVariablesButton';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {createVariable, createProcessInstance} from 'modules/testUtils';
+import type {QueryVariablesResponseBody} from '@camunda/camunda-api-zod-schemas/8.9';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockServer} from 'modules/mock-server/node';
+
+import {writeToClipboard} from './writeToClipboard';
+import {http, HttpResponse} from 'msw';
+
+vi.mock('./writeToClipboard', () => ({
+  writeToClipboard: vi.fn(),
+}));
+const mockWriteToClipboard = vi.mocked(writeToClipboard);
+
+const createWrapper = (processInstanceId = '123456') => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter initialEntries={[Paths.processInstance(processInstanceId)]}>
+        <Routes>
+          <Route path={Paths.processInstance()} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+describe('CopyVariableButton', () => {
+  it('should be disabled (no variables)', () => {
+    const emptyResponse: QueryVariablesResponseBody = {
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    };
+
+    mockServer.use(
+      http.get(
+        '/v2/process-instances/:processInstanceKey',
+        () => {
+          return HttpResponse.json(
+            createProcessInstance({processInstanceKey: '123456'}),
+          );
+        },
+        {once: true},
+      ),
+      http.post(
+        '/v2/variables/search',
+        () => {
+          return HttpResponse.json(emptyResponse);
+        },
+        {once: true},
+      ),
+    );
+
+    render(<CopyVariablesButton />, {wrapper: createWrapper()});
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('should be disabled (too many variables)', () => {
+    const variables = [...Array(50)].map((_, i) =>
+      createVariable({
+        name: i.toString(),
+        value: 'value',
+      }),
+    );
+
+    const response: QueryVariablesResponseBody = {
+      items: variables,
+      page: {
+        totalItems: 100,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    };
+
+    mockServer.use(
+      http.get(
+        '/v2/process-instances/:processInstanceKey',
+        () => {
+          return HttpResponse.json(
+            createProcessInstance({processInstanceKey: '123456'}),
+          );
+        },
+        {once: true},
+      ),
+      http.post(
+        '/v2/variables/search',
+        () => {
+          return HttpResponse.json(response);
+        },
+        {once: true},
+      ),
+    );
+
+    render(<CopyVariablesButton />, {wrapper: createWrapper()});
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('should be disabled (truncated values)', () => {
+    const response: QueryVariablesResponseBody = {
+      items: [createVariable({isTruncated: true})],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    };
+
+    mockServer.use(
+      http.get(
+        '/v2/process-instances/:processInstanceKey',
+        () => {
+          return HttpResponse.json(
+            createProcessInstance({processInstanceKey: '123456'}),
+          );
+        },
+        {once: true},
+      ),
+      http.post(
+        '/v2/variables/search',
+        () => {
+          return HttpResponse.json(response);
+        },
+        {once: true},
+      ),
+    );
+
+    render(<CopyVariablesButton />, {wrapper: createWrapper()});
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('should copy variables to clipboard', async () => {
+    const response: QueryVariablesResponseBody = {
+      items: [
+        createVariable({
+          name: 'jsonVariable',
+          value: JSON.stringify({a: 123, b: [1, 2, 3], c: 'text'}),
+        }),
+        createVariable({
+          name: 'numberVariable',
+          value: '666',
+        }),
+        createVariable({
+          name: 'stringVariable',
+          value: '"text"',
+        }),
+      ],
+      page: {
+        totalItems: 3,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    };
+
+    mockServer.use(
+      http.get(
+        '/v2/process-instances/:processInstanceKey',
+        () => {
+          return HttpResponse.json(
+            createProcessInstance({processInstanceKey: '123456'}),
+          );
+        },
+        {once: true},
+      ),
+      http.post(
+        '/v2/variables/search',
+        () => {
+          return HttpResponse.json(response);
+        },
+        {once: true},
+      ),
+    );
+
+    const {user} = render(<CopyVariablesButton />, {wrapper: createWrapper()});
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: 'Copy variables',
+        }),
+      ).toBeEnabled();
+    });
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Copy variables',
+      }),
+    );
+
+    expect(mockWriteToClipboard).toHaveBeenCalledWith(
+      '{"jsonVariable":{"a":123,"b":[1,2,3],"c":"text"},"numberVariable":666,"stringVariable":"text"}',
+    );
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/CopyVariablesButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/CopyVariablesButton.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Button} from '@carbon/react';
+import {Copy} from '@carbon/react/icons';
+import {
+  hasItems,
+  isPaginated,
+  isTruncated,
+  variablesAsJSON,
+} from 'modules/utils/variables';
+import {useVariables} from 'modules/queries/variables/useVariables';
+import {writeToClipboard} from './writeToClipboard';
+
+const CopyVariablesButton: React.FC = () => {
+  const {data} = useVariables();
+
+  const getErrorMessage = () => {
+    if (isPaginated(data)) {
+      return 'Copying is disabled for 50 variables or more';
+    }
+
+    if (isTruncated(data)) {
+      return 'Copying is disabled for variable values larger than 8192 characters';
+    }
+  };
+
+  const isDisabled = isPaginated(data) || isTruncated(data) || !hasItems(data);
+
+  return (
+    <Button
+      kind="ghost"
+      size="md"
+      disabled={isDisabled}
+      title={getErrorMessage() ?? 'Click to copy variables to clipboard'}
+      onClick={() => {
+        writeToClipboard(variablesAsJSON(data));
+      }}
+      renderIcon={Copy}
+    >
+      Copy variables
+    </Button>
+  );
+};
+
+export {CopyVariablesButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/NewVariable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/NewVariable.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {Field, useForm, useFormState} from 'react-final-form';
+import {Layer} from './styled';
+import {
+  validateNameCharacters,
+  validateValueValid,
+  validateValueComplete,
+  validateNameComplete,
+  validateNameNotDuplicate,
+} from '../validators';
+import {mergeValidators} from 'modules/utils/validators/mergeValidators';
+import {JSONEditorModal} from 'modules/components/JSONEditorModal';
+import {tracking} from 'modules/tracking';
+import {TextInputField} from 'modules/components/TextInputField';
+import {IconTextInputField} from 'modules/components/IconTextInputField';
+import {Maximize} from '@carbon/react/icons';
+import {Operations} from '../Operations';
+import {EditButtons} from '../EditButtons';
+import {useVariables} from 'modules/queries/variables/useVariables';
+
+const NewVariable: React.FC = () => {
+  const formState = useFormState();
+  const form = useForm();
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const {data: variablesData} = useVariables();
+  const allVariables =
+    variablesData?.pages.flatMap((page) => (page.items ? page.items : [])) ??
+    [];
+
+  return (
+    <>
+      <Layer>
+        <Field
+          name="name"
+          validate={mergeValidators(
+            validateNameCharacters,
+            validateNameComplete(allVariables),
+            validateNameNotDuplicate(allVariables),
+          )}
+          allowNull={false}
+          parse={(value) => value}
+        >
+          {({input}) => (
+            <TextInputField
+              {...input}
+              id="name"
+              size="sm"
+              hideLabel
+              labelText="Name"
+              type="text"
+              placeholder="Name"
+              autoFocus={true}
+            />
+          )}
+        </Field>
+        <Field
+          name="value"
+          validate={mergeValidators(validateValueComplete, validateValueValid)}
+          parse={(value) => value}
+        >
+          {({input}) => (
+            <IconTextInputField
+              {...input}
+              size="sm"
+              type="text"
+              id="value"
+              hideLabel
+              labelText="Value"
+              placeholder="Value"
+              buttonLabel="Open JSON editor"
+              tooltipPosition="left"
+              onIconClick={() => {
+                setIsModalVisible(true);
+                tracking.track({
+                  eventName: 'json-editor-opened',
+                  variant: 'add-variable',
+                });
+              }}
+              Icon={Maximize}
+            />
+          )}
+        </Field>
+        <Operations>
+          <EditButtons />
+        </Operations>
+      </Layer>
+      {isModalVisible && (
+        <JSONEditorModal
+          isVisible={isModalVisible}
+          title={
+            formState.values?.name
+              ? `Edit Variable "${formState.values?.name}"`
+              : 'Edit a new Variable'
+          }
+          value={formState.values?.value}
+          onClose={() => {
+            setIsModalVisible(false);
+            tracking.track({
+              eventName: 'json-editor-closed',
+              variant: 'add-variable',
+            });
+          }}
+          onApply={(value) => {
+            form.change('value', value);
+            setIsModalVisible(false);
+            tracking.track({
+              eventName: 'json-editor-saved',
+              variant: 'add-variable',
+            });
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export {NewVariable};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/index.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useForm} from 'react-final-form';
+import {NewVariable} from './NewVariable';
+import {FooterContainer} from './styled';
+import {AddVariableButton} from './AddVariableButton';
+import {CopyVariablesButton as CopyVariablesButtonV2} from './CopyVariablesButton';
+
+type Props = {
+  variant: 'initial' | 'disabled' | 'add-variable' | 'pending-variable';
+};
+
+const Footer: React.FC<Props> = ({variant}) => {
+  const form = useForm();
+
+  return (
+    <FooterContainer>
+      {variant === 'add-variable' && <NewVariable />}
+      {['initial', 'disabled'].includes(variant) && (
+        <AddVariableButton
+          onClick={() => {
+            form.reset({name: '', value: ''});
+          }}
+          disabled={variant === 'disabled'}
+        />
+      )}
+      <CopyVariablesButtonV2 />
+    </FooterContainer>
+  );
+};
+
+export {Footer};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/styled.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled, {css} from 'styled-components';
+import {Layer as BaseLayer} from '@carbon/react';
+
+const FooterContainer = styled.div`
+  margin-top: auto;
+  border-top: 1px solid var(--cds-border-subtle-01);
+`;
+
+type VariableContainerProps = {
+  $hasPendingVariable?: boolean;
+};
+
+const Layer = styled(BaseLayer)<VariableContainerProps>`
+  ${({$hasPendingVariable}) => {
+    return css`
+      width: 100%;
+      padding: var(--cds-spacing-02) var(--cds-spacing-07) var(--cds-spacing-02)
+        var(--cds-spacing-05);
+      display: grid;
+      grid-template-columns: 1fr 2fr auto;
+      grid-gap: var(--cds-spacing-05);
+      ${$hasPendingVariable &&
+      css`
+        background-color: var(--cds-layer);
+        align-items: center;
+      `}
+    `;
+  }};
+`;
+
+export {FooterContainer, Layer};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/writeToClipboard.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/writeToClipboard.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+function writeToClipboard(text: string) {
+  navigator.clipboard.writeText(text);
+}
+
+export {writeToClipboard};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/LoadingTextField/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/LoadingTextField/index.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {LoadingStateContainer} from './styled';
+import {IconTextInputField} from 'modules/components/IconTextInputField';
+import {Loading} from '@carbon/react';
+
+type Props = React.ComponentProps<typeof IconTextInputField> & {
+  isLoading: boolean;
+};
+
+const LoadingTextfield: React.FC<Props> = ({isLoading, ...props}) => {
+  if (isLoading) {
+    return (
+      <LoadingStateContainer>
+        <Loading small data-testid="full-variable-loader" />
+        <IconTextInputField {...props} />
+      </LoadingStateContainer>
+    );
+  }
+
+  return <IconTextInputField {...props} />;
+};
+
+export {LoadingTextfield};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/LoadingTextField/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/LoadingTextField/styled.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const LoadingStateContainer = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export {LoadingStateContainer};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Name.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Name.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Field, useForm} from 'react-final-form';
+import {createNewVariableFieldName} from '../createVariableFieldName';
+import {mergeValidators} from 'modules/utils/validators/mergeValidators';
+import {
+  validateNameCharacters,
+  validateModifiedNameComplete,
+  validateModifiedNameNotDuplicate,
+} from '../validators';
+import {TextInputField} from 'modules/components/TextInputField';
+import {useVariableFormFields} from './useVariableFormFields';
+import {createModification} from './createModification';
+import {Layer} from '@carbon/react';
+import {useEffect, useRef} from 'react';
+import {useSelectedElementName} from 'modules/hooks/elementSelection';
+import {useVariables} from 'modules/queries/variables/useVariables';
+
+type Props = {
+  variableName: string;
+  scopeId: string | null;
+};
+
+const Name: React.FC<Props> = ({variableName, scopeId}) => {
+  const form = useForm();
+
+  const {currentName, currentValue, currentId, areFormFieldsValid} =
+    useVariableFormFields(variableName);
+  const selectedElementName = useSelectedElementName() || '';
+  const inputRef = useRef<HTMLInputElement>(null);
+  const {data: variablesData} = useVariables();
+  const allVariables =
+    variablesData?.pages.flatMap((page) => (page.items ? page.items : [])) ??
+    [];
+
+  useEffect(() => {
+    inputRef?.current?.focus();
+  }, []);
+
+  return (
+    <Layer>
+      <Field
+        name={createNewVariableFieldName(variableName, 'name')}
+        validate={mergeValidators(
+          validateNameCharacters,
+          validateModifiedNameComplete,
+          validateModifiedNameNotDuplicate(allVariables),
+        )}
+        allowNull={false}
+        parse={(value) => value}
+      >
+        {({input}) => (
+          <TextInputField
+            {...input}
+            ref={inputRef}
+            data-testid="new-variable-name"
+            type="text"
+            placeholder="Name"
+            id={createNewVariableFieldName(variableName, 'name')}
+            size="sm"
+            hideLabel
+            labelText="Name"
+            onBlur={() => {
+              form.mutators?.triggerValidation?.(
+                createNewVariableFieldName(variableName, 'name'),
+              );
+
+              input.onBlur();
+
+              createModification({
+                scopeId,
+                areFormFieldsValid,
+                id: currentId,
+                name: currentName,
+                value: currentValue,
+                selectedElementName,
+              });
+            }}
+          />
+        )}
+      </Field>
+    </Layer>
+  );
+};
+
+export {Name};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Operation.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Operation.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useField} from 'react-final-form';
+import {createNewVariableFieldName} from '../createVariableFieldName';
+
+import {modificationsStore} from 'modules/stores/modifications';
+import {Button} from '@carbon/react';
+import {TrashCan} from '@carbon/react/icons';
+import {Operations} from '../Operations';
+import {useNewScopeKeyForElement} from 'modules/hooks/modifications';
+import {useVariableScopeKey} from 'modules/hooks/variables';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+
+type Props = {
+  variableName: string;
+  onRemove: () => void;
+};
+
+const Operation: React.FC<Props> = ({variableName, onRemove}) => {
+  const {
+    input: {value: currentId},
+  } = useField(createNewVariableFieldName(variableName, 'id'));
+  const {selectedElementId} = useProcessInstanceElementSelection();
+  const newScopeKeyForElement = useNewScopeKeyForElement(selectedElementId);
+  const scopeKey = useVariableScopeKey(newScopeKeyForElement);
+  return (
+    <Operations>
+      <Button
+        kind="ghost"
+        size="sm"
+        hasIconOnly
+        renderIcon={TrashCan}
+        iconDescription="Delete Variable"
+        tooltipPosition="left"
+        onClick={() => {
+          onRemove();
+          modificationsStore.removeVariableModification(
+            scopeKey!,
+            currentId,
+            'ADD_VARIABLE',
+            'variables',
+          );
+        }}
+      />
+    </Operations>
+  );
+};
+
+export {Operation};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Value.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Value.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {Field, useForm, useFormState} from 'react-final-form';
+import get from 'lodash/get';
+import {createNewVariableFieldName} from '../createVariableFieldName';
+import {JSONEditorModal} from 'modules/components/JSONEditorModal';
+import {mergeValidators} from 'modules/utils/validators/mergeValidators';
+import {
+  validateModifiedValueComplete,
+  validateModifiedValueValid,
+} from '../validators';
+import {IconTextInputField} from 'modules/components/IconTextInputField';
+import {Maximize} from '@carbon/react/icons';
+import {useVariableFormFields} from './useVariableFormFields';
+import {createModification} from './createModification';
+import {Layer} from '@carbon/react';
+import {useSelectedElementName} from 'modules/hooks/elementSelection';
+
+type Props = {
+  variableName: string;
+  scopeId: string | null;
+};
+
+const Value: React.FC<Props> = ({variableName, scopeId}) => {
+  const formState = useFormState();
+  const form = useForm();
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const valueFieldName = createNewVariableFieldName(variableName, 'value');
+  const selectedElementName = useSelectedElementName() || '';
+
+  const {
+    currentName,
+    currentValue,
+    currentId,
+    isNameFieldValid,
+    areFormFieldsValid,
+  } = useVariableFormFields(variableName);
+
+  return (
+    <Layer>
+      <Field
+        name={valueFieldName}
+        validate={mergeValidators(
+          validateModifiedValueComplete,
+          validateModifiedValueValid,
+        )}
+        parse={(value) => value}
+      >
+        {({input}) => (
+          <IconTextInputField
+            {...input}
+            data-testid="new-variable-value"
+            size="sm"
+            type="text"
+            id={valueFieldName}
+            hideLabel
+            labelText="Value"
+            placeholder="Value"
+            buttonLabel="Open JSON editor"
+            tooltipPosition="left"
+            onIconClick={() => {
+              setIsModalVisible(true);
+            }}
+            Icon={Maximize}
+            onBlur={() => {
+              form.mutators?.triggerValidation?.(valueFieldName);
+              input.onBlur();
+
+              createModification({
+                scopeId,
+                areFormFieldsValid,
+                id: currentId,
+                name: currentName,
+                value: currentValue,
+                selectedElementName,
+              });
+            }}
+          />
+        )}
+      </Field>
+
+      {isModalVisible && (
+        <JSONEditorModal
+          isVisible={isModalVisible}
+          title="Edit a new Variable"
+          value={get(formState.values, valueFieldName)}
+          onClose={() => {
+            setIsModalVisible(false);
+          }}
+          onApply={(value) => {
+            form.change(valueFieldName, value);
+            setIsModalVisible(false);
+            if (value !== undefined) {
+              createModification({
+                scopeId,
+                areFormFieldsValid:
+                  (isNameFieldValid &&
+                    form.getFieldState(valueFieldName)?.valid) ??
+                  false,
+                id: currentId,
+                name: currentName,
+                value: value,
+                selectedElementName,
+              });
+            }
+          }}
+        />
+      )}
+    </Layer>
+  );
+};
+
+export {Value};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/createModification.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/createModification.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {modificationsStore} from 'modules/stores/modifications';
+
+const createModification = ({
+  scopeId,
+  areFormFieldsValid,
+  id,
+  name,
+  value,
+  selectedElementName,
+}: {
+  scopeId: string | null;
+  areFormFieldsValid: boolean;
+  id: string;
+  name: string;
+  value: string;
+  selectedElementName: string;
+}) => {
+  if (scopeId === null || !areFormFieldsValid || name === '' || value === '') {
+    return;
+  }
+
+  const lastAddModification = modificationsStore.getLastVariableModification(
+    scopeId,
+    id,
+    'ADD_VARIABLE',
+  );
+
+  if (
+    lastAddModification === undefined ||
+    lastAddModification.name !== name ||
+    lastAddModification.newValue !== value
+  ) {
+    modificationsStore.addModification({
+      type: 'variable',
+      payload: {
+        operation: 'ADD_VARIABLE',
+        scopeId,
+        id,
+        elementName: selectedElementName,
+        name,
+        newValue: value,
+      },
+    });
+  }
+};
+
+export {createModification};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/useVariableFormFields.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/useVariableFormFields.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useField} from 'react-final-form';
+
+import {createNewVariableFieldName} from '../createVariableFieldName';
+
+const useVariableFormFields = (variableName: string) => {
+  const {
+    meta: {valid: isNameValid, validating: isNameValidating},
+    input: {value: currentName},
+  } = useField(createNewVariableFieldName(variableName, 'name'));
+
+  const {
+    meta: {valid: isValueValid, validating: isValueValidating},
+    input: {value: currentValue},
+  } = useField(createNewVariableFieldName(variableName, 'value'));
+
+  const {
+    input: {value: currentId},
+  } = useField(createNewVariableFieldName(variableName, 'id'));
+
+  const isNameFieldValid = (!isNameValidating && isNameValid) ?? false;
+  const isValueFieldValid = (!isValueValidating && isValueValid) ?? false;
+
+  return {
+    areFormFieldsValid: isNameFieldValid && isValueFieldValid,
+    isNameFieldValid,
+    currentName,
+    currentValue,
+    currentId,
+  };
+};
+
+export {useVariableFormFields};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/OnLastVariableModificationRemoved.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/OnLastVariableModificationRemoved.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useEffect} from 'react';
+import {modificationsStore} from 'modules/stores/modifications';
+import {observer} from 'mobx-react';
+import {useForm, useFormState} from 'react-final-form';
+import {createVariableFieldName} from './createVariableFieldName';
+import {reaction} from 'mobx';
+import {type VariableFormValues} from 'modules/types/variables';
+import {useFieldArray} from 'react-final-form-arrays';
+import {useVariableScopeKey} from 'modules/hooks/variables';
+
+const OnLastVariableModificationRemoved: React.FC = observer(() => {
+  const scopeKey = useVariableScopeKey();
+  const form = useForm();
+  const formState = useFormState<VariableFormValues>();
+  const fieldArray = useFieldArray('newVariables');
+  const newVariables = formState.values?.newVariables;
+
+  useEffect(() => {
+    const disposer = reaction(
+      () => modificationsStore.state.lastRemovedModification,
+      (lastRemovedModification) => {
+        if (
+          lastRemovedModification?.modification === undefined ||
+          lastRemovedModification.modification.type === 'token'
+        ) {
+          return;
+        }
+
+        const {payload} = lastRemovedModification.modification;
+
+        if (payload.operation === 'EDIT_VARIABLE') {
+          const {scopeId: removedVariableScopeId, id, name, oldValue} = payload;
+
+          if (removedVariableScopeId !== scopeKey) {
+            return;
+          }
+
+          const lastEditModification =
+            modificationsStore.getLastVariableModification(
+              scopeKey,
+              id,
+              'EDIT_VARIABLE',
+            );
+
+          form.change(
+            createVariableFieldName(name),
+            lastEditModification !== undefined
+              ? lastEditModification.newValue
+              : oldValue,
+          );
+        } else if (payload.operation === 'ADD_VARIABLE') {
+          const {scopeId: removedVariableScopeId, id} = payload;
+
+          if (
+            removedVariableScopeId !== scopeKey ||
+            newVariables === undefined
+          ) {
+            return;
+          }
+
+          const lastAddModification =
+            modificationsStore.getLastVariableModification(
+              scopeKey,
+              id,
+              'ADD_VARIABLE',
+            );
+
+          const index = newVariables.findIndex((field) => field.id === id);
+
+          if (index !== -1 && lastRemovedModification.source !== 'variables') {
+            if (lastAddModification !== undefined) {
+              fieldArray.fields.update(index, {
+                id: lastAddModification.id,
+                name: lastAddModification.name,
+                value: lastAddModification.newValue,
+              });
+            } else {
+              fieldArray.fields.remove(index);
+            }
+          }
+        }
+      },
+    );
+
+    return () => {
+      disposer();
+    };
+  }, [scopeKey, form, fieldArray, newVariables]);
+
+  return null;
+});
+
+export {OnLastVariableModificationRemoved};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Operations/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Operations/index.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Container, InlineLoading} from './styled';
+
+type Props = {
+  className?: string;
+  showLoadingIndicator?: boolean;
+  children?: React.ReactNode;
+};
+
+const Operations: React.FC<Props> = ({
+  className,
+  showLoadingIndicator,
+  children,
+}) => {
+  return (
+    <Container className={className}>
+      {showLoadingIndicator && (
+        <InlineLoading data-testid="variable-operation-spinner" />
+      )}
+      {children}
+    </Container>
+  );
+};
+
+export {Operations};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Operations/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Operations/styled.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {InlineLoading as BaseInlineLoading} from '@carbon/react';
+
+type ContainerProps = {
+  className?: string;
+};
+
+const Container = styled.div<ContainerProps>`
+  display: flex;
+  justify-content: end;
+  min-width: var(--cds-spacing-10);
+
+  .cds--tooltip-content {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+`;
+
+const InlineLoading = styled(BaseInlineLoading)`
+  justify-content: end;
+`;
+
+export {Container, InlineLoading};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Skeleton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Skeleton/index.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Ul, Li, SkeletonText} from './styled';
+
+const VariableRow: React.FC = () => {
+  return (
+    <Li>
+      <SkeletonText width="276px" />
+      <SkeletonText width="384px" />
+    </Li>
+  );
+};
+
+const Skeleton: React.FC = () => {
+  return (
+    <Ul data-testid="variables-skeleton">
+      {[...Array(20)].map((_, index) => (
+        <VariableRow key={index} />
+      ))}
+    </Ul>
+  );
+};
+
+export {Skeleton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Skeleton/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Skeleton/styled.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {SkeletonText as BaseSkeletonText} from '@carbon/react';
+import styled from 'styled-components';
+
+const Ul = styled.ul`
+  overflow: hidden;
+`;
+
+const Li = styled.li`
+  margin: var(--cds-spacing-05);
+  display: flex;
+  gap: var(--cds-spacing-05);
+`;
+
+const SkeletonText = styled(BaseSkeletonText)`
+  margin: 0;
+`;
+
+export {Ul, Li, SkeletonText};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useRef} from 'react';
+import {useForm, useFormState} from 'react-final-form';
+import {Button, Loading} from '@carbon/react';
+import {Edit} from '@carbon/react/icons';
+import {StructuredList, VariableName, VariableValue} from './styled';
+import {StructuredRows} from 'modules/components/StructuredList';
+import {OnLastVariableModificationRemoved} from './OnLastVariableModificationRemoved';
+import {FieldArray} from 'react-final-form-arrays';
+import {Operations} from './Operations';
+import type {VariableFormValues} from 'modules/types/variables';
+import {EditButtons} from './EditButtons';
+import {ExistingVariableValue} from './ExistingVariableValue';
+import {Name} from './NewVariableModification/Name';
+import {Value} from './NewVariableModification/Value';
+import {Operation} from './NewVariableModification/Operation';
+import {ViewFullVariableButton} from './ViewFullVariableButton';
+import {useIsProcessInstanceRunning} from 'modules/queries/processInstance/useIsProcessInstanceRunning';
+import {useVariables} from 'modules/queries/variables/useVariables';
+
+type Props = {
+  scopeId: string | null;
+  isModificationModeEnabled?: boolean;
+  isVariableModificationAllowed?: boolean;
+};
+
+const VariablesTable: React.FC<Props> = ({
+  scopeId,
+  isModificationModeEnabled,
+  isVariableModificationAllowed,
+}) => {
+  const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
+  const {initialValues} = useFormState();
+  const form = useForm<VariableFormValues>();
+  const variableNameRef = useRef<HTMLDivElement>(null);
+
+  const {
+    data: variablesData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useVariables();
+
+  const isEditMode = (variableName: string) =>
+    (initialValues?.name === variableName && isProcessInstanceRunning) ||
+    isVariableModificationAllowed;
+
+  const rows =
+    variablesData?.pages?.flatMap((page) =>
+      page.items.map(({name, value, variableKey, isTruncated}) => ({
+        key: name,
+        dataTestId: `variable-${name}`,
+        columns: [
+          {
+            cellContent: (
+              <VariableName title={name} ref={variableNameRef}>
+                {name}
+              </VariableName>
+            ),
+            width: '35%',
+          },
+          {
+            cellContent: isEditMode(name) ? (
+              <ExistingVariableValue
+                id={variableKey}
+                variableName={name}
+                variableValue={value}
+                // TODO #46571: Verify if it's really optional
+                isPreview={Boolean(isTruncated)}
+              />
+            ) : (
+              <VariableValue $hasBackdrop={true}>
+                {isFetchingNextPage && (
+                  <Loading small data-testid="full-variable-loader" />
+                )}
+                {value}
+              </VariableValue>
+            ),
+            width: '55%',
+          },
+          {
+            cellContent: (
+              <Operations>
+                {(() => {
+                  if (isModificationModeEnabled) {
+                    return null;
+                  }
+
+                  if (!isProcessInstanceRunning) {
+                    if (isTruncated) {
+                      return (
+                        <ViewFullVariableButton
+                          variableName={name}
+                          variableKey={variableKey}
+                        />
+                      );
+                    }
+                    return null;
+                  }
+
+                  if (initialValues?.name === name) {
+                    return <EditButtons />;
+                  }
+
+                  return (
+                    <Button
+                      kind="ghost"
+                      size="sm"
+                      tooltipPosition="left"
+                      iconDescription={`Edit variable ${name}`}
+                      aria-label={`Edit variable ${name}`}
+                      disabled={
+                        isFetchingNextPage || form.getState().submitting
+                      }
+                      onClick={async () => {
+                        form.reset({name, value});
+                        form.change('value', value);
+                      }}
+                      hasIconOnly
+                      renderIcon={Edit}
+                    />
+                  );
+                })()}
+              </Operations>
+            ),
+            width: '10%',
+          },
+        ],
+      })),
+    ) ?? [];
+
+  return (
+    <StructuredList
+      dataTestId="variables-list"
+      headerColumns={[
+        {cellContent: 'Name', width: '35%'},
+        {cellContent: 'Value', width: '55%'},
+        {cellContent: '', width: '10%'},
+      ]}
+      headerSize="sm"
+      verticalCellPadding="var(--cds-spacing-02)"
+      label="Variable List"
+      onVerticalScrollEndReach={() => {
+        if (hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      }}
+      dynamicRows={
+        isVariableModificationAllowed ? (
+          <>
+            <OnLastVariableModificationRemoved />
+            <FieldArray name="newVariables">
+              {({fields}) => (
+                <StructuredRows
+                  verticalCellPadding="var(--cds-spacing-02)"
+                  rows={fields.map((variableName, index) => ({
+                    key: fields.value[index]?.id ?? variableName,
+                    dataTestId: `variable-${variableName}`,
+                    columns: [
+                      {
+                        cellContent: (
+                          <Name variableName={variableName} scopeId={scopeId} />
+                        ),
+                        width: '35%',
+                      },
+                      {
+                        cellContent: (
+                          <Value
+                            variableName={variableName}
+                            scopeId={scopeId}
+                          />
+                        ),
+                        width: '55%',
+                      },
+                      {
+                        cellContent: (
+                          <Operation
+                            variableName={variableName}
+                            onRemove={() => {
+                              fields.remove(index);
+                            }}
+                          />
+                        ),
+                        width: '10%',
+                      },
+                    ],
+                  }))}
+                />
+              )}
+            </FieldArray>
+          </>
+        ) : undefined
+      }
+      rows={rows}
+    />
+  );
+};
+
+export {VariablesTable};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
+import {ViewFullVariableButton} from './index';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockGetVariable} from 'modules/mocks/api/v2/variables/getVariable';
+import {createVariable} from 'modules/testUtils';
+
+const createWrapper = () => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+describe('<ViewFullVariableButton />', () => {
+  it('should load full value', async () => {
+    const mockVariableName = 'foo-variable';
+    const mockVariableKey = 'variable-key-123';
+    const mockVariableValue = '{"foo": "bar", "test": 123}';
+
+    mockGetVariable().withSuccess(
+      createVariable({
+        variableKey: mockVariableKey,
+        name: mockVariableName,
+        value: mockVariableValue,
+      }),
+    );
+
+    const {user} = render(
+      <ViewFullVariableButton
+        variableName={mockVariableName}
+        variableKey={mockVariableKey}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /view full value of foo-variable/i,
+      }),
+    );
+
+    expect(
+      screen.getByTestId('variable-operation-spinner'),
+    ).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variable-operation-spinner'),
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {name: `Full value of ${mockVariableName}`}),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/"foo": "bar"/)).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {JSONEditorModal} from 'modules/components/JSONEditorModal';
+import {Button} from '@carbon/react';
+import {Maximize} from '@carbon/react/icons';
+import {Operations} from '../Operations';
+import {useVariable} from 'modules/queries/variables/useVariable';
+
+type Props = {
+  variableName: string;
+  variableKey: string;
+};
+
+const ViewFullVariableButton: React.FC<Props> = ({
+  variableName,
+  variableKey,
+}) => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const {data, isLoading} = useVariable(variableKey, {
+    enabled: isModalVisible,
+  });
+  const variableValue = data?.value;
+
+  return (
+    <>
+      <Operations showLoadingIndicator={isLoading}>
+        <Button
+          kind="ghost"
+          hasIconOnly
+          renderIcon={Maximize}
+          size="sm"
+          aria-label={`View full value of ${variableName}`}
+          iconDescription={`View full value of ${variableName}`}
+          tooltipPosition="left"
+          onClick={async () => {
+            setIsModalVisible(true);
+          }}
+        />
+      </Operations>
+      {variableValue !== undefined && (
+        <JSONEditorModal
+          value={variableValue}
+          isVisible={isModalVisible}
+          readOnly
+          onClose={() => setIsModalVisible(false)}
+          title={`Full value of ${variableName}`}
+        />
+      )}
+    </>
+  );
+};
+
+export {ViewFullVariableButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/constants.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/constants.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const VALIDATION_DELAY = 1000;
+const ERRORS = {
+  EMPTY_NAME: 'Name has to be filled',
+  INVALID_NAME: 'Name is invalid',
+  DUPLICATE_NAME: 'Name should be unique',
+  INVALID_VALUE: 'Value has to be JSON',
+  EMPTY_VALUE: 'Value has to be filled',
+} as const;
+
+export {VALIDATION_DELAY, ERRORS};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/createVariableFieldName.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/createVariableFieldName.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  createVariableFieldName,
+  createNewVariableFieldName,
+} from './createVariableFieldName';
+
+describe('createVariableFieldName', () => {
+  it('should create variable field name', () => {
+    expect(createVariableFieldName('someVariableName')).toBe(
+      '#someVariableName',
+    );
+  });
+  it('should encode variable field name with dots', () => {
+    expect(createVariableFieldName('a.b')).toBe('#a%2Eb');
+  });
+  it('should create new variable field name', () => {
+    expect(createNewVariableFieldName('newVariables[0]', 'name')).toBe(
+      'newVariables[0].name',
+    );
+    expect(createNewVariableFieldName('newVariables[0]', 'value')).toBe(
+      'newVariables[0].value',
+    );
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/createVariableFieldName.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/createVariableFieldName.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const createVariableFieldName = (name: string): `#${string}` => {
+  return `#${encodeURIComponent(name).replace(/\./g, '%2E')}`;
+};
+
+const createNewVariableFieldName = (prefix: string, suffix: string) => {
+  return `${prefix}.${suffix}`;
+};
+
+export {createVariableFieldName, createNewVariableFieldName};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/getError.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/getError.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const getError = (
+  nameFieldError?: string,
+  valueFieldError?: string,
+): string | undefined => {
+  if (nameFieldError === undefined && valueFieldError === undefined) {
+    return;
+  }
+
+  if (nameFieldError !== undefined && valueFieldError !== undefined) {
+    return `${nameFieldError} and ${valueFieldError}`;
+  }
+
+  return nameFieldError ?? valueFieldError;
+};
+
+export {getError};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/getNewVariablePrefix.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/getNewVariablePrefix.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getNewVariablePrefix} from './getNewVariablePrefix';
+
+describe('getVariableFieldName', () => {
+  it('should get new variable prefix', () => {
+    expect(getNewVariablePrefix('newVariables[0].name')).toBe(
+      'newVariables[0]',
+    );
+    expect(getNewVariablePrefix('newVariables[0].value')).toBe(
+      'newVariables[0]',
+    );
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/getNewVariablePrefix.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/getNewVariablePrefix.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const getNewVariablePrefix = (variableName: string) => {
+  return variableName.replace('.name', '').replace('.value', '');
+};
+
+export {getNewVariablePrefix};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/index.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect, useState} from 'react';
+import {VariablesContent, EmptyMessageWrapper} from './styled';
+import {observer} from 'mobx-react';
+import {reaction} from 'mobx';
+import {useForm, useFormState} from 'react-final-form';
+import {modificationsStore} from 'modules/stores/modifications';
+import {useFieldArray} from 'react-final-form-arrays';
+import {type VariableFormValues} from 'modules/types/variables';
+import {EmptyMessage} from 'modules/components/EmptyMessage';
+import {VariablesTable} from './VariablesTable';
+import {Footer} from './Footer';
+import {Skeleton} from './Skeleton';
+import {useNewScopeKeyForElement} from 'modules/hooks/modifications';
+import {useIsProcessInstanceRunning} from 'modules/queries/processInstance/useIsProcessInstanceRunning';
+import {useVariables} from 'modules/queries/variables/useVariables';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useVariableScopeKey} from 'modules/hooks/variables';
+
+type Props = {
+  isVariableModificationAllowed?: boolean;
+};
+
+type FooterVariant = React.ComponentProps<typeof Footer>['variant'];
+
+const Variables: React.FC<Props> = observer(
+  ({isVariableModificationAllowed = false}) => {
+    const {displayStatus} = useVariables();
+    const {selectedElementId, resolvedElementInstance, hasSelection} =
+      useProcessInstanceElementSelection();
+    const newScopeKeyForElement = useNewScopeKeyForElement(selectedElementId);
+    const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
+    const [footerVariant, setFooterVariant] =
+      useState<FooterVariant>('initial');
+
+    const scopeKey = useVariableScopeKey(newScopeKeyForElement);
+
+    const {isModificationModeEnabled} = modificationsStore;
+
+    const form = useForm<VariableFormValues>();
+
+    useEffect(() => {
+      const disposer = reaction(
+        () => modificationsStore.isModificationModeEnabled,
+        (isModificationModeEnabled) => {
+          if (!isModificationModeEnabled) {
+            form.reset({});
+          }
+        },
+      );
+
+      return disposer;
+    }, [isModificationModeEnabled, form]);
+
+    const {initialValues} = useFormState();
+
+    const fieldArray = useFieldArray('newVariables');
+
+    const isViewMode = isModificationModeEnabled
+      ? fieldArray.fields.length === 0 &&
+        modificationsStore.getAddVariableModifications(scopeKey).length === 0
+      : initialValues === undefined ||
+        Object.values(initialValues).length === 0;
+
+    useEffect(() => {
+      const isSelectedElementInstanceRunning =
+        resolvedElementInstance?.state === 'ACTIVE';
+
+      if (!isProcessInstanceRunning) {
+        setFooterVariant('disabled');
+        return;
+      }
+
+      if (initialValues?.name === '' && initialValues?.value === '') {
+        setFooterVariant('add-variable');
+        return;
+      }
+
+      if (!isViewMode || (hasSelection && !isSelectedElementInstanceRunning)) {
+        setFooterVariant('disabled');
+        return;
+      }
+
+      setFooterVariant('initial');
+    }, [
+      isProcessInstanceRunning,
+      initialValues,
+      isViewMode,
+      hasSelection,
+      resolvedElementInstance?.state,
+    ]);
+
+    if (displayStatus === 'no-content') {
+      return null;
+    }
+
+    return (
+      <VariablesContent>
+        {isViewMode && displayStatus === 'skeleton' && <Skeleton />}
+        {isViewMode && displayStatus === 'no-variables' && (
+          <EmptyMessageWrapper>
+            <EmptyMessage message="The element has no variables" />
+          </EmptyMessageWrapper>
+        )}
+        {(!isViewMode || displayStatus === 'variables') && (
+          <VariablesTable
+            scopeId={scopeKey}
+            isModificationModeEnabled={isModificationModeEnabled}
+            isVariableModificationAllowed={isVariableModificationAllowed}
+          />
+        )}
+
+        {!isModificationModeEnabled && <Footer variant={footerVariant} />}
+      </VariablesContent>
+    );
+  },
+);
+
+export {Variables};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/styled.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled, {css} from 'styled-components';
+import {StructuredList as BaseStructuredList} from 'modules/components/StructuredList';
+import {styles} from '@carbon/elements';
+
+const VariablesContent = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const VariableName = styled.div`
+  ${styles.bodyShort01};
+  margin: var(--cds-spacing-02) 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`;
+
+type VariableValueProps = {$hasBackdrop?: boolean};
+const VariableValue = styled.div<VariableValueProps>`
+  ${({$hasBackdrop}) => {
+    return css`
+      ${styles.bodyShort01};
+      margin: var(--cds-spacing-02) 0;
+      max-height: 78px;
+      overflow-y: auto;
+      overflow-wrap: break-word;
+      ${$hasBackdrop &&
+      css`
+        position: relative;
+      `}
+    `;
+  }}
+`;
+const StructuredList = styled(BaseStructuredList)`
+  padding: var(--cds-spacing-05);
+  [role='table'] {
+    table-layout: fixed;
+  }
+`;
+
+const EmptyMessageWrapper = styled.div`
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+`;
+
+export {
+  VariablesContent,
+  VariableName,
+  VariableValue,
+  StructuredList,
+  EmptyMessageWrapper,
+};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/validators.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/validators.test.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  validateModifiedNameComplete,
+  validateModifiedNameNotDuplicate,
+  validateModifiedValueComplete,
+  validateModifiedValueValid,
+  validateNameCharacters,
+  validateNameComplete,
+  validateNameNotDuplicate,
+  validateValueComplete,
+  validateValueValid,
+} from './validators';
+import type {Variable} from '@camunda/camunda-api-zod-schemas/8.9';
+import {createVariable} from 'modules/testUtils';
+
+const MOCK_FIELD_META_STATE = {
+  blur: vi.fn(),
+  change: vi.fn(),
+  focus: vi.fn(),
+  name: 'fieldName',
+} as const;
+
+describe('validators with allVariables', () => {
+  const allVariables: Variable[] = [
+    createVariable({
+      variableKey: '1',
+      name: 'existingName1',
+      value: 'value1',
+    }),
+    createVariable({
+      variableKey: '2',
+      name: 'existingName2',
+      value: 'value2',
+    }),
+  ];
+
+  describe('validateNameNotDuplicate', () => {
+    it('should return undefined if name is unique', async () => {
+      const result = await validateNameNotDuplicate(allVariables)(
+        'uniqueName',
+        {},
+        {...MOCK_FIELD_META_STATE, dirty: true},
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('should return error if name is a duplicate in allVariables', async () => {
+      const result = await validateNameNotDuplicate(allVariables)(
+        'existingName2',
+        {},
+        {...MOCK_FIELD_META_STATE, dirty: true},
+      );
+      expect(result).toBe('Name should be unique');
+    });
+
+    it('should return undefined if name is a duplicate but meta is not dirty', async () => {
+      const result = await validateNameNotDuplicate(allVariables)(
+        'existingName2',
+        {},
+        {...MOCK_FIELD_META_STATE, dirty: false},
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('validateModifiedNameNotDuplicate', () => {
+    it('should return undefined if no duplicate exists', () => {
+      const result = validateModifiedNameNotDuplicate(allVariables)(
+        'uniqueName',
+        {newVariables: [{name: 'uniqueName'}]},
+        {...MOCK_FIELD_META_STATE, dirty: true},
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('should return error if duplicate exists in allVariables', () => {
+      const result = validateModifiedNameNotDuplicate(allVariables)(
+        'existingName1',
+        {newVariables: [{name: 'existingName1'}]},
+        {...MOCK_FIELD_META_STATE, dirty: true},
+      );
+      expect(result).toBe('Name should be unique');
+    });
+
+    it('should return undefined if duplicate exists but meta is not dirty', () => {
+      const result = validateModifiedNameNotDuplicate(allVariables)(
+        'existingName1',
+        {newVariables: [{name: 'existingName1'}]},
+        {...MOCK_FIELD_META_STATE, dirty: false},
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('validateNameComplete', () => {
+    it('should return error if name is empty and value is not empty', () => {
+      const result = validateNameComplete(allVariables)(
+        '',
+        {value: 'someValue'},
+        {...MOCK_FIELD_META_STATE},
+      );
+      expect(result).toBe('Name has to be filled');
+    });
+
+    it('should return error if name is a duplicate in allVariables', () => {
+      const result = validateNameComplete(allVariables)(
+        'existingName1',
+        {value: 'someValue'},
+        {...MOCK_FIELD_META_STATE, dirty: true},
+      );
+      expect(result).toBe('Name should be unique');
+    });
+
+    it('should return undefined if name is unique', () => {
+      const result = validateNameComplete(allVariables)(
+        'uniqueName',
+        {value: 'someValue'},
+        {...MOCK_FIELD_META_STATE, dirty: true},
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+});
+
+describe('validators', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should validate name without delay', async () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    expect(validateNameCharacters('', {})).toBeUndefined();
+    expect(validateNameCharacters('test', {})).toBeUndefined();
+    expect(validateNameCharacters('"test"', {})).toBe('Name is invalid');
+    expect(validateNameCharacters('test with space', {})).toBe(
+      'Name is invalid',
+    );
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should validate value with delay', async () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    expect(validateValueComplete('', {name: ''})).toBeUndefined();
+
+    expect(validateValueComplete('123', {name: 'name'})).toBeUndefined();
+
+    expect(
+      validateValueComplete('"test value"', {name: 'name'}),
+    ).toBeUndefined();
+
+    expect(
+      validateValueComplete('{"foo":"bar"}', {name: 'name'}),
+    ).toBeUndefined();
+
+    expect(validateValueComplete('true', {name: 'name'})).toBeUndefined();
+
+    expect(validateValueComplete('false', {name: 'name'})).toBeUndefined();
+
+    expect(
+      validateValueComplete('invalid json', {name: 'name'}),
+    ).toBeUndefined();
+
+    await expect(
+      validateValueValid('invalid json', {name: 'name'}),
+    ).resolves.toBe('Value has to be JSON');
+
+    await expect(validateValueComplete('', {name: 'name'})).resolves.toBe(
+      'Value has to be filled',
+    );
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should validate modified name complete', () => {
+    expect(
+      validateModifiedNameComplete(
+        undefined,
+        {newVariables: [{}]},
+        {...MOCK_FIELD_META_STATE, name: 'newVariables[0]'},
+      ),
+    ).toBeUndefined();
+
+    expect(
+      validateModifiedNameComplete(
+        undefined,
+        {newVariables: [{value: '123'}]},
+        {...MOCK_FIELD_META_STATE, name: 'newVariables[0]'},
+      ),
+    ).toBe('Name has to be filled');
+  });
+
+  it('should validate modified value complete', () => {
+    expect(
+      validateModifiedValueComplete(
+        undefined,
+        {newVariables: [{}]},
+        {...MOCK_FIELD_META_STATE, visited: true, name: 'newVariables[0]'},
+      ),
+    ).toBeUndefined();
+
+    expect(
+      validateModifiedValueComplete(
+        undefined,
+        {newVariables: [{value: '123'}]},
+        {...MOCK_FIELD_META_STATE, visited: true, name: 'newVariables[0]'},
+      ),
+    ).toBeUndefined();
+
+    expect(
+      validateModifiedValueComplete(
+        undefined,
+        {newVariables: [{name: 'test'}]},
+        {...MOCK_FIELD_META_STATE, visited: true, name: 'newVariables[0]'},
+      ),
+    ).toBe('Value has to be filled');
+
+    expect(
+      validateModifiedValueComplete(
+        undefined,
+        {newVariables: [{name: 'test'}]},
+        {...MOCK_FIELD_META_STATE, name: 'newVariables[0]'},
+      ),
+    ).toBeUndefined();
+  });
+
+  it('should validate modified value valid', () => {
+    expect(
+      validateModifiedValueValid(
+        undefined,
+        {newVariables: [{}]},
+        MOCK_FIELD_META_STATE,
+      ),
+    ).toBeUndefined();
+
+    expect(
+      validateModifiedValueValid(
+        '{"key": "value"}',
+        {newVariables: [{value: {key: 'value'}}]},
+        MOCK_FIELD_META_STATE,
+      ),
+    ).toBeUndefined();
+
+    expect(
+      validateModifiedValueValid(
+        '{invalidKey": "value"}',
+        {newVariables: [{value: '{invalidKey": "value"}'}]},
+        MOCK_FIELD_META_STATE,
+      ),
+    ).toBe('Value has to be JSON');
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/validators.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/validators.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type FieldValidator} from 'final-form';
+import {isValidJSON} from 'modules/utils';
+import {promisifyValidator} from 'modules/utils/validators/promisifyValidator';
+import {ERRORS, VALIDATION_DELAY} from './constants';
+import get from 'lodash/get';
+import {getNewVariablePrefix} from './getNewVariablePrefix';
+import {type VariableFormValues} from 'modules/types/variables';
+import type {Variable} from '@camunda/camunda-api-zod-schemas/8.9';
+
+const validateNameCharacters: FieldValidator<string | undefined> = (
+  variableName = '',
+) => {
+  if (variableName.includes('"') || variableName.includes(' ')) {
+    return ERRORS.INVALID_NAME;
+  }
+};
+
+const validateModifiedNameComplete: FieldValidator<string | undefined> = (
+  variableName = '',
+  allValues: {value?: string} | undefined,
+  meta,
+) => {
+  const fieldName = meta?.name ?? '';
+
+  const variableValue =
+    get(allValues, `${getNewVariablePrefix(fieldName)}.value`) ?? '';
+
+  if (variableValue.trim() !== '' && variableName === '') {
+    return ERRORS.EMPTY_NAME;
+  }
+};
+
+const validateModifiedNameNotDuplicate =
+  (allVariables: Variable[]): FieldValidator<string | undefined> =>
+  (
+    variableName = '',
+    allValues:
+      | {value?: string; newVariables?: Array<VariableFormValues>}
+      | undefined,
+    meta,
+  ) => {
+    if (allValues?.newVariables === undefined) {
+      return;
+    }
+
+    const isVariableDuplicate = allVariables.some(
+      ({name}) => name === variableName,
+    );
+
+    if (meta?.dirty && isVariableDuplicate) {
+      return ERRORS.DUPLICATE_NAME;
+    }
+
+    if (
+      allValues.newVariables.filter(
+        (variable) => variable?.name === variableName,
+      ).length <= 1
+    ) {
+      return;
+    }
+
+    if (
+      meta?.active ||
+      meta?.error === ERRORS.DUPLICATE_NAME ||
+      meta?.validating
+    ) {
+      return ERRORS.DUPLICATE_NAME;
+    }
+
+    return;
+  };
+
+const validateNameComplete =
+  (allVariables: Variable[]): FieldValidator<string | undefined> =>
+  (variableName = '', allValues: {value?: string} | undefined, meta) => {
+    const variableValue = allValues?.value ?? '';
+
+    if (variableValue.trim() !== '' && variableName === '') {
+      return ERRORS.EMPTY_NAME;
+    }
+
+    const isVariableDuplicate = allVariables.some(
+      ({name}) => name === variableName,
+    );
+
+    if (meta?.dirty && isVariableDuplicate) {
+      return ERRORS.DUPLICATE_NAME;
+    }
+  };
+
+const validateNameNotDuplicate = (
+  allVariables: Variable[],
+): FieldValidator<string | undefined> =>
+  promisifyValidator((variableName = '', _, meta) => {
+    const isVariableDuplicate = allVariables.some(
+      ({name}) => name === variableName,
+    );
+
+    if (meta?.dirty && isVariableDuplicate) {
+      return ERRORS.DUPLICATE_NAME;
+    }
+  }, VALIDATION_DELAY);
+
+const validateValueComplete: FieldValidator<string | undefined> =
+  promisifyValidator(
+    (variableValue = '', allValues: {name?: string} | undefined) => {
+      const variableName = allValues?.name ?? '';
+
+      if (
+        (variableName === '' && variableValue === '') ||
+        variableValue !== ''
+      ) {
+        return;
+      }
+
+      return ERRORS.EMPTY_VALUE;
+    },
+    VALIDATION_DELAY,
+  );
+
+const validateValueValid: FieldValidator<string | undefined> =
+  promisifyValidator((variableValue = '') => {
+    if (variableValue === '' || isValidJSON(variableValue)) {
+      return;
+    }
+
+    return ERRORS.INVALID_VALUE;
+  }, VALIDATION_DELAY);
+
+const validateModifiedValueComplete: FieldValidator<string | undefined> = (
+  variableValue = '',
+  allValues: {name?: string} | undefined,
+  meta,
+) => {
+  if (!meta?.visited) {
+    return undefined;
+  }
+
+  const fieldName = meta?.name ?? '';
+
+  const variableName =
+    get(allValues, `${getNewVariablePrefix(fieldName)}.name`) ?? '';
+
+  if ((variableName === '' && variableValue === '') || variableValue !== '') {
+    return;
+  }
+
+  return ERRORS.EMPTY_VALUE;
+};
+
+const validateModifiedValueValid: FieldValidator<string | undefined> = (
+  variableValue = '',
+) => {
+  if (variableValue === '' || isValidJSON(variableValue)) {
+    return;
+  }
+
+  return ERRORS.INVALID_VALUE;
+};
+
+const validateValueNotEmpty = (variableValue = '') => {
+  if (variableValue === '') {
+    return ERRORS.INVALID_VALUE;
+  }
+
+  return;
+};
+
+export {
+  validateNameCharacters,
+  validateNameComplete,
+  validateNameNotDuplicate,
+  validateValueComplete,
+  validateValueValid,
+  validateModifiedNameComplete,
+  validateModifiedValueComplete,
+  validateModifiedValueValid,
+  validateModifiedNameNotDuplicate,
+  validateValueNotEmpty,
+};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/VariablesFinalForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/VariablesFinalForm.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Form as ReactFinalForm} from 'react-final-form';
+import {useMemo} from 'react';
+import {type VariableFormValues} from 'modules/types/variables';
+
+import arrayMutators from 'final-form-arrays';
+import {VariablesForm} from './VariablesForm';
+import {notificationsStore} from 'modules/stores/notifications';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {useQueryClient} from '@tanstack/react-query';
+import {queryKeys} from 'modules/queries/queryKeys';
+import {useElementInstanceVariables} from 'modules/mutations/elementInstances/useElementInstanceVariables';
+import {handleMutationError} from 'modules/utils/notifications';
+import {modificationsStore} from 'modules/stores/modifications';
+
+type Props = {
+  scopeKey: string;
+};
+
+const VariablesFinalForm: React.FC<Props> = ({scopeKey}) => {
+  const queryClient = useQueryClient();
+  const {processInstanceId = ''} = useProcessInstancePageParams();
+  const {mutateAsync: mutateAsyncVariables} = useElementInstanceVariables(
+    scopeKey,
+    processInstanceId,
+  );
+
+  const initialValues = useMemo(() => {
+    if (!modificationsStore.isModificationModeEnabled) {
+      return {};
+    }
+    const addVariableModifications =
+      modificationsStore.getAddVariableModifications(scopeKey);
+    if (addVariableModifications.length === 0) {
+      return {};
+    }
+    return {
+      newVariables: addVariableModifications,
+    };
+  }, [scopeKey]);
+
+  return (
+    <ReactFinalForm<VariableFormValues>
+      mutators={{
+        ...arrayMutators,
+        triggerValidation(fieldsToValidate: string[], state, {changeValue}) {
+          fieldsToValidate.forEach((fieldName) => {
+            changeValue(state, fieldName, (n) => n);
+          });
+        },
+      }}
+      key={scopeKey}
+      initialValues={initialValues}
+      render={(props) => <VariablesForm {...props} />}
+      onSubmit={async (values, form) => {
+        const {initialValues} = form.getState();
+        const isNewVariable = initialValues?.name === '';
+        const {name, value} = values;
+
+        await mutateAsyncVariables(
+          {name, value: JSON.stringify(JSON.parse(value))},
+          {
+            onSuccess: () => {
+              notificationsStore.displayNotification({
+                kind: 'success',
+                title: isNewVariable ? 'Variable added' : 'Variable updated',
+                isDismissable: true,
+              });
+            },
+            onError: (error) => {
+              handleMutationError({
+                statusCode: error.status,
+                title: 'Variable could not be saved',
+                subtitle: error.statusText,
+              });
+            },
+            onSettled: async () => {
+              form.reset({});
+              await queryClient.invalidateQueries({
+                queryKey: queryKeys.variables.search(),
+              });
+            },
+          },
+        ).catch(() => void 0);
+      }}
+    />
+  );
+};
+
+export {VariablesFinalForm};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/VariablesForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/VariablesForm.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {observer} from 'mobx-react';
+import {modificationsStore} from 'modules/stores/modifications';
+import {type VariableFormValues} from 'modules/types/variables';
+import {generateUniqueID} from 'modules/utils/generateUniqueID';
+import {type FormRenderProps} from 'react-final-form';
+import {AddVariableButton, Form, VariablesContainer} from './styled';
+import {Variables} from './Variables';
+import {useIsPlaceholderSelected} from 'modules/hooks/elementSelection';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {hasPendingAddOrMoveModification} from 'modules/utils/modifications';
+
+const useIsVariableModificationAllowed = () => {
+  const isPlaceholderSelected = useIsPlaceholderSelected();
+  const {hasSelection} = useProcessInstanceElementSelection();
+
+  switch (true) {
+    case !modificationsStore.isModificationModeEnabled:
+      return false;
+    case !hasSelection:
+      return hasPendingAddOrMoveModification();
+    default:
+      return isPlaceholderSelected;
+  }
+};
+
+const VariablesForm: React.FC<FormRenderProps<VariableFormValues>> = observer(
+  ({handleSubmit, form, values}) => {
+    const isModificationAllowed = useIsVariableModificationAllowed();
+    const hasEmptyNewVariable = values?.newVariables?.some(
+      (variable) =>
+        variable === undefined ||
+        variable.name === undefined ||
+        variable.value === undefined,
+    );
+
+    return (
+      <Form onSubmit={handleSubmit}>
+        {isModificationAllowed && (
+          <AddVariableButton
+            onClick={() => {
+              form.mutators.push?.('newVariables', {
+                id: generateUniqueID(),
+              });
+            }}
+            disabled={
+              form.getState().submitting ||
+              form.getState().hasValidationErrors ||
+              form.getState().validating ||
+              hasEmptyNewVariable
+            }
+          />
+        )}
+        <VariablesContainer>
+          <Variables isVariableModificationAllowed={isModificationAllowed} />
+        </VariablesContainer>
+      </Form>
+    );
+  },
+);
+
+export {VariablesForm};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {observer} from 'mobx-react';
+
+import {Content, EmptyMessageContainer} from './styled';
+import {ErrorMessage} from 'modules/components/ErrorMessage';
+import {EmptyMessage} from 'modules/components/EmptyMessage';
+import {Loading} from '@carbon/react';
+import {useVariables} from 'modules/queries/variables/useVariables';
+import {VariablesFinalForm} from './VariablesFinalForm';
+import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
+import {isRequestError} from 'modules/request';
+import {useVariableScopeKey} from 'modules/hooks/variables';
+
+const VariablesTab: React.FC = observer(() => {
+  const {displayStatus, error} = useVariables();
+  const scopeKey = useVariableScopeKey();
+
+  if (displayStatus === 'error') {
+    return (
+      <EmptyMessageContainer>
+        <ErrorMessage
+          message={
+            isRequestError(error) &&
+            error?.response?.status === HTTP_STATUS_FORBIDDEN
+              ? 'Missing permissions to access Variables'
+              : 'Variables could not be fetched'
+          }
+          additionalInfo={
+            isRequestError(error) &&
+            error?.response?.status === HTTP_STATUS_FORBIDDEN
+              ? 'Please contact your organization owner or admin to give you the necessary permissions to access variables'
+              : 'Refresh the page to try again'
+          }
+        />
+      </EmptyMessageContainer>
+    );
+  }
+
+  if (displayStatus === 'multi-instances') {
+    return (
+      <EmptyMessageContainer>
+        <EmptyMessage
+          message="To view the variables, select a single element instance in the
+          instance history."
+        />
+      </EmptyMessageContainer>
+    );
+  }
+
+  if (displayStatus === 'no-variables') {
+    return (
+      <Content>
+        {scopeKey !== null ? (
+          <VariablesFinalForm scopeKey={scopeKey} />
+        ) : (
+          <EmptyMessageContainer>
+            <EmptyMessage message="The element has no variables" />
+          </EmptyMessageContainer>
+        )}
+      </Content>
+    );
+  }
+
+  return (
+    <Content>
+      {displayStatus === 'spinner' && (
+        <Loading data-testid="variables-spinner" />
+      )}
+      {scopeKey !== null && <VariablesFinalForm scopeKey={scopeKey} />}
+    </Content>
+  );
+});
+
+export {VariablesTab};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/styled.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {AddVariableButton as BaseAddVariableButton} from './Variables/Footer/AddVariableButton';
+
+const EmptyMessageContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+
+const Content = styled.div`
+  position: relative;
+  height: 100%;
+  .cds--loading-overlay {
+    position: absolute;
+  }
+`;
+
+const AddVariableButton = styled(BaseAddVariableButton)`
+  align-self: flex-end;
+`;
+
+const Form = styled.form`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const VariablesContainer = styled.div`
+  height: 100%;
+  position: relative;
+`;
+
+export {
+  Content,
+  EmptyMessageContainer,
+  AddVariableButton,
+  Form,
+  VariablesContainer,
+};

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -93,7 +93,14 @@ const routes = createRoutesFromElements(
       >
         {IS_NEW_PROCESS_INSTANCE_PAGE ? (
           <>
-            <Route index element={null} />
+            <Route
+              index
+              lazy={async () => {
+                const {VariablesTab} =
+                  await import('./ProcessInstance/BottomPanelTabs/VariablesTab/index');
+                return {Component: VariablesTab};
+              }}
+            />
             <Route
               path={Paths.processInstanceDetails({isRelative: true})}
               element={null}
@@ -104,19 +111,35 @@ const routes = createRoutesFromElements(
             />
             <Route
               path={Paths.processInstanceInputMappings({isRelative: true})}
-              element={null}
+              lazy={async () => {
+                const {InputMappingsTab} =
+                  await import('./ProcessInstance/BottomPanelTabs/InputMappingsTab');
+                return {Component: InputMappingsTab};
+              }}
             />
             <Route
               path={Paths.processInstanceOutputMappings({isRelative: true})}
-              element={null}
+              lazy={async () => {
+                const {OutputMappingsTab} =
+                  await import('./ProcessInstance/BottomPanelTabs/OutputMappingsTab');
+                return {Component: OutputMappingsTab};
+              }}
             />
             <Route
               path={Paths.processInstanceListeners({isRelative: true})}
-              element={null}
+              lazy={async () => {
+                const {ListenersTab} =
+                  await import('./ProcessInstance/BottomPanelTabs/ListenersTab/index');
+                return {Component: ListenersTab};
+              }}
             />
             <Route
               path={Paths.processInstanceOperationsLog({isRelative: true})}
-              element={null}
+              lazy={async () => {
+                const {OperationsLogTab} =
+                  await import('./ProcessInstance/BottomPanelTabs/OperationsLogTab/index');
+                return {Component: OperationsLogTab};
+              }}
             />
           </>
         ) : null}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

99% of this PR is just copying code.

There are only differences on the following files:
- `src/App/index.tsx`
- `src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.tsx`
- `src/App/ProcessInstance/BottomPanelTabs/OperationsLogTab/index.tsx`
- `src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.tsx`
- `src/App/ProcessInstance/BottomPanelTabs/InputMappingsTab.tsx`
- `src/App/ProcessInstance/BottomPanelTabs/OutputMappingsTab.tsx`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47039
