### PR TITLE
[Backport stable/8.9] fix: ignore document_missing_exception for archived operation updates

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -228,7 +228,7 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
                 op ->
                     op.update(
                         u ->
-                            u.index(operationIndexTemplateDescriptor.getFullQualifiedName())
+                            u.index(operationIndexTemplateDescriptor.getIndexPattern())
                                 .id(id)
                                 .action(a -> a.doc(fieldsToUpdate))
                                 .retryOnConflict(3))));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -228,7 +228,7 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
                 op ->
                     op.update(
                         u ->
-                            u.index(operationIndexTemplateDescriptor.getIndexPattern())
+                            u.index(operationIndexTemplateDescriptor.getFullQualifiedName())
                                 .id(id)
                                 .action(a -> a.doc(fieldsToUpdate))
                                 .retryOnConflict(3))));
@@ -238,11 +238,28 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
         .thenComposeAsync(
             response -> {
               if (response.errors()) {
-                final var errorMessage =
-                    "Bulk updating operations by ids '%s' failed with errors: %s"
-                        .formatted(ids, response.items());
-                logger.error(errorMessage);
-                return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+                // Filter out errors from archived operations (document_missing_exception)
+                // These operations are already archived and will be cleaned up by retention
+                final var actualErrors =
+                    response.items().stream()
+                        .filter(item -> item.error() != null)
+                        .filter(
+                            item ->
+                                item.error().type() != null
+                                    && !item.error().type().equals("document_missing_exception"))
+                        .toList();
+
+                if (!actualErrors.isEmpty()) {
+                  final var errorMessage =
+                      "Bulk updating operations by ids '%s' failed with errors: %s"
+                          .formatted(ids, actualErrors);
+                  logger.error(errorMessage);
+                  return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+                }
+                // All errors were document_missing_exception, log as debug and continue
+                logger.debug(
+                    "Bulk updating operations completed with {} document_missing_exception errors (archived operations)",
+                    response.items().stream().filter(item -> item.error() != null).count());
               }
               return CompletableFuture.completedFuture(ids);
             },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -12,6 +12,7 @@ import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.search.Hit;
@@ -43,6 +44,7 @@ import org.slf4j.Logger;
 public class ElasticsearchHistoryDeletionRepository extends ElasticsearchRepository
     implements HistoryDeletionRepository {
 
+  private static final String DOCUMENT_MISSING_ERROR_TYPE = "document_missing_exception";
   private final IndexDescriptor indexDescriptor;
   private final IndexDescriptor auditLogCleanupIndex;
   private final int partitionId;
@@ -235,35 +237,46 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
 
     return client
         .bulk(bulkRequestBuilder.build())
-        .thenComposeAsync(
-            response -> {
-              if (response.errors()) {
-                // Filter out errors from archived operations (document_missing_exception)
-                // These operations are already archived and will be cleaned up by retention
-                final var actualErrors =
-                    response.items().stream()
-                        .filter(item -> item.error() != null)
-                        .filter(
-                            item ->
-                                item.error().type() != null
-                                    && !item.error().type().equals("document_missing_exception"))
-                        .toList();
+        .thenComposeAsync(response -> handleBulkResponseErrors(response, ids), executor);
+  }
 
-                if (!actualErrors.isEmpty()) {
-                  final var errorMessage =
-                      "Bulk updating operations by ids '%s' failed with errors: %s"
-                          .formatted(ids, actualErrors);
-                  logger.error(errorMessage);
-                  return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
-                }
-                // All errors were document_missing_exception, log as debug and continue
-                logger.debug(
-                    "Bulk updating operations completed with {} document_missing_exception errors (archived operations)",
-                    response.items().stream().filter(item -> item.error() != null).count());
-              }
-              return CompletableFuture.completedFuture(ids);
-            },
-            executor);
+  /**
+   * Handles errors from bulk update operations, filtering out document_missing_exception errors
+   * that occur when operations are already archived. We cannot update these as we don't know what
+   * index they are in.
+   *
+   * @param response the bulk response from Elasticsearch
+   * @param ids the list of operation IDs that were updated
+   * @return a CompletableFuture containing the list of IDs if successful, or a failed future if
+   *     there are actual errors
+   */
+  private CompletableFuture<List<String>> handleBulkResponseErrors(
+      final BulkResponse response, final List<String> ids) {
+    if (response.errors()) {
+      // Filter out errors from archived operations (document_missing_exception)
+      // These operations are already archived and will be cleaned up by retention
+      final var actualErrors =
+          response.items().stream()
+              .filter(item -> item.error() != null)
+              .filter(
+                  item ->
+                      item.error().type() != null
+                          && !item.error().type().equals(DOCUMENT_MISSING_ERROR_TYPE))
+              .toList();
+
+      if (!actualErrors.isEmpty()) {
+        final var errorMessage =
+            "Bulk updating operations by ids '%s' failed with errors: %s"
+                .formatted(ids, actualErrors);
+        logger.error(errorMessage);
+        return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+      }
+      // All errors were document_missing_exception, log as debug and continue
+      logger.debug(
+          "Bulk updating operations completed with {} document_missing_exception errors (archived operations)",
+          response.items().stream().filter(item -> item.error() != null).count());
+    }
+    return CompletableFuture.completedFuture(ids);
   }
 
   private SearchRequest createSearchRequest() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -236,7 +236,7 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
                 op ->
                     op.update(
                         u ->
-                            u.index(operationIndexTemplateDescriptor.getIndexPattern())
+                            u.index(operationIndexTemplateDescriptor.getFullQualifiedName())
                                 .id(id)
                                 .document(fieldsToUpdate)
                                 .retryOnConflict(3))));
