### PR TITLE
test: Migrate multiInstanceSelection.spec.ts to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -249,6 +249,22 @@ export class OperateDiagramPage {
     return this.popover.getByText(pattern);
   }
 
+  getIncidentsOverlay(elementId: string): Locator {
+    return this.page
+      .locator(`[data-container-id="${elementId}"]`)
+      .getByTestId('state-overlay-incidents');
+  }
+
+  getExecutionCountOverlay(elementId: string): Locator {
+    return this.page
+      .locator(`[data-container-id="${elementId}"]`)
+      .getByTestId('state-overlay-completed');
+  }
+
+  async clickShowIncident(): Promise<void> {
+    await this.popover.getByRole('button', {name: /^show incident$/i}).click();
+  }
+
   async clickPopoverLink(pattern: RegExp | string): Promise<void> {
     await this.popover.getByRole('link', {name: pattern}).click();
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -356,6 +356,30 @@ class OperateProcessInstancePage {
     });
   }
 
+  getSelectedIncidentRow(incidentType: string | RegExp): Locator {
+    return this.getIncidentRow(incidentType, true);
+  }
+
+  getSelectedTreeItemsInHistory(name: string | RegExp): Locator {
+    return this.instanceHistory.getByRole('treeitem', {name, selected: true});
+  }
+
+  findTreeItemInHistory(name: string | RegExp): Locator {
+    return this.instanceHistory.getByRole('treeitem', {name});
+  }
+
+  async expandTreeItemInHistory(name: string | RegExp): Promise<void> {
+    await this.instanceHistory
+      .getByRole('treeitem', {name})
+      .first()
+      .click();
+    await this.page.keyboard.press('ArrowRight');
+  }
+
+  async gotoProcessInstancePage(options: {id: string}): Promise<void> {
+    await this.navigateToProcessInstance(options.id);
+  }
+
   getIncidentRowOperationSpinner(incidentType: string | RegExp): Locator {
     return this.getIncidentRow(incidentType).getByTestId('operation-spinner');
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/multiInstanceProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/multiInstanceProcess.bpmn
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0dkpwbm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.10.0">
+  <bpmn:process id="multiInstanceProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0wumr00</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0wumr00" sourceRef="StartEvent_1" targetRef="taskA" />
+    <bpmn:serviceTask id="taskB" name="Task B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="multiInstanceProcessTaskB" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1jeebm1</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=clients" inputElement="client" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="taskA" name="Task A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="multiInstanceProcessTaskA" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0wumr00</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1gi2xny</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0j3eksh</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0j3eksh" sourceRef="taskA" targetRef="ExclusiveGateway_0cjcl1k" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_0cjcl1k" name="Continue?">
+      <bpmn:incoming>SequenceFlow_0j3eksh</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1jeebm1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_07u0xkc</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1jeebm1" name="yes" sourceRef="ExclusiveGateway_0cjcl1k" targetRef="taskB">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=i&lt;=loopCardinality</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="EndEvent_02f1al1">
+      <bpmn:incoming>SequenceFlow_07u0xkc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_07u0xkc" name="no" sourceRef="ExclusiveGateway_0cjcl1k" targetRef="EndEvent_02f1al1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=i&gt;loopCardinality</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:boundaryEvent id="Event_06lbs4q" cancelActivity="false" attachedToRef="taskB">
+      <bpmn:outgoing>SequenceFlow_1gi2xny</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0qjwf46">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1gi2xny" sourceRef="Event_06lbs4q" targetRef="taskA" />
+  </bpmn:process>
+  <bpmn:error id="Error_06pg7eb" name="taskBFailed" errorCode="taskBFailed" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="multiInstanceProcess">
+      <bpmndi:BPMNEdge id="SequenceFlow_07u0xkc_di" bpmnElement="SequenceFlow_07u0xkc">
+        <di:waypoint x="540" y="195" />
+        <di:waypoint x="540" y="350" />
+        <di:waypoint x="692" y="350" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="549" y="270" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gi2xny_di" bpmnElement="SequenceFlow_1gi2xny">
+        <di:waypoint x="730" y="112" />
+        <di:waypoint x="730" y="80" />
+        <di:waypoint x="380" y="80" />
+        <di:waypoint x="380" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jeebm1_di" bpmnElement="SequenceFlow_1jeebm1">
+        <di:waypoint x="565" y="170" />
+        <di:waypoint x="670" y="170" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="609" y="152" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j3eksh_di" bpmnElement="SequenceFlow_0j3eksh">
+        <di:waypoint x="430" y="170" />
+        <di:waypoint x="515" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wumr00_di" bpmnElement="SequenceFlow_0wumr00">
+        <di:waypoint x="178" y="170" />
+        <di:waypoint x="330" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="142" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_0cjcl1k_di" bpmnElement="ExclusiveGateway_0cjcl1k" isMarkerVisible="true">
+        <dc:Bounds x="515" y="145" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="514" y="133" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_02f1al1_di" bpmnElement="EndEvent_02f1al1">
+        <dc:Bounds x="692" y="332" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0s6kryf_di" bpmnElement="taskA">
+        <dc:Bounds x="330" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_185s3ko_di" bpmnElement="taskB">
+        <dc:Bounds x="670" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0x66g4j_di" bpmnElement="Event_06lbs4q">
+        <dc:Bounds x="712" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForFlowNodeIncidents} from 'utils/incidentsHelper';
+import {sleep} from 'utils/sleep';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let multiInstanceProcessInstance: ProcessInstance;
+// Workers must be stored to prevent garbage collection
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let workers: any[] = [];
+
+const LOOP_CARDINALITY = 5;
+const EXPANSIONS_COUNT = 2;
+
+test.afterAll(async () => {
+  await Promise.all(workers.map((w) => w.close()));
+  workers = [];
+});
+
+test.beforeAll(async ({request}) => {
+  await deploy(['./resources/multiInstanceProcess.bpmn']);
+  await sleep(2000);
+
+  workers.push(
+    createWorker('multiInstanceProcessTaskA', false, {}, (job) => {
+      return job.complete({i: Number(job.variables.i) + 1});
+    }),
+  );
+
+  workers.push(createWorker('multiInstanceProcessTaskB', true));
+
+  multiInstanceProcessInstance = await createSingleInstance(
+    'multiInstanceProcess',
+    1,
+    {
+      i: 0,
+      loopCardinality: 5,
+      clients: [0, 1, 2, 3, 4],
+    },
+  );
+
+  await waitForFlowNodeIncidents(
+    request,
+    multiInstanceProcessInstance.processInstanceKey,
+    'taskB',
+    25,
+  );
+});
+
+test.describe('Multi Instance Flow Node Selection', () => {
+  test.beforeEach(
+    async ({page, loginPage, operateHomePage, operateProcessInstancePage}) => {
+      await navigateToApp(page, 'operate');
+      await loginPage.login('demo', 'demo');
+      await expect(operateHomePage.operateBanner).toBeVisible();
+
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: multiInstanceProcessInstance.processInstanceKey,
+      });
+    },
+  );
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('expand multi instance flow nodes in instance history', async ({
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Verify that the process instance is selected by default', async () => {
+      await expect(
+        operateProcessInstancePage.getSelectedTreeItemsInHistory(
+          /multiInstanceProcess/,
+        ),
+      ).toHaveAttribute('aria-label', 'multiInstanceProcess');
+    });
+
+    await test.step('Unfold 2x Task B (Multi Instance)', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^task b \(multi instance\)$/i,
+      );
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^task b \(multi instance\)$/i,
+      );
+    });
+
+    await test.step('Verify 10x Task B visible', async () => {
+      await expect(
+        operateProcessInstancePage.findTreeItemInHistory('Task B'),
+      ).toHaveCount(EXPANSIONS_COUNT * LOOP_CARDINALITY);
+    });
+  });
+
+  test('select flow node in diagram', async ({
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    await test.step('Expand and click on Task B (Multi Instance) in instance history', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^task b \(multi instance\)$/i,
+      );
+      await operateProcessInstancePage
+        .findTreeItemInHistory(/^task b \(multi instance\)$/i)
+        .first()
+        .click();
+    });
+
+    await test.step('Verify 5 child Task B instances are visible', async () => {
+      await expect(
+        operateProcessInstancePage.findTreeItemInHistory(/^task b$/i),
+      ).toHaveCount(5);
+    });
+
+    await test.step('Enable execution count toggle', async () => {
+      await operateProcessInstancePage.toggleExecutionCount();
+    });
+
+    await test.step('Verify Task B shows 25 incidents overlay', async () => {
+      await expect(operateDiagramPage.getIncidentsOverlay('taskB')).toHaveText(
+        '25',
+      );
+    });
+
+    await test.step('Verify multi-instance timer event shows execution count of 5', async () => {
+      await expect(
+        operateDiagramPage.getExecutionCountOverlay('Event_06lbs4q'),
+      ).toHaveText('5');
+    });
+
+    await test.step('Verify incidents banner shows 25 incidents', async () => {
+      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
+      await expect(operateProcessInstancePage.incidentsBanner).toContainText(
+        '25 Incidents occurred',
+      );
+    });
+
+    await test.step('Click incidents banner to open incidents table', async () => {
+      await operateDiagramPage.clickFlowNode('taskB');
+      await operateProcessInstancePage.incidentsBanner.click();
+      await expect(
+        operateProcessInstancePage.incidentsViewHeader,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.incidentsViewHeader,
+      ).toContainText(/Incidents.*25 results/i);
+    });
+
+    await test.step('Verify incident table shows 25 "No retries left" errors', async () => {
+      await expect(
+        operateProcessInstancePage.getIncidentRow(/No more retries left/i),
+      ).toHaveCount(25);
+    });
+  });
+
+  test('select single task', async ({
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    await test.step('Select a single Task B instance', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^task b \(multi instance\)$/i,
+      );
+      await operateProcessInstancePage
+        .findTreeItemInHistory(/^task b$/i)
+        .first()
+        .click();
+    });
+
+    await test.step('Verify metadata popover shows flow node instance details', async () => {
+      await expect(
+        operateDiagramPage.getPopoverText(/flow node instance key/i),
+      ).toBeVisible();
+    });
+
+    await test.step('Open incident table and verify one incident is selected', async () => {
+      await operateDiagramPage.clickShowIncident();
+
+      await expect(
+        operateProcessInstancePage.getIncidentRow(/No more retries left/i),
+      ).toHaveCount(25);
+      await expect(
+        operateProcessInstancePage.getSelectedIncidentRow(
+          /No more retries left/i,
+        ),
+      ).toHaveCount(1);
+
+      await expect(
+        operateProcessInstancePage.incidentsViewHeader,
+      ).toContainText(/Incidents View.*25 results/i);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -254,7 +254,6 @@ test.describe('Process Instances Table', () => {
         maxRetries: 6,
       });
 
-      
       await expect
         .poll(() => instanceRows.nth(199).innerText())
         .toContain(descendingInstanceIds[199].toString());

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
@@ -54,6 +54,53 @@ export async function waitForIncidents(
   await sleep(2000);
 }
 
+export async function waitForFlowNodeIncidents(
+  _request: APIRequestContext,
+  processInstanceKey: string,
+  flowNodeId: string,
+  expectedCount: number,
+  timeout = 120000,
+): Promise<void> {
+  const baseURL =
+    process.env.CORE_APPLICATION_OPERATE_URL ?? 'http://localhost:8081';
+  const username = process.env.TEST_USERNAME || 'demo';
+  const password = process.env.TEST_PASSWORD || 'demo';
+
+  const apiContext = await request.newContext({baseURL});
+  await apiContext.post('/api/login', {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    form: {username, password},
+  });
+
+  try {
+    await expect
+      .poll(
+        async () => {
+          const response = await apiContext.post(
+            '/v1/flownode-instances/search',
+            {
+              data: {
+                filter: {
+                  processInstanceKey: parseInt(processInstanceKey),
+                  flowNodeId,
+                  incident: true,
+                },
+              },
+            },
+          );
+          const result: {total: number} = await response.json();
+          return result.total;
+        },
+        {timeout},
+      )
+      .toBe(expectedCount);
+  } finally {
+    await apiContext.dispose();
+  }
+
+  await sleep(2000);
+}
+
 export async function waitForProcessInstances(
   _request: APIRequestContext,
   instanceIds: string[],

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -67,6 +67,7 @@ const createWorker = (
         return job.complete(variables);
       }),
     pollInterval: 300,
+    loglevel: 'ERROR',
     ...(timeout ? {timeout} : {}),
   });
 };


### PR DESCRIPTION
## Description

This PR migrates [multiInstanceSelection.spec.ts](https://github.com/camunda/camunda/blob/main/operate/client/e2e-playwright/tests/multiInstanceSelection.spec.ts) to the Orchestration Cluster E2E test suite with comprehensive tests for multi-instance flow node selection, diagram navigation, and incident handling.

### Key Changes

- **New Tests**: Multi-instance expansion, flow node selection in diagrams, and single task incident filtering
- **New Utility**: `incidentsHelper.ts` for API-based incident polling to improve test reliability

🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/22859123645)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/34118
