### PR TITLE
fix: do not track backup metadata without continuous backups

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -16,14 +16,17 @@ public class CheckpointBackupConfirmedApplier {
   private final CheckpointState checkpointState;
   private final DbCheckpointMetadataState checkpointMetadataState;
   private final DbBackupRangeState backupRangeState;
+  private final boolean trackBackupMetadata;
 
   public CheckpointBackupConfirmedApplier(
       final CheckpointState checkpointState,
       final DbCheckpointMetadataState checkpointMetadataState,
-      final DbBackupRangeState backupRangeState) {
+      final DbBackupRangeState backupRangeState,
+      final boolean trackBackupMetadata) {
     this.checkpointState = checkpointState;
     this.checkpointMetadataState = checkpointMetadataState;
     this.backupRangeState = backupRangeState;
+    this.trackBackupMetadata = trackBackupMetadata;
   }
 
   public void apply(final CheckpointRecord checkpointRecord, final long checkpointTimestamp) {
@@ -34,10 +37,31 @@ public class CheckpointBackupConfirmedApplier {
     final var latestBackupId = checkpointState.getLatestBackupId();
     final var latestBackupPosition = checkpointState.getLatestBackupPosition();
 
+    if (trackBackupMetadata) {
+      updateRangeState(latestBackupId, firstLogPosition, latestBackupPosition, checkpointId);
+    }
+
+    // Update the existing checkpoint state (2-entry DEFAULT CF)
+    final var checkpointPosition = checkpointRecord.getCheckpointPosition();
+    final var checkpointType = checkpointRecord.getCheckpointType();
+    checkpointState.setLatestBackupInfo(
+        checkpointId, checkpointPosition, checkpointTimestamp, checkpointType, firstLogPosition);
+    if (trackBackupMetadata) {
+      checkpointMetadataState.addBackupCheckpoint(
+          checkpointId, checkpointPosition, checkpointTimestamp, checkpointType, firstLogPosition);
+    }
+  }
+
+  private void updateRangeState(
+      final long latestBackupId,
+      final long firstLogPosition,
+      final long latestBackupPosition,
+      final long checkpointId) {
     // Update range state: extend existing range or start a new one
     if (latestBackupId != CheckpointState.NO_CHECKPOINT
         && firstLogPosition <= latestBackupPosition + 1) {
-      // Contiguous with previous backup — find and extend the range that contains the latest backup
+      // Contiguous with previous backup — find and extend the range that contains the latest
+      // backup
       final var existingRange = backupRangeState.findRangeContaining(latestBackupId);
       if (existingRange.isPresent()) {
         backupRangeState.updateRangeEnd(existingRange.get().start(), checkpointId);
@@ -48,13 +72,5 @@ public class CheckpointBackupConfirmedApplier {
     } else {
       backupRangeState.startNewRange(checkpointId);
     }
-
-    // Update the existing checkpoint state (2-entry DEFAULT CF)
-    final var checkpointPosition = checkpointRecord.getCheckpointPosition();
-    final var checkpointType = checkpointRecord.getCheckpointType();
-    checkpointState.setLatestBackupInfo(
-        checkpointId, checkpointPosition, checkpointTimestamp, checkpointType, firstLogPosition);
-    checkpointMetadataState.addBackupCheckpoint(
-        checkpointId, checkpointPosition, checkpointTimestamp, checkpointType, firstLogPosition);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
@@ -35,14 +35,13 @@ public class CheckpointConfirmBackupProcessor {
       final CheckpointState checkpointState,
       final DbCheckpointMetadataState checkpointMetadataState,
       final DbBackupRangeState backupRangeState,
-      final BackupManager backupManager) {
+      final BackupManager backupManager,
+      final CheckpointBackupConfirmedApplier backupConfirmedApplier) {
     this.checkpointState = checkpointState;
     this.checkpointMetadataState = checkpointMetadataState;
     this.backupRangeState = backupRangeState;
     this.backupManager = backupManager;
-    backupConfirmedApplier =
-        new CheckpointBackupConfirmedApplier(
-            checkpointState, checkpointMetadataState, backupRangeState);
+    this.backupConfirmedApplier = backupConfirmedApplier;
   }
 
   public ProcessingResult process(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -8,11 +8,9 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.api.BackupManager;
-import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
-import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -22,7 +20,6 @@ import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
-import java.util.Set;
 
 public final class CheckpointCreateProcessor {
   private final CheckpointState checkpointState;
@@ -35,18 +32,16 @@ public final class CheckpointCreateProcessor {
   public CheckpointCreateProcessor(
       final CheckpointState checkpointState,
       final BackupManager backupManager,
-      final DbCheckpointMetadataState checkpointMetadataState,
-      final Set<CheckpointListener> listeners,
       final ScalingStatusSupplier scalingStatusSupplier,
       final PartitionCountSupplier partitionCountSupplier,
-      final CheckpointMetrics metrics) {
+      final CheckpointMetrics metrics,
+      final CheckpointCreatedEventApplier checkpointCreatedApplier) {
     this.checkpointState = checkpointState;
     this.backupManager = backupManager;
     this.scalingStatusSupplier = scalingStatusSupplier;
     this.metrics = metrics;
     this.partitionCountSupplier = partitionCountSupplier;
-    checkpointCreatedApplier =
-        new CheckpointCreatedEventApplier(checkpointState, checkpointMetadataState, listeners);
+    this.checkpointCreatedApplier = checkpointCreatedApplier;
   }
 
   public ProcessingResult process(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -19,14 +19,17 @@ public final class CheckpointCreatedEventApplier {
   private final CheckpointState checkpointState;
   private final DbCheckpointMetadataState checkpointMetadataState;
   private final Set<CheckpointListener> checkpointListeners;
+  private final boolean trackBackupMetadata;
 
   public CheckpointCreatedEventApplier(
       final CheckpointState checkpointState,
       final DbCheckpointMetadataState checkpointMetadataState,
-      final Set<CheckpointListener> checkpointListeners) {
+      final Set<CheckpointListener> checkpointListeners,
+      final boolean trackBackupMetadata) {
     this.checkpointState = checkpointState;
     this.checkpointMetadataState = checkpointMetadataState;
     this.checkpointListeners = checkpointListeners;
+    this.trackBackupMetadata = trackBackupMetadata;
   }
 
   public void apply(final CheckpointRecord checkpointRecord, final long checkpointTimestamp) {
@@ -36,7 +39,7 @@ public final class CheckpointCreatedEventApplier {
         checkpointTimestamp,
         checkpointRecord.getCheckpointType());
 
-    if (checkpointRecord.getCheckpointType() == CheckpointType.MARKER) {
+    if (trackBackupMetadata && checkpointRecord.getCheckpointType() == CheckpointType.MARKER) {
       checkpointMetadataState.addMarkerCheckpoint(
           checkpointRecord.getCheckpointId(),
           checkpointRecord.getCheckpointPosition(),

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -40,6 +40,7 @@ public final class CheckpointRecordsProcessor
   private static final Logger LOG = LoggerFactory.getLogger(CheckpointRecordsProcessor.class);
 
   private final BackupManager backupManager;
+  private final boolean trackBackupMetadata;
   private CheckpointCreateProcessor checkpointCreateProcessor;
   private CheckpointConfirmBackupProcessor checkpointConfirmBackupProcessor;
   private CheckpointDeleteBackupProcessor checkpointDeleteBackupProcessor;
@@ -61,8 +62,11 @@ public final class CheckpointRecordsProcessor
   private PartitionCountSupplier partitionCountSupplier;
 
   public CheckpointRecordsProcessor(
-      final BackupManager backupManager, final MeterRegistry registry) {
+      final BackupManager backupManager,
+      final MeterRegistry registry,
+      final boolean trackBackupMetadata) {
     this.backupManager = backupManager;
+    this.trackBackupMetadata = trackBackupMetadata;
     metrics = new CheckpointMetrics(registry);
   }
 
@@ -100,20 +104,35 @@ public final class CheckpointRecordsProcessor
     if (partitionCountSupplier == null) {
       throw new IllegalStateException("Partition count supplier is not initialized.");
     }
+    checkpointCreatedEventApplier =
+        new CheckpointCreatedEventApplier(
+            checkpointState, checkpointMetadataState, checkpointListeners, trackBackupMetadata);
+    checkpointBackupConfirmedApplier =
+        new CheckpointBackupConfirmedApplier(
+            checkpointState, checkpointMetadataState, backupRangeState, trackBackupMetadata);
+    checkpointBackupDeletedApplier =
+        new CheckpointBackupDeletedApplier(
+            checkpointMetadataState, backupRangeState, checkpointState);
+    checkpointStateClearedApplier =
+        new CheckpointStateClearedApplier(
+            checkpointState, checkpointMetadataState, backupRangeState);
 
     checkpointCreateProcessor =
         new CheckpointCreateProcessor(
             checkpointState,
             backupManager,
-            checkpointMetadataState,
-            checkpointListeners,
             scalingInProgressSupplier,
             partitionCountSupplier,
-            metrics);
+            metrics,
+            checkpointCreatedEventApplier);
 
     checkpointConfirmBackupProcessor =
         new CheckpointConfirmBackupProcessor(
-            checkpointState, checkpointMetadataState, backupRangeState, backupManager);
+            checkpointState,
+            checkpointMetadataState,
+            backupRangeState,
+            backupManager,
+            checkpointBackupConfirmedApplier);
 
     checkpointDeleteBackupProcessor =
         new CheckpointDeleteBackupProcessor(
@@ -122,19 +141,6 @@ public final class CheckpointRecordsProcessor
     checkpointClearStateProcessor =
         new CheckpointClearStateProcessor(
             checkpointState, checkpointMetadataState, backupRangeState, backupManager);
-
-    checkpointCreatedEventApplier =
-        new CheckpointCreatedEventApplier(
-            checkpointState, checkpointMetadataState, checkpointListeners);
-    checkpointBackupConfirmedApplier =
-        new CheckpointBackupConfirmedApplier(
-            checkpointState, checkpointMetadataState, backupRangeState);
-    checkpointBackupDeletedApplier =
-        new CheckpointBackupDeletedApplier(
-            checkpointMetadataState, backupRangeState, checkpointState);
-    checkpointStateClearedApplier =
-        new CheckpointStateClearedApplier(
-            checkpointState, checkpointMetadataState, backupRangeState);
 
     final long checkpointId = checkpointState.getLatestCheckpointId();
     final var checkpointType = checkpointState.getLatestCheckpointType();

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -89,7 +89,7 @@ final class CheckpointRecordsProcessorTest {
     final RecordProcessorContextImpl context = createContext(executor, zeebedb);
 
     resultBuilder = new MockProcessingResultBuilder();
-    processor = new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry());
+    processor = new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry(), true);
 
     processor.setScalingInProgressSupplier(scalingInProgress::get);
     processor.setPartitionCountSupplier(() -> (int) dynamicPartitionCount.get());
@@ -354,7 +354,7 @@ final class CheckpointRecordsProcessorTest {
   void shouldNotifyListenerOnInit() {
     // given
     final RecordProcessorContextImpl context = createContext(null, zeebedb);
-    processor = new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry());
+    processor = new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry(), true);
     processor.setScalingInProgressSupplier(scalingInProgress::get);
     processor.setPartitionCountSupplier(dynamicPartitionCount::get);
     final long checkpointId = 3;
@@ -779,6 +779,68 @@ final class CheckpointRecordsProcessorTest {
     verify(backupManager, times(0)).takeBackup(eq(backupId), any());
   }
 
+  @Test
+  void shouldNotStoreMarkerMetadataWhenRuntimeTrackingDisabled() {
+    // given
+    final RecordProcessorContextImpl context = createContext(executor, zeebedb);
+    final var processorWithoutRuntimeTracking =
+        new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry(), false);
+    processorWithoutRuntimeTracking.setScalingInProgressSupplier(scalingInProgress::get);
+    processorWithoutRuntimeTracking.setPartitionCountSupplier(dynamicPartitionCount::get);
+    processorWithoutRuntimeTracking.init(context);
+
+    final var checkpointId = 101L;
+    final var checkpointPosition = 1001L;
+    final var value =
+        new CheckpointRecord()
+            .setCheckpointId(checkpointId)
+            .setCheckpointPosition(checkpointPosition)
+            .setCheckpointType(CheckpointType.MARKER);
+    final var record =
+        new MockTypedCheckpointRecord(
+            checkpointPosition, 0, CheckpointIntent.CREATE, RecordType.COMMAND, value);
+
+    // when
+    processorWithoutRuntimeTracking.process(record, new MockProcessingResultBuilder());
+
+    // then
+    assertThat(state.getLatestCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getLatestCheckpointPosition()).isEqualTo(checkpointPosition);
+    assertThat(checkpointMetadataState.getCheckpoint(checkpointId)).isNull();
+  }
+
+  @Test
+  void shouldNotStoreBackupMetadataAndRangesWhenRuntimeTrackingDisabled() {
+    // given
+    final RecordProcessorContextImpl context = createContext(executor, zeebedb);
+    final var processorWithoutRuntimeTracking =
+        new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry(), false);
+    processorWithoutRuntimeTracking.setScalingInProgressSupplier(scalingInProgress::get);
+    processorWithoutRuntimeTracking.setPartitionCountSupplier(dynamicPartitionCount::get);
+    processorWithoutRuntimeTracking.init(context);
+
+    final var checkpointId = 202L;
+    final var checkpointPosition = 2002L;
+    final var value =
+        new CheckpointRecord()
+            .setCheckpointId(checkpointId)
+            .setCheckpointPosition(checkpointPosition)
+            .setCheckpointType(CheckpointType.MANUAL_BACKUP)
+            .setFirstLogPosition(2000L);
+    final var record =
+        new MockTypedCheckpointRecord(
+            checkpointPosition + 1, 0, CheckpointIntent.CONFIRM_BACKUP, RecordType.COMMAND, value);
+
+    // when
+    processorWithoutRuntimeTracking.process(record, new MockProcessingResultBuilder());
+
+    // then
+    assertThat(state.getLatestBackupId()).isEqualTo(checkpointId);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(checkpointPosition);
+    assertThat(checkpointMetadataState.getCheckpoint(checkpointId)).isNull();
+    assertThat(backupRangeState.getAllRanges()).isEmpty();
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"SCHEDULED_BACKUP", "MANUAL_BACKUP"})
   void shouldTakeBackupOnBackupType(final String checkpointType) {
@@ -915,7 +977,7 @@ final class CheckpointRecordsProcessorTest {
 
     final var context = createContext(executor, zeebedb);
     final var syncProcessor =
-        new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry());
+        new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry(), true);
     syncProcessor.setScalingInProgressSupplier(scalingInProgress::get);
     syncProcessor.setPartitionCountSupplier(dynamicPartitionCount::get);
     syncProcessor.init(context);
@@ -951,7 +1013,7 @@ final class CheckpointRecordsProcessorTest {
     // given — a processor with a backup manager and an existing newer backup
     final var context = createContext(executor, zeebedb);
     final var syncProcessor =
-        new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry());
+        new CheckpointRecordsProcessor(backupManager, context.getMeterRegistry(), true);
     syncProcessor.setScalingInProgressSupplier(scalingInProgress::get);
     syncProcessor.setPartitionCountSupplier(dynamicPartitionCount::get);
     syncProcessor.init(context);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -137,9 +137,10 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
 
   private static void installCheckpointProcessor(
       final PartitionTransitionContext context, final BackupManager backupManager) {
+    final var trackBackupMetadata = context.getBrokerCfg().getData().getBackup().isContinuous();
     final CheckpointRecordsProcessor checkpointRecordsProcessor =
         new CheckpointRecordsProcessor(
-            backupManager, context.getPartitionTransitionMeterRegistry());
+            backupManager, context.getPartitionTransitionMeterRegistry(), trackBackupMetadata);
     context.setCheckpointProcessor(checkpointRecordsProcessor);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMetadataTrackingDisabledIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMetadataTrackingDisabledIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.management.backups.BackupInfo;
+import io.camunda.management.backups.PartitionBackupInfo;
+import io.camunda.management.backups.StateCode;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies that backup runtime metadata (ranges) are not accumulated when continuous backups are
+ * disabled. This is the counterpart to {@link BackupRangeTrackingIT}, which tests that ranges ARE
+ * tracked when continuous backups are enabled.
+ */
+@Testcontainers
+@ZeebeIntegration
+final class BackupMetadataTrackingDisabledIT {
+  private static @TempDir Path tempDir;
+
+  private final Path basePath = tempDir.resolve(UUID.randomUUID().toString());
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(2)
+          .withGatewaysCount(1)
+          .withReplicationFactor(1)
+          .withPartitionsCount(2)
+          .withEmbeddedGateway(false)
+          .withBrokerConfig(this::configureBroker)
+          .build();
+
+  @Test
+  void shouldNotAccumulateRangesWhenContinuousBackupsDisabled() {
+    // given
+    final var actuator = BackupActuator.of(cluster.availableGateway());
+    try (final var client = cluster.newClientBuilder().build()) {
+      client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+    }
+
+    // when -- take multiple backups
+    actuator.take(1);
+    waitUntilBackupIsCompleted(actuator, 1L);
+    actuator.take(2);
+    waitUntilBackupIsCompleted(actuator, 2L);
+
+    // then -- no ranges should have been created
+    assertThat(actuator.state().getRanges())
+        .describedAs("Ranges should not be tracked when continuous backups are disabled")
+        .isEmpty();
+  }
+
+  private void configureBroker(final TestStandaloneBroker broker) {
+    broker.withUnifiedConfig(
+        cfg -> {
+          // Continuous backups are disabled by default; no need to set explicitly.
+          cfg.getData()
+              .getPrimaryStorage()
+              .getBackup()
+              .setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
+
+          final var config = new Filesystem();
+          config.setBasePath(basePath.toAbsolutePath().toString());
+          cfg.getData().getPrimaryStorage().getBackup().setFilesystem(config);
+        });
+  }
+
+  private static void waitUntilBackupIsCompleted(
+      final BackupActuator actuator, final long backupId) {
+    Awaitility.await("until a backup exists with the id %d".formatted(backupId))
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var status = actuator.status(backupId);
+              assertThat(status)
+                  .extracting(BackupInfo::getBackupId, BackupInfo::getState)
+                  .containsExactly(backupId, StateCode.COMPLETED);
+              assertThat(status.getDetails())
+                  .flatExtracting(PartitionBackupInfo::getPartitionId)
+                  .containsExactlyInAnyOrder(1, 2);
+            });
+  }
+}


### PR DESCRIPTION
When continuous backups are not enabled, we can never form proper backup ranges, instead we'd just slowly accumulate more and more single backup ranges that waste space.