### PR TITLE
fix: in FlowControl ringbuffer is not sparse

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -73,7 +73,7 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         flowControlCfg.getRequest() != null
             ? flowControlCfg.getRequest()
             : context.getBrokerCfg().getBackpressure();
-    final var ringBufferSizeMultiplier = 100;
+    final var ringBufferSizeMultiplier = 20;
     return logStreamBuilderSupplier
         .get()
         .withLogStorage(context.getLogStorage())

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -44,29 +45,32 @@ import org.jspecify.annotations.Nullable;
  *   <li>Calls to {@link #tryAcquire(WriteContext, List)} from the sequencer, outside the
  *       sequencer's write lock. Multiple calls can overlap concurrently.
  *   <li>Calls to {@link #registerEntry(long, InFlightEntry)} from the sequencer, under the
- *       sequencer's write lock. Only one call at a time.
+ *       sequencer's write lock. Only one call at a time. Returns a per-entry {@link
+ *       AppendListener}.
  *   <li>Calls to {@link #onAppended(InFlightEntry)} from the sequencer, outside the sequencer's
  *       write lock. Multiple calls can overlap concurrently and may also overlap with {@link
- *       #onWrite(long, long)} and {@link #onCommit(long, long)} callbacks.
- *   <li>Calls to {@link #onWrite(long, long)} from the log storage, serialized through the single
- *       raft thread.
- *   <li>Calls to {@link #onCommit(long, long)} from the log storage, serialized through the single
- *       raft thread.
+ *       AppendListener#onWrite} and {@link AppendListener#onCommit} callbacks.
+ *   <li>Per-entry {@link AppendListener#onWrite} from the log storage, serialized through the
+ *       single raft thread.
+ *   <li>Per-entry {@link AppendListener#onCommit} from the log storage, serialized through the
+ *       single raft thread.
  *   <li>Calls to {@link #onProcessed(long)} from the stream processor, serialized through the
  *       stream processor actor.
  * </ol>
  *
  * The entry is registered in the {@link #inFlight} ring buffer via {@link #registerEntry(long,
  * InFlightEntry)} inside the sequencer lock, before {@code logStorage.append} is called. This
- * guarantees that the entry is present in the buffer when {@link #onWrite(long, long)} and {@link
- * #onCommit(long, long)} callbacks fire.
+ * guarantees that the entry is present in the buffer when {@link AppendListener#onWrite} and {@link
+ * AppendListener#onCommit} callbacks fire.
  *
- * <p>{@link #onWrite(long, long)} and {@link #onCommit(long, long)} and {@link #onProcessed(long)}
- * can be called in any order.
+ * <p>Each {@link #registerEntry(long, InFlightEntry)} call returns a unique {@link
+ * PerEntryAppendListener} that captures the ring buffer index assigned to that entry. This allows
+ * {@code onWrite} and {@code onCommit} to look up the entry directly by index (O(1)), rather than
+ * searching by log position.
  *
- * <p>The {@link #inFlight} ring buffer is a fixed-capacity {@link RingBuffer} indexed by position.
- * It is modified by {@link #registerEntry(long, InFlightEntry)} (under the sequencer lock) and read
- * from other methods. The ring buffer uses an {@link
+ * <p>The {@link #inFlight} ring buffer is a fixed-capacity {@link RingBuffer} with sequential
+ * indexing. It is modified by {@link #registerEntry(long, InFlightEntry)} (under the sequencer
+ * lock) and read from other methods. The ring buffer uses an {@link
  * java.util.concurrent.atomic.AtomicReferenceArray} internally, providing volatile read/write
  * semantics per slot. This ensures that entries written by the sequencer thread are visible to the
  * raft thread ({@code onWrite}, {@code onCommit}) and the stream processor thread ({@code
@@ -81,7 +85,7 @@ import org.jspecify.annotations.Nullable;
  */
 @SuppressWarnings("UnstableApiUsage")
 @NullMarked
-public final class FlowControl implements AppendListener {
+public final class FlowControl {
 
   private final LogStreamMetrics metrics;
   @Nullable private RateLimit writeRateLimit;
@@ -178,8 +182,20 @@ public final class FlowControl implements AppendListener {
     return Either.right(new InFlightEntry(metrics, copiedMetadata, requestListener));
   }
 
-  public void registerEntry(final long highestPosition, final InFlightEntry entry) {
-    inFlight.put(highestPosition, entry);
+  /**
+   * Registers an in-flight entry in the ring buffer and returns a per-entry {@link AppendListener}
+   * that captures the assigned ring buffer index for direct O(1) lookup on write/commit callbacks.
+   *
+   * <p>Must be called under the sequencer lock.
+   *
+   * @param highestPosition the highest log position of the batch
+   * @param entry the in-flight entry to register
+   * @return a per-entry append listener to pass to {@code logStorage.append}
+   */
+  public AppendListener registerEntry(final long highestPosition, final InFlightEntry entry) {
+    entry.highestPosition = highestPosition;
+    inFlight.put(entry);
+    return new PerEntryAppendListener(entry);
   }
 
   public void onAppended(final InFlightEntry entry) {
@@ -187,39 +203,10 @@ public final class FlowControl implements AppendListener {
     metrics.increaseInflightAppends();
   }
 
-  @Override
-  public void onWrite(final long index, final long highestPosition) {
-    lastWrittenPosition = highestPosition;
-    updateWriteRateThrottle();
-    metrics.setLastWrittenPosition(highestPosition);
-    final var inFlightEntry = inFlight.get(highestPosition);
-    if (inFlightEntry != null) {
-      inFlightEntry.onWrite();
-    }
-    if (writeRate.observe(highestPosition)
-        && writeRateLimit != null
-        && writeRateLimit.enabled()
-        && writeRateLimiter != null) {
-      metrics.setPartitionLoad(
-          Math.min((float) (writeRate.rate() / writeRateLimiter.getRate() * 100L), 100));
-    }
-  }
-
-  @Override
-  public void onCommit(final long index, final long highestPosition) {
-    metrics.setLastCommittedPosition(highestPosition);
-    metrics.decreaseInflightAppends();
-    final var inFlightEntry = inFlight.get(highestPosition);
-    if (inFlightEntry != null) {
-      inFlightEntry.onCommit();
-    }
-  }
-
   public void onProcessed(final long position) {
-    final var inFlightEntry = inFlight.get(position);
-    if (inFlightEntry != null) {
-      inFlightEntry.onProcessed();
-      inFlight.remove(inFlightEntry);
+    final var entry = inFlight.findAndRemove(position);
+    if (entry != null) {
+      entry.onProcessed();
     }
   }
 
@@ -271,5 +258,43 @@ public final class FlowControl implements AppendListener {
   public enum Rejection {
     WriteRateLimitExhausted,
     RequestLimitExhausted
+  }
+
+  /**
+   * A per-entry {@link AppendListener} that captures the ring buffer index assigned during {@link
+   * #registerEntry}. This allows {@code onWrite} and {@code onCommit} to look up the entry directly
+   * by index + highestPosition (O(1) with collision guard), rather than scanning by log position.
+   */
+  private final class PerEntryAppendListener implements AppendListener {
+    private final InFlightEntry entry;
+
+    PerEntryAppendListener(final InFlightEntry entry) {
+      this.entry = Objects.requireNonNull(entry);
+    }
+
+    @Override
+    public void onWrite(final long index, final long highestPosition) {
+      // Global operations
+      lastWrittenPosition = highestPosition;
+      updateWriteRateThrottle();
+      metrics.setLastWrittenPosition(highestPosition);
+
+      // Per-entry: verify both index and highestPosition match
+      entry.onWrite();
+
+      if (writeRate.observe(highestPosition)
+          && writeRateLimit != null
+          && writeRateLimit.enabled()) {
+        metrics.setPartitionLoad(
+            Math.min((float) (writeRate.rate() / writeRateLimiter.getRate() * 100L), 100));
+      }
+    }
+
+    @Override
+    public void onCommit(final long index, final long highestPosition) {
+      metrics.setLastCommittedPosition(highestPosition);
+      metrics.decreaseInflightAppends();
+      entry.onCommit();
+    }
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -58,15 +58,11 @@ import org.jspecify.annotations.Nullable;
  *       stream processor actor.
  * </ol>
  *
- * The entry is registered in the {@link #inFlight} ring buffer via {@link #registerEntry(long,
- * InFlightEntry)} inside the sequencer lock, before {@code logStorage.append} is called. This
- * guarantees that the entry is present in the buffer when {@link AppendListener#onWrite} and {@link
- * AppendListener#onCommit} callbacks fire.
- *
- * <p>Each {@link #registerEntry(long, InFlightEntry)} call returns a unique {@link
- * PerEntryAppendListener} that captures the ring buffer index assigned to that entry. This allows
- * {@code onWrite} and {@code onCommit} to look up the entry directly by index (O(1)), rather than
- * searching by log position.
+ * Each {@link #registerEntry(long, InFlightEntry)} call returns a unique {@link
+ * PerEntryAppendListener} that captures the {@link InFlightEntry} reference directly. The {@code
+ * onWrite} and {@code onCommit} callbacks operate on the captured reference without any ring buffer
+ * lookup. The ring buffer is only needed for {@link #onProcessed(long)}, which searches by {@code
+ * highestPosition} via {@link RingBuffer#findAndRemove}.
  *
  * <p>The {@link #inFlight} ring buffer is a fixed-capacity {@link RingBuffer} with sequential
  * indexing. It is modified by {@link #registerEntry(long, InFlightEntry)} (under the sequencer
@@ -184,7 +180,7 @@ public final class FlowControl {
 
   /**
    * Registers an in-flight entry in the ring buffer and returns a per-entry {@link AppendListener}
-   * that captures the assigned ring buffer index for direct O(1) lookup on write/commit callbacks.
+   * that captures the entry reference directly for write/commit callbacks.
    *
    * <p>Must be called under the sequencer lock.
    *
@@ -261,9 +257,9 @@ public final class FlowControl {
   }
 
   /**
-   * A per-entry {@link AppendListener} that captures the ring buffer index assigned during {@link
-   * #registerEntry}. This allows {@code onWrite} and {@code onCommit} to look up the entry directly
-   * by index + highestPosition (O(1) with collision guard), rather than scanning by log position.
+   * A per-entry {@link AppendListener} that captures the {@link InFlightEntry} reference directly.
+   * The {@code onWrite} and {@code onCommit} callbacks operate on the captured reference without
+   * any ring buffer lookup.
    */
   private final class PerEntryAppendListener implements AppendListener {
     private final InFlightEntry entry;
@@ -279,12 +275,12 @@ public final class FlowControl {
       updateWriteRateThrottle();
       metrics.setLastWrittenPosition(highestPosition);
 
-      // Per-entry: verify both index and highestPosition match
       entry.onWrite();
 
       if (writeRate.observe(highestPosition)
           && writeRateLimit != null
-          && writeRateLimit.enabled()) {
+          && writeRateLimit.enabled()
+          && writeRateLimiter != null) {
         metrics.setPartitionLoad(
             Math.min((float) (writeRate.rate() / writeRateLimiter.getRate() * 100L), 100));
       }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -27,10 +27,10 @@ public final class InFlightEntry {
   final AtomicReference<@Nullable CloseableSilently> commitTimer;
 
   /**
-   * The position this entry was registered at in the ring buffer. Set by {@link RingBuffer#put}
-   * before the entry reference is published into the array. Used by {@link RingBuffer#get} to
-   * verify that the entry in a slot actually belongs to the requested position (guards against
-   * wraparound collisions).
+   * The sequential ring buffer index assigned to this entry. Set by {@link RingBuffer#put} before
+   * the entry reference is published into the array. Used by {@link RingBuffer#get} to verify that
+   * the entry in a slot actually belongs to the requested index (guards against wraparound
+   * collisions).
    *
    * <p>This field is intentionally <em>not</em> volatile. Visibility is guaranteed by the {@link
    * java.util.concurrent.atomic.AtomicReferenceArray} used in the ring buffer: {@code put} sets
@@ -39,6 +39,17 @@ public final class InFlightEntry {
    * establishes a happens-before edge that carries this plain write.
    */
   long position;
+
+  /**
+   * The highest log position of the batch this entry belongs to. Set by {@link
+   * FlowControl#registerEntry} before calling {@link RingBuffer#put}. Used by {@link
+   * RingBuffer#findAndRemove} to locate entries by log position (for {@code onProcessed}), and by
+   * {@link RingBuffer#get} as a secondary guard alongside the sequential index.
+   *
+   * <p>Same visibility contract as {@link #position}: written before the volatile publish in {@code
+   * put()}.
+   */
+  long highestPosition;
 
   public InFlightEntry(
       final LogStreamMetrics metrics,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -28,9 +28,9 @@ public final class InFlightEntry {
 
   /**
    * The sequential ring buffer index assigned to this entry. Set by {@link RingBuffer#put} before
-   * the entry reference is published into the array. Used by {@link RingBuffer#get} to verify that
-   * the entry in a slot actually belongs to the requested index (guards against wraparound
-   * collisions).
+   * the entry reference is published into the array. Used by {@link RingBuffer#findAndRemove} to
+   * verify that the entry in a slot belongs to the expected sequential index (guards against
+   * wraparound collisions).
    *
    * <p>This field is intentionally <em>not</em> volatile. Visibility is guaranteed by the {@link
    * java.util.concurrent.atomic.AtomicReferenceArray} used in the ring buffer: {@code put} sets
@@ -43,8 +43,7 @@ public final class InFlightEntry {
   /**
    * The highest log position of the batch this entry belongs to. Set by {@link
    * FlowControl#registerEntry} before calling {@link RingBuffer#put}. Used by {@link
-   * RingBuffer#findAndRemove} to locate entries by log position (for {@code onProcessed}), and by
-   * {@link RingBuffer#get} as a secondary guard alongside the sequential index.
+   * RingBuffer#findAndRemove} to locate entries by log position (for {@code onProcessed}).
    *
    * <p>Same visibility contract as {@link #position}: written before the volatile publish in {@code
    * put()}.

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -144,9 +144,9 @@ final class RingBuffer {
    * Used by {@code onProcessed} from the stream processor thread, which processes entries in order.
    *
    * <p>The scan starts from the last processed entry's sequential index and iterates forward in
-   * sequential index order (not slot order). Each entry's {@link InFlightEntry#position} is
-   * verified against the expected index to skip displaced entries (where the slot was overwritten
-   * by a newer {@link #put}).
+   * sequential index order. Each entry's {@link InFlightEntry#position} is verified against the
+   * expected index to skip displaced entries (where the slot was overwritten by a newer {@link
+   * #put}).
    *
    * <p>The scan range is {@code [max(lastProcessedIndex+1, nextIndex-capacity), nextIndex)}, which
    * is at most {@code capacity} iterations and in practice much less when the stream processor

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.agrona.BitUtil;
 import org.jspecify.annotations.NullMarked;
@@ -15,20 +16,39 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A fixed-capacity ring buffer for {@link InFlightEntry} instances, indexed by position. Uses
- * power-of-two capacity with {@code & mask} indexing for O(1) operations.
+ * A fixed-capacity ring buffer for {@link InFlightEntry} instances, specialized for the {@link
+ * FlowControl}/{@link io.camunda.zeebe.logstreams.impl.log.Sequencer} threading model. It is
+ * <em>not</em> a general-purpose concurrent data structure — its correctness depends on the
+ * specific access patterns of those callers:
+ *
+ * <ul>
+ *   <li>{@link #put} is called under the sequencer lock (single writer).
+ *   <li>{@link #get} is only used in tests.
+ *   <li>{@link #findAndRemove} is called from the stream processor thread (single caller, processes
+ *       entries in order).
+ * </ul>
+ *
+ * <p>The buffer is lossy by design: when a slot is reused after a full wraparound, the displaced
+ * entry is cleaned up rather than blocking the writer. Similarly, {@link #findAndRemove} cleans up
+ * all entries before the matched one, since they were skipped by the stream processor. This is
+ * acceptable because displaced or skipped entries represent in-flight appends whose metrics are no
+ * longer meaningful.
  *
  * <p>Each slot has volatile read/write semantics via {@link AtomicReferenceArray}, ensuring
  * visibility across threads without external synchronization.
  *
+ * <h3>Sequential indexing</h3>
+ *
+ * <p>The buffer uses a monotonically increasing counter ({@link #nextIndex}) incremented under the
+ * sequencer lock. Every slot is used before wrapping, giving effective capacity equal to the full
+ * buffer size.
+ *
  * <h3>Wraparound safety</h3>
  *
- * <p>Because multiple positions map to the same slot (modular indexing), a slot may be overwritten
- * by a newer position after a full wraparound. To guard against reading the wrong entry, {@link
- * #put(long, InFlightEntry)} stamps the entry with the position before the volatile write, and
- * {@link #get(long)} verifies that the entry's {@link InFlightEntry#position} matches the requested
- * position. This keeps all concurrency concerns (position stamping + volatile publication) inside
- * the ring buffer.
+ * <p>Because multiple indices map to the same slot (modular indexing), a slot may be overwritten by
+ * a newer index after a full wraparound. To guard against reading the wrong entry, {@link
+ * #put(InFlightEntry)} stamps the entry with the sequential index before the volatile write, and
+ * {@link #get(long, long)} verifies both the sequential index and the log position match.
  */
 @NullMarked
 final class RingBuffer {
@@ -37,8 +57,24 @@ final class RingBuffer {
 
   private final AtomicReferenceArray<@Nullable InFlightEntry> buffer;
   private final int mask;
-  // NOTE: this field is not volatile
-  private long lastWrittenPosition = -1;
+
+  /**
+   * Monotonically increasing counter for slot assignment.
+   *
+   * <p>Written by the sequencer thread (under lock) in {@link #put}. Read by the stream processor
+   * thread in {@link #findAndRemove} to bound the scan range.
+   */
+  private volatile long nextIndex = 0;
+
+  /**
+   * Tracks the sequential index of the last entry removed by {@link #findAndRemove(long)}.
+   * Subsequent scans start from {@code lastProcessedIndex + 1}, avoiding re-scanning already
+   * processed slots.
+   *
+   * <p>Written by the stream processor thread in {@link #findAndRemove}. Read by the sequencer
+   * thread indirectly (not currently used outside {@code findAndRemove}).
+   */
+  private volatile long lastProcessedIndex = -1;
 
   /**
    * Creates a new ring buffer with at least the given capacity. The actual capacity is rounded up
@@ -59,60 +95,87 @@ final class RingBuffer {
   }
 
   /**
-   * Puts an entry at the given position. Stamps {@code entry.position} before the volatile write so
-   * that it is published together with the reference. If the slot was occupied, the displaced
-   * entry's {@link InFlightEntry#cleanup()} is called to release resources (timers, request
-   * listeners).
+   * Puts an entry into the next sequential slot. Stamps {@code entry.position} with the assigned
+   * index before the volatile write so that it is published together with the reference. If the
+   * slot was occupied, the displaced entry's {@link InFlightEntry#cleanup()} is called to release
+   * resources (timers, request listeners).
+   *
+   * <p>Must be called under the sequencer lock.
+   *
+   * @return the assigned sequential index (captured by per-entry listeners for direct lookup)
    */
-  void put(final long position, final InFlightEntry entry) {
+  long put(final InFlightEntry entry) {
+    final long index = nextIndex++;
     // Plain write, published by the volatile getAndSet below (happens-before).
-    entry.position = position;
-    // IMPORTANT:
-    // lastWrittenPosition must be written before the buffer is modified:
-    // clients that will do a get() will see the updated value.
-    lastWrittenPosition = position;
-    final var displaced = buffer.getAndSet((int) (position & mask), entry);
+    entry.position = index;
+    final var displaced = buffer.getAndSet((int) (index & mask), entry);
     if (displaced != null) {
-      // position is a long, which will get boxed without the if check
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace(
-            "Found non-null entry at position {} while doing a put at position {}: cleaning it up",
+            "Found non-null entry at index {} (highestPosition {}) while doing a put at index {}"
+                + " (highestPosition {}): cleaning it up",
             displaced.position,
-            position);
+            displaced.highestPosition,
+            index,
+            entry.highestPosition);
       }
       displaced.cleanup();
     }
+    return index;
   }
 
   /**
-   * Returns the entry at the given position, or null if the slot is empty or holds an entry for a
-   * different position (i.e. the slot was overwritten by a wraparound).
-   */
-  @Nullable InFlightEntry get(final long position) {
-    final var entry = buffer.get((int) (position & mask));
-    return entry != null && entry.position == position ? entry : null;
-  }
-
-  /**
-   * The returned value is not a volatile read, so it might not be up to date, unless a {@link
-   * RingBuffer#get(long)} is called beforehand.
+   * Returns the entry at the given sequential index, but only if both the index and the
+   * highestPosition match. Returns null if the slot is empty, holds an entry for a different index
+   * (wraparound), or holds an entry with a different highestPosition (defense-in-depth).
    *
-   * <p>This is done to not add overhead (as it's in the hot path) as this getter is not really
-   * necessary in production code. If it becomes necessary to have a volatile read, then the field
-   * must be updated.
-   *
-   * @return the last written position to the buffer
+   * <p>Used by per-entry listeners for onWrite/onCommit lookups from the raft thread.
    */
-  long lastWrittenPosition() {
-    return lastWrittenPosition;
+  @VisibleForTesting
+  @Nullable InFlightEntry get(final long index, final long highestPosition) {
+    final var entry = buffer.get((int) (index & mask));
+    return entry != null && entry.position == index && entry.highestPosition == highestPosition
+        ? entry
+        : null;
   }
 
   /**
-   * Removes the entry at the given position by nulling the slot if the entry in the buffer matches
-   * {@param entry}
+   * Scans forward from {@link #lastProcessedIndex} to find and remove an entry by its log position.
+   * Used by {@code onProcessed} from the stream processor thread, which processes entries in order.
+   *
+   * <p>The scan starts from the last processed entry's sequential index and iterates forward in
+   * sequential index order (not slot order). Each entry's {@link InFlightEntry#position} is
+   * verified against the expected index to skip displaced entries (where the slot was overwritten
+   * by a newer {@link #put}).
+   *
+   * <p>The scan range is {@code [max(lastProcessedIndex+1, nextIndex-capacity), nextIndex)}, which
+   * is at most {@code capacity} iterations and in practice much less when the stream processor
+   * keeps up with the writer.
+   *
+   * @return the entry if found, or null if the entry was displaced or not present
    */
-  void remove(final InFlightEntry entry) {
-    buffer.compareAndExchange((int) (entry.position & mask), entry, null);
+  InFlightEntry findAndRemove(final long highestPosition) {
+    final long scanEnd = nextIndex; // volatile read — snapshot of writer progress
+    final long scanStart = Math.max(lastProcessedIndex + 1, scanEnd - buffer.length());
+
+    for (long idx = scanStart; idx < scanEnd; idx++) {
+      final int slot = (int) (idx & mask);
+      final var entry = buffer.get(slot);
+      if (entry == null || entry.position != idx) {
+        continue; // slot empty or entry displaced by a newer put
+      }
+      if (entry.highestPosition == highestPosition) {
+        buffer.compareAndExchange(slot, entry, null);
+        lastProcessedIndex = entry.position;
+        return entry;
+      }
+      if (entry.highestPosition < highestPosition) {
+        // Entry was skipped by the stream processor — clean it up
+        buffer.compareAndExchange(slot, entry, null);
+        entry.cleanup();
+      }
+    }
+    return null;
   }
 
   /** Returns the capacity of this ring buffer. */

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -171,6 +171,7 @@ final class RingBuffer {
         // Entry was skipped by the stream processor — clean it up
         buffer.compareAndExchange(slot, entry, null);
         entry.cleanup();
+        lastProcessedIndex = entry.position;
       }
     }
     return null;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -102,7 +102,7 @@ final class RingBuffer {
    *
    * <p>Must be called under the sequencer lock.
    *
-   * @return the assigned sequential index (captured by per-entry listeners for direct lookup)
+   * @return the assigned sequential index
    */
   long put(final InFlightEntry entry) {
     final long index = nextIndex++;
@@ -128,8 +128,6 @@ final class RingBuffer {
    * Returns the entry at the given sequential index, but only if both the index and the
    * highestPosition match. Returns null if the slot is empty, holds an entry for a different index
    * (wraparound), or holds an entry with a different highestPosition (defense-in-depth).
-   *
-   * <p>Used by per-entry listeners for onWrite/onCommit lookups from the raft thread.
    */
   @VisibleForTesting
   @Nullable InFlightEntry get(final long index, final long highestPosition) {
@@ -154,7 +152,7 @@ final class RingBuffer {
    *
    * @return the entry if found, or null if the entry was displaced or not present
    */
-  InFlightEntry findAndRemove(final long highestPosition) {
+  @Nullable InFlightEntry findAndRemove(final long highestPosition) {
     final long scanEnd = nextIndex; // volatile read — snapshot of writer progress
     final long scanStart = Math.max(lastProcessedIndex + 1, scanEnd - buffer.length());
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -71,10 +71,10 @@ final class RingBuffer {
    * Subsequent scans start from {@code lastProcessedIndex + 1}, avoiding re-scanning already
    * processed slots.
    *
-   * <p>Written by the stream processor thread in {@link #findAndRemove}. Read by the sequencer
-   * thread indirectly (not currently used outside {@code findAndRemove}).
+   * <p>Only accessed by the stream processor thread in {@link #findAndRemove}. Not volatile because
+   * no other thread reads or writes this field.
    */
-  private volatile long lastProcessedIndex = -1;
+  private long lastProcessedIndex = -1;
 
   /**
    * Creates a new ring buffer with at least the given capacity. The actual capacity is rounded up

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -116,8 +116,8 @@ final class Sequencer implements LogStreamWriter, Closeable {
       final var sequencedBatch =
           new SequencedBatch(
               clock.millis(), currentPosition, sourcePosition, appendEntries, batchLength);
-      flowControl.registerEntry(highestPosition, inFlightEntry);
-      logStorage.append(currentPosition, highestPosition, sequencedBatch, flowControl);
+      final var appendListener = flowControl.registerEntry(highestPosition, inFlightEntry);
+      logStorage.append(currentPosition, highestPosition, sequencedBatch, appendListener);
       position = currentPosition + batchSize;
     } finally {
       lock.unlock();

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -16,7 +16,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 import org.awaitility.Awaitility;
@@ -28,67 +28,275 @@ final class RingBufferTest {
   private static final LogStreamMetricsImpl METRICS =
       new LogStreamMetricsImpl(new SimpleMeterRegistry());
 
-  /** Creates a new InFlightEntry. Position is set by {@link RingBuffer#put}. */
+  /** Creates a new InFlightEntry with the given highestPosition. */
+  private static InFlightEntry newEntry(final long highestPosition) {
+    final var entry = new InFlightEntry(METRICS, null, null);
+    entry.highestPosition = highestPosition;
+    return entry;
+  }
+
+  /** Creates a new InFlightEntry with highestPosition = 0. */
   private static InFlightEntry newEntry() {
-    return new InFlightEntry(METRICS, null, null);
+    return newEntry(0);
+  }
+
+  @Test
+  void putReturnsSequentialIndices() {
+    // given
+    final var buffer = new RingBuffer(4);
+
+    // when
+    final var idx0 = buffer.put(newEntry(10));
+    final var idx1 = buffer.put(newEntry(20));
+    final var idx2 = buffer.put(newEntry(30));
+
+    // then
+    assertThat(idx0).isEqualTo(0);
+    assertThat(idx1).isEqualTo(1);
+    assertThat(idx2).isEqualTo(2);
   }
 
   @Test
   void getReturnsStoredEntry() {
+    // given
     final var buffer = new RingBuffer(4);
-    final var entry = newEntry();
-    buffer.put(1, entry);
-    assertThat(buffer.get(1)).isSameAs(entry);
+    final var entry = newEntry(42);
+
+    // when
+    final long idx = buffer.put(entry);
+
+    // then
+    assertThat(buffer.get(idx, 42)).isSameAs(entry);
   }
 
   @Test
-  void removeNullsTheSlot() {
+  void getReturnsNullWhenHighestPositionDoesNotMatch() {
+    // given
     final var buffer = new RingBuffer(4);
-    final var entry = newEntry();
-    buffer.put(3, entry);
-    buffer.remove(entry);
-    assertThat(buffer.get(3)).isNull();
+    final var entry = newEntry(42);
+    final long idx = buffer.put(entry);
+
+    // when
+    final var result = buffer.get(idx, 99);
+
+    // then
+    assertThat(result).isNull();
   }
 
   @Test
-  void removeDoesNotRemoveOverwrittenEntry() {
+  void getReturnsNullAfterDisplacement() {
+    // given
     final var buffer = new RingBuffer(4);
-    final var position = 3;
-    final var positionWrapped = position + buffer.capacity();
-    final var entry = newEntry();
-    buffer.put(position, entry);
-    final var secondEntry = newEntry();
-    buffer.put(positionWrapped, secondEntry);
-    buffer.remove(entry);
-    assertThat(buffer.get(position)).isNull();
-    assertThat(buffer.get(positionWrapped)).isSameAs(secondEntry);
-  }
+    final var first = newEntry(10);
+    final long firstIdx = buffer.put(first);
+    buffer.put(newEntry(20));
+    buffer.put(newEntry(30));
+    buffer.put(newEntry(40));
 
-  @Test
-  void getReturnsNullWhenPositionDoesNotMatch() {
-    // Position guard: after wraparound, get(oldPosition) returns null because
-    // the entry in the slot was stamped with the new position.
-    final var buffer = new RingBuffer(4);
-    buffer.put(5, newEntry());
-    // Overwrite slot with position 9 (same slot: 9 & 3 == 1 == 5 & 3)
-    final var lastEntry = newEntry();
-    buffer.put(9, lastEntry);
-    // get(5) should return null — the slot holds an entry for position 9
-    assertThat(buffer.get(5)).isNull();
-    // get(9) should return the entry
-    assertThat(buffer.get(9)).isNotNull().isSameAs(lastEntry);
+    // when — slot 0 is overwritten by index 4
+    final var displaced = newEntry(50);
+    final long displacedIdx = buffer.put(displaced);
+
+    // then
+    assertThat(buffer.get(firstIdx, 10)).isNull();
+    assertThat(buffer.get(displacedIdx, 50)).isSameAs(displaced);
   }
 
   @Test
   void putSetsPositionOnEntry() {
+    // given
     final var buffer = new RingBuffer(4);
-    final var entry = newEntry();
-    buffer.put(42, entry);
-    assertThat(entry.position).isEqualTo(42);
+    final var entry = newEntry(100);
+
+    // when
+    final long idx = buffer.put(entry);
+
+    // then
+    assertThat(entry.position).isEqualTo(idx);
+  }
+
+  @Test
+  void findAndRemoveFindsEntryByHighestPosition() {
+    // given
+    final var buffer = new RingBuffer(8);
+    final var e1 = newEntry(100);
+    final var e2 = newEntry(200);
+    final var e3 = newEntry(300);
+    buffer.put(e1);
+    buffer.put(e2);
+    buffer.put(e3);
+
+    // when / then — should find entries in order
+    assertThat(buffer.findAndRemove(100)).isSameAs(e1);
+    assertThat(buffer.findAndRemove(200)).isSameAs(e2);
+    assertThat(buffer.findAndRemove(300)).isSameAs(e3);
+  }
+
+  @Test
+  void findAndRemoveReturnsNullWhenNotFound() {
+    // given
+    final var buffer = new RingBuffer(4);
+    buffer.put(newEntry(100));
+
+    // when
+    final var result = buffer.findAndRemove(999);
+
+    // then
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void findAndRemoveCleansUpEntriesWithLowerHighestPosition() {
+    // given
+    final var buffer = new RingBuffer(8);
+    final var skipped = newEntry(100);
+    final var target = newEntry(200);
+    final long skippedIdx = buffer.put(skipped);
+    buffer.put(target);
+
+    // when — findAndRemove(200) should clean up the entry with hp=100
+    final var found = buffer.findAndRemove(200);
+
+    // then
+    assertThat(found).isSameAs(target);
+    assertThat(buffer.get(skippedIdx, 100))
+        .as("skipped entry should be removed from the buffer")
+        .isNull();
+  }
+
+  @Test
+  void findAndRemoveCleansUpMultipleSkippedEntries() {
+    // given
+    final var buffer = new RingBuffer(8);
+    final var e1 = newEntry(100);
+    final var e2 = newEntry(200);
+    final var e3 = newEntry(300);
+    final long idx1 = buffer.put(e1);
+    final long idx2 = buffer.put(e2);
+    buffer.put(e3);
+
+    // when — findAndRemove(300) should clean up both hp=100 and hp=200
+    final var found = buffer.findAndRemove(300);
+
+    // then
+    assertThat(found).isSameAs(e3);
+    assertThat(buffer.get(idx1, 100)).as("entry hp=100 should be cleaned up").isNull();
+    assertThat(buffer.get(idx2, 200)).as("entry hp=200 should be cleaned up").isNull();
+  }
+
+  @Test
+  void findAndRemoveCleansUpRequestListenerOnSkippedEntries() {
+    // given
+    final var ignored = new AtomicBoolean(false);
+    final Listener listener =
+        new Listener() {
+          @Override
+          public void onSuccess() {}
+
+          @Override
+          public void onIgnore() {
+            ignored.set(true);
+          }
+
+          @Override
+          public void onDropped() {}
+        };
+    final var buffer = new RingBuffer(8);
+    final var skipped = new InFlightEntry(METRICS, null, listener);
+    skipped.highestPosition = 100;
+    skipped.onAppend();
+    buffer.put(skipped);
+    buffer.put(newEntry(200));
+
+    // when
+    buffer.findAndRemove(200);
+
+    // then — cleanup() should have called onIgnore on the skipped entry's listener
+    assertThat(ignored.get()).as("skipped entry's listener should receive onIgnore").isTrue();
+  }
+
+  /**
+   * Verifies that findAndRemove finds first-lap entries after wraparound has overwritten earlier
+   * slots.
+   */
+  @Test
+  void findAndRemoveFindsFirstLapEntriesAfterWraparound() {
+    // given — capacity = 4, slots 0-3
+    final var buffer = new RingBuffer(4);
+
+    // Fill the buffer: indices 0-3, highestPositions 5,10,15,20
+    buffer.put(newEntry(5)); // index 0 → slot 0
+    buffer.put(newEntry(10)); // index 1 → slot 1
+    buffer.put(newEntry(15)); // index 2 → slot 2
+    buffer.put(newEntry(20)); // index 3 → slot 3
+
+    // Wraparound: indices 4-5 overwrite slots 0-1
+    buffer.put(newEntry(25)); // index 4 → slot 0 (displaces hp=5)
+    buffer.put(newEntry(30)); // index 5 → slot 1 (displaces hp=10)
+
+    // Buffer state:
+    //   slot 0: {index=4, hp=25}  ← second lap
+    //   slot 1: {index=5, hp=30}  ← second lap
+    //   slot 2: {index=2, hp=15}  ← first lap, still present
+    //   slot 3: {index=3, hp=20}  ← first lap, still present
+
+    // when
+    final var found = buffer.findAndRemove(15);
+
+    // then
+    assertThat(found).as("findAndRemove(15) should find the entry at slot 2").isNotNull();
+    assertThat(found.highestPosition).isEqualTo(15);
+
+    final var found2 = buffer.findAndRemove(20);
+    assertThat(found2).as("findAndRemove(20) should find the entry at slot 3").isNotNull();
+    assertThat(found2.highestPosition).isEqualTo(20);
+  }
+
+  /**
+   * Verifies that findAndRemove finds second-lap entries after partial processing and a full
+   * wraparound, where the scan starts mid-buffer at a slot with a higher sequential index.
+   */
+  @Test
+  void findAndRemoveFindsEntriesAfterPartialProcessingAndWraparound() {
+    // given — capacity = 4, slots 0-3
+    final var buffer = new RingBuffer(4);
+
+    // First lap: indices 0-3, highestPositions 5,10,15,20
+    buffer.put(newEntry(5)); // index 0 → slot 0
+    buffer.put(newEntry(10)); // index 1 → slot 1
+    buffer.put(newEntry(15)); // index 2 → slot 2
+    buffer.put(newEntry(20)); // index 3 → slot 3
+
+    // Process entries 0 and 1 in order → lastProcessedIndex = 1
+    assertThat(buffer.findAndRemove(5)).isNotNull(); // lastProcessedIndex → 0
+    assertThat(buffer.findAndRemove(10)).isNotNull(); // lastProcessedIndex → 1
+
+    // Second lap: indices 4-7 overwrite all slots
+    buffer.put(newEntry(25)); // index 4 → slot 0 (displaces hp=5, already removed)
+    buffer.put(newEntry(30)); // index 5 → slot 1 (displaces hp=10, already removed)
+    buffer.put(newEntry(35)); // index 6 → slot 2 (displaces hp=15, NOT yet processed!)
+    buffer.put(newEntry(40)); // index 7 → slot 3 (displaces hp=20, NOT yet processed!)
+
+    // Buffer state:
+    //   slot 0: {index=4, hp=25}  ← second lap
+    //   slot 1: {index=5, hp=30}  ← second lap
+    //   slot 2: {index=6, hp=35}  ← second lap (displaced hp=15)
+    //   slot 3: {index=7, hp=40}  ← second lap (displaced hp=20)
+
+    // hp=15 and hp=20 were displaced → findAndRemove returns null (correct)
+    // Now process the second-lap entries in order:
+
+    // when
+    final var found = buffer.findAndRemove(25);
+
+    // then
+    assertThat(found).as("findAndRemove(25) should find the entry at slot 0").isNotNull();
+    assertThat(found.highestPosition).isEqualTo(25);
   }
 
   @Test
   void constructorRoundsUpToNextPowerOfTwo() {
+    // given / when / then
     assertThat(new RingBuffer(1).capacity()).isEqualTo(1);
     assertThat(new RingBuffer(2).capacity()).isEqualTo(2);
     assertThat(new RingBuffer(3).capacity()).isEqualTo(4);
@@ -102,12 +310,16 @@ final class RingBufferTest {
 
   @Test
   void constructorUsesDefaultForZero() {
+    // given / when
     final var buffer = new RingBuffer(0);
+
+    // then
     assertThat(buffer.capacity()).isEqualTo(8192);
   }
 
   @Test
   void constructorRejectsNegative() {
+    // given / when / then
     assertThatThrownBy(() -> new RingBuffer(-1)).isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -120,21 +332,24 @@ final class RingBufferTest {
 
     /**
      * Simulates the FlowControl access pattern: one writer thread puts entries (sequencer), a
-     * reader thread reads them (raft thread). Verifies that entries written by the writer are
-     * visible to the reader.
+     * reader thread reads them via get(index, highestPosition) (raft thread). Verifies that entries
+     * written by the writer are visible to the reader.
      */
     @Test
     void writerIsVisibleToReader() {
+      // given
       final var buffer = new RingBuffer(CAPACITY);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
+      final var indices = new long[ITERATIONS + 1];
 
       final var writer =
           new Thread(
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
-                  buffer.put(pos, newEntry());
+                  final var entry = newEntry(pos);
+                  indices[(int) pos] = buffer.put(entry);
                 }
               });
 
@@ -144,11 +359,11 @@ final class RingBufferTest {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   InFlightEntry entry;
-                  while ((entry = buffer.get(pos)) == null) {
+                  while ((entry = buffer.get(indices[(int) pos], pos)) == null) {
                     LockSupport.parkNanos(1);
                   }
                   try {
-                    assertThat(entry.position).isEqualTo(pos);
+                    assertThat(entry.highestPosition).isEqualTo(pos);
                   } catch (final AssertionError e) {
                     failures.add(e);
                     return;
@@ -156,16 +371,18 @@ final class RingBufferTest {
                 }
               });
 
+      // when / then
       runAndAwait(startLatch, failures, writer, reader);
       assertThat(failures).isEmpty();
     }
 
     /**
-     * Simulates the full lifecycle: writer puts entries, a second thread reads and then removes
-     * them (like onProcessed). Verifies removal is visible.
+     * Simulates the full lifecycle: writer puts entries, a second thread finds and removes them
+     * (like onProcessed). Verifies findAndRemove works correctly.
      */
     @Test
-    void removeIsVisibleAcrossThreads() {
+    void findAndRemoveWorksAcrossThreads() {
+      // given
       final var buffer = new RingBuffer(CAPACITY);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
@@ -175,7 +392,7 @@ final class RingBufferTest {
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
-                  buffer.put(pos, newEntry());
+                  buffer.put(newEntry(pos));
                 }
               });
 
@@ -186,12 +403,11 @@ final class RingBufferTest {
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   InFlightEntry entry = null;
                   while (entry == null) {
-                    entry = buffer.get(pos);
+                    entry = buffer.findAndRemove(pos);
                     LockSupport.parkNanos(1);
                   }
-                  buffer.remove(entry);
                   try {
-                    assertThat(buffer.get(pos)).isNull();
+                    assertThat(entry.highestPosition).isEqualTo(pos);
                   } catch (final AssertionError e) {
                     failures.add(e);
                     return;
@@ -199,27 +415,30 @@ final class RingBufferTest {
                 }
               });
 
+      // when / then
       runAndAwait(startLatch, failures, writer, processor);
       assertThat(failures).isEmpty();
     }
 
     /**
-     * Multiple reader threads concurrently reading the same positions that a single writer is
+     * Multiple reader threads concurrently reading the same entries that a single writer is
      * publishing. Mirrors the FlowControl pattern where onWrite (raft thread), onCommit (raft
      * thread), and onProcessed (stream processor) may all read the same entry.
      */
     @Test
     void multipleReadersSeeWriterUpdates() {
+      // given
       final var buffer = new RingBuffer(CAPACITY);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
+      final var indices = new long[ITERATIONS + 1];
 
       final var writer =
           new Thread(
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
-                  buffer.put(pos, newEntry());
+                  indices[(int) pos] = buffer.put(newEntry(pos));
                 }
               });
 
@@ -231,11 +450,11 @@ final class RingBufferTest {
                   awaitLatch(startLatch);
                   for (long pos = 1; pos <= ITERATIONS; pos++) {
                     InFlightEntry entry;
-                    while ((entry = buffer.get(pos)) == null) {
+                    while ((entry = buffer.get(indices[(int) pos], pos)) == null) {
                       LockSupport.parkNanos(1);
                     }
                     try {
-                      assertThat(entry.position).isEqualTo(pos);
+                      assertThat(entry.highestPosition).isEqualTo(pos);
                     } catch (final AssertionError e) {
                       failures.add(e);
                       return;
@@ -247,56 +466,37 @@ final class RingBufferTest {
       final var allThreads = new Thread[readers.length + 1];
       allThreads[0] = writer;
       System.arraycopy(readers, 0, allThreads, 1, readers.length);
+
+      // when / then
       runAndAwait(startLatch, failures, allThreads);
       assertThat(failures).isEmpty();
     }
 
     /**
-     * Writer wraps around with a small capacity. The reader trails the writer using a shared
-     * progress counter, reading positions that the writer has recently written. This ensures both
-     * paths are exercised:
+     * Writer wraps around with a small capacity. The reader uses findAndRemove to process entries
+     * in order. Because entries are indexed sequentially, displacement only occurs after the full
+     * buffer capacity is used (unlike position-based indexing where it depended on batch size).
      *
-     * <ul>
-     *   <li><b>Hit</b>: the entry is still in the slot (reader is close behind the writer)
-     *   <li><b>Miss</b>: the entry was displaced by a newer write (reader fell behind by more than
-     *       capacity positions)
-     * </ul>
-     *
-     * The test asserts that both hits and misses occurred and that every hit returned the correct
-     * entry (position guard was not bypassed).
+     * <p>The test asserts that both hits (entry found and processed) and misses (entry displaced
+     * before processing) occurred, and that every hit returned the correct entry (position guard
+     * was not bypassed).
      */
     @Test
-    void positionGuardWorksUnderConcurrentWraparound() {
+    void sequentialIndexingWorksUnderConcurrentWraparound() {
+      // given
       final var smallCapacity = 64;
       final var buffer = new RingBuffer(smallCapacity);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
 
-      final var counter = new AtomicInteger(0);
-
-      final var limitListener =
-          new Listener() {
-            @Override
-            public void onSuccess() {
-              counter.incrementAndGet();
-            }
-
-            @Override
-            public void onIgnore() {
-              counter.incrementAndGet();
-            }
-
-            @Override
-            public void onDropped() {
-              counter.incrementAndGet();
-            }
-          };
       final var writer =
           new Thread(
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
-                  buffer.put(pos, new InFlightEntry(METRICS, null, limitListener));
+                  final var entry = new InFlightEntry(METRICS, null, null);
+                  entry.highestPosition = pos;
+                  buffer.put(entry);
                 }
               });
 
@@ -307,47 +507,27 @@ final class RingBufferTest {
           new Thread(
               () -> {
                 awaitLatch(startLatch);
-                long readerPos = 0;
-                while (readerPos < ITERATIONS) {
-                  final long writerPos = buffer.lastWrittenPosition();
-                  if (writerPos <= readerPos) {
-                    LockSupport.parkNanos(1);
-                    continue;
-                  }
-                  // Read a position that was recently written — may or may not have been displaced
-                  // by now. Read from (writerPos - smallCapacity + 1) to exercise the boundary
-                  // where entries are about to be displaced.
-                  final long readPos = Math.max(readerPos + 1, writerPos - smallCapacity + 1);
-                  readerPos = readPos;
-                  try {
-                    final var entry = buffer.get(readPos);
-                    if (entry != null) {
-                      assertThat(entry.position).isEqualTo(readPos);
-                      hits.incrementAndGet();
-                    } else {
-                      misses.incrementAndGet();
+                for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  final var entry = buffer.findAndRemove(pos);
+                  if (entry != null) {
+                    try {
+                      assertThat(entry.highestPosition).isEqualTo(pos);
+                    } catch (final AssertionError e) {
+                      failures.add(e);
+                      return;
                     }
-                  } catch (final AssertionError e) {
-                    failures.add(e);
-                    return;
+                    hits.incrementAndGet();
+                  } else {
+                    misses.incrementAndGet();
                   }
                 }
               });
 
+      // when / then
       runAndAwait(startLatch, failures, writer, reader);
       assertThat(failures).isEmpty();
       assertThat(hits.get()).as("expected some hits (entry still present)").isGreaterThan(0);
       assertThat(misses.get()).as("expected some misses (entry displaced)").isGreaterThan(0);
-
-      // Clean up the last entries still in the buffer (positions that were never displaced):
-      // the implementation checks the position, not just the array index.
-      for (long pos = ITERATIONS - smallCapacity + 1; pos <= ITERATIONS; pos++) {
-        final var entry = buffer.get(pos);
-        if (entry != null) {
-          entry.cleanup();
-        }
-      }
-      assertThat(counter.get()).isEqualTo(ITERATIONS);
     }
 
     /** Starts all threads, releases the latch, and waits for all threads to finish. */


### PR DESCRIPTION
## Description
The ringbuffer doesn't use the position as index anymore as it was
sparse (depending on the number of records in the batch).
Each entry is appended to the ringbuffer in the next available slot,
displacing the previous entry if possible.
The streamprocessor threads starts looking up entry by highestPosition
starting from the last index it consumed, so the efficiency stays the
same.
Whenever it skips an entry, it also cleans it up.

Because there are no unused position, we can use a smaller buffer.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
