### PR TITLE
[Backport stable/8.8] fix: preserve round-robin dispatch strategy across withAuthentication() calls

### DIFF
--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -84,6 +84,28 @@ public final class ProcessInstanceServices
       final CamundaAuthentication authentication,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    this(
+        brokerClient,
+        securityContextProvider,
+        processInstanceSearchClient,
+        sequenceFlowSearchClient,
+        incidentServices,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter,
+        new RequestRetryHandler(brokerClient, brokerClient.getTopologyManager()));
+  }
+
+  public ProcessInstanceServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ProcessInstanceSearchClient processInstanceSearchClient,
+      final SequenceFlowSearchClient sequenceFlowSearchClient,
+      final IncidentServices incidentServices,
+      final CamundaAuthentication authentication,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final RequestRetryHandler requestRetryHandler) {
     super(
         brokerClient,
         securityContextProvider,
@@ -93,7 +115,7 @@ public final class ProcessInstanceServices
     this.processInstanceSearchClient = processInstanceSearchClient;
     this.sequenceFlowSearchClient = sequenceFlowSearchClient;
     this.incidentServices = incidentServices;
-    requestRetryHandler = new RequestRetryHandler(brokerClient, brokerClient.getTopologyManager());
+    this.requestRetryHandler = requestRetryHandler;
     executor = executorProvider.getExecutor();
   }
 
@@ -107,7 +129,8 @@ public final class ProcessInstanceServices
         incidentServices,
         authentication,
         executorProvider,
-        brokerRequestAuthorizationConverter);
+        brokerRequestAuthorizationConverter,
+        requestRetryHandler);
   }
 
   @Override

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -773,6 +773,45 @@ public final class ProcessInstanceServiceTest {
               eq(java.time.Duration.ofMillis(600_000L)));
     }
 
+    @Test
+    void shouldPreserveRoundRobinDispatchStrategyAcrossWithAuthenticationCalls() {
+      // given - the services instance has a RequestRetryHandler with round-robin strategy
+      final var triedPartitions = new ArrayList<Integer>();
+      final var mockResponse = new ProcessInstanceCreationRecord();
+
+      when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+          .thenAnswer(
+              invocation -> {
+                final var brokerRequest =
+                    invocation.getArgument(0, BrokerCreateProcessInstanceRequest.class);
+                triedPartitions.add(brokerRequest.getPartitionId());
+                return CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse));
+              });
+
+      // when - calling withAuthentication multiple times and creating instances
+      final var auth1 = CamundaAuthentication.none();
+      final var auth2 = CamundaAuthentication.none();
+      final var auth3 = CamundaAuthentication.none();
+
+      services
+          .withAuthentication(auth1)
+          .createProcessInstance(createProcessInstanceRequest())
+          .join();
+      services
+          .withAuthentication(auth2)
+          .createProcessInstance(createProcessInstanceRequest())
+          .join();
+      services
+          .withAuthentication(auth3)
+          .createProcessInstance(createProcessInstanceRequest())
+          .join();
+
+      // then - the round robin strategy should distribute requests across different partitions
+      // With 3 partitions and round-robin, we expect different partitions to be used
+      assertThat(triedPartitions).hasSize(3);
+      assertThat(triedPartitions).doesNotHaveDuplicates();
+    }
+
     private ProcessInstanceServices.ProcessInstanceCreateRequest createProcessInstanceRequest() {
       return new ProcessInstanceServices.ProcessInstanceCreateRequest(
           123L, // processDefinitionKey


### PR DESCRIPTION
# Description
Backport of #47956 to `stable/8.8`.

relates to camunda/camunda#47955