### PR TITLE
[Backport stable/8.8] test: fix flaky ActivateJobsTest timeouts

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
@@ -73,25 +73,17 @@ class ActivateJobsTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void shouldReturnEmptyListOnUserDefinedGlobalRequestTimeout(final boolean useRest) {
-    // when
-    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(1)).build();
-    final var actual =
-        getCommand(client, useRest).jobType("notExisting").maxJobsToActivate(1).send().join();
-
-    // then
-    assertThat(actual.getJobs()).isEmpty();
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
   public void shouldReturnEmptyListOnUserDefinedCommandRequestTimeout(final boolean useRest) {
-    // when
+    // given - high global timeout
+    client.close();
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofMinutes(5)).build();
+
+    // when - low command timeout
     final var actual =
         getCommand(client, useRest)
             .jobType("notExisting")
             .maxJobsToActivate(1)
-            .requestTimeout(Duration.ofSeconds(1))
+            .requestTimeout(Duration.ofMillis(500))
             .send()
             .join();
 


### PR DESCRIPTION
# Description
Backport of #47839 to `stable/8.8`.

relates to camunda/camunda#47658