### PR TITLE
[Backport stable/8.9] ci: assign original author as reviewer of backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -49,6 +49,7 @@ jobs:
             relates to ${issue_refs}
 
           add_author_as_assignee: true
+          add_author_as_reviewer: true
           experimental: >
             {
               "conflict_resolution": "draft_commit_conflicts"


### PR DESCRIPTION
# Description
Backport of #47832 to `stable/8.9`.

relates to 