### PR TITLE
[Backport stable/8.9] docs: add sort limitation note to `isLatestVersion` filter description

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -342,6 +342,7 @@ components:
             Whether to only return the latest version of each process definition.
             When using this filter, pagination functionality is limited, you can only paginate forward using `after` and `limit`.
             The response contains no `startCursor` in the `page`, and requests ignore the `from` and `before` in the `page`.
+            When using this filter, sorting is limited to `processDefinitionId` and `tenantId` fields only.
           type: boolean
         resourceName:
           description: Resource name of this process definition.


### PR DESCRIPTION
# Description
Backport of #47952 to `stable/8.9`.

relates to 