### PR TITLE
feat: add Oracle 21c to test matrix

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -93,7 +93,11 @@ jobs:
       # start the required database service
       - name: Start Database service
         if: ${{ inputs.database-type != 'h2' }}
-        run: docker-compose -f db/docker-compose.yml up -d ${{ env.DATABASE_CONTAINER }}
+        run: |
+          docker compose -f db/docker-compose.yml up -d --wait ${{ env.DATABASE_CONTAINER }} || {
+            docker compose -f db/docker-compose.yml logs
+            exit 1
+          }
       # Build the platform before running the integration tests; skipping frontend
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -83,10 +83,14 @@ jobs:
             database-type: "mssql"
             database-image-version: "2025-latest"
             it-database-type: "rdbms_mssql"
-          # Oracle - Supported version: 23ai (19c not available as Docker image)
+          # Oracle - Supported version: 21c, 23ai (19c not available as Docker image)
           - database-name: "Oracle 23ai"
             database-type: "oracle"
             database-image-version: "23-slim-faststart"
+            it-database-type: "rdbms_oracle"
+          - database-name: "Oracle 21c"
+            database-type: "oracle-21"
+            database-image-version: "21-slim-faststart"
             it-database-type: "rdbms_oracle"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -72,6 +72,25 @@ services:
       retries: 10
       start_period: 5s
 
+  oracle-21:
+    # Docker Hub image (feel free to change the tag "latest" to any other available one)
+    image: gvenzl/oracle-xe:${IMAGE_VERSION:-21-slim-faststart}
+    # Forward Oracle port to localhost
+    ports:
+      - "1521:1521"
+    # Provide passwords and other environment variables to the container
+    environment:
+      ORACLE_PASSWORD: sys_user_password
+      APP_USER: camunda
+      APP_USER_PASSWORD: camunda
+    # Customize healthcheck script options for startup
+    healthcheck:
+      test: [ "CMD", "healthcheck.sh" ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.19.11}
     container_name: elasticsearch


### PR DESCRIPTION
## Description

- adds an Oracle 21 docker image to the db/docker-compose file (only works in x64)
- adds Oracle 21 to the nightly acceptance test matrix

## Related issues

closes #45768 
