### PR TITLE
[Backport stable/8.9] fix: use string-based @ConditionalOnClass for optional dependencies to fix Java 24+

### DIFF
--- a/clients/camunda-spring-boot-starter-virtual-threads/pom.xml
+++ b/clients/camunda-spring-boot-starter-virtual-threads/pom.xml
@@ -64,14 +64,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
 
-    <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -112,6 +111,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <dep>org.springframework.boot:spring-boot-starter-test</dep>
+            <dep>org.springframework.boot:spring-boot-actuator-autoconfigure</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
@@ -23,12 +23,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
-import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
 /**
@@ -46,27 +46,6 @@ import org.springframework.context.annotation.Lazy;
 public class VirtualThreadsAutoConfiguration {
 
   /**
-   * Creates a {@link CamundaClientExecutorService} that uses virtual threads for job execution with
-   * metrics support when Micrometer is available.
-   *
-   * @param meterRegistry optional meter registry for metrics (can be null)
-   * @return the configured executor service with virtual threads for job handling and a single
-   *     platform thread for scheduling
-   */
-  @Bean
-  @ConditionalOnClass({MeterRegistry.class, EndpointAutoConfiguration.class})
-  public CamundaClientExecutorService camundaClientExecutorService(
-      @Lazy final MeterRegistry meterRegistry) {
-    final ThreadFactory virtualThreadFactory = createVirtualThreadFactory();
-    final ExecutorService jobHandlingExecutor =
-        Executors.newThreadPerTaskExecutor(virtualThreadFactory);
-    final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
-
-    return new MeteredCamundaClientExecutorService(
-        scheduledExecutor, true, jobHandlingExecutor, true, meterRegistry);
-  }
-
-  /**
    * Fallback bean when Micrometer is not on the classpath.
    *
    * @return the configured executor service without metrics
@@ -82,7 +61,44 @@ public class VirtualThreadsAutoConfiguration {
     return new CamundaClientExecutorService(scheduledExecutor, true, jobHandlingExecutor, true);
   }
 
-  private ThreadFactory createVirtualThreadFactory() {
+  private static ThreadFactory createVirtualThreadFactory() {
     return Thread.ofVirtual().name("job-worker-virtual-", 0).factory();
+  }
+
+  /**
+   * Nested configuration that is only loaded when both Micrometer and Spring Boot Actuator are on
+   * the classpath. This must be a separate nested class because {@code MeterRegistry} is used as a
+   * method parameter type — if it appeared on the enclosing class, {@link
+   * Class#getDeclaredMethods()} would throw {@link NoClassDefFoundError} when Micrometer is absent.
+   *
+   * @see <a href="https://github.com/camunda/camunda/issues/47464">#47464</a>
+   */
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnClass(
+      name = {
+        "io.micrometer.core.instrument.MeterRegistry",
+        "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"
+      })
+  static class MeteredConfiguration {
+
+    /**
+     * Creates a {@link CamundaClientExecutorService} that uses virtual threads for job execution
+     * with metrics support when Micrometer is available.
+     *
+     * @param meterRegistry the meter registry for metrics
+     * @return the configured executor service with virtual threads for job handling and a single
+     *     platform thread for scheduling
+     */
+    @Bean
+    CamundaClientExecutorService camundaClientExecutorService(
+        @Lazy final MeterRegistry meterRegistry) {
+      final ThreadFactory virtualThreadFactory = createVirtualThreadFactory();
+      final ExecutorService jobHandlingExecutor =
+          Executors.newThreadPerTaskExecutor(virtualThreadFactory);
+      final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
+
+      return new MeteredCamundaClientExecutorService(
+          scheduledExecutor, true, jobHandlingExecutor, true, meterRegistry);
+    }
   }
 }

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/test/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/test/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.virtualthreads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Tests that {@link VirtualThreadsAutoConfiguration} degrades gracefully when optional dependencies
+ * (micrometer, actuator) are absent from the classpath. This is a regression test for Java 24+
+ * compatibility where Spring Framework's ClassFileMetadataReader eagerly resolves class references.
+ *
+ * @see <a href="https://github.com/camunda/camunda/issues/47464">#47464</a>
+ */
+class VirtualThreadsAutoConfigurationTest {
+
+  private ApplicationContextRunner contextRunner() {
+    return new ApplicationContextRunner()
+        .withUserConfiguration(VirtualThreadsAutoConfiguration.class);
+  }
+
+  @Test
+  void shouldCreateMeteredExecutorWhenBothMicrometerAndActuatorPresent() {
+    // Both micrometer-core and spring-boot-actuator-autoconfigure are on the test classpath
+    contextRunner()
+        .withBean(SimpleMeterRegistry.class)
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
+              assertThat(context.getBean(CamundaClientExecutorService.class))
+                  .isInstanceOf(MeteredCamundaClientExecutorService.class);
+            });
+  }
+
+  @Test
+  void shouldNotCreateMeteredExecutorWhenActuatorAbsent() {
+    // micrometer is on test classpath, but actuator is filtered out — metered bean requires both
+    contextRunner()
+        .withClassLoader(
+            new FilteredClassLoader(
+                "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"))
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(MeteredCamundaClientExecutorService.class);
+            });
+  }
+
+  @Test
+  void shouldFallBackToUnmeteredExecutorWhenMicrometerAbsent() {
+    contextRunner()
+        .withClassLoader(new FilteredClassLoader("io.micrometer.core.instrument.MeterRegistry"))
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
+              assertThat(context.getBean(CamundaClientExecutorService.class))
+                  .isNotInstanceOf(MeteredCamundaClientExecutorService.class);
+            });
+  }
+
+  @Test
+  void shouldFallBackToUnmeteredExecutorWhenBothAbsent() {
+    contextRunner()
+        .withClassLoader(
+            new FilteredClassLoader(
+                "io.micrometer.core.instrument.MeterRegistry",
+                "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"))
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
+              assertThat(context.getBean(CamundaClientExecutorService.class))
+                  .isNotInstanceOf(MeteredCamundaClientExecutorService.class);
+            });
+  }
+
+  /**
+   * Verifies that {@code MeterRegistry} does not leak into the outer class as a method parameter
+   * type. On Java 24+, {@link Class#getDeclaredMethods()} resolves all parameter types eagerly; if
+   * {@code MeterRegistry} appeared as a method parameter on the outer class (instead of a nested
+   * configuration class), Spring would throw {@link NoClassDefFoundError} when discovering
+   * {@code @Bean} methods — before it even evaluates any {@code @ConditionalOnClass}.
+   *
+   * <p>This test builds a classloader that genuinely excludes micrometer JARs (unlike {@link
+   * FilteredClassLoader}, which only intercepts {@link ClassLoader#loadClass} and cannot reproduce
+   * the native {@link Class#getDeclaredMethods()} failure). It then loads the outer configuration
+   * class and calls {@code getDeclaredMethods()}, which fails with {@link NoClassDefFoundError} if
+   * the refactor is reverted.
+   */
+  @Test
+  void shouldNotReferToMeterRegistryInOuterClassMethods() throws Exception {
+    final String classpath = System.getProperty("java.class.path");
+    final List<URL> urls = new ArrayList<>();
+    for (final String entry : classpath.split(File.pathSeparator)) {
+      if (!entry.contains("micrometer")) {
+        urls.add(new File(entry).toURI().toURL());
+      }
+    }
+
+    // Platform classloader skips the app classloader, so micrometer is truly absent
+    try (URLClassLoader loader =
+        new URLClassLoader(urls.toArray(new URL[0]), ClassLoader.getPlatformClassLoader())) {
+      final Class<?> outerClass =
+          loader.loadClass("io.camunda.client.virtualthreads.VirtualThreadsAutoConfiguration");
+      assertThatNoException()
+          .as("getDeclaredMethods() must not throw NoClassDefFoundError for MeterRegistry")
+          .isThrownBy(outerClass::getDeclaredMethods);
+    }
+  }
+}

