### PR TITLE
perf: suspend computation of `claims` in `AuthorizationRequest`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequest.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequest.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.property.Resour
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Lazy;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public record AuthorizationRequest(
-    Map<String, Object> claims,
+    Lazy<Map<String, Object>> lazyClaims,
     AuthorizationResourceType resourceType,
     PermissionType permissionType,
     String tenantId,
@@ -44,6 +45,11 @@ public record AuthorizationRequest(
       "Expected to perform operation '%s' on resource '%s' for tenant '%s', but user is not assigned to this tenant";
   private static final String NOT_FOUND_FOR_TENANT_ERROR_MESSAGE =
       "Expected to perform operation '%s' on resource '%s', but no resource was found for tenant '%s'";
+
+  /** Forces evaluation and returns the resolved claims map. */
+  public Map<String, Object> claims() {
+    return lazyClaims.get();
+  }
 
   public boolean hasResourceProperties() {
     return resourceProperties != null && resourceProperties.hasProperties();
@@ -167,7 +173,7 @@ public record AuthorizationRequest(
         throw new IllegalStateException("command and authorizationClaims are mutually exclusive");
       }
 
-      final var claims = resolveClaims();
+      final var lazyClaims = Lazy.of(this::resolveClaims);
       final var isTenantOwnedResource = tenantId != null && !tenantId.isEmpty();
       final var isTriggeredByInternalCommand = command != null && command.isInternalCommand();
 
@@ -176,7 +182,7 @@ public record AuthorizationRequest(
       }
 
       return new AuthorizationRequest(
-          claims,
+          lazyClaims,
           resourceType,
           permissionType,
           tenantId,

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Lazy.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Lazy.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * A lazily-evaluated value that defers computation until first access and caches the result.
+ *
+ * <p>Thread safety: under contention the supplier may be invoked more than once, but all threads
+ * will converge on the same result (the CAS winner's value). The supplier is not retained after
+ * evaluation.
+ *
+ * @param <T> the type of the lazily-computed value (may be null)
+ */
+public final class Lazy<T> implements Supplier<T> {
+
+  // guard to avoid looping if user provided supplier returns null
+  private static final Object UNINITIALIZED = new Object();
+
+  private final AtomicReference<Object> value = new AtomicReference<>(UNINITIALIZED);
+  private volatile Supplier<? extends T> supplier;
+
+  private Lazy(final Supplier<? extends T> supplier) {
+    this.supplier = Objects.requireNonNull(supplier, "supplier must not be null");
+  }
+
+  /** Creates a new lazy value that will be computed by the given supplier on first access. */
+  public static <T> Lazy<T> of(final Supplier<? extends T> supplier) {
+    return new Lazy<>(supplier);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public T get() {
+    final var current = value.get();
+    if (current != UNINITIALIZED) {
+      return (T) current;
+    }
+
+    final var computed = supplier.get();
+    if (value.compareAndSet(UNINITIALIZED, computed)) {
+      supplier = null; // release reference after successful evaluation
+    }
+    return (T) value.get();
+  }
+
+  /** Returns {@code true} if the value has been computed, without forcing evaluation. */
+  public boolean isEvaluated() {
+    return value.get() != UNINITIALIZED;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(get());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    return this == o || (o instanceof final Lazy<?> other && Objects.equals(get(), other.get()));
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(get());
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/LazyTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/LazyTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LazyTest {
+
+  @Nested
+  class Get {
+
+    @Test
+    void shouldComputeOnFirstAccess() {
+      // given
+      final var lazy = Lazy.of(() -> "hello");
+
+      // when
+      final var result = lazy.get();
+
+      // then
+      assertThat(result).isEqualTo("hello");
+    }
+
+    @Test
+    void shouldCacheAfterFirstAccess() {
+      // given
+      final var callCount = new AtomicInteger();
+      final var lazy =
+          Lazy.of(
+              () -> {
+                callCount.incrementAndGet();
+                return "cached";
+              });
+
+      // when
+      lazy.get();
+      lazy.get();
+      lazy.get();
+
+      // then
+      assertThat(callCount).hasValue(1);
+    }
+
+    @Test
+    void shouldSupportNullValue() {
+      // given
+      final var lazy = Lazy.of(() -> null);
+
+      // when
+      final var result = lazy.get();
+
+      // then
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldRejectNullSupplier() {
+      assertThatThrownBy(() -> Lazy.of(null)).isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  class IsEvaluated {
+
+    @Test
+    void shouldBeFalseBeforeAccess() {
+      // given
+      final var lazy = Lazy.of(() -> "value");
+
+      // then
+      assertThat(lazy.isEvaluated()).isFalse();
+    }
+
+    @Test
+    void shouldBeTrueAfterAccess() {
+      // given
+      final var lazy = Lazy.of(() -> "value");
+
+      // when
+      lazy.get();
+
+      // then
+      assertThat(lazy.isEvaluated()).isTrue();
+    }
+  }
+
+  @Nested
+  class EqualsAndHashCode {
+
+    @Test
+    void shouldBeEqualWhenValuesEqual() {
+      // given
+      final var a = Lazy.of(() -> "same");
+      final var b = Lazy.of(() -> "same");
+
+      // then
+      assertThat(a).isEqualTo(b);
+    }
+
+    @Test
+    void shouldNotBeEqualWhenValuesDiffer() {
+      // given
+      final var a = Lazy.of(() -> "one");
+      final var b = Lazy.of(() -> "two");
+
+      // then
+      assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void shouldHaveConsistentHashCode() {
+      // given
+      final var a = Lazy.of(() -> "same");
+      final var b = Lazy.of(() -> "same");
+
+      // then
+      assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void shouldHandleNullValues() {
+      // given
+      final var a = Lazy.of(() -> null);
+      final var b = Lazy.of(() -> null);
+
+      // then
+      assertThat(a).isEqualTo(b);
+      assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void shouldNotBeEqualToNonLazy() {
+      // given
+      final var lazy = Lazy.of(() -> "value");
+
+      // then
+      assertThat(lazy).isNotEqualTo("value");
+    }
+  }
+
+  @Nested
+  class ToString {
+
+    @Test
+    void shouldDelegateToValue() {
+      // given
+      final var lazy = Lazy.of(() -> 42);
+
+      // then
+      assertThat(lazy).hasToString("42");
+    }
+
+    @Test
+    void shouldHandleNullValue() {
+      // given
+      final var lazy = Lazy.of(() -> null);
+
+      // then
+      assertThat(lazy).hasToString("null");
+    }
+  }
+
+  @Nested
+  class ThreadSafety {
+
+    @Test
+    void shouldReturnSameValueAcrossThreads() throws InterruptedException {
+      // given
+      final var lazy = Lazy.of(() -> "shared");
+      final var threadCount = 16;
+      final var startLatch = new CountDownLatch(1);
+      final var doneLatch = new CountDownLatch(threadCount);
+      final var results = new CopyOnWriteArrayList<String>();
+
+      // when
+      IntStream.range(0, threadCount)
+          .forEach(
+              i -> {
+                final var thread =
+                    new Thread(
+                        () -> {
+                          try {
+                            startLatch.await();
+                            results.add(lazy.get());
+                          } catch (final InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                          } finally {
+                            doneLatch.countDown();
+                          }
+                        });
+                thread.start();
+              });
+
+      startLatch.countDown();
+      doneLatch.await();
+
+      // then
+      assertThat(results).hasSize(threadCount).containsOnly("shared");
+    }
+
+    @Test
+    void shouldCacheNullAcrossThreads() throws InterruptedException {
+      // given
+      final var callCount = new AtomicInteger();
+      final var lazy =
+          Lazy.of(
+              () -> {
+                callCount.incrementAndGet();
+                return null;
+              });
+      final var threadCount = 16;
+      final var startLatch = new CountDownLatch(1);
+      final var doneLatch = new CountDownLatch(threadCount);
+      final List<Object> results = new CopyOnWriteArrayList<>();
+
+      // when
+      IntStream.range(0, threadCount)
+          .forEach(
+              i -> {
+                final var thread =
+                    new Thread(
+                        () -> {
+                          try {
+                            startLatch.await();
+                            // Use sentinel to distinguish null result from "no result"
+                            final var result = lazy.get();
+                            results.add(result == null ? "NULL_SENTINEL" : result);
+                          } catch (final InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                          } finally {
+                            doneLatch.countDown();
+                          }
+                        });
+                thread.start();
+              });
+
+      startLatch.countDown();
+      doneLatch.await();
+
+      // then
+      assertThat(results).hasSize(threadCount).containsOnly("NULL_SENTINEL");
+    }
+  }
+}


### PR DESCRIPTION
## Description

### Lazy 
Adds a new `Lazy<T>` class that allows to suspend a computation to a later time (if needed):
Under concurrency, the supplier might be invoked more than once, but all
readers eventually converge on the same value.

Lazy<T> implements equals/hashcode/toString by delegating to the
supplier returned value.

### AuthorizationRequest claims
`claims` in `AuthorizationRequest` are not immediately computed in the builder, which is not necessary if authorizations are disabled. 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46873
