### PR TITLE
fix: ensure that GCS backup store can list many backups

### DIFF
--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -32,7 +32,9 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,12 +53,14 @@ public final class AzureBackupStore implements BackupStore {
   public static final String SEGMENTS_FILESET_NAME = "segments";
   public static final String METADATA_OBJECT_NAME = "metadata.json";
   private static final Logger LOG = LoggerFactory.getLogger(AzureBackupStore.class);
+  private static final int MAX_CONCURRENT_SAVES = 128;
   private final ExecutorService executor;
+  private final Semaphore saveSemaphore = new Semaphore(MAX_CONCURRENT_SAVES);
+  private final ReentrantLock containerCreationLock = new ReentrantLock();
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
   private final BlobContainerClient blobContainerClient;
-  private final boolean createContainer;
-  private boolean containerCreated;
+  private volatile boolean containerCreated;
 
   AzureBackupStore(final AzureBackupConfig config) {
     this(config, buildClient(config));
@@ -65,7 +69,7 @@ public final class AzureBackupStore implements BackupStore {
   AzureBackupStore(final AzureBackupConfig config, final BlobServiceClient client) {
     executor = Executors.newVirtualThreadPerTaskExecutor();
     blobContainerClient = getContainerClient(client, config);
-    createContainer = isCreateContainer(config);
+    final boolean createContainer = isCreateContainer(config);
     containerCreated = !createContainer;
 
     fileSetManager = new FileSetManager(blobContainerClient, createContainer);
@@ -135,14 +139,24 @@ public final class AzureBackupStore implements BackupStore {
   public CompletableFuture<Void> save(final Backup backup) {
     return CompletableFuture.runAsync(
         () -> {
-          final var persistedManifest = manifestManager.createInitialManifest(backup);
           try {
-            fileSetManager.save(backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot());
-            fileSetManager.save(backup.id(), SEGMENTS_FILESET_NAME, backup.segments());
-            manifestManager.completeManifest(persistedManifest);
-          } catch (final Exception e) {
-            manifestManager.markAsFailed(persistedManifest.manifest().id(), e.getMessage());
-            throw e;
+            saveSemaphore.acquire();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting to save backup", e);
+          }
+          try {
+            final var persistedManifest = manifestManager.createInitialManifest(backup);
+            try {
+              fileSetManager.save(backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot());
+              fileSetManager.save(backup.id(), SEGMENTS_FILESET_NAME, backup.segments());
+              manifestManager.completeManifest(persistedManifest);
+            } catch (final Exception e) {
+              manifestManager.markAsFailed(persistedManifest.manifest().id(), e.getMessage());
+              throw e;
+            }
+          } finally {
+            saveSemaphore.release();
           }
         },
         executor);
@@ -287,8 +301,15 @@ public final class AzureBackupStore implements BackupStore {
 
   private void assureContainerCreated() {
     if (!containerCreated) {
-      blobContainerClient.createIfNotExists();
-      containerCreated = true;
+      containerCreationLock.lock();
+      try {
+        if (!containerCreated) {
+          blobContainerClient.createIfNotExists();
+          containerCreated = true;
+        }
+      } finally {
+        containerCreationLock.unlock();
+      }
     }
   }
 

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -21,13 +21,15 @@ import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import java.nio.file.Path;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 final class FileSetManager {
   // The path format is constructed by contents/partitionId/checkpointId/nodeId/nameOfFile
   private static final String PATH_FORMAT = "contents/%s/%s/%s/%s/";
   private final BlobContainerClient containerClient;
-  private boolean containerCreated = false;
+  private final ReentrantLock containerCreationLock = new ReentrantLock();
+  private volatile boolean containerCreated = false;
 
   FileSetManager(final BlobContainerClient containerClient, final boolean createContainer) {
     this.containerClient = containerClient;
@@ -91,8 +93,15 @@ final class FileSetManager {
 
   void assureContainerCreated() {
     if (!containerCreated) {
-      containerClient.createIfNotExists();
-      containerCreated = true;
+      containerCreationLock.lock();
+      try {
+        if (!containerCreated) {
+          containerClient.createIfNotExists();
+          containerCreated = true;
+        }
+      } finally {
+        containerCreationLock.unlock();
+      }
     }
   }
 

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
 public final class ManifestManager {
@@ -64,7 +65,8 @@ public final class ManifestManager {
           .registerModule(new JavaTimeModule())
           .disable(WRITE_DATES_AS_TIMESTAMPS)
           .setSerializationInclusion(Include.NON_ABSENT);
-  private boolean containerCreated;
+  private volatile boolean containerCreated;
+  private final ReentrantLock containerCreationLock = new ReentrantLock();
   private final BlobContainerClient blobContainerClient;
 
   ManifestManager(final BlobContainerClient blobContainerClient, final boolean createContainer) {
@@ -266,8 +268,15 @@ public final class ManifestManager {
 
   void assureContainerCreated() {
     if (!containerCreated) {
-      blobContainerClient.createIfNotExists();
-      containerCreated = true;
+      containerCreationLock.lock();
+      try {
+        if (!containerCreated) {
+          blobContainerClient.createIfNotExists();
+          containerCreated = true;
+        }
+      } finally {
+        containerCreationLock.unlock();
+      }
     }
   }
 

--- a/zeebe/backup-stores/azure/src/test/resources/log4j2-test.xml
+++ b/zeebe/backup-stores/azure/src/test/resources/log4j2-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%X] [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda.zeebe" level="trace"/>
+    <Logger name="com.azure" level="debug"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/zeebe/backup-stores/filesystem/src/test/resources/log4j2-test.xml
+++ b/zeebe/backup-stores/filesystem/src/test/resources/log4j2-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%X] [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda.zeebe" level="trace"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -144,6 +144,19 @@
     </dependency>
 
     <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <!--  Ensure non-jqwik junit5 tests can be run -->
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
@@ -155,6 +168,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
+          <usedDependencies>
+            <dependency>net.jqwik:jqwik</dependency>
+          </usedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- Will be used soon and is already useful for bringing in dependencies on auto-generated google api libraries -->
             <ignoredUnusedDeclaredDependency>com.google.cloud:google-cloud-storage</ignoredUnusedDeclaredDependency>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -146,7 +146,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -150,6 +150,12 @@
     </dependency>
 
     <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <!--  Ensure non-jqwik junit5 tests can be run -->
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -130,8 +130,7 @@ public final class GcsBackupStore implements BackupStore {
   @Override
   public CompletableFuture<Collection<BackupStatus>> list(final BackupIdentifierWildcard wildcard) {
     return CompletableFuture.supplyAsync(
-        () -> manifestManager.listManifests(wildcard).stream().map(Manifest::toStatus).toList(),
-        executor);
+        () -> manifestManager.listBackupStatuses(wildcard), executor);
   }
 
   @Override

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -60,7 +60,7 @@ public final class GcsBackupStore implements BackupStore {
     basePath = Optional.ofNullable(config.basePath()).map(s -> s + "/").orElse("");
     this.client = client;
     executor = Executors.newVirtualThreadPerTaskExecutor();
-    manifestManager = new ManifestManager(client, bucketInfo, basePath);
+    manifestManager = new ManifestManager(client, bucketInfo, basePath, executor);
     fileSetManager =
         new FileSetManager(client, bucketInfo, basePath, executor, config.maxConcurrentTransfers());
   }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -29,12 +30,14 @@ import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.StreamSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ManifestManager {
 
@@ -49,6 +52,7 @@ public final class ManifestManager {
           .disable(WRITE_DATES_AS_TIMESTAMPS)
           .setSerializationInclusion(Include.NON_ABSENT);
   public static final int PRECONDITION_FAILED = 412;
+  private static final Logger LOG = LoggerFactory.getLogger(ManifestManager.class);
 
   /**
    * Format for path to all manifests.
@@ -78,11 +82,17 @@ public final class ManifestManager {
   private final BucketInfo bucketInfo;
   private final Storage client;
   private final String basePath;
+  private final ExecutorService executor;
 
-  ManifestManager(final Storage client, final BucketInfo bucketInfo, final String basePath) {
+  ManifestManager(
+      final Storage client,
+      final BucketInfo bucketInfo,
+      final String basePath,
+      final ExecutorService executor) {
     this.bucketInfo = bucketInfo;
     this.client = client;
     this.basePath = basePath;
+    this.executor = executor;
   }
 
   PersistedManifest createInitialManifest(final Backup backup) {
@@ -177,27 +187,38 @@ public final class ManifestManager {
   }
 
   public Collection<Manifest> listManifests(final BackupIdentifierWildcard wildcard) {
-    final var spliterator =
-        Spliterators.spliteratorUnknownSize(
-            client
-                .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
-                .iterateAll()
-                .iterator(),
-            Spliterator.IMMUTABLE);
-    return StreamSupport.stream(spliterator, false)
-        .filter(filterBlobsByWildcard(wildcard))
-        .parallel()
-        .map(Blob::getContent)
-        .map(
-            content -> {
-              try {
-                return MAPPER.readValue(content, Manifest.class);
-              } catch (final IOException e) {
-                throw new UncheckedIOException(e);
-              }
-            })
-        .filter(m -> wildcard.matches(m.id()))
-        .toList();
+    final var blobFilter = filterBlobsByWildcard(wildcard);
+    LOG.debug("Searching for matching blobs for wildcard {}", wildcard);
+
+    final var matchingBlobIds = new ArrayList<BlobId>();
+    for (final var blob :
+        client
+            .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
+            .iterateAll()) {
+      if (blobFilter.test(blob)) {
+        matchingBlobIds.add(blob.getBlobId());
+      }
+    }
+
+    LOG.trace("Found {} matching blobs for wildcard {}", matchingBlobIds.size(), wildcard);
+    final var futures =
+        matchingBlobIds.stream()
+            .map(
+                blobId ->
+                    CompletableFuture.supplyAsync(
+                        () -> {
+                          try {
+                            return MAPPER.readValue(client.readAllBytes(blobId), Manifest.class);
+                          } catch (final IOException e) {
+                            throw new UncheckedIOException(e);
+                          }
+                        },
+                        executor));
+
+    final var filtered =
+        futures.map(CompletableFuture::join).filter(m -> wildcard.matches(m.id())).toList();
+    LOG.debug("Found {} matching manifests for wildcard {}", filtered.size(), wildcard);
+    return filtered;
   }
 
   public void deleteManifest(final Manifest manifest) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -189,36 +188,36 @@ public final class ManifestManager {
   public Collection<Manifest> listManifests(final BackupIdentifierWildcard wildcard) {
     final var blobFilter = filterBlobsByWildcard(wildcard);
     LOG.debug("Searching for matching blobs for wildcard {}", wildcard);
-
-    final var matchingBlobIds = new ArrayList<BlobId>();
-    for (final var blob :
+    final var listing =
         client
             .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
-            .iterateAll()) {
-      if (blobFilter.test(blob)) {
-        matchingBlobIds.add(blob.getBlobId());
+            .iterateAll();
+    final var manifestFutures = new ArrayList<CompletableFuture<Manifest>>();
+    for (final var blob : listing) {
+      if (!blobFilter.test(blob)) {
+        continue;
       }
+      final var future =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  return MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
+                } catch (final IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+              },
+              executor);
+      manifestFutures.add(future);
     }
 
-    LOG.trace("Found {} matching blobs for wildcard {}", matchingBlobIds.size(), wildcard);
-    final var futures =
-        matchingBlobIds.stream()
-            .map(
-                blobId ->
-                    CompletableFuture.supplyAsync(
-                        () -> {
-                          try {
-                            return MAPPER.readValue(client.readAllBytes(blobId), Manifest.class);
-                          } catch (final IOException e) {
-                            throw new UncheckedIOException(e);
-                          }
-                        },
-                        executor));
+    CompletableFuture.allOf(manifestFutures.toArray(CompletableFuture[]::new)).join();
+    LOG.debug(
+        "Found {} matching manifestFutures for wildcard {}", manifestFutures.size(), wildcard);
 
-    final var filtered =
-        futures.map(CompletableFuture::join).filter(m -> wildcard.matches(m.id())).toList();
-    LOG.debug("Found {} matching manifests for wildcard {}", filtered.size(), wildcard);
-    return filtered;
+    return manifestFutures.stream()
+        .map(CompletableFuture::join)
+        .filter(manifest -> wildcard.matches(manifest.id()))
+        .toList();
   }
 
   public void deleteManifest(final Manifest manifest) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -207,18 +207,7 @@ public final class ManifestManager {
         statusFutures.add(CompletableFuture.completedFuture(fromMetadata.get()));
       } else {
         // Fallback: download the manifest for blobs without metadata
-        statusFutures.add(
-            CompletableFuture.supplyAsync(
-                () -> {
-                  try {
-                    final var manifest =
-                        MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
-                    return Manifest.toStatus(manifest);
-                  } catch (final IOException e) {
-                    throw new UncheckedIOException(e);
-                  }
-                },
-                executor));
+        statusFutures.add(downloadManifestStatus(blob));
       }
     }
 
@@ -229,6 +218,20 @@ public final class ManifestManager {
         .map(CompletableFuture::join)
         .filter(status -> wildcard.matches(status.id()))
         .toList();
+  }
+
+  private CompletableFuture<BackupStatus> downloadManifestStatus(final Blob blob) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            final var manifest =
+                MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
+            return Manifest.toStatus(manifest);
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        },
+        executor);
   }
 
   public void deleteManifest(final Manifest manifest) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -24,6 +24,7 @@ import com.google.cloud.storage.StorageException;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
@@ -95,14 +96,12 @@ public final class ManifestManager {
   }
 
   PersistedManifest createInitialManifest(final Backup backup) {
-    final var manifestBlobInfo = manifestBlobInfo(backup.id());
     final var manifest = Manifest.createInProgress(backup);
+    final var blobInfo = manifestBlobInfoWithMetadata(backup.id(), manifest);
     try {
       final var blob =
           client.create(
-              manifestBlobInfo,
-              MAPPER.writeValueAsBytes(manifest),
-              BlobTargetOption.doesNotExist());
+              blobInfo, MAPPER.writeValueAsBytes(manifest), BlobTargetOption.doesNotExist());
       return new PersistedManifest(blob.getGeneration(), manifest);
     } catch (final StorageException e) {
       if (e.getCode() == PRECONDITION_FAILED) { // blob must already exist
@@ -119,7 +118,7 @@ public final class ManifestManager {
     final var completed = persistedManifest.manifest().complete();
     try {
       client.create(
-          manifestBlobInfo(completed.id()),
+          manifestBlobInfoWithMetadata(completed.id(), completed),
           MAPPER.writeValueAsBytes(completed),
           BlobTargetOption.generationMatch(generation));
     } catch (final StorageException e) {
@@ -147,11 +146,11 @@ public final class ManifestManager {
   }
 
   void markAsFailed(final BackupIdentifier id, final String failureReason) {
-    final var blobInfo = manifestBlobInfo(id);
-    final var blob = client.get(blobInfo.getBlobId());
+    final var blob = client.get(manifestBlobInfo(id).getBlobId());
     try {
       if (blob == null) {
         final var failed = Manifest.createFailed(id);
+        final var blobInfo = manifestBlobInfoWithMetadata(id, failed);
         client.create(blobInfo, MAPPER.writeValueAsBytes(failed), BlobTargetOption.doesNotExist());
       } else {
         final var existingManifest = MAPPER.readValue(blob.getContent(), Manifest.class);
@@ -178,45 +177,57 @@ public final class ManifestManager {
     if (existingManifest != updatedManifest) {
       try {
         client.create(
-            manifestBlobInfo(existingManifest.id()), MAPPER.writeValueAsBytes(updatedManifest));
+            manifestBlobInfoWithMetadata(existingManifest.id(), updatedManifest),
+            MAPPER.writeValueAsBytes(updatedManifest));
       } catch (final JsonProcessingException e) {
         throw new RuntimeException(e);
       }
     }
   }
 
-  public Collection<Manifest> listManifests(final BackupIdentifierWildcard wildcard) {
+  /**
+   * Lists backup statuses by reading status information directly from blob custom metadata,
+   * avoiding the need to download each manifest's content. Falls back to downloading the manifest
+   * for blobs that don't have metadata (written by older versions).
+   */
+  public Collection<BackupStatus> listBackupStatuses(final BackupIdentifierWildcard wildcard) {
     final var blobFilter = filterBlobsByWildcard(wildcard);
-    LOG.debug("Searching for matching blobs for wildcard {}", wildcard);
+    LOG.debug("Listing backup statuses for wildcard {}", wildcard);
     final var listing =
         client
             .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
             .iterateAll();
-    final var manifestFutures = new ArrayList<CompletableFuture<Manifest>>();
+    final var statusFutures = new ArrayList<CompletableFuture<BackupStatus>>();
     for (final var blob : listing) {
       if (!blobFilter.test(blob)) {
         continue;
       }
-      final var future =
-          CompletableFuture.supplyAsync(
-              () -> {
-                try {
-                  return MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
-                } catch (final IOException e) {
-                  throw new UncheckedIOException(e);
-                }
-              },
-              executor);
-      manifestFutures.add(future);
+      final var fromMetadata = ManifestMetadata.toBackupStatus(blob, basePath, MANIFEST_BLOB_NAME);
+      if (fromMetadata.isPresent()) {
+        statusFutures.add(CompletableFuture.completedFuture(fromMetadata.get()));
+      } else {
+        // Fallback: download the manifest for blobs without metadata
+        statusFutures.add(
+            CompletableFuture.supplyAsync(
+                () -> {
+                  try {
+                    final var manifest =
+                        MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
+                    return Manifest.toStatus(manifest);
+                  } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                },
+                executor));
+      }
     }
 
-    CompletableFuture.allOf(manifestFutures.toArray(CompletableFuture[]::new)).join();
-    LOG.debug(
-        "Found {} matching manifestFutures for wildcard {}", manifestFutures.size(), wildcard);
+    CompletableFuture.allOf(statusFutures.toArray(CompletableFuture[]::new)).join();
+    LOG.debug("Found {} matching backup statuses for wildcard {}", statusFutures.size(), wildcard);
 
-    return manifestFutures.stream()
+    return statusFutures.stream()
         .map(CompletableFuture::join)
-        .filter(manifest -> wildcard.matches(manifest.id()))
+        .filter(status -> wildcard.matches(status.id()))
         .toList();
   }
 
@@ -234,9 +245,10 @@ public final class ManifestManager {
           case FAILED -> manifest.asFailed().delete();
         };
     if (manifest != deletedManifest) {
-      final var blobInfo = manifestBlobInfo(manifest.id());
       try {
-        client.create(blobInfo, MAPPER.writeValueAsBytes(deletedManifest));
+        client.create(
+            manifestBlobInfoWithMetadata(manifest.id(), deletedManifest),
+            MAPPER.writeValueAsBytes(deletedManifest));
       } catch (final JsonProcessingException e) {
         throw new RuntimeException(e);
       }
@@ -248,6 +260,17 @@ public final class ManifestManager {
         MANIFEST_PATH_FORMAT.formatted(
             basePath, id.partitionId(), id.checkpointId(), id.nodeId(), MANIFEST_BLOB_NAME);
     return BlobInfo.newBuilder(bucketInfo, blobName).setContentType("application/json").build();
+  }
+
+  private BlobInfo manifestBlobInfoWithMetadata(
+      final BackupIdentifier id, final Manifest manifest) {
+    final var blobName =
+        MANIFEST_PATH_FORMAT.formatted(
+            basePath, id.partitionId(), id.checkpointId(), id.nodeId(), MANIFEST_BLOB_NAME);
+    return BlobInfo.newBuilder(bucketInfo, blobName)
+        .setContentType("application/json")
+        .setMetadata(ManifestMetadata.fromManifest(manifest))
+        .build();
   }
 
   /**

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import com.google.cloud.storage.Blob;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * Converts backup manifest information to and from GCS blob custom metadata. This allows listing
+ * backup statuses without downloading the manifest content, eliminating one GET request per backup.
+ */
+final class ManifestMetadata {
+
+  static final String STATUS_CODE = "status-code";
+  static final String FAILURE_REASON = "failure-reason";
+  static final String CREATED_AT = "created-at";
+  static final String MODIFIED_AT = "modified-at";
+  static final String SNAPSHOT_ID = "snapshot-id";
+  static final String FIRST_LOG_POSITION = "first-log-position";
+  static final String CHECKPOINT_POSITION = "checkpoint-position";
+  static final String NUMBER_OF_PARTITIONS = "number-of-partitions";
+  static final String BROKER_VERSION = "broker-version";
+  static final String CHECKPOINT_TIMESTAMP = "checkpoint-timestamp";
+  static final String CHECKPOINT_TYPE = "checkpoint-type";
+
+  private ManifestMetadata() {}
+
+  static Map<String, String> fromManifest(final Manifest manifest) {
+    final var metadata = new HashMap<String, String>();
+    metadata.put(STATUS_CODE, manifest.statusCode().name());
+
+    if (manifest.createdAt() != null) {
+      metadata.put(CREATED_AT, manifest.createdAt().toString());
+    }
+    if (manifest.modifiedAt() != null) {
+      metadata.put(MODIFIED_AT, manifest.modifiedAt().toString());
+    }
+
+    if (manifest.statusCode() == Manifest.StatusCode.FAILED) {
+      final var failureReason = manifest.asFailed().failureReason();
+      if (failureReason != null) {
+        metadata.put(FAILURE_REASON, failureReason);
+      }
+    }
+
+    final var descriptor = manifest.descriptor();
+    if (descriptor != null) {
+      descriptor.snapshotId().ifPresent(id -> metadata.put(SNAPSHOT_ID, id));
+      final var firstLogPos = descriptor.firstLogPosition();
+      if (firstLogPos.isPresent()) {
+        metadata.put(FIRST_LOG_POSITION, Long.toString(firstLogPos.getAsLong()));
+      }
+      metadata.put(CHECKPOINT_POSITION, Long.toString(descriptor.checkpointPosition()));
+      metadata.put(NUMBER_OF_PARTITIONS, Integer.toString(descriptor.numberOfPartitions()));
+      metadata.put(BROKER_VERSION, descriptor.brokerVersion());
+      if (descriptor.checkpointTimestamp() != null) {
+        metadata.put(CHECKPOINT_TIMESTAMP, descriptor.checkpointTimestamp().toString());
+      }
+      if (descriptor.checkpointType() != null) {
+        metadata.put(CHECKPOINT_TYPE, descriptor.checkpointType().name());
+      }
+    }
+
+    return metadata;
+  }
+
+  /**
+   * Reconstructs a {@link BackupStatus} from the GCS blob's custom metadata and path. The blob path
+   * encodes the backup identifier (partitionId/checkpointId/nodeId).
+   *
+   * @return the backup status, or empty if the blob has no status metadata (e.g. written by an
+   *     older version)
+   */
+  static Optional<BackupStatus> toBackupStatus(
+      final Blob blob, final String basePath, final String manifestBlobName) {
+    final var metadata = blob.getMetadata();
+    if (metadata == null || !metadata.containsKey(STATUS_CODE)) {
+      return Optional.empty();
+    }
+
+    final var id = parseIdentifierFromPath(blob.getName(), basePath, manifestBlobName);
+    final var statusCode = BackupStatusCode.valueOf(metadata.get(STATUS_CODE));
+    final var failureReason = Optional.ofNullable(metadata.get(FAILURE_REASON));
+    final var created = Optional.ofNullable(metadata.get(CREATED_AT)).map(Instant::parse);
+    final var modified = Optional.ofNullable(metadata.get(MODIFIED_AT)).map(Instant::parse);
+    final var descriptor = parseDescriptor(metadata);
+
+    return Optional.of(
+        new BackupStatusImpl(id, descriptor, statusCode, failureReason, created, modified));
+  }
+
+  private static BackupIdentifier parseIdentifierFromPath(
+      final String blobName, final String basePath, final String manifestBlobName) {
+    // Path format: {basePath}manifests/{partitionId}/{checkpointId}/{nodeId}/manifest.json
+    final var manifestsPrefix = basePath + "manifests/";
+    final var relativePath =
+        blobName.substring(manifestsPrefix.length(), blobName.length() - manifestBlobName.length());
+    // relativePath is now: {partitionId}/{checkpointId}/{nodeId}/
+    final var parts = relativePath.split("/");
+    return new BackupIdentifierImpl(
+        Integer.parseInt(parts[2]), Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+  }
+
+  private static Optional<BackupDescriptor> parseDescriptor(final Map<String, String> metadata) {
+    final var checkpointPositionStr = metadata.get(CHECKPOINT_POSITION);
+    if (checkpointPositionStr == null) {
+      return Optional.empty();
+    }
+
+    final var checkpointType =
+        Optional.ofNullable(metadata.get(CHECKPOINT_TYPE))
+            .map(CheckpointType::valueOf)
+            .orElse(CheckpointType.MANUAL_BACKUP);
+
+    return Optional.of(
+        new BackupDescriptorImpl(
+            Optional.ofNullable(metadata.get(SNAPSHOT_ID)),
+            metadata.containsKey(FIRST_LOG_POSITION)
+                ? OptionalLong.of(Long.parseLong(metadata.get(FIRST_LOG_POSITION)))
+                : OptionalLong.empty(),
+            Long.parseLong(checkpointPositionStr),
+            Integer.parseInt(metadata.get(NUMBER_OF_PARTITIONS)),
+            metadata.get(BROKER_VERSION),
+            Optional.ofNullable(metadata.get(CHECKPOINT_TIMESTAMP))
+                .map(Instant::parse)
+                .orElse(null),
+            checkpointType));
+  }
+}

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
+import java.util.concurrent.Executors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,9 @@ final class ManifestManagerTest {
   void shouldCreateInitialManifest() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -68,7 +71,9 @@ final class ManifestManagerTest {
   void shouldCompleteManifest() throws IOException {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -108,7 +113,9 @@ final class ManifestManagerTest {
   void shouldThrowWhenManifestAlreadyExists() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -131,7 +138,9 @@ final class ManifestManagerTest {
   void shouldThrowWhenUnexpectedStorageExceptionOccurs() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -154,7 +163,9 @@ final class ManifestManagerTest {
   void shouldThrowWhenManifestChangedBeforeCompletion() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -186,7 +197,9 @@ final class ManifestManagerTest {
   void shouldThrowWhenCompletingManifestThrowsUnexpectedStorageException() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -220,7 +233,9 @@ final class ManifestManagerTest {
     void shouldMarkInProgressManifestAsDeleted() throws IOException {
       // given
       final var client = Mockito.mock(Storage.class);
-      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var manager =
+          new ManifestManager(
+              client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
       final var backup =
           new BackupImpl(
               new BackupIdentifierImpl(1, 2, 3),
@@ -252,7 +267,9 @@ final class ManifestManagerTest {
     void shouldMarkCompletedManifestAsDeleted() throws IOException {
       // given
       final var client = Mockito.mock(Storage.class);
-      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var manager =
+          new ManifestManager(
+              client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
       final var backup =
           new BackupImpl(
               new BackupIdentifierImpl(1, 2, 3),
@@ -284,7 +301,9 @@ final class ManifestManagerTest {
     void shouldMarkFailedManifestAsDeleted() throws IOException {
       // given
       final var client = Mockito.mock(Storage.class);
-      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var manager =
+          new ManifestManager(
+              client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
       final var backup =
           new BackupImpl(
               new BackupIdentifierImpl(1, 2, 3),
@@ -316,7 +335,9 @@ final class ManifestManagerTest {
     void shouldNotUpdateAlreadyDeletedManifest() throws IOException {
       // given
       final var client = Mockito.mock(Storage.class);
-      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var manager =
+          new ManifestManager(
+              client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
       final var backup =
           new BackupImpl(
               new BackupIdentifierImpl(1, 2, 3),

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataPropertyTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataPropertyTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.storage.Blob;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
+import java.util.Map;
+import java.util.OptionalLong;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.mockito.Mockito;
+
+final class ManifestMetadataPropertyTest {
+
+  private static final String BASE_PATH = "base/";
+  private static final String MANIFEST_BLOB_NAME = "manifest.json";
+
+  @Property(tries = 100)
+  void shouldRoundTripAnyManifest(@ForAll("manifests") final Manifest manifest) {
+    // given
+    final var expectedStatus = Manifest.toStatus(manifest);
+    final var id = manifest.id();
+    final var blobName =
+        BASE_PATH
+            + "manifests/"
+            + id.partitionId()
+            + "/"
+            + id.checkpointId()
+            + "/"
+            + id.nodeId()
+            + "/"
+            + MANIFEST_BLOB_NAME;
+
+    // when
+    final var metadata = ManifestMetadata.fromManifest(manifest);
+    final var blob = Mockito.mock(Blob.class);
+    Mockito.when(blob.getName()).thenReturn(blobName);
+    Mockito.when(blob.getMetadata()).thenReturn(metadata);
+    final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+    // then
+    assertThat(result).isPresent();
+    final var status = result.get();
+    assertThat(status.statusCode()).isEqualTo(expectedStatus.statusCode());
+    assertThat(status.id().nodeId()).isEqualTo(id.nodeId());
+    assertThat(status.id().partitionId()).isEqualTo(id.partitionId());
+    assertThat(status.id().checkpointId()).isEqualTo(id.checkpointId());
+    assertThat(status.failureReason()).isEqualTo(expectedStatus.failureReason());
+    assertThat(status.created()).isEqualTo(expectedStatus.created());
+    assertThat(status.lastModified()).isEqualTo(expectedStatus.lastModified());
+
+    if (expectedStatus.descriptor().isPresent()) {
+      assertThat(status.descriptor()).isPresent();
+      final var desc = status.descriptor().get();
+      final var expectedDesc = expectedStatus.descriptor().get();
+      assertThat(desc.snapshotId()).isEqualTo(expectedDesc.snapshotId());
+      assertThat(desc.firstLogPosition()).isEqualTo(expectedDesc.firstLogPosition());
+      assertThat(desc.checkpointPosition()).isEqualTo(expectedDesc.checkpointPosition());
+      assertThat(desc.numberOfPartitions()).isEqualTo(expectedDesc.numberOfPartitions());
+      assertThat(desc.brokerVersion()).isEqualTo(expectedDesc.brokerVersion());
+      assertThat(desc.checkpointTimestamp()).isEqualTo(expectedDesc.checkpointTimestamp());
+      assertThat(desc.checkpointType()).isEqualTo(expectedDesc.checkpointType());
+    } else {
+      assertThat(status.descriptor()).isEmpty();
+    }
+  }
+
+  @Provide
+  Arbitrary<Manifest> manifests() {
+    return backups()
+        .flatMap(
+            backup -> {
+              final var inProgress = Manifest.createInProgress(backup);
+              return Arbitraries.of("IN_PROGRESS", "COMPLETED", "FAILED", "DELETED")
+                  .map(
+                      state ->
+                          switch (state) {
+                            case "IN_PROGRESS" -> inProgress;
+                            case "COMPLETED" -> inProgress.complete();
+                            case "FAILED" -> inProgress.fail("test failure reason");
+                            case "DELETED" -> inProgress.complete().delete();
+                            default -> throw new IllegalStateException();
+                          });
+            });
+  }
+
+  Arbitrary<BackupImpl> backups() {
+    return Combinators.combine(identifiers(), descriptors())
+        .as(
+            (id, descriptor) ->
+                new BackupImpl(
+                    id,
+                    descriptor,
+                    new NamedFileSetImpl(Map.of()),
+                    new NamedFileSetImpl(Map.of())));
+  }
+
+  Arbitrary<BackupIdentifierImpl> identifiers() {
+    return Combinators.combine(
+            Arbitraries.integers().between(0, 100),
+            Arbitraries.integers().between(1, 64),
+            Arbitraries.longs().between(1L, 1_000_000L))
+        .as(BackupIdentifierImpl::new);
+  }
+
+  Arbitrary<BackupDescriptorImpl> descriptors() {
+    return Combinators.combine(
+            Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10).optional(),
+            Arbitraries.longs().between(0L, 1_000_000L).optional(),
+            Arbitraries.longs().between(0L, 1_000_000L),
+            Arbitraries.integers().between(1, 32),
+            Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(20),
+            Arbitraries.longs()
+                .between(
+                    Instant.parse("2020-01-01T00:00:00Z").getEpochSecond(),
+                    Instant.parse("2030-01-01T00:00:00Z").getEpochSecond())
+                .map(Instant::ofEpochSecond),
+            Arbitraries.of(CheckpointType.values()))
+        .as(
+            (snapshotId, firstLogPos, checkpointPos, partitions, version, timestamp, type) ->
+                new BackupDescriptorImpl(
+                    snapshotId,
+                    firstLogPos.map(OptionalLong::of).orElse(OptionalLong.empty()),
+                    checkpointPos,
+                    partitions,
+                    version,
+                    timestamp,
+                    type));
+  }
+}

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataTest.java
@@ -1,0 +1,537 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.storage.Blob;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+final class ManifestMetadataTest {
+
+  private static final String BASE_PATH = "my-prefix/";
+  private static final String MANIFEST_BLOB_NAME = "manifest.json";
+
+  private static BackupImpl createBackup(
+      final int nodeId, final int partitionId, final long checkpointId) {
+    return new BackupImpl(
+        new BackupIdentifierImpl(nodeId, partitionId, checkpointId),
+        new BackupDescriptorImpl(
+            Optional.of("snap-1"),
+            OptionalLong.of(100L),
+            500L,
+            3,
+            "8.5.0",
+            Instant.parse("2025-01-15T10:30:00Z"),
+            CheckpointType.MANUAL_BACKUP),
+        new NamedFileSetImpl(Map.of("file1", Path.of("f1"))),
+        new NamedFileSetImpl(Map.of("seg1", Path.of("s1"))));
+  }
+
+  private static BackupImpl createBackupWithMinimalDescriptor(
+      final int nodeId, final int partitionId, final long checkpointId) {
+    return new BackupImpl(
+        new BackupIdentifierImpl(nodeId, partitionId, checkpointId),
+        new BackupDescriptorImpl(
+            Optional.empty(), OptionalLong.empty(), 500L, 3, "8.5.0", null, null),
+        new NamedFileSetImpl(Map.of()),
+        new NamedFileSetImpl(Map.of()));
+  }
+
+  private static String blobPath(final int partitionId, final long checkpointId, final int nodeId) {
+    return BASE_PATH
+        + "manifests/"
+        + partitionId
+        + "/"
+        + checkpointId
+        + "/"
+        + nodeId
+        + "/"
+        + MANIFEST_BLOB_NAME;
+  }
+
+  private static Blob mockBlob(final String name, final Map<String, String> metadata) {
+    final var blob = Mockito.mock(Blob.class);
+    Mockito.when(blob.getName()).thenReturn(name);
+    Mockito.when(blob.getMetadata()).thenReturn(metadata);
+    return blob;
+  }
+
+  @Nested
+  class FromManifest {
+
+    @Test
+    void shouldIncludeStatusCodeForInProgressManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata).containsEntry(ManifestMetadata.STATUS_CODE, "IN_PROGRESS");
+    }
+
+    @Test
+    void shouldIncludeStatusCodeForCompletedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).complete();
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata).containsEntry(ManifestMetadata.STATUS_CODE, "COMPLETED");
+    }
+
+    @Test
+    void shouldIncludeFailureReasonForFailedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).fail("disk full");
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .containsEntry(ManifestMetadata.STATUS_CODE, "FAILED")
+          .containsEntry(ManifestMetadata.FAILURE_REASON, "disk full");
+    }
+
+    @Test
+    void shouldIncludeStatusCodeForDeletedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).complete().delete();
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata).containsEntry(ManifestMetadata.STATUS_CODE, "DELETED");
+    }
+
+    @Test
+    void shouldIncludeAllDescriptorFields() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .containsEntry(ManifestMetadata.SNAPSHOT_ID, "snap-1")
+          .containsEntry(ManifestMetadata.FIRST_LOG_POSITION, "100")
+          .containsEntry(ManifestMetadata.CHECKPOINT_POSITION, "500")
+          .containsEntry(ManifestMetadata.NUMBER_OF_PARTITIONS, "3")
+          .containsEntry(ManifestMetadata.BROKER_VERSION, "8.5.0")
+          .containsEntry(ManifestMetadata.CHECKPOINT_TIMESTAMP, "2025-01-15T10:30:00Z")
+          .containsEntry(ManifestMetadata.CHECKPOINT_TYPE, "MANUAL_BACKUP");
+    }
+
+    @Test
+    void shouldOmitOptionalDescriptorFieldsWhenAbsent() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackupWithMinimalDescriptor(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .doesNotContainKey(ManifestMetadata.SNAPSHOT_ID)
+          .doesNotContainKey(ManifestMetadata.FIRST_LOG_POSITION)
+          .doesNotContainKey(ManifestMetadata.CHECKPOINT_TIMESTAMP)
+          .doesNotContainKey(ManifestMetadata.CHECKPOINT_TYPE)
+          .containsEntry(ManifestMetadata.CHECKPOINT_POSITION, "500")
+          .containsEntry(ManifestMetadata.NUMBER_OF_PARTITIONS, "3");
+    }
+
+    @Test
+    void shouldIncludeCreatedAndModifiedTimestamps() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .containsKey(ManifestMetadata.CREATED_AT)
+          .containsKey(ManifestMetadata.MODIFIED_AT);
+      assertThat(Instant.parse(metadata.get(ManifestMetadata.CREATED_AT))).isNotNull();
+      assertThat(Instant.parse(metadata.get(ManifestMetadata.MODIFIED_AT))).isNotNull();
+    }
+
+    @Test
+    void shouldNotIncludeFailureReasonForNonFailedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).complete();
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata).doesNotContainKey(ManifestMetadata.FAILURE_REASON);
+    }
+
+    @Test
+    void shouldOmitDescriptorFieldsWhenDescriptorIsNull() {
+      // given
+      final var manifest = Manifest.createFailed(new BackupIdentifierImpl(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .containsEntry(ManifestMetadata.STATUS_CODE, "FAILED")
+          .doesNotContainKey(ManifestMetadata.CHECKPOINT_POSITION)
+          .doesNotContainKey(ManifestMetadata.BROKER_VERSION);
+    }
+  }
+
+  @Nested
+  class ToBackupStatus {
+
+    @Test
+    void shouldReturnEmptyWhenMetadataIsNull() {
+      // given
+      final var blob = mockBlob(blobPath(2, 3, 1), null);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenStatusCodeIsMissing() {
+      // given
+      final var blob = mockBlob(blobPath(2, 3, 1), Map.of("some-key", "some-value"));
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldParseCompletedStatusAndIdentifier() {
+      // given
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "COMPLETED",
+              ManifestMetadata.CHECKPOINT_POSITION, "500",
+              ManifestMetadata.NUMBER_OF_PARTITIONS, "3",
+              ManifestMetadata.BROKER_VERSION, "8.5.0");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
+      assertThat(status.id().partitionId()).isEqualTo(2);
+      assertThat(status.id().checkpointId()).isEqualTo(3L);
+      assertThat(status.id().nodeId()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldParseFailedStatusWithReason() {
+      // given
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "FAILED",
+              ManifestMetadata.FAILURE_REASON, "disk full");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(BackupStatusCode.FAILED);
+      assertThat(status.failureReason()).isEqualTo(Optional.of("disk full"));
+    }
+
+    @Test
+    void shouldParseCreatedAndModifiedTimestamps() {
+      // given
+      final var createdAt = Instant.parse("2025-01-15T10:00:00Z");
+      final var modifiedAt = Instant.parse("2025-01-15T11:00:00Z");
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "COMPLETED",
+              ManifestMetadata.CREATED_AT, createdAt.toString(),
+              ManifestMetadata.MODIFIED_AT, modifiedAt.toString());
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().created()).isEqualTo(Optional.of(createdAt));
+      assertThat(result.get().lastModified()).isEqualTo(Optional.of(modifiedAt));
+    }
+
+    @Test
+    void shouldReturnEmptyDescriptorWhenCheckpointPositionIsMissing() {
+      // given
+      final var metadata = Map.of(ManifestMetadata.STATUS_CODE, "IN_PROGRESS");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().descriptor()).isEmpty();
+    }
+
+    @Test
+    void shouldParseFullDescriptor() {
+      // given
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "COMPLETED",
+              ManifestMetadata.SNAPSHOT_ID, "snap-1",
+              ManifestMetadata.FIRST_LOG_POSITION, "100",
+              ManifestMetadata.CHECKPOINT_POSITION, "500",
+              ManifestMetadata.NUMBER_OF_PARTITIONS, "3",
+              ManifestMetadata.BROKER_VERSION, "8.5.0",
+              ManifestMetadata.CHECKPOINT_TIMESTAMP, "2025-01-15T10:30:00Z",
+              ManifestMetadata.CHECKPOINT_TYPE, "MANUAL_BACKUP");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var descriptor = result.get().descriptor();
+      assertThat(descriptor).isPresent();
+      assertThat(descriptor.get().snapshotId()).isEqualTo(Optional.of("snap-1"));
+      assertThat(descriptor.get().firstLogPosition()).isEqualTo(OptionalLong.of(100L));
+      assertThat(descriptor.get().checkpointPosition()).isEqualTo(500L);
+      assertThat(descriptor.get().numberOfPartitions()).isEqualTo(3);
+      assertThat(descriptor.get().brokerVersion()).isEqualTo("8.5.0");
+      assertThat(descriptor.get().checkpointTimestamp())
+          .isEqualTo(Instant.parse("2025-01-15T10:30:00Z"));
+      assertThat(descriptor.get().checkpointType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    }
+
+    @Test
+    void shouldDefaultCheckpointTypeToManualBackupWhenMissing() {
+      // given
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "COMPLETED",
+              ManifestMetadata.CHECKPOINT_POSITION, "500",
+              ManifestMetadata.NUMBER_OF_PARTITIONS, "3",
+              ManifestMetadata.BROKER_VERSION, "8.5.0");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().descriptor()).isPresent();
+      assertThat(result.get().descriptor().get().checkpointType())
+          .isEqualTo(CheckpointType.MANUAL_BACKUP);
+    }
+  }
+
+  @Nested
+  class PathParsing {
+
+    @Test
+    void shouldParseIdentifierFromPathWithBasePath() {
+      // given
+      final var metadata = Map.of(ManifestMetadata.STATUS_CODE, "COMPLETED");
+      final var blob = mockBlob("my-prefix/manifests/4/1000/2/manifest.json", metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, "my-prefix/", MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().id().partitionId()).isEqualTo(4);
+      assertThat(result.get().id().checkpointId()).isEqualTo(1000L);
+      assertThat(result.get().id().nodeId()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldParseIdentifierFromPathWithoutBasePath() {
+      // given
+      final var metadata = Map.of(ManifestMetadata.STATUS_CODE, "COMPLETED");
+      final var blob = mockBlob("manifests/1/99/0/manifest.json", metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, "", MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().id().partitionId()).isEqualTo(1);
+      assertThat(result.get().id().checkpointId()).isEqualTo(99L);
+      assertThat(result.get().id().nodeId()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldParseIdentifierWithLargeValues() {
+      // given
+      final var metadata = Map.of(ManifestMetadata.STATUS_CODE, "IN_PROGRESS");
+      final var blob = mockBlob(BASE_PATH + "manifests/100/9999999999/50/manifest.json", metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().id().partitionId()).isEqualTo(100);
+      assertThat(result.get().id().checkpointId()).isEqualTo(9999999999L);
+      assertThat(result.get().id().nodeId()).isEqualTo(50);
+    }
+  }
+
+  @Nested
+  class RoundTrip {
+
+    @Test
+    void shouldRoundTripCompletedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).complete();
+      final var expectedStatus = Manifest.toStatus(manifest);
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(expectedStatus.statusCode());
+      assertThat(status.id().nodeId()).isEqualTo(expectedStatus.id().nodeId());
+      assertThat(status.id().partitionId()).isEqualTo(expectedStatus.id().partitionId());
+      assertThat(status.id().checkpointId()).isEqualTo(expectedStatus.id().checkpointId());
+      assertThat(status.failureReason()).isEqualTo(expectedStatus.failureReason());
+      assertThat(status.created()).isEqualTo(expectedStatus.created());
+      assertThat(status.lastModified()).isEqualTo(expectedStatus.lastModified());
+      assertThat(status.descriptor()).isPresent();
+      final var desc = status.descriptor().get();
+      final var expectedDesc = expectedStatus.descriptor().get();
+      assertThat(desc.snapshotId()).isEqualTo(expectedDesc.snapshotId());
+      assertThat(desc.firstLogPosition()).isEqualTo(expectedDesc.firstLogPosition());
+      assertThat(desc.checkpointPosition()).isEqualTo(expectedDesc.checkpointPosition());
+      assertThat(desc.numberOfPartitions()).isEqualTo(expectedDesc.numberOfPartitions());
+      assertThat(desc.brokerVersion()).isEqualTo(expectedDesc.brokerVersion());
+      assertThat(desc.checkpointTimestamp()).isEqualTo(expectedDesc.checkpointTimestamp());
+      assertThat(desc.checkpointType()).isEqualTo(expectedDesc.checkpointType());
+    }
+
+    @Test
+    void shouldRoundTripInProgressManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(5, 10, 42));
+      final var expectedStatus = Manifest.toStatus(manifest);
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(10, 42, 5), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(BackupStatusCode.IN_PROGRESS);
+      assertThat(status.id().nodeId()).isEqualTo(expectedStatus.id().nodeId());
+      assertThat(status.id().partitionId()).isEqualTo(expectedStatus.id().partitionId());
+      assertThat(status.id().checkpointId()).isEqualTo(expectedStatus.id().checkpointId());
+      assertThat(status.descriptor()).isPresent();
+    }
+
+    @Test
+    void shouldRoundTripFailedManifestWithReason() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(0, 1, 7)).fail("out of space");
+      final var expectedStatus = Manifest.toStatus(manifest);
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(1, 7, 0), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(BackupStatusCode.FAILED);
+      assertThat(status.failureReason()).isEqualTo(Optional.of("out of space"));
+      assertThat(status.created()).isEqualTo(expectedStatus.created());
+      assertThat(status.lastModified()).isEqualTo(expectedStatus.lastModified());
+    }
+
+    @Test
+    void shouldRoundTripDeletedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(2, 3, 99)).complete().delete();
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(3, 99, 2), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().statusCode()).isEqualTo(BackupStatusCode.DELETED);
+    }
+
+    @Test
+    void shouldRoundTripManifestWithMinimalDescriptor() {
+      // given
+      final var manifest =
+          Manifest.createInProgress(createBackupWithMinimalDescriptor(1, 2, 3)).complete();
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var descriptor = result.get().descriptor();
+      assertThat(descriptor).isPresent();
+      assertThat(descriptor.get().snapshotId()).isEmpty();
+      assertThat(descriptor.get().firstLogPosition()).isEmpty();
+      assertThat(descriptor.get().checkpointPosition()).isEqualTo(500L);
+      assertThat(descriptor.get().checkpointTimestamp()).isNull();
+      assertThat(descriptor.get().checkpointType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    }
+  }
+}

--- a/zeebe/backup-stores/gcs/src/test/resources/log4j2-test.xml
+++ b/zeebe/backup-stores/gcs/src/test/resources/log4j2-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%X] [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda.zeebe" level="trace"/>
+    <Logger name="com.google" level="debug"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider;
 import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider.WildcardTestParameter;
@@ -23,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -72,6 +74,45 @@ public interface ListingBackups {
     assertThat(result)
         .map(BackupStatus::id)
         .containsExactlyInAnyOrderElementsOf(parameter.expectedIds());
+  }
+
+  @Test
+  default void canListManyBackups() throws IOException {
+    // given
+    final int backupCount = 2_000;
+    final var ids =
+        IntStream.rangeClosed(1, backupCount)
+            .mapToObj(i -> new BackupIdentifierImpl(1, 1, i))
+            .toList();
+    final var backupTemplate = getBackup(ids.getFirst());
+
+    CompletableFuture.allOf(
+            ids.stream()
+                .map(
+                    id ->
+                        getStore()
+                            .save(
+                                new BackupImpl(
+                                    id,
+                                    backupTemplate.descriptor(),
+                                    backupTemplate.snapshot(),
+                                    backupTemplate.segments())))
+                .toArray(CompletableFuture[]::new))
+        .join();
+
+    // when
+    final var status =
+        getStore()
+            .list(
+                new BackupIdentifierWildcardImpl(
+                    Optional.empty(), Optional.of(1), CheckpointPattern.any()));
+
+    // then
+    assertThat(status)
+        // Deliberately a lower timeout than the default response timeout of 15 seconds.
+        // If this is not enough, we might need to improve the implementation.
+        .succeedsWithin(Duration.ofSeconds(10))
+        .satisfies(statuses -> assertThat(statuses).hasSize(backupCount));
   }
 
   default Backup getBackup(final BackupIdentifierImpl id) throws IOException {


### PR DESCRIPTION
This pull request introduces significant improvements to concurrency control and efficiency in the Azure and GCS backup stores, as well as adds test dependencies and logging configuration for better observability and testing. The most notable changes include the introduction of semaphores and locks to manage concurrent operations and prevent race conditions, optimization of backup status listing in GCS by leveraging blob metadata, and the addition of new test resources and dependencies.

**Concurrency and Thread Safety Improvements:**

* Introduced a `Semaphore` (`saveSemaphore`) in `AzureBackupStore` to limit the maximum number of concurrent backup saves to 128, preventing resource exhaustion during high-concurrency operations.
* Added `ReentrantLock`-based locking to the container creation logic in `AzureBackupStore`, `FileSetManager`, and `ManifestManager` to ensure thread-safe, idempotent creation of Azure Blob containers.

**Efficiency and API Improvements in GCS Backup Store:**

* Refactored `ManifestManager` in GCS to provide a new `listBackupStatuses` method, which lists backup statuses using blob metadata when available, falling back to downloading manifests only when necessary. This improves performance for large numbers of backups.
* Updated `GcsBackupStore` to use the new `listBackupStatuses` method for listing backups, and passed the executor to `ManifestManager` for parallel operations.

**Test and Build Configuration:**

* Added `jqwik` (property-based testing) and `junit-jupiter-engine` dependencies to the GCS backup store module to enhance testing capabilities.
* Added `log4j2-test.xml` configuration files for both Azure and filesystem backup stores to improve logging during tests.

**Other Code Quality Improvements:**

* Refactored manifest creation and update logic in GCS to consistently use blob metadata, enhancing maintainability and future extensibility.

These changes collectively strengthen the reliability, scalability, and observability of the backup store implementations.This pull request introduces several improvements to the Azure and GCS backup store implementations, focusing on thread safety, concurrency control, and improved logging and testing. The most important changes are grouped below:

**Concurrency and Thread Safety Enhancements (Azure backup store):**

* Introduced a `Semaphore` (`saveSemaphore`) to limit the maximum number of concurrent backup save operations to 128 in `AzureBackupStore`, preventing resource exhaustion during high concurrency. 
* Added `ReentrantLock` and `volatile` usage to ensure thread-safe creation of blob containers in `AzureBackupStore`, `FileSetManager`, and `ManifestManager`, preventing race conditions during container creation.

**Performance and Parallelism Improvements (GCS backup store):**

* Refactored `ManifestManager` in the GCS backup store to use an `ExecutorService` for parallel loading and filtering of manifests, improving performance when listing many manifests.

**Logging and Observability:**

* Added detailed debug and trace logging in the GCS `ManifestManager` to aid in troubleshooting and monitoring backup operations.
* Added `log4j2-test.xml` configuration files for both Azure and filesystem backup store tests to standardize and improve logging output during test runs.