### PR TITLE
fix: fix identity version resolution and GitHub release creation

### DIFF
--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -29,6 +29,11 @@ jobs:
       uses: YunaBraska/java-info-action@main
       with:
         work-dir: ./optimize
+    - name: "Read Parent Pom Info"
+      id: "parent-pom-info"
+      uses: YunaBraska/java-info-action@main
+      with:
+        work-dir: .
     - name: Expose common variables as Env
       run: |
         {
@@ -83,7 +88,7 @@ jobs:
         OPTIMIZE_IMAGE_TAG: ${{ env.DOCKER_TAG }}
         ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
         ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
-        IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version }}
+        IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version || steps.parent-pom-info.outputs.x_version_identity }}
         OPERATE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
 
     - name: Wait for Optimize to start

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -203,6 +203,12 @@ jobs:
         with:
           work-dir: ./optimize
 
+      - name: "Read Parent Pom Info"
+        id: "parent-pom-info"
+        uses: YunaBraska/java-info-action@main
+        with:
+          work-dir: .
+
       - name: Clean release
         run: |
           mvn release:clean
@@ -334,7 +340,7 @@ jobs:
           OPTIMIZE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
           ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
           ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
-          IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version }}
+          IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version || steps.parent-pom-info.outputs.x_version_identity }}
           OPERATE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
 
       - name: Wait for Optimize to start
@@ -354,7 +360,7 @@ jobs:
         uses: octokit/request-action@v2.3.1
         with:
           route: POST /repos/camunda/camunda/releases
-          make_latest: false
+          make_latest: "false"
           name: ${{ env.TAG }}
           tag_name: ${{ env.TAG }}
           generate_release_notes: true


### PR DESCRIPTION
## Description
This PR:

- Fixes `IDENTITY_VERSION` resolution by adding a fallback to parent/pom.xml (version.identity) when optimize/pom.xml doesn't define identity.version

- Fixes "Create a GitHub release" step 422 error by quoting make_latest: `false` (GitHub API requires a string, not a YAML boolean)

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
