### PR TITLE
[Backport stable/8.6] fix: preserve round-robin dispatch strategy across withAuthentication() calls

### DIFF
--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -55,13 +55,28 @@ public final class ProcessInstanceServices
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
+    this(
+        brokerClient,
+        searchClient,
+        transformers,
+        authentication,
+        new RequestRetryHandler(brokerClient, brokerClient.getTopologyManager()));
+  }
+
+  public ProcessInstanceServices(
+      final BrokerClient brokerClient,
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication,
+      final RequestRetryHandler requestRetryHandler) {
     super(brokerClient, searchClient, transformers, authentication);
-    requestRetryHandler = new RequestRetryHandler(brokerClient, brokerClient.getTopologyManager());
+    this.requestRetryHandler = requestRetryHandler;
   }
 
   @Override
   public ProcessInstanceServices withAuthentication(final Authentication authentication) {
-    return new ProcessInstanceServices(brokerClient, searchClient, transformers, authentication);
+    return new ProcessInstanceServices(
+        brokerClient, searchClient, transformers, authentication, requestRetryHandler);
   }
 
   @Override

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -251,6 +251,49 @@ public final class ProcessInstanceServiceTest {
               eq(java.time.Duration.ofMillis(600_000L)));
     }
 
+    @Test
+    void shouldPreserveRoundRobinDispatchStrategyAcrossWithAuthenticationCalls() {
+      // given - the services instance has a RequestRetryHandler with round-robin strategy
+      final var triedPartitions = new ArrayList<Integer>();
+      final var mockResponse = new ProcessInstanceCreationRecord();
+
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                return CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse));
+              });
+
+      // when - calling withAuthentication multiple times and creating instances
+      final var auth1 = authentication("token1");
+      final var auth2 = authentication("token2");
+      final var auth3 = authentication("token3");
+
+      services
+          .withAuthentication(auth1)
+          .createProcessInstance(createProcessInstanceRequest())
+          .join();
+      services
+          .withAuthentication(auth2)
+          .createProcessInstance(createProcessInstanceRequest())
+          .join();
+      services
+          .withAuthentication(auth3)
+          .createProcessInstance(createProcessInstanceRequest())
+          .join();
+
+      // then - the round robin strategy should distribute requests across different partitions
+      // With 3 partitions and round-robin, we expect different partitions to be used
+      assertThat(triedPartitions).hasSize(3);
+      assertThat(triedPartitions).doesNotHaveDuplicates();
+    }
+
+    private Authentication authentication(final String token1) {
+      return new Authentication.Builder().token(token1).build();
+    }
+
     private ProcessInstanceServices.ProcessInstanceCreateRequest createProcessInstanceRequest() {
       return new ProcessInstanceServices.ProcessInstanceCreateRequest(
           123L, // processDefinitionKey


### PR DESCRIPTION
# Description
Backport of #47956 to `stable/8.6`.

relates to camunda/camunda#47955