### PR TITLE
fix: run compatibility workflow also from stable/8.9

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test-trigger.yml
+++ b/.github/workflows/camunda-client-compatibility-test-trigger.yml
@@ -1,7 +1,7 @@
 # description: trigger workflow to run the camunda-client-compatibility-test.yml workflow on a schedule
 # type: CI
 # owner: @camunda/camunda-ex
-name: Camunda Compatibility Tests - stable/8.8
+name: Camunda Compatibility Tests - Trigger
 
 on:
   schedule:
@@ -9,13 +9,24 @@ on:
     - cron: "0 2 * * *"
 
 jobs:
-  trigger-action-on-production:
+  trigger-stable-8-8:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger action on the production branch
+      - name: Trigger compatibility tests on stable/8.8
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run .github/workflows/camunda-client-compatibility-test.yml \
             --ref stable/8.8 \
+            --repo ${{ github.repository }}
+
+  trigger-stable-8-9:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger compatibility tests on stable/8.9
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run .github/workflows/camunda-client-compatibility-test.yml \
+            --ref stable/8.9 \
             --repo ${{ github.repository }}

--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -171,6 +171,10 @@ jobs:
           if [[ "$IS_MAIN" == "true" ]]; then
             # On main, the only client is the pom version
             CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
+          elif (( CLIENT_COUNT == 0 )); then
+            # On stable branches with no GA tags yet, use the pom SNAPSHOT version
+            CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
+            echo "No GA tags found for stable version $STABLE_VERSION - using pom SNAPSHOT as client"
           fi
 
           echo "$CLIENT_LIST" > /tmp/client_list.txt

--- a/.github/workflows/camunda-process-test-compatibility-trigger.yml
+++ b/.github/workflows/camunda-process-test-compatibility-trigger.yml
@@ -1,7 +1,7 @@
 # description: trigger workflow to run the camunda-process-test-compatibility.yml workflow on a schedule
 # type: CI
 # owner: @camunda/camunda-ex
-name: CPT Compatibility Tests - stable/8.8
+name: CPT Compatibility Tests - Trigger
 
 on:
   schedule:
@@ -9,13 +9,24 @@ on:
     - cron: "0 2 * * *"
 
 jobs:
-  trigger-action-on-production:
+  trigger-stable-8-8:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger action on the production branch
+      - name: Trigger CPT compatibility tests on stable/8.8
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run .github/workflows/camunda-process-test-compatibility.yml \
             --ref stable/8.8 \
+            --repo ${{ github.repository }}
+
+  trigger-stable-8-9:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CPT compatibility tests on stable/8.9
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run .github/workflows/camunda-process-test-compatibility.yml \
+            --ref stable/8.9 \
             --repo ${{ github.repository }}

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -169,6 +169,10 @@ jobs:
           if [[ "$IS_MAIN" == "true" ]]; then
             # On main, the only client is the pom version
             CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
+          elif (( CLIENT_COUNT == 0 )); then
+            # On stable branches with no GA tags yet, use the pom SNAPSHOT version
+            CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
+            echo "No GA tags found for stable version $STABLE_VERSION - using pom SNAPSHOT as client"
           fi
 
           echo "$CLIENT_LIST" > /tmp/client_list.txt

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml
@@ -1,7 +1,7 @@
 # description: trigger workflow to run the camunda-spring-boot-starter-compatibility-test.yml workflow on a schedule
 # type: CI
 # owner: @camunda/camunda-ex
-name: Camunda Spring Boot Starter Compatibility Tests - stable/8.8
+name: Camunda Spring Boot Starter Compatibility Tests - Trigger
 
 on:
   schedule:
@@ -9,13 +9,24 @@ on:
     - cron: "0 2 * * *"
 
 jobs:
-  trigger-action-on-production:
+  trigger-stable-8-8:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger action on the production branch
+      - name: Trigger Spring Boot Starter compatibility tests on stable/8.8
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run .github/workflows/camunda-spring-boot-starter-compatibility-test.yml \
             --ref stable/8.8 \
+            --repo ${{ github.repository }}
+
+  trigger-stable-8-9:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Spring Boot Starter compatibility tests on stable/8.9
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run .github/workflows/camunda-spring-boot-starter-compatibility-test.yml \
+            --ref stable/8.9 \
             --repo ${{ github.repository }}

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -167,6 +167,10 @@ jobs:
           if [[ "$IS_MAIN" == "true" ]]; then
             # On main, the only client is the pom version
             CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
+          elif (( CLIENT_COUNT == 0 )); then
+            # On stable branches with no GA tags yet, use the pom SNAPSHOT version
+            CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
+            echo "No GA tags found for stable version $STABLE_VERSION - using pom SNAPSHOT as client"
           fi
 
           echo "$CLIENT_LIST" > /tmp/client_list.txt

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTimeSeriesStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTimeSeriesStatisticsIT.java
@@ -31,8 +31,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@MultiDbTest
-@CompatibilityTest
+//@MultiDbTest
+@CompatibilityTest(envVars = "ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBMETRICS_EXPORTINTERVAL=PT2S")
 public class JobTimeSeriesStatisticsIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTimeSeriesStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTimeSeriesStatisticsIT.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-//@MultiDbTest
+@MultiDbTest
 @CompatibilityTest(envVars = "ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBMETRICS_EXPORTINTERVAL=PT2S")
 public class JobTimeSeriesStatisticsIT {
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Allow the workflows to run also on stable/8.9
