### PR TITLE
feat: return 403 when the Job metrics feature is disabled

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -47,6 +47,8 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.util.Either;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
@@ -129,8 +131,9 @@ public class JobController {
   public ResponseEntity<GlobalJobStatisticsQueryResult> getGlobalJobStatistics(
       @RequestParam final OffsetDateTime from,
       @RequestParam final OffsetDateTime to,
-      @RequestParam(required = false) final String jobType) {
-    return requireJobMetricsEnabled()
+      @RequestParam(required = false) final String jobType,
+      final HttpServletRequest request) {
+    return requireJobMetricsEnabled(request)
         .flatMap(ok -> SearchQueryRequestMapper.toGlobalJobStatisticsQuery(from, to, jobType))
         .fold(RestErrorMapper::mapProblemToResponse, this::getGlobalStatistics);
   }
@@ -138,8 +141,8 @@ public class JobController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/by-types")
   public ResponseEntity<JobTypeStatisticsQueryResult> getJobTypeStatistics(
-      @RequestBody final JobTypeStatisticsQuery request) {
-    return requireJobMetricsEnabled()
+      @RequestBody final JobTypeStatisticsQuery request, final HttpServletRequest httpRequest) {
+    return requireJobMetricsEnabled(httpRequest)
         .flatMap(ok -> SearchQueryRequestMapper.toJobTypeStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getTypeStatistics);
   }
@@ -147,8 +150,8 @@ public class JobController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/by-workers")
   public ResponseEntity<JobWorkerStatisticsQueryResult> getJobWorkerStatistics(
-      @RequestBody final JobWorkerStatisticsQuery request) {
-    return requireJobMetricsEnabled()
+      @RequestBody final JobWorkerStatisticsQuery request, final HttpServletRequest httpRequest) {
+    return requireJobMetricsEnabled(httpRequest)
         .flatMap(ok -> SearchQueryRequestMapper.toJobWorkerStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getWorkerStatistics);
   }
@@ -156,8 +159,9 @@ public class JobController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/time-series")
   public ResponseEntity<JobTimeSeriesStatisticsQueryResult> getJobTimeSeriesStatistics(
-      @RequestBody final JobTimeSeriesStatisticsQuery request) {
-    return requireJobMetricsEnabled()
+      @RequestBody final JobTimeSeriesStatisticsQuery request,
+      final HttpServletRequest httpRequest) {
+    return requireJobMetricsEnabled(httpRequest)
         .flatMap(ok -> SearchQueryRequestMapper.toJobTimeSeriesStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getTimeSeriesStatistics);
   }
@@ -312,12 +316,13 @@ public class JobController {
     }
   }
 
