### PR TITLE
fix: get CSRF token from session storage instead

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -101,7 +101,7 @@ management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
 springdoc.swagger-ui.csrf.enabled=true
 springdoc.swagger-ui.csrf.header-name=X-CSRF-TOKEN
 springdoc.swagger-ui.csrf.session-storage-key=X-CSRF-TOKEN
-springdoc.swagger-ui.csrf.use-session-storage=false
-springdoc.swagger-ui.csrf.use-local-storage=true
+springdoc.swagger-ui.csrf.use-session-storage=true
+springdoc.swagger-ui.csrf.use-local-storage=false
 
 camunda.security.multiTenancy.checksEnabled=${zeebe.broker.gateway.multiTenancy.enabled:false}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fixes the null CSRF token since it's now saved in session storage instead of local storage for 8.8 stable. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related to #47872 

closes #44367 
