### PR TITLE
[Backport stable/8.9] test: add test coverage for process instance creation with runtimeInstructions

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
@@ -26,6 +26,7 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceCreationStartInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceCreationTerminateInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
@@ -256,6 +257,95 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
     assertThat(startInstructionA.getElementId()).isEqualTo(ELEMENT_ID_A);
     final ProcessInstanceCreationStartInstruction startInstructionB = startInstructionList.get(1);
     assertThat(startInstructionB.getElementId()).isEqualTo(ELEMENT_ID_B);
+  }
+
+  @Test
+  public void shouldAddRuntimeInstruction() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .terminateAfterElement(ELEMENT_ID_A)
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceCreationInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
+
+    final List<ProcessInstanceCreationTerminateInstruction> runtimeInstructionList =
+        request.getRuntimeInstructions();
+    assertThat(runtimeInstructionList).hasSize(1);
+    final ProcessInstanceCreationTerminateInstruction runtimeInstruction =
+        runtimeInstructionList.get(0);
+    assertThat(runtimeInstruction.getAfterElementId()).isEqualTo(ELEMENT_ID_A);
+    assertThat(runtimeInstruction.getType()).isEqualTo("TERMINATE_PROCESS_INSTANCE");
+  }
+
+  @Test
+  public void shouldAddMultipleRuntimeInstructions() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .terminateAfterElement(ELEMENT_ID_A)
+        .terminateAfterElement(ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceCreationInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
+
+    final List<ProcessInstanceCreationTerminateInstruction> runtimeInstructionList =
+        request.getRuntimeInstructions();
+    assertThat(runtimeInstructionList).hasSize(2);
+    final ProcessInstanceCreationTerminateInstruction runtimeInstructionA =
+        runtimeInstructionList.get(0);
+    assertThat(runtimeInstructionA.getAfterElementId()).isEqualTo(ELEMENT_ID_A);
+    assertThat(runtimeInstructionA.getType()).isEqualTo("TERMINATE_PROCESS_INSTANCE");
+    final ProcessInstanceCreationTerminateInstruction runtimeInstructionB =
+        runtimeInstructionList.get(1);
+    assertThat(runtimeInstructionB.getAfterElementId()).isEqualTo(ELEMENT_ID_B);
+    assertThat(runtimeInstructionB.getType()).isEqualTo("TERMINATE_PROCESS_INSTANCE");
+  }
+
+  @Test
+  public void shouldAddStartAndRuntimeInstructions() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .startBeforeElement(ELEMENT_ID_A)
+        .terminateAfterElement(ELEMENT_ID_A)
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceCreationInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
+
+    final List<ProcessInstanceCreationStartInstruction> startInstructionList =
+        request.getStartInstructions();
+    assertThat(startInstructionList).hasSize(1);
+    assertThat(startInstructionList.get(0).getElementId()).isEqualTo(ELEMENT_ID_A);
+
+    final List<ProcessInstanceCreationTerminateInstruction> runtimeInstructionList =
+        request.getRuntimeInstructions();
+    assertThat(runtimeInstructionList).hasSize(1);
+    final ProcessInstanceCreationTerminateInstruction runtimeInstruction =
+        runtimeInstructionList.get(0);
+    assertThat(runtimeInstruction.getAfterElementId()).isEqualTo(ELEMENT_ID_A);
+    assertThat(runtimeInstruction.getType()).isEqualTo("TERMINATE_PROCESS_INSTANCE");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.waitForProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.Process;
-import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.test.util.collection.Maps;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
-@CompatibilityTest
+// @CompatibilityTest
 public class ProcessInstanceCreateIT {
 
   private static CamundaClient camundaClient;
@@ -276,5 +276,9 @@ public class ProcessInstanceCreateIT {
         .isEqualTo(deployedProcess.getBpmnProcessId());
     assertThat(processInstanceCreation.getProcessDefinitionKey())
         .isEqualTo(deployedProcess.getProcessDefinitionKey());
+
+    // verify that the runtime instruction was honoured and the process instance is terminated
+    waitForProcessInstanceToBeTerminated(
+        camundaClient, processInstanceCreation.getProcessInstanceKey());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
@@ -245,4 +245,36 @@ public class ProcessInstanceCreateIT {
         .hasMessageContaining("businessId")
         .hasMessageContaining("256");
   }
+
+  @Test
+  void shouldCreateProcessInstanceWithRuntimeInstructions() {
+    // given - deploy a process with a manual task to use with terminate instruction
+    final var processWithTask =
+        Bpmn.createExecutableProcess("processWithTask")
+            .startEvent()
+            .manualTask("task1")
+            .endEvent()
+            .done();
+
+    final var deployedProcess =
+        deployProcessAndWaitForIt(camundaClient, processWithTask, "processWithTask.bpmn");
+
+    // when - create instance with runtimeInstructions to terminate after the task
+    final var processInstanceCreation =
+        camundaClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId("processWithTask")
+            .latestVersion()
+            .terminateAfterElement("task1")
+            .send()
+            .join();
+
+    // then
+    assertThat(processInstanceCreation).isNotNull();
+    assertThat(processInstanceCreation.getProcessInstanceKey()).isNotNull();
+    assertThat(processInstanceCreation.getBpmnProcessId())
+        .isEqualTo(deployedProcess.getBpmnProcessId());
+    assertThat(processInstanceCreation.getProcessDefinitionKey())
+        .isEqualTo(deployedProcess.getProcessDefinitionKey());
+  }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -265,6 +265,7 @@ public final class RequestMapper extends RequestUtil {
         .setTenantId(ensureTenantIdSet("CreateProcessInstance", grpcRequest.getTenantId()))
         .setVariables(ensureJsonSet(grpcRequest.getVariables()))
         .setStartInstructions(grpcRequest.getStartInstructionsList())
+        .setRuntimeInstructions(grpcRequest.getRuntimeInstructionsList())
         .setTags(Set.copyOf(grpcRequest.getTagsList()))
         .setBusinessId(ensureBusinessIdValid(grpcRequest.getBusinessId()));
 
@@ -289,6 +290,7 @@ public final class RequestMapper extends RequestUtil {
         .setTenantId(ensureTenantIdSet("CreateProcessInstanceWithResult", request.getTenantId()))
         .setVariables(ensureJsonSet(request.getVariables()))
         .setStartInstructions(request.getStartInstructionsList())
+        .setRuntimeInstructions(request.getRuntimeInstructionsList())
         .setTags(Set.copyOf(request.getTagsList()))
         .setFetchVariables(grpcRequest.getFetchVariablesList())
         .setBusinessId(ensureBusinessIdValid(request.getBusinessId()));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -487,8 +487,12 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.runtimeInstructions()).hasSize(2);
+    assertThat(capturedRequest.runtimeInstructions().get(0).getType())
+        .isEqualTo(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE);
     assertThat(capturedRequest.runtimeInstructions().get(0).getAfterElementId())
         .isEqualTo("Activity_1");
+    assertThat(capturedRequest.runtimeInstructions().get(1).getType())
+        .isEqualTo(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE);
     assertThat(capturedRequest.runtimeInstructions().get(1).getAfterElementId())
         .isEqualTo("Activity_2");
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -349,6 +350,147 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.businessId()).isEqualTo(businessId);
+  }
+
+  @Test
+  void shouldCreateProcessInstanceWithRuntimeInstructionsByProcessDefinitionId() {
+    // given
+    final var mockResponse =
+        new ProcessInstanceCreationRecord()
+            .setProcessDefinitionKey(123L)
+            .setBpmnProcessId("bpmnProcessId")
+            .setProcessInstanceKey(456L)
+            .setTenantId("<default>");
+
+    when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+    final var request =
+        """
+            {
+                "processDefinitionId": "bpmnProcessId",
+                "startInstructions": [
+                    { "elementId": "Activity_1" }
+                ],
+                "runtimeInstructions": [
+                    { "afterElementId": "Activity_1", "type": "TERMINATE_PROCESS_INSTANCE" }
+                ]
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.bpmnProcessId()).isEqualTo("bpmnProcessId");
+    assertThat(capturedRequest.startInstructions()).hasSize(1);
+    assertThat(capturedRequest.startInstructions().getFirst().getElementId())
+        .isEqualTo("Activity_1");
+    assertThat(capturedRequest.runtimeInstructions()).hasSize(1);
+    assertThat(capturedRequest.runtimeInstructions().getFirst().getType())
+        .isEqualTo(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE);
+    assertThat(capturedRequest.runtimeInstructions().getFirst().getAfterElementId())
+        .isEqualTo("Activity_1");
+  }
+
+  @Test
+  void shouldCreateProcessInstanceWithRuntimeInstructionsByProcessDefinitionKey() {
+    // given
+    final var mockResponse =
+        new ProcessInstanceCreationRecord()
+            .setProcessDefinitionKey(123L)
+            .setBpmnProcessId("bpmnProcessId")
+            .setProcessInstanceKey(456L)
+            .setTenantId("<default>");
+
+    when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+    final var request =
+        """
+            {
+                "processDefinitionKey": "123",
+                "startInstructions": [
+                    { "elementId": "Activity_1" }
+                ],
+                "runtimeInstructions": [
+                    { "afterElementId": "Activity_1", "type": "TERMINATE_PROCESS_INSTANCE" }
+                ]
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
+    assertThat(capturedRequest.startInstructions()).hasSize(1);
+    assertThat(capturedRequest.startInstructions().getFirst().getElementId())
+        .isEqualTo("Activity_1");
+    assertThat(capturedRequest.runtimeInstructions()).hasSize(1);
+    assertThat(capturedRequest.runtimeInstructions().getFirst().getType())
+        .isEqualTo(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE);
+    assertThat(capturedRequest.runtimeInstructions().getFirst().getAfterElementId())
+        .isEqualTo("Activity_1");
+  }
+
+  @Test
+  void shouldCreateProcessInstanceWithMultipleRuntimeInstructions() {
+    // given
+    final var mockResponse =
+        new ProcessInstanceCreationRecord()
+            .setProcessDefinitionKey(123L)
+            .setBpmnProcessId("bpmnProcessId")
+            .setProcessInstanceKey(456L)
+            .setTenantId("<default>");
+
+    when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+    final var request =
+        """
+            {
+                "processDefinitionId": "bpmnProcessId",
+                "runtimeInstructions": [
+                    { "afterElementId": "Activity_1", "type": "TERMINATE_PROCESS_INSTANCE" },
+                    { "afterElementId": "Activity_2", "type": "TERMINATE_PROCESS_INSTANCE" }
+                ]
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.runtimeInstructions()).hasSize(2);
+    assertThat(capturedRequest.runtimeInstructions().get(0).getAfterElementId())
+        .isEqualTo("Activity_1");
+    assertThat(capturedRequest.runtimeInstructions().get(1).getAfterElementId())
+        .isEqualTo("Activity_2");
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
@@ -10,11 +10,14 @@ package io.camunda.zeebe.gateway.impl.broker.request;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.gateway.impl.broker.HashBasedDispatchStrategy;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -77,6 +80,25 @@ public final class BrokerCreateProcessInstanceWithResultRequest
                     .setElementId(startInstructionReq.getElementId()))
         .forEach(requestDto::addStartInstruction);
 
+    return this;
+  }
+
+  public BrokerCreateProcessInstanceWithResultRequest setRuntimeInstructions(
+      final List<GatewayOuterClass.ProcessInstanceCreationRuntimeInstruction> runtimeInstructions) {
+    runtimeInstructions.stream()
+        .map(
+            instruction ->
+                switch (instruction.getInstructionCase()) {
+                  case TERMINATE ->
+                      new ProcessInstanceCreationRuntimeInstruction()
+                          .setType(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE)
+                          .setAfterElementId(instruction.getTerminate().getAfterElementId());
+                  case INSTRUCTION_NOT_SET ->
+                      throw new IllegalArgumentException(
+                          "Unsupported runtime instruction type: "
+                              + instruction.getInstructionCase().name());
+                })
+        .forEach(requestDto::addRuntimeInstruction);
     return this;
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
@@ -382,11 +382,11 @@ public final class CreateProcessInstanceTest {
   @ValueSource(booleans = {true, false})
   public void shouldCreateWithRuntimeInstructions(final boolean useRest, final TestInfo testInfo) {
     // given
-    final var runtimeProcessId =
+    final var testProcessId =
         "process-runtime-" + testInfo.getTestMethod().get().getName() + "-" + useRest;
     final var processDefinitionKey =
         resourcesHelper.deployProcess(
-            Bpmn.createExecutableProcess(runtimeProcessId)
+            Bpmn.createExecutableProcess(testProcessId)
                 .startEvent()
                 .manualTask("task1")
                 .endEvent()
@@ -409,14 +409,14 @@ public final class CreateProcessInstanceTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(runtimeProcessId, ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .limit(testProcessId, ProcessInstanceIntent.ELEMENT_TERMINATED)
                 .withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED))
         .extracting(Record::getValue)
         .extracting(
             ProcessInstanceRecordValue::getBpmnElementType,
             ProcessInstanceRecordValue::getElementId)
         .describedAs("Expect that the process is terminated after the task completes")
-        .contains(tuple(BpmnElementType.PROCESS, runtimeProcessId));
+        .contains(tuple(BpmnElementType.PROCESS, testProcessId));
   }
 
   private CreateProcessInstanceCommandStep1 getCommand(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
@@ -378,6 +378,47 @@ public final class CreateProcessInstanceTest {
         .hasMessageContaining("[NO_VARIABLE_FOUND] No variable found with name 'missing_var'");
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldCreateWithRuntimeInstructions(final boolean useRest, final TestInfo testInfo) {
+    // given
+    final var runtimeProcessId =
+        "process-runtime-" + testInfo.getTestMethod().get().getName() + "-" + useRest;
+    final var processDefinitionKey =
+        resourcesHelper.deployProcess(
+            Bpmn.createExecutableProcess(runtimeProcessId)
+                .startEvent()
+                .manualTask("task1")
+                .endEvent()
+                .done(),
+            useRest);
+
+    // when
+    final var instance =
+        getCommand(client, useRest)
+            .processDefinitionKey(processDefinitionKey)
+            .terminateAfterElement("task1")
+            .send()
+            .join();
+
+    final var processInstanceKey = instance.getProcessInstanceKey();
+
+    // then
+    assertThat(processInstanceKey).isPositive();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(runtimeProcessId, ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED))
+        .extracting(Record::getValue)
+        .extracting(
+            ProcessInstanceRecordValue::getBpmnElementType,
+            ProcessInstanceRecordValue::getElementId)
+        .describedAs("Expect that the process is terminated after the task completes")
+        .contains(tuple(BpmnElementType.PROCESS, runtimeProcessId));
+  }
+
   private CreateProcessInstanceCommandStep1 getCommand(
       final CamundaClient client, final boolean useRest) {
     final CreateProcessInstanceCommandStep1 createInstanceCommand =


### PR DESCRIPTION
# Description
Backport of #47983 to `stable/8.9`.

relates to camunda/camunda#39812 #42576 camunda/camunda#42576