### PR TITLE
feat: add support for building optimize Docker image based on input flag

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -295,11 +295,18 @@ jobs:
         with:
           directory: ./identity/client
           package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Optimize Frontend
+        id: build-optimize-fe
+        if: ${{ inputs.build-frontend && inputs.enable-optimize }}
+        with:
+          directory: ./optimize/client
+          package-manager: "yarn"
       - uses: ./.github/actions/build-zeebe
         name: Build Camunda Platform
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -PskipFrontendBuild ${{ inputs.enable-optimize && '-Pinclude-optimize' || '-P\!include-optimize' }}
       - uses: ./.github/actions/build-platform-docker
         name: Build Camunda Docker Image
         with:
@@ -309,6 +316,16 @@ jobs:
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           dockerfile: 'camunda.Dockerfile'
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Optimize Docker Image
+        if: ${{ inputs.enable-optimize }}
+        with:
+          repository: '${{ env.IMAGE_REPOSITORY }}/optimize'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
+          dockerfile: 'optimize.Dockerfile'
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -422,7 +422,7 @@ jobs:
         run: |
           cd load-tests/setup/${{ env.NAMESPACE }}
 
-          # Build additional load test configuration
+          # Build load test configuration
           load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
                             --set global.image.repository=${{ env.IMAGE_REPOSITORY }} \
                             --set global.image.pullSecrets[0].name=harbor-registry \
@@ -433,11 +433,34 @@ jobs:
             load_test_config="$load_test_config ${{ needs.calculate-scenario-config.outputs.load-test-load }}"
           fi
 
-          # Build additional platform configuration, including any scenario-specific overrides
-          additional_platform_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }} --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/camunda' }} --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.platform-helm-values }}"
+          # Resolve image registry/repository based on whether official images are used
+          image_registry="${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}"
+          camunda_repo="${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/camunda' }}"
+          optimize_repo="${{ inputs.use-official-docker-images && 'camunda/optimize' || 'team-zeebe/optimize' }}"
+          image_tag="${{ needs.calculate-image-tag.outputs.image-tag }}"
+
+          # Build platform configuration
+          additional_platform_config="--set global.image.tag=${image_tag} \
+            --set orchestration.image.registry=${image_registry} \
+            --set orchestration.image.repository=${camunda_repo} \
+            --set orchestration.image.tag=${image_tag}"
+
+          # Append optimize image config if enabled
+          if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
+            additional_platform_config+=" \
+              --set optimize.image.registry=${image_registry} \
+              --set optimize.image.repository=${optimize_repo} \
+              --set optimize.image.tag=${image_tag}"
+          fi
+
+          # Append user-provided helm values if present
+          if [[ -n "${{ inputs.platform-helm-values }}" ]]; then
+            additional_platform_config+=" ${{ inputs.platform-helm-values }}"
+          fi
+
           # Append scenario-specific platform configuration if present (e.g. max scenario disables consistency checks)
           if [[ -n "${{ needs.calculate-scenario-config.outputs.platform-additional-config }}" ]]; then
-            additional_platform_config="$additional_platform_config ${{ needs.calculate-scenario-config.outputs.platform-additional-config }}"
+            additional_platform_config+=" ${{ needs.calculate-scenario-config.outputs.platform-additional-config }}"
           fi
 
           make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \


### PR DESCRIPTION
## Description
This pull request updates the `camunda-load-test` GitHub workflow to add support for optionally building and deploying the Optimize component. The changes conditionally build the Optimize Docker image and adjust deployment configuration to include Optimize image settings when enabled.

Build and deployment enhancements:

* Conditional Maven build arguments: The `maven-extra-args` now includes `-Pinclude-optimize` only if `enable-optimize` is set, otherwise it uses `-P!include-optimize`.
* Optimize Docker image build: Added a step to build and push the Optimize Docker image if `enable-optimize` is enabled, using the `optimize.Dockerfile` and the correct distribution archive.

Deployment configuration improvements:

* Helm values update: The `additional_platform_configuration` now conditionally adds Optimize image registry, repository, and tag settings when `enable-optimize` is enabled, ensuring Optimize is deployed with the correct image.

## Success Run:
https://github.com/camunda/camunda/actions/runs/22824248451

## Related issues

closes #46436 
