### PR TITLE
fix: adjust ref handling for load test workflows to support official Docker image

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -319,7 +319,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          # When using official Docker images, the release tag may predate load-tests/load-tester
+          # being added to the Maven reactor. In that case we build the starter/worker from the
+          # current workflow SHA (main) which always has the module. For all other cases we
+          # honour inputs.ref so developers can test a specific load-tester branch.
+          ref: ${{ inputs.use-official-docker-images && '' || inputs.ref }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -323,7 +323,9 @@ jobs:
           # being added to the Maven reactor. In that case we build the starter/worker from the
           # current workflow SHA (main) which always has the module. For all other cases we
           # honour inputs.ref so developers can test a specific load-tester branch.
-          ref: ${{ inputs.use-official-docker-images && '' || inputs.ref }}
+          # Note: github.sha (truthy) is used instead of '' so the ternary pattern works correctly —
+          # an empty string is falsy in GHA expressions and would always fall through to inputs.ref.
+          ref: ${{ inputs.use-official-docker-images && github.sha || inputs.ref }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true


### PR DESCRIPTION
## Description
This pull request makes a small but important change to the workflow logic in `.github/workflows/camunda-load-test.yml`. It adjusts how the `ref` is selected for the `actions/checkout` step to ensure compatibility when using official Docker images.

* Workflow logic update: Modified the `ref` selection so that when official Docker images are used, it defaults to the current workflow SHA (main), ensuring the required module is always present. Otherwise, it honors `inputs.ref` for branch-specific testing. (`.github/workflows/camunda-load-test.yml`)

closes https://camunda.slack.com/archives/C013MEVQ4M9/p1773117265446189