### PR TITLE
[Backport stable/8.9] fix: re-enable test

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateIT.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.Process;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.test.util.collection.Maps;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
-// @CompatibilityTest
+@CompatibilityTest
 public class ProcessInstanceCreateIT {
 
   private static CamundaClient camundaClient;


### PR DESCRIPTION
# Description
Backport of #48070 to `stable/8.9`.

relates to 