### PR TITLE
test: migrate operation.spec.ts to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
@@ -130,4 +130,23 @@ export class OperateOperationPanelPage {
       .filter({hasText: operationId});
     await operationEntryById.click();
   }
+
+  getRetryOperationEntry(successCount: number): Locator {
+    return this.getAllOperationEntries()
+      .filter({hasText: 'Retry'})
+      .filter({hasText: `${successCount} success`})
+      .first();
+  }
+
+  getCancelOperationEntry(successCount: number): Locator {
+    return this.getAllOperationEntries()
+      .filter({hasText: 'Cancel'})
+      .filter({hasText: `${successCount} success`});
+  }
+
+  async clickOperationLink(operationEntry: Locator): Promise<void> {
+    await OperateOperationPanelPage.getOperationID(operationEntry)
+      .first()
+      .click({timeout: 30000});
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -52,6 +52,14 @@ class OperateProcessesPage {
   readonly resultsText: Locator;
   readonly viewParentInstanceLink: Locator;
   readonly calledInstanceCell: Locator;
+  readonly singleOperationSpinner: Locator;
+  readonly selectAllRowsCheckbox: Locator;
+  readonly retryButton: Locator;
+  readonly cancelButton: Locator;
+  readonly applyButton: Locator;
+  readonly resultsCount: Locator;
+  readonly scheduledOperationsIcons: Locator;
+  readonly processInstanceLinkByKey: (processInstanceKey: string) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -155,6 +163,19 @@ class OperateProcessesPage {
       .getByTestId('data-list')
       .getByTestId('cell-processInstanceKey')
       .first();
+    this.singleOperationSpinner = page.getByTestId('operation-spinner');
+    this.selectAllRowsCheckbox = page.getByRole('columnheader', {
+      name: 'Select all rows',
+    });
+    this.retryButton = page.getByRole('button', {name: 'Retry', exact: true});
+    this.cancelButton = page.getByRole('button', {name: 'Cancel', exact: true});
+    this.applyButton = page.getByRole('button', {name: 'Apply'});
+    this.resultsCount = page.getByText(/\d+ results?/);
+    this.scheduledOperationsIcons = page.getByTitle(
+      /has scheduled operations/i,
+    );
+    this.processInstanceLinkByKey = (processInstanceKey: string) =>
+      page.getByRole('link', {name: processInstanceKey});
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -387,6 +408,42 @@ class OperateProcessesPage {
 
   async clickViewParentInstanceFromList(): Promise<void> {
     await this.viewParentInstanceLink.click();
+  }
+
+  getInstanceRow(index: number): Locator {
+    return this.dataList.getByRole('row').nth(index);
+  }
+
+  getCanceledIcon(processInstanceKey: string): Locator {
+    return this.page.getByTestId(`CANCELED-icon-${processInstanceKey}`);
+  }
+
+  getRetryInstanceButton(processInstanceKey: string): Locator {
+    return this.page.getByRole('button', {
+      name: `Retry Instance ${processInstanceKey}`,
+    });
+  }
+
+  getCancelInstanceButton(processInstanceKey: string): Locator {
+    return this.page.getByRole('button', {
+      name: `Cancel Instance ${processInstanceKey}`,
+    });
+  }
+
+  async clickRetryInstanceButton(processInstanceKey: string): Promise<void> {
+    const button = this.getRetryInstanceButton(processInstanceKey);
+    try {
+      await button.click({timeout: 30000});
+    } catch {
+      await button.scrollIntoViewIfNeeded({timeout: 60000});
+      await button.click({timeout: 60000});
+    }
+  }
+
+  async clickCancelInstanceButton(processInstanceKey: string): Promise<void> {
+    const button = this.getCancelInstanceButton(processInstanceKey);
+    await button.scrollIntoViewIfNeeded({timeout: 30000});
+    await button.click({timeout: 30000});
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/operationsProcessA.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/operationsProcessA.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0j0fp4a" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="operationsProcessA" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>SequenceFlow_05ep9w5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>SequenceFlow_05ep9w5</bpmn:incoming>
+      <bpmn:errorEventDefinition errorRef="Error_1" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_05ep9w5" sourceRef="start" targetRef="end" />
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="errorEnd" errorCode="end" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="error-end-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_13vjvo9_di" bpmnElement="end">
+        <dc:Bounds x="252" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_05ep9w5_di" bpmnElement="SequenceFlow_05ep9w5">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="252" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/operationsProcessB.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/operationsProcessB.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0j0fp4a" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="operationsProcessB" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>SequenceFlow_05ep9w5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>SequenceFlow_05ep9w5</bpmn:incoming>
+      <bpmn:errorEventDefinition errorRef="Error_1" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_05ep9w5" sourceRef="start" targetRef="end" />
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="errorEnd" errorCode="end" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="error-end-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_13vjvo9_di" bpmnElement="end">
+        <dc:Bounds x="252" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_05ep9w5_di" bpmnElement="SequenceFlow_05ep9w5">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="252" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -1,0 +1,300 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp, validateURL} from '@pages/UtilitiesPage';
+import {DATE_REGEX} from 'utils/constants';
+import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {createDemoOperations} from 'utils/operations.helper';
+import {waitForIncidents} from 'utils/incidentsHelper';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+  bpmnProcessId: string;
+};
+
+let initialData: {
+  singleOperationInstance: ProcessInstance;
+  batchOperationInstances: ProcessInstance[];
+};
+
+test.beforeAll(async ({request}) => {
+  await deploy([
+    './resources/operationsProcessA.bpmn',
+    './resources/operationsProcessB.bpmn',
+  ]);
+
+  const singleInstance = await createSingleInstance('operationsProcessA', 1);
+  const batchInstances = await createInstances('operationsProcessB', 1, 10);
+
+  initialData = {
+    singleOperationInstance: {
+      processInstanceKey: singleInstance.processInstanceKey,
+      bpmnProcessId: 'operationsProcessA',
+    },
+    batchOperationInstances: batchInstances.map((instance) => ({
+      processInstanceKey: instance.processInstanceKey,
+      bpmnProcessId: 'operationsProcessB',
+    })),
+  };
+  await sleep(2500);
+  await createDemoOperations(
+    request,
+    initialData.singleOperationInstance.processInstanceKey,
+    50,
+  );
+  await sleep(1000);
+  await waitForIncidents(
+    request,
+    initialData.singleOperationInstance.processInstanceKey,
+  );
+});
+
+test.describe('Operations', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Infinite scrolling', async ({operateOperationPanelPage}) => {
+    await test.step('Expand operations panel and verify initial batch loaded', async () => {
+      await operateOperationPanelPage.expandOperationIdField();
+
+      await expect
+        .poll(async () => {
+          return operateOperationPanelPage.getAllOperationEntries().count();
+        })
+        .toBe(20);
+    });
+
+    await test.step('Scroll to bottom and verify more operations loaded', async () => {
+      await operateOperationPanelPage
+        .getAllOperationEntries()
+        .nth(19)
+        .scrollIntoViewIfNeeded();
+
+      await expect(
+        operateOperationPanelPage.getAllOperationEntries(),
+      ).toHaveCount(40, {timeout: 30000});
+    });
+  });
+
+  test('Retry and cancel single instance', async ({
+    page,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateOperationPanelPage,
+  }) => {
+    const instance = initialData.singleOperationInstance;
+
+    await test.step('Filter by Process Instance Key', async () => {
+      await expect(operateProcessesPage.dataList).toBeVisible();
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.processInstanceKeysFilter.fill(
+        instance.processInstanceKey,
+      );
+      await expect(page.getByText('1 result')).toBeVisible();
+    });
+
+    await test.step('Retry single instance using operation button', async () => {
+      await operateProcessesPage.clickRetryInstanceButton(
+        instance.processInstanceKey,
+      );
+
+      await expect(operateProcessesPage.singleOperationSpinner).toBeVisible();
+      await expect
+        .poll(() => operateProcessesPage.singleOperationSpinner.isVisible(), {
+          timeout: 60000,
+        })
+        .toBeFalsy();
+    });
+
+    await test.step('Cancel single instance using operation button', async () => {
+      await operateProcessesPage.clickCancelInstanceButton(
+        instance.processInstanceKey,
+      );
+
+      await operateProcessesPage.applyButton.click();
+
+      await expect(operateProcessesPage.noMatchingInstancesMessage).toBeVisible(
+        {timeout: 60000},
+      );
+    });
+
+    await test.step('Validate operation in operations list', async () => {
+      await expect(operateOperationPanelPage.operationList).toBeHidden();
+      await operateOperationPanelPage.expandOperationIdField();
+
+      await expect(operateOperationPanelPage.operationList).toBeVisible();
+
+      const operationEntry =
+        operateOperationPanelPage.getCancelOperationEntry(1);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operationEntry).toBeVisible();
+          await expect(operationEntry.getByText(DATE_REGEX)).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 10,
+      });
+
+      const operationId = await operationEntry.getByRole('link').innerText();
+
+      await operateOperationPanelPage.clickOperationLink(operationEntry);
+      await expect(operateFiltersPanelPage.operationIdFilter).toHaveValue(
+        operationId,
+      );
+      await expect(page.getByText('1 result')).toBeVisible();
+    });
+
+    await test.step('Validate canceled instance details', async () => {
+      const instanceRow = operateProcessesPage.getInstanceRow(0);
+
+      await expect(
+        operateProcessesPage.getCanceledIcon(instance.processInstanceKey),
+      ).toBeVisible();
+
+      await expect(instanceRow.getByText(instance.bpmnProcessId)).toBeVisible();
+      await expect(
+        instanceRow.getByText(instance.processInstanceKey),
+      ).toBeVisible();
+
+      await operateOperationPanelPage.collapseOperationIdField();
+    });
+  });
+
+  test('Retry and cancel multiple instances', async ({
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateOperationPanelPage,
+    page,
+  }) => {
+    const instances = initialData.batchOperationInstances.slice(0, 5);
+
+    await test.step('Filter by Process Instance Keys', async () => {
+      await expect(operateProcessesPage.dataList).toBeVisible();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.processInstanceKeysFilter.fill(
+        instances.map((instance) => instance.processInstanceKey).join(','),
+      );
+
+      await expect(operateProcessesPage.dataList.getByRole('row')).toHaveCount(
+        instances.length,
+      );
+    });
+
+    await test.step('Select all instances and retry', async () => {
+      await operateProcessesPage.selectAllRowsCheckbox.click();
+
+      await operateProcessesPage.retryButton.click();
+
+      await expect(operateOperationPanelPage.operationList).toBeHidden();
+
+      await operateProcessesPage.applyButton.click();
+
+      await expect(operateOperationPanelPage.operationList).toBeVisible({
+        timeout: 30000,
+      });
+      await sleep(500);
+
+      await operateOperationPanelPage.expandOperationsPanel();
+    });
+
+    await test.step('Wait for operation to complete', async () => {
+      const operationEntry = operateOperationPanelPage.getRetryOperationEntry(
+        instances.length,
+      );
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operationEntry).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 10,
+      });
+
+      await operateOperationPanelPage.clickOperationLink(operationEntry);
+
+      await validateURL(page, /operationId=/);
+
+      await Promise.all(
+        instances.map((instance) =>
+          expect(
+            operateProcessesPage.processInstanceLinkByKey(
+              instance.processInstanceKey,
+            ),
+          ).toBeVisible(),
+        ),
+      );
+    });
+
+    await test.step('Cancel all instances', async () => {
+      await operateOperationPanelPage.collapseOperationIdField();
+      await operateProcessesPage.selectAllRowsCheckbox.click();
+
+      await operateProcessesPage.cancelButton.click();
+      await operateProcessesPage.applyButton.click();
+
+      await expect(operateOperationPanelPage.operationList).toBeVisible({
+        timeout: 30000,
+      });
+      await sleep(500);
+
+      await operateOperationPanelPage.expandOperationsPanel();
+
+      await expect
+        .poll(async () => {
+          return operateProcessesPage.scheduledOperationsIcons.count();
+        })
+        .toBe(instances.length);
+
+      const operationEntry = operateOperationPanelPage.getCancelOperationEntry(
+        instances.length,
+      );
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operationEntry).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 10,
+      });
+
+      await Promise.all(
+        instances.map((instance) =>
+          expect(
+            operateProcessesPage.getCanceledIcon(instance.processInstanceKey),
+          ).toBeVisible({timeout: 120000}),
+        ),
+      );
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export const DATE_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export type Credentials = {
+  baseUrl: string;
+  accessToken: string;
+};
+
+export const credentials: Credentials = {
+  baseUrl: process.env.CORE_APPLICATION_OPERATE_URL ?? 'http://localhost:8081',
+  accessToken: encode(
+    `${process.env.TEST_USERNAME ?? 'demo'}:${process.env.TEST_PASSWORD ?? 'demo'}`,
+  ),
+};
+
+export function encode(auth: string) {
+  return Buffer.from(auth).toString('base64');
+}
+
+export function authHeaders(token?: string): Record<string, string> {
+  const h: Record<string, string> = {};
+  if (token) h.Authorization = `Basic ${token}`;
+  return h;
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, request, APIRequestContext} from '@playwright/test';
+
+export async function createDemoOperations(
+  _request: APIRequestContext,
+  processInstanceKey: string,
+  count: number,
+): Promise<void> {
+  const baseURL =
+    process.env.CORE_APPLICATION_OPERATE_URL ?? 'http://localhost:8081';
+  const username = process.env.TEST_USERNAME || 'demo';
+  const password = process.env.TEST_PASSWORD || 'demo';
+
+  const apiContext = await request.newContext({baseURL});
+  await apiContext.post('/api/login', {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    form: {username, password},
+  });
+
+  try {
+    // Wait until the process instance is indexed in Operate before creating operations
+    await expect
+      .poll(
+        async () => {
+          const response = await apiContext.get(
+            `/v1/process-instances/${processInstanceKey}`,
+          );
+          return response.status();
+        },
+        {timeout: 60000},
+      )
+      .toBe(200);
+
+    for (let index = 0; index < count; index++) {
+      const response = await apiContext.post(
+        `/api/process-instances/${processInstanceKey}/operation`,
+        {
+          data: {operationType: 'RESOLVE_INCIDENT'},
+        },
+      );
+      if (!response.ok()) {
+        const errorBody = await response.text();
+        console.error(
+          `Failed to create operation ${index + 1}/${count}: ${response.status()} ${response.statusText()}`,
+        );
+        console.error(`Process Instance Key: ${processInstanceKey}`);
+        console.error(`Response body: ${errorBody}`);
+      }
+      expect(
+        response.ok(),
+        `Operation ${index + 1}/${count} failed: ${response.status()} ${response.statusText()}`,
+      ).toBeTruthy();
+    }
+
+    await expect
+      .poll(
+        async () => {
+          const response = await apiContext.post('/api/batch-operations', {
+            data: {pageSize: count},
+          });
+          const operations = await response.json();
+          return operations.length;
+        },
+        {timeout: 30000},
+      )
+      .toBeGreaterThanOrEqual(count);
+  } finally {
+    await apiContext.dispose();
+  }
+}


### PR DESCRIPTION
## Description
Migrated `operations.spec.ts` from the old Operate e2e-playwright suite to the new c8-orchestration-cluster-e2e-test-suite following POM patterns and test suite conventions.

## Key Changes

### Test Migration
- **`tests/operate/operations.spec.ts`** - Migrated 3 test cases (infinite scrolling, retry/cancel single and batch operations)



### New Utility (`utils/operations.helper.ts`)
- Created `createDemoOperations()` helper to generate test operations via API
- Reuses shared authentication utilities from `http.ts`
- Includes error logging for failed operations





🧪 [Test Run](https://github.com/camunda/camunda/actions/runs/22760148888)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34110
