### PR TITLE
test: migrate processInstnace.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -201,11 +201,11 @@ export class OperateDiagramPage {
       this.popover.getByRole('heading', {
         name: 'Incident',
       }),
-    ).toBeVisible();
+    ).toBeVisible({timeout: 30000});
 
     await expect(
       this.popover.locator('dd').getByText(incidentPattern),
-    ).toBeVisible();
+    ).toBeVisible({timeout: 30000});
   }
 
   async closeMetadataModal(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -44,6 +44,26 @@ class OperateProcessInstancePage {
   readonly processInstanceKeyCell: Locator;
   readonly viewAllCalledInstancesLink: Locator;
   readonly viewParentInstanceLink: Locator;
+  readonly drilldownButton: Locator;
+  readonly canceledIcon: Locator;
+  readonly editVariableButtonInList: Locator;
+  readonly incidentsTableOperationSpinner: Locator;
+  readonly incidentsTableRows: Locator;
+  readonly incidentIconsInHistory: Locator;
+  readonly rootProcessNode: Locator;
+  readonly applyButton: Locator;
+  readonly stateOverlayActive: Locator;
+  readonly stateOverlayCompletedEndEvents: Locator;
+  readonly cancelInstanceButton: (instanceId: string) => Locator;
+  readonly incidentBannerButton: (count: number) => Locator;
+  readonly incidentTypeFilter: Locator;
+  readonly executionCountToggle: Locator;
+  readonly executionCountToggleButton: Locator;
+  readonly modifyDialog: Locator;
+  readonly modifyDialogContinueButton: Locator;
+  readonly endDateField: Locator;
+  readonly incidentsViewHeader: Locator;
+  readonly viewAllChildProcessesLink: Locator;
   readonly variableCellByName: (name: string | RegExp) => Locator;
 
   constructor(page: Page) {
@@ -101,6 +121,53 @@ class OperateProcessInstancePage {
       this.variablesList.getByRole('cell', {name});
     this.viewParentInstanceLink = this.instanceHeader.getByRole('link', {
       name: /view parent instance/i,
+    });
+    this.drilldownButton = page.locator('.bjs-drilldown');
+    this.canceledIcon = page
+      .getByTestId('instance-header')
+      .getByTestId('CANCELED-icon');
+    this.editVariableButtonInList = this.variablesList.getByRole('button', {
+      name: /edit variable/i,
+    });
+    this.rootProcessNode = this.instanceHistory
+      .locator('[data-testid^="node-details-"]')
+      .first();
+    this.incidentsTableOperationSpinner =
+      this.incidentsTable.getByTestId('operation-spinner');
+    this.incidentIconsInHistory = this.instanceHistory
+      .getByRole('treeitem')
+      .getByTestId('INCIDENT-icon');
+    this.incidentsTableRows = this.incidentsTable.getByRole('row');
+    this.applyButton = page.getByRole('button', {name: 'Apply', exact: true});
+    this.stateOverlayActive = page.getByTestId('state-overlay-active');
+    this.stateOverlayCompletedEndEvents = page.getByTestId(
+      'state-overlay-completedEndEvents',
+    );
+    this.modifyDialog = this.page.getByLabel(
+      'Process Instance Modification Mode',
+    );
+    this.modifyDialogContinueButton = this.modifyDialog.getByRole('button', {
+      name: 'Continue',
+    });
+    this.cancelInstanceButton = (instanceId: string) =>
+      page.getByRole('button', {name: `Cancel Instance ${instanceId}`});
+    this.incidentBannerButton = (count: number) =>
+      page.getByRole('button', {
+        name: new RegExp(`view ${count} incidents in instance`, 'i'),
+      });
+    this.incidentTypeFilter = page.getByRole('combobox', {
+      name: /filter by incident type/i,
+    });
+    this.executionCountToggle = this.instanceHistory.locator(
+      '[aria-label="Show Execution Count"], [aria-label="Hide Execution Count"]',
+    );
+    this.executionCountToggleButton = this.page.locator(
+      '#toggle-execution-count_label',
+    );
+    this.endDateField = this.instanceHeader.getByTestId('end-date');
+    this.incidentsViewHeader = page.getByText(/incidents view/i);
+    this.viewAllChildProcessesLink = this.instanceHeader.getByRole('link', {
+      name: 'View all',
     });
   }
 
@@ -212,6 +279,60 @@ class OperateProcessInstancePage {
 
   async clickDiagramElement(elementId: string): Promise<void> {
     await this.getDiagramElement(elementId).click();
+  }
+
+  getTreeItem(name: string | RegExp, exact?: boolean): Locator {
+    return this.page.getByRole('treeitem', {name, exact});
+  }
+
+  async clickTreeItem(name: string | RegExp, exact?: boolean): Promise<void> {
+    await this.getTreeItem(name, exact).click();
+  }
+
+  getIncidentRow(incidentType: string | RegExp, selected?: boolean): Locator {
+    return this.incidentsTable.getByRole('row', {
+      name: incidentType,
+      ...(selected !== undefined && {selected}),
+    });
+  }
+
+  getIncidentRowOperationSpinner(incidentType: string | RegExp): Locator {
+    return this.getIncidentRow(incidentType).getByTestId('operation-spinner');
+  }
+
+  async retryIncident(incidentType: string | RegExp): Promise<void> {
+    await this.getIncidentRow(incidentType)
+      .getByRole('button', {name: 'Retry Incident'})
+      .click();
+  }
+
+  async cancelInstance(instanceId: string): Promise<void> {
+    await this.cancelInstanceButton(instanceId).click();
+    await this.applyButton.click();
+  }
+
+  async clickIncidentBanner(count: number): Promise<void> {
+    await this.incidentBannerButton(count).click();
+  }
+
+  async toggleExecutionCount(): Promise<void> {
+    await this.executionCountToggleButton.click();
+  }
+
+  async verifyExecutionCountBadgesNotVisible(
+    elementIds: string[],
+  ): Promise<void> {
+    for (const elementId of elementIds) {
+      await expect(
+        this.diagram.locator(`[data-element-id="${elementId}"] .badge`),
+      ).toHaveCount(0);
+    }
+  }
+
+  async verifyExecutionCountBadgesVisible(elementIds: string[]): Promise<void> {
+    for (const elementId of elementIds) {
+      await expect(this.getDiagramElement(elementId)).toBeVisible();
+    }
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -195,7 +195,7 @@ class OperateProcessInstancePage {
 
   async getProcessInstanceKey(): Promise<string> {
     const url = this.page.url();
-    const matches = url.match(/instances\/(\d+)/);
+    const matches = url.match(/processes\/(\d+)/);
     return matches ? matches[1] : '';
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/collapsedSubprocess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/collapsedSubprocess.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="ec44b09" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0" camunda:diagramRelationId="97752a52-92e8-4e3d-aba1-a1cc8ba7a296">
+  <bpmn:process id="collapsedSubProcess" isExecutable="true">
+    <bpmn:startEvent id="startEvent">
+      <bpmn:outgoing>Flow_09qh7s6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="endEvent">
+      <bpmn:incoming>Flow_1u7ld98</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:subProcess id="subProcess_endEvent" name="submit application">
+      <bpmn:incoming>Flow_09qh7s6</bpmn:incoming>
+      <bpmn:outgoing>Flow_1u7ld98</bpmn:outgoing>
+      <bpmn:startEvent id="subProcess_startEvent">
+        <bpmn:outgoing>Flow_15uldre</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_15uldre" sourceRef="subProcess_startEvent" targetRef="Activity_04hk2q7" />
+      <bpmn:endEvent id="Event_056f4tx">
+        <bpmn:incoming>Flow_1mr2uuj</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1mr2uuj" sourceRef="Activity_04hk2q7" targetRef="Event_056f4tx" />
+      <bpmn:userTask id="Activity_04hk2q7" name="fill form">
+        <bpmn:incoming>Flow_15uldre</bpmn:incoming>
+        <bpmn:outgoing>Flow_1mr2uuj</bpmn:outgoing>
+      </bpmn:userTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_09qh7s6" sourceRef="startEvent" targetRef="subProcess_endEvent" />
+    <bpmn:sequenceFlow id="Flow_1u7ld98" sourceRef="subProcess_endEvent" targetRef="endEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collapsedSubProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEvent">
+        <dc:Bounds x="160" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ucebu5_di" bpmnElement="endEvent">
+        <dc:Bounds x="532" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17qrkii_di" bpmnElement="subProcess_endEvent">
+        <dc:Bounds x="320" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09qh7s6_di" bpmnElement="Flow_09qh7s6">
+        <di:waypoint x="196" y="118" />
+        <di:waypoint x="320" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1u7ld98_di" bpmnElement="Flow_1u7ld98">
+        <di:waypoint x="420" y="118" />
+        <di:waypoint x="532" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_10qlk19">
+    <bpmndi:BPMNPlane id="BPMNPlane_0w8j7z5" bpmnElement="subProcess_endEvent">
+      <bpmndi:BPMNShape id="Event_1kmtbvl_di" bpmnElement="subProcess_startEvent">
+        <dc:Bounds x="152" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_056f4tx_di" bpmnElement="Event_056f4tx">
+        <dc:Bounds x="462" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qur5x1_di" bpmnElement="Activity_04hk2q7">
+        <dc:Bounds x="280" y="90" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_15uldre_di" bpmnElement="Flow_15uldre">
+        <di:waypoint x="188" y="130" />
+        <di:waypoint x="280" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mr2uuj_di" bpmnElement="Flow_1mr2uuj">
+        <di:waypoint x="380" y="130" />
+        <di:waypoint x="462" y="130" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/executionCountProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/executionCountProcess.bpmn
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hns2p1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="executionCountProcess" name="Execution Count Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start 1">
+      <bpmn:outgoing>Flow_1v5450p</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1v5450p" sourceRef="StartEvent_1" targetRef="ParallelGateway" />
+    <bpmn:endEvent id="EndEvent_1" name="End 1">
+      <bpmn:incoming>Flow_0uefhnd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0wkuz23" sourceRef="ParallelGateway" targetRef="ExclusiveGateway" />
+    <bpmn:parallelGateway id="ParallelGateway" name="Parallel Gateway">
+      <bpmn:incoming>Flow_1v5450p</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wkuz23</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1r38fwf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0hjordd</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:exclusiveGateway id="ExclusiveGateway" name="Exclusive Gateway">
+      <bpmn:incoming>Flow_0wkuz23</bpmn:incoming>
+      <bpmn:incoming>Flow_1r38fwf</bpmn:incoming>
+      <bpmn:incoming>Flow_0hjordd</bpmn:incoming>
+      <bpmn:outgoing>Flow_0inw5ur</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0inw5ur" sourceRef="ExclusiveGateway" targetRef="SubProcess" />
+    <bpmn:sequenceFlow id="Flow_1r38fwf" sourceRef="ParallelGateway" targetRef="ExclusiveGateway" />
+    <bpmn:sequenceFlow id="Flow_0hjordd" sourceRef="ParallelGateway" targetRef="ExclusiveGateway" />
+    <bpmn:subProcess id="SubProcess" name="Sub Process">
+      <bpmn:incoming>Flow_0inw5ur</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uefhnd</bpmn:outgoing>
+      <bpmn:startEvent id="StartEvent_2" name="Start 2">
+        <bpmn:outgoing>Flow_1s8ic8s</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_2" name="End 2">
+        <bpmn:incoming>Flow_1s8ic8s</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1s8ic8s" sourceRef="StartEvent_2" targetRef="EndEvent_2" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_0uefhnd" sourceRef="SubProcess" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="executionCountProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="181" y="202" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0e3uc69_di" bpmnElement="ParallelGateway">
+        <dc:Bounds x="265" y="152" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="249" y="209" width="84" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1r41wo3_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
+        <dc:Bounds x="445" y="152" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="447" y="209" width="47" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1x7ujit_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1002" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1006" y="202" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0qdo087_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="570" y="77" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ifhrpf_di" bpmnElement="StartEvent_2">
+        <dc:Bounds x="610" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="612" y="202" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_147nn0v_di" bpmnElement="EndEvent_2">
+        <dc:Bounds x="832" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="836" y="202" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1s8ic8s_di" bpmnElement="Flow_1s8ic8s">
+        <di:waypoint x="646" y="177" />
+        <di:waypoint x="832" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v5450p_di" bpmnElement="Flow_1v5450p">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="265" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkuz23_di" bpmnElement="Flow_0wkuz23">
+        <di:waypoint x="315" y="177" />
+        <di:waypoint x="445" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1r38fwf_di" bpmnElement="Flow_1r38fwf">
+        <di:waypoint x="290" y="152" />
+        <di:waypoint x="290" y="110" />
+        <di:waypoint x="470" y="110" />
+        <di:waypoint x="470" y="152" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hjordd_di" bpmnElement="Flow_0hjordd">
+        <di:waypoint x="290" y="202" />
+        <di:waypoint x="290" y="250" />
+        <di:waypoint x="470" y="250" />
+        <di:waypoint x="470" y="202" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0inw5ur_di" bpmnElement="Flow_0inw5ur">
+        <di:waypoint x="495" y="177" />
+        <di:waypoint x="570" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uefhnd_di" bpmnElement="Flow_0uefhnd">
+        <di:waypoint x="920" y="177" />
+        <di:waypoint x="1002" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithMultiIncidents.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithMultiIncidents.bpmn
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0hir062" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
+  <bpmn:process id="processWithMultiIncidents" isExecutable="true">
+    <bpmn:startEvent id="startEvent">
+      <bpmn:outgoing>SequenceFlow_1gvaaro</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1gvaaro" sourceRef="startEvent" targetRef="Gateway_0nqznhg" />
+    <bpmn:endEvent id="EndEvent_1w1u88d" name="endUp">
+      <bpmn:incoming>SequenceFlow_1pzygua</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="exclusiveGateway1" name="Where to go?">
+      <bpmn:incoming>Flow_0c49v7f</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1pzygua</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1goon4z</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1pzygua" name="goUp &#62; 5" sourceRef="exclusiveGateway1" targetRef="EndEvent_1w1u88d">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=goUp &gt; 5</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="EndEvent_0tfsfo0" name="endDown">
+      <bpmn:incoming>SequenceFlow_1goon4z</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1goon4z" name="goUp &#60; 0" sourceRef="exclusiveGateway1" targetRef="EndEvent_0tfsfo0">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=goUp &lt; 0</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0c49v7f" sourceRef="Gateway_0nqznhg" targetRef="exclusiveGateway1" />
+    <bpmn:parallelGateway id="Gateway_0nqznhg">
+      <bpmn:incoming>SequenceFlow_1gvaaro</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c49v7f</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14t36gr</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:exclusiveGateway id="exclusiveGateway2" name="Is cool?">
+      <bpmn:incoming>Flow_14t36gr</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yl9tau</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0pjsspz</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1yl9tau" name="yes" sourceRef="exclusiveGateway2" targetRef="Event_05hrrre">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assert(isCool,isCool!=null) = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_14t36gr" sourceRef="Gateway_0nqznhg" targetRef="exclusiveGateway2" />
+    <bpmn:sequenceFlow id="Flow_0pjsspz" name="no" sourceRef="exclusiveGateway2" targetRef="Event_0eqdpr7">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assert(isCool,isCool!=null) = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0eqdpr7" name="endDown">
+      <bpmn:incoming>Flow_0pjsspz</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_05hrrre" name="endUp">
+      <bpmn:incoming>Flow_1yl9tau</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_0hh3rtz" name="clientMessage">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=clientId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1agndym" name="dataReceived">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=clientId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithMultiIncidents">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEvent">
+        <dc:Bounds x="149" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1w1u88d_di" bpmnElement="EndEvent_1w1u88d">
+        <dc:Bounds x="547" y="83" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="550" y="126" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_01pou5h_di" bpmnElement="exclusiveGateway1" isMarkerVisible="true">
+        <dc:Bounds x="405" y="125" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="355" y="117" width="67" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0tfsfo0_di" bpmnElement="EndEvent_0tfsfo0">
+        <dc:Bounds x="547" y="190" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="542" y="233" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0hamspu_di" bpmnElement="Gateway_0nqznhg">
+        <dc:Bounds x="265" y="225" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_14pylkw_di" bpmnElement="exclusiveGateway2" isMarkerVisible="true">
+        <dc:Bounds x="405" y="344" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="370" y="335" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0eqdpr7_di" bpmnElement="Event_0eqdpr7">
+        <dc:Bounds x="547" y="409" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="542" y="452" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05hrrre_di" bpmnElement="Event_05hrrre">
+        <dc:Bounds x="547" y="292" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="550" y="335" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gvaaro_di" bpmnElement="SequenceFlow_1gvaaro">
+        <di:waypoint x="185" y="250" />
+        <di:waypoint x="265" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pzygua_di" bpmnElement="SequenceFlow_1pzygua">
+        <di:waypoint x="430" y="125" />
+        <di:waypoint x="430" y="101" />
+        <di:waypoint x="547" y="101" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="447" y="83" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1goon4z_di" bpmnElement="SequenceFlow_1goon4z">
+        <di:waypoint x="430" y="175" />
+        <di:waypoint x="430" y="208" />
+        <di:waypoint x="547" y="208" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="450" y="214" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c49v7f_di" bpmnElement="Flow_0c49v7f">
+        <di:waypoint x="290" y="225" />
+        <di:waypoint x="290" y="150" />
+        <di:waypoint x="405" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yl9tau_di" bpmnElement="Flow_1yl9tau">
+        <di:waypoint x="430" y="344" />
+        <di:waypoint x="430" y="310" />
+        <di:waypoint x="547" y="310" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="462" y="292" width="17" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14t36gr_di" bpmnElement="Flow_14t36gr">
+        <di:waypoint x="290" y="275" />
+        <di:waypoint x="290" y="369" />
+        <di:waypoint x="405" y="369" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pjsspz_di" bpmnElement="Flow_0pjsspz">
+        <di:waypoint x="430" y="394" />
+        <di:waypoint x="430" y="427" />
+        <di:waypoint x="547" y="427" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="466" y="433" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -23,9 +23,10 @@ const NUM_SELECTED_PROCESS_INSTANCES = 4;
 
 test.beforeAll(async () => {
   await deploy(['./resources/orderProcessBatchMod_v_1.bpmn']);
+  await sleep(1500);
   await createInstances('orderProcessBatchMod', 1, NUM_PROCESS_INSTANCES);
 
-  await sleep(5000);
+  await sleep(6000);
 });
 
 test.describe('Process Instance Batch Modification', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -25,6 +25,7 @@ test.beforeAll(async () => {
     './resources/calledProcess.bpmn',
   ]);
 
+  await sleep(1500);
   const instance = await createSingleInstance(
     'CallActivityNavigationProcess',
     1,
@@ -33,7 +34,7 @@ test.beforeAll(async () => {
     processInstanceKey: instance.processInstanceKey,
   };
 
-  await sleep(3000);
+  await sleep(4000);
 });
 
 test.describe('Call Activities', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -19,7 +19,7 @@ test.describe('Decision Instances', () => {
     await deploy(['./resources/decisions_v_1.dmn']);
     await deploy(['./resources/decisions_v_2.dmn']);
 
-    await sleep(3000);
+    await sleep(5000);
   });
 
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -173,7 +173,7 @@ test.describe('Operations', () => {
 
       await expect(
         operateProcessesPage.getCanceledIcon(instance.processInstanceKey),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 60000});
 
       await expect(instanceRow.getByText(instance.bpmnProcessId)).toBeVisible();
       await expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -100,7 +100,7 @@ test.describe('Process Instance', () => {
       await operateProcessInstancePage.editVariableButtonInList.click();
 
       await operateProcessInstancePage.editVariableValueField.clear();
-      await operateProcessInstancePage.editVariableValueField.type('20');
+      await operateProcessInstancePage.editVariableValueField.fill('20');
 
       await expect(operateProcessInstancePage.saveVariableButton).toBeEnabled();
       await operateProcessInstancePage.saveVariableButton.click();
@@ -146,7 +146,9 @@ test.describe('Process Instance', () => {
 
       await operateProcessInstancePage.saveVariableButton.click();
       await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
-      await expect(operateProcessInstancePage.variableSpinner).toBeHidden();
+      await expect(operateProcessInstancePage.variableSpinner).toBeHidden({
+        timeout: 30000,
+      });
     });
 
     await test.step('Retry second incident to resolve it', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -1,0 +1,320 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {DATE_REGEX} from 'utils/constants';
+import {sleep} from 'utils/sleep';
+import {waitForProcessInstances} from 'utils/incidentsHelper';
+import {waitForAssertion} from 'utils/waitForAssertion';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let instanceWithIncidentToResolve: ProcessInstance;
+let instanceWithIncidentToCancel: ProcessInstance;
+let collapsedSubProcessInstance: ProcessInstance;
+let executionCountProcessInstance: ProcessInstance;
+
+test.beforeAll(async ({request}) => {
+  await deploy([
+    './resources/processWithAnIncident.bpmn',
+    './resources/processWithMultiIncidents.bpmn',
+    './resources/collapsedSubprocess.bpmn',
+    './resources/executionCountProcess.bpmn',
+  ]);
+
+  instanceWithIncidentToCancel = await createSingleInstance(
+    'processWithAnIncident',
+    1,
+  );
+
+  instanceWithIncidentToResolve = await createSingleInstance(
+    'processWithMultiIncidents',
+    1,
+    {goUp: 3},
+  );
+
+  collapsedSubProcessInstance = await createSingleInstance(
+    'collapsedSubProcess',
+    1,
+  );
+
+  executionCountProcessInstance = await createSingleInstance(
+    'executionCountProcess',
+    1,
+  );
+
+  // Wait for process instances with incidents to be indexed
+  await waitForProcessInstances(
+    request,
+    [
+      instanceWithIncidentToCancel.processInstanceKey,
+      instanceWithIncidentToResolve.processInstanceKey,
+    ],
+    2,
+  );
+});
+
+test.describe('Process Instance', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Resolve an incident', async ({operateProcessInstancePage}) => {
+    await test.step('Navigate to process instance with incident', async () => {
+      await operateProcessInstancePage.navigateToProcessInstance(
+        instanceWithIncidentToResolve.processInstanceKey,
+      );
+    });
+
+    await test.step('Verify incident banner is visible', async () => {
+      await sleep(500);
+      await expect(
+        operateProcessInstancePage.incidentBannerButton(2),
+      ).toBeVisible();
+    });
+
+    await test.step('Click and expand incident bar', async () => {
+      await operateProcessInstancePage.clickIncidentBanner(2);
+      await expect(operateProcessInstancePage.incidentTypeFilter).toBeVisible();
+    });
+
+    await test.step('Edit goUp variable', async () => {
+      await operateProcessInstancePage.editVariableButtonInList.click();
+
+      await operateProcessInstancePage.editVariableValueField.clear();
+      await operateProcessInstancePage.editVariableValueField.type('20');
+
+      await expect(operateProcessInstancePage.saveVariableButton).toBeEnabled();
+      await operateProcessInstancePage.saveVariableButton.click();
+
+      await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
+      await expect(operateProcessInstancePage.variableSpinner).toBeHidden({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Retry one incident to resolve it', async () => {
+      await operateProcessInstancePage.retryIncident(/Condition error/i);
+
+      await expect(
+        operateProcessInstancePage.getIncidentRowOperationSpinner(
+          /Condition error/i,
+        ),
+      ).toBeVisible();
+
+      await expect(
+        operateProcessInstancePage.incidentsTableOperationSpinner,
+      ).not.toBeVisible({timeout: 60000});
+
+      await expect(operateProcessInstancePage.incidentsTableRows).toHaveCount(
+        1,
+      );
+
+      await expect(
+        operateProcessInstancePage.incidentsTable.getByText(/is cool\?/i),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.incidentsTable.getByText(/where to go\?/i),
+      ).toBeHidden();
+    });
+
+    await test.step('Add variable isCool', async () => {
+      await operateProcessInstancePage.addVariableButton.click();
+
+      await operateProcessInstancePage.newVariableNameField.type('isCool');
+      await operateProcessInstancePage.newVariableValueField.type('true');
+
+      await expect(operateProcessInstancePage.saveVariableButton).toBeEnabled();
+
+      await operateProcessInstancePage.saveVariableButton.click();
+      await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
+      await expect(operateProcessInstancePage.variableSpinner).toBeHidden();
+    });
+
+    await test.step('Retry second incident to resolve it', async () => {
+      await operateProcessInstancePage.retryIncident(/Extract value error/i);
+
+      await expect(
+        operateProcessInstancePage.getIncidentRowOperationSpinner(
+          /Extract value error/i,
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Expect all incidents resolved', async () => {
+      await expect(operateProcessInstancePage.incidentsBanner).toBeHidden({
+        timeout: 15000,
+      });
+      await expect(operateProcessInstancePage.incidentsTable).toBeHidden();
+      await expect(operateProcessInstancePage.completedIcon).toBeVisible();
+    });
+  });
+
+  test('Cancel an instance', async ({operateProcessInstancePage, page}) => {
+    const instanceId = instanceWithIncidentToCancel.processInstanceKey;
+
+    await test.step('Navigate to process instance with incident', async () => {
+      await operateProcessInstancePage.navigateToProcessInstance(instanceId);
+    });
+
+    await test.step('Verify incident banner is visible', async () => {
+      await expect(
+        operateProcessInstancePage.incidentBannerButton(3),
+      ).toBeVisible();
+    });
+
+    await test.step('Cancel the instance', async () => {
+      await operateProcessInstancePage.cancelInstance(instanceId);
+
+      await expect(operateProcessInstancePage.operationSpinner).toBeVisible();
+      await expect(operateProcessInstancePage.operationSpinner).toBeHidden();
+    });
+
+    await test.step('Verify instance is canceled', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.incidentBannerButton(3),
+          ).toBeHidden();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 5,
+      });
+
+      await expect(operateProcessInstancePage.canceledIcon).toBeVisible();
+
+      expect(await operateProcessInstancePage.endDateField.innerText()).toMatch(
+        DATE_REGEX,
+      );
+    });
+  });
+
+  test('Should render collapsed sub process and navigate between planes', async ({
+    page,
+    operateProcessInstancePage,
+  }) => {
+    const diagram = operateProcessInstancePage.diagram;
+
+    await test.step('Navigate to collapsed sub process instance', async () => {
+      await operateProcessInstancePage.navigateToProcessInstance(
+        collapsedSubProcessInstance.processInstanceKey,
+      );
+    });
+
+    await test.step('Click on startEvent in instance history', async () => {
+      await operateProcessInstancePage.clickTreeItem('startEvent');
+      await expect(page.getByText(/execution duration/i)).toBeVisible();
+    });
+
+    await test.step('Click on submit application in instance history', async () => {
+      await operateProcessInstancePage.clickTreeItem(/submit application/i);
+
+      await expect(
+        diagram.getByText('submit application', {exact: false}),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to fill form flow node', async () => {
+      await page.keyboard.press('ArrowRight');
+      await operateProcessInstancePage.clickTreeItem(/fill form/i);
+
+      await expect(
+        diagram.getByText('fill form', {exact: false}),
+      ).toBeVisible();
+      await expect(page.getByText(/retries left/i)).toBeVisible();
+    });
+
+    await test.step('Click on collapsed sub process', async () => {
+      await diagram.getByText('collapsedSubProcess').click();
+
+      await expect(
+        diagram.getByText('submit application', {exact: false}),
+      ).toBeVisible();
+      await expect(diagram.getByText('fill form', {exact: false})).toBeHidden();
+    });
+
+    await test.step('Navigate back to start event', async () => {
+      await operateProcessInstancePage.clickTreeItem('startEvent', true);
+
+      await expect(
+        diagram.getByText('submit application', {exact: false}),
+      ).toBeVisible();
+    });
+
+    await test.step('Drill down into sub process', async () => {
+      await operateProcessInstancePage.drilldownButton.click();
+
+      await expect(
+        diagram.getByText('fill form', {exact: false}),
+      ).toBeVisible();
+    });
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Should render execution count badges', async ({
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Navigate to execution count process instance', async () => {
+      await operateProcessInstancePage.navigateToProcessInstance(
+        executionCountProcessInstance.processInstanceKey,
+      );
+    });
+
+    const elementIds = [
+      'StartEvent_1',
+      'ParallelGateway',
+      'ExclusiveGateway',
+      'StartEvent_2',
+      'EndEvent_2',
+      'SubProcess',
+    ];
+
+    await test.step('Verify execution count badges are not visible by default', async () => {
+      await operateProcessInstancePage.verifyExecutionCountBadgesNotVisible(
+        elementIds,
+      );
+    });
+
+    await test.step('Toggle execution count on', async () => {
+      await operateProcessInstancePage.toggleExecutionCount();
+    });
+
+    await test.step('Verify execution count badges are visible', async () => {
+      await operateProcessInstancePage.verifyExecutionCountBadgesVisible([
+        'StartEvent_1',
+        'ParallelGateway',
+        'ExclusiveGateway',
+      ]);
+    });
+
+    await test.step('Toggle execution count off', async () => {
+      await operateProcessInstancePage.toggleExecutionCount();
+    });
+
+    await test.step('Verify execution count badges are not visible again', async () => {
+      await operateProcessInstancePage.verifyExecutionCountBadgesNotVisible(
+        elementIds,
+      );
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -187,7 +187,9 @@ test.describe('Process Instance', () => {
       await operateProcessInstancePage.cancelInstance(instanceId);
 
       await expect(operateProcessInstancePage.operationSpinner).toBeVisible();
-      await expect(operateProcessInstancePage.operationSpinner).toBeHidden();
+      await expect(operateProcessInstancePage.operationSpinner).toBeHidden({
+        timeout: 60000,
+      });
     });
 
     await test.step('Verify instance is canceled', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -148,7 +148,7 @@ test.describe.serial('Process Instance Migration', () => {
     await test.step('Verify target process is preselected with auto-mapping and Complete Migration', async () => {
       await expect(
         operateProcessMigrationModePage.targetProcessCombobox,
-      ).toHaveValue(targetBpmnProcessId);
+      ).toHaveValue(targetBpmnProcessId, {timeout: 30000});
 
       await operateProcessMigrationModePage.verifyFlowNodeMappings([
         {
@@ -572,6 +572,7 @@ test.describe.serial('Process Instance Migration', () => {
         maxRetries: 60,
       });
 
+      await operateFiltersPanelPage.clickResetFilters();
       await operateOperationPanelPage.clickOperationEntryById(migratedIds[0]);
 
       await validateURL(page, /operationId=/);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -646,11 +646,8 @@ test.describe.serial('Process Instance Migration', () => {
 
     await test.step('Verify Business rule task incident migration', async () => {
       await operateDiagramPage.clickFlowNode('BusinessRuleTask2');
-      await operateDiagramPage.showMetaData();
 
       await operateDiagramPage.verifyIncidentInPopover(/invalid.*decision/i);
-
-      await operateDiagramPage.closeMetadataModal();
     });
   });
 


### PR DESCRIPTION
## Description

This PR migrates [processInstance.spec.ts](https://github.com/camunda/camunda/blob/main/operate/client/e2e-playwright/tests/processInstance.spec.ts) from Operate component folder to OC test suite covering:
- Resolve an incident
- Cancel an instance
- Collapsed sub process navigation
- Execution count badges

Also includes flakiness fixes across `processInstanceMigration`, `operations`, `batchMoveModification`, `callActivities`, and `decisionInstances` specs.

🧪 [Test run](https://github.com/camunda/camunda/actions/runs/22849564225)

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34117