### PR TITLE
test: migrate processInstanceListeners.spec to oc test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -33,6 +33,9 @@ class OperateProcessInstancePage {
   readonly executionCountToggleOn: Locator;
   readonly executionCountToggleOff: Locator;
   readonly listenersTabButton: Locator;
+  readonly startFlowNode: Locator;
+  readonly serviceTaskBFlowNode: Locator;
+  readonly executionListenerText: Locator;
   readonly metadataModal: Locator;
   readonly modifyInstanceButton: Locator;
   readonly listenerTypeFilter: Locator;
@@ -102,6 +105,9 @@ class OperateProcessInstancePage {
       'hide execution count',
     );
     this.listenersTabButton = page.getByTestId('listeners-tab-button');
+    this.startFlowNode = page.getByLabel('StartEvent_1');
+    this.serviceTaskBFlowNode = page.getByLabel(/service task b/i);
+    this.executionListenerText = page.getByText('Execution listener');
     this.metadataModal = this.page.getByRole('dialog', {name: 'metadata'});
     this.modifyInstanceButton = page.getByTestId('enter-modification-mode');
     this.listenerTypeFilter = page.getByTestId('listener-type-filter');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithListener.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithListener.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0w6mdov" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
+  <bpmn:process id="processWithListener" name="processWithListener" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0kmwpwc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="taskWithListener" name="Service Task B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="serviceTaskB" retries="3" />
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="listener_start" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0kmwpwc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cwk0jf</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0kmwpwc" sourceRef="StartEvent_1" targetRef="taskWithListener" />
+    <bpmn:endEvent id="Event_1uhi56e">
+      <bpmn:incoming>Flow_0cwk0jf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0cwk0jf" sourceRef="taskWithListener" targetRef="Event_1uhi56e" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithListener">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pg75w9_di" bpmnElement="taskWithListener">
+        <dc:Bounds x="350" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1uhi56e_di" bpmnElement="Event_1uhi56e">
+        <dc:Bounds x="592" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0kmwpwc_di" bpmnElement="Flow_0kmwpwc">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="350" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cwk0jf_di" bpmnElement="Flow_0cwk0jf">
+        <di:waypoint x="450" y="117" />
+        <di:waypoint x="592" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForProcessInstances} from 'utils/incidentsHelper';
+
+let processInstanceKey: string;
+
+test.beforeAll(async ({request}) => {
+  await deploy(['./resources/processWithListener.bpmn']);
+
+  const instance = await createSingleInstance('processWithListener', 1);
+  processInstanceKey = String(instance.processInstanceKey);
+
+  await waitForProcessInstances(request, [processInstanceKey], 1);
+});
+
+test.describe('Process Instance Listeners', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Listeners tab button show/hide', async ({
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Navigate to process instance', async () => {
+      await operateProcessInstancePage.navigateToProcessInstance(
+        processInstanceKey,
+      );
+    });
+
+    await test.step('Start flow node should NOT show listeners tab', async () => {
+      await operateProcessInstancePage.startFlowNode.click();
+      await expect(operateProcessInstancePage.listenersTabButton).toBeHidden();
+    });
+
+    await test.step('Service task flow node should show listeners tab', async () => {
+      await operateProcessInstancePage.serviceTaskBFlowNode.click();
+      await expect(operateProcessInstancePage.listenersTabButton).toBeVisible();
+    });
+  });
+
+  test('Listeners data displayed', async ({operateProcessInstancePage}) => {
+    await test.step('Navigate to process instance', async () => {
+      await operateProcessInstancePage.navigateToProcessInstance(
+        processInstanceKey,
+      );
+    });
+
+    await test.step('Click service task and open listeners tab', async () => {
+      await operateProcessInstancePage.serviceTaskBFlowNode.click();
+      await operateProcessInstancePage.listenersTabButton.click();
+    });
+
+    await test.step('Verify execution listener is displayed', async () => {
+      await expect(
+        operateProcessInstancePage.executionListenerText,
+      ).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Migrate the `processInstanceListeners.spec` test from an Operate test suite to the Orchestration Cluster (OC) E2E test suite.


🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/22850726948)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/34108, https://github.com/camunda/camunda/issues/34089
