### PR TITLE
fix: add preemptive basic auth for OpenSearch to prevent intermittent…

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -16,6 +16,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.property.ProxyProperties;
 import io.camunda.operate.property.SslProperties;
 import io.camunda.search.connect.plugin.PluginRepository;
+import io.camunda.search.connect.util.HttpAuthUtil;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -230,36 +231,10 @@ public class OpensearchConnector {
             osConfig.getUsername(), osConfig.getPassword().toCharArray()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
-
-    // Add a preemptive basic auth interceptor to ensure the Authorization header is always sent
-    // on the first request. The opensearch-java ApacheHttpClient5Transport uses an internal
-    // WrappingAuthCache for preemptive auth, but its AuthScope matching with
-    // BasicCredentialsProvider can intermittently fail to attach credentials. Since the
-    // opensearch-java transport treats HTTP 401 as terminal (no retry/challenge handling),
-    // a missing Authorization header causes an unrecoverable authentication failure.
-    addPreemptiveBasicAuthInterceptor(builder, osConfig.getUsername(), osConfig.getPassword());
+    HttpAuthUtil.addPreemptiveBasicAuthInterceptor(
+        builder, osConfig.getUsername(), osConfig.getPassword());
 
     return builder;
-  }
-
-  private void addPreemptiveBasicAuthInterceptor(
-      final HttpAsyncClientBuilder httpAsyncClientBuilder,
-      final String username,
-      final String password) {
-    final String credentials = username + ":" + password;
-    final String encodedCredentials =
-        Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
-    final String basicAuthHeaderValue = "Basic " + encodedCredentials;
-
-    httpAsyncClientBuilder.addRequestInterceptorFirst(
-        (HttpRequestInterceptor)
-            (request, entity, context) -> {
-              if (!request.containsHeader("Authorization")) {
-                request.addHeader("Authorization", basicAuthHeaderValue);
-              }
-            });
-
-    LOGGER.debug("Preemptive basic authentication enabled for OpenSearch");
   }
 
   private void addPreemptiveProxyAuthInterceptor(

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -230,7 +230,36 @@ public class OpensearchConnector {
             osConfig.getUsername(), osConfig.getPassword().toCharArray()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
+
+    // Add a preemptive basic auth interceptor to ensure the Authorization header is always sent
+    // on the first request. The opensearch-java ApacheHttpClient5Transport uses an internal
+    // WrappingAuthCache for preemptive auth, but its AuthScope matching with
+    // BasicCredentialsProvider can intermittently fail to attach credentials. Since the
+    // opensearch-java transport treats HTTP 401 as terminal (no retry/challenge handling),
+    // a missing Authorization header causes an unrecoverable authentication failure.
+    addPreemptiveBasicAuthInterceptor(builder, osConfig.getUsername(), osConfig.getPassword());
+
     return builder;
+  }
+
+  private void addPreemptiveBasicAuthInterceptor(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder,
+      final String username,
+      final String password) {
+    final String credentials = username + ":" + password;
+    final String encodedCredentials =
+        Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    final String basicAuthHeaderValue = "Basic " + encodedCredentials;
+
+    httpAsyncClientBuilder.addRequestInterceptorFirst(
+        (HttpRequestInterceptor)
+            (request, entity, context) -> {
+              if (!request.containsHeader("Authorization")) {
+                request.addHeader("Authorization", basicAuthHeaderValue);
+              }
+            });
+
+    LOGGER.debug("Preemptive basic authentication enabled for OpenSearch");
   }
 
   private void addPreemptiveProxyAuthInterceptor(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -41,6 +41,7 @@ import io.camunda.optimize.service.util.mapper.CustomReportDefinitionDeserialize
 import io.camunda.optimize.service.util.mapper.ObjectMapperFactory;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import io.camunda.search.connect.plugin.PluginRepository;
+import io.camunda.search.connect.util.HttpAuthUtil;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -275,6 +276,8 @@ public class OpenSearchClientBuilder {
         new UsernamePasswordCredentials(username, password.toCharArray()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
+    HttpAuthUtil.addPreemptiveBasicAuthInterceptor(builder, username, password);
+
     return builder;
   }
 

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -234,6 +234,15 @@ public final class OpensearchConnector {
             configuration.getUsername(), configuration.getPassword().toCharArray()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
+
+    // Add a preemptive basic auth interceptor to ensure the Authorization header is always sent
+    // on the first request. The opensearch-java ApacheHttpClient5Transport uses an internal
+    // WrappingAuthCache for preemptive auth, but its AuthScope matching with
+    // BasicCredentialsProvider can intermittently fail to attach credentials. Since the
+    // opensearch-java transport treats HTTP 401 as terminal (no retry/challenge handling),
+    // a missing Authorization header causes an unrecoverable authentication failure.
+    addPreemptiveBasicAuthInterceptor(builder, username, password);
+
     return builder;
   }
 
@@ -244,6 +253,26 @@ public final class OpensearchConnector {
             proxyConfig.isSslEnabled() ? "https" : "http",
             proxyConfig.getHost(),
             proxyConfig.getPort()));
+  }
+
+  private void addPreemptiveBasicAuthInterceptor(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder,
+      final String username,
+      final String password) {
+    final String credentials = username + ":" + password;
+    final String encodedCredentials =
+        Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    final String basicAuthHeaderValue = "Basic " + encodedCredentials;
+
+    httpAsyncClientBuilder.addRequestInterceptorFirst(
+        (HttpRequestInterceptor)
+            (request, entity, context) -> {
+              if (!request.containsHeader("Authorization")) {
+                request.addHeader("Authorization", basicAuthHeaderValue);
+              }
+            });
+
+    LOGGER.debug("Preemptive basic authentication enabled for OpenSearch");
   }
 
   private void addPreemptiveProxyAuthInterceptor(

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -15,6 +15,7 @@ import io.camunda.search.connect.configuration.SecurityConfiguration;
 import io.camunda.search.connect.jackson.JacksonConfiguration;
 import io.camunda.search.connect.os.json.SearchRequestJacksonJsonpMapperWrapper;
 import io.camunda.search.connect.plugin.PluginRepository;
+import io.camunda.search.connect.util.HttpAuthUtil;
 import io.camunda.search.connect.util.SecurityUtil;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -234,14 +235,7 @@ public final class OpensearchConnector {
             configuration.getUsername(), configuration.getPassword().toCharArray()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
-
-    // Add a preemptive basic auth interceptor to ensure the Authorization header is always sent
-    // on the first request. The opensearch-java ApacheHttpClient5Transport uses an internal
-    // WrappingAuthCache for preemptive auth, but its AuthScope matching with
-    // BasicCredentialsProvider can intermittently fail to attach credentials. Since the
-    // opensearch-java transport treats HTTP 401 as terminal (no retry/challenge handling),
-    // a missing Authorization header causes an unrecoverable authentication failure.
-    addPreemptiveBasicAuthInterceptor(builder, username, password);
+    HttpAuthUtil.addPreemptiveBasicAuthInterceptor(builder, username, password);
 
     return builder;
   }
@@ -253,26 +247,6 @@ public final class OpensearchConnector {
             proxyConfig.isSslEnabled() ? "https" : "http",
             proxyConfig.getHost(),
             proxyConfig.getPort()));
-  }
-
-  private void addPreemptiveBasicAuthInterceptor(
-      final HttpAsyncClientBuilder httpAsyncClientBuilder,
-      final String username,
-      final String password) {
-    final String credentials = username + ":" + password;
-    final String encodedCredentials =
-        Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
-    final String basicAuthHeaderValue = "Basic " + encodedCredentials;
-
-    httpAsyncClientBuilder.addRequestInterceptorFirst(
-        (HttpRequestInterceptor)
-            (request, entity, context) -> {
-              if (!request.containsHeader("Authorization")) {
-                request.addHeader("Authorization", basicAuthHeaderValue);
-              }
-            });
-
-    LOGGER.debug("Preemptive basic authentication enabled for OpenSearch");
   }
 
   private void addPreemptiveProxyAuthInterceptor(

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/util/HttpAuthUtil.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/util/HttpAuthUtil.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility for configuring preemptive HTTP Basic authentication on Apache HttpClient 5 async
+ * builders used by OpenSearch (and Elasticsearch) connectors.
+ *
+ * <h2>Background</h2>
+ *
+ * <p>The opensearch-java client (3.4.0) delegates preemptive auth to its internal {@code
+ * WrappingAuthCache}, which participates in a multi-step pipeline inside Apache HttpClient 5's
+ * async execution chain. That pipeline involves:
+ *
+ * <ol>
+ *   <li>{@code AsyncProtocolExec.execute()} invoking {@code AuthCacheKeeper.loadPreemptively(host,
+ *       pathPrefix, authExchange, context)}
+ *   <li>{@code WrappingAuthCache.get(host)} looking up the cached {@code BasicScheme}, retrieving
+ *       credentials via {@code context.getCredentialsProvider().getCredentials(authScope,
+ *       context)}, and calling {@code BasicScheme.initPreemptive(credentials)}
+ *   <li>{@code AsyncProtocolExec.internalExecute()} checking for an existing {@code Authorization}
+ *       header, and if absent, calling {@code AuthenticationHandler.addAuthResponse()} which
+ *       delegates to {@code BasicScheme.generateAuthResponse()}
+ * </ol>
+ *
+ * <p>If any step in this pipeline fails to produce credentials (e.g. {@code getCredentials()}
+ * returns {@code null}), then {@code BasicScheme.generateAuthResponse()} throws an {@code
+ * AuthenticationException("User credentials not set")}. That exception is caught and logged at
+ * ERROR level inside {@code AuthenticationHandler.addAuthResponse()}, but the request proceeds
+ * <em>without</em> an {@code Authorization} header.
+ *
+ * <h2>Why a missing header is fatal</h2>
+ *
+ * <p>The opensearch-java transport treats HTTP 401 responses as terminal errors. In {@code
+ * ApacheHttpClient5Transport.prepareResponse()}, a 401 status immediately throws a {@code
+ * TransportException("Unauthorized access")} with no retry and no challenge-response negotiation.
+ * Additionally, automatic retries are disabled via {@code disableAutomaticRetries()} in {@code
+ * ApacheHttpClient5TransportBuilder.build()}. A single missing {@code Authorization} header
+ * therefore causes an unrecoverable authentication failure.
+ *
+ * <p>This is particularly problematic with AWS OpenSearch Service using fine-grained access control
+ * (FGAC) with the internal user database, where the security plugin returns 401 with {@code
+ * "Authentication finally failed"} when no credentials are presented.
+ *
+ * <h2>The fix</h2>
+ *
+ * <p>This utility adds a request interceptor via {@code
+ * HttpAsyncClientBuilder.addRequestInterceptorFirst()} that directly sets the {@code Authorization:
+ * Basic} header on every outgoing request. Because request interceptors registered this way run
+ * inside the {@code HttpProcessor} chain in {@code HttpAsyncMainClientExec} (which executes before
+ * {@code AsyncProtocolExec} checks for the header), the {@code Authorization} header is guaranteed
+ * to be present regardless of whether the standard auth cache pipeline succeeds. This is the same
+ * pattern used by {@code addPreemptiveProxyAuthInterceptor} for proxy authentication throughout the
+ * codebase.
+ *
+ * @see <a href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac.html">AWS
+ *     OpenSearch Fine-Grained Access Control</a>
+ */
+public final class HttpAuthUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpAuthUtil.class);
+
+  private HttpAuthUtil() {}
+
+  /**
+   * Adds a request interceptor to the given {@link HttpAsyncClientBuilder} that sets the {@code
+   * Authorization: Basic} header on every outgoing request if one is not already present.
+   *
+   * <p>This should be called in addition to (not instead of) setting a {@link
+   * org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider} on the builder, so that the
+   * standard auth pipeline is still available as a fallback.
+   *
+   * @param builder the HTTP async client builder to configure
+   * @param username the basic auth username
+   * @param password the basic auth password
+   */
+  public static void addPreemptiveBasicAuthInterceptor(
+      final HttpAsyncClientBuilder builder, final String username, final String password) {
+    final String credentials = username + ":" + password;
+    final String encodedCredentials =
+        Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    final String basicAuthHeaderValue = "Basic " + encodedCredentials;
+
+    builder.addRequestInterceptorFirst(
+        (HttpRequestInterceptor)
+            (request, entity, context) -> {
+              if (!request.containsHeader("Authorization")) {
+                request.addHeader("Authorization", basicAuthHeaderValue);
+              }
+            });
+
+    LOGGER.debug("Preemptive basic authentication enabled for search engine connection");
+  }
+}

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.os;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.connect.plugin.PluginRepository;
+import io.camunda.search.connect.util.HttpAuthUtil;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.OpenSearchProperties;
@@ -187,6 +188,9 @@ public class OpenSearchConnector {
             osConfig.getUsername(), osConfig.getPassword().toCharArray()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
+    HttpAuthUtil.addPreemptiveBasicAuthInterceptor(
+        builder, osConfig.getUsername(), osConfig.getPassword());
+
     return builder;
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchConnector.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchConnector.java
@@ -220,6 +220,15 @@ public final class OpensearchConnector {
             configuration.getUsername(), configuration.getPassword().toCharArray()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
+
+    // Add a preemptive basic auth interceptor to ensure the Authorization header is always sent
+    // on the first request. The opensearch-java ApacheHttpClient5Transport uses an internal
+    // WrappingAuthCache for preemptive auth, but its AuthScope matching with
+    // BasicCredentialsProvider can intermittently fail to attach credentials. Since the
+    // opensearch-java transport treats HTTP 401 as terminal (no retry/challenge handling),
+    // a missing Authorization header causes an unrecoverable authentication failure.
+    addPreemptiveBasicAuthInterceptor(builder, username, password);
+
     return builder;
   }
 
@@ -252,6 +261,26 @@ public final class OpensearchConnector {
             proxyConfig.isSslEnabled() ? "https" : "http",
             proxyConfig.getHost(),
             proxyConfig.getPort()));
