### PR TITLE
[Backport stable/8.9] Fix Swagger UI missing CSRF token and base64 encoding

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rest/HttpMessageConverterConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/HttpMessageConverterConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
@@ -38,6 +39,14 @@ public class HttpMessageConverterConfiguration {
     // objects to plain Strings.
     // This behavior (custom converters taking precedence) changed with Spring Boot 4.0
     return new StringHttpMessageConverter(StandardCharsets.UTF_8);
+  }
+
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE + 1)
+  public ByteArrayHttpMessageConverter byteHttpMessageConverter() {
+    // This converter is needed to properly handle byte arrays
+    // e.g. in the context of OpenAPI JSON schema generation
+    return new ByteArrayHttpMessageConverter();
   }
 
   @Bean

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -99,8 +99,8 @@ management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
 springdoc.swagger-ui.csrf.enabled=true
 springdoc.swagger-ui.csrf.header-name=X-CSRF-TOKEN
 springdoc.swagger-ui.csrf.session-storage-key=X-CSRF-TOKEN
-springdoc.swagger-ui.csrf.use-session-storage=false
-springdoc.swagger-ui.csrf.use-local-storage=true
+springdoc.swagger-ui.csrf.use-session-storage=true
+springdoc.swagger-ui.csrf.use-local-storage=false
 
 # Spring AI MCP integration - disabled by default
 spring.ai.mcp.server.enabled=false


### PR DESCRIPTION
# Description
Backport of #47872 to `stable/8.9`.

relates to #44367