### PR TITLE
fix: fix process instance key filter serialization

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camunda-operate",
-  "version": "8.8.15-SNAPSHOT",
+  "version": "8.8.16-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "camunda-operate",
-      "version": "8.8.15-SNAPSHOT",
+      "version": "8.8.16-SNAPSHOT",
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-operate",
-  "version": "8.8.15-SNAPSHOT",
+  "version": "8.8.16-SNAPSHOT",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -160,6 +160,50 @@ describe('useProcessInstanceFilters', () => {
     expect(result.current).toEqual(expectedRequest);
   });
 
+  it('should parse space-separated process instance keys', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      ids: 'id1 id2 id3',
+    };
+
+    mockedUseFilters.mockReturnValue({
+      getFilters: () => mockFilters,
+      setFilters: vi.fn(),
+      areProcessInstanceStatesApplied: vi.fn(),
+      areDecisionInstanceStatesApplied: vi.fn(),
+    });
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual({
+      filter: {
+        processInstanceKey: {
+          $in: ['id1', 'id2', 'id3'],
+        },
+      },
+    });
+  });
+
+  it('should parse comma-and-space-separated process instance keys', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      ids: 'id1, id2, id3',
+    };
+
+    mockedUseFilters.mockReturnValue({
+      getFilters: () => mockFilters,
+      setFilters: vi.fn(),
+      areProcessInstanceStatesApplied: vi.fn(),
+      areDecisionInstanceStatesApplied: vi.fn(),
+    });
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual({
+      filter: {
+        processInstanceKey: {
+          $in: ['id1', 'id2', 'id3'],
+        },
+      },
+    });
+  });
+
   it('should handle partial filters', () => {
     const mockFilters: ProcessInstanceFilters = {
       startDateAfter: '2023-01-01',

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -57,7 +57,7 @@ function mapFiltersToRequest(
 
   if (ids) {
     request.filter.processInstanceKey = {
-      $in: ids.split(','),
+      $in: ids.split(/[\s,]+/).filter(Boolean),
     };
   }
 

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -13,6 +13,7 @@ import {
   type ProcessInstanceState,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {formatToISO} from 'modules/utils/date/formatDate';
+import {parseIds} from 'modules/utils/filter';
 
 function mapFiltersToRequest(
   filters: ProcessInstanceFilters,
@@ -56,9 +57,10 @@ function mapFiltersToRequest(
   }
 
   if (ids) {
-    request.filter.processInstanceKey = {
-      $in: ids.split(/[\s,]+/).filter(Boolean),
-    };
+    const keys = parseIds(ids);
+    if (keys.length > 0) {
+      request.filter.processInstanceKey = {$in: keys};
+    }
   }
 
   if (parentInstanceId) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This bug is happening on 8.8 only. Probably we missed a backport somewhere

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47971
