### PR TITLE
[Backport stable/8.9] Require wildcard read permission when retrieving global listeners

### DIFF
--- a/service/src/main/java/io/camunda/service/GlobalListenerServices.java
+++ b/service/src/main/java/io/camunda/service/GlobalListenerServices.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.service;
 
+import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.GLOBAL_TASK_LISTENER_READ_AUTHORIZATION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD_CHAR;
 
 import io.camunda.search.clients.GlobalListenerSearchClient;
 import io.camunda.search.entities.GlobalListenerEntity;
@@ -68,7 +70,8 @@ public final class GlobalListenerServices
             globalListenerSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication, GLOBAL_TASK_LISTENER_READ_AUTHORIZATION))
+                        authentication,
+                        withAuthorization(GLOBAL_TASK_LISTENER_READ_AUTHORIZATION, WILDCARD_CHAR)))
                 .getGlobalListener(
                     request.getId(), GlobalListenerType.valueOf(request.getListenerType().name())));
   }


### PR DESCRIPTION
# Description
Backport of #48063 to `stable/8.9`.

relates to #48056