### PR TITLE
[Backport stable/8.9]  perf: avoid reading unused values while iterating through column families

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
@@ -173,6 +173,6 @@ public final class DbBackupRangeState {
 
   /** Removes all range entries. Used during state reset when switching backup stores. */
   public void clearAll() {
-    rangesColumnFamily.forEach((key, value) -> rangesColumnFamily.deleteExisting(key));
+    rangesColumnFamily.forEachKey(rangesColumnFamily::deleteExisting);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
@@ -163,6 +163,6 @@ public final class DbCheckpointMetadataState {
 
   /** Removes all checkpoint entries. Used during state reset when switching backup stores. */
   public void clearAll() {
-    checkpointsColumnFamily.forEach((key, value) -> checkpointsColumnFamily.deleteExisting(key));
+    checkpointsColumnFamily.forEachKey(checkpointsColumnFamily::deleteExisting);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV1Applier.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 
 /** Applies state changes for `ProcessInstance:Element_Activating` */
 final class ProcessInstanceElementActivatingV1Applier
@@ -221,7 +220,7 @@ final class ProcessInstanceElementActivatingV1Applier
             value.getElementIdBuffer(),
             ExecutableFlowNode.class);
     final var size = executableFlowNode.getIncoming().size();
-    IntStream.range(0, size).forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(size);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 
@@ -230,8 +229,7 @@ final class ProcessInstanceElementActivatingV1Applier
     // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
     // active sequence flows based on the satisfied incoming sequence flows.
 
-    IntStream.range(0, numberOfTakenSequenceFlows)
-        .forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(numberOfTakenSequenceFlows);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV2Applier.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 
 /** Applies state changes for `ProcessInstance:Element_Activating` */
 final class ProcessInstanceElementActivatingV2Applier
@@ -228,7 +227,7 @@ final class ProcessInstanceElementActivatingV2Applier
             value.getElementIdBuffer(),
             ExecutableFlowNode.class);
     final var size = executableFlowNode.getIncoming().size();
-    IntStream.range(0, size).forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(size);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 
@@ -237,8 +236,7 @@ final class ProcessInstanceElementActivatingV2Applier
     // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
     // active sequence flows based on the satisfied incoming sequence flows.
 
-    IntStream.range(0, numberOfTakenSequenceFlows)
-        .forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(numberOfTakenSequenceFlows);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV3Applier.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 
 /** Applies state changes for `ProcessInstance:Element_Activating` */
 final class ProcessInstanceElementActivatingV3Applier
@@ -233,7 +232,7 @@ final class ProcessInstanceElementActivatingV3Applier
             value.getElementIdBuffer(),
             ExecutableFlowNode.class);
     final var size = executableFlowNode.getIncoming().size();
-    IntStream.range(0, size).forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(size);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 
@@ -242,8 +241,7 @@ final class ProcessInstanceElementActivatingV3Applier
     // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
     // active sequence flows based on the satisfied incoming sequence flows.
 
-    IntStream.range(0, numberOfTakenSequenceFlows)
-        .forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(numberOfTakenSequenceFlows);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMembershipState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMembershipState.java
@@ -79,7 +79,7 @@ public final class DbMembershipState implements MutableMembershipState {
 
     relationsByEntity.whileEqualPrefix(
         new EntityKeyAndRelationType(entityType, entityId, relationType),
-        (key, value) -> {
+        key -> {
           relationIds.add(key.relation().id());
         });
 
@@ -107,7 +107,7 @@ public final class DbMembershipState implements MutableMembershipState {
       final BiFunction<EntityType, String, Boolean> visitor) {
     entitiesByRelation.whileEqualPrefix(
         new RelationKey(relationType, relationId),
-        (key, value) -> {
+        key -> {
           return visitor.apply(key.entity().type(), key.entity().id());
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -332,7 +332,7 @@ public class DbBatchOperationState implements MutableBatchOperationState {
     final var pendingBatchOperation = new AtomicReference<PersistedBatchOperation>();
 
     pendingBatchOperationColumnFamily.whileTrue(
-        (key, nil) -> {
+        key -> {
           final var batchOperation = batchOperationColumnFamily.get(key);
           if (batchOperation != null) {
             pendingBatchOperation.set(batchOperation);
@@ -377,10 +377,7 @@ public class DbBatchOperationState implements MutableBatchOperationState {
 
     // then delete all chunks
     batchOperationChunksColumnFamily.whileEqualPrefix(
-        batchKey,
-        (compositeKey, entityTypeValue) -> {
-          batchOperationChunksColumnFamily.deleteExisting(compositeKey);
-        });
+        batchKey, batchOperationChunksColumnFamily::deleteExisting);
 
     // finally delete batch operation itself
     batchOperationColumnFamily.deleteExisting(batchKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/conditional/DbConditionalSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/conditional/DbConditionalSubscriptionState.java
@@ -174,7 +174,7 @@ public class DbConditionalSubscriptionState implements MutableConditionalSubscri
 
     scopeKeyColumnFamily.whileEqualPrefix(
         this.scopeKey,
-        (key, ignore) -> {
+        key -> {
           subscriptionKey.wrapLong(key.second().wrappedKey().getValue());
           tenantIdKey.wrapBuffer(key.second().tenantKey().getBuffer());
           final var subscription =
@@ -196,8 +196,8 @@ public class DbConditionalSubscriptionState implements MutableConditionalSubscri
 
     processDefinitionKeyColumnFamily.whileEqualPrefix(
         this.processDefinitionKey,
-        (key, nil) -> {
-          tenantIdKey.wrapString(key.second().tenantKey().toString());
+        key -> {
+          tenantIdKey.wrapBuffer(key.second().tenantKey().getBuffer());
           subscriptionKey.wrapLong(key.second().wrappedKey().getValue());
           final var subscription =
               subscriptionKeyColumnFamily.get(
@@ -216,7 +216,7 @@ public class DbConditionalSubscriptionState implements MutableConditionalSubscri
 
     tenantIdColumnFamily.whileEqualPrefix(
         tenantIdKey,
-        (key, nil) -> {
+        key -> {
           subscriptionKey.wrapLong(key.wrappedKey().getValue());
           final var subscription =
               subscriptionKeyColumnFamily.get(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -315,10 +315,10 @@ public final class DbDecisionState implements MutableDecisionState {
     dbDecisionRequirementsKey.wrapLong(decisionRequirementsKey);
     decisionKeyByDecisionRequirementsKey.whileEqualPrefix(
         new DbCompositeKey<>(tenantIdKey, dbDecisionRequirementsKey),
-        ((key, nil) -> {
+        key -> {
           final var decisionKey = key.second().inner().wrappedKey().getValue();
           findDecisionByTenantAndKey(tenantId, decisionKey).ifPresent(decisions::add);
-        }));
+        });
 
     return decisions;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -106,7 +106,7 @@ public final class DbDeploymentState implements MutableDeploymentState {
     final var hasPending = new MutableBoolean();
     pendingDeploymentColumnFamily.whileEqualPrefix(
         this.deploymentKey,
-        (dbLongDbIntDbCompositeKey, dbNil) -> {
+        ignored -> {
           hasPending.set(true);
           return false;
         });
@@ -153,8 +153,8 @@ public final class DbDeploymentState implements MutableDeploymentState {
 
     final MutableReference<DirectBuffer> lastDeployment = new MutableReference<>();
     final MutableLong lastDeploymentKey = new MutableLong(0);
-    pendingDeploymentColumnFamily.forEach(
-        (compositeKey, nil) -> {
+    pendingDeploymentColumnFamily.forEachKey(
+        (compositeKey) -> {
           final var deploymentKey = compositeKey.first().getValue();
           final var partitionId = compositeKey.second().getValue();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -196,7 +196,7 @@ public class DbDistributionState implements MutableDistributionState {
     final var hasRetriable = new MutableBoolean();
     retriableDistributionColumnFamily.whileEqualPrefix(
         this.distributionKey,
-        (compositeKey, dbNil) -> {
+        ignored -> {
           hasRetriable.set(true);
           return false;
         });
@@ -211,7 +211,7 @@ public class DbDistributionState implements MutableDistributionState {
     final var hasPending = new MutableBoolean();
     pendingDistributionColumnFamily.whileEqualPrefix(
         this.distributionKey,
-        (compositeKey, dbNil) -> {
+        ignored -> {
           hasPending.set(true);
           return false;
         });
@@ -274,8 +274,8 @@ public class DbDistributionState implements MutableDistributionState {
     final var lastDistributionKey = new MutableLong(0);
     final var lastPendingDistribution = new MutableReference<CommandDistributionRecord>();
 
-    retriableDistributionColumnFamily.forEach(
-        (compositeKey, nil) -> {
+    retriableDistributionColumnFamily.forEachKey(
+        (compositeKey) -> {
           final var distributionKey = compositeKey.first().inner().getValue();
           final var partitionId = compositeKey.second().getValue();
 
@@ -307,7 +307,7 @@ public class DbDistributionState implements MutableDistributionState {
     final var lastCommandDistribution = new MutableReference<CommandDistributionRecord>();
 
     pendingDistributionColumnFamily.whileTrue(
-        (compositeKey, nil) -> {
+        compositeKey -> {
           final var distributionKey = compositeKey.first().inner().getValue();
           final var partitionId = compositeKey.second().getValue();
 
@@ -341,7 +341,7 @@ public class DbDistributionState implements MutableDistributionState {
     final var nextDistributionKey = new MutableReference<Long>(null);
     queuedCommandDistributionColumnFamily.whileEqualPrefix(
         queuePerPartitionKey,
-        (key, value) -> {
+        key -> {
           nextDistributionKey.set(key.second().second().inner().getValue());
           return false;
         });
@@ -362,7 +362,7 @@ public class DbDistributionState implements MutableDistributionState {
     final var hasQueuedDistributions = new MutableBoolean();
     queuedCommandDistributionColumnFamily.whileEqualPrefix(
         queueId,
-        (key, value) -> {
+        key -> {
           hasQueuedDistributions.set(true);
           return false;
         });
@@ -375,7 +375,7 @@ public class DbDistributionState implements MutableDistributionState {
     queueId.wrapString(queue);
     continuationCommandColumnFamily.whileEqualPrefix(
         queueId,
-        (key, value) -> {
+        key -> {
           final var continuationKey = key.second().getValue();
           consumer.visit(continuationKey);
           return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/globallistener/DbGlobalListenersState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/globallistener/DbGlobalListenersState.java
@@ -144,7 +144,7 @@ public final class DbGlobalListenersState implements MutableGlobalListenersState
     final var referenced = new MutableBoolean(false);
     pinnedConfigColumnFamily.whileEqualPrefix(
         this.versionKey,
-        (compositeKey, nil) -> {
+        ignored -> {
           referenced.set(true);
           // Early exit as soon as we find a reference
           return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -298,7 +298,8 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
     numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
         flowScopeKeyAndElementId,
-        (key, number) -> {
+        key -> {
+          final var number = numberOfTakenSequenceFlowsColumnFamily.get(key);
           final var newValue = number.getValue() - 1;
           if (newValue > 0) {
             numberOfTakenSequenceFlows.wrapInt(newValue);
@@ -403,7 +404,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
       parentChildColumnFamily.whileEqualPrefix(
           this.parentKey,
-          (key, value) -> {
+          key -> {
             final var childKey = key.second().inner();
             final var childInstance = getInstance(childKey.getValue());
             children.add(childInstance);
@@ -425,7 +426,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     this.parentKey.inner().wrapLong(parentKey);
     parentChildColumnFamily.whileEqualPrefix(
         this.parentKey,
-        (key, ignore) -> {
+        key -> {
           final var childKey = key.second().inner();
           return visitor.apply(childKey.getValue());
         });
@@ -447,7 +448,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     parentChildColumnFamily.whileEqualPrefix(
         this.parentKey,
         compositeKey,
-        (key, value) -> {
+        key -> {
           final DbLong childKey = key.second().inner();
           final ElementInstance childInstance = getInstance(childKey.getValue());
 
@@ -488,7 +489,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     final var count = new MutableInteger(0);
     numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
         this.flowScopeKey,
-        (key, number) -> {
+        key -> {
           count.increment();
         });
 
@@ -504,7 +505,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     final Set<DirectBuffer> takenSequenceFlows = new LinkedHashSet<>();
     numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
         flowScopeKeyAndElementId,
-        (key, number) -> {
+        key -> {
           takenSequenceFlows.add(BufferUtil.cloneBuffer(key.second().getBuffer()));
         });
 
@@ -533,7 +534,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
     processInstanceKeyByProcessDefinitionKeyColumnFamily.whileEqualPrefix(
         this.processDefinitionKey,
-        (key, value) -> {
+        key -> {
           final DbLong processInstanceKey = key.second();
           processInstanceKeys.add(processInstanceKey.getValue());
         });
@@ -548,7 +549,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
     processInstanceKeyByProcessDefinitionKeyColumnFamily.whileEqualPrefix(
         this.processDefinitionKey,
-        (key, value) -> {
+        key -> {
           // A banned instance should not be considered as active
           if (bannedInstances.contains(key.second().getValue())) {
             return true;
@@ -587,7 +588,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     final var exists = new AtomicBoolean(false);
     processInstanceByBusinessIdIndexKeyColumnFamily.whileEqualPrefix(
         businessIdIndexKey,
-        (key, value) -> {
+        key -> {
           if (ignoreWhen.test(key.processInstanceKey())) {
             return true;
           }
@@ -602,10 +603,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     this.flowScopeKey.wrapLong(flowScopeKey);
 
     numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
-        this.flowScopeKey,
-        (key, number) -> {
-          numberOfTakenSequenceFlowsColumnFamily.deleteExisting(key);
-        });
+        this.flowScopeKey, numberOfTakenSequenceFlowsColumnFamily::deleteExisting);
   }
 
   private static class KeyWithTenantId<T extends DbKey> extends DbCompositeKey<T, DbString> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -298,8 +298,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
     numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
         flowScopeKeyAndElementId,
-        key -> {
-          final var number = numberOfTakenSequenceFlowsColumnFamily.get(key);
+        (key, number) -> {
           final var newValue = number.getValue() - 1;
           if (newValue > 0) {
             numberOfTakenSequenceFlows.wrapInt(newValue);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -472,14 +472,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     this.flowScopeKey.wrapLong(flowScopeKey);
     this.gatewayElementId.wrapBuffer(gatewayElementId);
 
-    final var count = new MutableInteger(0);
-    numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
-        flowScopeKeyAndElementId,
-        (key, number) -> {
-          count.increment();
-        });
-
-    return count.get();
+    return (int) numberOfTakenSequenceFlowsColumnFamily.countEqualPrefix(flowScopeKeyAndElementId);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 
@@ -76,9 +75,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     eventTriggerScopeKey.wrapLong(eventScopeKey);
 
     eventTriggerColumnFamily.whileEqualPrefix(
-        eventTriggerScopeKey,
-        (BiConsumer<DbCompositeKey<DbLong, DbLong>, EventTrigger>)
-            (key, value) -> deleteTrigger(key));
+        eventTriggerScopeKey, (DbCompositeKey<DbLong, DbLong> key) -> deleteTrigger(key));
 
     this.eventScopeKey.wrapLong(eventScopeKey);
     eventScopeInstanceColumnFamily.deleteIfExists(this.eventScopeKey);
@@ -90,7 +87,8 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     final EventTrigger[] next = new EventTrigger[1];
     eventTriggerColumnFamily.whileEqualPrefix(
         eventTriggerScopeKey,
-        (key, value) -> {
+        key -> {
+          final var value = eventTriggerColumnFamily.get(key);
           next[0] = new EventTrigger(value);
           deleteTrigger(key);
           return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -87,8 +87,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     final EventTrigger[] next = new EventTrigger[1];
     eventTriggerColumnFamily.whileEqualPrefix(
         eventTriggerScopeKey,
-        key -> {
-          final var value = eventTriggerColumnFamily.get(key);
+        (key, value) -> {
           next[0] = new EventTrigger(value);
           deleteTrigger(key);
           return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -227,7 +227,7 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void cleanupTimeoutsWithoutJobs() {
     deadlinesColumnFamily.whileTrue(
-        (key, value) -> {
+        key -> {
           final var jobKey = key.second().inner();
           final var deadline = key.first().getValue();
           final var job = jobsColumnFamily.get(jobKey);
@@ -241,7 +241,7 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void cleanupBackoffsWithoutJobs() {
     backoffColumnFamily.whileTrue(
-        (key, value) -> {
+        key -> {
           final var jobKey = key.second().inner();
           final var backoff = key.first().getValue();
           final var job = jobsColumnFamily.get(jobKey);
@@ -279,8 +279,8 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void restoreBackoff() {
     final var jobsWithBackoff = new LongHashSet();
-    backoffColumnFamily.forEach(
-        (key, value) -> {
+    backoffColumnFamily.forEachKey(
+        (key) -> {
           final var jobRecord = jobsColumnFamily.get(jobKey);
           if (jobRecord == null
               || jobRecord.getRecord().getRetries() <= 0
@@ -359,7 +359,7 @@ public final class DbJobState implements JobState, MutableJobState {
     final var lastVisitedIndex = new AtomicReference<DeadlineIndex>();
     deadlinesColumnFamily.whileTrue(
         startAtKey,
-        (key, value) -> {
+        key -> {
           final var deadline = key.first().getValue();
           final var isDue = deadline < executionTimestamp;
           if (!isDue) {
@@ -410,7 +410,7 @@ public final class DbJobState implements JobState, MutableJobState {
 
     activatableColumnFamily.whileEqualPrefix(
         jobTypeKey,
-        ((tenantAwareCompositeKey, zbNil) -> {
+        tenantAwareCompositeKey -> {
           final DbLong jobKey = tenantAwareCompositeKey.wrappedKey().second().inner();
           final String tenantId = tenantAwareCompositeKey.tenantKey().toString();
 
@@ -419,7 +419,7 @@ public final class DbJobState implements JobState, MutableJobState {
           }
           // we want to continue with the iteration
           return true;
-        }));
+        });
   }
 
   @Override
@@ -449,7 +449,7 @@ public final class DbJobState implements JobState, MutableJobState {
   public long findBackedOffJobs(final long timestamp, final BiPredicate<Long, JobRecord> callback) {
     nextBackOffDueDate = -1L;
     backoffColumnFamily.whileTrue(
-        (key, value) -> {
+        key -> {
           final long deadline = key.first().getValue();
           boolean consumed = false;
           if (deadline <= timestamp) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -95,7 +95,7 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
     nextDueDate = -1L;
 
     dueDateColumnFamily.whileTrue(
-        (key, nil) -> {
+        key -> {
           final var dueDate = key.first().getValue();
           final var elementAndTimerKey = key.second();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -271,7 +271,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     return parentKeyProp.getValue();
   }
 
-  public long getActiveSequenceFlows() {
+  public int getActiveSequenceFlows() {
     return activeSequenceFlowsProp.getValue();
   }
 
@@ -284,6 +284,13 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
       //      throw new IllegalStateException(
       //          "Not expected to have an active sequence flow count lower then zero!");
       //    }
+    }
+  }
+
+  public void decrementActiveSequenceFlows(final int amount) {
+    final var current = getActiveSequenceFlows();
+    if (current > 0) {
+      activeSequenceFlowsProp.setValue(current - amount);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -290,7 +290,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   public void decrementActiveSequenceFlows(final int amount) {
     final var current = getActiveSequenceFlows();
     if (current > 0) {
-      activeSequenceFlowsProp.setValue(current - amount);
+      activeSequenceFlowsProp.setValue(Math.max(0, current - amount));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobmetrics/DbJobMetricsState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobmetrics/DbJobMetricsState.java
@@ -122,8 +122,10 @@ public class DbJobMetricsState implements MutableJobMetricsState {
   }
 
   private void populateStringEncodingCache() {
-    stringEncodingColumnFamily.forEach(
-        (key, value) -> stringEncodingCache.put(key.toString(), value.getValue()));
+    stringEncodingColumnFamily.forEachKey(
+        (key) ->
+            stringEncodingCache.put(
+                key.toString(), stringEncodingColumnFamily.get(key).getValue()));
   }
 
   private void populateMetricsCache() {
@@ -194,11 +196,10 @@ public class DbJobMetricsState implements MutableJobMetricsState {
   @Override
   public void cleanUp() {
     // Delete all keys in metrics column family
-    metricsColumnFamily.forEach((mk, mv) -> metricsColumnFamily.deleteExisting(mk));
+    metricsColumnFamily.forEachKey(metricsColumnFamily::deleteExisting);
 
     // Delete all keys in string encoding column family
-    stringEncodingColumnFamily.forEach(
-        (dbString, dbInt) -> stringEncodingColumnFamily.deleteExisting(dbString));
+    stringEncodingColumnFamily.forEachKey(stringEncodingColumnFamily::deleteExisting);
 
     // Clear the caches
     stringEncodingCache.clear();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobmetrics/DbJobMetricsState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobmetrics/DbJobMetricsState.java
@@ -122,10 +122,8 @@ public class DbJobMetricsState implements MutableJobMetricsState {
   }
 
   private void populateStringEncodingCache() {
-    stringEncodingColumnFamily.forEachKey(
-        (key) ->
-            stringEncodingCache.put(
-                key.toString(), stringEncodingColumnFamily.get(key).getValue()));
+    stringEncodingColumnFamily.forEach(
+        (key, value) -> stringEncodingCache.put(key.toString(), value.getValue()));
   }
 
   private void populateMetricsCache() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
@@ -126,7 +126,7 @@ public final class DbMessageStartEventSubscriptionState
 
     subscriptionsOfProcessDefinitionKeyColumnFamily.whileEqualPrefix(
         this.processDefinitionKey,
-        (key, value) -> {
+        (key) -> {
           tenantIdKey.wrapBuffer(key.second().tenantKey().getBuffer());
           final var subscription =
               subscriptionsColumnFamily.get(messageNameAndProcessDefinitionKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -341,10 +341,7 @@ public final class DbMessageState implements MutableMessageState {
     bufferedMessagesMetrics.setBufferedMessagesCounter(localMessageDeadlineCount);
 
     correlatedMessageColumnFamily.whileEqualPrefix(
-        messageKey,
-        ((compositeKey, zbNil) -> {
-          correlatedMessageColumnFamily.deleteExisting(compositeKey);
-        }));
+        messageKey, (correlatedMessageColumnFamily::deleteExisting));
   }
 
   @Override
@@ -419,7 +416,7 @@ public final class DbMessageState implements MutableMessageState {
     final var stoppedByVisitor = new MutableBoolean(false);
     deadlineColumnFamily.whileTrue(
         startAtKey,
-        (key, value) -> {
+        key -> {
           boolean shouldContinue = false;
           final long deadlineEntry = key.first().getValue();
           if (deadlineEntry <= timestamp) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -124,7 +124,7 @@ public final class DbMessageSubscriptionState
 
     messageNameAndCorrelationKeyColumnFamily.whileEqualPrefix(
         tenantAwareNameAndCorrelationKey,
-        (compositeKey, nil) -> {
+        compositeKey -> {
           return visitMessageSubscription(elementKeyAndMessageName, visitor);
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
@@ -54,7 +54,7 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     final var counter = new AtomicInteger(0);
-    bannedInstanceColumnFamily.forEach(ignore -> counter.getAndIncrement());
+    bannedInstanceColumnFamily.forEachKey(ignore -> counter.getAndIncrement());
     bannedInstanceMetrics.setBannedInstanceCounter(counter.get());
   }
 
@@ -89,7 +89,7 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   @Override
   public List<Long> getBannedProcessInstanceKeys() {
     final List<Long> bannedInstanceKeys = new ArrayList<>();
-    bannedInstanceColumnFamily.forEach((key, nil) -> bannedInstanceKeys.add(key.getValue()));
+    bannedInstanceColumnFamily.forEachKey(key -> bannedInstanceKeys.add(key.getValue()));
     return bannedInstanceKeys;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/signal/DbSignalSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/signal/DbSignalSubscriptionState.java
@@ -128,7 +128,7 @@ public final class DbSignalSubscriptionState implements MutableSignalSubscriptio
   private void visitSubscriptions(final SignalSubscriptionVisitor visitor) {
     subscriptionKeyAndSignalNameColumnFamily.whileEqualPrefix(
         subscriptionKey,
-        (key, value) -> {
+        key -> {
           signalName.wrapBuffer(key.second().wrappedKey().getBuffer());
           tenantIdKey.wrapBuffer(key.second().tenantKey().getBuffer());
           final var subscription =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/MemoryBoundedColumnIterationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/MemoryBoundedColumnIterationTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.db.KeyValuePairVisitor;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -72,6 +73,7 @@ final class MemoryBoundedColumnIterationTest {
     iteration.drain(spiedColumn, (k, v) -> {});
 
     // then - expect 4 transactions since our limit is 50 longs, and each iteration adds 2 longs
-    Mockito.verify(spiedColumn, Mockito.times(4)).whileTrue(Mockito.any());
+    Mockito.verify(spiedColumn, Mockito.times(4))
+        .whileTrue(Mockito.<KeyValuePairVisitor<DbLong, DbLong>>any());
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v1.golden
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 
 /** Applies state changes for `ProcessInstance:Element_Activating` */
 final class ProcessInstanceElementActivatingV1Applier
@@ -221,7 +220,7 @@ final class ProcessInstanceElementActivatingV1Applier
             value.getElementIdBuffer(),
             ExecutableFlowNode.class);
     final var size = executableFlowNode.getIncoming().size();
-    IntStream.range(0, size).forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(size);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 
@@ -230,8 +229,7 @@ final class ProcessInstanceElementActivatingV1Applier
     // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
     // active sequence flows based on the satisfied incoming sequence flows.
 
-    IntStream.range(0, numberOfTakenSequenceFlows)
-        .forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(numberOfTakenSequenceFlows);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v2.golden
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 
 /** Applies state changes for `ProcessInstance:Element_Activating` */
 final class ProcessInstanceElementActivatingV2Applier
@@ -228,7 +227,7 @@ final class ProcessInstanceElementActivatingV2Applier
             value.getElementIdBuffer(),
             ExecutableFlowNode.class);
     final var size = executableFlowNode.getIncoming().size();
-    IntStream.range(0, size).forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(size);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 
@@ -237,8 +236,7 @@ final class ProcessInstanceElementActivatingV2Applier
     // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
     // active sequence flows based on the satisfied incoming sequence flows.
 
-    IntStream.range(0, numberOfTakenSequenceFlows)
-        .forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(numberOfTakenSequenceFlows);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v3.golden
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 
 /** Applies state changes for `ProcessInstance:Element_Activating` */
 final class ProcessInstanceElementActivatingV3Applier
@@ -233,7 +232,7 @@ final class ProcessInstanceElementActivatingV3Applier
             value.getElementIdBuffer(),
             ExecutableFlowNode.class);
     final var size = executableFlowNode.getIncoming().size();
-    IntStream.range(0, size).forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(size);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 
@@ -242,8 +241,7 @@ final class ProcessInstanceElementActivatingV3Applier
     // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
     // active sequence flows based on the satisfied incoming sequence flows.
 
-    IntStream.range(0, numberOfTakenSequenceFlows)
-        .forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    flowScopeInstance.decrementActiveSequenceFlows(numberOfTakenSequenceFlows);
     elementInstanceState.updateInstance(flowScopeInstance);
   }
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -164,6 +164,95 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue>
    */
   void whileTrueReverse(KeyType startAtKey, KeyValuePairVisitor<KeyType, ValueType> visitor);
 
+  // ---- Key-only iteration methods ----
+  // These methods iterate over keys without reading the corresponding values from the database,
+  // which can be significantly more efficient when only the keys are needed.
+
+  /**
+   * Visits the keys stored in the column family without reading the values. The ordering depends on
+   * the key.
+   *
+   * <p>The given consumer accepts the keys. Be aware that the given DbKey wraps the stored key and
+   * reflects the current iteration step. The DbKey should not be stored, since it will change its
+   * internal value during iteration.
+   *
+   * @param consumer the consumer which accepts the key
+   */
+  void forEachKey(Consumer<KeyType> consumer);
+
+  /**
+   * Visits the keys stored in the column family without reading the values. The ordering depends on
+   * the key. The visitor can indicate via the return value whether the iteration should continue or
+   * not. This means if the visitor returns false the iteration will stop.
+   *
+   * @param visitor the visitor which visits the keys
+   */
+  void whileTrue(KeyVisitor<KeyType> visitor);
+
+  /**
+   * Visits the keys stored in the column family without reading the values. The ordering depends on
+   * the key. The visitor can indicate via the return value whether the iteration should continue or
+   * not. This means if the visitor returns false the iteration will stop.
+   *
+   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exists,
+   * the first key will be equal to {@code startAtKey}. If the key doesn't exist it will start
+   * after.
+   *
+   * @param startAtKey indicates on which key the iteration should start
+   * @param visitor the visitor which visits the keys
+   */
+  void whileTrue(KeyType startAtKey, KeyVisitor<KeyType> visitor);
+
+  /**
+   * Visits the keys stored in the column family which have the same common prefix, without reading
+   * the values. The ordering depends on the key.
+   *
+   * @param keyPrefix the prefix which should have the keys in common
+   * @param visitor the consumer which accepts the keys
+   */
+  void whileEqualPrefix(DbKey keyPrefix, Consumer<KeyType> visitor);
+
+  /**
+   * Visits the keys stored in the column family which have the same common prefix, without reading
+   * the values. The ordering depends on the key. The visitor can indicate via the return value
+   * whether the iteration should continue or not. This means if the visitor returns false the
+   * iteration will stop.
+   *
+   * @param keyPrefix the prefix which should have the keys in common
+   * @param visitor the visitor which visits the keys
+   */
+  void whileEqualPrefix(DbKey keyPrefix, KeyVisitor<KeyType> visitor);
+
+  /**
+   * Visits the keys stored in the column family which have the same common prefix, without reading
+   * the values. The ordering depends on the key. The visitor can indicate via the return value
+   * whether the iteration should continue or not. This means if the visitor returns false the
+   * iteration will stop.
+   *
+   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exists,
+   * the first key will be equal to {@code startAtKey}. If the key doesn't exist it will start
+   * after.
+   *
+   * @param keyPrefix the prefix which should have the keys in common
+   * @param startAtKey indicates on which key the iteration should start
+   * @param visitor the visitor which visits the keys
+   */
+  void whileEqualPrefix(DbKey keyPrefix, KeyType startAtKey, KeyVisitor<KeyType> visitor);
+
+  /**
+   * Visits the keys in reverse order stored in the column family without reading the values. The
+   * visitor can indicate via the return value whether the iteration should continue or not. This
+   * means if the visitor returns false the iteration will stop.
+   *
+   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exists,
+   * the first key will be equal to {@code startAtKey}. If the key doesn't exist it will start at
+   * the key just before it.
+   *
+   * @param startAtKey indicates on which key the reverse iteration should start
+   * @param visitor the visitor which visits the keys
+   */
+  void whileTrueReverse(KeyType startAtKey, KeyVisitor<KeyType> visitor);
+
   /**
    * Deletes the key-value pair with the given key if it exists in the column family
    *

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/KeyVisitor.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/KeyVisitor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db;
+
+/**
+ * Represents a function that accepts a key and produces a primitive boolean as result, indicating
+ * whether iteration should continue. Unlike {@link KeyValuePairVisitor}, this visitor does not
+ * receive the value, which allows implementations to skip reading the value from the database
+ * entirely.
+ *
+ * @param <KeyType> the type of the key
+ */
+@FunctionalInterface
+public interface KeyVisitor<KeyType extends DbKey> {
+
+  /**
+   * Visits the key. The result indicates whether it should visit more keys or not.
+   *
+   * @param key the key
+   * @return true if the visiting should continue, false otherwise
+   */
+  boolean visit(KeyType key);
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
@@ -55,6 +55,27 @@ public class RawTransactionalColumnFamily {
         });
   }
 
+  /**
+   * Run the given visitor for each key in the column family, without reading the values.
+   *
+   * @param visitor to run for each key: the key bytearray is "raw", i.e. contains also the column
+   *     family prefix. In order to get access to the key without the prefix, you need to use {@link
+   *     ColumnFamilyContext#wrapKeyView(byte[])}
+   */
+  public void forEachKey(final TransactionContext context, final KeyOnlyVisitor visitor) {
+    context.runInTransaction(
+        () -> {
+          columnFamilyContext.withPrefixKey(
+              new DbNullKey(),
+              (prefixKey, prefixLength) -> {
+                try (final RocksIterator iterator =
+                    newIterator(context, transactionDb.getPrefixReadOptions())) {
+                  forEachKey(iterator, columnFamily, prefixKey, 0, prefixLength, visitor);
+                }
+              });
+        });
+  }
+
   public void put(
       final ZeebeTransaction transaction,
       final byte[] key,
@@ -198,6 +219,45 @@ public class RawTransactionalColumnFamily {
     }
   }
 
+  /**
+   * Iterates over the column family with prefix {@param prefixKey}, visiting only keys without
+   * reading values from the database.
+   *
+   * @param iterator the underlying rocksDB iterator
+   * @param columnFamily the column family being iterated
+   * @param prefixKey the prefix key to filter the iteration
+   * @param prefixOffset the offset in the prefix key array
+   * @param prefixLength the length of the prefix key
+   * @param visitor the visitor to apply to each key
+   */
+  public static void forEachKey(
+      final RocksIterator iterator,
+      final ZbColumnFamilies columnFamily,
+      final byte[] prefixKey,
+      final int prefixOffset,
+      final int prefixLength,
+      final KeyOnlyVisitor visitor) {
+    final var seekTarget = new DbNullKey();
+    boolean shouldVisitNext = true;
+    final var columnFamilyContext = new ColumnFamilyContext(columnFamily.getValue());
+    for (iterator.seek(columnFamilyContext.keyWithColumnFamily(seekTarget));
+        iterator.isValid() && shouldVisitNext;
+        iterator.next()) {
+      final var keyBytes = iterator.key();
+
+      if (!startsWith(prefixKey, prefixOffset, prefixLength, keyBytes, 0, keyBytes.length)) {
+        break;
+      }
+      try {
+        shouldVisitNext = visitor.visit(keyBytes, 0, keyBytes.length);
+      } catch (final Exception e) {
+        LOG.error(
+            "Error visiting key {} in column family {}", new String(keyBytes), columnFamily, e);
+        shouldVisitNext = false;
+      }
+    }
+  }
+
   RocksIterator newIterator(final TransactionContext context, final ReadOptions options) {
     final var currentTransaction = (ZeebeTransaction) context.getCurrentTransaction();
     return currentTransaction.newIterator(options, transactionDb.getDefaultHandle());
@@ -218,5 +278,22 @@ public class RawTransactionalColumnFamily {
      */
     boolean visit(
         byte[] key, int keyOffset, int keyLen, byte[] value, int valueOffset, int valueLen);
+  }
+
+  /**
+   * A visitor that receives only the key bytes during iteration, without reading the value from the
+   * database. This can be significantly more efficient when only the keys are needed.
+   */
+  public interface KeyOnlyVisitor {
+
+    /**
+     * Visits a key in the column family during iteration.
+     *
+     * @param key the key byte array
+     * @param keyOffset the offset in the key array
+     * @param keyLen the length of the key
+     * @return true if iteration should continue, false otherwise
+     */
+    boolean visit(byte[] key, int keyOffset, int keyLen);
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -25,11 +25,11 @@ import io.camunda.zeebe.protocol.EnumValue;
 import io.camunda.zeebe.protocol.ScopedColumnFamily;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.MutableLong;
 import org.agrona.collections.MutableReference;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.rocksdb.ReadOptions;
@@ -558,7 +558,7 @@ class TransactionalColumnFamily<
   private long countEachInPrefix(final DbKey prefix) {
     final var seekTarget = Objects.requireNonNull(prefix);
 
-    final var count = new AtomicLong(0);
+    final var count = new MutableLong(0);
 
     /*
      * NOTE: it doesn't seem possible in Java RocksDB to set a flexible prefix extractor on
@@ -583,7 +583,7 @@ class TransactionalColumnFamily<
                 break;
               }
 
-              count.getAndIncrement();
+              count.increment();
             }
           }
         });

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.db.ContainsForeignKeys;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.KeyValuePairVisitor;
+import io.camunda.zeebe.db.KeyVisitor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.db.impl.rocksdb.DbNullKey;
@@ -252,6 +253,60 @@ class TransactionalColumnFamily<
       final KeyType startAtKey, final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     ensureInOpenTransaction(
         transaction -> forEachInPrefixReverse(startAtKey, new DbNullKey(), visitor));
+  }
+
+  // ---- Key-only iteration methods ----
+
+  @Override
+  public void forEachKey(final Consumer<KeyType> consumer) {
+    ensureInOpenTransaction(
+        transaction ->
+            forEachKeyInPrefix(
+                new DbNullKey(),
+                k -> {
+                  consumer.accept(k);
+                  return true;
+                }));
+  }
+
+  @Override
+  public void whileTrue(final KeyVisitor<KeyType> visitor) {
+    ensureInOpenTransaction(transaction -> forEachKeyInPrefix(new DbNullKey(), visitor));
+  }
+
+  @Override
+  public void whileTrue(final KeyType startAtKey, final KeyVisitor<KeyType> visitor) {
+    ensureInOpenTransaction(
+        transaction -> forEachKeyInPrefix(startAtKey, new DbNullKey(), visitor));
+  }
+
+  @Override
+  public void whileEqualPrefix(final DbKey keyPrefix, final Consumer<KeyType> visitor) {
+    ensureInOpenTransaction(
+        transaction ->
+            forEachKeyInPrefix(
+                keyPrefix,
+                k -> {
+                  visitor.accept(k);
+                  return true;
+                }));
+  }
+
+  @Override
+  public void whileEqualPrefix(final DbKey keyPrefix, final KeyVisitor<KeyType> visitor) {
+    ensureInOpenTransaction(transaction -> forEachKeyInPrefix(keyPrefix, visitor));
+  }
+
+  @Override
+  public void whileEqualPrefix(
+      final DbKey keyPrefix, final KeyType startAtKey, final KeyVisitor<KeyType> visitor) {
+    ensureInOpenTransaction(transaction -> forEachKeyInPrefix(startAtKey, keyPrefix, visitor));
+  }
+
+  @Override
+  public void whileTrueReverse(final KeyType startAtKey, final KeyVisitor<KeyType> visitor) {
+    ensureInOpenTransaction(
+        transaction -> forEachKeyInPrefixReverse(startAtKey, new DbNullKey(), visitor));
   }
 
   @Override
@@ -534,6 +589,109 @@ class TransactionalColumnFamily<
         });
 
     return count.get();
+  }
+
+  /**
+   * Key-only counterpart of {@link #forEachInPrefix(DbKey, KeyValuePairVisitor)}. Iterates over
+   * keys within the given prefix without reading values from the database.
+   *
+   * @param prefix of all keys that are iterated over.
+   * @param visitor called for all keys that match the given prefix. The visitor can indicate
+   *     whether iteration should continue or not, see {@link KeyVisitor}.
+   */
+  private void forEachKeyInPrefix(final DbKey prefix, final KeyVisitor<KeyType> visitor) {
+    forEachKeyInPrefix(prefix, prefix, visitor);
+  }
+
+  /**
+   * Key-only counterpart of {@link #forEachInPrefix(DbKey, DbKey, KeyValuePairVisitor)}. Iterates
+   * over keys within the given prefix without reading values from the database.
+   *
+   * @param startAt seek to this key before starting iteration. If null, seek to {@code prefix}
+   *     instead.
+   * @param prefix of all keys that are iterated over.
+   * @param visitor called for all keys that match the given prefix. The visitor can indicate
+   *     whether iteration should continue or not, see {@link KeyVisitor}.
+   */
+  private void forEachKeyInPrefix(
+      final DbKey startAt, final DbKey prefix, final KeyVisitor<KeyType> visitor) {
+    try (final var timer = metrics.measureIterateLatency()) {
+      final var seekTarget = Objects.requireNonNullElse(startAt, prefix);
+      Objects.requireNonNull(prefix);
+      Objects.requireNonNull(visitor);
+
+      columnFamilyContext.withPrefixKey(
+          prefix,
+          (prefixKey, prefixLength) -> {
+            try (final RocksIterator iterator =
+                newIterator(context, transactionDb.getPrefixReadOptions())) {
+
+              boolean shouldVisitNext = true;
+
+              for (iterator.seek(columnFamilyContext.keyWithColumnFamily(seekTarget));
+                  iterator.isValid() && shouldVisitNext;
+                  iterator.next()) {
+                final byte[] keyBytes = iterator.key();
+                if (!startsWith(prefixKey, 0, prefixLength, keyBytes, 0, keyBytes.length)) {
+                  break;
+                }
+
+                shouldVisitNext = visitKeyOnly(keyInstance, visitor, keyBytes);
+              }
+            }
+          });
+    }
+  }
+
+  /**
+   * Key-only counterpart of {@link #forEachInPrefixReverse(DbKey, DbKey, KeyValuePairVisitor)}.
+   * Iterates backward over keys within the given prefix without reading values from the database.
+   *
+   * @param startAt seek to this key before starting reverse iteration.
+   * @param prefix of all keys that are iterated over.
+   * @param visitor called for all keys that match the given prefix. The visitor can indicate
+   *     whether iteration should continue or not, see {@link KeyVisitor}.
+   */
+  private void forEachKeyInPrefixReverse(
+      final DbKey startAt, final DbKey prefix, final KeyVisitor<KeyType> visitor) {
+    try (final var timer = metrics.measureIterateLatency()) {
+      Objects.requireNonNull(startAt);
+      Objects.requireNonNull(prefix);
+      Objects.requireNonNull(visitor);
+
+      columnFamilyContext.withPrefixKey(
+          prefix,
+          (prefixKey, prefixLength) -> {
+            try (final RocksIterator iterator =
+                newIterator(context, transactionDb.getPrefixReadOptions())) {
+
+              final var seekTarget = columnFamilyContext.keyWithColumnFamily(startAt);
+
+              boolean shouldVisitNext = true;
+
+              for (iterator.seekForPrev(seekTarget);
+                  iterator.isValid() && shouldVisitNext;
+                  iterator.prev()) {
+                final byte[] keyBytes = iterator.key();
+                if (!startsWith(prefixKey, 0, prefixLength, keyBytes, 0, keyBytes.length)) {
+                  break;
+                }
+
+                shouldVisitNext = visitKeyOnly(keyInstance, visitor, keyBytes);
+              }
+            }
+          });
+    }
+  }
+
+  private boolean visitKeyOnly(
+      final KeyType keyInstance, final KeyVisitor<KeyType> visitor, final byte[] keyBytes) {
+    columnFamilyContext.wrapKeyView(keyBytes);
+
+    final DirectBuffer keyViewBuffer = columnFamilyContext.getKeyView();
+    keyInstance.wrap(keyViewBuffer, 0, keyViewBuffer.capacity());
+
+    return visitor.visit(keyInstance);
   }
 
   private boolean visit(

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -621,6 +621,187 @@ public final class ColumnFamilyTest {
     assertThat(keys).isEmpty();
   }
 
+  // ---- Key-only iteration tests ----
+
+  @Test
+  public void shouldUseForEachKey() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    columnFamily.forEachKey(key -> keys.add(key.getValue()));
+
+    // then
+    assertThat(keys).containsExactly(1L, 1213L, 4567L, 6734L, (long) Short.MAX_VALUE);
+  }
+
+  @Test
+  public void shouldUseWhileTrueKey() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    columnFamily.whileTrue(
+        key -> {
+          keys.add(key.getValue());
+          return key.getValue() != 4567;
+        });
+
+    // then
+    assertThat(keys).containsExactly(1L, 1213L, 4567L);
+  }
+
+  @Test
+  public void shouldUseWhileTrueKeyWithStartAt() {
+    // given
+    final var startAt = new DbLong();
+    startAt.wrapLong(1213);
+
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    columnFamily.whileTrue(
+        startAt,
+        key -> {
+          keys.add(key.getValue());
+          return key.getValue() != 4567;
+        });
+
+    // then
+    assertThat(keys).containsExactly(1213L, 4567L);
+  }
+
+  @Test
+  public void shouldUseWhileTrueKeyWithStartAtMissingKey() {
+    // given
+    final var startAt = new DbLong();
+    startAt.wrapLong(1212);
+
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    columnFamily.whileTrue(
+        startAt,
+        key -> {
+          keys.add(key.getValue());
+          return key.getValue() != 4567;
+        });
+
+    // then
+    assertThat(keys).containsExactly(1213L, 4567L);
+  }
+
+  @Test
+  public void shouldUseWhileTrueReverseKey() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    final var startAt = new DbLong();
+    startAt.wrapLong(6734);
+    columnFamily.whileTrueReverse(
+        startAt,
+        key -> {
+          keys.add(key.getValue());
+          return key.getValue() != 1213;
+        });
+
+    // then — reverse from 6734: 6734, 4567, 1213 (stops because visitor returns false)
+    assertThat(keys).containsExactly(6734L, 4567L, 1213L);
+  }
+
+  @Test
+  public void shouldUseWhileTrueReverseKeyWithMissingKey() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when — start at 5000 which doesn't exist, seekForPrev lands on 4567
+    final List<Long> keys = new ArrayList<>();
+    final var startAt = new DbLong();
+    startAt.wrapLong(5000);
+    columnFamily.whileTrueReverse(
+        startAt,
+        key -> {
+          keys.add(key.getValue());
+          return true;
+        });
+
+    // then — reverse from 4567: 4567, 1213, 1
+    assertThat(keys).containsExactly(4567L, 1213L, 1L);
+  }
+
+  @Test
+  public void shouldUseWhileTrueReverseKeyAll() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when — start at Long.MAX_VALUE to iterate all in reverse
+    final List<Long> keys = new ArrayList<>();
+    final var startAt = new DbLong();
+    startAt.wrapLong(Long.MAX_VALUE);
+    columnFamily.whileTrueReverse(
+        startAt,
+        key -> {
+          keys.add(key.getValue());
+          return true;
+        });
+
+    // then — all keys in reverse order
+    assertThat(keys).containsExactly((long) Short.MAX_VALUE, 6734L, 4567L, 1213L, 1L);
+  }
+
+  @Test
+  public void shouldReturnEmptyOnWhileTrueReverseKeyWithNoEntries() {
+    // given — empty CF
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    final var startAt = new DbLong();
+    startAt.wrapLong(100);
+    columnFamily.whileTrueReverse(
+        startAt,
+        key -> {
+          keys.add(key.getValue());
+          return true;
+        });
+
+    // then
+    assertThat(keys).isEmpty();
+  }
+
   private void upsertKeyValuePair(final int key, final int value) {
     this.key.wrapLong(key);
     this.value.wrapLong(value);

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
@@ -613,6 +613,174 @@ public final class DbCompositeKeyColumnFamilyTest {
     assertThat(count).describedAs("Only counts entries matching 'foo'").isEqualTo(2);
   }
 
+  // ---- Key-only iteration tests ----
+
+  @Test
+  public void shouldUseForEachKey() {
+    // given
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
+
+    // when
+    final List<String> firstKeyParts = new ArrayList<>();
+    final List<Long> secondKeyParts = new ArrayList<>();
+    columnFamily.forEachKey(
+        key -> {
+          firstKeyParts.add(key.first().toString());
+          secondKeyParts.add(key.second().getValue());
+        });
+
+    // then
+    assertThat(firstKeyParts)
+        .containsExactly("foo", "foo", "hello", "might", "another", "this is the one");
+    assertThat(secondKeyParts).containsExactly(12L, 13L, 34L, 37426L, 923113L, 255L);
+  }
+
+  @Test
+  public void shouldUseWhileEqualPrefixKey() {
+    // given
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foobar", 53, "expected value");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("foo", 213, "oh wow");
+    upsertKeyValuePair("foo", 53, "expected value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
+
+    // when
+    firstKey.wrapString("foo");
+    final List<String> firstKeyParts = new ArrayList<>();
+    final List<Long> secondKeyParts = new ArrayList<>();
+    columnFamily.whileEqualPrefix(
+        firstKey,
+        key -> {
+          firstKeyParts.add(key.first().toString());
+          secondKeyParts.add(key.second().getValue());
+        });
+
+    // then
+    assertThat(firstKeyParts).containsOnly("foo");
+    assertThat(secondKeyParts).containsExactly(12L, 13L, 53L, 213L);
+  }
+
+  @Test
+  public void shouldUseWhileEqualPrefixKeyAndTrue() {
+    // given
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foobar", 53, "expected value");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("foo", 213, "oh wow");
+    upsertKeyValuePair("foo", 53, "expected value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
+
+    // when
+    firstKey.wrapString("foo");
+    final List<String> firstKeyParts = new ArrayList<>();
+    final List<Long> secondKeyParts = new ArrayList<>();
+    columnFamily.whileEqualPrefix(
+        firstKey,
+        key -> {
+          firstKeyParts.add(key.first().toString());
+          secondKeyParts.add(key.second().getValue());
+          return key.second().getValue() < 50;
+        });
+
+    // then
+    assertThat(firstKeyParts).containsOnly("foo");
+    assertThat(secondKeyParts).containsExactly(12L, 13L, 53L);
+  }
+
+  @Test
+  public void shouldUseWhileEqualPrefixKeyWithStartAt() {
+    // given
+    upsertKeyValuePair("foo", 1, "first");
+    upsertKeyValuePair("bar", 2, "second");
+    upsertKeyValuePair("foo", 3, "third");
+    upsertKeyValuePair("foo", 4, "fourth");
+    upsertKeyValuePair("baz", 5, "fifth");
+
+    // when
+    firstKey.wrapString("foo");
+    secondKey.wrapLong(3L);
+    final List<String> firstKeyParts = new ArrayList<>();
+    final List<Long> secondKeyParts = new ArrayList<>();
+    columnFamily.whileEqualPrefix(
+        firstKey,
+        compositeKey,
+        key -> {
+          firstKeyParts.add(key.first().toString());
+          secondKeyParts.add(key.second().getValue());
+          return true;
+        });
+
+    // then
+    assertThat(firstKeyParts).containsOnly("foo");
+    assertThat(secondKeyParts).containsExactly(3L, 4L);
+  }
+
+  @Test
+  public void shouldUseWhileEqualPrefixKeyWithStartAtMissingKey() {
+    // given
+    upsertKeyValuePair("foo", 1, "first");
+    upsertKeyValuePair("bar", 2, "second");
+    upsertKeyValuePair("foo", 4, "fourth");
+    upsertKeyValuePair("baz", 5, "fifth");
+
+    // when
+    firstKey.wrapString("foo");
+    secondKey.wrapLong(3L);
+    final List<String> firstKeyParts = new ArrayList<>();
+    final List<Long> secondKeyParts = new ArrayList<>();
+    columnFamily.whileEqualPrefix(
+        firstKey,
+        compositeKey,
+        key -> {
+          firstKeyParts.add(key.first().toString());
+          secondKeyParts.add(key.second().getValue());
+          return true;
+        });
+
+    // then
+    assertThat(firstKeyParts).containsOnly("foo");
+    assertThat(secondKeyParts).containsExactly(4L);
+  }
+
+  @Test
+  public void shouldUseWhileEqualPrefixKeyWithStartAtMissingPrefix() {
+    // given
+    upsertKeyValuePair("foo", 1, "first");
+    upsertKeyValuePair("bar", 2, "second");
+    upsertKeyValuePair("foo", 3, "third");
+    upsertKeyValuePair("foo", 4, "fourth");
+
+    // when
+    firstKey.wrapString("baz");
+    secondKey.wrapLong(1L);
+    final List<String> firstKeyParts = new ArrayList<>();
+    final List<Long> secondKeyParts = new ArrayList<>();
+    columnFamily.whileEqualPrefix(
+        firstKey,
+        compositeKey,
+        key -> {
+          firstKeyParts.add(key.first().toString());
+          secondKeyParts.add(key.second().getValue());
+          return true;
+        });
+
+    // then
+    assertThat(firstKeyParts).isEmpty();
+    assertThat(secondKeyParts).isEmpty();
+  }
+
   private void upsertKeyValuePair(final String firstKey, final long secondKey, final String value) {
     this.firstKey.wrapString(firstKey);
     this.secondKey.wrapLong(secondKey);

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
@@ -101,4 +101,50 @@ public class RawTransactionalColumnFamilyTest {
     // then
     assertThat(i.get()).isEqualTo(numEntries);
   }
+
+  @ParameterizedTest
+  @EnumSource(ZbColumnFamilies.class)
+  public void shouldIterateOverAllKeys(final ZbColumnFamilies cf) {
+    // given
+    final int numEntries = 100;
+    final var rawCF = columnFamilies.get(cf);
+    final var expected = new HashMap<Integer, byte[]>();
+    context.runInTransaction(
+        () -> {
+          for (int i = 0; i < numEntries; i++) {
+            final var bytes =
+                ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(i).array();
+            expected.put(i, bytes);
+            rawCF.put(
+                (ZeebeTransaction) context.getCurrentTransaction(),
+                bytes,
+                0,
+                bytes.length,
+                bytes,
+                0,
+                bytes.length);
+          }
+        });
+    // when — iterate using key-only visitor (no value is read)
+    final var i = new MutableReference<>(0);
+    rawCF.forEachKey(
+        context,
+        (rawKey, keyOffset, keyLen) -> {
+          final var cfContext = new ColumnFamilyContext(cf.getValue());
+          assertThat(keyOffset).isZero();
+
+          cfContext.wrapKeyView(rawKey);
+          final var key = new byte[cfContext.getKeyView().capacity()];
+          cfContext.getKeyView().getBytes(0, key);
+
+          // then — keys match what was inserted
+          assertThat(key).isEqualTo(expected.get(i.get()));
+
+          i.set(i.get() + 1);
+          return true;
+        });
+
+    // then
+    assertThat(i.get()).isEqualTo(numEntries);
+  }
 }


### PR DESCRIPTION
# Description
Backport of #47690 to `stable/8.9`.

relates to 