### PR TITLE
fix: use recent tag in release load test workflow

### DIFF
--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           branch: ${{ inputs.name || 'dry-run-release-8-8-x' }}
           max_length: 50  # reduced to account for load-test prefix "c8-" and potential suffixes for uniqueness
-      # We prepare the tag to default to '8.8.3' if not provided, to ensure that the load test creation can proceed with a valid tag even in the case of missing input (e.g., during schedule runs)
+      # Prepare a default tag if none is provided, to ensure that the load test creation can proceed with a valid tag even in the case of missing input (e.g., during scheduled runs)
       - id: prepare_tag
         run: echo "test-tag=${{ inputs.tag || '8.9.0-alpha5' }}" >> "$GITHUB_OUTPUT"
       - name: Observe build status

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -49,7 +49,7 @@ jobs:
           max_length: 50  # reduced to account for load-test prefix "c8-" and potential suffixes for uniqueness
       # We prepare the tag to default to '8.8.3' if not provided, to ensure that the load test creation can proceed with a valid tag even in the case of missing input (e.g., during schedule runs)
       - id: prepare_tag
-        run: echo "test-tag=${{ inputs.tag || '8.8.3' }}" >> "$GITHUB_OUTPUT"
+        run: echo "test-tag=${{ inputs.tag || '8.9.0-alpha5' }}" >> "$GITHUB_OUTPUT"
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

* We used an older tag (8.8.3) which doesn't work with our current setup and how we build the starter/worker applications, as we move from `zeebe/benchmark/project` to `load-tests/load-tester` and this fails if we use an older tag with referencing a different module.

<!-- Describe the goal and purpose of this PR. -->
## Related issues

See related slack thread https://camunda.slack.com/archives/C013MEVQ4M9/p1773118461432669
