### PR TITLE
fix: prevent NPE in OidcUserAuthenticationConverter when issuerUri is null

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/converter/OidcUserAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/OidcUserAuthenticationConverter.java
@@ -140,7 +140,10 @@ public class OidcUserAuthenticationConverter
         clientRegistrationId,
         k -> {
           final var issuerUri = clientRegistration.getProviderDetails().getIssuerUri();
-          final var additionalUris = additionalJwkSetUrisByIssuer.get(issuerUri);
+          // issuerUri may be null when configured without auto-discovery (e.g. explicit
+          // jwkSetUri/authorizationUri/tokenUri). Guard against NPE on the immutable map.
+          final var additionalUris =
+              issuerUri != null ? additionalJwkSetUrisByIssuer.get(issuerUri) : null;
           return accessTokenDecoderFactory.createAccessTokenDecoder(
               clientRegistration, additionalUris);
         });

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
@@ -8,6 +8,7 @@
 package io.camunda.authentication.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -334,6 +335,59 @@ public class OidcUserAuthenticationConverterTest {
 
     // then — decoder factory called only once (cached)
     verify(oidcAccessTokenDecoderFactory, times(1)).createAccessTokenDecoder(any(), any());
+  }
+
+  @Test
+  public void shouldNotThrowWhenIssuerUriIsNull() {
+    // given — OIDC provider configured without issuer-uri (only
+    // jwkSetUri/authorizationUri/tokenUri)
+    // This is the regression test for the NPE introduced by PR #47219:
+    // additionalJwkSetUrisByIssuer is an immutable Map.copyOf() and does not permit null key
+    // lookups.
+    final var converter =
+        new OidcUserAuthenticationConverter(
+            authorizedClientRepository,
+            oidcAccessTokenDecoderFactory,
+            tokenClaimsConverter,
+            request,
+            Map.of("https://other-issuer.example.com", List.of("https://other/jwks")));
+
+    final var oidcUser = mock(OidcUser.class);
+    when(oidcUser.getAttributes()).thenReturn(Map.of("sub", "test-user"));
+
+    final var authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(oidcUser);
+
+    final var accessToken = mock(OAuth2AccessToken.class);
+    when(accessToken.getTokenValue()).thenReturn("test-access-token");
+
+    // issuerUri is null — provider configured with explicit jwkSetUri/authorizationUri/tokenUri
+    final var providerDetails = mock(ClientRegistration.ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn(null);
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getRegistrationId()).thenReturn("no-issuer-reg");
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
+
+    final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
+        .thenReturn(authorizedClient);
+
+    final var jwt = mock(Jwt.class);
+    when(jwt.getClaims()).thenReturn(Map.of("sub", "test-user"));
+    when(oidcAccessTokenDecoderFactory.createAccessTokenDecoder(any(), any()))
+        .thenReturn(jwtDecoder);
+    when(jwtDecoder.decode(any())).thenReturn(jwt);
+    when(tokenClaimsConverter.convert(any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("foo")));
+
+    // when / then — must not throw NullPointerException when issuerUri is null
+    assertThatCode(() -> converter.convert(authentication)).doesNotThrowAnyException();
+
+    // and — null is passed to decoder factory since issuer has no additional JWKS configured
+    verify(oidcAccessTokenDecoderFactory)
+        .createAccessTokenDecoder(eq(clientRegistration), isNull());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #47219 where configuring OIDC without `issuer-uri` (using explicit `jwkSetUri`/`authorizationUri`/`tokenUri` instead of OIDC auto-discovery) causes a `NullPointerException` at runtime.

## Root Cause

PR #47219 added `additionalJwkSetUrisByIssuer` to `OidcUserAuthenticationConverter` and stored it as an **immutable map** via `Collectors.toUnmodifiableMap()` (which produces `Map.copyOf()`). When `issuerUri` is `null`, the call:

```java
additionalJwkSetUrisByIssuer.get(issuerUri) // issuerUri = null
```

throws `NullPointerException` because `Map.copyOf()` does not permit null key lookups — unlike `HashMap` which simply returns `null`.

This broke the previously supported configuration pattern where `issuer-uri` is omitted and the individual endpoints (`jwk-set-uri`, `authorization-uri`, `token-uri`) are provided directly (e.g. via `global.identity.auth.issuer` in Helm instead of `publicIssuerUrl`).

## Fix

Added a null-guard before the map lookup in `OidcUserAuthenticationConverter.getJwtDecoder()`:

```java
// before
final var additionalUris = additionalJwkSetUrisByIssuer.get(issuerUri);

// after
final var additionalUris = issuerUri != null ? additionalJwkSetUrisByIssuer.get(issuerUri) : null;
```

When `issuerUri` is `null`, `null` is passed to `createAccessTokenDecoder()` (meaning no additional JWKS URIs), which is the correct behaviour — matching the single-provider path in `WebSecurityConfig`.

## Changes

- `OidcUserAuthenticationConverter.java` — null-guard on `issuerUri` before map lookup
- `OidcUserAuthenticationConverterTest.java` — regression test `shouldNotThrowWhenIssuerUriIsNull()`

## Testing

```
./mvnw -pl authentication test -DskipITs -DskipChecks -Dtest=OidcUserAuthenticationConverterTest
```

All 10 tests pass (9 pre-existing + 1 new regression test).