--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -118,12 +118,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
     </dependency>
 

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java
@@ -26,21 +26,20 @@ import io.camunda.client.spring.actuator.CamundaClientHealthIndicator;
 import io.camunda.client.spring.actuator.JobWorkerController;
 import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 
 @AutoConfigureBefore(MetricsDefaultConfiguration.class)
 @ConditionalOnCamundaClientEnabled
-@ConditionalOnClass({
-  EndpointAutoConfiguration.class,
-  MeterRegistry.class
-}) // only if actuator is on classpath
+@ConditionalOnClass(
+    name = {
+      "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration",
+      "io.micrometer.core.instrument.MeterRegistry"
+    }) // only if actuator is on classpath
 public class CamundaActuatorConfiguration {
 
   @Bean
@@ -71,7 +70,7 @@ public class CamundaActuatorConfiguration {
       prefix = "management.health.camunda",
       name = "enabled",
       matchIfMissing = true)
-  @ConditionalOnClass(HealthIndicator.class)
+  @ConditionalOnClass(name = "org.springframework.boot.health.contributor.HealthIndicator")
   @ConditionalOnMissingBean(name = "camundaClientHealthIndicator")
   public CamundaClientHealthIndicator camundaClientHealthIndicator(final HealthCheck healthCheck) {
     return new CamundaClientHealthIndicator(healthCheck);

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.context.annotation.Bean;
 @ImportAutoConfiguration({
   ExecutorServiceConfiguration.class,
   CamundaActuatorConfiguration.class,
+  MetricsDefaultConfiguration.class,
   JsonMapperConfiguration.class,
   Jackson3JsonMapperConfiguration.class,
   DefaultJsonMapperConfiguration.class,

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/ExecutorServiceConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/ExecutorServiceConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
-@ConditionalOnClass(MeterRegistry.class)
+@ConditionalOnClass(name = "io.micrometer.core.instrument.MeterRegistry")
 @ConditionalOnMissingBean(CamundaClientExecutorService.class)
 public class ExecutorServiceConfiguration {
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/CamundaActuatorConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/CamundaActuatorConfigurationTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.metrics.DefaultNoopMetricsRecorder;
+import io.camunda.client.metrics.JobWorkerMetricsFactory;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.metrics.NoopJobWorkerMetricsFactory;
+import io.camunda.client.spring.actuator.JobWorkerController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Tests that auto-configuration degrades gracefully when optional dependencies (actuator,
+ * micrometer) are absent from the classpath. This is a regression test for Java 24+ compatibility
+ * where Spring Framework's ClassFileMetadataReader eagerly resolves class literals in annotations.
+ *
+ * @see <a href="https://github.com/camunda/camunda/issues/47464">#47464</a>
+ */
+class CamundaActuatorConfigurationTest {
+
+  private ApplicationContextRunner contextRunner() {
+    return new ApplicationContextRunner()
+        .withUserConfiguration(
+            CamundaActuatorConfiguration.class, MetricsDefaultConfiguration.class);
+  }
+
+  @Test
+  void shouldSkipActuatorConfigWhenActuatorAutoconfigureAbsent() {
+    contextRunner()
+        .withClassLoader(
+            new FilteredClassLoader(
+                "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"))
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(JobWorkerController.class);
+              assertThat(context).doesNotHaveBean("micrometerMetricsRecorder");
+            });
+  }
+
+  @Test
+  void shouldSkipActuatorConfigWhenMicrometerAbsent() {
+    contextRunner()
+        .withClassLoader(new FilteredClassLoader("io.micrometer.core.instrument.MeterRegistry"))
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(JobWorkerController.class);
+              assertThat(context).doesNotHaveBean("micrometerMetricsRecorder");
+            });
+  }
+
+  @Test
+  void shouldFallBackToNoopMetricsWhenActuatorAbsent() {
+    contextRunner()
+        .withClassLoader(
+            new FilteredClassLoader(
+                "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"))
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(MetricsRecorder.class);
+              assertThat(context.getBean(MetricsRecorder.class))
+                  .isInstanceOf(DefaultNoopMetricsRecorder.class);
+
+              assertThat(context).hasSingleBean(JobWorkerMetricsFactory.class);
+              assertThat(context.getBean(JobWorkerMetricsFactory.class))
+                  .isInstanceOf(NoopJobWorkerMetricsFactory.class);
+            });
+  }
+
+  @Test
+  void shouldFallBackToNoopMetricsWhenMicrometerAbsent() {
+    contextRunner()
+        .withClassLoader(new FilteredClassLoader("io.micrometer.core.instrument.MeterRegistry"))
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(MetricsRecorder.class);
+              assertThat(context.getBean(MetricsRecorder.class))
+                  .isInstanceOf(DefaultNoopMetricsRecorder.class);
+
+              assertThat(context).hasSingleBean(JobWorkerMetricsFactory.class);
+              assertThat(context.getBean(JobWorkerMetricsFactory.class))
+                  .isInstanceOf(NoopJobWorkerMetricsFactory.class);
+            });
+  }
+
+  @Test
+  void shouldFallBackToNoopMetricsWhenBothAbsent() {
+    contextRunner()
+        .withClassLoader(
+            new FilteredClassLoader(
+                "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration",
+                "io.micrometer.core.instrument.MeterRegistry"))
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(JobWorkerController.class);
+
+              assertThat(context).hasSingleBean(MetricsRecorder.class);
+              assertThat(context.getBean(MetricsRecorder.class))
+                  .isInstanceOf(DefaultNoopMetricsRecorder.class);
+
+              assertThat(context).hasSingleBean(JobWorkerMetricsFactory.class);
+              assertThat(context.getBean(JobWorkerMetricsFactory.class))
+                  .isInstanceOf(NoopJobWorkerMetricsFactory.class);
+            });
+  }
+}


### PR DESCRIPTION
# Description
Backport of #47466 to `stable/8.9`.

relates to #47464