### PR TITLE
[Backport stable/8.9] Improve test coverage of Global Task Listeners

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GlobalTaskListenerAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GlobalTaskListenerAuthorizationIT.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_TASK_LISTENER;
+import static io.camunda.client.api.search.enums.PermissionType.DELETE_TASK_LISTENER;
+import static io.camunda.client.api.search.enums.PermissionType.READ_TASK_LISTENER;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE_TASK_LISTENER;
+import static io.camunda.client.api.search.enums.ResourceType.GLOBAL_LISTENER;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD_CHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class GlobalTaskListenerAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  private static final String ADMIN = "admin";
+  private static final String CREATE_AUTHORIZED = "createAuthorized";
+  private static final String READ_AUTHORIZED = "readAuthorized";
+  private static final String UPDATE_AUTHORIZED = "updateAuthorized";
+  private static final String DELETE_AUTHORIZED = "deleteAuthorized";
+  private static final String UNAUTHORIZED = "unauthorized";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER =
+      new TestUser(
+          ADMIN,
+          "password",
+          List.of(
+              new Permissions(GLOBAL_LISTENER, CREATE_TASK_LISTENER, List.of(WILDCARD_CHAR)),
+              new Permissions(GLOBAL_LISTENER, READ_TASK_LISTENER, List.of(WILDCARD_CHAR)),
+              new Permissions(GLOBAL_LISTENER, UPDATE_TASK_LISTENER, List.of(WILDCARD_CHAR)),
+              new Permissions(GLOBAL_LISTENER, DELETE_TASK_LISTENER, List.of(WILDCARD_CHAR))));
+
+  @UserDefinition
+  private static final TestUser CREATE_AUTHORIZED_USER =
+      new TestUser(
+          CREATE_AUTHORIZED,
+          "password",
+          List.of(new Permissions(GLOBAL_LISTENER, CREATE_TASK_LISTENER, List.of(WILDCARD_CHAR))));
+
+  @UserDefinition
+  private static final TestUser READ_AUTHORIZED_USER =
+      new TestUser(
+          READ_AUTHORIZED,
+          "password",
+          List.of(new Permissions(GLOBAL_LISTENER, READ_TASK_LISTENER, List.of(WILDCARD_CHAR))));
+
+  @UserDefinition
+  private static final TestUser UPDATE_AUTHORIZED_USER =
+      new TestUser(
+          UPDATE_AUTHORIZED,
+          "password",
+          List.of(new Permissions(GLOBAL_LISTENER, UPDATE_TASK_LISTENER, List.of(WILDCARD_CHAR))));
+
+  @UserDefinition
+  private static final TestUser DELETE_AUTHORIZED_USER =
+      new TestUser(
+          DELETE_AUTHORIZED,
+          "password",
+          List.of(new Permissions(GLOBAL_LISTENER, DELETE_TASK_LISTENER, List.of(WILDCARD_CHAR))));
+
+  @UserDefinition
+  private static final TestUser UNAUTHORIZED_USER =
+      new TestUser(UNAUTHORIZED, "password", List.of());
+
+  @Test
+  void shouldAllowCreateOfGlobalTaskListenerWithCreateAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(CREATE_AUTHORIZED) final CamundaClient authorizedClient) {
+    // given a global listener id
+    final var listenerId = UUID.randomUUID().toString();
+
+    // when an authorized user tries to create the global listener
+    authorizedClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+
+    // then the global listener is correctly created
+    Awaitility.await("global listener should become available in search layer")
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .until(() -> adminClient.newGlobalTaskListenerGetRequest(listenerId).send().join() != null);
+  }
+
+  @Test
+  void shouldAllowReadOfGlobalTaskListenerWithReadAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(READ_AUTHORIZED) final CamundaClient authorizedClient) {
+    // given an existing global listener
+    final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an authorized user tries to read the global listener
+    final var readListener =
+        authorizedClient.newGlobalTaskListenerGetRequest(listenerId).send().join();
+
+    // then the listener is correctly retrieved
+    assertThat(readListener).as("global listener should be retrieved").isNotNull();
+  }
+
+  @Test
+  void shouldAllowUpdateOfGlobalTaskListenerWithUpdateAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(UPDATE_AUTHORIZED) final CamundaClient authorizedClient) {
+    // given an existing global listener
+    final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an authorized user tries to update the global listener
+    authorizedClient
+        .newUpdateGlobalTaskListenerRequest(listenerId)
+        .type("updated-job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+
+    // then the global listener is correctly updated
+    Awaitility.await("global listener should have data updated in search layer")
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .until(
+            () -> {
+              final var globalListener =
+                  adminClient.newGlobalTaskListenerGetRequest(listenerId).send().join();
+              return globalListener != null && globalListener.getType().equals("updated-job-type");
+            });
+  }
+
+  @Test
+  void shouldAllowDeleteOfGlobalTaskListenerWithDeleteAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(DELETE_AUTHORIZED) final CamundaClient authorizedClient) {
+    // given an existing global listener
+    final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an authorized user tries to delete the global listener
+    authorizedClient.newDeleteGlobalTaskListenerRequest(listenerId).send().join();
+
+    // then the global listener is correctly deleted
+    Awaitility.await("global listener should become unavailable in search layer")
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(
+                        () -> adminClient.newGlobalTaskListenerGetRequest(listenerId).send().join())
+                    .isInstanceOf(io.camunda.client.api.command.ProblemException.class)
+                    .satisfies(
+                        e -> {
+                          final var problemException =
+                              (io.camunda.client.api.command.ProblemException) e;
+                          assertThat(problemException.code()).isEqualTo(404);
+                        }));
+  }
+
+  @Test
+  void shouldAllowSearchOfGlobalTaskListenerWithSearchAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(READ_AUTHORIZED) final CamundaClient authorizedClient) {
+    // given an existing global listener
+    final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an authorized user tries to search the global listener
+    final var foundListeners =
+        authorizedClient
+            .newGlobalTaskListenerSearchRequest()
+            .filter(f -> f.id(listenerId))
+            .send()
+            .join();
+
+    // then the global listener is correctly updated
+    assertThat(foundListeners).as("search result should not be null").isNotNull();
+    assertThat(foundListeners.items())
+        .as("the desired global listener should be found in search result")
+        .hasSize(1);
+  }
+
+  @Test
+  void shouldForbidCreateOfGlobalTaskListenerWithoutAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(UNAUTHORIZED) final CamundaClient unauthorizedClient) {
+    // given a global listener id
+    final var listenerId = UUID.randomUUID().toString();
+
+    // when an unauthorized user tries to create the global listener
+    // then a 403 Forbidden error is returned
+    assertThatThrownBy(
+            () ->
+                unauthorizedClient
+                    .newCreateGlobalTaskListenerRequest()
+                    .id(listenerId)
+                    .type("job-type")
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .isInstanceOf(io.camunda.client.api.command.ProblemException.class)
+        .satisfies(
+            e -> {
+              final var problemException = (io.camunda.client.api.command.ProblemException) e;
+              assertThat(problemException.code()).isEqualTo(403);
+            });
+  }
+
+  @Test
+  void shouldForbidReadOfGlobalTaskListenerWithoutAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(UNAUTHORIZED) final CamundaClient unauthorizedClient) {
+    // given an existing global listener
+    final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an unauthorized user tries to read the global listener
+    // then a 403 Forbidden error is returned
+    assertThatThrownBy(
+            () -> unauthorizedClient.newGlobalTaskListenerGetRequest(listenerId).send().join())
+        .isInstanceOf(io.camunda.client.api.command.ProblemException.class)
+        .satisfies(
+            e -> {
+              final var problemException = (io.camunda.client.api.command.ProblemException) e;
+              assertThat(problemException.code()).isEqualTo(403);
+            });
+  }
+
+  @Test
+  void shouldForbidUpdateOfGlobalTaskListenerWithoutAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(UNAUTHORIZED) final CamundaClient unauthorizedClient) {
+    // given an existing global listener
+    final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an unauthorized user tries to update the global listener
+    // then a 403 Forbidden error is returned
+    assertThatThrownBy(
+            () ->
+                unauthorizedClient
+                    .newUpdateGlobalTaskListenerRequest(listenerId)
+                    .type("updated-job-type")
+                    .eventTypes(GlobalTaskListenerEventType.CREATING)
+                    .send()
+                    .join())
+        .isInstanceOf(io.camunda.client.api.command.ProblemException.class)
+        .satisfies(
+            e -> {
+              final var problemException = (io.camunda.client.api.command.ProblemException) e;
+              assertThat(problemException.code()).isEqualTo(403);
+            });
+  }
+
+  @Test
+  void shouldForbidDeleteOfGlobalTaskListenerWithoutAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(UNAUTHORIZED) final CamundaClient unauthorizedClient) {
+    // given an existing global listener
+    final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an unauthorized user tries to delete the global listener
+    // then a 403 Forbidden error is returned
+    assertThatThrownBy(
+            () -> unauthorizedClient.newDeleteGlobalTaskListenerRequest(listenerId).send().join())
+        .isInstanceOf(io.camunda.client.api.command.ProblemException.class)
+        .satisfies(
+            e -> {
+              final var problemException = (io.camunda.client.api.command.ProblemException) e;
+              assertThat(problemException.code()).isEqualTo(403);
+            });
+  }
+
+  @Test
+  void shouldForbidSearchOfGlobalTaskListenerWithoutAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(UNAUTHORIZED) final CamundaClient unauthorizedClient) {
+    // given an existing global listener
+    final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an unauthorized user tries to read the global listener
+    // then a 403 Forbidden error is returned
+    assertThatThrownBy(
+            () -> unauthorizedClient.newGlobalTaskListenerGetRequest(listenerId).send().join())
+        .isInstanceOf(io.camunda.client.api.command.ProblemException.class)
+        .satisfies(
+            e -> {
+              final var problemException = (io.camunda.client.api.command.ProblemException) e;
+              assertThat(problemException.code()).isEqualTo(403);
+            });
+  }
+
+  public static void waitForCreatedGlobalListener(
+      final CamundaClient camundaClient, final String globalListenerId) {
+    Awaitility.await("should wait for global listener to be available in search layer")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .until(
+            () ->
+                camundaClient.newGlobalTaskListenerGetRequest(globalListenerId).send().join()
+                    != null);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GlobalTaskListenerAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GlobalTaskListenerAuthorizationIT.java
@@ -43,6 +43,7 @@ class GlobalTaskListenerAuthorizationIT {
   private static final String ADMIN = "admin";
   private static final String CREATE_AUTHORIZED = "createAuthorized";
   private static final String READ_AUTHORIZED = "readAuthorized";
+  private static final String PARTIAL_READ_AUTHORIZED = "partialReadAuthorized";
   private static final String UPDATE_AUTHORIZED = "updateAuthorized";
   private static final String DELETE_AUTHORIZED = "deleteAuthorized";
   private static final String UNAUTHORIZED = "unauthorized";
@@ -71,6 +72,13 @@ class GlobalTaskListenerAuthorizationIT {
           READ_AUTHORIZED,
           "password",
           List.of(new Permissions(GLOBAL_LISTENER, READ_TASK_LISTENER, List.of(WILDCARD_CHAR))));
+
+  @UserDefinition
+  private static final TestUser PARTIAL_READ_AUTHORIZED_USER =
+      new TestUser(
+          PARTIAL_READ_AUTHORIZED,
+          "password",
+          List.of(new Permissions(GLOBAL_LISTENER, READ_TASK_LISTENER, List.of("listenerId"))));
 
   @UserDefinition
   private static final TestUser UPDATE_AUTHORIZED_USER =
@@ -265,6 +273,33 @@ class GlobalTaskListenerAuthorizationIT {
       @Authenticated(UNAUTHORIZED) final CamundaClient unauthorizedClient) {
     // given an existing global listener
     final var listenerId = UUID.randomUUID().toString();
+    adminClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("job-type")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+    waitForCreatedGlobalListener(adminClient, listenerId);
+
+    // when an unauthorized user tries to read the global listener
+    // then a 403 Forbidden error is returned
+    assertThatThrownBy(
+            () -> unauthorizedClient.newGlobalTaskListenerGetRequest(listenerId).send().join())
+        .isInstanceOf(io.camunda.client.api.command.ProblemException.class)
+        .satisfies(
+            e -> {
+              final var problemException = (io.camunda.client.api.command.ProblemException) e;
+              assertThat(problemException.code()).isEqualTo(403);
+            });
+  }
+
+  @Test
+  void shouldForbidReadOfGlobalTaskListenerWithNonWildcardAuthorization(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(PARTIAL_READ_AUTHORIZED) final CamundaClient unauthorizedClient) {
+    // given an existing global listener
+    final var listenerId = "listenerId";
     adminClient
         .newCreateGlobalTaskListenerRequest()
         .id(listenerId)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
@@ -23,6 +23,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.GlobalListenerSort;
 import io.camunda.security.reader.ResourceAccessChecks;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -649,6 +650,123 @@ public class GlobalListenerFilterIT {
                     new GlobalListenerFilter.Builder()
                         .types(testIdentifier)
                         .priorityOperations(Operation.in(2, 5))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithEqEventTypeFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with "assigning" event type
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.eventTypes(List.of("creating")).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(
+            testApplication, b -> b.eventTypes(List.of("assigning")).type(testIdentifier));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.eventTypes(List.of("updating")).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(
+            testApplication,
+            b -> b.eventTypes(List.of("completing", "assigning")).type(testIdentifier));
+
+    // when searching by equal event type
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .eventTypeOperations(Operation.eq("assigning"))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithLikeEventTypeFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with event type matching the "c*" pattern
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.eventTypes(List.of("updating")).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(
+            testApplication, b -> b.eventTypes(List.of("creating")).type(testIdentifier));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.eventTypes(List.of("assigning")).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(
+            testApplication,
+            b -> b.eventTypes(List.of("canceling", "assigning")).type(testIdentifier));
+
+    // when searching by event type matching pattern
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .eventTypeOperations(Operation.like("c*"))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithInEventTypeFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with event type either "creating" or "canceling"
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.eventTypes(List.of("updating")).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(
+            testApplication, b -> b.eventTypes(List.of("creating")).type(testIdentifier));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.eventTypes(List.of("assigning")).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(
+            testApplication,
+            b -> b.eventTypes(List.of("canceling", "assigning")).type(testIdentifier));
+
+    // when searching by event type in provided set
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .eventTypeOperations(Operation.in("creating", "canceling"))
                         .build(),
                     GlobalListenerSort.of(b -> b),
                     SearchQueryPage.of(b -> b)),

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.engine.client.command;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
 import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenerCfg;
 import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenersCfg;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
@@ -355,6 +356,160 @@ public class GlobalUserTaskListenersTest {
         .containsExactly("oldCreating");
   }
 
+  @Test
+  void shouldMergeConfigurationAndApiGlobalTaskListener() {
+    // given: a process definition and global listeners defined through configuration and API
+
+    // configure global listeners
+    configureGlobalListeners(
+        List.of(
+            createListenerConfig("10_configuration", List.of("creating"), false),
+            createListenerConfig("20_configuration", List.of("creating"), false)));
+    restartBroker();
+
+    // add global listener via API (note that no restart is needed)
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id("15_api")
+        .type("15_api")
+        .eventTypes(GlobalTaskListenerEventType.CREATING)
+        .send()
+        .join();
+
+    // setup workers for listeners
+    setupAutocompleteWorker("10_configuration");
+    setupAutocompleteWorker("20_configuration");
+    setupAutocompleteWorker("15_api");
+
+    // deploy process definition
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("processWithUserTask")
+            .startEvent("start")
+            .userTask("task")
+            .zeebeUserTask()
+            .endEvent("end")
+            .done();
+    final long processDefinitionKey = resourcesHelper.deployProcess(processDefinition);
+
+    // when: process with task is created
+    final var processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+
+    // then: all listeners are executed in correct order
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r -> // skip until task creation is started
+                    r.getIntent() == UserTaskIntent.CREATING
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                .limit(
+                    r -> // stop after task creation has been completed
+                    r.getIntent() == UserTaskIntent.CREATED
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                // get all completed task listener jobs
+                .jobRecords()
+                .withJobKind(JobKind.TASK_LISTENER)
+                .withIntent(JobIntent.COMPLETED))
+        .extracting(Record::getValue)
+        // check that all jobs are for creating event
+        .allMatch(job -> job.getJobListenerEventType() == JobListenerEventType.CREATING)
+        .extracting(JobRecordValue::getType)
+        // check correct listeners have been executed in correct order
+        .containsExactly("10_configuration", "15_api", "20_configuration");
+  }
+
+  @Test
+  void shouldReplaceOnlyConfigurationDefinedGlobalTaskListenersAfterRestart() {
+    // given: a process definition and global listeners defined through configuration and API
+
+    // configure "old" global listeners
+    configureGlobalListeners(
+        List.of(
+            createListenerConfig("10_configuration", List.of("creating"), false),
+            createListenerConfig("20_configuration", List.of("assigning"), false)));
+    restartBroker();
+
+    // add global listener via API (note that no restart is needed)
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id("15_api")
+        .type("15_api")
+        .eventTypes(GlobalTaskListenerEventType.CREATING)
+        .send()
+        .join();
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id("30_api")
+        .type("30_api")
+        .eventTypes(GlobalTaskListenerEventType.CREATING)
+        .send()
+        .join();
+
+    // setup workers for listeners
+    setupAutocompleteWorker("10_configuration");
+    setupAutocompleteWorker("20_configuration");
+    setupAutocompleteWorker("15_api");
+    setupAutocompleteWorker("30_api");
+
+    // deploy process definition
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("processWithUserTask")
+            .startEvent("start")
+            .userTask("task")
+            .zeebeUserTask()
+            .endEvent("end")
+            .done();
+    final long processDefinitionKey = resourcesHelper.deployProcess(processDefinition);
+
+    // when: the configuration is changed and the cluster restarted
+
+    // configure "new" global listeners
+    configureGlobalListeners(
+        List.of(
+            // 10_configuration removed
+            // 20_configuration is still there but with different event type
+            createListenerConfig("20_configuration", List.of("creating"), false),
+            // 01_configuration added
+            createListenerConfig("40_configuration", List.of("creating"), false)));
+    restartBroker();
+
+    // setup worker for new listener
+    setupAutocompleteWorker("40_configuration");
+
+    // then: the correct listeners are executed, replacing old configuration-defined listeners
+    //       with the new ones while keeping the API-defined listeners intact
+    // Expected listeners:
+    // 15_api (API, should not be replaced)
+    // 20_configuration (old configuration but with updated event type)
+    // 30_api (API, should not be replaced)
+    // 40_configuration (new configuration)
+    // Note: 10_configuration should not be executed as it has been removed from the configuration
+    final var processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r -> // skip until task creation is started
+                    r.getIntent() == UserTaskIntent.CREATING
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                .limit(
+                    r -> // stop after task creation has been completed
+                    r.getIntent() == UserTaskIntent.CREATED
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                // get all completed task listener jobs
+                .jobRecords()
+                .withJobKind(JobKind.TASK_LISTENER)
+                .withIntent(JobIntent.COMPLETED))
+        .extracting(Record::getValue)
+        // check that all jobs are for creating event
+        .allMatch(job -> job.getJobListenerEventType() == JobListenerEventType.CREATING)
+        .extracting(JobRecordValue::getType)
+        // check correct listeners have been executed in correct order
+        .containsExactly("15_api", "20_configuration", "30_api", "40_configuration");
+  }
+
   private void setupAutocompleteWorker(final String jobType) {
     camundaClient
         .newWorker()
@@ -381,7 +536,7 @@ public class GlobalUserTaskListenersTest {
   private GlobalListenerCfg createListenerConfig(
       final String type, final List<String> eventTypes, final boolean afterNonGlobal) {
     final GlobalListenerCfg listenerCfg = new GlobalListenerCfg();
-    listenerCfg.setId("GlobalListener_" + type);
+    listenerCfg.setId(type);
     listenerCfg.setType(type);
     listenerCfg.setEventTypes(eventTypes);
     listenerCfg.setAfterNonGlobal(afterNonGlobal);


### PR DESCRIPTION
# Description
Backport of #48066 to `stable/8.9`.

relates to #46969