### PR TITLE
fix: restore backup actuator endpoint link names

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -131,14 +131,8 @@ public final class BackupEndpoint {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> query(
-      @Selector(match = Match.ALL_REMAINING) final String[] arguments) {
-    if (arguments.length > 1) {
-      return new WebEndpointResponse<>(
-          new Error().message("Invalid arguments provided."),
-          WebEndpointResponse.STATUS_BAD_REQUEST);
-    }
-    final String argument = arguments[0];
+  public WebEndpointResponse<?> query(@Selector final String prefixOrId) {
+    final String argument = prefixOrId;
     if (BackupApi.STATE.equals(argument)) {
       return state();
     }
@@ -160,25 +154,19 @@ public final class BackupEndpoint {
   }
 
   @DeleteOperation
-  public WebEndpointResponse<?> delete(@Selector(match = Match.ALL_REMAINING) final String[] path) {
-    if (path.length == 1 && BackupApi.STATE.equals(path[0])) {
+  public WebEndpointResponse<?> delete(@Selector final String id) {
+    if (BackupApi.STATE.equals(id)) {
       return deleteState();
     }
-    if (path.length == 1) {
-      final long id;
-      try {
-        id = Long.parseLong(path[0]);
-      } catch (final NumberFormatException e) {
-        return new WebEndpointResponse<>(
-            new Error()
-                .message("Expected a backup ID or 'state', but got '%s'.".formatted(path[0])),
-            WebEndpointResponse.STATUS_BAD_REQUEST);
-      }
-      return deleteBackup(id);
+    final long backupId;
+    try {
+      backupId = Long.parseLong(id);
+    } catch (final NumberFormatException e) {
+      return new WebEndpointResponse<>(
+          new Error().message("Expected a backup ID or 'state', but got '%s'.".formatted(id)),
+          WebEndpointResponse.STATUS_BAD_REQUEST);
     }
-    return new WebEndpointResponse<>(
-        new Error().message("Unknown delete operation: " + String.join("/", path)),
-        WebEndpointResponse.STATUS_BAD_REQUEST);
+    return deleteBackup(backupId);
   }
 
   private WebEndpointResponse<?> deleteBackup(final long id) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
@@ -48,13 +48,12 @@ public final class BackupEndpointStandalone {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> query(
-      @Selector(match = Match.ALL_REMAINING) final String[] arguments) {
-    return backupEndpoint.query(arguments);
+  public WebEndpointResponse<?> query(@Selector final String prefixOrId) {
+    return backupEndpoint.query(prefixOrId);
   }
 
   @DeleteOperation
-  public WebEndpointResponse<?> delete(@Selector(match = Match.ALL_REMAINING) final String[] path) {
-    return backupEndpoint.delete(path);
+  public WebEndpointResponse<?> delete(@Selector final String id) {
+    return backupEndpoint.delete(id);
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
@@ -54,27 +54,27 @@ public abstract class BackupEndpointStandaloneTest {
   @Test
   public void shouldCallGetWhenIsStandalone() {
     // when
-    backupEndpointStandalone.query(new String[] {"11"});
+    backupEndpointStandalone.query("11");
 
     // then
-    verify(backupEndpoint).query(new String[] {"11"});
+    verify(backupEndpoint).query("11");
   }
 
   @Test
   public void shouldCallDeleteWhenIsStandalone() {
     // when
-    backupEndpointStandalone.delete(new String[] {"11"});
+    backupEndpointStandalone.delete("11");
 
     // then
-    verify(backupEndpoint).delete(new String[] {"11"});
+    verify(backupEndpoint).delete("11");
   }
 
   @Test
   public void shouldCallQueryWhenIsStandalone() {
     // when
-    backupEndpointStandalone.query(new String[] {BackupApi.STATE});
+    backupEndpointStandalone.query(BackupApi.STATE);
 
     // then
-    verify(backupEndpoint).query(new String[] {BackupApi.STATE});
+    verify(backupEndpoint).query(BackupApi.STATE);
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -448,7 +448,7 @@ final class BackupEndpointTest {
       doThrow(failure).when(api).getStatus(anyLong());
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {"1"});
+      final WebEndpointResponse<?> response = endpoint.query("1");
 
       // then
       assertThat(response.getBody())
@@ -470,7 +470,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.completedFuture(backupStatus)).when(api).getStatus(anyLong());
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {"1"});
+      final WebEndpointResponse<?> response = endpoint.query("1");
 
       // then
       assertThat(response.getStatus()).isEqualTo(404);
@@ -492,7 +492,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.failedFuture(error)).when(api).getStatus(anyLong());
 
       // when
-      final var response = endpoint.query(new String[] {"1"});
+      final var response = endpoint.query("1");
 
       // then
       assertThat(response.getStatus()).isEqualTo(expectedCode);
@@ -551,7 +551,7 @@ final class BackupEndpointTest {
       final BackupInfo expectedResponse = mapper.readValue(expectedJson, BackupInfo.class);
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {"1"});
+      final WebEndpointResponse<?> response = endpoint.query("1");
 
       // then
       assertThat(response.getBody())
@@ -602,7 +602,7 @@ final class BackupEndpointTest {
       final BackupInfo expectedResponse = mapper.readValue(expectedJson, BackupInfo.class);
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {"1"});
+      final WebEndpointResponse<?> response = endpoint.query("1");
 
       // then
       assertThat(response.getBody())
@@ -824,7 +824,7 @@ final class BackupEndpointTest {
       doThrow(failure).when(api).deleteBackup(1);
 
       // when
-      final WebEndpointResponse<?> response = endpoint.delete(new String[] {"1"});
+      final WebEndpointResponse<?> response = endpoint.delete("1");
 
       // then
       assertThat(response.getBody())
@@ -845,7 +845,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.failedFuture(error)).when(api).deleteBackup(anyLong());
 
       // when
-      final var response = endpoint.delete(new String[] {"1"});
+      final var response = endpoint.delete("1");
 
       // then
       assertThat(response.getStatus()).isEqualTo(expectedCode);
@@ -868,7 +868,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.completedFuture(null)).when(api).deleteBackup(1);
 
       // when
-      final WebEndpointResponse<?> response = endpoint.delete(new String[] {"1"});
+      final WebEndpointResponse<?> response = endpoint.delete("1");
 
       // then
       assertThat(response.getStatus()).isEqualTo(204);
@@ -887,7 +887,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.completedFuture(null)).when(api).deleteRuntimeState();
 
       // when
-      final WebEndpointResponse<?> response = endpoint.delete(new String[] {"state"});
+      final WebEndpointResponse<?> response = endpoint.delete("state");
 
       // then
       assertThat(response.getStatus()).isEqualTo(204);
@@ -903,7 +903,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.failedFuture(error)).when(api).deleteRuntimeState();
 
       // when
-      final var response = endpoint.delete(new String[] {"state"});
+      final var response = endpoint.delete("state");
 
       // then
       assertThat(response.getStatus()).isEqualTo(expectedCode);
@@ -924,7 +924,7 @@ final class BackupEndpointTest {
       doThrow(failure).when(api).deleteRuntimeState();
 
       // when
-      final WebEndpointResponse<?> response = endpoint.delete(new String[] {"state"});
+      final WebEndpointResponse<?> response = endpoint.delete("state");
 
       // then
       assertThat(response.getBody())
@@ -962,7 +962,7 @@ final class BackupEndpointTest {
       when(api.getBackupRanges()).thenReturn(CompletableFuture.completedFuture(rangesResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
+      final WebEndpointResponse<?> response = endpoint.query(BackupApi.STATE);
 
       // then
       assertThat(response.getBody())
@@ -1020,7 +1020,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
+      final WebEndpointResponse<?> response = endpoint.query(BackupApi.STATE);
 
       // then
       assertThat(response.getBody())
@@ -1061,7 +1061,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
+      final WebEndpointResponse<?> response = endpoint.query(BackupApi.STATE);
 
       // then
       assertThat(response.getBody())
@@ -1106,7 +1106,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
+      final WebEndpointResponse<?> response = endpoint.query(BackupApi.STATE);
 
       // then
       assertThat(response.getBody())
@@ -1151,7 +1151,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
+      final WebEndpointResponse<?> response = endpoint.query(BackupApi.STATE);
 
       // then
       assertThat(response.getBody())
@@ -1233,7 +1233,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
+      final WebEndpointResponse<?> response = endpoint.query(BackupApi.STATE);
 
       // then
       assertThat(response.getBody())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupErrorResponseTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupErrorResponseTest.java
@@ -132,7 +132,7 @@ class BackupErrorResponseTest {
     @Test
     void shouldReturn400() {
       // when - then
-      assertThat(backupEndpoint.query(new String[] {"1"}).getStatus()).isEqualTo(400);
+      assertThat(backupEndpoint.query("1").getStatus()).isEqualTo(400);
     }
   }
 
@@ -163,7 +163,7 @@ class BackupErrorResponseTest {
       clusteringRule.disconnect(clusteringRule.getBroker(0));
 
       // when - then
-      assertThat(backupEndpoint.query(new String[] {"1"}).getStatus()).isEqualTo(504);
+      assertThat(backupEndpoint.query("1").getStatus()).isEqualTo(504);
     }
   }
 


### PR DESCRIPTION
Restores the backup actuator endpoint link names that were broken by the use of `@Selector(match = Match.ALL_REMAINING)` on the `query` and `delete` methods in `BackupEndpoint` and `BackupEndpointStandalone`.

The `ALL_REMAINING` selector caused Spring Boot Actuator to advertise generic catch-all path patterns (`{*arguments}`, `{*path}`) instead of the original named patterns (`{prefixOrId}`, `{id}`) in the `/actuator` discovery response, breaking clients that rely on stable link names for endpoint discovery. This reverts `query` and `delete` to use plain `@Selector` with single `String` parameters while keeping `write`'s `ALL_REMAINING` for the multi-segment `/state/sync` path.