### PR TITLE
test: migrate decisionInstances.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -20,6 +20,7 @@ import {OperateFiltersPanelPage} from '@pages/OperateFiltersPanelPage';
 import {OperateDiagramPage} from '@pages/OperateDiagramPage';
 import {OperateOperationPanelPage} from '@pages/OperateOperationPanelPage';
 import {OperateDashboardPage} from '@pages/OperateDashboardPage';
+import {OperateDecisionsPage} from '@pages/OperateDecisionsPage';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
 import {TasklistProcessesPage} from '@pages/TasklistProcessesPage';
@@ -40,6 +41,7 @@ type PlaywrightFixtures = {
   operateProcessModificationModePage: OperateProcessModificationModePage;
   operateFiltersPanelPage: OperateFiltersPanelPage;
   operateDashboardPage: OperateDashboardPage;
+  operateDecisionsPage: OperateDecisionsPage;
   operateDiagramPage: OperateDiagramPage;
   operateOperationPanelPage: OperateOperationPanelPage;
   taskDetailsPage: TaskDetailsPage;
@@ -127,6 +129,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateDashboardPage: async ({page}, use) => {
     await use(new OperateDashboardPage(page));
+  },
+  operateDecisionsPage: async ({page}, use) => {
+    await use(new OperateDecisionsPage(page));
   },
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+class OperateDecisionsPage {
+  private page: Page;
+  readonly decisionViewer: Locator;
+  readonly decisionNameFilter: Locator;
+  readonly decisionVersionFilter: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.decisionViewer = page.getByTestId('decision-viewer');
+    this.decisionNameFilter = page.getByRole('combobox', {name: 'Name'});
+    this.decisionVersionFilter = page.getByRole('combobox', {
+      name: 'Version',
+    });
+  }
+
+  async selectDecisionName(name: string): Promise<void> {
+    await this.decisionNameFilter.click();
+    await this.page.getByRole('option', {name, exact: true}).click();
+  }
+
+  async selectVersion(version: string): Promise<void> {
+    await this.decisionVersionFilter.click();
+    await this.page.getByRole('option', {name: version, exact: true}).click();
+  }
+
+  async clearComboBox(): Promise<void> {
+    await this.page.getByRole('button', {name: 'Clear selected item'}).click();
+  }
+}
+
+export {OperateDecisionsPage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
@@ -12,6 +12,7 @@ class OperateHomePage {
   private page: Page;
   readonly operateBanner: Locator;
   readonly processesTab: Locator;
+  readonly decisionsTab: Locator;
   readonly informationDialog: Locator;
   readonly editVariableButton: Locator;
   readonly variableValueInput: Locator;
@@ -23,6 +24,10 @@ class OperateHomePage {
     this.operateBanner = page.getByRole('link', {name: 'Camunda logo Operate'});
     this.processesTab = page.getByRole('link', {
       name: 'Processes',
+      exact: true,
+    });
+    this.decisionsTab = page.getByRole('link', {
+      name: 'Decisions',
       exact: true,
     });
     this.informationDialog = page.getByRole('button', {
@@ -43,6 +48,10 @@ class OperateHomePage {
 
   async clickProcessesTab(): Promise<void> {
     await this.processesTab.click();
+  }
+
+  async clickDecisionsTab(): Promise<void> {
+    await this.decisionsTab.click();
   }
 
   async clickDashboardLink(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decisions_v_1.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decisions_v_1.dmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Decisions" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <decision id="Decision_1" name="Decision 1">
+    <decisionTable id="DecisionTable_0q1ija9" hitPolicy="FIRST">
+      <input id="Input_1" biodi:width="190">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1dpokim">
+          <text>"foo"</text>
+        </inputValues>
+      </input>
+      <output id="Output_1" name="output" typeRef="string">
+        <outputValues id="UnaryTests_15zmna2">
+          <text>"bar"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_11sxdbc">
+        <description>Version 1</description>
+        <inputEntry id="UnaryTests_04ikdpm">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0gskvdh">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="Decision_2" name="Decision 2">
+    <informationRequirement id="InformationRequirement_12qlkki">
+      <requiredDecision href="#Decision_1" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_1rgra48" hitPolicy="COLLECT">
+      <input id="InputClause_16q7mmf">
+        <inputExpression id="LiteralExpression_02j1kik" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0ct2zzd">
+          <text>"foo"</text>
+        </inputValues>
+      </input>
+      <output id="OutputClause_1mncnxr" name="outout" typeRef="string">
+        <outputValues id="UnaryTests_1pzzcto">
+          <text>"bar"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_1t96xjw">
+        <description>Version 1</description>
+        <inputEntry id="UnaryTests_1cidmy0">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1rbbzgc">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_0lmkq71" dmnElementRef="Decision_2">
+        <dc:Bounds height="80" width="180" x="410" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0mtid1m" dmnElementRef="InformationRequirement_12qlkki">
+        <di:waypoint x="340" y="140" />
+        <di:waypoint x="390" y="140" />
+        <di:waypoint x="410" y="140" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decisions_v_2.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decisions_v_2.dmn
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Decisions" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <decision id="Decision_1" name="Decision 1">
+    <decisionTable id="DecisionTable_0q1ija9" hitPolicy="COLLECT">
+      <input id="Input_1" biodi:width="190">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1dpokim">
+          <text>"foo"</text>
+        </inputValues>
+      </input>
+      <output id="Output_1" name="output" typeRef="string">
+        <outputValues id="UnaryTests_15zmna2">
+          <text>"bar"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_11sxdbc">
+        <description>Version 2</description>
+        <inputEntry id="UnaryTests_04ikdpm">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0gskvdh">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1waaksc">
+        <inputEntry id="UnaryTests_123ng7i">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0vtifd8">
+          <text>"baz"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="Decision_2" name="Decision 2">
+    <informationRequirement id="InformationRequirement_12qlkki">
+      <requiredDecision href="#Decision_1" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_1rgra48" hitPolicy="COLLECT">
+      <input id="InputClause_16q7mmf">
+        <inputExpression id="LiteralExpression_02j1kik" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0ct2zzd">
+          <text>"foo"</text>
+        </inputValues>
+      </input>
+      <output id="OutputClause_1mncnxr" name="output" typeRef="string">
+        <outputValues id="UnaryTests_1pzzcto">
+          <text>"bar"</text>
+        </outputValues>
+      </output>
+      <output id="OutputClause_0kf4cjf" label="output2" name="output2" typeRef="string" />
+      <rule id="DecisionRule_0gmxo7c">
+        <inputEntry id="UnaryTests_1xn32yh">
+          <text>"bar"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_18626pp">
+          <text>"baz"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1hn9h4g">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1t96xjw">
+        <description>Version 2</description>
+        <inputEntry id="UnaryTests_1cidmy0">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1rbbzgc">
+          <text>"bar"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0n7652y">
+          <text>"baz"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_0lmkq71" dmnElementRef="Decision_2">
+        <dc:Bounds height="80" width="180" x="410" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0mtid1m" dmnElementRef="InformationRequirement_12qlkki">
+        <di:waypoint x="340" y="140" />
+        <di:waypoint x="390" y="140" />
+        <di:waypoint x="410" y="140" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {deploy} from 'utils/zeebeClient';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+test.describe('Decision Instances', () => {
+  test.beforeAll(async ({}) => {
+    // Deploy decision versions 1 and 2
+    await deploy(['./resources/decisions_v_1.dmn']);
+    await deploy(['./resources/decisions_v_2.dmn']);
+
+    await sleep(2000);
+  });
+
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Switch between Decision versions', async ({
+    operateDecisionsPage,
+    operateHomePage,
+  }) => {
+    await test.step('Navigate to Decisions page', async () => {
+      await operateHomePage.clickDecisionsTab();
+    });
+
+    await test.step('Select Decision 1 Version 1', async () => {
+      await operateDecisionsPage.selectDecisionName('Decision 1');
+      await operateDecisionsPage.selectVersion('1');
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 1'),
+      ).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Version 1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Switch to Decision 1 Version 2', async () => {
+      await operateDecisionsPage.selectVersion('2');
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 1'),
+      ).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Version 2'),
+      ).toBeVisible();
+    });
+
+    await test.step('Clear selection and select Decision 2', async () => {
+      await operateDecisionsPage.clearComboBox();
+      await operateDecisionsPage.selectDecisionName('Decision 2');
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 2'),
+      ).toBeVisible();
+    });
+
+    await test.step('Select Decision 2 Version 1', async () => {
+      await operateDecisionsPage.selectVersion('1');
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 2'),
+      ).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Version 1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Switch to Decision 2 Version 2', async () => {
+      await operateDecisionsPage.selectVersion('2');
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 2'),
+      ).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Version 2'),
+      ).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Migrated `decisionInstances.spec.ts` from operate component folder to c8-orchestration-cluster-e2e-test-suite following the new architecture patterns.

[Test run](https://github.com/camunda/camunda/actions/runs/22764300428)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #34113 
