### PR TITLE
ci: look up medic via .codeowners for tests

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -1,41 +1,96 @@
-#
-# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
-# one or more contributor license agreements. See the NOTICE file distributed
-# with this work for additional information regarding copyright ownership.
-# Licensed under the Camunda License 1.0. You may not use this file
-# except in compliance with the Camunda License 1.0.
-#
+
 declare -A lookupTeamMedic
+
 # @core-features-medic
 coreFeaturesMedic="<!subteam^S08P2CU9V8W|core-features-medic>"
 lookupTeamMedic["team-core-features"]=$coreFeaturesMedic
 lookupTeamMedic["Core Features"]=$coreFeaturesMedic
 lookupTeamMedic["CoreFeatures"]=$coreFeaturesMedic
+lookupTeamMedic["@camunda/core-features"]=$coreFeaturesMedic
 
 # @data-layer-medic
 dataLayerMedic="<!subteam^S08P2CSC06S|data-layer-medic>"
 lookupTeamMedic["team-data-layer"]=$dataLayerMedic
 lookupTeamMedic["Data Layer"]=$dataLayerMedic
 lookupTeamMedic["DataLayer"]=$dataLayerMedic
+lookupTeamMedic["@camunda/data-layer"]=$dataLayerMedic
 
 # @identity-medic
 identityMedic="<!subteam^S053MF48SSH|identity-medic>"
 lookupTeamMedic["team-identity"]=$identityMedic
 lookupTeamMedic["Identity"]=$identityMedic
+lookupTeamMedic["@camunda/identity"]=$identityMedic
+lookupTeamMedic["@camunda/identity-frontend"]=$identityMedic
 
 # @distributed-systems-medic
 distributedSystemsMedic="<!subteam^S09B7LXB77D|distributed-systems-medic>"
 lookupTeamMedic["team-distributed-systems"]=$distributedSystemsMedic
 lookupTeamMedic["Distributed Systems"]=$distributedSystemsMedic
 lookupTeamMedic["DistributedSystems"]=$distributedSystemsMedic
+lookupTeamMedic["@camunda/zeebe-distributed-platform"]=$distributedSystemsMedic
 
 # @camunda-ex-medic
 camundaExMedic="<!subteam^S064J3N99A5|camunda-ex-medic>"
 lookupTeamMedic["Camunda Ex"]=$camundaExMedic
 lookupTeamMedic["CamundaEx"]=$camundaExMedic
+lookupTeamMedic["@camunda/camundaex"]=$camundaExMedic
+
+# @distro-medic
+distroMedic="<!subteam^S053K7C7QKU|distro-medic>"
+lookupTeamMedic["@camunda/distribution"]=$distroMedic
+
+# @reliability-testing-team
+reliabilityTestingTeam="<!subteam^S0A1Q2TJ6MB|reliability-testing-team>"
+lookupTeamMedic["@camunda/reliability-testing"]=$reliabilityTestingTeam
+
+# @qa-medic
+qaMedic="<!subteam^S09UBFWENKF|qa-medic>"
+lookupTeamMedic["@camunda/qa-engineering"]=$qaMedic
+
+# @monorepo-ci-medic
+monorepoCIMedic="<!subteam^S07D6C6B18T|monorepo-ci-medic>"
+lookupTeamMedic["@camunda/monorepo-devops-team"]=$monorepoCIMedic
 
 # failure in QA test
 lookupTeamMedic["QA"]="QA Acceptance Test, requires investigation"
 
 # catch all for tests without an assigned team
 lookupTeamMedic["General"]="General Test, requires investigation"
