### PR TITLE
[Backport stable/8.9] fix: normalize negative exported position in restore range filter

### DIFF
--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
@@ -244,12 +244,16 @@ public class RestorePointResolver {
       @Nullable final Instant from,
       @Nullable final Long exportedPosition,
       @NonNull final BackupMetadata metadata) {
+    // An exported position of -1 means nothing has been exported yet, so the backup needs to
+    // start from position 1 (the first exportable log entry).
+    final Long effectiveExportedPosition =
+        exportedPosition != null && exportedPosition < 0 ? Long.valueOf(1L) : exportedPosition;
     LOG.atDebug()
         .addKeyValue("partition", metadata.partitionId())
         .log(
             "Finding restorable range covering {} and exported position {} in {} available ranges",
             from,
-            exportedPosition,
+            effectiveExportedPosition,
             metadata.ranges().size());
     return metadata.ranges().stream()
         .<RestorableRange>mapMulti(
@@ -272,8 +276,8 @@ public class RestorePointResolver {
                         from);
                 return;
               }
-              if (exportedPosition != null
-                  && startInfo.getFirstLogPositionOrDefault() > exportedPosition) {
+              if (effectiveExportedPosition != null
+                  && startInfo.getFirstLogPositionOrDefault() > effectiveExportedPosition) {
                 LOG.atTrace()
                     .addKeyValue("partition", metadata.partitionId())
                     .log(
@@ -281,10 +285,11 @@ public class RestorePointResolver {
                         range.start(),
                         range.end(),
                         startInfo.firstLogPosition(),
-                        exportedPosition);
+                        effectiveExportedPosition);
                 return;
               }
-              if (exportedPosition != null && endInfo.checkpointPosition() < exportedPosition) {
+              if (effectiveExportedPosition != null
+                  && endInfo.checkpointPosition() < effectiveExportedPosition) {
                 LOG.atTrace()
                     .addKeyValue("partition", metadata.partitionId())
                     .log(
@@ -292,7 +297,7 @@ public class RestorePointResolver {
                         range.start(),
                         range.end(),
                         endInfo.checkpointPosition(),
-                        exportedPosition);
+                        effectiveExportedPosition);
                 return;
               }
               LOG.atDebug()
@@ -306,7 +311,10 @@ public class RestorePointResolver {
                 new IllegalStateException(
                     "No usable range found for partition %d with from=%s, exportedPosition=%s. Available ranges: %s"
                         .formatted(
-                            metadata.partitionId(), from, exportedPosition, metadata.ranges())));
+                            metadata.partitionId(),
+                            from,
+                            effectiveExportedPosition,
+                            metadata.ranges())));
   }
 
   /** Binary search for a checkpoint entry in a sorted list of checkpoint entries. */

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestorePointResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestorePointResolverTest.java
@@ -746,6 +746,53 @@ final class RestorePointResolverTest {
   }
 
   @Test
+  void shouldResolveWhenExportedPositionIsNegativeOne() {
+    // given – exported position -1 means nothing has been exported yet; the backup needs to start
+    // from position 1 (the first exportable log entry). A range whose first log position is 1
+    // should be accepted.
+    final var t1 = Instant.parse("2025-01-01T00:00:00Z");
+    final var cp = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(1));
+    final var meta = metadata(1, List.of(cp), List.of(new RangeEntry(1, 1)));
+
+    // when – exportedPosition=-1 is normalized to 1; cp.firstLogPosition=1 <= 1 -> range accepted
+    final var result = RestorePointResolver.resolve(List.of(meta), null, null, Map.of(1, -1L));
+
+    // then
+    assertThat(result.globalCheckpointId()).isEqualTo(1);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp);
+  }
+
+  @Test
+  void shouldResolveMultiplePartitionsWhenOneHasExportedPositionNegativeOne() {
+    // given – two partitions; partition 2 has exportedPosition=-1 (nothing exported yet)
+    final var t1 = Instant.parse("2025-01-01T00:00:00Z");
+    final var t2 = Instant.parse("2025-01-02T00:00:00Z");
+
+    final var metadataByPartition =
+        List.of(
+            metadata(
+                1,
+                List.of(
+                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(1)),
+                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101))),
+                List.of(new RangeEntry(1, 2))),
+            metadata(
+                2,
+                List.of(
+                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(1)),
+                    entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(111))),
+                List.of(new RangeEntry(1, 2))));
+
+    // when – P1 exported 100, P2 exported nothing (-1 → normalized to 1)
+    final var result =
+        RestorePointResolver.resolve(metadataByPartition, null, null, Map.of(1, 100L, 2, -1L));
+
+    // then – both partitions resolve successfully
+    assertThat(result.globalCheckpointId()).isEqualTo(2);
+    assertThat(result.backupsByPartitionId()).hasSize(2);
+  }
+
+  @Test
   void shouldThrowWhenBackupsHaveDataGapAcrossMultiplePartitions() {
     // given – partition 1 is contiguous, partition 2 has a gap
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");


### PR DESCRIPTION
# Description
Backport of #47611 to `stable/8.9`.

relates to #47587