### PR TITLE
[Backport stable/8.8] build: enforce minimum Maven version 3.9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2702,6 +2702,20 @@
           <version>${plugin.version.enforcer}</version>
           <executions>
             <execution>
+              <id>enforce-maven-version</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>[3.9,)</version>
+                    <message>Maven 3.9 or higher is required.</message>
+                  </requireMavenVersion>
+                </rules>
+              </configuration>
+            </execution>
+            <execution>
               <id>enforce-dependency-convergence</id>
               <goals>
                 <goal>enforce</goal>


### PR DESCRIPTION
# Description
Backport of #48057 to `stable/8.8`.

relates to #47159