### PR TITLE
fix: handle Oracle empty-string-to-NULL for required RDBMS fields

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/NullSafeStrings.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/NullSafeStrings.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read;
+
+/**
+ * Oracle treats empty strings as NULL. This utility converts null values back to empty strings for
+ * fields that are required (non-nullable) in the API specification but may legitimately be empty
+ * (e.g., protobuf default values).
+ */
+public final class NullSafeStrings {
+
+  private NullSafeStrings() {
+    // utility class — no instantiation
+  }
+
+  /** Returns the given string, or {@code ""} if it is {@code null}. */
+  public static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapper.java
@@ -15,20 +15,29 @@ public class CorrelatedMessageSubscriptionEntityMapper {
   public static CorrelatedMessageSubscriptionEntity toEntity(
       final CorrelatedMessageSubscriptionDbModel dbModel) {
     return CorrelatedMessageSubscriptionEntity.builder()
-        .correlationKey(dbModel.correlationKey())
+        .correlationKey(nullToEmpty(dbModel.correlationKey()))
         .correlationTime(dbModel.correlationTime())
-        .flowNodeId(dbModel.flowNodeId())
+        .flowNodeId(nullToEmpty(dbModel.flowNodeId()))
         .flowNodeInstanceKey(dbModel.flowNodeInstanceKey())
         .messageKey(dbModel.messageKey())
-        .messageName(dbModel.messageName())
+        .messageName(nullToEmpty(dbModel.messageName()))
         .partitionId(dbModel.partitionId())
-        .processDefinitionId(dbModel.processDefinitionId())
+        .processDefinitionId(nullToEmpty(dbModel.processDefinitionId()))
         .processDefinitionKey(dbModel.processDefinitionKey())
         .processInstanceKey(dbModel.processInstanceKey())
         .rootProcessInstanceKey(dbModel.rootProcessInstanceKey())
         .subscriptionKey(dbModel.subscriptionKey())
         .subscriptionType(dbModel.subscriptionType())
-        .tenantId(dbModel.tenantId())
+        .tenantId(nullToEmpty(dbModel.tenantId()))
         .build();
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., correlationKey for message start event subscriptions).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.mapper;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.write.domain.CorrelatedMessageSubscriptionDbModel;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 
@@ -30,14 +32,5 @@ public class CorrelatedMessageSubscriptionEntityMapper {
         .subscriptionType(dbModel.subscriptionType())
         .tenantId(nullToEmpty(dbModel.tenantId()))
         .build();
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., correlationKey for message start event subscriptions).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/FlowNodeInstanceEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/FlowNodeInstanceEntityMapper.java
@@ -20,15 +20,24 @@ public class FlowNodeInstanceEntityMapper {
         dbModel.processDefinitionKey(),
         dbModel.startDate(),
         dbModel.endDate(),
-        dbModel.flowNodeId(),
-        dbModel.flowNodeName(),
+        nullToEmpty(dbModel.flowNodeId()),
+        nullToEmpty(dbModel.flowNodeName()),
         dbModel.treePath(),
         dbModel.type(),
         dbModel.state(),
         dbModel.hasIncident(),
         dbModel.incidentKey(),
-        dbModel.processDefinitionId(),
-        dbModel.tenantId(),
+        nullToEmpty(dbModel.processDefinitionId()),
+        nullToEmpty(dbModel.tenantId()),
         dbModel.partitionId());
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/FlowNodeInstanceEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/FlowNodeInstanceEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.mapper;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 
@@ -30,14 +32,5 @@ public class FlowNodeInstanceEntityMapper {
         nullToEmpty(dbModel.processDefinitionId()),
         nullToEmpty(dbModel.tenantId()),
         dbModel.partitionId());
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapper.java
@@ -17,13 +17,22 @@ public class GlobalListenerEntityMapper {
     }
     return new GlobalListenerEntity(
         dbModel.id(),
-        dbModel.listenerId(),
-        dbModel.type(),
+        nullToEmpty(dbModel.listenerId()),
+        nullToEmpty(dbModel.type()),
         dbModel.eventTypes(),
         dbModel.retries(),
         dbModel.afterNonGlobal(),
         dbModel.priority(),
         dbModel.source(),
         dbModel.listenerType());
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.mapper;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
 import io.camunda.search.entities.GlobalListenerEntity;
 
@@ -25,14 +27,5 @@ public class GlobalListenerEntityMapper {
         dbModel.priority(),
         dbModel.source(),
         dbModel.listenerType());
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.mapper;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.write.domain.JobDbModel;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobEntity.JobKind;
@@ -42,14 +44,5 @@ public class JobEntityMapper {
         .creationTime(jobDbModel.creationTime())
         .lastUpdateTime(jobDbModel.lastUpdateTime())
         .build();
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
@@ -12,15 +12,14 @@ import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobEntity.JobKind;
 import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.entities.JobEntity.ListenerEventType;
-import java.util.Objects;
 
 public class JobEntityMapper {
 
   public static JobEntity toEntity(final JobDbModel jobDbModel) {
     return new JobEntity.Builder()
         .jobKey(jobDbModel.jobKey())
-        .type(jobDbModel.type())
-        .worker(Objects.requireNonNullElse(jobDbModel.worker(), ""))
+        .type(nullToEmpty(jobDbModel.type()))
+        .worker(nullToEmpty(jobDbModel.worker()))
         .state(JobState.valueOf(jobDbModel.state().name()))
         .kind(JobKind.valueOf(jobDbModel.kind().name()))
         .listenerEventType(ListenerEventType.valueOf(jobDbModel.listenerEventType().name()))
@@ -33,15 +32,24 @@ public class JobEntityMapper {
         .customHeaders(jobDbModel.customHeaders())
         .deadline(jobDbModel.deadline())
         .endTime(jobDbModel.endTime())
-        .processDefinitionId(jobDbModel.processDefinitionId())
+        .processDefinitionId(nullToEmpty(jobDbModel.processDefinitionId()))
         .processDefinitionKey(jobDbModel.processDefinitionKey())
         .processInstanceKey(jobDbModel.processInstanceKey())
         .rootProcessInstanceKey(jobDbModel.rootProcessInstanceKey())
         .elementId(jobDbModel.elementId())
         .elementInstanceKey(jobDbModel.elementInstanceKey())
-        .tenantId(jobDbModel.tenantId())
+        .tenantId(nullToEmpty(jobDbModel.tenantId()))
         .creationTime(jobDbModel.creationTime())
         .lastUpdateTime(jobDbModel.lastUpdateTime())
         .build();
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -16,17 +16,26 @@ public class MessageSubscriptionEntityMapper {
       final MessageSubscriptionDbModel messageSubscriptionDbModel) {
     return MessageSubscriptionEntity.builder()
         .messageSubscriptionKey(messageSubscriptionDbModel.messageSubscriptionKey())
-        .processDefinitionId(messageSubscriptionDbModel.processDefinitionId())
+        .processDefinitionId(nullToEmpty(messageSubscriptionDbModel.processDefinitionId()))
         .processDefinitionKey(messageSubscriptionDbModel.processDefinitionKey())
         .processInstanceKey(messageSubscriptionDbModel.processInstanceKey())
         .rootProcessInstanceKey(messageSubscriptionDbModel.rootProcessInstanceKey())
-        .flowNodeId(messageSubscriptionDbModel.flowNodeId())
+        .flowNodeId(nullToEmpty(messageSubscriptionDbModel.flowNodeId()))
         .flowNodeInstanceKey(messageSubscriptionDbModel.flowNodeInstanceKey())
         .messageSubscriptionState(messageSubscriptionDbModel.messageSubscriptionState())
         .dateTime(messageSubscriptionDbModel.dateTime())
-        .messageName(messageSubscriptionDbModel.messageName())
-        .correlationKey(messageSubscriptionDbModel.correlationKey())
-        .tenantId(messageSubscriptionDbModel.tenantId())
+        .messageName(nullToEmpty(messageSubscriptionDbModel.messageName()))
+        .correlationKey(nullToEmpty(messageSubscriptionDbModel.correlationKey()))
+        .tenantId(nullToEmpty(messageSubscriptionDbModel.tenantId()))
         .build();
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.mapper;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 
@@ -28,14 +30,5 @@ public class MessageSubscriptionEntityMapper {
         .correlationKey(nullToEmpty(messageSubscriptionDbModel.correlationKey()))
         .tenantId(nullToEmpty(messageSubscriptionDbModel.tenantId()))
         .build();
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/SequenceFlowEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/SequenceFlowEntityMapper.java
@@ -15,11 +15,20 @@ public class SequenceFlowEntityMapper {
   public static SequenceFlowEntity toEntity(final SequenceFlowDbModel dbModel) {
     return new SequenceFlowEntity(
         dbModel.sequenceFlowId(),
-        dbModel.flowNodeId(),
+        nullToEmpty(dbModel.flowNodeId()),
         dbModel.processInstanceKey(),
         dbModel.rootProcessInstanceKey(),
         dbModel.processDefinitionKey(),
-        dbModel.processDefinitionId(),
-        dbModel.tenantId());
+        nullToEmpty(dbModel.processDefinitionId()),
+        nullToEmpty(dbModel.tenantId()));
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/SequenceFlowEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/SequenceFlowEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.mapper;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.write.domain.SequenceFlowDbModel;
 import io.camunda.search.entities.SequenceFlowEntity;
 
@@ -21,14 +23,5 @@ public class SequenceFlowEntityMapper {
         dbModel.processDefinitionKey(),
         nullToEmpty(dbModel.processDefinitionId()),
         nullToEmpty(dbModel.tenantId()));
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.mapper;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.db.rdbms.write.util.CustomHeaderSerializer;
 import io.camunda.search.entities.UserTaskEntity;
@@ -40,14 +42,5 @@ public class UserTaskEntityMapper {
         CustomHeaderSerializer.deserialize(dbModel.serializedCustomHeaders()),
         dbModel.priority(),
         dbModel.tags());
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapper.java
@@ -17,9 +17,9 @@ public class UserTaskEntityMapper {
   public static UserTaskEntity toEntity(final UserTaskDbModel dbModel) {
     return new UserTaskEntity(
         dbModel.userTaskKey(),
-        dbModel.elementId(),
+        nullToEmpty(dbModel.elementId()),
         dbModel.name(),
-        dbModel.processDefinitionId(),
+        nullToEmpty(dbModel.processDefinitionId()),
         null, // filled later from ProcessCache in UserTaskService
         dbModel.creationDate(),
         dbModel.completionDate(),
@@ -30,7 +30,7 @@ public class UserTaskEntityMapper {
         dbModel.processInstanceKey(),
         dbModel.rootProcessInstanceKey(),
         dbModel.elementInstanceKey(),
-        dbModel.tenantId(),
+        nullToEmpty(dbModel.tenantId()),
         dbModel.dueDate(),
         dbModel.followUpDate(),
         dbModel.candidateGroups(),
@@ -40,5 +40,14 @@ public class UserTaskEntityMapper {
         CustomHeaderSerializer.deserialize(dbModel.serializedCustomHeaders()),
         dbModel.priority(),
         dbModel.tags());
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.GroupDbQuery;
 import io.camunda.db.rdbms.sql.GroupMapper;
@@ -88,15 +90,6 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
         nullToEmpty(model.groupId()),
         nullToEmpty(model.name()),
         model.description());
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 
   private boolean shouldReturnEmptyResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
@@ -83,7 +83,20 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
   }
 
   private GroupEntity map(final GroupDbModel model) {
-    return new GroupEntity(model.groupKey(), model.groupId(), model.name(), model.description());
+    return new GroupEntity(
+        model.groupKey(),
+        nullToEmpty(model.groupId()),
+        nullToEmpty(model.name()),
+        model.description());
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 
   private boolean shouldReturnEmptyResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.RoleDbQuery;
 import io.camunda.db.rdbms.sql.RoleMapper;
@@ -87,15 +89,6 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
         nullToEmpty(model.roleId()),
         nullToEmpty(model.name()),
         model.description());
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 
   private boolean shouldReturnEmptyResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
@@ -82,7 +82,20 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
   }
 
   private RoleEntity map(final RoleDbModel model) {
-    return new RoleEntity(model.roleKey(), model.roleId(), model.name(), model.description());
+    return new RoleEntity(
+        model.roleKey(),
+        nullToEmpty(model.roleId()),
+        nullToEmpty(model.name()),
+        model.description());
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 
   private boolean shouldReturnEmptyResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
@@ -83,7 +83,20 @@ public class TenantDbReader extends AbstractEntityReader<TenantEntity> implement
   }
 
   private TenantEntity map(final TenantDbModel model) {
-    return new TenantEntity(model.tenantKey(), model.tenantId(), model.name(), model.description());
+    return new TenantEntity(
+        model.tenantKey(),
+        nullToEmpty(model.tenantId()),
+        nullToEmpty(model.name()),
+        model.description());
+  }
+
+  /**
+   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
+   * fields that are required (non-nullable) in the API specification but may legitimately be empty
+   * (e.g., protobuf default values).
+   */
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
   }
 
   private boolean shouldReturnEmptyResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.TenantDbQuery;
 import io.camunda.db.rdbms.sql.TenantMapper;
@@ -88,15 +90,6 @@ public class TenantDbReader extends AbstractEntityReader<TenantEntity> implement
         nullToEmpty(model.tenantId()),
         nullToEmpty(model.name()),
         model.description());
-  }
-
-  /**
-   * Oracle treats empty strings as NULL. This method converts null values back to empty strings for
-   * fields that are required (non-nullable) in the API specification but may legitimately be empty
-   * (e.g., protobuf default values).
-   */
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 
   private boolean shouldReturnEmptyResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/typehandler/NullToEmptyStringTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/typehandler/NullToEmptyStringTypeHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.typehandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+/**
+ * Oracle treats empty strings as NULL. This type handler converts null values back to empty strings
+ * when reading from the database, ensuring that fields which are required (non-nullable) in the API
+ * specification are never returned as null even if the underlying database stored them as NULL.
+ *
+ * <p>Use this handler on MyBatis result map columns for String fields that are required and
+ * non-nullable in the API contract but may legitimately be empty (e.g., protobuf default values).
+ */
+public final class NullToEmptyStringTypeHandler extends BaseTypeHandler<String> {
+
+  @Override
+  public void setNonNullParameter(
+      final PreparedStatement ps, final int i, final String parameter, final JdbcType jdbcType)
+      throws SQLException {
+    ps.setString(i, parameter);
+  }
+
+  @Override
+  public String getNullableResult(final ResultSet rs, final String columnName) throws SQLException {
+    return nullToEmpty(rs.getString(columnName));
+  }
+
+  @Override
+  public String getNullableResult(final ResultSet rs, final int columnIndex) throws SQLException {
+    return nullToEmpty(rs.getString(columnIndex));
+  }
+
+  @Override
+  public String getNullableResult(final CallableStatement cs, final int columnIndex)
+      throws SQLException {
+    return nullToEmpty(cs.getString(columnIndex));
+  }
+
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/typehandler/NullToEmptyStringTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/typehandler/NullToEmptyStringTypeHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.typehandler;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -45,9 +47,5 @@ public final class NullToEmptyStringTypeHandler extends BaseTypeHandler<String> 
   public String getNullableResult(final CallableStatement cs, final int columnIndex)
       throws SQLException {
     return nullToEmpty(cs.getString(columnIndex));
-  }
-
-  private static String nullToEmpty(final String value) {
-    return value == null ? "" : value;
   }
 }

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -13,9 +13,12 @@
   <resultMap id="clusterVariableResultMap" type="io.camunda.search.entities.ClusterVariableEntity">
     <constructor>
       <idArg column="CLUSTER_VARIABLE_ID" javaType="java.lang.String"/>
-      <arg column="VAR_NAME" javaType="java.lang.String"/>
-      <arg column="VAR_VALUE" javaType="java.lang.String"/>
-      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
+      <arg column="VAR_NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="VAR_VALUE" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="IS_PREVIEW" javaType="boolean"/>
       <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -17,8 +17,7 @@
         typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VAR_VALUE" javaType="java.lang.String"
         typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
       <arg column="IS_PREVIEW" javaType="boolean"/>
       <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -49,6 +49,62 @@
       </when>
     </choose>
   </sql>
+  <!--
+    Oracle treats empty strings as NULL. When filtering with EQUALS '' or NOT_EQUALS '',
+    we must use IS NULL / IS NOT NULL instead, because NULL = '' evaluates to UNKNOWN in SQL.
+  -->
+  <sql id="operationCondition" databaseId="oracle">
+    <choose>
+      <when test="operation.operator.name().equals('EQUALS')">
+        <choose>
+          <when test="operation.value != null and operation.value.toString().equals('')">
+            IS NULL
+          </when>
+          <otherwise>
+            = #{operation.value}
+          </otherwise>
+        </choose>
+      </when>
+      <when test="operation.operator.name().equals('NOT_EQUALS')">
+        <choose>
+          <when test="operation.value != null and operation.value.toString().equals('')">
+            IS NOT NULL
+          </when>
+          <otherwise>
+            != #{operation.value}
+          </otherwise>
+        </choose>
+      </when>
+      <when test="operation.operator.name().equals('EXISTS')">
+        IS NOT NULL
+      </when>
+      <when test="operation.operator.name().equals('NOT_EXISTS')">
+        IS NULL
+      </when>
+      <when test="operation.operator.name().equals('GREATER_THAN')">
+        &gt; #{operation.value}
+      </when>
+      <when test="operation.operator.name().equals('GREATER_THAN_EQUALS')">
+        &gt;= #{operation.value}
+      </when>
+      <when test="operation.operator.name().equals('LOWER_THAN')">
+        &lt; #{operation.value}
+      </when>
+      <when test="operation.operator.name().equals('LOWER_THAN_EQUALS')">
+        &lt;= #{operation.value}
+      </when>
+      <when test="operation.operator.name().equals('IN')">
+        IN <foreach collection="operation.values" item="value" open="(" separator=", " close=")">#{value}</foreach>
+      </when>
+      <when test="operation.operator.name().equals('NOT_IN')">
+        NOT IN <foreach collection="operation.values" item="value" open="(" separator=", " close=")">#{value}</foreach>
+      </when>
+      <when test="operation.operator.name().equals('LIKE')">
+        LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler}
+          ESCAPE ${escapeChar}
+      </when>
+    </choose>
+  </sql>
 
   <sql id="keySetPageFilter">
     <if test="page != null and page.keySetPagination != null and !page.keySetPagination.isEmpty()">

--- a/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
@@ -125,14 +125,19 @@
   <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionDefinitionEntity">
     <constructor>
       <idArg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
-      <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"/>
-      <arg column="NAME" javaType="java.lang.String"/>
+      <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VERSION" javaType="java.lang.Integer"/>
-      <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"/>
+      <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
-      <arg column="DECISION_REQUIREMENTS_NAME" javaType="java.lang.String"/>
+      <arg column="DECISION_REQUIREMENTS_NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_REQUIREMENTS_VERSION" javaType="java.lang.Integer"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -204,15 +204,19 @@
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
-      <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
-      <arg column="DECISION_DEFINITION_NAME" javaType="java.lang.String"/>
+      <arg column="DECISION_DEFINITION_NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_DEFINITION_VERSION" javaType="java.lang.Integer"/>
       <arg column="TYPE"
         javaType="io.camunda.search.entities.DecisionInstanceEntity$DecisionDefinitionType"/>
       <arg column="ROOT_DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
-      <arg column="RESULT" javaType="java.lang.String"/>
+      <arg column="RESULT" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <!-- The list is loaded separately (optional). But we still need a value (NULL) here.
        we use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
       <arg column="EVALUATED_INPUTS" javaType="java.util.List"

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -98,12 +98,16 @@
   <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionRequirementsEntity">
     <constructor>
       <idArg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
-      <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"/>
-      <arg column="NAME" javaType="java.lang.String"/>
+      <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VERSION" javaType="java.lang.Integer"/>
-      <arg column="RESOURCE_NAME" javaType="java.lang.String"/>
+      <arg column="RESOURCE_NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="XML" javaType="java.lang.String"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/FormMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FormMapper.xml
@@ -15,9 +15,12 @@
   <resultMap id="searchResultMap" type="io.camunda.search.entities.FormEntity">
     <constructor>
       <idArg column="FORM_KEY" javaType="java.lang.Long"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
-      <arg column="FORM_ID" javaType="java.lang.String"/>
-      <arg column="SCHEMA_XML" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="FORM_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="SCHEMA_XML" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VERSION" javaType="java.lang.Long"/>
     </constructor>
   </resultMap>

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -160,17 +160,21 @@
     <constructor>
       <idArg column="INCIDENT_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
-      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ERROR_TYPE" javaType="io.camunda.search.entities.IncidentEntity$ErrorType"/>
-      <arg column="ERROR_MESSAGE" javaType="java.lang.String"/>
-      <arg column="FLOW_NODE_ID" javaType="java.lang.String"/>
+      <arg column="ERROR_MESSAGE" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="FLOW_NODE_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="CREATION_DATE" javaType="java.time.OffsetDateTime" />
       <arg column="STATE" javaType="io.camunda.search.entities.IncidentEntity$IncidentState"/>
       <arg column="JOB_KEY" javaType="java.lang.Long"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
 
   </resultMap>

--- a/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
@@ -14,11 +14,15 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.MappingRuleEntity">
     <constructor>
-      <idArg column="MAPPING_RULE_ID" javaType="string"/>
+      <idArg column="MAPPING_RULE_ID" javaType="string"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="MAPPING_RULE_KEY" javaType="long"/>
-      <arg column="CLAIM_NAME" javaType="string"/>
-      <arg column="CLAIM_VALUE" javaType="string"/>
-      <arg column="NAME" javaType="string"/>
+      <arg column="CLAIM_NAME" javaType="string"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="CLAIM_VALUE" javaType="string"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="NAME" javaType="string"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -130,12 +130,15 @@
     <constructor>
       <idArg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
       <arg column="NAME" javaType="java.lang.String"/>
-      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="BPMN_XML" javaType="java.lang.String"/>
-      <arg column="RESOURCE_NAME" javaType="java.lang.String"/>
+      <arg column="RESOURCE_NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VERSION" javaType="java.lang.Integer"/>
       <arg column="VERSION_TAG" javaType="java.lang.String"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="FORM_ID" javaType="java.lang.String"/>
     </constructor>
   </resultMap>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -356,7 +356,8 @@
     <constructor>
       <idArg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="PROCESS_DEFINITION_NAME" javaType="java.lang.String"/>
       <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer"/>
       <arg column="PROCESS_DEFINITION_VERSION_TAG" javaType="java.lang.String"/>
@@ -367,7 +368,8 @@
       <arg column="END_DATE" javaType="java.time.OffsetDateTime" />
       <arg column="STATE" javaType="io.camunda.search.entities.ProcessInstanceEntity$ProcessInstanceState"/>
       <arg column="HAS_INCIDENT" javaType="java.lang.Boolean"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="TREE_PATH" javaType="java.lang.String"/>
       <arg column="BUSINESS_ID" javaType="java.lang.String"/>
     </constructor>

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -89,7 +89,8 @@
   <resultMap id="searchResultMap" type="io.camunda.search.entities.UserEntity">
     <constructor>
       <idArg column="USER_KEY" javaType="java.lang.Long"/>
-      <arg column="USERNAME" javaType="java.lang.String"/>
+      <arg column="USERNAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="NAME" javaType="java.lang.String"/>
       <arg column="EMAIL" javaType="java.lang.String"/>
       <arg column="PASSWORD" javaType="java.lang.String"/>

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -129,15 +129,20 @@
   <resultMap id="searchResultMap" type="io.camunda.search.entities.VariableEntity">
     <constructor>
       <idArg column="VAR_KEY" javaType="java.lang.Long"/>
-      <arg column="VAR_NAME" javaType="java.lang.String"/>
-      <arg column="VAR_VALUE" javaType="java.lang.String"/>
-      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
+      <arg column="VAR_NAME" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="VAR_VALUE" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="IS_PREVIEW" javaType="java.lang.Boolean"/>
       <arg column="SCOPE_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
-      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
-      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"
+        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -133,8 +133,7 @@
         typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VAR_VALUE" javaType="java.lang.String"
         typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
       <arg column="IS_PREVIEW" javaType="java.lang.Boolean"/>
       <arg column="SCOPE_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/NullSafeStringsTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/NullSafeStringsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class NullSafeStringsTest {
+
+  @Test
+  void shouldReturnEmptyStringForNull() {
+    assertThat(NullSafeStrings.nullToEmpty(null)).isEqualTo("");
+  }
+
+  @Test
+  void shouldReturnValueForNonNull() {
+    assertThat(NullSafeStrings.nullToEmpty("hello")).isEqualTo("hello");
+  }
+
+  @Test
+  void shouldReturnEmptyStringForEmptyString() {
+    assertThat(NullSafeStrings.nullToEmpty("")).isEqualTo("");
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapperTest.java
@@ -43,4 +43,43 @@ public class CorrelatedMessageSubscriptionEntityMapperTest {
     // Then
     assertThat(entity).usingRecursiveComparison().isEqualTo(model);
   }
+
+  @Test
+  public void testToEntityWithNullValues() {
+    // Given
+    final var model =
+        new CorrelatedMessageSubscriptionDbModel.Builder()
+            .correlationKey(null)
+            .correlationTime(null)
+            .messageKey(123L)
+            .messageName(null)
+            .flowNodeId(null)
+            .flowNodeInstanceKey(456L)
+            .partitionId(4)
+            .processDefinitionId(null)
+            .processDefinitionKey(789L)
+            .processInstanceKey(1011L)
+            .rootProcessInstanceKey(2022L)
+            .subscriptionKey(321L)
+            .subscriptionType(MessageSubscriptionType.PROCESS_EVENT)
+            .tenantId(null)
+            .build();
+
+    // When
+    final var entity = CorrelatedMessageSubscriptionEntityMapper.toEntity(model);
+
+    // Then
+    assertThat(entity.correlationKey())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.correlationTime()).isNull();
+    assertThat(entity.messageKey()).isNotNull();
+    assertThat(entity.messageName())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.flowNodeId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.processDefinitionId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.tenantId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+  }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/FlowNodeInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/FlowNodeInstanceEntityMapperTest.java
@@ -96,16 +96,20 @@ public class FlowNodeInstanceEntityMapperTest {
     assertThat(entity.flowNodeInstanceKey()).isNotNull();
     assertThat(entity.processInstanceKey()).isNotNull();
     assertThat(entity.processDefinitionKey()).isNotNull();
-    assertThat(entity.processDefinitionId()).isNull();
+    assertThat(entity.processDefinitionId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.startDate()).isNull();
     assertThat(entity.endDate()).isNull();
-    assertThat(entity.flowNodeId()).isNull();
-    assertThat(entity.flowNodeName()).isNull();
+    assertThat(entity.flowNodeId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.flowNodeName())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.treePath()).isNull();
     assertThat(entity.type()).isNotNull();
     assertThat(entity.state()).isNotNull();
     assertThat(entity.incidentKey()).isNotNull();
     assertThat(entity.hasIncident()).isNotNull();
-    assertThat(entity.tenantId()).isNull();
+    assertThat(entity.tenantId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapperTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel.GlobalListenerDbModelBuilder;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerSource;
+import io.camunda.search.entities.GlobalListenerType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class GlobalListenerEntityMapperTest {
+
+  @Test
+  public void testToEntity() {
+    // Given
+    final GlobalListenerDbModel dbModel =
+        new GlobalListenerDbModelBuilder()
+            .listenerId("my-listener")
+            .type("io.camunda.zeebe:userTask")
+            .retries(3)
+            .eventTypes(List.of("start", "complete"))
+            .afterNonGlobal(false)
+            .priority(10)
+            .source(GlobalListenerSource.CONFIGURATION)
+            .listenerType(GlobalListenerType.USER_TASK)
+            .build();
+
+    // When
+    final GlobalListenerEntity entity = GlobalListenerEntityMapper.toEntity(dbModel);
+
+    // Then
+    assertThat(entity.id()).isNotNull();
+    assertThat(entity.listenerId()).isEqualTo("my-listener");
+    assertThat(entity.type()).isEqualTo("io.camunda.zeebe:userTask");
+    assertThat(entity.retries()).isEqualTo(3);
+    assertThat(entity.eventTypes()).containsExactly("start", "complete");
+    assertThat(entity.afterNonGlobal()).isFalse();
+    assertThat(entity.priority()).isEqualTo(10);
+    assertThat(entity.source()).isEqualTo(GlobalListenerSource.CONFIGURATION);
+    assertThat(entity.listenerType()).isEqualTo(GlobalListenerType.USER_TASK);
+  }
+
+  @Test
+  public void testToEntityWithNullValues() {
+    // Given
+    final GlobalListenerDbModel dbModel =
+        new GlobalListenerDbModelBuilder()
+            .listenerId(null)
+            .type(null)
+            .retries(3)
+            .eventTypes(List.of())
+            .afterNonGlobal(false)
+            .priority(10)
+            .source(GlobalListenerSource.CONFIGURATION)
+            .listenerType(GlobalListenerType.USER_TASK)
+            .build();
+
+    // When
+    final GlobalListenerEntity entity = GlobalListenerEntityMapper.toEntity(dbModel);
+
+    // Then
+    assertThat(entity.listenerId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.type())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.retries()).isEqualTo(3);
+    assertThat(entity.source()).isEqualTo(GlobalListenerSource.CONFIGURATION);
+    assertThat(entity.listenerType()).isEqualTo(GlobalListenerType.USER_TASK);
+  }
+
+  @Test
+  public void testToEntityWithNullModel() {
+    // When
+    final GlobalListenerEntity entity = GlobalListenerEntityMapper.toEntity(null);
+
+    // Then
+    assertThat(entity).isNull();
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
@@ -102,7 +102,8 @@ public class JobEntityMapperTest {
 
     // Then
     assertThat(entity.jobKey()).isNotNull();
-    assertThat(entity.type()).isNull();
+    assertThat(entity.type())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.worker()).isEqualTo(""); // worker must be empty string
     assertThat(entity.state()).isNotNull();
     assertThat(entity.kind()).isNotNull();
@@ -116,9 +117,11 @@ public class JobEntityMapperTest {
     assertThat(entity.customHeaders()).isEmpty();
     assertThat(entity.deadline()).isNull();
     assertThat(entity.endTime()).isNull();
-    assertThat(entity.processDefinitionId()).isNull();
+    assertThat(entity.processDefinitionId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.elementId()).isNull();
-    assertThat(entity.tenantId()).isNull();
+    assertThat(entity.tenantId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.creationTime()).isNotNull();
     assertThat(entity.lastUpdateTime()).isNotNull();
   }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
@@ -40,4 +40,40 @@ public class MessageSubscriptionEntityMapperTest {
     // Then
     assertThat(entity).usingRecursiveComparison().isEqualTo(model);
   }
+
+  @Test
+  public void testToEntityWithNullValues() {
+    // Given
+    final var model =
+        new MessageSubscriptionDbModel.Builder()
+            .messageSubscriptionKey(1L)
+            .processDefinitionId(null)
+            .processDefinitionKey(1L)
+            .processInstanceKey(1L)
+            .flowNodeId(null)
+            .flowNodeInstanceKey(1L)
+            .messageSubscriptionState(MessageSubscriptionState.CREATED)
+            .dateTime(null)
+            .messageName(null)
+            .correlationKey(null)
+            .tenantId(null)
+            .build();
+
+    // When
+    final var entity = MessageSubscriptionEntityMapper.toEntity(model);
+
+    // Then
+    assertThat(entity.messageSubscriptionKey()).isNotNull();
+    assertThat(entity.processDefinitionId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.flowNodeId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.dateTime()).isNull();
+    assertThat(entity.messageName())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.correlationKey())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.tenantId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+  }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/SequenceFlowEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/SequenceFlowEntityMapperTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.SequenceFlowDbModel;
+import org.junit.jupiter.api.Test;
+
+public class SequenceFlowEntityMapperTest {
+
+  @Test
+  public void testToEntity() {
+    // Given
+    final var dbModel =
+        new SequenceFlowDbModel.Builder()
+            .flowNodeId("flowNodeId")
+            .processInstanceKey(1L)
+            .rootProcessInstanceKey(2L)
+            .processDefinitionKey(3L)
+            .processDefinitionId("processDefinitionId")
+            .tenantId("tenantId")
+            .partitionId(1)
+            .build();
+
+    // When
+    final var entity = SequenceFlowEntityMapper.toEntity(dbModel);
+
+    // Then
+    assertThat(entity.sequenceFlowId()).isEqualTo("1_flowNodeId");
+    assertThat(entity.flowNodeId()).isEqualTo("flowNodeId");
+    assertThat(entity.processInstanceKey()).isEqualTo(1L);
+    assertThat(entity.rootProcessInstanceKey()).isEqualTo(2L);
+    assertThat(entity.processDefinitionKey()).isEqualTo(3L);
+    assertThat(entity.processDefinitionId()).isEqualTo("processDefinitionId");
+    assertThat(entity.tenantId()).isEqualTo("tenantId");
+  }
+
+  @Test
+  public void testToEntityWithNullValues() {
+    // Given
+    final var dbModel =
+        new SequenceFlowDbModel.Builder()
+            .flowNodeId(null)
+            .processInstanceKey(1L)
+            .rootProcessInstanceKey(2L)
+            .processDefinitionKey(3L)
+            .processDefinitionId(null)
+            .tenantId(null)
+            .partitionId(1)
+            .build();
+
+    // When
+    final var entity = SequenceFlowEntityMapper.toEntity(dbModel);
+
+    // Then
+    assertThat(entity.flowNodeId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.processDefinitionId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.tenantId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.processInstanceKey()).isEqualTo(1L);
+    assertThat(entity.rootProcessInstanceKey()).isEqualTo(2L);
+    assertThat(entity.processDefinitionKey()).isEqualTo(3L);
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapperTest.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Test;
 
@@ -129,5 +130,48 @@ public class UserTaskEntityMapperTest {
     assertThat(entity.dueDate()).isNull();
     assertThat(entity.followUpDate()).isNull();
     assertThat(entity.tags()).isNotNull().isEmpty();
+  }
+
+  @Test
+  public void testToEntityWithNullStringValues() {
+    // Given
+    final UserTaskDbModel dbModel =
+        new Builder()
+            .userTaskKey(1L)
+            .elementId(null)
+            .processDefinitionId(null)
+            .creationDate(OffsetDateTime.now())
+            .completionDate(null)
+            .assignee(null)
+            .state(UserTaskDbModel.UserTaskState.CREATED)
+            .formKey(1L)
+            .processDefinitionKey(1L)
+            .processInstanceKey(1L)
+            .rootProcessInstanceKey(1L)
+            .elementInstanceKey(1L)
+            .tenantId(null)
+            .dueDate(null)
+            .followUpDate(null)
+            .candidateGroups(List.of())
+            .candidateUsers(List.of())
+            .externalFormReference(null)
+            .processDefinitionVersion(1)
+            .customHeaders(Map.of())
+            .priority(1)
+            .tags(Set.of())
+            .build();
+
+    // When
+    final UserTaskEntity entity = UserTaskEntityMapper.toEntity(dbModel);
+
+    // Then
+    assertThat(entity.elementId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.processDefinitionId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.tenantId())
+        .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.assignee()).isNull();
+    assertThat(entity.completionDate()).isNull();
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GroupDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GroupDbReaderTest.java
@@ -16,11 +16,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.sql.GroupMapper;
+import io.camunda.db.rdbms.write.domain.GroupDbModel;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -57,5 +59,26 @@ class GroupDbReaderTest {
     assertThat(result.total()).isEqualTo(21L);
     assertThat(result.items()).isEmpty();
     verify(mapper, times(0)).search(any());
+  }
+
+  @Test
+  void shouldMapNullStringFieldsToEmptyStrings() {
+    // Given: a GroupDbModel with null groupId and name (simulates Oracle NULL for empty strings)
+    final var model = new GroupDbModel.Builder().groupKey(1L).build();
+    when(mapper.count(any())).thenReturn(1L);
+    when(mapper.search(any())).thenReturn(List.of(model));
+
+    final GroupQuery query = GroupQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // When
+    final var result = reader.search(query, resourceAccessChecks);
+
+    // Then: required string fields should be empty strings, not null
+    assertThat(result.items()).hasSize(1);
+    final var entity = result.items().getFirst();
+    assertThat(entity.groupId()).isEqualTo("");
+    assertThat(entity.name()).isEqualTo("");
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RoleDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RoleDbReaderTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.sql.RoleMapper;
+import io.camunda.db.rdbms.write.domain.RoleDbModel;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.reader.AuthorizationCheck;
@@ -63,5 +64,26 @@ class RoleDbReaderTest {
     assertThat(result.total()).isEqualTo(21L);
     assertThat(result.items()).isEmpty();
     verify(roleMapper, times(0)).search(any());
+  }
+
+  @Test
+  void shouldMapNullStringFieldsToEmptyStrings() {
+    // Given: a RoleDbModel with null roleId and name (simulates Oracle NULL for empty strings)
+    final var model = new RoleDbModel.Builder().roleKey(1L).build();
+    when(roleMapper.count(any())).thenReturn(1L);
+    when(roleMapper.search(any())).thenReturn(List.of(model));
+
+    final RoleQuery query = RoleQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // When
+    final var result = roleDbReader.search(query, resourceAccessChecks);
+
+    // Then: required string fields should be empty strings, not null
+    assertThat(result.items()).hasSize(1);
+    final var entity = result.items().getFirst();
+    assertThat(entity.roleId()).isEqualTo("");
+    assertThat(entity.name()).isEqualTo("");
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/TenantDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/TenantDbReaderTest.java
@@ -16,11 +16,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.sql.TenantMapper;
+import io.camunda.db.rdbms.write.domain.TenantDbModel;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -57,5 +59,26 @@ class TenantDbReaderTest {
     assertThat(result.total()).isEqualTo(21L);
     assertThat(result.items()).isEmpty();
     verify(mapper, times(0)).search(any());
+  }
+
+  @Test
+  void shouldMapNullStringFieldsToEmptyStrings() {
+    // Given: a TenantDbModel with null tenantId and name (simulates Oracle NULL for empty strings)
+    final var model = new TenantDbModel.Builder().tenantKey(1L).build();
+    when(mapper.count(any())).thenReturn(1L);
+    when(mapper.search(any())).thenReturn(List.of(model));
+
+    final TenantQuery query = TenantQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // When
+    final var result = reader.search(query, resourceAccessChecks);
+
+    // Then: required string fields should be empty strings, not null
+    assertThat(result.items()).hasSize(1);
+    final var entity = result.items().getFirst();
+    assertThat(entity.tenantId()).isEqualTo("");
+    assertThat(entity.name()).isEqualTo("");
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/typehandler/NullToEmptyStringTypeHandlerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/typehandler/NullToEmptyStringTypeHandlerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.typehandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NullToEmptyStringTypeHandlerTest {
+
+  private NullToEmptyStringTypeHandler typeHandler;
+
+  @BeforeEach
+  void setUp() {
+    typeHandler = new NullToEmptyStringTypeHandler();
+  }
+
+  @Test
+  void shouldReturnEmptyStringWhenResultSetReturnsNullByColumnName() throws Exception {
+    // given
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("column")).thenReturn(null);
+
+    // when
+    final String result = typeHandler.getNullableResult(rs, "column");
+
+    // then
+    assertThat(result).isEqualTo("");
+  }
+
+  @Test
+  void shouldReturnValueWhenResultSetReturnsNonNullByColumnName() throws Exception {
+    // given
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("column")).thenReturn("hello");
+
+    // when
+    final String result = typeHandler.getNullableResult(rs, "column");
+
+    // then
+    assertThat(result).isEqualTo("hello");
+  }
+
+  @Test
+  void shouldReturnEmptyStringWhenResultSetReturnsNullByColumnIndex() throws Exception {
+    // given
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString(1)).thenReturn(null);
+
+    // when
+    final String result = typeHandler.getNullableResult(rs, 1);
+
+    // then
+    assertThat(result).isEqualTo("");
+  }
+
+  @Test
+  void shouldReturnValueWhenResultSetReturnsNonNullByColumnIndex() throws Exception {
+    // given
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString(1)).thenReturn("world");
+
+    // when
+    final String result = typeHandler.getNullableResult(rs, 1);
+
+    // then
+    assertThat(result).isEqualTo("world");
+  }
+
+  @Test
+  void shouldReturnEmptyStringWhenCallableStatementReturnsNull() throws Exception {
+    // given
+    final CallableStatement cs = mock(CallableStatement.class);
+    when(cs.getString(1)).thenReturn(null);
+
+    // when
+    final String result = typeHandler.getNullableResult(cs, 1);
+
+    // then
+    assertThat(result).isEqualTo("");
+  }
+
+  @Test
+  void shouldReturnValueWhenCallableStatementReturnsNonNull() throws Exception {
+    // given
+    final CallableStatement cs = mock(CallableStatement.class);
+    when(cs.getString(1)).thenReturn("value");
+
+    // when
+    final String result = typeHandler.getNullableResult(cs, 1);
+
+    // then
+    assertThat(result).isEqualTo("value");
+  }
+
+  @Test
+  void shouldPassThroughEmptyStringUnchanged() throws Exception {
+    // given
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("column")).thenReturn("");
+
+    // when
+    final String result = typeHandler.getNullableResult(rs, "column");
+
+    // then
+    assertThat(result).isEqualTo("");
+  }
+
+  @Test
+  void shouldSetNonNullParameterOnPreparedStatement() throws Exception {
+    // given
+    final PreparedStatement ps = mock(PreparedStatement.class);
+
+    // when
+    typeHandler.setNonNullParameter(ps, 1, "test", null);
+
+    // then
+    verify(ps).setString(1, "test");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/FlowNodeInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/FlowNodeInstanceFixtures.java
@@ -31,6 +31,7 @@ public final class FlowNodeInstanceFixtures extends CommonFixtures {
             .processDefinitionKey(nextKey())
             .processDefinitionId("process-" + generateRandomString(20))
             .flowNodeId("flowNode-" + generateRandomString(20))
+            .flowNodeName("flowNodeName-" + generateRandomString(20))
             .flowNodeScopeKey(nextKey())
             .startDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
             .endDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobFixtures.java
@@ -24,6 +24,7 @@ public final class JobFixtures extends CommonFixtures {
     final var builder =
         new JobDbModel.Builder()
             .jobKey(nextKey())
+            .type("type-" + generateRandomString(20))
             .processDefinitionKey(nextKey())
             .processDefinitionId("job-" + generateRandomString(20))
             .processInstanceKey(nextKey())


### PR DESCRIPTION
## Summary

Oracle treats empty strings (`""`) as `NULL`. When protobuf default empty-string values are written to Oracle via the RDBMS exporter, they are stored as `NULL`. This causes two problems:

1. **Read side**: `NULL` values read back violate the API specification's `required` (non-nullable) field constraints, causing `ResponseValidationAdvice` to throw HTTP 500 errors.
2. **Query/filter side**: When searching with an empty string filter value (e.g., `correlationKey=""`), Oracle generates `WHERE CORRELATION_KEY = ''` which doesn't match `NULL` in SQL, returning empty results.

The immediate trigger was `CorrelatedMessageSubscriptionSearchIT` failing with:
> Gateway response validation: response violates the API specification. Response validation failed: items[0].correlationKey: must not be null (was: null)

CI link: https://github.com/camunda/camunda/actions/runs/22750407062/job/65983565211

## Approach

### Read-side fix: Convert `NULL` → `""` on read

For **all** required non-nullable string fields across **all** RDBMS entity mappers, using two mechanisms:

#### Java entity mappers — `NullSafeStrings.nullToEmpty()` utility

A shared `NullSafeStrings` utility class in `io.camunda.db.rdbms.read` provides a single `nullToEmpty()` method, statically imported by all mappers:

| Mapper | Protected Fields |
|---|---|
| `CorrelatedMessageSubscriptionEntityMapper` | `correlationKey`, `flowNodeId`, `messageName`, `processDefinitionId`, `tenantId` |
| `FlowNodeInstanceEntityMapper` | `flowNodeId`, `flowNodeName`, `processDefinitionId`, `tenantId` |
| `GlobalListenerEntityMapper` | `listenerId`, `type` |
| `JobEntityMapper` | `type`, `worker`, `processDefinitionId`, `tenantId` |
| `MessageSubscriptionEntityMapper` | `correlationKey`, `flowNodeId`, `messageName`, `processDefinitionId`, `tenantId` |
| `SequenceFlowEntityMapper` | `flowNodeId`, `processDefinitionId`, `tenantId` |
| `UserTaskEntityMapper` | `elementId`, `processDefinitionId`, `tenantId` |
| `GroupDbReader` | `groupId`, `name` |
| `RoleDbReader` | `roleId`, `name` |
| `TenantDbReader` | `tenantId`, `name` |

#### XML MyBatis mappers — `NullToEmptyStringTypeHandler`

For entities mapped directly by MyBatis XML result maps, a `NullToEmptyStringTypeHandler` (extends `BaseTypeHandler<String>`) is applied to `<arg>`/`<result>` columns. Auto-discovered by MyBatis via fully-qualified class name.

| XML Mapper | Protected Fields |
|---|---|
| `ClusterVariableMapper.xml` | `VAR_NAME`, `VAR_VALUE`, `VAR_FULL_VALUE` |
| `DecisionDefinitionMapper.xml` | `DECISION_DEFINITION_ID`, `NAME`, `DECISION_REQUIREMENTS_ID`, `DECISION_REQUIREMENTS_NAME`, `TENANT_ID` |
| `DecisionInstanceMapper.xml` | `DECISION_DEFINITION_ID`, `DECISION_DEFINITION_NAME`, `RESULT`, `TENANT_ID` |
| `DecisionRequirementsMapper.xml` | `DECISION_REQUIREMENTS_ID`, `DECISION_REQUIREMENTS_NAME`, `RESOURCE_NAME`, `TENANT_ID` |
| `FormMapper.xml` | `FORM_ID`, `SCHEMA_XML`, `TENANT_ID` |
| `IncidentMapper.xml` | `PROCESS_DEFINITION_ID`, `ERROR_MESSAGE`, `FLOW_NODE_ID`, `TENANT_ID` |
| `MappingRuleMapper.xml` | `MAPPING_RULE_ID`, `CLAIM_NAME`, `CLAIM_VALUE`, `NAME` |
| `ProcessDefinitionMapper.xml` | `PROCESS_DEFINITION_ID`, `RESOURCE_NAME`, `TENANT_ID` |
| `ProcessInstanceMapper.xml` | `PROCESS_DEFINITION_ID`, `TENANT_ID` |
| `UserMapper.xml` | `USERNAME` |
| `VariableMapper.xml` | `VAR_NAME`, `VAR_VALUE`, `VAR_FULL_VALUE`, `PROCESS_DEFINITION_ID`, `TENANT_ID` |

### Query/filter-side fix: Oracle-specific `operationCondition`

An Oracle-specific (`databaseId="oracle"`) `operationCondition` SQL fragment in `Commons.xml` converts:
- `EQUALS ''` → `IS NULL`
- `NOT_EQUALS ''` → `IS NOT NULL`

This ensures that filter queries like `correlationKey=""` correctly match rows where Oracle stored the empty string as `NULL`.

### New files

- `db/rdbms/src/main/java/io/camunda/db/rdbms/read/NullSafeStrings.java` — shared utility
- `db/rdbms/src/main/java/io/camunda/db/rdbms/typehandler/NullToEmptyStringTypeHandler.java` — MyBatis type handler

### Test coverage

- `NullSafeStringsTest` — tests null→"", non-null passthrough, empty string passthrough
- `NullToEmptyStringTypeHandlerTest` — tests all 3 `getNullableResult` overrides with null/non-null, plus `setNonNullParameter`
- `FlowNodeInstanceEntityMapperTest` — null values → `""` assertions
- `JobEntityMapperTest` — null values → `""` assertions
- `CorrelatedMessageSubscriptionEntityMapperTest` — added `testToEntityWithNullValues`
- `MessageSubscriptionEntityMapperTest` — added `testToEntityWithNullValues`
- `UserTaskEntityMapperTest` — added `testToEntityWithNullStringValues`
- `SequenceFlowEntityMapperTest` — new file with happy path + null values tests
- `GlobalListenerEntityMapperTest` — new file with happy path + null values + null model tests

## Completeness

A comprehensive audit was performed against all OpenAPI YAML specs in `zeebe/gateway-protocol/src/main/proto/v2/` to identify every response schema with required non-nullable string fields. All 19 entity types were verified:
- **17 entity types** have protection applied (this PR)
- **2 entity types** (`AuditLog`, `BatchOperation`) need no protection — all their required string fields are already marked `nullable: true` in the API spec

## Verification

- `./mvnw verify -pl db/rdbms -Dquickly -DskipTests=false -DskipITs` — **1259 tests pass, 0 failures**
- `./mvnw spotless:check license:check -pl db/rdbms` — **PASS**