### PR TITLE
fix: revert visual tests operate docker start script

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -60,7 +60,7 @@
     "generate-screenshots": "playwright test --project=screenshot-generator",
     "test:e2e:ci": "cross-env IS_E2E=true PORT=8080 playwright test --project=e2e",
     "coverage": "npm run test -- --coverage --changed",
-    "start-visual-regression-docker": "docker run --rm --add-host=host.docker.internal:host-gateway -e PLAYWRIGHT_BASE_HOST=host.docker.internal -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v1.58.2 /bin/bash",
+    "start-visual-regression-docker": "docker run --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v1.58.2 /bin/bash",
     "start:visual-regression": "serve build/ -p 8081 -n -s -L",
     "build:visual-regression": "cross-env VITE_VERSION=0.0.0-SNAPSHOT vite build --mode visual-regression",
     "extract-sbom": "vite build --mode sbom",


### PR DESCRIPTION
## Description

Revert Operate docker script to run visual tests. See reasoning [here](https://camunda.slack.com/archives/C0A0SKKTXD0/p1773144273134379)

More investigation on my local env setup will follow

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
