### PR TITLE
Migrate decision navigation.spec to oc test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -21,6 +21,7 @@ import {OperateDiagramPage} from '@pages/OperateDiagramPage';
 import {OperateOperationPanelPage} from '@pages/OperateOperationPanelPage';
 import {OperateDashboardPage} from '@pages/OperateDashboardPage';
 import {OperateDecisionsPage} from '@pages/OperateDecisionsPage';
+import {OperateDecisionInstancePage} from '@pages/OperateDecisionInstancePage';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
 import {TasklistProcessesPage} from '@pages/TasklistProcessesPage';
@@ -42,6 +43,7 @@ type PlaywrightFixtures = {
   operateFiltersPanelPage: OperateFiltersPanelPage;
   operateDashboardPage: OperateDashboardPage;
   operateDecisionsPage: OperateDecisionsPage;
+  operateDecisionInstancePage: OperateDecisionInstancePage;
   operateDiagramPage: OperateDiagramPage;
   operateOperationPanelPage: OperateOperationPanelPage;
   taskDetailsPage: TaskDetailsPage;
@@ -132,6 +134,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateDecisionsPage: async ({page}, use) => {
     await use(new OperateDecisionsPage(page));
+  },
+  operateDecisionInstancePage: async ({page}, use) => {
+    await use(new OperateDecisionInstancePage(page));
   },
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+class OperateDecisionInstancePage {
+  private page: Page;
+  readonly decisionPanel: Locator;
+  readonly closeDrdPanelButton: Locator;
+  readonly instanceHeader: Locator;
+  readonly decisionInstanceIdCell: Locator;
+  readonly viewProcessInstanceLink: (processInstanceKey: string) => Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.decisionPanel = page.getByTestId('decision-panel');
+    this.closeDrdPanelButton = page.getByRole('button', {
+      name: /close drd panel/i,
+    });
+    this.instanceHeader = page.getByTestId('instance-header');
+    this.decisionInstanceIdCell = this.instanceHeader
+      .locator('tbody td')
+      .nth(1);
+    this.viewProcessInstanceLink = (processInstanceKey: string) =>
+      page.getByRole('link', {
+        name: `View process instance ${processInstanceKey}`,
+      });
+  }
+
+  async closeDrdPanel(): Promise<void> {
+    await this.closeDrdPanelButton.click();
+  }
+
+  async getDecisionInstanceId(): Promise<string> {
+    const url = this.page.url();
+    const match = url.match(/\/decisions\/([^/?]+)/);
+    if (match && match[1]) {
+      const decisionInstanceId = match[1];
+      return decisionInstanceId;
+    }
+    throw new Error(`Could not extract decision instance ID from URL: ${url}`);
+  }
+
+  async gotoDecisionInstancePage(options: {id: string}): Promise<void> {
+    await this.page.goto(`/decisions/${options.id}`);
+  }
+
+  async clickViewProcessInstanceLink(
+    processInstanceKey: string,
+  ): Promise<void> {
+    await this.viewProcessInstanceLink(processInstanceKey).click();
+  }
+}
+
+export {OperateDecisionInstancePage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
@@ -13,6 +13,7 @@ class OperateDecisionsPage {
   readonly decisionViewer: Locator;
   readonly decisionNameFilter: Locator;
   readonly decisionVersionFilter: Locator;
+  readonly viewDecisionInstanceLink: (decisionInstanceId: string) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -21,6 +22,10 @@ class OperateDecisionsPage {
     this.decisionVersionFilter = page.getByRole('combobox', {
       name: 'Version',
     });
+    this.viewDecisionInstanceLink = (decisionInstanceId: string) =>
+      page.getByRole('link', {
+        name: `View decision instance ${decisionInstanceId}`,
+      });
   }
 
   async selectDecisionName(name: string): Promise<void> {
@@ -35,6 +40,12 @@ class OperateDecisionsPage {
 
   async clearComboBox(): Promise<void> {
     await this.page.getByRole('button', {name: 'Clear selected item'}).click();
+  }
+
+  async clickViewDecisionInstanceLink(
+    decisionInstanceId: string,
+  ): Promise<void> {
+    await this.viewDecisionInstanceLink(decisionInstanceId).click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -19,6 +19,7 @@ export class OperateDiagramPage {
   readonly metadataModal: Locator;
   readonly metadataModalCloseButton: Locator;
   readonly monacoScrollableElement: Locator;
+  readonly viewRootCauseDecisionLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -39,6 +40,9 @@ export class OperateDiagramPage {
     this.monacoScrollableElement = this.metadataModal.locator(
       '.monaco-scrollable-element',
     );
+    this.viewRootCauseDecisionLink = this.page.getByRole('link', {
+      name: /View root cause decision/i,
+    });
   }
 
   async moveCanvasHorizontally(dx: number) {
@@ -247,5 +251,14 @@ export class OperateDiagramPage {
 
   async clickPopoverLink(pattern: RegExp | string): Promise<void> {
     await this.popover.getByRole('link', {name: pattern}).click();
+  }
+
+  async clickViewRootCauseDecisionLink(): Promise<void> {
+    await this.viewRootCauseDecisionLink.scrollIntoViewIfNeeded();
+    await this.viewRootCauseDecisionLink.waitFor({
+      state: 'visible',
+      timeout: 30000,
+    });
+    await this.viewRootCauseDecisionLink.click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -205,6 +205,14 @@ class OperateProcessInstancePage {
     }
     throw new Error(`Active icon not visible after ${maxRetries} attempts.`);
   }
+
+  getDiagramElement(elementId: string): Locator {
+    return this.diagram.locator(`[data-element-id="${elementId}"]`);
+  }
+
+  async clickDiagramElement(elementId: string): Promise<void> {
+    await this.getDiagramElement(elementId).click();
+  }
 }
 
 export {OperateProcessInstancePage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/invoice.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/invoice.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0h0cvk6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="invoice" name="DMN invoice" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1950eph</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1950eph" sourceRef="StartEvent_1" targetRef="Activity_1tjwahx" />
+    <bpmn:businessRuleTask id="Activity_1tjwahx" name="Define approver">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="invoiceAssignApprover" resultVariable="approverGroups" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1950eph</bpmn:incoming>
+      <bpmn:outgoing>Flow_0932klu</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:endEvent id="Event_1ymurqn">
+      <bpmn:incoming>Flow_1k2uryn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0932klu" sourceRef="Activity_1tjwahx" targetRef="Activity_11ptrz9" />
+    <bpmn:sequenceFlow id="Flow_1k2uryn" sourceRef="Activity_11ptrz9" targetRef="Event_1ymurqn" />
+    <bpmn:userTask id="Activity_11ptrz9" name="Check invoice">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition candidateGroups="=approverGroups" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0932klu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1k2uryn</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="invoice">
+      <bpmndi:BPMNEdge id="Flow_0932klu_di" bpmnElement="Flow_0932klu">
+        <di:waypoint x="380" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1950eph_di" bpmnElement="Flow_1950eph">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="280" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k2uryn_di" bpmnElement="Flow_1k2uryn">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="582" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0fbk7jp_di" bpmnElement="Activity_1tjwahx">
+        <dc:Bounds x="280" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ymurqn_di" bpmnElement="Event_1ymurqn">
+        <dc:Bounds x="582" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0787kv0_di" bpmnElement="Activity_11ptrz9">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/invoiceBusinessDecisions.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/invoiceBusinessDecisions.dmn
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="invoiceBusinessDecisions" name="Invoice Business Decisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
+  <decision id="invoiceClassification" name="Invoice Classification">
+    <decisionTable id="decisionTable">
+      <input id="clause1" label="Invoice Amount" camunda:inputVariable="">
+        <inputExpression id="inputExpression1" typeRef="double">
+          <text>assert(amount,amount!=null)</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_15qmk0v" label="Invoice Category" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_1oi86cw" typeRef="string">
+          <text>invoiceCategory</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0kisa67">
+          <text>"Travel Expenses","Misc","Software License Costs"</text>
+        </inputValues>
+      </input>
+      <output id="clause3" label="Classification" name="invoiceClassification" typeRef="string">
+        <outputValues id="UnaryTests_08dl8wf">
+          <text>"day-to-day expense","budget","exceptional"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_1of5a87">
+        <inputEntry id="LiteralExpression_0yrqmtg">
+          <text>&lt; 250</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06edsin">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_046antl">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ak4z14">
+        <inputEntry id="LiteralExpression_0qmsef6">
+          <text>[250..1000]</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09b743h">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_05xxvip">
+          <text>"budget"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-4">
+        <inputEntry id="UnaryTests_0le0gl8">
+          <text>&gt; 1000</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pukamj">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1e76ugx">
+          <text>"exceptional"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0cuxolz">
+        <inputEntry id="LiteralExpression_05lyjk7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ve4z34">
+          <text>"Travel Expenses"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1bq8m03">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-2">
+        <inputEntry id="UnaryTests_1nssdlk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01ppb4l">
+          <text>"Software License Costs"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0y00iih">
+          <text>"budget"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="invoiceAssignApprover" name="Assign Approver Group">
+    <informationRequirement id="InformationRequirement_1kkeocv">
+      <requiredDecision href="#invoiceClassification" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_16o85h8" hitPolicy="COLLECT">
+      <input id="InputClause_0og2hn3" label="Invoice Classification" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_1vywt5q" typeRef="string">
+          <text>invoiceClassification</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0by7qiy">
+          <text>"day-to-day expense","budget","exceptional"</text>
+        </inputValues>
+      </input>
+      <output id="OutputClause_1cthd0w" label="Approver Group" name="result" typeRef="string">
+        <outputValues id="UnaryTests_1ulmk9p">
+          <text>"management","accounting","sales"</text>
+        </outputValues>
+      </output>
+      <rule id="row-49839158-1">
+        <inputEntry id="UnaryTests_18ifczd">
+          <text>"day-to-day expense"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0sgxulk">
+          <text>"accounting"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-6">
+        <inputEntry id="UnaryTests_0kfae8g">
+          <text>"day-to-day expense"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1iksrro">
+          <text>"sales"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-5">
+        <inputEntry id="UnaryTests_08cevwi">
+          <text>"budget", "exceptional"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c7hz8g">
+          <text>"management"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1cuuevk">
+      <dmndi:DMNShape id="DMNShape_1abvt5s" dmnElementRef="invoiceClassification">
+        <dc:Bounds height="55" width="100" x="153" y="215" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_1ay7af5" dmnElementRef="invoiceAssignApprover">
+        <dc:Bounds height="55" width="100" x="224" y="84" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_1wn1950" dmnElementRef="InformationRequirement_1kkeocv">
+        <di:waypoint x="218" y="215" />
+        <di:waypoint x="258" y="139" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -19,7 +19,7 @@ test.describe('Decision Instances', () => {
     await deploy(['./resources/decisions_v_1.dmn']);
     await deploy(['./resources/decisions_v_2.dmn']);
 
-    await sleep(2000);
+    await sleep(3000);
   });
 
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let processInstanceWithFailedDecision: ProcessInstance;
+let calledDecisionInstanceId: string;
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/invoiceBusinessDecisions.dmn',
+    './resources/invoice.bpmn',
+  ]);
+
+  processInstanceWithFailedDecision = await createSingleInstance('invoice', 1);
+
+  await sleep(2000);
+});
+
+test.describe('Decision Navigation', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Navigation between process and decision', async ({
+    operateProcessInstancePage,
+    operateDecisionInstancePage,
+    operateDecisionsPage,
+    operateHomePage,
+    operateDiagramPage,
+  }) => {
+    const processInstanceKey =
+      processInstanceWithFailedDecision.processInstanceKey;
+
+    await test.step('Navigate to process instance', async () => {
+      await operateProcessInstancePage.navigateToProcessInstance(
+        processInstanceKey,
+      );
+    });
+
+    await test.step('Verify process diagram is visible', async () => {
+      await expect(operateProcessInstancePage.diagram).toBeInViewport();
+      await expect(
+        operateProcessInstancePage.getDiagramElement('Activity_1tjwahx'),
+      ).toBeVisible();
+    });
+
+    await test.step('Wait for incidents banner to be visible', async () => {
+      await expect
+        .poll(
+          async () => {
+            return await operateProcessInstancePage.incidentsBanner.isVisible();
+          },
+          {timeout: 30000},
+        )
+        .toBe(true);
+    });
+
+    await test.step('Click on business rule task in diagram', async () => {
+      await operateProcessInstancePage.clickDiagramElement('Activity_1tjwahx');
+    });
+
+    await test.step('Verify popover appears and navigate to decision', async () => {
+      await expect(operateDiagramPage.popover).toBeVisible();
+      await operateDiagramPage.clickViewRootCauseDecisionLink();
+    });
+
+    await test.step('Verify decision panel is visible', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.decisionPanel.getByText('Invoice Amount'),
+      ).toBeVisible();
+    });
+
+    await test.step('Get decision instance ID', async () => {
+      calledDecisionInstanceId =
+        await operateDecisionInstancePage.getDecisionInstanceId();
+    });
+
+    await test.step('Close decision panel and return to process', async () => {
+      await operateDecisionInstancePage.closeDrdPanel();
+      await operateDecisionInstancePage.clickViewProcessInstanceLink(
+        processInstanceKey,
+      );
+    });
+
+    await test.step('Verify back to process instance view', async () => {
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          processInstanceKey,
+          {exact: true},
+        ),
+      ).toBeVisible();
+
+      await expect(operateProcessInstancePage.diagram).toBeInViewport();
+
+      await expect(
+        operateProcessInstancePage.getDiagramElement('Activity_1tjwahx'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to decisions section', async () => {
+      await operateHomePage.clickDecisionsTab();
+    });
+
+    await test.step('View specific decision instance', async () => {
+      await operateDecisionsPage.clickViewDecisionInstanceLink(
+        calledDecisionInstanceId,
+      );
+    });
+
+    await test.step('Verify decision panel is visible again', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.decisionPanel.getByText('Invoice Amount'),
+      ).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Migrates `decisionNavigation.spec.ts` from the Operate component folder to the c8-orchestration-cluster-e2e-test-suite following POM patterns.

## Changes
- **Test Migration**
- **New Page Objects**: 
  - `OperateDecisionInstancePage.ts` - Decision instance interactions
  - `OperateDecisionsPage.ts` - Decisions list navigation

🧪 [Test run](https://github.com/camunda/camunda/actions/runs/22766392280/job/66035455272)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #34112 