+
+
+resolve_test_source_file() {
+    # Resolves a Java test class FQCN to the exact repo-relative test source file path.
+    #
+    # Input: fully qualified test class name, e.g. io.camunda.foo.BarTest
+    # Output: prints a single repo-relative path or empty string.
+    local fqcn="$1"
+    local rel_test_path="${fqcn//./\/}.java"
+
+    # Find the test file location (first match is good enough)
+    local test_file
+    test_file="$(git ls-files "**/src/test/java/${rel_test_path}" 2>/dev/null | head -n 1)"
+    if [[ -z "${test_file}" ]]; then
+        # Some tests live under integrationTest or other conventions
+        test_file="$(git ls-files "**/src/*Test/java/${rel_test_path}" 2>/dev/null | head -n 1)"
+    fi
+
+    if [[ -n "${test_file}" && -f "${test_file}" ]]; then
+        echo "${test_file}"
+        return 0
+    fi
+
+    echo ""
+}
+
+resolve_codeowners_team() {
+    # Input: repo-relative file path
+    # Output: prints first required owner or empty string
+    local file_path="$1"
+
+    if [[ -z "${file_path}" || ! -f "${file_path}" ]]; then
+        echo ""
+        return 0
+    fi
+
+    codeowners-cli owner --format json "${file_path}" 2>/dev/null | jq -r --arg f "${file_path}" '(.[$f].required // [])[0] // ""' || true
+}

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Setup codeowners-cli
+        uses: ./.github/actions/codeowners-setup-cli
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
@@ -56,6 +59,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
+          set -euo pipefail
+
           # use setup-medic-lookup.sh to set up lookupTeamMedic lookup array
           source .ci/scripts/ci/setup-medic-lookup.sh
 
@@ -66,7 +71,7 @@ jobs:
           # shellcheck disable=SC2016
           NUMBER_OF_FLAKYTESTS_JOBS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT COUNT(*) as number_of_all_jobs FROM `ci-30-162810.prod_ci_analytics.build_status_v2` WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=report_time AND report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ci_url="https://github.com/camunda/camunda" AND user_reason="flaky-tests"' | jq -r '.[0].number_of_all_jobs')
           # shellcheck disable=SC2016
-          TOP5_FLAKYTESTS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT test_class_name, test_name, COUNT(*) as number_of_flakes, user_description FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=ts.report_time AND ts.report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ts.ci_url="https://github.com/camunda/camunda" AND test_status = "flaky" GROUP BY test_class_name, test_name, user_description ORDER BY number_of_flakes DESC LIMIT 5')
+          TOP5_FLAKYTESTS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT test_class_name, test_name, COUNT(*) as number_of_flakes FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=ts.report_time AND ts.report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ts.ci_url="https://github.com/camunda/camunda" AND test_status = "flaky" GROUP BY test_class_name, test_name ORDER BY number_of_flakes DESC LIMIT 5')
 
           {
             echo "MESSAGE<<EOF"
@@ -80,7 +85,18 @@ jobs:
               FULLY_QUALIFIED_TEST_CLASS_NAME=$(echo "$top_flakytest" | jq -r '.test_class_name')
               TEST_CLASS_NAME="${FULLY_QUALIFIED_TEST_CLASS_NAME##*.}"
               TEST_NAME=$(echo "$top_flakytest" | jq -r '.test_name')
-              TEST_OWNER=$(echo "$top_flakytest" | jq -r '.user_description')
+
+              # Resolve medic of owning team via .codeowners by mapping test class to test source file
+              MEDIC=""
+              SOURCE_FILE_PATH="$(resolve_test_source_file "${FULLY_QUALIFIED_TEST_CLASS_NAME}")"
+              if [[ -n "${SOURCE_FILE_PATH}" ]]; then
+                TEST_OWNER="$(resolve_codeowners_team "${SOURCE_FILE_PATH}")"
+
+                if [[ -n "${TEST_OWNER}" && -n "${lookupTeamMedic["${TEST_OWNER}"]+x}" ]]; then
+                  MEDIC="${lookupTeamMedic["${TEST_OWNER}"]}"
+                fi
+              fi
+
               SUFFIX=""
 
               # Try to find GH issues about related flaky tests:
@@ -97,8 +113,8 @@ jobs:
               printf "• %sx \`%s.%s\`%s\n\n" "$NUMBER_OF_FLAKES" "$TEST_CLASS_NAME" "$TEST_NAME" "$SUFFIX"
               # only notify if the owner is a team name and the number of flakes is above the threshold and there is no GH issue
               if [ "${NUMBER_OF_FLAKES}" -ge "${FLAKY_TEST_THRESHOLD}" ] && [ -z "$GH_ISSUE_ID" ]; then
-                if [[ -n "${lookupTeamMedic[$TEST_OWNER]}" ]]; then
-                  printf ":arrow_right: %s\n\n" "${lookupTeamMedic[$TEST_OWNER]}"
+                if [[ -n "${MEDIC}" ]]; then
+                  printf ":arrow_right:  %s\n\n" "${MEDIC}"
                 fi
               fi
 

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Setup codeowners-cli
+        uses: ./.github/actions/codeowners-setup-cli
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
@@ -58,13 +61,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
+          set -euo pipefail
+
           # use setup-medic-lookup.sh to set up lookupTeamMedic lookup array
           source .ci/scripts/ci/setup-medic-lookup.sh
 
           # number of tests that need to fail before notifying team medic
-          FAILED_TEST_THRESHOLD=5
+          FAILED_TEST_THRESHOLD=3
           # shellcheck disable=SC2016
-          TOP5_FAILINGTESTS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT test_class_name, test_name, COUNT(*) as number_of_fails, user_description FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 7 DAY)<=ts.report_time AND ts.report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ts.ci_url="https://github.com/camunda/camunda" AND test_status = "failure" AND ((build_trigger="merge_group" AND build_base_ref="refs/heads/main") OR (build_trigger="push" AND build_ref="refs/heads/main")) GROUP BY test_class_name, test_name, user_description ORDER BY number_of_fails DESC LIMIT 5')
+          TOP5_FAILINGTESTS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT test_class_name, test_name, COUNT(*) as number_of_fails FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 7 DAY)<=ts.report_time AND ts.report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ts.ci_url="https://github.com/camunda/camunda" AND test_status = "failure" AND ((build_trigger="merge_group" AND build_base_ref="refs/heads/main") OR (build_trigger="push" AND build_ref="refs/heads/main")) GROUP BY test_class_name, test_name ORDER BY number_of_fails DESC LIMIT 5')
 
           {
             echo "MESSAGE<<EOF"
@@ -75,7 +80,18 @@ jobs:
               FULLY_QUALIFIED_TEST_CLASS_NAME=$(echo "$top_failingtest" | jq -r '.test_class_name')
               TEST_CLASS_NAME="${FULLY_QUALIFIED_TEST_CLASS_NAME##*.}"
               TEST_NAME=$(echo "$top_failingtest" | jq -r '.test_name')
-              TEST_OWNER=$(echo "$top_failingtest" | jq -r '.user_description')
+
+              # Resolve medic of owning team via .codeowners by mapping test class to test source file
+              MEDIC=""
+              SOURCE_FILE_PATH="$(resolve_test_source_file "${FULLY_QUALIFIED_TEST_CLASS_NAME}")"
+              if [[ -n "${SOURCE_FILE_PATH}" ]]; then
+                TEST_OWNER="$(resolve_codeowners_team "${SOURCE_FILE_PATH}")"
+
+                if [[ -n "${TEST_OWNER}" && -n "${lookupTeamMedic["${TEST_OWNER}"]+x}" ]]; then
+                  MEDIC="${lookupTeamMedic["${TEST_OWNER}"]}"
+                fi
+              fi
+
               SUFFIX=""
 
               # Try to find GH issues about related (failing) tests:
@@ -93,8 +109,8 @@ jobs:
 
               # only notify team medic if the owner is a team name and the number of failures is above the threshold and there is no GH issue
               if [ "${NUMBER_OF_FAILS}" -ge "${FAILED_TEST_THRESHOLD}" ]  && [ -z "$GH_ISSUE_ID" ]; then
-                if [[ -n "${lookupTeamMedic[$TEST_OWNER]}" ]]; then
-                  printf ":arrow_right:  %s\n\n" "${lookupTeamMedic[$TEST_OWNER]}"
+                if [[ -n "${MEDIC}" ]]; then
+                  printf ":arrow_right:  %s\n\n" "${MEDIC}"
                 fi
               fi
 


### PR DESCRIPTION
## Description

Overall Epic ticket: https://github.com/camunda/camunda/issues/47825

This PR adjusts the failing and flaky test Slack posts to use `.codeowners` file for attribution (on test source file level), instead of CI Analytics data for job-level attribution.

Demo of working attribution:

* flaky tests (daily): https://github.com/camunda/camunda/actions/runs/22900278226/job/66444789317?pr=48167#step:9:50
* failing tests (weekly): https://github.com/camunda/camunda/actions/runs/22901132734/job/66447642391?pr=48167#step:9:28

Mis-attributions can be fixed autonomously by teams via editing the `.codeowners`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not needed, scheduled workflows only run using `main`

## Related issues

Closes #47924 #47925 