### PR TITLE
fix: in ProcessingSession there's no need to copy authInfo

### DIFF
--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +43,24 @@ final class RecordMetadataTest {
     assertThat(metadata.getAgent()).isNull();
     assertThat(metadata.getBrokerVersion()).isEqualTo(RecordMetadata.CURRENT_BROKER_VERSION);
     assertThat(metadata.getRecordVersion()).isEqualTo(RecordMetadata.DEFAULT_RECORD_VERSION);
+  }
+
+  @Test
+  void shouldCopyAuthInfoWhenSettingAuthorization() {
+    // given
+    final var metadata = new RecordMetadata();
+    final var authInfo = new AuthInfo();
+    authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+    authInfo.setClaims(Map.of("key", "value"));
+
+    // when
+    metadata.authorization(authInfo);
+    authInfo.reset();
+
+    // then -- metadata should still have the original values
+    final var storedAuth = metadata.getAuthorization();
+    assertThat(storedAuth.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+    assertThat(storedAuth.getClaims()).isEqualTo(Map.of("key", "value"));
   }
 
   private void encodeDecode(final RecordMetadata metadata) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -41,6 +41,7 @@ public interface ProcessingSession {
 
   default void appendAuthInfoToFollowUps(final AuthInfo authInfo) {
     if (authInfo != null && authInfo.hasAnyClaims()) {
+      // no explicit copy needed: RecordMetadata.authorization() already copies via copyFrom()
       appendMetadataToFollowUps(metadata -> metadata.authorization(authInfo));
     }
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -41,9 +41,7 @@ public interface ProcessingSession {
 
   default void appendAuthInfoToFollowUps(final AuthInfo authInfo) {
     if (authInfo != null && authInfo.hasAnyClaims()) {
-      // make a copy to rule out any side effects
-      final var authorization = AuthInfo.of(authInfo);
-      appendMetadataToFollowUps(metadata -> metadata.authorization(authorization));
+      appendMetadataToFollowUps(metadata -> metadata.authorization(authInfo));
     }
   }
 


### PR DESCRIPTION
## Description
There was an extra copy `AuthInfo.of` even though
`metadata.authorization(authInfo)` copies it anyway in its preallocated instance.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
