### PR TITLE
[Backport stable/8.9] feat: always display json editor on Operate variables

### DIFF
--- a/operate/client/e2e-playwright/a11y/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/a11y/processInstance.spec.ts
@@ -156,7 +156,9 @@ test.describe('process detail', () => {
     validateResults(results);
 
     await page.getByRole('button', {name: /continue/i}).click();
-    await processInstancePage.diagram.getFlowNodeById('Activity_0dex012').click();
+    await processInstancePage.diagram
+      .getFlowNodeById('Activity_0dex012')
+      .click();
     await page
       .getByRole('button', {name: 'Add single element instance'})
       .click();

--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
@@ -363,9 +363,7 @@ test.describe('process instance migration', () => {
     ).toHaveCount(2);
 
     // Verify user task element is shown in the source diagram
-    await expect(
-      processesPage.diagram.getFlowNodeById('A'),
-    ).toHaveCount(1);
+    await expect(processesPage.diagram.getFlowNodeById('A')).toHaveCount(1);
 
     // Map the ad hoc subprocess
     await migrationView.mapElement({

--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
@@ -409,7 +409,8 @@ test.describe('process instance modification', () => {
 
     await page.getByRole('button', {name: 'Continue'}).click();
 
-    const timerEvent = processInstancePage.diagram.getFlowNodeById('timerEvent');
+    const timerEvent =
+      processInstancePage.diagram.getFlowNodeById('timerEvent');
 
     await commonPage.addDownArrow(timerEvent);
 

--- a/operate/client/e2e-playwright/tests/decisionNavigation.spec.ts
+++ b/operate/client/e2e-playwright/tests/decisionNavigation.spec.ts
@@ -89,10 +89,15 @@ test.describe('Decision Navigation', () => {
 
     await expect(page.getByTestId('diagram')).toBeInViewport();
     await expect(
-      page.getByTestId('diagram').locator('[data-element-id="Activity_1tjwahx"]'),
+      page
+        .getByTestId('diagram')
+        .locator('[data-element-id="Activity_1tjwahx"]'),
     ).toBeVisible();
 
-    await page.getByTestId('diagram').locator('[data-element-id="Activity_1tjwahx"]').click();
+    await page
+      .getByTestId('diagram')
+      .locator('[data-element-id="Activity_1tjwahx"]')
+      .click();
 
     await expect(page.getByTestId('popover')).toBeVisible();
     await page
@@ -130,7 +135,9 @@ test.describe('Decision Navigation', () => {
     await expect(page.getByTestId('diagram')).toBeInViewport();
 
     await expect(
-      page.getByTestId('diagram').locator('[data-element-id="Activity_1tjwahx"]'),
+      page
+        .getByTestId('diagram')
+        .locator('[data-element-id="Activity_1tjwahx"]'),
     ).toBeVisible();
 
     await page

--- a/operate/client/e2e-playwright/visual/modifications.spec.ts
+++ b/operate/client/e2e-playwright/visual/modifications.spec.ts
@@ -85,7 +85,9 @@ test.describe('modifications', () => {
         name: /continue/i,
       })
       .click();
-    await processInstancePage.diagram.getFlowNodeById('Activity_0dex012').click();
+    await processInstancePage.diagram
+      .getFlowNodeById('Activity_0dex012')
+      .click();
     await page
       .getByRole('button', {name: 'Add single element instance'})
       .click();

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/editVariable.test.tsx
@@ -763,7 +763,7 @@ describe('Edit variable', () => {
     });
   });
 
-  it('should not display edit button next to variables if instance is completed or canceled', async () => {
+  it('should display view full value button and not display edit button if instance is completed or canceled', async () => {
     mockFetchProcessInstance().withSuccess({
       ...mockProcessInstance,
       state: 'TERMINATED',
@@ -782,8 +782,17 @@ describe('Edit variable', () => {
       wrapper: getWrapper(),
     });
 
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
     expect(
       screen.queryByRole('button', {name: /edit variable/i}),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /view full value of testVariableName/i,
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/VariablesTable.tsx
@@ -94,15 +94,12 @@ const VariablesTable: React.FC<Props> = ({
                   }
 
                   if (!isProcessInstanceRunning) {
-                    if (isTruncated) {
-                      return (
-                        <ViewFullVariableButton
-                          variableName={name}
-                          variableKey={variableKey}
-                        />
-                      );
-                    }
-                    return null;
+                    return (
+                      <ViewFullVariableButton
+                        variableName={name}
+                        variableKey={variableKey}
+                      />
+                    );
                   }
 
                   if (initialValues?.name === name) {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -94,15 +94,12 @@ const VariablesTable: React.FC<Props> = ({
                   }
 
                   if (!isProcessInstanceRunning) {
-                    if (isTruncated) {
-                      return (
-                        <ViewFullVariableButton
-                          variableName={name}
-                          variableKey={variableKey}
-                        />
-                      );
-                    }
-                    return null;
+                    return (
+                      <ViewFullVariableButton
+                        variableName={name}
+                        variableKey={variableKey}
+                      />
+                    );
                   }
 
                   if (initialValues?.name === name) {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, waitFor} from 'modules/testing-library';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {Paths} from 'modules/Routes';
+import {VariablesTab} from './index';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {createVariable} from 'modules/testUtils';
+
+const getWrapper = () => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+        <Routes>
+          <Route path={Paths.processInstance()} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('VariablesTab', () => {
+  it('should display view full value button and not display edit button if instance is completed or canceled', async () => {
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessInstance().withSuccess({
+      processInstanceKey: '1',
+      state: 'TERMINATED',
+      startDate: '2018-06-21',
+      endDate: null,
+      processDefinitionKey: '2',
+      processDefinitionVersion: 1,
+      processDefinitionVersionTag: null,
+      processDefinitionId: 'someKey',
+      tenantId: '<default>',
+      processDefinitionName: 'someProcessName',
+      hasIncident: false,
+      parentProcessInstanceKey: null,
+      parentElementInstanceKey: null,
+      rootProcessInstanceKey: null,
+      tags: [],
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('button', {name: /edit variable/i}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /view full value of testVariableName/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Description
Backport of #48047 to `stable/8.9`.

relates to camunda/camunda#32516