@@ -248,11 +248,30 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
                 .thenComposeAsync(
                     response -> {
                       if (response.errors()) {
-                        final var errorMessage =
-                            "Bulk updating operations by ids '%s' failed with errors: %s"
-                                .formatted(ids, response.items());
-                        logger.error(errorMessage);
-                        return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+                        // Filter out errors from archived operations (document_missing_exception)
+                        // These operations are already archived and will be cleaned up by retention
+                        final var actualErrors =
+                            response.items().stream()
+                                .filter(item -> item.error() != null)
+                                .filter(
+                                    item ->
+                                        item.error().type() != null
+                                            && !item.error()
+                                                .type()
+                                                .equals("document_missing_exception"))
+                                .toList();
+
+                        if (!actualErrors.isEmpty()) {
+                          final var errorMessage =
+                              "Bulk updating operations by ids '%s' failed with errors: %s"
+                                  .formatted(ids, actualErrors);
+                          logger.error(errorMessage);
+                          return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+                        }
+                        // All errors were document_missing_exception, log as debug and continue
+                        logger.debug(
+                            "Bulk updating operations completed with {} document_missing_exception errors (archived operations)",
+                            response.items().stream().filter(item -> item.error() != null).count());
                       }
                       return CompletableFuture.completedFuture(ids);
                     },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
     implements HistoryDeletionRepository {
 
+  private static final String DOCUMENT_MISSING_ERROR_TYPE = "document_missing_exception";
   private final IndexDescriptor indexDescriptor;
   private final IndexDescriptor auditLogCleanupIndex;
   private final int partitionId;
@@ -245,37 +246,43 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
         () ->
             client
                 .bulk(bulkRequestBuilder.build())
-                .thenComposeAsync(
-                    response -> {
-                      if (response.errors()) {
-                        // Filter out errors from archived operations (document_missing_exception)
-                        // These operations are already archived and will be cleaned up by retention
-                        final var actualErrors =
-                            response.items().stream()
-                                .filter(item -> item.error() != null)
-                                .filter(
-                                    item ->
-                                        item.error().type() != null
-                                            && !item.error()
-                                                .type()
-                                                .equals("document_missing_exception"))
-                                .toList();
+                .thenComposeAsync(response -> handleBulkResponseErrors(response, ids), executor));
+  }
 
-                        if (!actualErrors.isEmpty()) {
-                          final var errorMessage =
-                              "Bulk updating operations by ids '%s' failed with errors: %s"
-                                  .formatted(ids, actualErrors);
-                          logger.error(errorMessage);
-                          return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
-                        }
-                        // All errors were document_missing_exception, log as debug and continue
-                        logger.debug(
-                            "Bulk updating operations completed with {} document_missing_exception errors (archived operations)",
-                            response.items().stream().filter(item -> item.error() != null).count());
-                      }
-                      return CompletableFuture.completedFuture(ids);
-                    },
-                    executor));
+  /**
+   * Handles errors from bulk update operations, filtering out document_missing_exception errors
+   * that occur when operations are already archived. We cannot update these as we don't know what
+   * index they are in.
+   *
+   * @param response the bulk response from Opensearch
+   * @param ids the list of operation IDs that were updated
+   * @return a CompletableFuture containing the list of IDs if successful, or a failed future if
+   *     there are actual errors
+   */
+  private CompletableFuture<List<String>> handleBulkResponseErrors(
+      final org.opensearch.client.opensearch.core.BulkResponse response, final List<String> ids) {
+    if (response.errors()) {
+      // Filter out errors from archived operations (document_missing_exception)
+      // These operations are already archived and will be cleaned up by retention
+      final var actualErrors =
+          response.items().stream()
+              .filter(item -> item.error() != null)
+              .filter(item -> !item.error().type().equals(DOCUMENT_MISSING_ERROR_TYPE))
+              .toList();
+
+      if (!actualErrors.isEmpty()) {
+        final var errorMessage =
+            "Bulk updating operations by ids '%s' failed with errors: %s"
+                .formatted(ids, actualErrors);
+        logger.error(errorMessage);
+        return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+      }
+      // All errors were document_missing_exception, log as debug and continue
+      logger.debug(
+          "Bulk updating operations completed with {} document_missing_exception errors (archived operations)",
+          response.items().stream().filter(item -> item.error() != null).count());
+    }
+    return CompletableFuture.completedFuture(ids);
   }
 
   private SearchRequest createSearchRequest() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -236,7 +236,7 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
                 op ->
                     op.update(
                         u ->
-                            u.index(operationIndexTemplateDescriptor.getFullQualifiedName())
+                            u.index(operationIndexTemplateDescriptor.getIndexPattern())
                                 .id(id)
                                 .document(fieldsToUpdate)
                                 .retryOnConflict(3))));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
