### PR TITLE
feat: add drilldown navigation to pi elements

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -62,6 +62,8 @@ import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/usePro
 import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 import {isInstanceRunning} from 'modules/utils/instance';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useDrillDownNavigation} from 'modules/hooks/useDrilldownNavigation';
+import {isDrillDownCandidate} from 'modules/utils/drilldown';
 import {getAncestorScopeType} from 'modules/utils/processInstanceDetailsDiagram';
 import {IS_NEW_PROCESS_INSTANCE_PAGE} from 'modules/feature-flags';
 
@@ -249,6 +251,29 @@ const TopPanel: React.FC = observer(() => {
 
   const {isModificationModeEnabled} = modificationsStore;
 
+  const {handleDrillDown} = useDrillDownNavigation(processInstanceId);
+
+  const drilldownElements = useMemo(() => {
+    if (
+      !IS_NEW_PROCESS_INSTANCE_PAGE ||
+      isModificationModeEnabled ||
+      !businessObjects ||
+      !totalRunningInstancesByElement
+    ) {
+      return [];
+    }
+
+    return Object.entries(businessObjects)
+      .filter(([elementId, bo]) =>
+        isDrillDownCandidate(elementId, bo, totalRunningInstancesByElement),
+      )
+      .map(([elementId]) => elementId);
+  }, [
+    businessObjects,
+    totalRunningInstancesByElement,
+    isModificationModeEnabled,
+  ]);
+
   useEffect(() => {
     if (!isModificationModeEnabled) {
       if (selectedElementId) {
@@ -393,6 +418,10 @@ const TopPanel: React.FC = observer(() => {
                   !isModificationModeEnabled ||
                   hasSelectedElementMultipleRunningInstances
                 }
+                drilldownElements={drilldownElements}
+                onElementDoubleClick={() => {
+                  handleDrillDown();
+                }}
               >
                 {stateOverlays.map((overlay) => {
                   const payload = overlay.payload as {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -251,9 +251,12 @@ const TopPanel: React.FC = observer(() => {
 
   const {isModificationModeEnabled} = modificationsStore;
 
-  const {handleDrillDown} = useDrillDownNavigation(processInstanceId);
+  const {handleDrillDown, pendingDrillDownElementId} =
+    useDrillDownNavigation(processInstanceId);
 
-  const drilldownElements = useMemo(() => {
+  const customElementClasses = useMemo<
+    [elementId: string, className: string][]
+  >(() => {
     if (
       !IS_NEW_PROCESS_INSTANCE_PAGE ||
       isModificationModeEnabled ||
@@ -263,15 +266,25 @@ const TopPanel: React.FC = observer(() => {
       return [];
     }
 
-    return Object.entries(businessObjects)
+    const drilldownClasses: [string, string][] = Object.entries(businessObjects)
       .filter(([elementId, bo]) =>
         isDrillDownCandidate(elementId, bo, totalRunningInstancesByElement),
       )
-      .map(([elementId]) => elementId);
+      .map(([elementId]) => [elementId, 'op-drilldown'] as const);
+
+    if (pendingDrillDownElementId !== null) {
+      drilldownClasses.push([
+        pendingDrillDownElementId,
+        'op-drilldown-loading',
+      ]);
+    }
+
+    return drilldownClasses;
   }, [
     businessObjects,
     totalRunningInstancesByElement,
     isModificationModeEnabled,
+    pendingDrillDownElementId,
   ]);
 
   useEffect(() => {
@@ -418,9 +431,9 @@ const TopPanel: React.FC = observer(() => {
                   !isModificationModeEnabled ||
                   hasSelectedElementMultipleRunningInstances
                 }
-                drilldownElements={drilldownElements}
-                onElementDoubleClick={() => {
-                  handleDrillDown();
+                customElementClasses={customElementClasses}
+                onElementDoubleClick={(elementId) => {
+                  handleDrillDown(elementId);
                 }}
               >
                 {stateOverlays.map((overlay) => {

--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -30,6 +30,8 @@ type OnElementSelection = (
   isMultiInstance?: boolean,
 ) => void;
 
+type OnElementDoubleClick = (elementId: string) => void;
+
 type RenderOptions = {
   container: HTMLElement;
   xml: string;
@@ -40,6 +42,7 @@ type RenderOptions = {
   highlightedElementIds?: string[];
   nonSelectableNodeTooltipText?: string;
   hasOuterBorderOnSelection: boolean;
+  drilldownElements?: string[];
 };
 
 class BpmnJS {
@@ -52,15 +55,21 @@ class BpmnJS {
   #highlightedElementIds: string[] = [];
   selectedElement?: SVGGraphicsElement;
   onElementSelection?: OnElementSelection;
+  onElementDoubleClick?: OnElementDoubleClick;
   onViewboxChange?: (isChanging: boolean) => void;
   onRootChange?: (rootElementId: string) => void;
   #overlaysData: OverlayData[] = [];
   #hasOuterBorderOnSelection = false;
   #rootElement?: BpmnElement;
+  #drilldownElements: string[] = [];
 
   import = async (xml: string) => {
     // Cleanup before importing
     this.#navigatedViewer!.off('element.click', this.#handleElementClick);
+    this.#navigatedViewer!.off(
+      'element.dblclick',
+      this.#handleElementDoubleClick,
+    );
     this.#navigatedViewer!.off('canvas.viewbox.changing', () => {
       this.onViewboxChange?.(true);
     });
@@ -73,6 +82,7 @@ class BpmnJS {
     this.#selectableElements = [];
     this.#selectedElementIds = undefined;
     this.#hasOuterBorderOnSelection = false;
+    this.#drilldownElements = [];
     this.#rootElement = undefined;
 
     await this.#navigatedViewer!.importXML(xml);
@@ -80,6 +90,10 @@ class BpmnJS {
     // Initialize after importing
     this.zoomReset();
     this.#navigatedViewer!.on('element.click', this.#handleElementClick);
+    this.#navigatedViewer!.on(
+      'element.dblclick',
+      this.#handleElementDoubleClick,
+    );
     this.#navigatedViewer!.on('canvas.viewbox.changing', () => {
       this.onViewboxChange?.(true);
     });
@@ -102,6 +116,7 @@ class BpmnJS {
       highlightedElementIds: unfilteredHighlightedElementIds = [],
       nonSelectableNodeTooltipText,
       hasOuterBorderOnSelection,
+      drilldownElements: unfilteredDrilldownElements = [],
     } = options;
 
     if (this.#navigatedViewer === null) {
@@ -125,6 +140,8 @@ class BpmnJS {
       unfilteredHighlightedElementIds?.filter(doesElementExist);
     const selectableElements =
       unfilteredSelectableElements?.filter(doesElementExist);
+    const drilldownElements =
+      unfilteredDrilldownElements?.filter(doesElementExist);
 
     // if render is called a second time before importing has finished,
     // exit early because there is no root element yet.
@@ -229,6 +246,17 @@ class BpmnJS {
       });
 
       this.#highlightedElementIds = highlightedElementIds;
+    }
+
+    // handle op-drilldown markers
+    if (!isEqual(this.#drilldownElements, drilldownElements)) {
+      this.#drilldownElements.forEach((elementId) => {
+        this.#removeMarker(elementId, 'op-drilldown');
+      });
+      drilldownElements.forEach((elementId) => {
+        this.#addMarker(elementId, 'op-drilldown');
+      });
+      this.#drilldownElements = drilldownElements;
     }
 
     // handle overlays
@@ -406,6 +434,18 @@ class BpmnJS {
     }
   };
 
+  #handleElementDoubleClick = (event: Event) => {
+    const element = event.element;
+
+    if (element.type === 'label') {
+      return;
+    }
+
+    if (this.#drilldownElements.includes(element.id)) {
+      this.onElementDoubleClick?.(element.id);
+    }
+  };
+
   #handleRootChange = () => {
     this.#rootElement = this.#navigatedViewer?.get('canvas')?.getRootElement();
 
@@ -420,6 +460,7 @@ class BpmnJS {
 
   reset = () => {
     this.onElementSelection = undefined;
+    this.onElementDoubleClick = undefined;
     this.onViewboxChange = undefined;
     this.#destroy();
   };
@@ -483,5 +524,5 @@ class BpmnJS {
 }
 
 export {BpmnJS};
-export type {OnElementSelection};
+export type {OnElementSelection, OnElementDoubleClick};
 export type {OverlayData} from './overlayTypes';

--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -42,7 +42,7 @@ type RenderOptions = {
   highlightedElementIds?: string[];
   nonSelectableNodeTooltipText?: string;
   hasOuterBorderOnSelection: boolean;
-  drilldownElements?: string[];
+  customElementClasses?: [elementId: string, className: string][];
 };
 
 class BpmnJS {
@@ -61,7 +61,7 @@ class BpmnJS {
   #overlaysData: OverlayData[] = [];
   #hasOuterBorderOnSelection = false;
   #rootElement?: BpmnElement;
-  #drilldownElements: string[] = [];
+  #customElementClasses: [elementId: string, className: string][] = [];
 
   import = async (xml: string) => {
     // Cleanup before importing
@@ -82,7 +82,7 @@ class BpmnJS {
     this.#selectableElements = [];
     this.#selectedElementIds = undefined;
     this.#hasOuterBorderOnSelection = false;
-    this.#drilldownElements = [];
+    this.#customElementClasses = [];
     this.#rootElement = undefined;
 
     await this.#navigatedViewer!.importXML(xml);
@@ -116,7 +116,7 @@ class BpmnJS {
       highlightedElementIds: unfilteredHighlightedElementIds = [],
       nonSelectableNodeTooltipText,
       hasOuterBorderOnSelection,
-      drilldownElements: unfilteredDrilldownElements = [],
+      customElementClasses: unfilteredCustomElementClasses = [],
     } = options;
 
     if (this.#navigatedViewer === null) {
@@ -140,8 +140,9 @@ class BpmnJS {
       unfilteredHighlightedElementIds?.filter(doesElementExist);
     const selectableElements =
       unfilteredSelectableElements?.filter(doesElementExist);
-    const drilldownElements =
-      unfilteredDrilldownElements?.filter(doesElementExist);
+    const customElementClasses = unfilteredCustomElementClasses?.filter(
+      ([elementId]) => doesElementExist(elementId),
+    );
 
     // if render is called a second time before importing has finished,
     // exit early because there is no root element yet.
@@ -248,15 +249,15 @@ class BpmnJS {
       this.#highlightedElementIds = highlightedElementIds;
     }
 
-    // handle op-drilldown markers
-    if (!isEqual(this.#drilldownElements, drilldownElements)) {
-      this.#drilldownElements.forEach((elementId) => {
-        this.#removeMarker(elementId, 'op-drilldown');
+    // handle custom element classes
+    if (!isEqual(this.#customElementClasses, customElementClasses)) {
+      this.#customElementClasses.forEach(([elementId, className]) => {
+        this.#removeMarker(elementId, className);
       });
-      drilldownElements.forEach((elementId) => {
-        this.#addMarker(elementId, 'op-drilldown');
+      customElementClasses.forEach(([elementId, className]) => {
+        this.#addMarker(elementId, className);
       });
-      this.#drilldownElements = drilldownElements;
+      this.#customElementClasses = customElementClasses;
     }
 
     // handle overlays
@@ -441,7 +442,9 @@ class BpmnJS {
       return;
     }
 
-    if (this.#drilldownElements.includes(element.id)) {
+    if (
+      this.#customElementClasses.some(([elementId]) => elementId === element.id)
+    ) {
       this.onElementDoubleClick?.(element.id);
     }
   };

--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -16,6 +16,7 @@ import React, {
 import {
   BpmnJS,
   type OnElementSelection,
+  type OnElementDoubleClick,
   type OverlayData,
 } from 'modules/bpmn-js/BpmnJS';
 import DiagramControls from './DiagramControls';
@@ -50,6 +51,8 @@ type Props = {
   highlightedElementIds?: string[];
   nonSelectableNodeTooltipText?: string;
   hasOuterBorderOnSelection?: boolean;
+  onElementDoubleClick?: OnElementDoubleClick;
+  drilldownElements?: string[];
 };
 
 const useFullscreen = (
@@ -135,6 +138,8 @@ const Diagram: React.FC<Props> = observer(
     highlightedElementIds,
     nonSelectableNodeTooltipText,
     hasOuterBorderOnSelection = true,
+    onElementDoubleClick,
+    drilldownElements,
   }) => {
     const diagramCanvasRef = useRef<HTMLDivElement | null>(null);
     const diagramRef = useRef<HTMLDivElement | null>(null);
@@ -174,6 +179,7 @@ const Diagram: React.FC<Props> = observer(
             highlightedElementIds,
             nonSelectableNodeTooltipText,
             hasOuterBorderOnSelection,
+            drilldownElements,
           });
           setIsDiagramRendered(true);
           resetMinimap();
@@ -191,6 +197,7 @@ const Diagram: React.FC<Props> = observer(
       nonSelectableNodeTooltipText,
       hasOuterBorderOnSelection,
       resetMinimap,
+      drilldownElements,
     ]);
 
     useEffect(() => {
@@ -204,7 +211,9 @@ const Diagram: React.FC<Props> = observer(
           onRootChange?.(rootElementId, getSelectionRootId);
         };
       }
-    }, [viewer, onElementSelection, onRootChange]);
+
+      viewer.onElementDoubleClick = onElementDoubleClick;
+    }, [viewer, onElementSelection, onRootChange, onElementDoubleClick]);
 
     useEffect(() => {
       return () => {

--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -52,7 +52,7 @@ type Props = {
   nonSelectableNodeTooltipText?: string;
   hasOuterBorderOnSelection?: boolean;
   onElementDoubleClick?: OnElementDoubleClick;
-  drilldownElements?: string[];
+  customElementClasses?: [elementId: string, className: string][];
 };
 
 const useFullscreen = (
@@ -139,7 +139,7 @@ const Diagram: React.FC<Props> = observer(
     nonSelectableNodeTooltipText,
     hasOuterBorderOnSelection = true,
     onElementDoubleClick,
-    drilldownElements,
+    customElementClasses,
   }) => {
     const diagramCanvasRef = useRef<HTMLDivElement | null>(null);
     const diagramRef = useRef<HTMLDivElement | null>(null);
@@ -179,7 +179,7 @@ const Diagram: React.FC<Props> = observer(
             highlightedElementIds,
             nonSelectableNodeTooltipText,
             hasOuterBorderOnSelection,
-            drilldownElements,
+            customElementClasses,
           });
           setIsDiagramRendered(true);
           resetMinimap();
@@ -197,7 +197,7 @@ const Diagram: React.FC<Props> = observer(
       nonSelectableNodeTooltipText,
       hasOuterBorderOnSelection,
       resetMinimap,
-      drilldownElements,
+      customElementClasses,
     ]);
 
     useEffect(() => {

--- a/operate/client/src/modules/components/Diagram/styled.ts
+++ b/operate/client/src/modules/components/Diagram/styled.ts
@@ -47,6 +47,15 @@ const DiagramCanvas = styled.div`
     cursor: not-allowed;
   }
 
+  .op-drilldown {
+    user-select: none;
+  }
+
+  .op-drilldown-loading,
+  .op-drilldown-loading * {
+    cursor: wait;
+  }
+
   .op-selected .djs-visual {
     rect,
     circle,

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, act} from '@testing-library/react';
+import {MemoryRouter} from 'react-router-dom';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {useDrillDownNavigation} from './useDrilldownNavigation';
+import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
+import {notificationsStore} from 'modules/stores/notifications';
+import {Paths} from 'modules/Routes';
+import {createProcessInstance, searchResult} from 'modules/testUtils';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const PROCESS_INSTANCE_KEY = '2251799813685249';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false}},
+  });
+
+  return ({children}: {children: React.ReactNode}) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('useDrillDownNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should navigate directly to the called instance when there is exactly one', async () => {
+    const calledInstance = createProcessInstance({
+      processInstanceKey: 'called-200',
+    });
+
+    mockSearchProcessInstances().withSuccess(searchResult([calledInstance], 1));
+
+    const {result} = renderHook(
+      () => useDrillDownNavigation(PROCESS_INSTANCE_KEY),
+      {wrapper: createWrapper()},
+    );
+
+    await act(async () => {
+      result.current.handleDrillDown();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Paths.processInstance('called-200'),
+    );
+  });
+
+  it('should not navigate when there are multiple called instances', async () => {
+    const calledInstances = [
+      createProcessInstance({processInstanceKey: 'called-200'}),
+      createProcessInstance({processInstanceKey: 'called-201'}),
+    ];
+
+    mockSearchProcessInstances().withSuccess(searchResult(calledInstances, 2));
+
+    const {result} = renderHook(
+      () => useDrillDownNavigation(PROCESS_INSTANCE_KEY),
+      {wrapper: createWrapper()},
+    );
+
+    await act(async () => {
+      result.current.handleDrillDown();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should not navigate when there are no called instances', async () => {
+    mockSearchProcessInstances().withSuccess(searchResult([], 0));
+
+    const {result} = renderHook(
+      () => useDrillDownNavigation(PROCESS_INSTANCE_KEY),
+      {wrapper: createWrapper()},
+    );
+
+    await act(async () => {
+      result.current.handleDrillDown();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should show error toast when API call fails', async () => {
+    mockSearchProcessInstances().withServerError();
+
+    const {result} = renderHook(
+      () => useDrillDownNavigation(PROCESS_INSTANCE_KEY),
+      {wrapper: createWrapper()},
+    );
+
+    await act(async () => {
+      result.current.handleDrillDown();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'error',
+      title: 'Failed to resolve called instances',
+      isDismissable: true,
+    });
+  });
+});

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
@@ -35,6 +35,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 const PROCESS_INSTANCE_KEY = '2251799813685249';
+const ELEMENT_ID = 'confirmDelivery';
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -66,7 +67,7 @@ describe('useDrillDownNavigation', () => {
     );
 
     await act(async () => {
-      result.current.handleDrillDown();
+      result.current.handleDrillDown(ELEMENT_ID);
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -88,7 +89,7 @@ describe('useDrillDownNavigation', () => {
     );
 
     await act(async () => {
-      result.current.handleDrillDown();
+      result.current.handleDrillDown(ELEMENT_ID);
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -103,7 +104,7 @@ describe('useDrillDownNavigation', () => {
     );
 
     await act(async () => {
-      result.current.handleDrillDown();
+      result.current.handleDrillDown(ELEMENT_ID);
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -118,7 +119,7 @@ describe('useDrillDownNavigation', () => {
     );
 
     await act(async () => {
-      result.current.handleDrillDown();
+      result.current.handleDrillDown(ELEMENT_ID);
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.ts
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTransition} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {useQueryClient} from '@tanstack/react-query';
+import {searchProcessInstances} from 'modules/api/v2/processInstances/searchProcessInstances';
+import {Paths} from 'modules/Routes';
+import {notificationsStore} from 'modules/stores/notifications';
+import {queryKeys} from 'modules/queries/queryKeys';
+
+const LOADING_CLASS = 'op-drilldown-loading';
+
+const setDiagramLoading = (loading: boolean) => {
+  const container = document.querySelector<HTMLElement>('.djs-container');
+  if (container) {
+    container.classList.toggle(LOADING_CLASS, loading);
+  }
+};
+
+const useDrillDownNavigation = (processInstanceKey: string) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [isPending, startTransition] = useTransition();
+
+  function handleDrillDown() {
+    if (isPending) {
+      return;
+    }
+
+    startTransition(async () => {
+      setDiagramLoading(true);
+
+      try {
+        const response = await queryClient.fetchQuery({
+          queryKey: queryKeys.processInstances.search({
+            filter: {parentProcessInstanceKey: processInstanceKey},
+            page: {limit: 1},
+          }),
+          queryFn: async () => {
+            const {response, error} = await searchProcessInstances({
+              filter: {parentProcessInstanceKey: processInstanceKey},
+              page: {limit: 1},
+            });
+            if (response !== null) {
+              return response;
+            }
+            throw error;
+          },
+        });
+
+        if (response.page.totalItems === 1) {
+          navigate(
+            Paths.processInstance(response.items[0]!.processInstanceKey),
+          );
+        }
+      } catch {
+        notificationsStore.displayNotification({
+          kind: 'error',
+          title: 'Failed to resolve called instances',
+          isDismissable: true,
+        });
+      } finally {
+        setDiagramLoading(false);
+      }
+    });
+  }
+
+  return {handleDrillDown};
+};
+
+export {useDrillDownNavigation};

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.ts
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useTransition} from 'react';
+import {useState, useTransition} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {useQueryClient} from '@tanstack/react-query';
 import {searchProcessInstances} from 'modules/api/v2/processInstances/searchProcessInstances';
@@ -14,27 +14,21 @@ import {Paths} from 'modules/Routes';
 import {notificationsStore} from 'modules/stores/notifications';
 import {queryKeys} from 'modules/queries/queryKeys';
 
-const LOADING_CLASS = 'op-drilldown-loading';
-
-const setDiagramLoading = (loading: boolean) => {
-  const container = document.querySelector<HTMLElement>('.djs-container');
-  if (container) {
-    container.classList.toggle(LOADING_CLASS, loading);
-  }
-};
-
 const useDrillDownNavigation = (processInstanceKey: string) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [isPending, startTransition] = useTransition();
+  const [pendingDrillDownElementId, setPendingDrillDownElementId] = useState<
+    string | null
+  >(null);
 
-  function handleDrillDown() {
+  function handleDrillDown(elementId: string) {
     if (isPending) {
       return;
     }
 
     startTransition(async () => {
-      setDiagramLoading(true);
+      setPendingDrillDownElementId(elementId);
 
       try {
         const response = await queryClient.fetchQuery({
@@ -66,12 +60,12 @@ const useDrillDownNavigation = (processInstanceKey: string) => {
           isDismissable: true,
         });
       } finally {
-        setDiagramLoading(false);
+        setPendingDrillDownElementId(null);
       }
     });
   }
 
-  return {handleDrillDown};
+  return {handleDrillDown, pendingDrillDownElementId};
 };
 
 export {useDrillDownNavigation};

--- a/operate/client/src/modules/utils/drilldown.test.ts
+++ b/operate/client/src/modules/utils/drilldown.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {
+  isCallActivity,
+  isElementRunning,
+  isDrillDownCandidate,
+} from './drilldown';
+
+function createBusinessObject(
+  type: string,
+  overrides?: Partial<BusinessObject>,
+): BusinessObject {
+  return {
+    id: 'element_1',
+    name: 'Test Element',
+    $type: type as BusinessObject['$type'],
+    ...overrides,
+  } as BusinessObject;
+}
+
+describe('drilldown utilities', () => {
+  it('isCallActivity should return true for bpmn:CallActivity', () => {
+    expect(isCallActivity(createBusinessObject('bpmn:CallActivity'))).toBe(
+      true,
+    );
+  });
+
+  it('isCallActivity should return false for bpmn:SubProcess', () => {
+    expect(isCallActivity(createBusinessObject('bpmn:SubProcess'))).toBe(false);
+  });
+
+  it('isCallActivity should return false for bpmn:ServiceTask', () => {
+    expect(isCallActivity(createBusinessObject('bpmn:ServiceTask'))).toBe(
+      false,
+    );
+  });
+
+  it('isCallActivity should return false for bpmn:BusinessRuleTask', () => {
+    expect(isCallActivity(createBusinessObject('bpmn:BusinessRuleTask'))).toBe(
+      false,
+    );
+  });
+
+  it('isCallActivity should return false for bpmn:AdHocSubProcess', () => {
+    expect(isCallActivity(createBusinessObject('bpmn:AdHocSubProcess'))).toBe(
+      false,
+    );
+  });
+
+  it('isElementRunning should return true when running count is greater than 0', () => {
+    expect(isElementRunning('el_1', {el_1: 3})).toBe(true);
+  });
+
+  it('isElementRunning should return false when running count is 0', () => {
+    expect(isElementRunning('el_1', {el_1: 0})).toBe(false);
+  });
+
+  it('isElementRunning should return false when element is not in the map', () => {
+    expect(isElementRunning('el_1', {})).toBe(false);
+  });
+
+  it('isElementRunning should return false when element is not in the map with other elements', () => {
+    expect(isElementRunning('el_1', {el_2: 5})).toBe(false);
+  });
+
+  it('isDrillDownCandidate should return true for a running CallActivity', () => {
+    const bo = createBusinessObject('bpmn:CallActivity');
+    expect(isDrillDownCandidate('el_1', bo, {el_1: 2})).toBe(true);
+  });
+
+  it('isDrillDownCandidate should return false for a non-running CallActivity', () => {
+    const bo = createBusinessObject('bpmn:CallActivity');
+    expect(isDrillDownCandidate('el_1', bo, {el_1: 0})).toBe(false);
+  });
+
+  it('isDrillDownCandidate should return false for a CallActivity not in running map', () => {
+    const bo = createBusinessObject('bpmn:CallActivity');
+    expect(isDrillDownCandidate('el_1', bo, {})).toBe(false);
+  });
+
+  it('isDrillDownCandidate should return false for a running SubProcess', () => {
+    const bo = createBusinessObject('bpmn:SubProcess');
+    expect(isDrillDownCandidate('el_1', bo, {el_1: 2})).toBe(false);
+  });
+
+  it('isDrillDownCandidate should return false for a running ServiceTask', () => {
+    const bo = createBusinessObject('bpmn:ServiceTask');
+    expect(isDrillDownCandidate('el_1', bo, {el_1: 1})).toBe(false);
+  });
+});

--- a/operate/client/src/modules/utils/drilldown.test.ts
+++ b/operate/client/src/modules/utils/drilldown.test.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import type {BusinessObject, ElementType} from 'bpmn-js/lib/NavigatedViewer';
 import {
   isCallActivity,
   isElementRunning,
@@ -14,15 +14,15 @@ import {
 } from './drilldown';
 
 function createBusinessObject(
-  type: string,
+  type: ElementType,
   overrides?: Partial<BusinessObject>,
 ): BusinessObject {
   return {
     id: 'element_1',
     name: 'Test Element',
-    $type: type as BusinessObject['$type'],
+    $type: type,
     ...overrides,
-  } as BusinessObject;
+  } satisfies BusinessObject;
 }
 
 describe('drilldown utilities', () => {

--- a/operate/client/src/modules/utils/drilldown.ts
+++ b/operate/client/src/modules/utils/drilldown.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+const isCallActivity = (businessObject: BusinessObject): boolean => {
+  return businessObject.$type === 'bpmn:CallActivity';
+};
+
+const isElementRunning = (
+  elementId: string,
+  runningInstancesByElement: Record<string, number>,
+): boolean => {
+  return (runningInstancesByElement[elementId] ?? 0) > 0;
+};
+
+const isDrillDownCandidate = (
+  elementId: string,
+  businessObject: BusinessObject,
+  runningInstancesByElement: Record<string, number>,
+): boolean => {
+  return (
+    isCallActivity(businessObject) &&
+    isElementRunning(elementId, runningInstancesByElement)
+  );
+};
+
+export {isCallActivity, isElementRunning, isDrillDownCandidate};


### PR DESCRIPTION
## Description

 - Adds double-click drill-down navigation on running Call Activity elements in the process instance diagram
 - When a user double-clicks a running Call Activity, the app resolves called process instances via API and navigates to the called instance
 
 > [!NOTE]
 > I've investigated the way WebModeler is processing the diagram interactions(self-contained extention moduleas and dedicated stores) and I think we can stick to a simplified one(using props) for now.
> Why:
> 1. **Consistency**: `BpmnJS` class in Operate already uses prop-threading for every interaction(`selectableElements`, `overlaysData`, `highlightedSequenceFlows`, `nonSelectableNodeTooltipText`).
> 2. **No `additionalModules` precedent in Operate**: so adding a custom interaction extension would be a new architectural pattern.
> 3. **Minimal surface area**: drilldown feature only needs two things from the diagram layer: (a) apply/remove a CSS marker, and (b) fire a callback on dblclick. Both are simple and easily handled by curent approach

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47043 
