### PR TITLE
refactor: consolidate dashboard table pagination into shared hook

### DIFF
--- a/operate/client/src/App/Dashboard/IncidentsByError/index.test.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/index.test.tsx
@@ -7,13 +7,7 @@
  */
 
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
-import {
-  render,
-  within,
-  screen,
-  waitForElementToBeRemoved,
-  waitFor,
-} from 'modules/testing-library';
+import {render, within, screen, waitFor} from 'modules/testing-library';
 import {IncidentsByError} from './index';
 import {
   mockIncidentsByError,
@@ -23,11 +17,10 @@ import {
 } from './index.setup';
 import {LocationLog} from 'modules/utils/LocationLog';
 import {Paths} from 'modules/Routes';
-import {mockFetchIncidentProcessInstanceStatisticsByError} from 'modules/mocks/api/v2/incidents/fetchIncidentProcessInstanceStatisticsByError';
 import {mockFetchIncidentProcessInstanceStatisticsByDefinition} from 'modules/mocks/api/v2/incidents/fetchIncidentProcessInstanceStatisticsByDefinition';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import {createUser, searchResult} from 'modules/testUtils';
+import {createUser} from 'modules/testUtils';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {useEffect} from 'react';
 import {panelStatesStore} from 'modules/stores/panelStates';
@@ -54,20 +47,20 @@ function createWrapper(initialPath: string = Paths.dashboard()) {
   return Wrapper;
 }
 
-describe('IncidentsByError', () => {
-  const mockScrollableContainerRef = {current: null};
+const mockScrollableContainerRef = {current: null};
+const mockScrollHandlers = {
+  onScrollStartReach: () => {},
+  onScrollEndReach: () => {},
+};
 
+describe('IncidentsByError', () => {
   beforeEach(() => {
     mockMe().withSuccess(createUser());
   });
 
-  const mockIncidentQueries = ({
-    incidents = mockIncidentsByError,
+  const mockDefinitionQueries = ({
     definitions = mockIncidentStatisticsByDefinition,
   } = {}) => {
-    mockFetchIncidentProcessInstanceStatisticsByError().withSuccess(incidents);
-    mockFetchIncidentProcessInstanceStatisticsByError().withSuccess(incidents);
-
     mockFetchIncidentProcessInstanceStatisticsByDefinition().withSuccess(
       definitions,
     );
@@ -76,77 +69,62 @@ describe('IncidentsByError', () => {
     );
   };
 
-  it('should display skeleton when loading', async () => {
-    mockIncidentQueries();
-
+  it('should display skeleton when loading', () => {
     render(
-      <IncidentsByError scrollableContainerRef={mockScrollableContainerRef} />,
+      <IncidentsByError
+        status="pending"
+        items={[]}
+        totalCount={0}
+        scrollableContainerRef={mockScrollableContainerRef}
+        isFetchingNextPage={false}
+        isFetchingPreviousPage={false}
+        {...mockScrollHandlers}
+      />,
       {
         wrapper: createWrapper(),
       },
     );
 
     expect(screen.getByTestId('data-table-skeleton')).toBeInTheDocument();
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('data-table-skeleton'),
-    );
-
-    expect(await screen.findByTestId('incident-byError')).toBeInTheDocument();
   });
 
-  it('should handle server errors', async () => {
-    Array.from({length: 5}).forEach(() => {
-      mockFetchIncidentProcessInstanceStatisticsByError().withServerError();
-    });
-
+  it('should handle errors', () => {
     render(
-      <IncidentsByError scrollableContainerRef={mockScrollableContainerRef} />,
+      <IncidentsByError
+        status="error"
+        items={[]}
+        totalCount={0}
+        scrollableContainerRef={mockScrollableContainerRef}
+        isFetchingNextPage={false}
+        isFetchingPreviousPage={false}
+        {...mockScrollHandlers}
+      />,
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(screen.getByText('Data could not be fetched')).toBeInTheDocument();
+  });
+
+  it('should display information message when there are no incidents', () => {
+    render(
+      <IncidentsByError
+        status="success"
+        items={[]}
+        totalCount={0}
+        scrollableContainerRef={mockScrollableContainerRef}
+        isFetchingNextPage={false}
+        isFetchingPreviousPage={false}
+        {...mockScrollHandlers}
+      />,
       {
         wrapper: createWrapper(),
       },
     );
 
     expect(
-      await screen.findByText('Data could not be fetched'),
-    ).toBeInTheDocument();
-  });
-
-  it('should handle network errors', async () => {
-    const consoleErrorMock = vi
-      .spyOn(global.console, 'error')
-      .mockImplementation(() => {});
-
-    Array.from({length: 5}).forEach(() => {
-      mockFetchIncidentProcessInstanceStatisticsByError().withNetworkError();
-    });
-
-    render(
-      <IncidentsByError scrollableContainerRef={mockScrollableContainerRef} />,
-      {
-        wrapper: createWrapper(),
-      },
-    );
-
-    expect(
-      await screen.findByText('Data could not be fetched'),
-    ).toBeInTheDocument();
-
-    consoleErrorMock.mockRestore();
-  });
-
-  it('should display information message when there are no incidents', async () => {
-    mockIncidentQueries({incidents: searchResult([])});
-
-    render(
-      <IncidentsByError scrollableContainerRef={mockScrollableContainerRef} />,
-      {
-        wrapper: createWrapper(),
-      },
-    );
-
-    expect(
-      await screen.findByText('Your processes are healthy'),
+      screen.getByText('Your processes are healthy'),
     ).toBeInTheDocument();
     expect(
       screen.getByText('There are no incidents on any instances.'),
@@ -154,17 +132,25 @@ describe('IncidentsByError', () => {
   });
 
   it('should render process incidents with expandable process list', async () => {
-    mockIncidentQueries();
+    mockDefinitionQueries();
 
     const {user} = render(
-      <IncidentsByError scrollableContainerRef={mockScrollableContainerRef} />,
+      <IncidentsByError
+        status="success"
+        items={mockIncidentsByError.items}
+        totalCount={mockIncidentsByError.page.totalItems}
+        scrollableContainerRef={mockScrollableContainerRef}
+        isFetchingNextPage={false}
+        isFetchingPreviousPage={false}
+        {...mockScrollHandlers}
+      />,
       {
         wrapper: createWrapper(),
       },
     );
 
     const withinIncident = within(
-      await screen.findByTestId('incident-byError-0'),
+      screen.getByTestId('incident-byError-0'),
     );
 
     const expandButton = withinIncident.getByRole('button', {
@@ -205,17 +191,25 @@ describe('IncidentsByError', () => {
       multiTenancyEnabled: true,
     });
 
-    mockIncidentQueries();
+    mockDefinitionQueries();
 
     const {user} = render(
-      <IncidentsByError scrollableContainerRef={mockScrollableContainerRef} />,
+      <IncidentsByError
+        status="success"
+        items={mockIncidentsByError.items}
+        totalCount={mockIncidentsByError.page.totalItems}
+        scrollableContainerRef={mockScrollableContainerRef}
+        isFetchingNextPage={false}
+        isFetchingPreviousPage={false}
+        {...mockScrollHandlers}
+      />,
       {
         wrapper: createWrapper(),
       },
     );
 
     const expandButton = within(
-      await screen.findByTestId('incident-byError-0'),
+      screen.getByTestId('incident-byError-0'),
     ).getByRole('button', {name: 'Expand current row'});
 
     await user.click(expandButton);
@@ -232,12 +226,18 @@ describe('IncidentsByError', () => {
   });
 
   it('should truncate the error message in search params', async () => {
-    mockIncidentQueries({
-      incidents: mockIncidentStatisticsByErrorWithBigMessage,
-    });
+    mockDefinitionQueries();
 
     const {user} = render(
-      <IncidentsByError scrollableContainerRef={mockScrollableContainerRef} />,
+      <IncidentsByError
+        status="success"
+        items={mockIncidentStatisticsByErrorWithBigMessage.items}
+        totalCount={mockIncidentStatisticsByErrorWithBigMessage.page.totalItems}
+        scrollableContainerRef={mockScrollableContainerRef}
+        isFetchingNextPage={false}
+        isFetchingPreviousPage={false}
+        {...mockScrollHandlers}
+      />,
       {
         wrapper: createWrapper(),
       },
@@ -251,7 +251,7 @@ describe('IncidentsByError', () => {
     }).toString();
 
     const withinIncident = within(
-      await screen.findByTestId('incident-byError-0'),
+      screen.getByTestId('incident-byError-0'),
     );
 
     const expandButton = withinIncident.getByRole('button', {
@@ -285,10 +285,18 @@ describe('IncidentsByError', () => {
   });
 
   it('should expand filters panel on click', async () => {
-    mockIncidentQueries();
+    mockDefinitionQueries();
 
     const {user} = render(
-      <IncidentsByError scrollableContainerRef={mockScrollableContainerRef} />,
+      <IncidentsByError
+        status="success"
+        items={mockIncidentsByError.items}
+        totalCount={mockIncidentsByError.page.totalItems}
+        scrollableContainerRef={mockScrollableContainerRef}
+        isFetchingNextPage={false}
+        isFetchingPreviousPage={false}
+        {...mockScrollHandlers}
+      />,
       {
         wrapper: createWrapper(),
       },
@@ -297,7 +305,7 @@ describe('IncidentsByError', () => {
     expect(panelStatesStore.state.isFiltersCollapsed).toBe(false);
 
     const withinIncident = within(
-      await screen.findByTestId('incident-byError-0'),
+      screen.getByTestId('incident-byError-0'),
     );
 
     const expandButton = withinIncident.getByRole('button', {

--- a/operate/client/src/App/Dashboard/IncidentsByError/index.test.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/index.test.tsx
@@ -123,9 +123,7 @@ describe('IncidentsByError', () => {
       },
     );
 
-    expect(
-      screen.getByText('Your processes are healthy'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Your processes are healthy')).toBeInTheDocument();
     expect(
       screen.getByText('There are no incidents on any instances.'),
     ).toBeInTheDocument();
@@ -149,9 +147,7 @@ describe('IncidentsByError', () => {
       },
     );
 
-    const withinIncident = within(
-      screen.getByTestId('incident-byError-0'),
-    );
+    const withinIncident = within(screen.getByTestId('incident-byError-0'));
 
     const expandButton = withinIncident.getByRole('button', {
       name: 'Expand current row',
@@ -250,9 +246,7 @@ describe('IncidentsByError', () => {
       incidents: 'true',
     }).toString();
 
-    const withinIncident = within(
-      screen.getByTestId('incident-byError-0'),
-    );
+    const withinIncident = within(screen.getByTestId('incident-byError-0'));
 
     const expandButton = withinIncident.getByRole('button', {
       name: 'Expand current row',
@@ -304,9 +298,7 @@ describe('IncidentsByError', () => {
 
     expect(panelStatesStore.state.isFiltersCollapsed).toBe(false);
 
-    const withinIncident = within(
-      screen.getByTestId('incident-byError-0'),
-    );
+    const withinIncident = within(screen.getByTestId('incident-byError-0'));
 
     const expandButton = withinIncident.getByRole('button', {
       name: 'Expand current row',

--- a/operate/client/src/App/Dashboard/IncidentsByError/index.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/index.tsx
@@ -30,7 +30,7 @@ type Props = {
   isFetchingNextPage: boolean;
   isFetchingPreviousPage: boolean;
   onScrollStartReach?: (scrollDown: (distance: number) => void) => void;
-  onScrollEndReach: () => void;
+  onScrollEndReach: (scrollUp: (distance: number) => void) => void;
 };
 
 const IncidentsByError: React.FC<Props> = ({

--- a/operate/client/src/App/Dashboard/IncidentsByError/index.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/index.tsx
@@ -18,35 +18,34 @@ import {Skeleton} from '../PartiallyExpandableDataTable/Skeleton';
 import {LinkWrapper, ErrorMessage, LoadingContainer} from '../styled';
 import {EmptyState} from 'modules/components/EmptyState';
 import EmptyStateProcessIncidents from 'modules/components/Icon/empty-state-process-incidents.svg?react';
-import {
-  PAGE_LIMIT,
-  useIncidentProcessInstanceStatisticsByErrorPaginated,
-} from 'modules/queries/incidentStatistics/useIncidentProcessInstanceStatisticsByErrorPaginated';
 import type {IncidentProcessInstanceStatisticsByError} from '@camunda/camunda-api-zod-schemas/8.9';
 import {Details} from './Details';
 import {InlineLoading} from '@carbon/react';
 
-const ROW_HEIGHT = 64;
-const SMOOTH_SCROLL_STEP_SIZE = PAGE_LIMIT * ROW_HEIGHT;
-
 type Props = {
+  status: 'pending' | 'error' | 'success';
+  items: IncidentProcessInstanceStatisticsByError[];
+  totalCount: number;
   scrollableContainerRef: React.RefObject<HTMLDivElement | null>;
+  isFetchingNextPage: boolean;
+  isFetchingPreviousPage: boolean;
+  onScrollStartReach?: (scrollDown: (distance: number) => void) => void;
+  onScrollEndReach: () => void;
 };
 
-const IncidentsByError: React.FC<Props> = ({scrollableContainerRef}) => {
-  const result = useIncidentProcessInstanceStatisticsByErrorPaginated({
-    enablePeriodicRefetch: true,
-    select: (data) => ({
-      items: data.pages.flatMap((page) => page.items),
-      totalCount: data.pages[0]?.page.totalItems ?? 0,
-    }),
-  });
-  const incidents = result.data?.items ?? [];
-  const totalCount = result.data?.totalCount ?? 0;
-
+const IncidentsByError: React.FC<Props> = ({
+  status,
+  items,
+  totalCount,
+  scrollableContainerRef,
+  isFetchingNextPage,
+  isFetchingPreviousPage,
+  onScrollStartReach,
+  onScrollEndReach,
+}) => {
   const rows = useMemo(
     () =>
-      incidents.map((item: IncidentProcessInstanceStatisticsByError) => {
+      items.map((item: IncidentProcessInstanceStatisticsByError) => {
         const {errorHashCode, errorMessage, activeInstancesWithErrorCount} =
           item;
 
@@ -80,12 +79,12 @@ const IncidentsByError: React.FC<Props> = ({scrollableContainerRef}) => {
           ),
         };
       }),
-    [incidents],
+    [items],
   );
 
   const expandedContents = useMemo(
     () =>
-      incidents.reduce<Record<string, React.ReactElement<{tabIndex: number}>>>(
+      items.reduce<Record<string, React.ReactElement<{tabIndex: number}>>>(
         (accumulator, item) => {
           accumulator[String(item.errorHashCode)] = (
             <Details
@@ -97,33 +96,18 @@ const IncidentsByError: React.FC<Props> = ({scrollableContainerRef}) => {
         },
         {},
       ),
-    [incidents],
+    [items],
   );
 
-  const handleScrollStartReach = async (
-    scrollDown: (distance: number) => void,
-  ) => {
-    if (result.hasPreviousPage && !result.isFetchingPreviousPage) {
-      await result.fetchPreviousPage();
-      scrollDown(SMOOTH_SCROLL_STEP_SIZE);
-    }
-  };
-
-  const handleScrollEndReach = () => {
-    if (result.hasNextPage && !result.isFetchingNextPage) {
-      result.fetchNextPage();
-    }
-  };
-
-  if (result.status === 'pending' && !result.data) {
+  if (status === 'pending') {
     return <Skeleton />;
   }
 
-  if (result.status === 'error') {
+  if (status === 'error') {
     return <ErrorMessage />;
   }
 
-  if (result.status === 'success' && totalCount === 0) {
+  if (status === 'success' && totalCount === 0) {
     return (
       <EmptyState
         icon={<EmptyStateProcessIncidents title="Your processes are healthy" />}
@@ -135,7 +119,7 @@ const IncidentsByError: React.FC<Props> = ({scrollableContainerRef}) => {
 
   return (
     <>
-      {result.isFetchingPreviousPage && (
+      {isFetchingPreviousPage && (
         <LoadingContainer>
           <InlineLoading description="Loading previous incidents..." />
         </LoadingContainer>
@@ -143,13 +127,13 @@ const IncidentsByError: React.FC<Props> = ({scrollableContainerRef}) => {
       <PartiallyExpandableDataTable
         dataTestId="incident-byError"
         headers={[{key: 'incident', header: 'incident'}]}
-        onVerticalScrollStartReach={handleScrollStartReach}
-        onVerticalScrollEndReach={handleScrollEndReach}
+        onVerticalScrollStartReach={onScrollStartReach}
+        onVerticalScrollEndReach={onScrollEndReach}
         scrollableContainerRef={scrollableContainerRef}
         expandedContents={expandedContents}
         rows={rows}
       />
-      {result.isFetchingNextPage && (
+      {isFetchingNextPage && (
         <LoadingContainer>
           <InlineLoading description="Loading more incidents..." />
         </LoadingContainer>

--- a/operate/client/src/App/Dashboard/InstancesByProcessDefinition/index.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcessDefinition/index.tsx
@@ -31,7 +31,7 @@ type Props = {
   isFetchingNextPage: boolean;
   isFetchingPreviousPage: boolean;
   onScrollStartReach?: (scrollDown: (distance: number) => void) => void;
-  onScrollEndReach: () => void;
+  onScrollEndReach: (scrollUp: (distance: number) => void) => void;
 };
 
 const InstancesByProcessDefinition: React.FC<Props> = ({

--- a/operate/client/src/App/Dashboard/index.tsx
+++ b/operate/client/src/App/Dashboard/index.tsx
@@ -13,25 +13,31 @@ import {PAGE_TITLE} from 'modules/constants';
 import {Grid, ScrollableContent, Tile, TileTitle} from './styled';
 import {InstancesByProcessDefinition} from './InstancesByProcessDefinition';
 import {IncidentsByError} from './IncidentsByError';
-import {
-  useProcessDefinitionStatisticsPaginated,
-  PAGES_LIMIT,
-} from 'modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated';
+import {useProcessDefinitionStatisticsPaginated} from 'modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated';
+import {useIncidentProcessInstanceStatisticsByErrorPaginated} from 'modules/queries/incidentStatistics/useIncidentProcessInstanceStatisticsByErrorPaginated';
 import {NoInstancesEmptyState} from './NoInstancesEmptyState';
-
-const ROW_HEIGHT = 64;
-const SMOOTH_SCROLL_STEP_SIZE = PAGES_LIMIT * ROW_HEIGHT;
+import {
+  useDashboardScrollPagination,
+  flattenPaginatedPages,
+} from './useDashboardScrollPagination';
 
 const Dashboard: React.FC = () => {
   const scrollableContentRef = useRef<HTMLDivElement>(null);
   const incidentScrollableContentRef = useRef<HTMLDivElement>(null);
+
   const processStats = useProcessDefinitionStatisticsPaginated({
     enablePeriodicRefetch: true,
-    select: (data) => ({
-      items: data.pages.flatMap((page) => page.items),
-      totalCount: data.pages[0]?.page.totalItems ?? 0,
-    }),
+    select: flattenPaginatedPages,
   });
+
+  const incidentStats = useIncidentProcessInstanceStatisticsByErrorPaginated({
+    enablePeriodicRefetch: true,
+    select: flattenPaginatedPages,
+  });
+
+  const processScroll = useDashboardScrollPagination(processStats);
+  const incidentScroll = useDashboardScrollPagination(incidentStats);
+
   const hasNoInstances =
     processStats.status === 'success' &&
     (processStats.data?.totalCount ?? 0) === 0;
@@ -39,21 +45,6 @@ const Dashboard: React.FC = () => {
   useEffect(() => {
     document.title = PAGE_TITLE.DASHBOARD;
   }, []);
-
-  const handleScrollStartReach = async (
-    scrollDown: (distance: number) => void,
-  ) => {
-    if (processStats.hasPreviousPage && !processStats.isFetchingPreviousPage) {
-      await processStats.fetchPreviousPage();
-      scrollDown(SMOOTH_SCROLL_STEP_SIZE);
-    }
-  };
-
-  const handleScrollEndReach = () => {
-    if (processStats.hasNextPage && !processStats.isFetchingNextPage) {
-      processStats.fetchNextPage();
-    }
-  };
 
   return (
     <Grid $numberOfColumns={hasNoInstances ? 1 : 2}>
@@ -71,10 +62,10 @@ const Dashboard: React.FC = () => {
               status={processStats.status}
               items={processStats.data?.items ?? []}
               scrollableContainerRef={scrollableContentRef}
-              isFetchingNextPage={processStats.isFetchingNextPage}
-              isFetchingPreviousPage={processStats.isFetchingPreviousPage}
-              onScrollStartReach={handleScrollStartReach}
-              onScrollEndReach={handleScrollEndReach}
+              isFetchingNextPage={processScroll.isFetchingNextPage}
+              isFetchingPreviousPage={processScroll.isFetchingPreviousPage}
+              onScrollStartReach={processScroll.handleScrollStartReach}
+              onScrollEndReach={processScroll.handleScrollEndReach}
             />
           )}
         </ScrollableContent>
@@ -85,7 +76,14 @@ const Dashboard: React.FC = () => {
           <TileTitle>Process Incidents by Error Message</TileTitle>
           <ScrollableContent ref={incidentScrollableContentRef}>
             <IncidentsByError
+              status={incidentStats.status}
+              items={incidentStats.data?.items ?? []}
+              totalCount={incidentStats.data?.totalCount ?? 0}
               scrollableContainerRef={incidentScrollableContentRef}
+              isFetchingNextPage={incidentScroll.isFetchingNextPage}
+              isFetchingPreviousPage={incidentScroll.isFetchingPreviousPage}
+              onScrollStartReach={incidentScroll.handleScrollStartReach}
+              onScrollEndReach={incidentScroll.handleScrollEndReach}
             />
           </ScrollableContent>
         </Tile>

--- a/operate/client/src/App/Dashboard/index.tsx
+++ b/operate/client/src/App/Dashboard/index.tsx
@@ -13,8 +13,14 @@ import {PAGE_TITLE} from 'modules/constants';
 import {Grid, ScrollableContent, Tile, TileTitle} from './styled';
 import {InstancesByProcessDefinition} from './InstancesByProcessDefinition';
 import {IncidentsByError} from './IncidentsByError';
-import {useProcessDefinitionStatisticsPaginated} from 'modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated';
-import {useIncidentProcessInstanceStatisticsByErrorPaginated} from 'modules/queries/incidentStatistics/useIncidentProcessInstanceStatisticsByErrorPaginated';
+import {
+  useProcessDefinitionStatisticsPaginated,
+  PAGE_LIMIT as PROCESS_PAGE_LIMIT,
+} from 'modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated';
+import {
+  useIncidentProcessInstanceStatisticsByErrorPaginated,
+  PAGE_LIMIT as INCIDENT_PAGE_LIMIT,
+} from 'modules/queries/incidentStatistics/useIncidentProcessInstanceStatisticsByErrorPaginated';
 import {NoInstancesEmptyState} from './NoInstancesEmptyState';
 import {
   useDashboardScrollPagination,
@@ -32,11 +38,20 @@ const Dashboard: React.FC = () => {
 
   const incidentStats = useIncidentProcessInstanceStatisticsByErrorPaginated({
     enablePeriodicRefetch: true,
+    enabled:
+      processStats.status !== 'success' ||
+      (processStats.data?.totalCount ?? 0) > 0,
     select: flattenPaginatedPages,
   });
 
-  const processScroll = useDashboardScrollPagination(processStats);
-  const incidentScroll = useDashboardScrollPagination(incidentStats);
+  const processScroll = useDashboardScrollPagination(
+    processStats,
+    PROCESS_PAGE_LIMIT,
+  );
+  const incidentScroll = useDashboardScrollPagination(
+    incidentStats,
+    INCIDENT_PAGE_LIMIT,
+  );
 
   const hasNoInstances =
     processStats.status === 'success' &&

--- a/operate/client/src/App/Dashboard/index.tsx
+++ b/operate/client/src/App/Dashboard/index.tsx
@@ -22,10 +22,8 @@ import {
   PAGE_LIMIT as INCIDENT_PAGE_LIMIT,
 } from 'modules/queries/incidentStatistics/useIncidentProcessInstanceStatisticsByErrorPaginated';
 import {NoInstancesEmptyState} from './NoInstancesEmptyState';
-import {
-  useDashboardScrollPagination,
-  flattenPaginatedPages,
-} from './useDashboardScrollPagination';
+import {useDashboardScrollPagination} from './useDashboardScrollPagination';
+import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
 
 const Dashboard: React.FC = () => {
   const scrollableContentRef = useRef<HTMLDivElement>(null);

--- a/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
+++ b/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
@@ -10,7 +10,6 @@ import type {UseInfiniteQueryResult} from '@tanstack/react-query';
 import {useCallback} from 'react';
 
 const ROW_HEIGHT = 64;
-const DEFAULT_PAGE_SIZE = 50;
 
 type PaginatedResult = Pick<
   UseInfiniteQueryResult,
@@ -24,7 +23,7 @@ type PaginatedResult = Pick<
 
 function useDashboardScrollPagination(
   queryResult: PaginatedResult,
-  pageSize: number = DEFAULT_PAGE_SIZE,
+  pageSize: number,
 ) {
   const {
     hasPreviousPage,

--- a/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
+++ b/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
@@ -43,7 +43,12 @@ function useDashboardScrollPagination(
         scrollDown(smoothScrollStepSize);
       }
     },
-    [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage, smoothScrollStepSize],
+    [
+      hasPreviousPage,
+      isFetchingPreviousPage,
+      fetchPreviousPage,
+      smoothScrollStepSize,
+    ],
   );
 
   const handleScrollEndReach = useCallback(() => {

--- a/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
+++ b/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useCallback} from 'react';
+import type {InfiniteData} from '@tanstack/react-query';
+
+const ROW_HEIGHT = 64;
+const PAGE_LIMIT = 50;
+const SMOOTH_SCROLL_STEP_SIZE = PAGE_LIMIT * ROW_HEIGHT;
+
+type PaginatedResult = {
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+  isFetchingPreviousPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchPreviousPage: () => Promise<unknown>;
+  fetchNextPage: () => Promise<unknown>;
+};
+
+function useDashboardScrollPagination(queryResult: PaginatedResult) {
+  const {
+    hasPreviousPage,
+    hasNextPage,
+    isFetchingPreviousPage,
+    isFetchingNextPage,
+    fetchPreviousPage,
+    fetchNextPage,
+  } = queryResult;
+
+  const handleScrollStartReach = useCallback(
+    async (scrollDown: (distance: number) => void) => {
+      if (hasPreviousPage && !isFetchingPreviousPage) {
+        await fetchPreviousPage();
+        scrollDown(SMOOTH_SCROLL_STEP_SIZE);
+      }
+    },
+    [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage],
+  );
+
+  const handleScrollEndReach = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return {
+    handleScrollStartReach,
+    handleScrollEndReach,
+    isFetchingPreviousPage,
+    isFetchingNextPage,
+  };
+}
+
+type PageResponse = {
+  items: unknown[];
+  page: {totalItems: number};
+};
+
+/**
+ * Shared select function for dashboard paginated queries.
+ * Flattens infinite query pages into a single items array with totalCount.
+ */
+function flattenPaginatedPages<T extends PageResponse>(
+  data: InfiniteData<T>,
+): {items: T['items']; totalCount: number} {
+  return {
+    items: data.pages.flatMap((page) => page.items),
+    totalCount: data.pages[0]?.page.totalItems ?? 0,
+  };
+}
+
+export {useDashboardScrollPagination, flattenPaginatedPages};

--- a/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
+++ b/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
@@ -51,11 +51,14 @@ function useDashboardScrollPagination(
     ],
   );
 
-  const handleScrollEndReach = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const handleScrollEndReach = useCallback(
+    (_scrollUp: (distance: number) => void) => {
+      if (hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  );
 
   return {
     handleScrollStartReach,

--- a/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
+++ b/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
@@ -6,19 +6,21 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {UseInfiniteQueryResult} from '@tanstack/react-query';
 import {useCallback} from 'react';
 
 const ROW_HEIGHT = 64;
 const DEFAULT_PAGE_SIZE = 50;
 
-type PaginatedResult = {
-  hasPreviousPage: boolean;
-  hasNextPage: boolean;
-  isFetchingPreviousPage: boolean;
-  isFetchingNextPage: boolean;
-  fetchPreviousPage: () => Promise<unknown>;
-  fetchNextPage: () => Promise<unknown>;
-};
+type PaginatedResult = Pick<
+  UseInfiniteQueryResult,
+  | 'hasPreviousPage'
+  | 'hasNextPage'
+  | 'isFetchingPreviousPage'
+  | 'isFetchingNextPage'
+  | 'fetchPreviousPage'
+  | 'fetchNextPage'
+>;
 
 function useDashboardScrollPagination(
   queryResult: PaginatedResult,

--- a/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
+++ b/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
@@ -10,8 +10,7 @@ import {useCallback} from 'react';
 import type {InfiniteData} from '@tanstack/react-query';
 
 const ROW_HEIGHT = 64;
-const PAGE_LIMIT = 50;
-const SMOOTH_SCROLL_STEP_SIZE = PAGE_LIMIT * ROW_HEIGHT;
+const DEFAULT_PAGE_SIZE = 50;
 
 type PaginatedResult = {
   hasPreviousPage: boolean;
@@ -22,7 +21,10 @@ type PaginatedResult = {
   fetchNextPage: () => Promise<unknown>;
 };
 
-function useDashboardScrollPagination(queryResult: PaginatedResult) {
+function useDashboardScrollPagination(
+  queryResult: PaginatedResult,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+) {
   const {
     hasPreviousPage,
     hasNextPage,
@@ -32,14 +34,16 @@ function useDashboardScrollPagination(queryResult: PaginatedResult) {
     fetchNextPage,
   } = queryResult;
 
+  const smoothScrollStepSize = pageSize * ROW_HEIGHT;
+
   const handleScrollStartReach = useCallback(
     async (scrollDown: (distance: number) => void) => {
       if (hasPreviousPage && !isFetchingPreviousPage) {
         await fetchPreviousPage();
-        scrollDown(SMOOTH_SCROLL_STEP_SIZE);
+        scrollDown(smoothScrollStepSize);
       }
     },
-    [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage],
+    [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage, smoothScrollStepSize],
   );
 
   const handleScrollEndReach = useCallback(() => {

--- a/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
+++ b/operate/client/src/App/Dashboard/useDashboardScrollPagination.ts
@@ -7,7 +7,6 @@
  */
 
 import {useCallback} from 'react';
-import type {InfiniteData} from '@tanstack/react-query';
 
 const ROW_HEIGHT = 64;
 const DEFAULT_PAGE_SIZE = 50;
@@ -65,22 +64,4 @@ function useDashboardScrollPagination(
   };
 }
 
-type PageResponse = {
-  items: unknown[];
-  page: {totalItems: number};
-};
-
-/**
- * Shared select function for dashboard paginated queries.
- * Flattens infinite query pages into a single items array with totalCount.
- */
-function flattenPaginatedPages<T extends PageResponse>(
-  data: InfiniteData<T>,
-): {items: T['items']; totalCount: number} {
-  return {
-    items: data.pages.flatMap((page) => page.items),
-    totalCount: data.pages[0]?.page.totalItems ?? 0,
-  };
-}
-
-export {useDashboardScrollPagination, flattenPaginatedPages};
+export {useDashboardScrollPagination};

--- a/operate/client/src/modules/queries/flattenPaginatedPages.ts
+++ b/operate/client/src/modules/queries/flattenPaginatedPages.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {InfiniteData} from '@tanstack/react-query';
+
+type PageResponse = {
+  items: unknown[];
+  page: {totalItems: number};
+};
+
+/**
+ * Shared select function for paginated infinite queries.
+ * Flattens infinite query pages into a single items array with totalCount.
+ */
+function flattenPaginatedPages<T extends PageResponse>(
+  data: InfiniteData<T>,
+): {items: T['items']; totalCount: number} {
+  return {
+    items: data.pages.flatMap((page) => page.items),
+    totalCount: data.pages[0]?.page.totalItems ?? 0,
+  };
+}
+
+export {flattenPaginatedPages};

--- a/operate/client/src/modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated.ts
+++ b/operate/client/src/modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated.ts
@@ -85,4 +85,4 @@ const useProcessDefinitionStatisticsPaginated = <
   });
 };
 
-export {useProcessDefinitionStatisticsPaginated, PAGES_LIMIT};
+export {useProcessDefinitionStatisticsPaginated, PAGE_LIMIT, PAGES_LIMIT};

--- a/operate/client/src/modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated.ts
+++ b/operate/client/src/modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated.ts
@@ -85,4 +85,4 @@ const useProcessDefinitionStatisticsPaginated = <
   });
 };
 
-export {useProcessDefinitionStatisticsPaginated, PAGE_LIMIT, PAGES_LIMIT};
+export {useProcessDefinitionStatisticsPaginated, PAGE_LIMIT};

--- a/operate/client/src/modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated.ts
+++ b/operate/client/src/modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated.ts
@@ -85,4 +85,4 @@ const useProcessDefinitionStatisticsPaginated = <
   });
 };
 
-export {useProcessDefinitionStatisticsPaginated, PAGE_LIMIT};
+export {useProcessDefinitionStatisticsPaginated};

--- a/operate/client/src/modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated.ts
+++ b/operate/client/src/modules/queries/processDefinitionStatistics/useProcessDefinitionStatisticsPaginated.ts
@@ -85,4 +85,4 @@ const useProcessDefinitionStatisticsPaginated = <
   });
 };
 
-export {useProcessDefinitionStatisticsPaginated};
+export {useProcessDefinitionStatisticsPaginated, PAGE_LIMIT};


### PR DESCRIPTION
closes #46381

## Description
This PR:
- Extract shared `useDashboardScrollPagination` hook and `flattenPaginatedPages` helper to eliminate duplicated scroll/pagination logic between the two dashboard panels
- Move incident stats query ownership from `IncidentsByError` up to `Dashboard`, so both child components now follow the same props-based pattern
- Fix scroll step bug: was using `PAGES_LIMIT` (5) instead of `PAGE_LIMIT` (50) for the process instances scroll step calculation

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46381
