### PR TITLE
Hackathon: Async `CamundaExporter` flushing

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -189,13 +189,6 @@ public class CamundaExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-
-    // If a failure was recorded while flushing, throw it when trying to export the next record
-    final var failure = flusher.failure();
-    if (failure != null) {
-      throw failure;
-    }
-
     if (writer.getBatchSize() == 0) {
       metrics.startFlushLatencyMeasurement();
     }
@@ -400,30 +393,16 @@ public class CamundaExporter implements Exporter {
   }
 
   class Flusher {
-    final Semaphore flushQueue = new Semaphore(WRITERS_NUMBER);
-    final Semaphore errorSemaphore = new Semaphore(1);
+    final Semaphore semaphore = new Semaphore(WRITERS_NUMBER);
     private final ScheduledExecutorService flushExecutorService;
-    private ExporterException currentException = null;
 
     Flusher() {
       flushExecutorService = Executors.newSingleThreadScheduledExecutor();
     }
 
-    ExporterException failure() {
-      try {
-        errorSemaphore.acquire();
-      } catch (final InterruptedException e) {
-        throw new RuntimeException(e);
-      }
-      final var exception = currentException;
-      currentException = null;
-      errorSemaphore.release();
-      return exception;
-    }
-
     void flush() {
       try {
-        flushQueue.acquire();
+        semaphore.acquire();
       } catch (final InterruptedException e) {
         throw new RuntimeException(e);
       }
@@ -432,13 +411,6 @@ public class CamundaExporter implements Exporter {
       final var currentLastPosition = lastPosition;
       flushExecutorService.submit(
           () -> {
-            if (currentException != null) {
-              // Do nothing if there is already a recorded exception
-              flushQueue.release();
-              return;
-            }
-
-            // Execute flush
             try (final var ignored = metrics.measureFlushDuration()) {
               metrics.recordBulkSize(currentWriter.getBatchSize());
               final BatchRequest batchRequest =
@@ -448,19 +420,9 @@ public class CamundaExporter implements Exporter {
               metrics.stopFlushLatencyMeasurement();
             } catch (final PersistenceException ex) {
               metrics.recordFailedFlush();
-
-              // Record the exception and release the semaphore only after all other queued flushes
-              // are done
-              try {
-                errorSemaphore.acquire();
-              } catch (final InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-              currentException = new ExporterException(ex.getMessage(), ex);
-              flushExecutorService.submit(() -> errorSemaphore.release());
-              return;
+              throw new ExporterException(ex.getMessage(), ex);
             } finally {
-              flushQueue.release();
+              semaphore.release();
             }
 
             // Update the record counters only after the flush was successful. If the synchronous

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -189,6 +189,13 @@ public class CamundaExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
+
+    // If a failure was recorded while flushing, throw it when trying to export the next record
+    final var failure = flusher.failure();
+    if (failure != null) {
+      throw failure;
+    }
+
     if (writer.getBatchSize() == 0) {
       metrics.startFlushLatencyMeasurement();
     }
@@ -393,16 +400,30 @@ public class CamundaExporter implements Exporter {
   }
 
   class Flusher {
-    final Semaphore semaphore = new Semaphore(WRITERS_NUMBER);
+    final Semaphore flushQueue = new Semaphore(WRITERS_NUMBER);
+    final Semaphore errorSemaphore = new Semaphore(1);
     private final ScheduledExecutorService flushExecutorService;
+    private ExporterException currentException = null;
 
     Flusher() {
       flushExecutorService = Executors.newSingleThreadScheduledExecutor();
     }
 
+    ExporterException failure() {
+      try {
+        errorSemaphore.acquire();
+      } catch (final InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      final var exception = currentException;
+      currentException = null;
+      errorSemaphore.release();
+      return exception;
+    }
+
     void flush() {
       try {
-        semaphore.acquire();
+        flushQueue.acquire();
       } catch (final InterruptedException e) {
         throw new RuntimeException(e);
       }
@@ -411,6 +432,13 @@ public class CamundaExporter implements Exporter {
       final var currentLastPosition = lastPosition;
       flushExecutorService.submit(
           () -> {
+            if (currentException != null) {
+              // Do nothing if there is already a recorded exception
+              flushQueue.release();
+              return;
+            }
+
+            // Execute flush
             try (final var ignored = metrics.measureFlushDuration()) {
               metrics.recordBulkSize(currentWriter.getBatchSize());
               final BatchRequest batchRequest =
@@ -420,9 +448,19 @@ public class CamundaExporter implements Exporter {
               metrics.stopFlushLatencyMeasurement();
             } catch (final PersistenceException ex) {
               metrics.recordFailedFlush();
-              throw new ExporterException(ex.getMessage(), ex);
+
+              // Record the exception and release the semaphore only after all other queued flushes
+              // are done
+              try {
+                errorSemaphore.acquire();
+              } catch (final InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+              currentException = new ExporterException(ex.getMessage(), ex);
+              flushExecutorService.submit(() -> errorSemaphore.release());
+              return;
             } finally {
-              semaphore.release();
+              flushQueue.release();
             }
 
             // Update the record counters only after the flush was successful. If the synchronous

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -116,9 +116,6 @@ public class CamundaExporter implements Exporter {
     this.metadata = metadata;
 
     flusher = new Flusher();
-    for (int i = 0; i < WRITERS_NUMBER; i++) {
-      writersPool.add(createBatchWriter());
-    }
   }
 
   @Override
@@ -147,6 +144,10 @@ public class CamundaExporter implements Exporter {
         }
       }
 
+      writersPool.clear();
+      for (int i = 0; i < WRITERS_NUMBER; i++) {
+        writersPool.add(createBatchWriter());
+      }
       nextWriter();
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -67,6 +67,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -84,6 +85,8 @@ public class CamundaExporter implements Exporter {
 
   private ExporterBatchWriter writer;
   private final Flusher flusher;
+  private final List<ExporterBatchWriter> writersPool = new ArrayList<>(WRITERS_NUMBER);
+  private int currentWriterIndex = 0;
 
   private Controller controller;
   private ExporterConfiguration configuration;
@@ -113,6 +116,9 @@ public class CamundaExporter implements Exporter {
     this.metadata = metadata;
 
     flusher = new Flusher();
+    for (int i = 0; i < WRITERS_NUMBER; i++) {
+      writersPool.add(createBatchWriter());
+    }
   }
 
   @Override
@@ -141,7 +147,7 @@ public class CamundaExporter implements Exporter {
         }
       }
 
-      writer = createBatchWriter();
+      nextWriter();
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
       scheduleDelayedFlush();
@@ -235,6 +241,11 @@ public class CamundaExporter implements Exporter {
     } finally {
       close();
     }
+  }
+
+  private void nextWriter() {
+    currentWriterIndex = (currentWriterIndex + 1) % WRITERS_NUMBER;
+    writer = writersPool.get(currentWriterIndex);
   }
 
   private void verifySetupOfResources() {
@@ -430,7 +441,7 @@ public class CamundaExporter implements Exporter {
             // fails then the exporter will be invoked with the same record again.
             updateLastExportedPosition(currentLastPosition);
           });
-      writer = createBatchWriter();
+      nextWriter();
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,10 +80,14 @@ import org.slf4j.LoggerFactory;
 public class CamundaExporter implements Exporter {
   private static final Logger LOG = LoggerFactory.getLogger(CamundaExporter.class);
 
+  private final int WRITERS_NUMBER = 3;
+
+  private ExporterBatchWriter writer;
+  private final Flusher flusher;
+
   private Controller controller;
   private ExporterConfiguration configuration;
   private ClientAdapter clientAdapter;
-  private ExporterBatchWriter writer;
   private long lastPosition = -1;
   private final ExporterResourceProvider provider;
   private CamundaExporterMetrics metrics;
@@ -91,7 +96,6 @@ public class CamundaExporter implements Exporter {
   private SearchEngineClient searchEngineClient;
   private int partitionId;
   private Context context;
-  private final ScheduledExecutorService flushExecutorService;
 
   public CamundaExporter() {
     // the metadata will be initialized on open
@@ -108,7 +112,7 @@ public class CamundaExporter implements Exporter {
     this.provider = provider;
     this.metadata = metadata;
 
-    flushExecutorService = Executors.newScheduledThreadPool(1);
+    flusher = new Flusher();
   }
 
   @Override
@@ -332,24 +336,7 @@ public class CamundaExporter implements Exporter {
       return;
     }
 
-    final var currentWriter = writer;
-
-    flushExecutorService.submit(
-        () -> {
-          try (final var ignored = metrics.measureFlushDuration()) {
-            metrics.recordBulkSize(currentWriter.getBatchSize());
-            final BatchRequest batchRequest =
-                clientAdapter.createBatchRequest().withMetrics(metrics);
-            currentWriter.flush(batchRequest);
-            metrics.recordFlushOccurrence(Instant.now());
-            metrics.stopFlushLatencyMeasurement();
-          } catch (final PersistenceException ex) {
-            metrics.recordFailedFlush();
-            throw new ExporterException(ex.getMessage(), ex);
-          }
-        });
-
-    writer = createBatchWriter();
+    flusher.flush();
 
     // Update the record counters only after the flush was successful. If the synchronous flush
     // fails then the exporter will be invoked with the same record again.
@@ -406,6 +393,42 @@ public class CamundaExporter implements Exporter {
     @Override
     public boolean acceptValue(final ValueType valueType) {
       return VALUE_TYPES_2_EXPORT.contains(valueType);
+    }
+  }
+
+  class Flusher {
+    final Semaphore semaphore = new Semaphore(WRITERS_NUMBER);
+    private final ScheduledExecutorService flushExecutorService;
+
+    Flusher() {
+      flushExecutorService = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    void flush() {
+      try {
+        semaphore.acquire();
+      } catch (final InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+
+      final var currentWriter = writer;
+      flushExecutorService.submit(
+          () -> {
+            try (final var ignored = metrics.measureFlushDuration()) {
+              metrics.recordBulkSize(currentWriter.getBatchSize());
+              final BatchRequest batchRequest =
+                  clientAdapter.createBatchRequest().withMetrics(metrics);
+              currentWriter.flush(batchRequest);
+              metrics.recordFlushOccurrence(Instant.now());
+              metrics.stopFlushLatencyMeasurement();
+            } catch (final PersistenceException ex) {
+              metrics.recordFailedFlush();
+              throw new ExporterException(ex.getMessage(), ex);
+            } finally {
+              semaphore.release();
+            }
+          });
+      writer = createBatchWriter();
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -70,6 +70,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,6 +91,7 @@ public class CamundaExporter implements Exporter {
   private SearchEngineClient searchEngineClient;
   private int partitionId;
   private Context context;
+  private final ScheduledExecutorService flushExecutorService;
 
   public CamundaExporter() {
     // the metadata will be initialized on open
@@ -104,6 +107,8 @@ public class CamundaExporter implements Exporter {
   public CamundaExporter(final ExporterResourceProvider provider, final ExporterMetadata metadata) {
     this.provider = provider;
     this.metadata = metadata;
+
+    flushExecutorService = Executors.newScheduledThreadPool(1);
   }
 
   @Override
@@ -327,16 +332,24 @@ public class CamundaExporter implements Exporter {
       return;
     }
 
-    try (final var ignored = metrics.measureFlushDuration()) {
-      metrics.recordBulkSize(writer.getBatchSize());
-      final BatchRequest batchRequest = clientAdapter.createBatchRequest().withMetrics(metrics);
-      writer.flush(batchRequest);
-      metrics.recordFlushOccurrence(Instant.now());
-      metrics.stopFlushLatencyMeasurement();
-    } catch (final PersistenceException ex) {
-      metrics.recordFailedFlush();
-      throw new ExporterException(ex.getMessage(), ex);
-    }
+    final var currentWriter = writer;
+
+    flushExecutorService.submit(
+        () -> {
+          try (final var ignored = metrics.measureFlushDuration()) {
+            metrics.recordBulkSize(currentWriter.getBatchSize());
+            final BatchRequest batchRequest =
+                clientAdapter.createBatchRequest().withMetrics(metrics);
+            currentWriter.flush(batchRequest);
+            metrics.recordFlushOccurrence(Instant.now());
+            metrics.stopFlushLatencyMeasurement();
+          } catch (final PersistenceException ex) {
+            metrics.recordFailedFlush();
+            throw new ExporterException(ex.getMessage(), ex);
+          }
+        });
+
+    writer = createBatchWriter();
 
     // Update the record counters only after the flush was successful. If the synchronous flush
     // fails then the exporter will be invoked with the same record again.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -337,10 +337,6 @@ public class CamundaExporter implements Exporter {
     }
 
     flusher.flush();
-
-    // Update the record counters only after the flush was successful. If the synchronous flush
-    // fails then the exporter will be invoked with the same record again.
-    updateLastExportedPosition(lastPosition);
   }
 
   private void updateLastExportedPosition(final long lastPosition) {
@@ -412,6 +408,7 @@ public class CamundaExporter implements Exporter {
       }
 
       final var currentWriter = writer;
+      final var currentLastPosition = lastPosition;
       flushExecutorService.submit(
           () -> {
             try (final var ignored = metrics.measureFlushDuration()) {
@@ -427,6 +424,11 @@ public class CamundaExporter implements Exporter {
             } finally {
               semaphore.release();
             }
+
+            // Update the record counters only after the flush was successful. If the synchronous
+            // flush
+            // fails then the exporter will be invoked with the same record again.
+            updateLastExportedPosition(currentLastPosition);
           });
       writer = createBatchWriter();
     }


### PR DESCRIPTION
## Description

This pull request introduces a new mechanism for batching and flushing export operations in the `CamundaExporter` by implementing a pool of batch writers and a dedicated asynchronous flushing system. The changes aim to improve concurrency, reliability, and performance of the exporter by rotating writers and handling flushes in a controlled, thread-safe manner.

**Batch writer pooling and asynchronous flushing:**

* Introduced a pool of `ExporterBatchWriter` instances (`writersPool`) and logic to rotate through them for each batch, improving concurrency and potentially reducing contention during flushes. 
* Added a new `Flusher` inner class that manages asynchronous flush operations using a `ScheduledExecutorService` and a `Semaphore` to control concurrent flushes, ensuring only a limited number of writers can flush at once.
* Refactored the `flush()` method to delegate flush logic to the new `Flusher` class, making flushes asynchronous and thread-safe. 

These changes collectively aim to make the exporter's batching and flushing more robust and performant by leveraging multiple writers and asynchronous execution.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48005
