### PR TITLE
feat: add index on audit_log.entity_key

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -1291,4 +1291,11 @@
     <renameColumn tableName="${prefix}GROUP_" oldColumnName="DESCRIPTION_CLOB" newColumnName="DESCRIPTION"/>
   </changeSet>
 
+  <changeSet id="create_audit_log_entity_key_index" author="camunda">
+    <!-- Index for ENTITY_KEY - optimizes history cleanup as the entityKey is a central column there -->
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_ENTITY_KEY">
+      <column name="ENTITY_KEY"/>
+    </createIndex>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Description

The `audit_log.entity_key` column is now a central column used for history cleanup and is therefore used very often.

This PR adds an index to that column.

## Related issues

closes #48133 
