### PR TITLE
test: Migrate modifications.spec.ts to oc test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -68,6 +68,22 @@ class OperateProcessInstancePage {
   readonly incidentsViewHeader: Locator;
   readonly viewAllChildProcessesLink: Locator;
   readonly variableCellByName: (name: string | RegExp) => Locator;
+  readonly getVariableRow: (variableName: string) => Locator;
+  readonly getEditVariableFieldSelector: (variableName: string) => Locator;
+  readonly getNewVariableNameFieldSelector: (variableName: string) => Locator;
+  readonly getNewVariableValueFieldSelector: (variableName: string) => Locator;
+  readonly getLastModificationLabel: (pattern: string | RegExp) => Locator;
+  readonly getModificationSummaryItem: (text: string | RegExp) => Locator;
+  readonly getNthDeleteVariableModificationButtonInSummary: (
+    index: number,
+  ) => Locator;
+  readonly modificationModeText: Locator;
+  readonly lastModificationFooter: Locator;
+  readonly noVariablesText: Locator;
+  readonly applyModificationsButton: Locator;
+  readonly deleteVariableModificationButton: Locator;
+  readonly cancelModificationSummaryButton: Locator;
+  readonly undoButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -175,6 +191,44 @@ class OperateProcessInstancePage {
     this.viewAllChildProcessesLink = this.instanceHeader.getByRole('link', {
       name: 'View all',
     });
+    this.getVariableRow = (variableName: string) =>
+      page.getByTestId(`variable-${variableName}`);
+    this.getEditVariableFieldSelector = (variableName: string) =>
+      page
+        .getByTestId(`variable-${variableName}`)
+        .getByRole('textbox', {name: /value/i});
+    this.getNewVariableNameFieldSelector = (variableName: string) =>
+      page
+        .getByTestId(`variable-${variableName}`)
+        .getByTestId('new-variable-name');
+    this.getNewVariableValueFieldSelector = (variableName: string) =>
+      page
+        .getByTestId(`variable-${variableName}`)
+        .getByTestId('new-variable-value');
+    this.getLastModificationLabel = (pattern: string | RegExp) =>
+      page.getByText(pattern);
+    this.getModificationSummaryItem = (text: string | RegExp) =>
+      page.getByRole('dialog').getByText(text);
+    this.getNthDeleteVariableModificationButtonInSummary = (index: number) =>
+      page
+        .getByRole('dialog')
+        .getByRole('button', {name: 'Delete variable modification'})
+        .nth(index);
+    this.modificationModeText = page.getByText(
+      'Process Instance Modification Mode',
+    );
+    this.lastModificationFooter = page.getByText('Last added modification:');
+    this.noVariablesText = page.getByText(/The Flow Node has no Variables/i);
+    this.applyModificationsButton = page.getByRole('button', {
+      name: /apply modifications/i,
+    });
+    this.deleteVariableModificationButton = page.getByRole('button', {
+      name: /delete variable modification/i,
+    });
+    this.cancelModificationSummaryButton = page
+      .getByRole('dialog')
+      .getByRole('button', {name: 'Cancel'});
+    this.undoButton = page.getByRole('button', {name: /undo/i});
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -323,6 +377,65 @@ class OperateProcessInstancePage {
 
   async toggleExecutionCount(): Promise<void> {
     await this.executionCountToggleButton.click();
+  }
+
+  async undoModification(): Promise<void> {
+    await this.undoButton.click();
+  }
+
+  async enterModificationMode(): Promise<void> {
+    await this.modifyInstanceButton.click();
+  }
+
+  async clickApplyModificationsButton(): Promise<void> {
+    await this.applyModificationsButton.click();
+  }
+
+  async clickDeleteVariableModification(): Promise<void> {
+    await this.deleteVariableModificationButton.click();
+  }
+
+  async cancelModificationSummary(): Promise<void> {
+    await this.cancelModificationSummaryButton.click();
+  }
+
+  async clickAddVariableInModificationMode(): Promise<void> {
+    await this.addVariableButton.click();
+  }
+
+  async pressTab(): Promise<void> {
+    await this.page.keyboard.press('Tab');
+  }
+
+  async assertAndEnterModificationMode(): Promise<void> {
+    await expect(this.getVariableRow('foo')).toBeVisible();
+    await this.enterModificationMode();
+    await expect(this.modificationModeText).toBeVisible();
+  }
+
+  async editExistingVariable(name: string, value: string): Promise<void> {
+    await this.getEditVariableFieldSelector(name).clear();
+    await this.getEditVariableFieldSelector(name).fill(value);
+    await this.pressTab();
+  }
+
+  async assertLastModificationIs(label: string | RegExp): Promise<void> {
+    await expect(this.lastModificationFooter).toBeVisible();
+    await expect(this.getLastModificationLabel(label)).toBeVisible();
+  }
+
+  async addNewVariableInModificationMode(
+    rowKey: string,
+    name: string,
+    value: string,
+  ): Promise<void> {
+    await this.clickAddVariableInModificationMode();
+    await expect(this.getVariableRow(rowKey)).toBeVisible();
+    await this.getNewVariableNameFieldSelector(rowKey).clear();
+    await this.getNewVariableNameFieldSelector(rowKey).fill(name);
+    await this.pressTab();
+    await this.getNewVariableValueFieldSelector(rowKey).fill(value);
+    await this.pressTab();
   }
 
   async verifyExecutionCountBadgesNotVisible(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processInstanceModifications_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processInstanceModifications_v_1.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="processInstanceModifications" name="Process Instance Modifications" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverFails" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="neverFails" targetRef="end" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverFails" name="Never fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processInstanceModifications">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="502" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint x="602" y="120" />
+        <di:waypoint x="867" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverFails">
+        <dc:Bounds x="502" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -1,0 +1,337 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp, hideModificationHelperModal} from '@pages/UtilitiesPage';
+import {waitForProcessInstances} from 'utils/incidentsHelper';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let instanceWithoutAnIncident: ProcessInstance;
+
+test.beforeAll(async ({request}) => {
+  await deploy(['./resources/processInstanceModifications_v_1.bpmn']);
+
+  instanceWithoutAnIncident = await createSingleInstance(
+    'processInstanceModifications',
+    1,
+    {
+      test: 123,
+      foo: 'bar',
+    },
+  );
+
+  await waitForProcessInstances(
+    request,
+    [instanceWithoutAnIncident.processInstanceKey],
+    1,
+  );
+});
+
+test.describe('Modifications', () => {
+  test.beforeEach(
+    async ({page, loginPage, operateHomePage, operateProcessInstancePage}) => {
+      await hideModificationHelperModal(page);
+      await navigateToApp(page, 'operate');
+      await loginPage.login('demo', 'demo');
+      await expect(operateHomePage.operateBanner).toBeVisible();
+      await operateProcessInstancePage.navigateToProcessInstance(
+        instanceWithoutAnIncident.processInstanceKey,
+      );
+    },
+  );
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Should apply/remove edit variable modifications', async ({
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.assertAndEnterModificationMode();
+    });
+
+    await test.step('Edit variable "foo" to 1', async () => {
+      await operateProcessInstancePage.editExistingVariable('foo', '1');
+      await operateProcessInstancePage.assertLastModificationIs(
+        /edit variable "foo"/i,
+      );
+    });
+
+    await test.step('Edit variable "test" to 2', async () => {
+      await operateProcessInstancePage.editExistingVariable('test', '2');
+      await operateProcessInstancePage.assertLastModificationIs(
+        /edit variable "test"/i,
+      );
+    });
+
+    await test.step('Edit variable "foo" to 3', async () => {
+      await operateProcessInstancePage.editExistingVariable('foo', '3');
+      await operateProcessInstancePage.assertLastModificationIs(
+        /edit variable "foo"/i,
+      );
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('3');
+    });
+
+    await test.step('Undo last edit – value reverts to 1', async () => {
+      await operateProcessInstancePage.undoModification();
+
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('1');
+      await operateProcessInstancePage.assertLastModificationIs(
+        /edit variable "test"/i,
+      );
+    });
+
+    await test.step('Navigate to another flow node and undo from there', async () => {
+      await operateProcessInstancePage.instanceHistory
+        .getByText(/never fails/i)
+        .click();
+      await expect(operateProcessInstancePage.noVariablesText).toBeVisible();
+
+      await operateProcessInstancePage.undoModification();
+      await operateProcessInstancePage.assertLastModificationIs(
+        /edit variable "foo"/i,
+      );
+
+      await operateProcessInstancePage.instanceHistory
+        .getByText(/process instance modifications/i)
+        .click();
+
+      await expect(
+        operateProcessInstancePage.getVariableRow('foo'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('test'),
+      ).toHaveValue('123');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('1');
+    });
+
+    await test.step('Undo again – footer disappears and all values revert', async () => {
+      await operateProcessInstancePage.undoModification();
+
+      await expect(
+        operateProcessInstancePage.lastModificationFooter,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('test'),
+      ).toHaveValue('123');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('"bar"');
+    });
+
+    await test.step('Remove modification from summary modal', async () => {
+      await operateProcessInstancePage.editExistingVariable('foo', '1');
+      await operateProcessInstancePage.editExistingVariable('foo', '2');
+      await operateProcessInstancePage.clickApplyModificationsButton();
+
+      await expect(
+        operateProcessInstancePage.getModificationSummaryItem('foo: 2'),
+      ).toBeVisible();
+
+      await operateProcessInstancePage.clickDeleteVariableModification();
+      await operateProcessInstancePage.cancelModificationSummary();
+
+      await expect(
+        operateProcessInstancePage.lastModificationFooter,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('"bar"');
+    });
+  });
+
+  test('Should apply/remove add variable modifications', async ({
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.assertAndEnterModificationMode();
+    });
+
+    await test.step('Add new variable "test2"', async () => {
+      await operateProcessInstancePage.addNewVariableInModificationMode(
+        'newVariables[0]',
+        'test2',
+        '1',
+      );
+      await operateProcessInstancePage.assertLastModificationIs(
+        /add new variable "test2"/i,
+      );
+    });
+
+    await test.step('Add new variable "test3"', async () => {
+      await operateProcessInstancePage.addNewVariableInModificationMode(
+        'newVariables[1]',
+        'test3',
+        '2',
+      );
+      await operateProcessInstancePage.assertLastModificationIs(
+        /add new variable "test3"/i,
+      );
+    });
+
+    await test.step('Edit first added variable name to "test2-edited"', async () => {
+      await operateProcessInstancePage
+        .getNewVariableNameFieldSelector('newVariables[0]')
+        .clear();
+      await operateProcessInstancePage
+        .getNewVariableNameFieldSelector('newVariables[0]')
+        .fill('test2-edited');
+      await operateProcessInstancePage.pressTab();
+
+      await operateProcessInstancePage.assertLastModificationIs(
+        /add new variable "test2-edited"/i,
+      );
+      await expect(
+        operateProcessInstancePage.getNewVariableNameFieldSelector(
+          'newVariables[0]',
+        ),
+      ).toHaveValue('test2-edited');
+      await expect(
+        operateProcessInstancePage.getNewVariableNameFieldSelector(
+          'newVariables[1]',
+        ),
+      ).toHaveValue('test3');
+    });
+
+    await test.step('Undo last edit – name reverts to "test2"', async () => {
+      await operateProcessInstancePage.undoModification();
+
+      await expect(
+        operateProcessInstancePage.getNewVariableNameFieldSelector(
+          'newVariables[0]',
+        ),
+      ).toHaveValue('test2');
+      await operateProcessInstancePage.assertLastModificationIs(
+        /add new variable "test3"/i,
+      );
+    });
+
+    await test.step('Navigate away, undo removes test3 from other scope', async () => {
+      await operateProcessInstancePage.instanceHistory
+        .getByText(/never fails/i)
+        .click();
+      await expect(operateProcessInstancePage.noVariablesText).toBeVisible();
+
+      await operateProcessInstancePage.undoModification();
+      await operateProcessInstancePage.assertLastModificationIs(
+        /add new variable "test2"/i,
+      );
+
+      await operateProcessInstancePage.instanceHistory
+        .getByText(/process instance modifications/i)
+        .click();
+
+      await expect(
+        operateProcessInstancePage.getVariableRow('newVariables[0]'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getVariableRow('newVariables[1]'),
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getNewVariableNameFieldSelector(
+          'newVariables[0]',
+        ),
+      ).toHaveValue('test2');
+      await expect(
+        operateProcessInstancePage.getNewVariableValueFieldSelector(
+          'newVariables[0]',
+        ),
+      ).toHaveValue('1');
+    });
+
+    await test.step('Undo again – footer disappears and new variable field removed', async () => {
+      await operateProcessInstancePage.undoModification();
+
+      await expect(
+        operateProcessInstancePage.lastModificationFooter,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getVariableRow('newVariables[0]'),
+      ).toBeHidden();
+    });
+
+    await test.step('Add same variable to two scopes then delete one from summary', async () => {
+      await operateProcessInstancePage.addNewVariableInModificationMode(
+        'newVariables[0]',
+        'test2',
+        '1',
+      );
+
+      await operateProcessInstancePage.instanceHistory
+        .getByText(/never fails/i)
+        .click();
+      await expect(operateProcessInstancePage.noVariablesText).toBeVisible();
+
+      await operateProcessInstancePage.addNewVariableInModificationMode(
+        'newVariables[0]',
+        'test2',
+        '1',
+      );
+
+      await operateProcessInstancePage.clickApplyModificationsButton();
+
+      await expect(
+        operateProcessInstancePage.getModificationSummaryItem('test2: 1'),
+      ).toHaveCount(2);
+
+      await operateProcessInstancePage
+        .getNthDeleteVariableModificationButtonInSummary(1)
+        .click();
+      await operateProcessInstancePage.cancelModificationSummary();
+
+      await expect(
+        operateProcessInstancePage.getVariableRow('newVariables[0]'),
+      ).toBeHidden();
+
+      await operateProcessInstancePage.instanceHistory
+        .getByText(/process instance modifications/i)
+        .click();
+
+      await expect(
+        operateProcessInstancePage.getVariableRow('newVariables[0]'),
+      ).toBeVisible();
+    });
+
+    await test.step('Change added variable value then remove from summary', async () => {
+      await operateProcessInstancePage
+        .getNewVariableValueFieldSelector('newVariables[0]')
+        .fill('21');
+      await operateProcessInstancePage.pressTab();
+
+      await operateProcessInstancePage.clickApplyModificationsButton();
+
+      await expect(
+        operateProcessInstancePage.getModificationSummaryItem('test2: 21'),
+      ).toBeVisible();
+
+      await operateProcessInstancePage.clickDeleteVariableModification();
+      await operateProcessInstancePage.cancelModificationSummary();
+
+      await expect(
+        operateProcessInstancePage.lastModificationFooter,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getVariableRow('newVariables[0]'),
+      ).toBeHidden();
+    });
+  });
+});


### PR DESCRIPTION
<!-- Describe the goal and purpose of this PR. -->
Migrated process instance modifications test from operate component folder to OC test suite and refactored to use proper Page Object Model, improving maintainability and reducing code duplication.

🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/22853508435)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/34111
