### PR TITLE
ci: adjust misattribution of devops files

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -1,6 +1,6 @@
-# This is a comment.
 # Each line is a file pattern followed by one or more owners.
-# If you'd like to be added as an owner, don't hesitate to reach out to one of the existing ones.
+# If you'd like to be added as an owner, open a Pull Request and contact an existing owner.
+# Ownership information is used for attributing e.g. failing or flaky tests, broken CI workflows, etc.
 
 ################################
 ## @camunda/orchestration-cluster
@@ -27,6 +27,7 @@ SECURITY.md                 @camunda/orchestration-cluster
 /dist/                      @camunda/orchestration-cluster
 /docker-notice.txt          @camunda/orchestration-cluster
 /monitor/                   @camunda/orchestration-cluster
+/licenses/                  @camunda/orchestration-cluster
 
 commitlint*                 @camunda/orchestration-cluster
 .dockerignore               @camunda/orchestration-cluster
@@ -60,7 +61,6 @@ buf.yaml                    @camunda/orchestration-cluster
 /bom/                       @camunda/monorepo-devops-team
 /bom-deprecated/            @camunda/monorepo-devops-team
 /scripts/                   @camunda/monorepo-devops-team
-/licenses/                  @camunda/monorepo-devops-team
 /monorepo-docs-site/        @camunda/monorepo-devops-team
 
 .fossa.yml                  @camunda/monorepo-devops-team
@@ -104,6 +104,12 @@ mwnw*                       @camunda/monorepo-devops-team
 # Acceptance tests
 /qa/acceptance-tests/src/test/java/io/camunda/it/client/     @camunda/camundaex
 /qa/acceptance-tests/src/test/java/io/camunda/it/spring/     @camunda/camundaex
+
+# CI
+/.github/workflows/camunda8-getting-started-bundle.yaml @camunda/camundaex
+/.github/workflows/camunda-client-compatibility-test* @camunda/camundaex
+/.github/workflows/camunda-process-test-compatibility* @camunda/camundaex
+
 
 ################################
 ## @camunda/connectors-agentic-ai
@@ -252,6 +258,15 @@ optimize.Dockerfile         @camunda/core-features
 /qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/    @camunda/core-features
 
 # CI/CD Workflows
+/.ci/scripts/distribution/qa-testbench.sh @camunda/core-features
+/.github/actions/compose/ @camunda/core-features
+/.github/actions/core-features/ @camunda/core-features
+/.github/actions/docker-logs/ @camunda/core-features
+/.github/actions/execute-healthcheck-and-push-image/ @camunda/core-features
+/.github/actions/git-environment/ @camunda/core-features
+/.github/actions/run-maven/ @camunda/core-features
+/.github/optimize/scripts/ @camunda/core-features
+/.github/workflows/assign-urgency-to-issue* @camunda/core-features
 /.github/workflows/operate-ci-build-observe-reusable.yml @camunda/core-features
 /.github/workflows/operate-ci-build-reusable.yml @camunda/core-features
 /.github/workflows/operate-ci.yml @camunda/core-features
@@ -263,19 +278,15 @@ optimize.Dockerfile         @camunda/core-features
 /.github/workflows/ci-operate.yml @camunda/core-features
 /.github/workflows/ci-tasklist.yml @camunda/core-features
 /.github/workflows/ci-client-components.yml @camunda/core-features
-/.github/workflows/tasklist-ci-test-reusable.yml @camunda/core-features
-/.github/workflows/tasklist-ci.yml @camunda/core-features
-/.github/workflows/tasklist-e2e-tests.yml @camunda/core-features
-/.github/workflows/tasklist-docker-tests.yml @camunda/core-features
-/.github/workflows/tasklist-update_visual_snapshots.yml @camunda/core-features
+/.github/workflows/ci-webapp-run-ut-reuseable.yml @camunda/core-features
+/.github/workflows/tasklist* @camunda/core-features
 /.github/workflows/ci-optimize.yml @camunda/core-features
 /.github/workflows/optimize-*.yml @camunda/core-features
-/.github/workflows/zeebe-daily-qa.yml @camunda/core-features
 /.github/workflows/ci-zeebe.yml @camunda/core-features
-/.github/workflows/zeebe-*.yml @camunda/core-features
+/.github/workflows/zeebe* @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-*.yml @camunda/core-features
 /.github/workflows/gh-inherit-core-fields.yml @camunda/core-features
-/.github/workflows/assign-urgency-to-issue.yml @camunda/core-features
+/.github/workflows/publish-zod-schemas.yml @camunda/core-features
 
 ################################
 ## @camunda/reliability-testing
@@ -291,6 +302,7 @@ optimize.Dockerfile         @camunda/core-features
 
 # CI/CD Workflows
 /.github/workflows/*load-test*.yml @camunda/reliability-testing
+/.github/workflows/*load-test*.yaml @camunda/reliability-testing
 /.github/workflows/profile-load-test.yml @camunda/reliability-testing
 
 ################################
@@ -337,6 +349,9 @@ optimize.Dockerfile         @camunda/core-features
 /qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ @camunda/data-layer
 
 # CI/CD Workflows
+/.github/actions/rdbms/* @camunda/data-layer
+/.github/actions/setup-aws-opensearch-env/* @camunda/data-layer
+/.github/workflows/ci-database-integration-tests-reusable.yml @camunda/data-layer
 /.github/workflows/operate-test-backup-restore.yml @camunda/data-layer
 /.github/workflows/operate-test-importer.yml @camunda/data-layer
 
@@ -348,5 +363,8 @@ optimize.Dockerfile         @camunda/core-features
 /c8run/                     @camunda/distribution
 
 # CI/CD
-/.github/actions/setup-c8run/* @camunda/distribution
-/.github/workflows/c8run*   @camunda/distribution
+/.github/actions/setup-c8run/*       @camunda/distribution
+/.github/actions/sign-and-notarize/* @camunda/distribution
+/.github/workflows/c8run*            @camunda/distribution
+/.github/workflows/docker-build-helm-integration.yml @camunda/distribution
+/.github/workflows/trigger-c8run-e2e-tests.yml @camunda/distribution


### PR DESCRIPTION
## Description

We already have owner information in each GHA workflow YAML file. This PR transfers them into `.codeowners` (maybe we can automatically check for alignment later).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