@@ -19,6 +19,7 @@ import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.io.IOException;
@@ -42,6 +43,7 @@ abstract class HistoryDeletionRepositoryIT {
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   protected final HistoryDeletionIndex historyDeletionIndex;
   protected final AuditLogCleanupIndex auditLogCleanupIndex;
+  protected final OperationTemplate operationTemplate;
   @AutoClose protected final ClientAdapter clientAdapter;
   protected final SearchEngineClient engineClient;
   protected final ExporterConfiguration config;
@@ -61,12 +63,14 @@ abstract class HistoryDeletionRepositoryIT {
 
     historyDeletionIndex = new HistoryDeletionIndex(indexPrefix, isElastic);
     auditLogCleanupIndex = new AuditLogCleanupIndex(indexPrefix, isElastic);
+    operationTemplate = new OperationTemplate(indexPrefix, isElastic);
   }
 
   @BeforeEach
   void beforeEach() {
     engineClient.createIndex(historyDeletionIndex, new IndexConfiguration());
     engineClient.createIndex(auditLogCleanupIndex, new IndexConfiguration());
+    engineClient.createIndex(operationTemplate, new IndexConfiguration());
     repository = createRepository(indexPrefix, PARTITION_ID);
   }
 
@@ -76,6 +80,8 @@ abstract class HistoryDeletionRepositoryIT {
     engineClient.createIndex(historyDeletionIndex, new IndexConfiguration());
     engineClient.deleteIndex(auditLogCleanupIndex.getFullQualifiedName());
     engineClient.createIndex(auditLogCleanupIndex, new IndexConfiguration());
+    engineClient.deleteIndex(operationTemplate.getFullQualifiedName());
+    engineClient.createIndex(operationTemplate, new IndexConfiguration());
   }
 
   protected abstract HistoryDeletionRepository createRepository(
@@ -212,5 +218,18 @@ abstract class HistoryDeletionRepositoryIT {
               final long auditLogCount = countAuditLogCleanupEntries();
               assertThat(auditLogCount).isEqualTo(2);
             });
+  }
+
+  @Test
+  void shouldIgnoreDocumentMissingExceptionWhenCompletingNonExistentOperations() {
+    // given - non-existent operation IDs that will trigger document_missing_exception
+    final var nonExistentIds = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+    // when
+    final var result = repository.completeOperations(nonExistentIds);
+
+    // then - should complete successfully
+    assertThat(result).succeedsWithin(REQUEST_TIMEOUT);
+    assertThat(result.join()).containsExactlyElementsOf(nonExistentIds);
   }
 }


### PR DESCRIPTION
# Description
Backport of #47826 to `stable/8.9`.

relates to camunda/camunda#47680