### PR TITLE
test: nightly 8.6 run 

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -171,7 +171,7 @@ class TaskDetailsPage {
     await this.getNthVariableValueInput(1).fill(value);
     await expect(this.getNthVariableNameInput(1)).toHaveValue(name);
     await expect(this.getNthVariableValueInput(1)).toHaveValue(value);
-    await sleep(500);
+    await sleep(1000);
   }
 
   async fillNumber(number: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -119,9 +119,25 @@ class TaskDetailsPage {
   }
 
   async clickCompleteTaskButton() {
-    await this.completeTaskButton.click({timeout: 60000});
-    await expect(this.taskCompletedBanner).toBeVisible({
-      timeout: 200000,
+    await expect(this.completeTaskButton).toBeVisible({timeout: 60000});
+    await this.completeTaskButton.click();
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.taskCompletedBanner.first()).toBeVisible({
+          timeout: 60000,
+        });
+      },
+      onFailure: async () => {
+        console.log('Task completed banner not visible, retrying...');
+        await this.page.reload();
+        await sleep(1000);
+        if (
+          (await this.completeTaskButton.isVisible()) &&
+          (await this.completeTaskButton.isEnabled())
+        ) {
+          await this.completeTaskButton.click();
+        }
+      },
     });
   }
 
@@ -153,6 +169,9 @@ class TaskDetailsPage {
     await this.clickAddVariableButton();
     await this.getNthVariableNameInput(1).fill(name);
     await this.getNthVariableValueInput(1).fill(value);
+    await expect(this.getNthVariableNameInput(1)).toHaveValue(name);
+    await expect(this.getNthVariableValueInput(1)).toHaveValue(value);
+    await sleep(200);
   }
 
   async fillNumber(number: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -171,7 +171,7 @@ class TaskDetailsPage {
     await this.getNthVariableValueInput(1).fill(value);
     await expect(this.getNthVariableNameInput(1)).toHaveValue(name);
     await expect(this.getNthVariableValueInput(1)).toHaveValue(value);
-    await sleep(200);
+    await sleep(500);
   }
 
   async fillNumber(number: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -217,10 +217,9 @@ test.describe('task details page', () => {
     await expect(taskDetailsPage.unassignButton).toBeHidden();
     await expect(taskDetailsPage.completeTaskButton).toBeHidden();
 
-    await taskPanelPage.openTask('JobWorker_user_task');
-
     await waitForAssertion({
       assertion: async () => {
+        await taskPanelPage.openTask('JobWorker_user_task');
         await expect(page.getByText('jobWorkerVar')).toBeVisible();
         await expect(page.getByText('zeebeVar')).toBeVisible({timeout: 60000});
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -205,7 +205,14 @@ test.describe('task details page', () => {
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.assertCompletedHeadingVisible();
     await taskPanelPage.openTask('Zeebe_user_task');
-    await expect(page.getByText('zeebeVar')).toBeVisible({timeout: 60000});
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(page.getByText('zeebeVar', {exact: true})).toBeVisible();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
     await expect(taskDetailsPage.assignToMeButton).toBeHidden();
     await expect(taskDetailsPage.unassignButton).toBeHidden();
     await expect(taskDetailsPage.completeTaskButton).toBeHidden();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -424,6 +424,7 @@ test.describe('task details page', () => {
     await taskDetailsPage.assertFieldValue('Number', '2');
     await taskDetailsPage.clickDecrementButton();
     await taskDetailsPage.assertFieldValue('Number', '1');
+    await sleep(1000);
     await taskDetailsPage.clickCompleteTaskButton();
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
 


### PR DESCRIPTION
## Description

Added retires for the variable test.

[Successful run](https://github.com/camunda/camunda/actions/runs/22776864574/job/66072527360) ✅ 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
