### PR TITLE
[Backport stable/8.6] fix: timers must not be completed on cleanup

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -76,8 +76,11 @@ public final class InFlightEntry {
 
   public void cleanup() {
     closeRequestListener(Listener::onIgnore);
-    closeIfPossible(writeTimer);
-    closeIfPossible(commitTimer);
+    // Discard timers without recording — displaced entries don't represent actual
+    // write/commit latency. Timer.Sample is a pure value object (two longs), so
+    // dropping it without stop() does not leak resources.
+    writeTimer.getAndSet(null);
+    commitTimer.getAndSet(null);
   }
 
   private void closeIfPossible(final AtomicReference<CloseableSilently> closeableRef) {

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntryTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntryTest.java
@@ -188,14 +188,16 @@ final class InFlightEntryTest {
     }
 
     @Test
-    void closesTimers() {
+    void discardsTimersWithoutRecording() {
       final var entry = new InFlightEntry(metrics, null, null);
       entry.onAppend();
 
       entry.cleanup();
 
-      assertThat(writeTimerFromMetrics.closeCount.get()).isEqualTo(1);
-      assertThat(commitTimerFromMetrics.closeCount.get()).isEqualTo(1);
+      assertThat(writeTimerFromMetrics.closeCount.get()).isEqualTo(0);
+      assertThat(commitTimerFromMetrics.closeCount.get()).isEqualTo(0);
+      assertThat(entry.writeTimer.get()).isNull();
+      assertThat(entry.commitTimer.get()).isNull();
     }
 
     @Test
@@ -274,12 +276,13 @@ final class InFlightEntryTest {
       doneLatch.await();
 
       for (int i = 0; i < entryCount; i++) {
+        // Timer closed at most once: onWrite/onCommit may close it, or cleanup may discard it
         assertThat(writeTimers[i].closeCount.get())
-            .describedAs("write timer %d closed exactly once", i)
-            .isEqualTo(1);
+            .describedAs("write timer %d closed at most once", i)
+            .isLessThanOrEqualTo(1);
         assertThat(commitTimers[i].closeCount.get())
-            .describedAs("commit timer %d closed exactly once", i)
-            .isEqualTo(1);
+            .describedAs("commit timer %d closed at most once", i)
+            .isLessThanOrEqualTo(1);
         final int callbacks = listeners[i].successCount.get() + listeners[i].ignoreCount.get();
         assertThat(callbacks).describedAs("listener %d called back exactly once", i).isEqualTo(1);
       }


### PR DESCRIPTION
# Description
Backport of #48087 to `stable/8.6`.

relates to 