### PR TITLE
fix: show actual range start info

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -523,20 +523,23 @@ final class BackupServiceImpl {
       final SequencedCollection<BackupRange> ranges) {
     final var result = new ArrayList<BackupRangeStatus>(ranges.size());
     for (final var range : ranges) {
+      // IMPORTANT: getCheckpoint() returns a shared mutable flyweight from the column
+      // family. We must extract data into an immutable record immediately after each
+      // call, before the next call overwrites the flyweight's internal buffer.
       final var firstMeta = checkpointMetadataState.getCheckpoint(range.start());
+      final var first = firstMeta == null ? null : toCheckpointInfo(range.start(), firstMeta);
       final var lastMeta = checkpointMetadataState.getCheckpoint(range.end());
-      if (firstMeta == null || lastMeta == null) {
+      final var last = lastMeta == null ? null : toCheckpointInfo(range.end(), lastMeta);
+      if (first == null || last == null) {
         LOG.atWarn()
             .addKeyValue("rangeStart", range.start())
             .addKeyValue("rangeEnd", range.end())
-            .addKeyValue("firstMetaPresent", firstMeta != null)
-            .addKeyValue("lastMetaPresent", lastMeta != null)
+            .addKeyValue("firstMetaPresent", first != null)
+            .addKeyValue("lastMetaPresent", last != null)
             .setMessage("Checkpoint metadata missing for range boundary, skipping range")
             .log();
         continue;
       }
-      final var first = toCheckpointInfo(range.start(), firstMeta);
-      final var last = toCheckpointInfo(range.end(), lastMeta);
       result.add(new BackupRangeStatus(first, last));
     }
     future.complete(result);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
@@ -116,6 +116,11 @@ final class BackupRangeTrackingIT {
                                       .isGreaterThanOrEqualTo(range.getStart().getCheckpointId());
                                 });
                         assertThat(range.getEnd()).isNotEqualTo(range.getStart());
+                        assertThat(range.getStart().getCheckpointTimestamp())
+                            .describedAs(
+                                "Start and end timestamps must differ because they are"
+                                    + " distinct backups taken at different times")
+                            .isNotEqualTo(range.getEnd().getCheckpointTimestamp());
                       });
             });
   }


### PR DESCRIPTION
Fixes the `/actuator/backupRuntime/state` endpoint returning identical metadata for the first and last backup in each range. All fields (checkpoint position, timestamp, type, and first log position) were affected.

`DbCheckpointMetadataState.getCheckpoint()` returns a shared mutable flyweight from the column family. In `BackupServiceImpl.buildRangeStatuses()`, both `range.start()` and `range.end()` were looked up before reading data from either result. The second `getCheckpoint()` call overwrote the flyweight returned by the first, so `toCheckpointInfo()` produced identical values for both boundaries. The fix converts each flyweight into an immutable `CheckpointInfo` record immediately after the lookup, before the next call can overwrite the shared buffer.