### PR TITLE
[Backport stable/8.8] fix: use string-based @ConditionalOnClass for optional dependencies to fix Java 24+

### DIFF
--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -66,11 +66,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
     <!-- New in Spring Boot 4: Jackson module is separate -->
@@ -173,6 +168,8 @@
                     <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.class</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.class</exclude>
+                    <exclude>io/camunda/client/spring/configuration/ExecutorServiceConfiguration.class</exclude>
                     <!-- Exclude META-INF services that we override -->
                     <exclude>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</exclude>
                   </excludes>

--- a/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java
+++ b/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java
@@ -22,12 +22,10 @@ import io.camunda.client.metrics.MicrometerMetricsRecorder;
 import io.camunda.client.spring.actuator.CamundaClientHealthIndicator;
 import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 
@@ -37,10 +35,11 @@ import org.springframework.context.annotation.Lazy;
  */
 @AutoConfigureBefore(MetricsDefaultConfiguration.class)
 @ConditionalOnCamundaClientEnabled
-@ConditionalOnClass({
-  EndpointAutoConfiguration.class,
-  MeterRegistry.class
-}) // only if actuator is on classpath
+@ConditionalOnClass(
+    name = {
+      "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration",
+      "io.micrometer.core.instrument.MeterRegistry"
+    }) // only if actuator is on classpath
 public class CamundaActuatorConfiguration {
   @Bean
   @ConditionalOnMissingBean
@@ -59,7 +58,7 @@ public class CamundaActuatorConfiguration {
       prefix = "management.health.camunda",
       name = "enabled",
       matchIfMissing = true)
-  @ConditionalOnClass(HealthIndicator.class)
+  @ConditionalOnClass(name = "org.springframework.boot.health.contributor.HealthIndicator")
   @ConditionalOnMissingBean(name = "camundaClientHealthIndicator")
   public CamundaClientHealthIndicator camundaClientHealthIndicator(final HealthCheck healthCheck) {
     return new CamundaClientHealthIndicator(healthCheck);

--- a/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java
+++ b/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.CredentialsProvider;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.impl.CamundaClientImpl;
+import io.camunda.client.impl.util.ExecutorResource;
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
+import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.camunda.client.spring.testsupport.CamundaSpringProcessTestContext;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/*
+ * All configurations that will only be used in production code - meaning NO TEST cases
+ */
+@ConditionalOnCamundaClientEnabled
+@ConditionalOnMissingBean(CamundaSpringProcessTestContext.class)
+@ImportAutoConfiguration({
+  ExecutorServiceConfiguration.class,
+  CamundaActuatorConfiguration.class,
+  MetricsDefaultConfiguration.class,
+  JsonMapperConfiguration.class,
+  CredentialsProviderConfiguration.class
+})
+@AutoConfigureBefore(CamundaClientAllAutoConfiguration.class)
+@EnableConfigurationProperties(CamundaClientProperties.class)
+public class CamundaClientProdAutoConfiguration {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CamundaClientProdAutoConfiguration.class);
+
+  @Bean
+  public CamundaClientConfiguration camundaClientConfiguration(
+      final CamundaClientProperties camundaClientProperties,
+      final JsonMapper jsonMapper,
+      final List<ClientInterceptor> interceptors,
+      final List<AsyncExecChainHandler> chainHandlers,
+      final CamundaClientExecutorService camundaClientExecutorService,
+      final CredentialsProvider camundaClientCredentialsProvider) {
+    return new SpringCamundaClientConfiguration(
+        camundaClientProperties,
+        jsonMapper,
+        interceptors,
+        chainHandlers,
+        camundaClientExecutorService,
+        camundaClientCredentialsProvider);
+  }
+
+  @Bean(destroyMethod = "close")
+  public CamundaClient camundaClient(final CamundaClientConfiguration configuration) {
+    LOG.debug("Creating camundaClient using {}", configuration);
+    final ScheduledExecutorService jobWorkerExecutor = configuration.jobWorkerExecutor();
+    if (jobWorkerExecutor != null) {
+      final ManagedChannel managedChannel = CamundaClientImpl.buildChannel(configuration);
+      final GatewayGrpc.GatewayStub gatewayStub =
+          CamundaClientImpl.buildGatewayStub(managedChannel, configuration);
+      final ExecutorResource executorResource =
+          new ExecutorResource(jobWorkerExecutor, configuration.ownsJobWorkerExecutor());
+      return new CamundaClientImpl(configuration, managedChannel, gatewayStub, executorResource);
+    } else {
+      return new CamundaClientImpl(configuration);
+    }
+  }
+}

--- a/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/ExecutorServiceConfiguration.java
+++ b/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/ExecutorServiceConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Spring Boot 4 compatible executor service configuration. Uses string-based @ConditionalOnClass to
+ * avoid eager class resolution on Java 24+ with Spring Framework 7's ClassFileMetadataReader.
+ */
+@ConditionalOnClass(name = "io.micrometer.core.instrument.MeterRegistry")
+@ConditionalOnMissingBean(CamundaClientExecutorService.class)
+public class ExecutorServiceConfiguration {
+
+  private final CamundaClientProperties camundaClientProperties;
+
+  public ExecutorServiceConfiguration(final CamundaClientProperties camundaClientProperties) {
+    this.camundaClientProperties = camundaClientProperties;
+  }
+
+  @Bean
+  public CamundaClientExecutorService camundaClientThreadPool(
+      @Autowired(required = false) final MeterRegistry meterRegistry) {
+    final int executionThreads = camundaClientProperties.getExecutionThreads();
+    final ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(executionThreads);
+    if (meterRegistry != null) {
+      final MeterBinder threadPoolMetrics =
+          new ExecutorServiceMetrics(
+              threadPool,
+              "camundaClientExecutor",
+              Collections.singleton(Tag.of("name", "zeebe_client_thread_pool")));
+      threadPoolMetrics.bindTo(meterRegistry);
+    }
+    return new CamundaClientExecutorService(threadPool, true);
+  }
+}

--- a/clients/camunda-spring-boot-4-starter/src/test/java/io/camunda/client/spring/configuration/CamundaActuatorConfigurationTest.java
+++ b/clients/camunda-spring-boot-4-starter/src/test/java/io/camunda/client/spring/configuration/CamundaActuatorConfigurationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.metrics.DefaultNoopMetricsRecorder;
+import io.camunda.client.metrics.MetricsRecorder;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Tests that auto-configuration degrades gracefully when optional dependencies (actuator,
+ * micrometer) are absent from the classpath. This is a regression test for Java 24+ compatibility
+ * where Spring Framework's ClassFileMetadataReader eagerly resolves class literals in annotations.
+ *
+ * @see <a href="https://github.com/camunda/camunda/issues/47464">#47464</a>
+ */
+class CamundaActuatorConfigurationTest {
+
+  private ApplicationContextRunner contextRunner() {
+    return new ApplicationContextRunner()
+        .withUserConfiguration(
+            CamundaActuatorConfiguration.class, MetricsDefaultConfiguration.class);
+  }
+
+  @Test
+  void shouldSkipActuatorConfigWhenActuatorAutoconfigureAbsent() {
+    contextRunner()
+        .withClassLoader(
+            new FilteredClassLoader(
+                "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"))
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean("micrometerMetricsRecorder");
+            });
+  }
+
+  @Test
+  void shouldSkipActuatorConfigWhenMicrometerAbsent() {
+    contextRunner()
+        .withClassLoader(new FilteredClassLoader("io.micrometer.core.instrument.MeterRegistry"))
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean("micrometerMetricsRecorder");
+            });
+  }
+
+  @Test
+  void shouldFallBackToNoopMetricsWhenActuatorAbsent() {
+    contextRunner()
+        .withClassLoader(
+            new FilteredClassLoader(
+                "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"))
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(MetricsRecorder.class);
+              assertThat(context.getBean(MetricsRecorder.class))
+                  .isInstanceOf(DefaultNoopMetricsRecorder.class);
+            });
+  }
+
+  @Test
+  void shouldFallBackToNoopMetricsWhenMicrometerAbsent() {
+    contextRunner()
+        .withClassLoader(new FilteredClassLoader("io.micrometer.core.instrument.MeterRegistry"))
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(MetricsRecorder.class);
+              assertThat(context.getBean(MetricsRecorder.class))
+                  .isInstanceOf(DefaultNoopMetricsRecorder.class);
+            });
+  }
+
+  @Test
+  void shouldFallBackToNoopMetricsWhenBothAbsent() {
+    contextRunner()
+        .withClassLoader(
+            new FilteredClassLoader(
+                "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration",
+                "io.micrometer.core.instrument.MeterRegistry"))
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean("micrometerMetricsRecorder");
+
+              assertThat(context).hasSingleBean(MetricsRecorder.class);
+              assertThat(context.getBean(MetricsRecorder.class))
+                  .isInstanceOf(DefaultNoopMetricsRecorder.class);
+            });
+  }
+}


### PR DESCRIPTION
# Description
Backport of #47466 to `stable/8.8`.

The base `camunda-spring-boot-starter` module (Spring Boot 3) is left unchanged
as this issue only affects Spring Boot 4 / Spring Framework 7.

relates to #47464