### PR TITLE
RocksDB: Change default memory allocation strategy to FRACTION

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY;
+
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
 import java.util.Properties;
@@ -71,7 +73,8 @@ public class RocksDb {
    * memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
    * to RocksDB that can be configured via the memoryFraction configuration [0,1].
    */
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.FRACTION;
+  private MemoryAllocationStrategy memoryAllocationStrategy =
+      DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY;
 
   /**
    * Configures the fraction of total system memory to allocate to RocksDB when using the 'FRACTION'

--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -71,7 +71,7 @@ public class RocksDb {
    * memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
    * to RocksDB that can be configured via the memoryFraction configuration [0,1].
    */
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
+  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.FRACTION;
 
   /**
    * Configures the fraction of total system memory to allocate to RocksDB when using the 'FRACTION'

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -67,10 +67,6 @@ public class RocksDbSharedCache {
       // check that memoryFraction is between 0 and 1 and warn if it is too high
       warnIfTooHighFraction(rocksdbCfg);
     } else {
-      if (rocksdbCfg.getMemoryAllocationStrategy() == MemoryAllocationStrategy.PARTITION) {
-        LOGGER.warn(
-            "Note: CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYFRACTION is set to PARTITION, this configuration will be set to FRACTION by default in 8.10. If the intended goal is to use PARTITION strategy, please set it explicitly.");
-      }
       // for strategies other than FRACTION which are static sizes, we check if maxMemoryFraction is
       // correctly set, and if so, we validate the allocated memory does not go above the threshold.
       validateMaxMemoryFraction(rocksdbCfg, totalMemorySize, blockCacheBytes);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
+import static io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY;
+
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
@@ -29,7 +31,8 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
   private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.FRACTION;
+  private MemoryAllocationStrategy memoryAllocationStrategy =
+      DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY;
   private double memoryFraction = 0.1;
   private double maxMemoryFraction = -1;
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -29,7 +29,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
   private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
+  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.FRACTION;
   private double memoryFraction = 0.1;
   private double maxMemoryFraction = -1;
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -31,11 +31,6 @@ class RocksDbSharedCacheTest {
   void setUp() {
     brokerCfg = new BrokerCfg();
     brokerCfg.getExperimental().getRocksdb().setMemoryLimit(DataSize.ofBytes(512 * 1024 * 1024L));
-    // it's already the default, but to be explicit
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
   }
 
   /**
@@ -78,6 +73,10 @@ class RocksDbSharedCacheTest {
   void shouldValidateMaxMemoryFractionConfiguration(
       final double maxMemoryFraction, final boolean shouldThrow) {
     // when
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
     brokerCfg.getExperimental().getRocksdb().setMaxMemoryFraction(maxMemoryFraction);
     brokerCfg.getExperimental().getRocksdb().setMemoryLimit(DataSize.ofBytes(128L * 1024 * 1024L));
     // then
@@ -109,6 +108,10 @@ class RocksDbSharedCacheTest {
   void shouldValidateMemoryAllocationAgainstMaxFraction(
       final DataSize memoryLimit, final double fraction, final boolean shouldThrow) {
     // when
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
     brokerCfg.getExperimental().getRocksdb().setMaxMemoryFraction(fraction);
     brokerCfg.getExperimental().getRocksdb().setMemoryLimit(memoryLimit);
 
@@ -138,6 +141,10 @@ class RocksDbSharedCacheTest {
   @Test
   void shouldThrowIfTriesToAllocateMoreThanFractionalOfRam() {
     // when
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
     brokerCfg.getExperimental().getRocksdb().setMaxMemoryFraction(0.100);
     brokerCfg
         .getExperimental()
@@ -167,6 +174,10 @@ class RocksDbSharedCacheTest {
     brokerCfg
         .getExperimental()
         .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
         .setMemoryLimit(DataSize.ofBytes(200L * 1024 * 1024)); // 200MB
     // then when we allocate more than half of the memory to rocks db, we expect NO exception
     try (final var managementFactoryMock = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB
@@ -183,6 +194,10 @@ class RocksDbSharedCacheTest {
   void shouldThrowIfMemoryPerPartitionTooSmall() {
     // when
     // we only give half of the minimum required memory per partition
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
     brokerCfg
         .getExperimental()
         .getRocksdb()

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -43,7 +43,7 @@ public final class RocksDbConfiguration {
 
   public static final int DEFAULT_IO_RATE_BYTES_PER_SECOND = 0;
   public static final MemoryAllocationStrategy DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY =
-      MemoryAllocationStrategy.PARTITION;
+      MemoryAllocationStrategy.FRACTION;
   private Properties columnFamilyOptions = new Properties();
   private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;
   private long memoryLimit = DEFAULT_MEMORY_LIMIT;


### PR DESCRIPTION
## Description

Now that we did the [code freeze for 8.9](https://camunda.slack.com/archives/C08F5RD5X8B/p1773064834296659), we can already change the default memory allocation strategy to FRACTION, as it is intended to have in 8.10. 
This will also unblock testing with the default orchestration cluster values here https://github.com/camunda/camunda/issues/47252.

Relates to https://github.com/camunda/camunda/issues/36455

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