+  }
+
+  private void addPreemptiveBasicAuthInterceptor(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder,
+      final String username,
+      final String password) {
+    final String credentials = username + ":" + password;
+    final String encodedCredentials =
+        Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    final String basicAuthHeaderValue = "Basic " + encodedCredentials;
+
+    httpAsyncClientBuilder.addRequestInterceptorFirst(
+        (HttpRequestInterceptor)
+            (request, entity, context) -> {
+              if (!request.containsHeader("Authorization")) {
+                request.addHeader("Authorization", basicAuthHeaderValue);
+              }
+            });
+
+    LOGGER.debug("Preemptive basic authentication enabled for OpenSearch");
   }
 
   private void addPreemptiveProxyAuthInterceptor(

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchConnector.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchConnector.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.opensearch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.connect.SearchClientConnectException;
 import io.camunda.search.connect.plugin.PluginRepository;
+import io.camunda.search.connect.util.HttpAuthUtil;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.AuthenticationConfiguration;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.ProxyConfiguration;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.SecurityConfiguration;
@@ -220,14 +221,7 @@ public final class OpensearchConnector {
             configuration.getUsername(), configuration.getPassword().toCharArray()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
-
-    // Add a preemptive basic auth interceptor to ensure the Authorization header is always sent
-    // on the first request. The opensearch-java ApacheHttpClient5Transport uses an internal
-    // WrappingAuthCache for preemptive auth, but its AuthScope matching with
-    // BasicCredentialsProvider can intermittently fail to attach credentials. Since the
-    // opensearch-java transport treats HTTP 401 as terminal (no retry/challenge handling),
-    // a missing Authorization header causes an unrecoverable authentication failure.
-    addPreemptiveBasicAuthInterceptor(builder, username, password);
+    HttpAuthUtil.addPreemptiveBasicAuthInterceptor(builder, username, password);
 
     return builder;
   }
@@ -261,26 +255,6 @@ public final class OpensearchConnector {
             proxyConfig.isSslEnabled() ? "https" : "http",
             proxyConfig.getHost(),
             proxyConfig.getPort()));
