### PR TITLE
feat: fix flaky test

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -836,16 +836,26 @@ public class ExpressionEvaluationIT {
   // ============ ERROR HANDLING TESTS ============
 
   @Test
-  void shouldRejectExpressionWithNonExistentClusterVariable() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newEvaluateExpressionCommand()
-                    .expression("=camunda.vars.cluster.nonExistentVar_" + UUID.randomUUID())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class);
+  void shouldEvaluateNonExistentClusterVariableAsNull() {
+    // when - accessing a non-existent cluster variable should evaluate to null (not throw)
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "=camunda.vars.cluster.nonExistentVar_"
+                    + UUID.randomUUID().toString().replace("-", ""))
+            .send()
+            .join();
+
+    // then - result is null and warnings are produced
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isNull();
+    assertThat(response.getWarnings())
+        .anySatisfy(
+            warning ->
+                assertThat(warning)
+                    .contains("The context is empty")
+                    .contains("No context entry found with key"));
   }
 
   @Test


### PR DESCRIPTION
The issue was flaky, and wrongly named, it was supposed to test that it fails when expression is invalid, but in our case it is only invalid 65% of the time

the first character of the last segment:

Digit (0–9): 10 out of 16 = 62.5% tests passes an exception is raised
Letter (a–f): 6 out of 16 = 37.5% tests does not pass, because the last part is considered as a valid expression but returns null

A test for invalid expression already exists, this test is modified to verify unknown expression returns `null`


This pull request updates the error handling behavior for evaluating expressions with non-existent cluster variables. Instead of throwing an exception, the expression now evaluates to `null` and produces warnings, improving user experience and aligning with expected behavior.

Error handling improvements:

* Changed the test method to verify that accessing a non-existent cluster variable evaluates to `null` and returns warnings, rather than throwing a `ProblemException`. (`qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java`)