### PR TITLE
fix: remove contradictory object type from filters

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -518,7 +518,6 @@ components:
 
     AuditLogEntityKeyFilterProperty:
       description: EntityKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -556,7 +555,6 @@ components:
 
     EntityTypeFilterProperty:
       description: AuditLogEntityTypeEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -591,7 +589,6 @@ components:
 
     OperationTypeFilterProperty:
       description: AuditLogOperationTypeEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -626,7 +623,6 @@ components:
 
     CategoryFilterProperty:
       description: AuditLogCategoryEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -661,7 +657,6 @@ components:
 
     AuditLogResultFilterProperty:
       description: AuditLogResultEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -696,7 +691,6 @@ components:
 
     AuditLogActorTypeFilterProperty:
       description: AuditLogActorTypeEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -684,7 +684,6 @@ components:
 
     BatchOperationTypeFilterProperty:
       description: BatchOperationTypeEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -719,7 +718,6 @@ components:
 
     BatchOperationStateFilterProperty:
       description: BatchOperationStateEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -754,7 +752,6 @@ components:
 
     BatchOperationItemStateFilterProperty:
       description: BatchOperationItemStateEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -465,7 +465,6 @@ components:
           type: boolean
     ClusterVariableScopeFilterProperty:
       description: ClusterVariableScopeEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -513,7 +513,6 @@ components:
 
     DecisionInstanceStateFilterProperty:
       description: DecisionInstanceStateEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -477,7 +477,6 @@ components:
 
     DeploymentKeyFilterProperty:
       description: DeploymentKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -515,7 +514,6 @@ components:
 
     ResourceKeyFilterProperty:
       description: ResourceKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -340,7 +340,6 @@ components:
 
     ElementInstanceStateFilterProperty:
       description: ElementInstanceStateEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/filters.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/filters.yaml
@@ -50,7 +50,6 @@ components:
 
     BasicStringFilterProperty:
       description: String property with basic advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -59,7 +58,6 @@ components:
 
     StringFilterProperty:
       description: String property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -107,7 +105,6 @@ components:
 
     IntegerFilterProperty:
       description: Integer property with advanced search capabilities.
-      type: object
       oneOf:
         - type: integer
           format: int32
@@ -156,7 +153,6 @@ components:
 
     DateTimeFilterProperty:
       description: Date-time property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           format: date-time

--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -340,7 +340,6 @@ components:
             - $ref: '#/components/schemas/GlobalListenerSourceFilterProperty'
     GlobalListenerSourceFilterProperty:
       description: Global listener source property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -373,7 +372,6 @@ components:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
     GlobalTaskListenerEventTypeFilterProperty:
       description: Global listener event type property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -253,7 +253,6 @@ components:
 
     IncidentErrorTypeFilterProperty:
       description: IncidentErrorTypeEnum with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -314,7 +313,6 @@ components:
 
     IncidentStateFilterProperty:
       description: IncidentStateEnum with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1029,7 +1029,6 @@ components:
 
     JobKindFilterProperty:
       description: JobKindEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -1064,7 +1063,6 @@ components:
 
     JobListenerEventTypeFilterProperty:
       description: JobListenerEventTypeEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -1099,7 +1097,6 @@ components:
 
     JobStateFilterProperty:
       description: JobStateEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -165,7 +165,6 @@ components:
 
     ProcessDefinitionKeyFilterProperty:
       description: ProcessDefinitionKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -203,7 +202,6 @@ components:
 
     ProcessInstanceKeyFilterProperty:
       description: ProcessInstanceKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -241,7 +239,6 @@ components:
 
     ElementInstanceKeyFilterProperty:
       description: ElementInstanceKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -279,7 +276,6 @@ components:
 
     JobKeyFilterProperty:
       description: JobKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -317,7 +313,6 @@ components:
 
     DecisionDefinitionKeyFilterProperty:
       description: DecisionDefinitionKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -357,7 +352,6 @@ components:
       description: |
         ScopeKey property with full advanced search capabilities. Filter by the key of the
         element instance or process instance that defines the scope of a variable.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -395,7 +389,6 @@ components:
 
     VariableKeyFilterProperty:
       description: VariableKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -433,7 +426,6 @@ components:
 
     DecisionEvaluationInstanceKeyFilterProperty:
       description: DecisionEvaluationInstanceKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -471,7 +463,6 @@ components:
 
     AuditLogKeyFilterProperty:
       description: AuditLogKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -509,7 +500,6 @@ components:
 
     FormKeyFilterProperty:
       description: FormKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -548,7 +538,6 @@ components:
 
     DecisionEvaluationKeyFilterProperty:
       description: DecisionEvaluationKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -586,7 +575,6 @@ components:
 
     DecisionRequirementsKeyFilterProperty:
       description: DecisionRequirementsKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -576,7 +576,6 @@ components:
 
     MessageSubscriptionStateFilterProperty:
       description: MessageSubscriptionStateEnum with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match
@@ -638,7 +637,6 @@ components:
 
     MessageSubscriptionKeyFilterProperty:
       description: MessageSubscriptionKey property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1688,7 +1688,6 @@ components:
 
     ProcessInstanceStateFilterProperty:
       description: ProcessInstanceStateEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -817,7 +817,6 @@ components:
 
     UserTaskStateFilterProperty:
       description: UserTaskStateEnum property with full advanced search capabilities.
-      type: object
       oneOf:
         - type: string
           title: Exact match


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
AdvancedFilters have been declared with `type: object`. This creates a contradictory constraint, because they are a `oneOf` composition that is made up of an object and a scalar. 

This PR removes the contradictory constraint, allowing consumers to correctly reason from the schema about the shape of the filter. 

This was caught by a change to `CorrelatedMessageSubscriptionSearchQuery` from string to complex filter. Because the string scalar is covered by the top-level object type declaration, it broke the type system in the TS SDK. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
