### PR TITLE
[Backport stable/8.9] fix: in ProcessingSession there's no need to copy authInfo

### DIFF
--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +43,24 @@ final class RecordMetadataTest {
     assertThat(metadata.getAgent()).isNull();
     assertThat(metadata.getBrokerVersion()).isEqualTo(RecordMetadata.CURRENT_BROKER_VERSION);
     assertThat(metadata.getRecordVersion()).isEqualTo(RecordMetadata.DEFAULT_RECORD_VERSION);
+  }
+
+  @Test
+  void shouldCopyAuthInfoWhenSettingAuthorization() {
+    // given
+    final var metadata = new RecordMetadata();
+    final var authInfo = new AuthInfo();
+    authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+    authInfo.setClaims(Map.of("key", "value"));
+
+    // when
+    metadata.authorization(authInfo);
+    authInfo.reset();
+
+    // then -- metadata should still have the original values
+    final var storedAuth = metadata.getAuthorization();
+    assertThat(storedAuth.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+    assertThat(storedAuth.getClaims()).isEqualTo(Map.of("key", "value"));
   }
 
   private void encodeDecode(final RecordMetadata metadata) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -41,6 +41,7 @@ public interface ProcessingSession {
 
   default void appendAuthInfoToFollowUps(final AuthInfo authInfo) {
     if (authInfo != null && authInfo.hasAnyClaims()) {
+      // no explicit copy needed: RecordMetadata.authorization() already copies via copyFrom()
       appendMetadataToFollowUps(metadata -> metadata.authorization(authInfo));
     }
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -41,9 +41,7 @@ public interface ProcessingSession {
 
   default void appendAuthInfoToFollowUps(final AuthInfo authInfo) {
     if (authInfo != null && authInfo.hasAnyClaims()) {
-      // make a copy to rule out any side effects
-      final var authorization = AuthInfo.of(authInfo);
-      appendMetadataToFollowUps(metadata -> metadata.authorization(authorization));
+      appendMetadataToFollowUps(metadata -> metadata.authorization(authInfo));
     }
   }
 


### PR DESCRIPTION
# Description
Backport of #48069 to `stable/8.9`.

relates to 