### PR TITLE
feat: Throttle Archiver Parallelism

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -25,6 +25,7 @@ public class DocumentBasedHistory {
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
   private static final String DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "1h";
+  private static final int DEFAULT_HISTORY_MAX_PARALLEL_ARCHIVER_REINDEX_TASKS = 5;
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
           "process-instance-enabled",
@@ -70,6 +71,9 @@ public class DocumentBasedHistory {
 
   /** Maximum millisecond interval between archiver runs due to failure backoffs */
   private Duration maxDelayBetweenRuns = DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS;
+
+  /** Maximum archiver reindex tasks per partition (set `-1` for unlimited with caution) */
+  private int maxParallelArchiverReindexTasks = DEFAULT_HISTORY_MAX_PARALLEL_ARCHIVER_REINDEX_TASKS;
 
   /** Defines the name of the created and applied ILM policy. */
   private String policyName = DEFAULT_HISTORY_POLICY_NAME;
@@ -185,6 +189,14 @@ public class DocumentBasedHistory {
 
   public void setMaxDelayBetweenRuns(final Duration maxDelayBetweenRuns) {
     this.maxDelayBetweenRuns = maxDelayBetweenRuns;
+  }
+
+  public int getMaxParallelArchiverReindexTasks() {
+    return maxParallelArchiverReindexTasks;
+  }
+
+  public void setMaxParallelArchiverReindexTasks(final int maxParallelArchiverReindexTasks) {
+    this.maxParallelArchiverReindexTasks = maxParallelArchiverReindexTasks;
   }
 
   public String getPolicyName() {

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -72,7 +72,7 @@ public class DocumentBasedHistory {
   /** Maximum millisecond interval between archiver runs due to failure backoffs */
   private Duration maxDelayBetweenRuns = DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS;
 
-  /** Maximum archiver reindex tasks per partition (set `-1` for unlimited with caution) */
+  /** Maximum archiver reindex tasks per partition (set `<=0` for unlimited with caution) */
   private int maxParallelArchiverReindexTasks = DEFAULT_HISTORY_MAX_PARALLEL_ARCHIVER_REINDEX_TASKS;
 
   /** Defines the name of the created and applied ILM policy. */

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -151,6 +151,8 @@ public final class CamundaExporterConfigurationApplier {
     target.setRolloverInterval(source.getHistory().getRolloverInterval());
     target.setRolloverBatchSize(source.getHistory().getRolloverBatchSize());
     target.setWaitPeriodBeforeArchiving(source.getHistory().getWaitPeriodBeforeArchiving());
+    target.setMaxParallelArchiverReindexTasks(
+        source.getHistory().getMaxParallelArchiverReindexTasks());
     target.setDelayBetweenRuns(
         Math.toIntExact(source.getHistory().getDelayBetweenRuns().toMillis()));
     target.setMaxDelayBetweenRuns(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -230,6 +230,8 @@ public class ExporterConfiguration {
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
     private int maxDelayBetweenRuns = 60000;
+    // use `-1` for unlimited parallel archiver reindex tasks, use with caution
+    private int maxParallelArchiverReindexTasks = 5;
     private RetentionConfiguration retention = new RetentionConfiguration();
     private boolean trackArchivalMetricsForProcessInstance = true;
 
@@ -309,6 +311,14 @@ public class ExporterConfiguration {
       this.maxDelayBetweenRuns = maxDelayBetweenRuns;
     }
 
+    public int getMaxParallelArchiverReindexTasks() {
+      return maxParallelArchiverReindexTasks;
+    }
+
+    public void setMaxParallelArchiverReindexTasks(final int maxParallelArchiverReindexTasks) {
+      this.maxParallelArchiverReindexTasks = maxParallelArchiverReindexTasks;
+    }
+
     @Override
     public String toString() {
       return "ArchiverConfiguration{"
@@ -327,6 +337,8 @@ public class ExporterConfiguration {
           + delayBetweenRuns
           + ", maxDelayBetweenRuns="
           + maxDelayBetweenRuns
+          + ", maxParallelArchiverReindexTasks="
+          + maxParallelArchiverReindexTasks
           + ", retention="
           + retention
           + ", trackArchivalMetricsForProcessInstance="

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -230,7 +230,7 @@ public class ExporterConfiguration {
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
     private int maxDelayBetweenRuns = 60000;
-    // use `-1` for unlimited parallel archiver reindex tasks, use with caution
+    // use `<=0` for unlimited parallel archiver reindex tasks, use with caution
     private int maxParallelArchiverReindexTasks = 5;
     private RetentionConfiguration retention = new RetentionConfiguration();
     private boolean trackArchivalMetricsForProcessInstance = true;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -99,6 +99,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   private final AtomicReference<Instant> lastFlushTime = new AtomicReference<>(Instant.now());
   private final AtomicInteger processInstancesAwaitingArchival = new AtomicInteger(0);
+  private final AtomicInteger archiverReindexTasksInFlight = new AtomicInteger(0);
 
   public CamundaExporterMetrics(final MeterRegistry meterRegistry) {
     this(meterRegistry, InstantSource.system());
@@ -285,6 +286,13 @@ public class CamundaExporterMetrics implements AutoCloseable {
             AtomicInteger::get)
         .description("Number of process instances awaiting archival (approximate)")
         .register(meterRegistry);
+
+    Gauge.builder(
+            meterName("archiver.reindex.tasks.inflight"),
+            archiverReindexTasksInFlight,
+            AtomicInteger::get)
+        .description("Number of archiver reindexing tasks inflight")
+        .register(meterRegistry);
   }
 
   public CloseableSilently measureFlushDuration() {
@@ -401,6 +409,14 @@ public class CamundaExporterMetrics implements AutoCloseable {
     processInstancesAwaitingArchival.set(count);
   }
 
+  public void beginArchiverReindexTask() {
+    archiverReindexTasksInFlight.incrementAndGet();
+  }
+
+  public void completeArchiverReindexTask() {
+    archiverReindexTasksInFlight.decrementAndGet();
+  }
+
   /**
    * For each record write timestamp, observes the export latency by subtracting the timestamp from
    * the current stream clock.
@@ -464,6 +480,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(meterName("since.last.flush.seconds"));
     removeGaugeIfExists(meterName("process.instances.awaiting.archival"));
+    removeGaugeIfExists(meterName("archiver.reindex.tasks.inflight"));
   }
 
   private void removeGaugeIfExists(final String meterName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -67,6 +67,7 @@ import java.time.Duration;
 import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -85,7 +86,7 @@ public final class BackgroundTaskManagerFactory {
   private final ObjectMapper objectMapper;
 
   private ScheduledThreadPoolExecutor executor;
-  private Semaphore reindexSemaphore;
+  private ReindexThrottler reindexThrottler;
   private ArchiverRepository archiverRepository;
   private IncidentUpdateRepository incidentRepository;
   private BatchOperationUpdateRepository batchOperationUpdateRepository;
@@ -119,7 +120,9 @@ public final class BackgroundTaskManagerFactory {
 
   public BackgroundTaskManager build() {
     executor = buildExecutor();
-    reindexSemaphore = new Semaphore(getMaxParallelArchiverReindexTasks());
+    reindexThrottler =
+        new ReindexThrottler(
+            getMaxParallelArchiverReindexTasks(), config.getConnect().getSocketTimeout(), logger);
 
     // initialize all repositories based on connection type to reuse clients
     if (config.getConnect().getTypeEnum().isOpenSearch()) {
@@ -427,7 +430,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
-            reindexSemaphore));
+            reindexThrottler));
   }
 
   private ReschedulingTask buildBatchOperationArchiverJob() {
@@ -445,7 +448,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
-            reindexSemaphore));
+            reindexThrottler));
   }
 
   private ReschedulingTask buildUsageMetricsArchiverJob() {
@@ -456,7 +459,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
-            reindexSemaphore));
+            reindexThrottler));
   }
 
   private ReschedulingTask buildUsageMetricsTUArchiverJob() {
@@ -467,7 +470,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
-            reindexSemaphore));
+            reindexThrottler));
   }
 
   private ReschedulingTask buildJobBatchMetricsArchiverJob() {
@@ -478,7 +481,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
-            reindexSemaphore));
+            reindexThrottler));
   }
 
   private ReschedulingTask buildStandaloneDecisionArchiverJob() {
@@ -495,7 +498,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
-            reindexSemaphore,
+            reindexThrottler,
             dependantTemplates));
   }
 
@@ -541,7 +544,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
-            reindexSemaphore));
+            reindexThrottler));
   }
 
   private ScheduledThreadPoolExecutor buildExecutor() {
@@ -558,5 +561,54 @@ public final class BackgroundTaskManagerFactory {
     executor.setKeepAliveTime(1, TimeUnit.MINUTES);
 
     return executor;
+  }
+
+  public static class ReindexThrottler {
+    private static final int ACQUIRE_RETRIES = 10;
+    private final Semaphore reindexThrottler;
+    private final int acquireTimeoutSeconds;
+    private final Logger logger;
+
+    public ReindexThrottler(
+        final int maxParallelArchiverReindexTasks,
+        final Integer socketTimeoutMs,
+        final Logger logger) {
+      reindexThrottler = new Semaphore(maxParallelArchiverReindexTasks);
+      acquireTimeoutSeconds =
+          (Math.max(Optional.ofNullable(socketTimeoutMs).orElse(0), 30_000) * 3) / 1000;
+      this.logger = logger;
+    }
+
+    public static ReindexThrottler unlimited(final Logger logger) {
+      return new ReindexThrottler(Integer.MAX_VALUE, 30000, logger);
+    }
+
+    public boolean acquirePermit() {
+      try {
+        // we will wait 30x of configured socket timeout (or minimum 30s) in total, which
+        // should be more than enough for a very large reindexing to finish with long timeout
+        for (int i = 0; i < ACQUIRE_RETRIES; i++) {
+          if (reindexThrottler.tryAcquire(acquireTimeoutSeconds, TimeUnit.SECONDS)) {
+            return true;
+          }
+          logger.debug(
+              "Another reindexing task in progress and no permit is available to acquire. "
+                  + "Waiting for permit to be available, retry attempt {}/10",
+              i + 1);
+        }
+        return false;
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+    }
+
+    public void releasePermit() {
+      reindexThrottler.release();
+    }
+
+    public int availablePermits() {
+      return reindexThrottler.availablePermits();
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -68,6 +68,7 @@ import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
@@ -84,6 +85,7 @@ public final class BackgroundTaskManagerFactory {
   private final ObjectMapper objectMapper;
 
   private ScheduledThreadPoolExecutor executor;
+  private Semaphore reindexSemaphore;
   private ArchiverRepository archiverRepository;
   private IncidentUpdateRepository incidentRepository;
   private BatchOperationUpdateRepository batchOperationUpdateRepository;
@@ -117,6 +119,7 @@ public final class BackgroundTaskManagerFactory {
 
   public BackgroundTaskManager build() {
     executor = buildExecutor();
+    reindexSemaphore = new Semaphore(getMaxParallelArchiverReindexTasks());
 
     // initialize all repositories based on connection type to reuse clients
     if (config.getConnect().getTypeEnum().isOpenSearch()) {
@@ -153,6 +156,22 @@ public final class BackgroundTaskManagerFactory {
         executor,
         tasks,
         Duration.ofSeconds(5));
+  }
+
+  private int getMaxParallelArchiverReindexTasks() {
+    if (config.getHistory().getMaxParallelArchiverReindexTasks() <= 0) {
+      logger.info(
+          "Creating a reindexing throttler with unlimited parallel execution permits. Use "
+              + "the `history.maxParallelArchiverReindexTasks` config property to set a lower "
+              + "number of parallel execution permits to reduce resource usage.");
+      return Integer.MAX_VALUE;
+    }
+
+    logger.debug(
+        "Creating reindexing throttler with {} parallel permits.",
+        config.getHistory().getMaxParallelArchiverReindexTasks());
+
+    return config.getHistory().getMaxParallelArchiverReindexTasks();
   }
 
   private OpensearchBatchOperationUpdateRepository createBatchOperationRepository(
@@ -408,7 +427,8 @@ public final class BackgroundTaskManagerFactory {
             dependantTemplates,
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildBatchOperationArchiverJob() {
@@ -425,7 +445,8 @@ public final class BackgroundTaskManagerFactory {
             dependantTemplates,
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildUsageMetricsArchiverJob() {
@@ -435,7 +456,8 @@ public final class BackgroundTaskManagerFactory {
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildUsageMetricsTUArchiverJob() {
@@ -445,7 +467,8 @@ public final class BackgroundTaskManagerFactory {
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildJobBatchMetricsArchiverJob() {
@@ -455,7 +478,8 @@ public final class BackgroundTaskManagerFactory {
             resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ReschedulingTask buildStandaloneDecisionArchiverJob() {
@@ -472,6 +496,7 @@ public final class BackgroundTaskManagerFactory {
             metrics,
             logger,
             executor,
+            reindexSemaphore,
             dependantTemplates));
   }
 
@@ -516,7 +541,8 @@ public final class BackgroundTaskManagerFactory {
             resourceProvider.getIndexTemplateDescriptor(AuditLogTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            reindexSemaphore));
   }
 
   private ScheduledThreadPoolExecutor buildExecutor() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -161,9 +161,8 @@ public final class BackgroundTaskManagerFactory {
   private int getMaxParallelArchiverReindexTasks() {
     if (config.getHistory().getMaxParallelArchiverReindexTasks() <= 0) {
       logger.info(
-          "Creating a reindexing throttler with unlimited parallel execution permits. Use "
-              + "the `history.maxParallelArchiverReindexTasks` config property to set a lower "
-              + "number of parallel execution permits to reduce resource usage.");
+          "Creating a reindexing throttler with unlimited parallel execution permits. Set a "
+              + "lower number of parallel execution permits to reduce resource usage.");
       return Integer.MAX_VALUE;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.BackgroundTask;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.zeebe.util.FunctionUtil;
 import io.micrometer.core.instrument.Timer;
@@ -19,7 +20,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 
@@ -32,14 +32,13 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
 
   // Virtual-thread executor used exclusively for blocking semaphore.acquire() calls.
   // This prevents using main (platform-threaded) executor, avoiding thread starvation.
-  private static final ExecutorService SEMAPHORE_EXECUTOR =
-      Executors.newVirtualThreadPerTaskExecutor();
+  private final ExecutorService semaphoreExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
   private final ArchiverRepository archiverRepository;
   private final CamundaExporterMetrics exporterMetrics;
   private final Logger logger;
   private final Executor executor;
-  private final Semaphore reindexSemaphore;
+  private final ReindexThrottler reindexThrottler;
 
   private final Consumer<Integer> recordArchivingMetric;
   private final Consumer<Integer> recordArchivedMetric;
@@ -49,14 +48,14 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
       final Executor executor,
-      final Semaphore reindexSemaphore,
+      final ReindexThrottler reindexThrottler,
       final Consumer<Integer> recordArchivingMetric,
       final Consumer<Integer> recordArchivedMetric) {
     this.archiverRepository = archiverRepository;
     this.exporterMetrics = exporterMetrics;
     this.logger = logger;
     this.executor = executor;
-    this.reindexSemaphore = reindexSemaphore;
+    this.reindexThrottler = reindexThrottler;
     this.recordArchivingMetric = recordArchivingMetric;
     this.recordArchivedMetric = recordArchivedMetric;
   }
@@ -98,7 +97,7 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
 
   @Override
   public void close() {
-    SEMAPHORE_EXECUTOR.close();
+    semaphoreExecutor.close();
     BackgroundTask.super.close();
   }
 
@@ -152,7 +151,7 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
     final var finishDate = batch.finishDate();
 
     // Note: Acquire the semaphore on a virtual thread to avoid blocking the main executor threads
-    return CompletableFuture.supplyAsync(this::getReindexPermit, SEMAPHORE_EXECUTOR)
+    return CompletableFuture.supplyAsync(reindexThrottler::acquirePermit, semaphoreExecutor)
         .thenComposeAsync(
             permit -> {
               if (!permit) {
@@ -163,11 +162,12 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
                             + " and date "
                             + finishDate));
               }
+              exporterMetrics.beginArchiverReindexTask();
               return archiverRepository.moveDocuments(
                   sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor);
             },
             executor)
-        .whenCompleteAsync((result, error) -> releaseReindexPermit(), SEMAPHORE_EXECUTOR)
+        .whenCompleteAsync((result, error) -> releaseReindexPermit(), semaphoreExecutor)
         .thenApply(ok -> batch.size());
   }
 
@@ -183,21 +183,8 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
   protected abstract Map<String, List<String>> createIdsByFieldMap(
       final IndexTemplateDescriptor templateDescriptor, final B batch);
 
-  private boolean getReindexPermit() {
-    try {
-      reindexSemaphore.acquire();
-      exporterMetrics.beginArchiverReindexTask();
-      return true;
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      logger.error(
-          "Archiver job interrupted while waiting for reindex permit: {}", e.getMessage(), e);
-      return false;
-    }
-  }
-
   private void releaseReindexPermit() {
-    reindexSemaphore.release();
+    reindexThrottler.releasePermit();
     exporterMetrics.completeArchiverReindexTask();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -163,11 +163,12 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
                             + finishDate));
               }
               exporterMetrics.beginArchiverReindexTask();
-              return archiverRepository.moveDocuments(
-                  sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor);
+              return archiverRepository
+                  .moveDocuments(
+                      sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor)
+                  .whenCompleteAsync((result, error) -> releaseReindexPermit());
             },
             executor)
-        .whenCompleteAsync((result, error) -> releaseReindexPermit(), semaphoreExecutor)
         .thenApply(ok -> batch.size());
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundTask {
 
   // Virtual-thread executor used exclusively for blocking semaphore.acquire() calls.
-  // This prevent using main (platform-threaded) executor, avoiding thread starvation.
+  // This prevents using main (platform-threaded) executor, avoiding thread starvation.
   private static final ExecutorService SEMAPHORE_EXECUTOR =
       Executors.newVirtualThreadPerTaskExecutor();
 
@@ -97,6 +97,12 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
   }
 
   @Override
+  public void close() {
+    SEMAPHORE_EXECUTOR.close();
+    BackgroundTask.super.close();
+  }
+
+  @Override
   public String toString() {
     return String.format("%s archiver job", getJobName());
   }
@@ -148,9 +154,18 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
     // Note: Acquire the semaphore on a virtual thread to avoid blocking the main executor threads
     return CompletableFuture.supplyAsync(this::getReindexPermit, SEMAPHORE_EXECUTOR)
         .thenComposeAsync(
-            ignored ->
-                archiverRepository.moveDocuments(
-                    sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor),
+            permit -> {
+              if (!permit) {
+                return CompletableFuture.failedFuture(
+                    new IllegalStateException(
+                        "Could not acquire reindex permit. Abandoning archiving for index "
+                            + sourceIdxName
+                            + " and date "
+                            + finishDate));
+              }
+              return archiverRepository.moveDocuments(
+                  sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor);
+            },
             executor)
         .whenCompleteAsync((result, error) -> releaseReindexPermit(), SEMAPHORE_EXECUTOR)
         .thenApply(ok -> batch.size());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -17,6 +17,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 
@@ -27,10 +30,16 @@ import org.slf4j.Logger;
  */
 public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundTask {
 
+  // Virtual-thread executor used exclusively for blocking semaphore.acquire() calls.
+  // This prevent using main (platform-threaded) executor, avoiding thread starvation.
+  private static final ExecutorService SEMAPHORE_EXECUTOR =
+      Executors.newVirtualThreadPerTaskExecutor();
+
   private final ArchiverRepository archiverRepository;
   private final CamundaExporterMetrics exporterMetrics;
   private final Logger logger;
   private final Executor executor;
+  private final Semaphore reindexSemaphore;
 
   private final Consumer<Integer> recordArchivingMetric;
   private final Consumer<Integer> recordArchivedMetric;
@@ -40,12 +49,14 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
       final Executor executor,
+      final Semaphore reindexSemaphore,
       final Consumer<Integer> recordArchivingMetric,
       final Consumer<Integer> recordArchivedMetric) {
     this.archiverRepository = archiverRepository;
     this.exporterMetrics = exporterMetrics;
     this.logger = logger;
     this.executor = executor;
+    this.reindexSemaphore = reindexSemaphore;
     this.recordArchivingMetric = recordArchivingMetric;
     this.recordArchivedMetric = recordArchivedMetric;
   }
@@ -133,9 +144,16 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
     final var sourceIdxName = templateDescriptor.getFullQualifiedName();
     final var idsMap = createIdsByFieldMap(templateDescriptor, batch);
     final var finishDate = batch.finishDate();
-    return archiverRepository
-        .moveDocuments(sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor)
-        .thenApplyAsync(ok -> batch.size(), executor);
+
+    // Note: Acquire the semaphore on a virtual thread to avoid blocking the main executor threads
+    return CompletableFuture.supplyAsync(this::getReindexPermit, SEMAPHORE_EXECUTOR)
+        .thenComposeAsync(
+            ignored ->
+                archiverRepository.moveDocuments(
+                    sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor),
+            executor)
+        .whenCompleteAsync((result, error) -> releaseReindexPermit(), SEMAPHORE_EXECUTOR)
+        .thenApply(ok -> batch.size());
   }
 
   /**
@@ -149,4 +167,22 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
    */
   protected abstract Map<String, List<String>> createIdsByFieldMap(
       final IndexTemplateDescriptor templateDescriptor, final B batch);
+
+  private boolean getReindexPermit() {
+    try {
+      reindexSemaphore.acquire();
+      exporterMetrics.beginArchiverReindexTask();
+      return true;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.error(
+          "Archiver job interrupted while waiting for reindex permit: {}", e.getMessage(), e);
+      return false;
+    }
+  }
+
+  private void releaseReindexPermit() {
+    reindexSemaphore.release();
+    exporterMetrics.completeArchiverReindexTask();
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -97,8 +97,11 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
 
   @Override
   public void close() {
-    semaphoreExecutor.close();
-    BackgroundTask.super.close();
+    try{
+      semaphoreExecutor.close();
+    }finally{
+      BackgroundTask.super.close();
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -97,9 +97,9 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
 
   @Override
   public void close() {
-    try{
+    try {
       semaphoreExecutor.close();
-    }finally{
+    } finally {
       BackgroundTask.super.close();
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
@@ -28,12 +29,14 @@ public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
       final AuditLogTemplate auditLogTemplate,
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         archiverRepository,
         exporterMetrics,
         logger,
         executor,
+        reindexSemaphore,
         exporterMetrics::recordAuditLogsArchiving,
         exporterMetrics::recordAuditLogsArchived);
     this.repository = repository;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
@@ -15,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
@@ -30,13 +30,13 @@ public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
       final Executor executor,
-      final Semaphore reindexSemaphore) {
+      final ReindexThrottler reindexThrottler) {
     super(
         archiverRepository,
         exporterMetrics,
         logger,
         executor,
-        reindexSemaphore,
+        reindexThrottler,
         exporterMetrics::recordAuditLogsArchiving,
         exporterMetrics::recordAuditLogsArchived);
     this.repository = repository;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -31,12 +32,14 @@ public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArc
       final List<BatchOperationDependant> batchOperationDependants,
       final CamundaExporterMetrics metrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         metrics,
         logger,
         executor,
+        reindexSemaphore,
         metrics::recordBatchOperationsArchiving,
         metrics::recordBatchOperationsArchived);
     this.batchOperationTemplate = batchOperationTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -18,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -33,13 +33,13 @@ public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArc
       final CamundaExporterMetrics metrics,
       final Logger logger,
       final Executor executor,
-      final Semaphore reindexSemaphore) {
+      final ReindexThrottler reindexThrottler) {
     super(
         repository,
         metrics,
         logger,
         executor,
-        reindexSemaphore,
+        reindexThrottler,
         metrics::recordBatchOperationsArchiving,
         metrics::recordBatchOperationsArchived);
     this.batchOperationTemplate = batchOperationTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
@@ -15,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -28,13 +28,13 @@ public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
       final Executor executor,
-      final Semaphore reindexSemaphore) {
+      final ReindexThrottler reindexThrottler) {
     super(
         repository,
         exporterMetrics,
         logger,
         executor,
-        reindexSemaphore,
+        reindexThrottler,
         exporterMetrics::recordJobBatchMetricsArchiving,
         exporterMetrics::recordJobBatchMetricsArchived);
     this.jobMetricsBatchTemplate = jobMetricsBatchTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -26,12 +27,14 @@ public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
       final JobMetricsBatchTemplate jobMetricsBatchTemplate,
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         exporterMetrics,
         logger,
         executor,
+        reindexSemaphore,
         exporterMetrics::recordJobBatchMetricsArchiving,
         exporterMetrics::recordJobBatchMetricsArchived);
     this.jobMetricsBatchTemplate = jobMetricsBatchTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 /**
@@ -37,12 +38,14 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
       final List<ProcessInstanceDependant> processInstanceDependants,
       final CamundaExporterMetrics metrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         metrics,
         logger,
         executor,
+        reindexSemaphore,
         metrics::recordProcessInstancesArchiving,
         metrics::recordProcessInstancesArchived);
     this.processInstanceTemplate = processInstanceTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
@@ -19,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 /**
@@ -39,13 +39,13 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
       final CamundaExporterMetrics metrics,
       final Logger logger,
       final Executor executor,
-      final Semaphore reindexSemaphore) {
+      final ReindexThrottler reindexThrottler) {
     super(
         repository,
         metrics,
         logger,
         executor,
-        reindexSemaphore,
+        reindexThrottler,
         metrics::recordProcessInstancesArchiving,
         metrics::recordProcessInstancesArchived);
     this.processInstanceTemplate = processInstanceTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -31,12 +32,14 @@ public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch
       final CamundaExporterMetrics metrics,
       final Logger logger,
       final Executor executor,
+      final Semaphore reindexSemaphore,
       final List<DecisionInstanceDependant> decisionInstanceDependants) {
     super(
         repository,
         metrics,
         logger,
         executor,
+        reindexSemaphore,
         metrics::recordStandaloneDecisionsArchiving,
         metrics::recordStandaloneDecisionsArchived);
     this.decisionInstanceTemplate = decisionInstanceTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -17,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -32,14 +32,14 @@ public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch
       final CamundaExporterMetrics metrics,
       final Logger logger,
       final Executor executor,
-      final Semaphore reindexSemaphore,
+      final ReindexThrottler reindexThrottler,
       final List<DecisionInstanceDependant> decisionInstanceDependants) {
     super(
         repository,
         metrics,
         logger,
         executor,
-        reindexSemaphore,
+        reindexThrottler,
         metrics::recordStandaloneDecisionsArchiving,
         metrics::recordStandaloneDecisionsArchived);
     this.decisionInstanceTemplate = decisionInstanceTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
@@ -15,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -28,13 +28,13 @@ public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
       final Executor executor,
-      final Semaphore reindexSemaphore) {
+      final ReindexThrottler reindexThrottler) {
     super(
         repository,
         exporterMetrics,
         logger,
         executor,
-        reindexSemaphore,
+        reindexThrottler,
         exporterMetrics::recordUsageMetricsArchiving,
         exporterMetrics::recordUsageMetricsArchived);
     this.usageMetricTemplate = usageMetricTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
@@ -26,12 +27,14 @@ public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
       final UsageMetricTemplate usageMetricTemplate,
       final CamundaExporterMetrics exporterMetrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         exporterMetrics,
         logger,
         executor,
+        reindexSemaphore,
         exporterMetrics::recordUsageMetricsArchiving,
         exporterMetrics::recordUsageMetricsArchived);
     this.usageMetricTemplate = usageMetricTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -25,12 +26,14 @@ public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArch
       final UsageMetricTUTemplate usageMetricTUTemplate,
       final CamundaExporterMetrics metrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final Semaphore reindexSemaphore) {
     super(
         repository,
         metrics,
         logger,
         executor,
+        reindexSemaphore,
         metrics::recordUsageMetricsTUArchiving,
         metrics::recordUsageMetricsTUArchived);
     this.usageMetricTUTemplate = usageMetricTUTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
@@ -8,13 +8,13 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 
 public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -27,13 +27,13 @@ public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArch
       final CamundaExporterMetrics metrics,
       final Logger logger,
       final Executor executor,
-      final Semaphore reindexSemaphore) {
+      final ReindexThrottler reindexThrottler) {
     super(
         repository,
         metrics,
         logger,
         executor,
-        reindexSemaphore,
+        reindexThrottler,
         metrics::recordUsageMetricsTUArchiving,
         metrics::recordUsageMetricsTUArchived);
     this.usageMetricTUTemplate = usageMetricTUTemplate;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
@@ -18,12 +18,15 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +38,7 @@ final class ArchiverJobTest {
   private static final String SOURCE_INDEX_NAME = "test-index_";
   private static final String ID_FIELD_NAME = "id-field";
 
-  private final Executor executor = Runnable::run;
+  private final Executor executor = Executors.newSingleThreadExecutor();
   private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
@@ -47,13 +50,10 @@ final class ArchiverJobTest {
   @SuppressWarnings("unchecked")
   private final Consumer<Integer> recordArchived = mock(Consumer.class);
 
-  private final IdxTemplateArchiver job =
-      new IdxTemplateArchiver(
-          repository, metrics, LOGGER, executor, reindexSemaphore, recordArchiving, recordArchived);
-
   @Test
   void shouldReturnZeroIfNoBatchGiven() {
     // given no batch
+    final IdxTemplateArchiver job = getArchiverJob(reindexSemaphore);
     repository.batch = null;
 
     // when
@@ -72,6 +72,7 @@ final class ArchiverJobTest {
   @Test
   void shouldReturnZeroIfNoBatchIdsGiven() {
     // given
+    final IdxTemplateArchiver job = getArchiverJob(reindexSemaphore);
     repository.batch = new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of());
 
     // when
@@ -90,6 +91,7 @@ final class ArchiverJobTest {
   @Test
   void shouldMoveInstancesById() {
     // given
+    final IdxTemplateArchiver job = getArchiverJob(reindexSemaphore);
     repository.batch = new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
 
     // when
@@ -109,6 +111,86 @@ final class ArchiverJobTest {
     verify(recordArchiving).accept(3);
     verify(recordArchived).accept(3);
     verify(metrics).measureArchivingDuration(any());
+  }
+
+  @Test
+  void whenThrottlingWithSemaphore() {
+    // given - start with 0 permits so both archives block until we release
+    final Semaphore limitingSemaphore = new Semaphore(0);
+    final Executor multiThreadExecutor = Executors.newFixedThreadPool(2);
+    final ArchiverRepository archiverRepository = mock(ArchiverRepository.class);
+    final BasicArchiveBatch batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // given - setup jobs & response
+    final IdxTemplateArchiver firstJob =
+        getArchiverJob(limitingSemaphore, archiverRepository, multiThreadExecutor);
+    final CompletableFuture<Integer> firstJobFuture =
+        firstJob.archive(firstJob.getTemplateDescriptor(), batch);
+
+    final IdxTemplateArchiver secondJob =
+        getArchiverJob(limitingSemaphore, archiverRepository, multiThreadExecutor);
+    final CompletableFuture<Integer> secondJobFuture =
+        secondJob.archive(secondJob.getTemplateDescriptor(), batch);
+
+    final CompletableFuture<Void> jobOneResponse = new CompletableFuture<>();
+    final CompletableFuture<Void> jobTwoResponse = new CompletableFuture<>();
+    when(archiverRepository.moveDocuments(any(), any(), any(), any(), any()))
+        .thenReturn(jobOneResponse)
+        .thenReturn(jobTwoResponse);
+
+    // when - trigger both archive futures without blocking
+    final CompletableFuture<Object> eitherDone =
+        CompletableFuture.anyOf(firstJobFuture, secondJobFuture);
+
+    // then - neither should have completed yet since no permits are available
+    assertThat(firstJobFuture).isNotDone();
+    assertThat(secondJobFuture).isNotDone();
+    assertThat(limitingSemaphore.availablePermits()).isEqualTo(0);
+
+    // when - release one permit, allowing exactly one archive to proceed
+    limitingSemaphore.release();
+
+    // eventually no permits should be available since the released permit should be
+    // acquired by the job waiting for repository
+    Awaitility.await("Either job should complete after releasing one permit")
+        .timeout(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(limitingSemaphore.availablePermits()).isEqualTo(0));
+
+    // then - return first repository response
+    jobOneResponse.complete(null);
+
+    // then ensure one job is done
+    assertThat(eitherDone).succeedsWithin(java.time.Duration.ofSeconds(5));
+
+    // then - return second repository response
+    jobTwoResponse.complete(null);
+
+    // then - both should complete
+    assertThat(firstJobFuture).succeedsWithin(java.time.Duration.ofSeconds(5));
+    assertThat(secondJobFuture).succeedsWithin(java.time.Duration.ofSeconds(5));
+    assertThat(firstJobFuture.join()).isEqualTo(3);
+    assertThat(secondJobFuture.join()).isEqualTo(3);
+
+    // then - verify that the semaphore is released after both complete
+    assertThat(limitingSemaphore.availablePermits()).isEqualTo(1);
+  }
+
+  private IdxTemplateArchiver getArchiverJob(final Semaphore reindexSemaphore) {
+    return getArchiverJob(reindexSemaphore, repository, executor);
+  }
+
+  private IdxTemplateArchiver getArchiverJob(
+      final Semaphore reindexSemaphore,
+      final ArchiverRepository archiverRepository,
+      final Executor executor) {
+    return new IdxTemplateArchiver(
+        archiverRepository,
+        metrics,
+        LOGGER,
+        executor,
+        reindexSemaphore,
+        recordArchiving,
+        recordArchived);
   }
 
   static class IdxTemplateArchiver extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -134,6 +216,28 @@ final class ArchiverJobTest {
       indexTemplateDescriptor = mock(IndexTemplateDescriptor.class);
       when(indexTemplateDescriptor.getIdField()).thenReturn(ID_FIELD_NAME);
       when(indexTemplateDescriptor.getFullQualifiedName()).thenReturn(SOURCE_INDEX_NAME);
+    }
+
+    public IdxTemplateArchiver(
+        final ArchiverRepository archiverRepository,
+        final CamundaExporterMetrics exporterMetrics,
+        final Logger logger,
+        final Executor executor,
+        final Semaphore reindexSemaphore,
+        final Consumer<Integer> recordArchivingMetric,
+        final Consumer<Integer> recordArchivedMetric,
+        final String sourceIndexName) {
+      super(
+          archiverRepository,
+          exporterMetrics,
+          logger,
+          executor,
+          reindexSemaphore,
+          recordArchivingMetric,
+          recordArchivedMetric);
+      indexTemplateDescriptor = mock(IndexTemplateDescriptor.class);
+      when(indexTemplateDescriptor.getIdField()).thenReturn(ID_FIELD_NAME);
+      when(indexTemplateDescriptor.getFullQualifiedName()).thenReturn(sourceIndexName);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -35,6 +36,7 @@ final class ArchiverJobTest {
   private static final String ID_FIELD_NAME = "id-field";
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final CamundaExporterMetrics metrics = mock(CamundaExporterMetrics.class);
@@ -47,7 +49,7 @@ final class ArchiverJobTest {
 
   private final IdxTemplateArchiver job =
       new IdxTemplateArchiver(
-          repository, metrics, LOGGER, executor, recordArchiving, recordArchived);
+          repository, metrics, LOGGER, executor, reindexSemaphore, recordArchiving, recordArchived);
 
   @Test
   void shouldReturnZeroIfNoBatchGiven() {
@@ -118,6 +120,7 @@ final class ArchiverJobTest {
         final CamundaExporterMetrics exporterMetrics,
         final Logger logger,
         final Executor executor,
+        final Semaphore reindexSemaphore,
         final Consumer<Integer> recordArchivingMetric,
         final Consumer<Integer> recordArchivedMetric) {
       super(
@@ -125,6 +128,7 @@ final class ArchiverJobTest {
           exporterMetrics,
           logger,
           executor,
+          reindexSemaphore,
           recordArchivingMetric,
           recordArchivedMetric);
       indexTemplateDescriptor = mock(IndexTemplateDescriptor.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -24,7 +25,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -39,7 +39,7 @@ final class ArchiverJobTest {
   private static final String ID_FIELD_NAME = "id-field";
 
   private final Executor executor = Executors.newSingleThreadExecutor();
-  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
+  private final ReindexThrottler reindexThrottler = ReindexThrottler.unlimited(LOGGER);
 
   private final TestRepository repository = new TestRepository();
   private final CamundaExporterMetrics metrics = mock(CamundaExporterMetrics.class);
@@ -53,7 +53,7 @@ final class ArchiverJobTest {
   @Test
   void shouldReturnZeroIfNoBatchGiven() {
     // given no batch
-    final IdxTemplateArchiver job = getArchiverJob(reindexSemaphore);
+    final IdxTemplateArchiver job = getArchiverJob(reindexThrottler);
     repository.batch = null;
 
     // when
@@ -72,7 +72,7 @@ final class ArchiverJobTest {
   @Test
   void shouldReturnZeroIfNoBatchIdsGiven() {
     // given
-    final IdxTemplateArchiver job = getArchiverJob(reindexSemaphore);
+    final IdxTemplateArchiver job = getArchiverJob(reindexThrottler);
     repository.batch = new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of());
 
     // when
@@ -91,7 +91,7 @@ final class ArchiverJobTest {
   @Test
   void shouldMoveInstancesById() {
     // given
-    final IdxTemplateArchiver job = getArchiverJob(reindexSemaphore);
+    final IdxTemplateArchiver job = getArchiverJob(reindexThrottler);
     repository.batch = new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
 
     // when
@@ -116,19 +116,19 @@ final class ArchiverJobTest {
   @Test
   void whenThrottlingWithSemaphore() {
     // given - start with 0 permits so both archives block until we release
-    final Semaphore limitingSemaphore = new Semaphore(0);
+    final ReindexThrottler reindexThrottler = new ReindexThrottler(0, 0, LOGGER);
     final Executor multiThreadExecutor = Executors.newFixedThreadPool(2);
     final ArchiverRepository archiverRepository = mock(ArchiverRepository.class);
     final BasicArchiveBatch batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
 
     // given - setup jobs & response
     final IdxTemplateArchiver firstJob =
-        getArchiverJob(limitingSemaphore, archiverRepository, multiThreadExecutor);
+        getArchiverJob(reindexThrottler, archiverRepository, multiThreadExecutor);
     final CompletableFuture<Integer> firstJobFuture =
         firstJob.archive(firstJob.getTemplateDescriptor(), batch);
 
     final IdxTemplateArchiver secondJob =
-        getArchiverJob(limitingSemaphore, archiverRepository, multiThreadExecutor);
+        getArchiverJob(reindexThrottler, archiverRepository, multiThreadExecutor);
     final CompletableFuture<Integer> secondJobFuture =
         secondJob.archive(secondJob.getTemplateDescriptor(), batch);
 
@@ -145,16 +145,16 @@ final class ArchiverJobTest {
     // then - neither should have completed yet since no permits are available
     assertThat(firstJobFuture).isNotDone();
     assertThat(secondJobFuture).isNotDone();
-    assertThat(limitingSemaphore.availablePermits()).isEqualTo(0);
+    assertThat(reindexThrottler.availablePermits()).isEqualTo(0);
 
     // when - release one permit, allowing exactly one archive to proceed
-    limitingSemaphore.release();
+    reindexThrottler.releasePermit();
 
     // eventually no permits should be available since the released permit should be
     // acquired by the job waiting for repository
     Awaitility.await("Either job should complete after releasing one permit")
         .timeout(Duration.ofSeconds(5))
-        .untilAsserted(() -> assertThat(limitingSemaphore.availablePermits()).isEqualTo(0));
+        .untilAsserted(() -> assertThat(reindexThrottler.availablePermits()).isEqualTo(0));
 
     // then - return first repository response
     jobOneResponse.complete(null);
@@ -172,15 +172,15 @@ final class ArchiverJobTest {
     assertThat(secondJobFuture.join()).isEqualTo(3);
 
     // then - verify that the semaphore is released after both complete
-    assertThat(limitingSemaphore.availablePermits()).isEqualTo(1);
+    assertThat(reindexThrottler.availablePermits()).isEqualTo(1);
   }
 
-  private IdxTemplateArchiver getArchiverJob(final Semaphore reindexSemaphore) {
-    return getArchiverJob(reindexSemaphore, repository, executor);
+  private IdxTemplateArchiver getArchiverJob(final ReindexThrottler reindexThrottler) {
+    return getArchiverJob(reindexThrottler, repository, executor);
   }
 
   private IdxTemplateArchiver getArchiverJob(
-      final Semaphore reindexSemaphore,
+      final ReindexThrottler reindexThrottler,
       final ArchiverRepository archiverRepository,
       final Executor executor) {
     return new IdxTemplateArchiver(
@@ -188,7 +188,7 @@ final class ArchiverJobTest {
         metrics,
         LOGGER,
         executor,
-        reindexSemaphore,
+        reindexThrottler,
         recordArchiving,
         recordArchived);
   }
@@ -202,7 +202,7 @@ final class ArchiverJobTest {
         final CamundaExporterMetrics exporterMetrics,
         final Logger logger,
         final Executor executor,
-        final Semaphore reindexSemaphore,
+        final ReindexThrottler reindexThrottler,
         final Consumer<Integer> recordArchivingMetric,
         final Consumer<Integer> recordArchivedMetric) {
       super(
@@ -210,7 +210,7 @@ final class ArchiverJobTest {
           exporterMetrics,
           logger,
           executor,
-          reindexSemaphore,
+          reindexThrottler,
           recordArchivingMetric,
           recordArchivedMetric);
       indexTemplateDescriptor = mock(IndexTemplateDescriptor.class);
@@ -223,7 +223,7 @@ final class ArchiverJobTest {
         final CamundaExporterMetrics exporterMetrics,
         final Logger logger,
         final Executor executor,
-        final Semaphore reindexSemaphore,
+        final ReindexThrottler reindexThrottler,
         final Consumer<Integer> recordArchivingMetric,
         final Consumer<Integer> recordArchivedMetric,
         final String sourceIndexName) {
@@ -232,7 +232,7 @@ final class ArchiverJobTest {
           exporterMetrics,
           logger,
           executor,
-          reindexSemaphore,
+          reindexThrottler,
           recordArchivingMetric,
           recordArchivedMetric);
       indexTemplateDescriptor = mock(IndexTemplateDescriptor.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
@@ -16,6 +16,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -26,6 +27,7 @@ public class AuditLogArchiverJobTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final NoopAuditLogArchiverRepository auditLogArchiverRepository =
       new NoopAuditLogArchiverRepository();
@@ -40,7 +42,8 @@ public class AuditLogArchiverJobTest {
           auditLogTemplate,
           metrics,
           LOGGER,
-          executor);
+          executor,
+          reindexSemaphore);
 
   @AfterEach
   void cleanUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
@@ -10,13 +10,13 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -27,7 +27,7 @@ public class AuditLogArchiverJobTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
-  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
+  private final ReindexThrottler reindexThrottler = ReindexThrottler.unlimited(LOGGER);
 
   private final NoopAuditLogArchiverRepository auditLogArchiverRepository =
       new NoopAuditLogArchiverRepository();
@@ -43,7 +43,7 @@ public class AuditLogArchiverJobTest {
           metrics,
           LOGGER,
           executor,
-          reindexSemaphore);
+          reindexThrottler);
 
   @AfterEach
   void cleanUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -18,6 +18,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
   private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final BatchOperationTemplate batchOperationTemplate =
@@ -38,7 +40,13 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
 
   private final BatchOperationArchiverJob job =
       new BatchOperationArchiverJob(
-          repository, batchOperationTemplate, List.of(auditLogTemplate), metrics, LOGGER, executor);
+          repository,
+          batchOperationTemplate,
+          List.of(auditLogTemplate),
+          metrics,
+          LOGGER,
+          executor,
+          reindexSemaphore);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
@@ -18,7 +19,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
   private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
-  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
+  private final ReindexThrottler reindexThrottler = ReindexThrottler.unlimited(LOGGER);
 
   private final TestRepository repository = new TestRepository();
   private final BatchOperationTemplate batchOperationTemplate =
@@ -46,7 +46,7 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
           metrics,
           LOGGER,
           executor,
-          reindexSemaphore);
+          reindexThrottler);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
@@ -17,7 +18,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
       LoggerFactory.getLogger(JobBatchMetricsArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
-  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
+  private final ReindexThrottler reindexThrottler = ReindexThrottler.unlimited(LOGGER);
 
   private final TestRepository repository = new TestRepository();
   private final JobMetricsBatchTemplate jobMetricsBatchTemplate =
@@ -40,7 +40,7 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
 
   private final JobBatchMetricsArchiverJob job =
       new JobBatchMetricsArchiverJob(
-          repository, jobMetricsBatchTemplate, metrics, LOGGER, executor, reindexSemaphore);
+          repository, jobMetricsBatchTemplate, metrics, LOGGER, executor, reindexThrottler);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
       LoggerFactory.getLogger(JobBatchMetricsArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final JobMetricsBatchTemplate jobMetricsBatchTemplate =
@@ -38,7 +40,7 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
 
   private final JobBatchMetricsArchiverJob job =
       new JobBatchMetricsArchiverJob(
-          repository, jobMetricsBatchTemplate, metrics, LOGGER, executor);
+          repository, jobMetricsBatchTemplate, metrics, LOGGER, executor, reindexSemaphore);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
@@ -21,7 +22,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
       LoggerFactory.getLogger(ProcessInstanceArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
-  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
+  private final ReindexThrottler reindexThrottler = ReindexThrottler.unlimited(LOGGER);
 
   private final TestRepository repository = new TestRepository();
   private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
@@ -53,7 +53,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
           metrics,
           LOGGER,
           executor,
-          reindexSemaphore);
+          reindexThrottler);
 
   @BeforeEach
   void setUp() {
@@ -93,7 +93,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
             metrics,
             LOGGER,
             executor,
-            reindexSemaphore);
+            reindexThrottler);
 
     // when
     final int count = processInstanceJob.execute().toCompletableFuture().join();
@@ -184,7 +184,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
             metrics,
             LOGGER,
             executor,
-            reindexSemaphore);
+            reindexThrottler);
     repository.batch = new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L), List.of());
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
       LoggerFactory.getLogger(ProcessInstanceArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
@@ -50,7 +52,8 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
           List.of(decisionInstanceTemplate, sequenceFlowTemplate, auditLogTemplate),
           metrics,
           LOGGER,
-          executor);
+          executor,
+          reindexSemaphore);
 
   @BeforeEach
   void setUp() {
@@ -84,7 +87,13 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     // given
     final ProcessInstanceArchiverJob processInstanceJob =
         new ProcessInstanceArchiverJob(
-            repository, processInstanceTemplate, List.of(), metrics, LOGGER, executor);
+            repository,
+            processInstanceTemplate,
+            List.of(),
+            metrics,
+            LOGGER,
+            executor,
+            reindexSemaphore);
 
     // when
     final int count = processInstanceJob.execute().toCompletableFuture().join();
@@ -169,7 +178,13 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     final var dependant = new WeirdlyNamedDependant();
     final var job =
         new ProcessInstanceArchiverJob(
-            repository, processInstanceTemplate, List.of(dependant), metrics, LOGGER, executor);
+            repository,
+            processInstanceTemplate,
+            List.of(dependant),
+            metrics,
+            LOGGER,
+            executor,
+            reindexSemaphore);
     repository.batch = new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L), List.of());
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
       LoggerFactory.getLogger(StandaloneDecisionArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final DecisionInstanceTemplate decisionInstanceTemplate =
@@ -47,6 +49,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
           metrics,
           LOGGER,
           executor,
+          reindexSemaphore,
           List.of(auditLogTemplate));
 
   @BeforeEach
@@ -80,7 +83,13 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     // given
     final StandaloneDecisionArchiverJob standaloneDecisionArchiverJob =
         new StandaloneDecisionArchiverJob(
-            repository, decisionInstanceTemplate, metrics, LOGGER, executor, List.of());
+            repository,
+            decisionInstanceTemplate,
+            metrics,
+            LOGGER,
+            executor,
+            reindexSemaphore,
+            List.of());
 
     // when
     final int count = standaloneDecisionArchiverJob.execute().toCompletableFuture().join();
@@ -149,7 +158,13 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     final var dependant = new WeirdlyNamedDependant();
     final var job =
         new StandaloneDecisionArchiverJob(
-            repository, decisionInstanceTemplate, metrics, LOGGER, executor, List.of(dependant));
+            repository,
+            decisionInstanceTemplate,
+            metrics,
+            LOGGER,
+            executor,
+            reindexSemaphore,
+            List.of(dependant));
     repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2"));
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
@@ -19,7 +20,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
       LoggerFactory.getLogger(StandaloneDecisionArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
-  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
+  private final ReindexThrottler reindexThrottler = ReindexThrottler.unlimited(LOGGER);
 
   private final TestRepository repository = new TestRepository();
   private final DecisionInstanceTemplate decisionInstanceTemplate =
@@ -49,7 +49,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
           metrics,
           LOGGER,
           executor,
-          reindexSemaphore,
+          reindexThrottler,
           List.of(auditLogTemplate));
 
   @BeforeEach
@@ -88,7 +88,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
             metrics,
             LOGGER,
             executor,
-            reindexSemaphore,
+            reindexThrottler,
             List.of());
 
     // when
@@ -163,7 +163,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
             metrics,
             LOGGER,
             executor,
-            reindexSemaphore,
+            reindexThrottler,
             List.of(dependant));
     repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2"));
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   private static final Logger LOGGER = LoggerFactory.getLogger(UsageMetricArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final UsageMetricTemplate usageMetricTemplate = new UsageMetricTemplate("", true);
@@ -35,7 +37,8 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
 
   private final UsageMetricArchiverJob job =
-      new UsageMetricArchiverJob(repository, usageMetricTemplate, metrics, LOGGER, executor);
+      new UsageMetricArchiverJob(
+          repository, usageMetricTemplate, metrics, LOGGER, executor, reindexSemaphore);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
@@ -17,7 +18,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   private static final Logger LOGGER = LoggerFactory.getLogger(UsageMetricArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
-  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
+  private final ReindexThrottler reindexThrottler = ReindexThrottler.unlimited(LOGGER);
 
   private final TestRepository repository = new TestRepository();
   private final UsageMetricTemplate usageMetricTemplate = new UsageMetricTemplate("", true);
@@ -38,7 +38,7 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
 
   private final UsageMetricArchiverJob job =
       new UsageMetricArchiverJob(
-          repository, usageMetricTemplate, metrics, LOGGER, executor, reindexSemaphore);
+          repository, usageMetricTemplate, metrics, LOGGER, executor, reindexThrottler);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   private static final Logger LOGGER = LoggerFactory.getLogger(UsageMetricTUArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
 
   private final TestRepository repository = new TestRepository();
   private final UsageMetricTUTemplate usageMetricTUTemplate = new UsageMetricTUTemplate("", true);
@@ -34,7 +36,8 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
 
   private final UsageMetricTUArchiverJob job =
-      new UsageMetricTUArchiverJob(repository, usageMetricTUTemplate, metrics, LOGGER, executor);
+      new UsageMetricTUArchiverJob(
+          repository, usageMetricTUTemplate, metrics, LOGGER, executor, reindexSemaphore);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.BackgroundTaskManagerFactory.ReindexThrottler;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
@@ -17,7 +18,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   private static final Logger LOGGER = LoggerFactory.getLogger(UsageMetricTUArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
-  private final Semaphore reindexSemaphore = new Semaphore(Integer.MAX_VALUE);
+  private final ReindexThrottler reindexThrottler = ReindexThrottler.unlimited(LOGGER);
 
   private final TestRepository repository = new TestRepository();
   private final UsageMetricTUTemplate usageMetricTUTemplate = new UsageMetricTUTemplate("", true);
@@ -37,7 +37,7 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
 
   private final UsageMetricTUArchiverJob job =
       new UsageMetricTUArchiverJob(
-          repository, usageMetricTUTemplate, metrics, LOGGER, executor, reindexSemaphore);
+          repository, usageMetricTUTemplate, metrics, LOGGER, executor, reindexThrottler);
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION

## Description

At the moment, there is nothing we can control to limit the number of reindexing tasks scheduled at any given time. This has resulted in many tasks being issued to Elasticsearch/OpenSearch clusters simultaneously, consuming available CPU and memory and causing performance degradation due to CPU throttling and, in the worst cases, even OOMs.

With this change, we introduce a throttler using a Semaphore to limit the number of parallel reindexing tasks that can be scheduled at any given time. The number of parallel tasks can be configured via the `history.maxParallelArchiverReindexTasks` config property, which defaults to `5` to minimize the risk of performance degradation while not being overly restrictive. Setting it to a higher value allows more parallelism at the cost of higher resource usage, while setting it to 0 or a negative value allows unlimited parallelism.

Also note that throttling happens at the partition level, so the actual number of parallel reindexing tasks issued to the ES/OS cluster will be higher and will scale with the number of partitions. Therefore, it is important to set this config property to a value that the ES/OS cluster can safely handle based on its resources and workload.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
