### PR TITLE
fix(operate): disable sorting for Operation State column

### DIFF
--- a/operate/client/e2e-playwright/visual/processes.spec.ts
+++ b/operate/client/e2e-playwright/visual/processes.spec.ts
@@ -385,7 +385,8 @@ test.describe('processes page', () => {
       'bf547ac3-9a35-45b9-ab06-b80b43785153',
     );
 
-    await expect(page.getByLabel('Sort by Operation State')).toBeInViewport();
+    await expect(page.getByText('Operation State')).toBeInViewport();
+    await expect(page.getByLabel('Sort by Operation State')).toHaveCount(0);
 
     await expect(page).toHaveScreenshot();
   });

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -247,6 +247,7 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
                   {
                     header: 'Operation State',
                     key: 'instanceOperationState',
+                    isDisabled: true,
                   },
                 ]
               : []),

--- a/operate/client/src/App/Processes/ListView/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/tests/index.test.tsx
@@ -394,6 +394,9 @@ describe('Instances', () => {
     });
 
     expect(screen.getByText('Operation State')).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Sort by Operation State'),
+    ).not.toBeInTheDocument();
   });
 
   it('should show correct error message when error row is expanded', async () => {

--- a/operate/client/src/modules/components/SortableTable/ColumnHeader/index.tsx
+++ b/operate/client/src/modules/components/SortableTable/ColumnHeader/index.tsx
@@ -67,14 +67,18 @@ const ColumnHeader: React.FC<Props> = ({
     <TableHeader
       {...rest}
       onClick={() => {
+        if (isDisabled) {
+          return;
+        }
+
         onSort?.(sortKey);
         navigate({
           search: toggleSorting(location.search, sortKey, currentSortOrder),
         });
       }}
       isSortHeader={!isDisabled}
-      title={`Sort by ${label}`}
-      aria-label={`Sort by ${label}`}
+      title={isDisabled ? undefined : `Sort by ${label}`}
+      aria-label={isDisabled ? undefined : `Sort by ${label}`}
       sortDirection={
         displaySortIcon
           ? currentSortOrder === 'asc'


### PR DESCRIPTION
## Description

Fixes Operate allowing users to sort by the `instanceOperationState` column, which is not a backend-supported sort key (camunda/camunda#45569).

### What changed
- Marked the **Operation State** column as disabled in the instances table header config.
- Updated shared `ColumnHeader` behavior to no-op on click when a header is disabled.
- Removed sort title/aria-label on disabled headers so the Operation State column is not exposed as sortable.
- Updated unit + visual test expectations for Operation State to verify it is shown but not sortable.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45569

## Testing

- `npm test -- src/App/Processes/ListView/tests/index.test.tsx`