-  }
-
-  private void addPreemptiveBasicAuthInterceptor(
-      final HttpAsyncClientBuilder httpAsyncClientBuilder,
-      final String username,
-      final String password) {
-    final String credentials = username + ":" + password;
-    final String encodedCredentials =
-        Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
-    final String basicAuthHeaderValue = "Basic " + encodedCredentials;
-
-    httpAsyncClientBuilder.addRequestInterceptorFirst(
-        (HttpRequestInterceptor)
-            (request, entity, context) -> {
-              if (!request.containsHeader("Authorization")) {
-                request.addHeader("Authorization", basicAuthHeaderValue);
-              }
-            });
-
-    LOGGER.debug("Preemptive basic authentication enabled for OpenSearch");
   }
 
   private void addPreemptiveProxyAuthInterceptor(


### PR DESCRIPTION
… 401s

The opensearch-java ApacheHttpClient5Transport relies on an internal WrappingAuthCache with BasicCredentialsProvider for preemptive auth, but the AuthScope matching can intermittently fail to attach credentials. Since the transport treats HTTP 401 as terminal (no retry or challenge handling), a missing Authorization header causes an unrecoverable authentication failure.

This adds a direct HttpRequestInterceptor that always sets the Authorization: Basic header on every request, mirroring the existing preemptive proxy auth interceptor pattern. Applied to all three OpenSearch connector classes: Operate, search-client-connect, and the Zeebe exporter.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
