### PR TITLE
fix: throttle inter-partition command write failure log

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -25,12 +25,15 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.time.Duration;
 import java.util.Optional;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
 final class InterPartitionCommandReceiverImpl {
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
+  private final Logger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(15));
   private final Decoder decoder = new Decoder();
   private final LogStreamWriter logStreamWriter;
   private boolean diskSpaceAvailable = true;
@@ -82,12 +85,12 @@ final class InterPartitionCommandReceiverImpl {
 
   private void logWriteFailure(
       final MemberId memberId, final DecodedMessage decoded, final WriteFailure failure) {
-    LOG.warn(
-        "Failed to write command {} {} from {} to logstream (error = {})",
+    throttledLog.warn(
+        "Failed to write received command {}.{} to logstream (error = {}, sender = {})",
         decoded.metadata.getValueType(),
         decoded.metadata.getIntent(),
-        memberId,
-        failure);
+        failure,
+        memberId);
   }
 
   private Either<WriteFailure, Long> writeCheckpoint(final DecodedMessage decoded) {


### PR DESCRIPTION
Throttles the `logWriteFailure` warning in `InterPartitionCommandReceiverImpl` using a `ThrottledLogger` with a 15-second interval. This prevents log flooding when the logstream writer repeatedly rejects commands (e.g. due to `WRITE_LIMIT_EXHAUSTED`).

The log message is also improved to include the command type and intent in dot notation (`PROCESS_MESSAGE_SUBSCRIPTION.CORRELATE`) and the sender id, making it easier to diagnose which commands from which brokers are being dropped.