-  private Either<ProblemDetail, Void> requireJobMetricsEnabled() {
+  private Either<ProblemDetail, Void> requireJobMetricsEnabled(final HttpServletRequest request) {
     if (!gatewayRestConfiguration.getJobMetrics().isEnabled()) {
       final var problemDetail =
           CamundaProblemDetail.forStatusAndDetail(
               HttpStatus.FORBIDDEN, "Job metrics feature is disabled");
       problemDetail.setTitle("FORBIDDEN");
+      problemDetail.setInstance(URI.create(request.getRequestURI()));
       return Either.left(problemDetail);
     }
     return Either.right(null);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -133,7 +133,7 @@ public class JobController {
       @RequestParam final OffsetDateTime to,
       @RequestParam(required = false) final String jobType,
       final HttpServletRequest request) {
-    return requireJobMetricsEnabled(request)
+    return requireJobMetricsEnabled(request.getRequestURI())
         .flatMap(ok -> SearchQueryRequestMapper.toGlobalJobStatisticsQuery(from, to, jobType))
         .fold(RestErrorMapper::mapProblemToResponse, this::getGlobalStatistics);
   }
@@ -142,7 +142,7 @@ public class JobController {
   @CamundaPostMapping(path = "/statistics/by-types")
   public ResponseEntity<JobTypeStatisticsQueryResult> getJobTypeStatistics(
       @RequestBody final JobTypeStatisticsQuery request, final HttpServletRequest httpRequest) {
-    return requireJobMetricsEnabled(httpRequest)
+    return requireJobMetricsEnabled(httpRequest.getRequestURI())
         .flatMap(ok -> SearchQueryRequestMapper.toJobTypeStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getTypeStatistics);
   }
@@ -151,7 +151,7 @@ public class JobController {
   @CamundaPostMapping(path = "/statistics/by-workers")
   public ResponseEntity<JobWorkerStatisticsQueryResult> getJobWorkerStatistics(
       @RequestBody final JobWorkerStatisticsQuery request, final HttpServletRequest httpRequest) {
-    return requireJobMetricsEnabled(httpRequest)
+    return requireJobMetricsEnabled(httpRequest.getRequestURI())
         .flatMap(ok -> SearchQueryRequestMapper.toJobWorkerStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getWorkerStatistics);
   }
@@ -161,7 +161,7 @@ public class JobController {
   public ResponseEntity<JobTimeSeriesStatisticsQueryResult> getJobTimeSeriesStatistics(
       @RequestBody final JobTimeSeriesStatisticsQuery request,
       final HttpServletRequest httpRequest) {
-    return requireJobMetricsEnabled(httpRequest)
+    return requireJobMetricsEnabled(httpRequest.getRequestURI())
         .flatMap(ok -> SearchQueryRequestMapper.toJobTimeSeriesStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getTimeSeriesStatistics);
   }
@@ -316,13 +316,13 @@ public class JobController {
     }
   }
 
-  private Either<ProblemDetail, Void> requireJobMetricsEnabled(final HttpServletRequest request) {
+  private Either<ProblemDetail, Void> requireJobMetricsEnabled(final String requestUri) {
     if (!gatewayRestConfiguration.getJobMetrics().isEnabled()) {
       final var problemDetail =
           CamundaProblemDetail.forStatusAndDetail(
               HttpStatus.FORBIDDEN, "Job metrics feature is disabled");
       problemDetail.setTitle("FORBIDDEN");
-      problemDetail.setInstance(URI.create(request.getRequestURI()));
+      problemDetail.setInstance(URI.create(requestUri));
       return Either.left(problemDetail);
     }
     return Either.right(null);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -16,6 +16,7 @@ import io.camunda.gateway.mapping.http.RequestMapper.FailJobRequest;
 import io.camunda.gateway.mapping.http.RequestMapper.UpdateJobRequest;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.protocol.model.CamundaProblemDetail;
 import io.camunda.gateway.protocol.model.GlobalJobStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobActivationRequest;
 import io.camunda.gateway.protocol.model.JobActivationResult;
@@ -42,10 +43,14 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.util.Either;
 import java.time.OffsetDateTime;
 import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -60,16 +65,19 @@ public class JobController {
   private final JobServices<JobActivationResult> jobServices;
   private final MultiTenancyConfiguration multiTenancyCfg;
   private final CamundaAuthenticationProvider authenticationProvider;
+  private final GatewayRestConfiguration gatewayRestConfiguration;
 
   public JobController(
       final JobServices<JobActivationResult> jobServices,
       final ResponseObserverProvider responseObserverProvider,
       final MultiTenancyConfiguration multiTenancyCfg,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final GatewayRestConfiguration gatewayRestConfiguration) {
     this.jobServices = jobServices;
     this.responseObserverProvider = responseObserverProvider;
     this.multiTenancyCfg = multiTenancyCfg;
     this.authenticationProvider = authenticationProvider;
+    this.gatewayRestConfiguration = gatewayRestConfiguration;
   }
 
   @CamundaPostMapping(path = "/activation")
@@ -122,7 +130,8 @@ public class JobController {
       @RequestParam final OffsetDateTime from,
       @RequestParam final OffsetDateTime to,
       @RequestParam(required = false) final String jobType) {
-    return SearchQueryRequestMapper.toGlobalJobStatisticsQuery(from, to, jobType)
+    return requireJobMetricsEnabled()
+        .flatMap(ok -> SearchQueryRequestMapper.toGlobalJobStatisticsQuery(from, to, jobType))
         .fold(RestErrorMapper::mapProblemToResponse, this::getGlobalStatistics);
   }
 
@@ -130,7 +139,8 @@ public class JobController {
   @CamundaPostMapping(path = "/statistics/by-types")
   public ResponseEntity<JobTypeStatisticsQueryResult> getJobTypeStatistics(
       @RequestBody final JobTypeStatisticsQuery request) {
-    return SearchQueryRequestMapper.toJobTypeStatisticsQuery(request)
+    return requireJobMetricsEnabled()
+        .flatMap(ok -> SearchQueryRequestMapper.toJobTypeStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getTypeStatistics);
   }
 
@@ -138,7 +148,8 @@ public class JobController {
   @CamundaPostMapping(path = "/statistics/by-workers")
   public ResponseEntity<JobWorkerStatisticsQueryResult> getJobWorkerStatistics(
       @RequestBody final JobWorkerStatisticsQuery request) {
-    return SearchQueryRequestMapper.toJobWorkerStatisticsQuery(request)
+    return requireJobMetricsEnabled()
+        .flatMap(ok -> SearchQueryRequestMapper.toJobWorkerStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getWorkerStatistics);
   }
 
@@ -146,7 +157,8 @@ public class JobController {
   @CamundaPostMapping(path = "/statistics/time-series")
   public ResponseEntity<JobTimeSeriesStatisticsQueryResult> getJobTimeSeriesStatistics(
       @RequestBody final JobTimeSeriesStatisticsQuery request) {
-    return SearchQueryRequestMapper.toJobTimeSeriesStatisticsQuery(request)
+    return requireJobMetricsEnabled()
+        .flatMap(ok -> SearchQueryRequestMapper.toJobTimeSeriesStatisticsQuery(request))
         .fold(RestErrorMapper::mapProblemToResponse, this::getTimeSeriesStatistics);
   }
 
@@ -298,5 +310,16 @@ public class JobController {
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
+  }
+
+  private Either<ProblemDetail, Void> requireJobMetricsEnabled() {
+    if (!gatewayRestConfiguration.getJobMetrics().isEnabled()) {
+      final var problemDetail =
+          CamundaProblemDetail.forStatusAndDetail(
+              HttpStatus.FORBIDDEN, "Job metrics feature is disabled");
+      problemDetail.setTitle("FORBIDDEN");
+      return Either.left(problemDetail);
+    }
+    return Either.right(null);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.controller.util.ResettableJobActivationRequestResponseObserver;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -66,6 +67,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
   @MockitoSpyBean ResettableJobActivationRequestResponseObserver responseObserver;
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setup() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.controller.util.ResettableJobActivationRequestResponseObserver;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -63,6 +64,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
   @MockitoSpyBean ResettableJobActivationRequestResponseObserver responseObserver;
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setup() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -2406,64 +2406,73 @@ public class JobControllerTest extends RestControllerTest {
     verifyNoInteractions(jobServices);
   }
 
-  @Test
-  void shouldReturn403ForGlobalStatisticsWhenJobMetricsDisabled() {
-    // given
-    final var disabledCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
-    disabledCfg.setEnabled(false);
-    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(disabledCfg);
-
-    // when/then
-    webClient
-        .get()
-        .uri(
-            JOBS_BASE_URL
-                + "/statistics/global?from=2024-07-28T15:51:28.071Z&to=2024-07-29T15:51:28.071Z")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isForbidden()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(
+  static Stream<Arguments> jobMetricsDisabledEndpoints() {
+    return Stream.of(
+        Arguments.of(
+            "/statistics/global?from=2024-07-28T15:51:28.071Z&to=2024-07-29T15:51:28.071Z",
+            "GET",
+            null,
+            "/v2/jobs/statistics/global"),
+        Arguments.of(
+            "/statistics/by-types",
+            "POST",
             """
-            {
-              "type": "about:blank",
-              "title": "FORBIDDEN",
-              "status": 403,
-              "detail": "Job metrics feature is disabled",
-              "instance": "/v2/jobs/statistics/global"
-            }
-            """,
-            JsonCompareMode.STRICT);
-
-    verifyNoInteractions(jobServices);
+                {
+                  "filter": {
+                    "from": "2024-07-28T15:51:28.071Z",
+                    "to": "2024-07-29T15:51:28.071Z"
+                  }
+                }""",
+            "/v2/jobs/statistics/by-types"),
+        Arguments.of(
+            "/statistics/by-workers",
+            "POST",
+            """
+                {
+                  "filter": {
+                    "from": "2024-07-28T15:51:28.071Z",
+                    "to": "2024-07-29T15:51:28.071Z"
+                  }
+                }""",
+            "/v2/jobs/statistics/by-workers"),
+        Arguments.of(
+            "/statistics/time-series",
+            "POST",
+            """
+                {
+                  "filter": {
+                    "from": "2024-07-28T15:51:28.071Z",
+                    "to": "2024-07-29T15:51:28.071Z",
+                    "jobType": "fetch-customer-data"
+                  }
+                }""",
+            "/v2/jobs/statistics/time-series"));
   }
 
-  @Test
-  void shouldReturn403ForJobTypeStatisticsWhenJobMetricsDisabled() {
+  @ParameterizedTest(name = "shouldReturn403For {0} statistics when job metrics disabled")
+  @MethodSource("jobMetricsDisabledEndpoints")
+  void shouldReturn403WhenJobMetricsDisabled(
+      final String uriSuffix,
+      final String httpMethod,
+      final String requestBody,
+      final String expectedInstance) {
     // given
     final var disabledCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
     disabledCfg.setEnabled(false);
     when(gatewayRestConfiguration.getJobMetrics()).thenReturn(disabledCfg);
 
-    final var request =
-        """
-            {
-              "filter": {
-                "from": "2024-07-28T15:51:28.071Z",
-                "to": "2024-07-29T15:51:28.071Z"
-              }
-            }""";
-
     // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/statistics/by-types")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
+    final var requestSpec =
+        "GET".equals(httpMethod)
+            ? webClient.get().uri(JOBS_BASE_URL + uriSuffix).accept(MediaType.APPLICATION_JSON)
+            : webClient
+                .post()
+                .uri(JOBS_BASE_URL + uriSuffix)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody);
+
+    requestSpec
         .exchange()
         .expectStatus()
         .isForbidden()
@@ -2477,98 +2486,10 @@ public class JobControllerTest extends RestControllerTest {
               "title": "FORBIDDEN",
               "status": 403,
               "detail": "Job metrics feature is disabled",
-              "instance": "/v2/jobs/statistics/by-types"
+              "instance": "%s"
             }
-            """,
-            JsonCompareMode.STRICT);
-
-    verifyNoInteractions(jobServices);
-  }
-
-  @Test
-  void shouldReturn403ForJobWorkerStatisticsWhenJobMetricsDisabled() {
-    // given
-    final var disabledCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
-    disabledCfg.setEnabled(false);
-    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(disabledCfg);
-
-    final var request =
-        """
-            {
-              "filter": {
-                "from": "2024-07-28T15:51:28.071Z",
-                "to": "2024-07-29T15:51:28.071Z"
-              }
-            }""";
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/statistics/by-workers")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isForbidden()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(
             """
-            {
-              "type": "about:blank",
-              "title": "FORBIDDEN",
-              "status": 403,
-              "detail": "Job metrics feature is disabled",
-              "instance": "/v2/jobs/statistics/by-workers"
-            }
-            """,
-            JsonCompareMode.STRICT);
-
-    verifyNoInteractions(jobServices);
-  }
-
-  @Test
-  void shouldReturn403ForJobTimeSeriesStatisticsWhenJobMetricsDisabled() {
-    // given
-    final var disabledCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
-    disabledCfg.setEnabled(false);
-    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(disabledCfg);
-
-    final var request =
-        """
-            {
-              "filter": {
-                "from": "2024-07-28T15:51:28.071Z",
-                "to": "2024-07-29T15:51:28.071Z",
-                "jobType": "fetch-customer-data"
-              }
-            }""";
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/statistics/time-series")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isForbidden()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(
-            """
-            {
-              "type": "about:blank",
-              "title": "FORBIDDEN",
-              "status": 403,
-              "detail": "Job metrics feature is disabled",
-              "instance": "/v2/jobs/statistics/time-series"
-            }
-            """,
+                .formatted(expectedInstance),
             JsonCompareMode.STRICT);
 
     verifyNoInteractions(jobServices);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -31,6 +31,7 @@ import io.camunda.service.JobServices;
 import io.camunda.service.JobServices.ActivateJobsRequest;
 import io.camunda.service.JobServices.UpdateJobChangeset;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
@@ -63,12 +64,16 @@ public class JobControllerTest extends RestControllerTest {
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean ResponseObserverProvider responseObserverProvider;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setup() {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(jobServices.withAuthentication(any(CamundaAuthentication.class))).thenReturn(jobServices);
+    final var jobMetricsCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
+    jobMetricsCfg.setEnabled(true);
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(jobMetricsCfg);
   }
 
   @Test
@@ -2397,6 +2402,174 @@ public class JobControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldReturn403ForGlobalStatisticsWhenJobMetricsDisabled() {
+    // given
+    final var disabledCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
+    disabledCfg.setEnabled(false);
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(disabledCfg);
+
+    // when/then
+    webClient
+        .get()
+        .uri(
+            JOBS_BASE_URL
+                + "/statistics/global?from=2024-07-28T15:51:28.071Z&to=2024-07-29T15:51:28.071Z")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "FORBIDDEN",
+              "status": 403,
+              "detail": "Job metrics feature is disabled",
+              "instance": "/v2/jobs/statistics/global"
+            }
+            """,
+            JsonCompareMode.STRICT);
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldReturn403ForJobTypeStatisticsWhenJobMetricsDisabled() {
+    // given
+    final var disabledCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
+    disabledCfg.setEnabled(false);
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(disabledCfg);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-types")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "FORBIDDEN",
+              "status": 403,
+              "detail": "Job metrics feature is disabled",
+              "instance": "/v2/jobs/statistics/by-types"
+            }
+            """,
+            JsonCompareMode.STRICT);
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldReturn403ForJobWorkerStatisticsWhenJobMetricsDisabled() {
+    // given
+    final var disabledCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
+    disabledCfg.setEnabled(false);
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(disabledCfg);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "FORBIDDEN",
+              "status": 403,
+              "detail": "Job metrics feature is disabled",
+              "instance": "/v2/jobs/statistics/by-workers"
+            }
+            """,
+            JsonCompareMode.STRICT);
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldReturn403ForJobTimeSeriesStatisticsWhenJobMetricsDisabled() {
+    // given
+    final var disabledCfg = new GatewayRestConfiguration.JobMetricsConfiguration();
+    disabledCfg.setEnabled(false);
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(disabledCfg);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/time-series")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "FORBIDDEN",
+              "status": 403,
+              "detail": "Job metrics feature is disabled",
+              "instance": "/v2/jobs/statistics/time-series"
+            }
+            """,
+            JsonCompareMode.STRICT);
 
     verifyNoInteractions(jobServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -24,6 +24,7 @@ import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +120,7 @@ public class JobQueryControllerTest extends RestControllerTest {
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean ResponseObserverProvider responseObserverProvider;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setupJobServices() {


### PR DESCRIPTION
This pull request introduces a new system configuration endpoint and enforces feature flag checks for job metrics-related endpoints. The changes provide a way for clients to query the current system configuration, including job metrics settings, and ensure that job metrics endpoints return a proper error when the feature is disabled. Additionally, the tests have been updated to verify the new behavior and endpoint.

**API enhancements and feature flag enforcement:**

* Added `/system/configuration` endpoint to the REST and OpenAPI definitions, allowing clients to query system configuration, including job metrics settings. The response structure is defined and documented as an alpha feature. [[1]](diffhunk://#diff-3b6f45130d7e41d7fd7ecbf0f742873b3cd0bb8d52ae42599bf27ffba42ece4dR368-R369) [[2]](diffhunk://#diff-e017b3694edf023467818d387c928a92ba42072999fc45fe9d0e496b66650760R80-R114) [[3]](diffhunk://#diff-e017b3694edf023467818d387c928a92ba42072999fc45fe9d0e496b66650760R156-R207)
* Introduced feature flag enforcement for job metrics endpoints in `JobController`, returning HTTP 403 with a structured problem detail response when job metrics are disabled. [[1]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceL123-R159) [[2]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR291-R301)

**Controller refactoring and implementation:**

* Refactored `UsageMetricsController` to `SystemController`, moved usage metrics and added system configuration endpoint implementation, wiring configuration properties for response construction. [[1]](diffhunk://#diff-b4a7754bf1cb5dc3132c79f78397f6619879b396c1edbbc018e635518741248cR14-R23) [[2]](diffhunk://#diff-b4a7754bf1cb5dc3132c79f78397f6619879b396c1edbbc018e635518741248cL28-R48) [[3]](diffhunk://#diff-b4a7754bf1cb5dc3132c79f78397f6619879b396c1edbbc018e635518741248cR59-R73)

**Testing improvements:**

* Updated `JobControllerTest` to mock and verify feature flag behavior, including new tests for forbidden responses when job metrics are disabled. [[1]](diffhunk://#diff-27d6092983141c51e9f725dfd10ba2565d0d2c3f95bf27115a3487dc1a03323eR33) [[2]](diffhunk://#diff-27d6092983141c51e9f725dfd10ba2565d0d2c3f95bf27115a3487dc1a03323eR66-R75) [[3]](diffhunk://#diff-27d6092983141c51e9f725dfd10ba2565d0d2c3f95bf27115a3487dc1a03323eR2164-R2331)
* Updated and renamed `UsageMetricsControllerTest` to `SystemControllerTest`, adding tests for the new configuration endpoint. [[1]](diffhunk://#diff-2a1006bb80aba5a08901d088a454a0294cad09784c9dc0c711dc577fcf8e4aceR24-R27) [[2]](diffhunk://#diff-2a1006bb80aba5a08901d088a454a0294cad09784c9dc0c711dc577fcf8e4aceL35-R41)