### PR TITLE
Require wildcard read permission when retrieving global listeners

### DIFF
--- a/service/src/main/java/io/camunda/service/GlobalListenerServices.java
+++ b/service/src/main/java/io/camunda/service/GlobalListenerServices.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.service;
 
+import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.GLOBAL_TASK_LISTENER_READ_AUTHORIZATION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD_CHAR;
 
 import io.camunda.search.clients.GlobalListenerSearchClient;
 import io.camunda.search.entities.GlobalListenerEntity;
@@ -68,7 +70,8 @@ public final class GlobalListenerServices
             globalListenerSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication, GLOBAL_TASK_LISTENER_READ_AUTHORIZATION))
+                        authentication,
+                        withAuthorization(GLOBAL_TASK_LISTENER_READ_AUTHORIZATION, WILDCARD_CHAR)))
                 .getGlobalListener(
                     request.getId(), GlobalListenerType.valueOf(request.getListenerType().name())));
   }


### PR DESCRIPTION
## Description

When executing a GET request in a search client, access to the retrieved resource is checked through the
DefaultResourceAccessProvider#hasResourceAccess method. The latter expects the provided authorization to either:
- define property-based access
- provide a list of resource IDs
- provide a resource ID supplier If none of those are available, the access check fails with an exception.

Since the permission to read global task listener is all-or-nothing, no resource ID was previously provided in the
GlobalListenerServices#getGlobalTaskListener method, incurring in the above exception.

This behaviour is now correctly mapped by requiring a "wildcard" (`*`) permission of type `READ_TASK_LISTENER` to access global listeners.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48056
