### PR TITLE
feat: add Optimize report evaluation metric

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/MetricEnum.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/MetricEnum.java
@@ -9,23 +9,27 @@ package io.camunda.optimize;
 
 public enum MetricEnum {
   OVERALL_IMPORT_TIME_METRIC(
+      MetricType.IMPORT,
       "overallImportTime",
       "Records the time between the timestamp of a Zeebe record and the time of successful import to Optimize"),
   INDEXING_DURATION_METRIC(
+      MetricType.IMPORT,
       "indexingDuration",
       "Records the time spent indexing data from Zeebe into Optimize Elasticsearch indexes"),
   NEW_PAGE_FETCH_TIME_METRIC(
+      MetricType.IMPORT,
       "newPageFetchTime",
-      "Records the time spent for fetching next import page from Zeebe Elasticsearch");
-  private static final String IMPORT_METRICS_PREFIX = "optimize.import";
+      "Records the time spent for fetching next import page from Zeebe Elasticsearch"),
+  REPORT_LATENCY_METRIC(
+      MetricType.REPORT, "reportLatency", "Records the time taken to evaluate a report");
   private final String id;
   private final String name;
   private final String description;
 
-  MetricEnum(final String id, final String description) {
+  MetricEnum(final MetricType metricType, final String id, final String description) {
     this.id = id;
     this.description = description;
-    name = IMPORT_METRICS_PREFIX + "." + id;
+    name = metricType.prefix + "." + id;
   }
 
   public String getId() {
@@ -38,5 +42,15 @@ public enum MetricEnum {
 
   public String getDescription() {
     return description;
+  }
+
+  private enum MetricType {
+    IMPORT("optimize.import"),
+    REPORT("optimize.report");
+    private final String prefix;
+
+    MetricType(final String prefix) {
+      this.prefix = prefix;
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/ReportMetrics.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/ReportMetrics.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import io.camunda.optimize.dto.optimize.ReportType;
+import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+public final class ReportMetrics {
+  public static final String REPORT_TYPE_TAG = "REPORT_TYPE";
+  public static final String REPORT_CATEGORY_TAG = "REPORT_CATEGORY";
+  public static final String STATUS_TAG = "STATUS";
+  public static final String SAVED_TAG = "SAVED";
+
+  private ReportMetrics() {}
+
+  public static <T> T recordLatency(
+      final MetricEnum metric,
+      final Supplier<ReportDefinitionDto<?>> reportSupplier,
+      final Callable<T> action) {
+    final long startNanos = System.nanoTime();
+    String status = "success";
+    try {
+      return action.call();
+    } catch (final RuntimeException e) {
+      status = "error";
+      throw e;
+    } catch (final Exception e) {
+      status = "error";
+      throw new RuntimeException(e);
+    } finally {
+      final long durationMillis = NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+      final Tags tags = tagsFor(reportSupplier.get(), status);
+      Timer.builder(metric.getName())
+          .description(metric.getDescription())
+          .tags(tags)
+          .register(Metrics.globalRegistry)
+          .record(durationMillis, MILLISECONDS);
+    }
+  }
+
+  static Tags buildTags(final ReportDefinitionDto<?> report, final String status) {
+    return Tags.of(
+        REPORT_CATEGORY_TAG,
+        report.isCombined() ? "combined" : "single",
+        REPORT_TYPE_TAG,
+        Optional.ofNullable(report.getReportType()).map(ReportType::getId).orElse("unknown"),
+        SAVED_TAG,
+        String.valueOf(report.getId() != null),
+        STATUS_TAG,
+        status);
+  }
+
+  static Tags buildFallbackTags(final String status) {
+    return Tags.of(
+        REPORT_CATEGORY_TAG, "unknown",
+        REPORT_TYPE_TAG, "unknown",
+        SAVED_TAG, "false",
+        STATUS_TAG, status);
+  }
+
+  private static Tags tagsFor(final ReportDefinitionDto<?> report, final String status) {
+    return report != null ? buildTags(report, status) : buildFallbackTags(status);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.optimize.service.db.report;
 
+import static io.camunda.optimize.MetricEnum.REPORT_LATENCY_METRIC;
 import static io.camunda.optimize.dto.optimize.ReportConstants.ALL_VERSIONS;
 import static io.camunda.optimize.service.util.ExceptionUtil.isTooManyBucketsException;
 import static java.util.stream.Collectors.mapping;
 
+import io.camunda.optimize.ReportMetrics;
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.TenantDto;
@@ -86,24 +88,31 @@ public abstract class ReportEvaluationHandler {
 
   public AuthorizedReportEvaluationResult evaluateReport(
       final ReportEvaluationInfo evaluationInfo) {
-    evaluationInfo.postFetchSavedReport(reportService);
-    updateAndSetLatestReportDefinitionXml(evaluationInfo);
-    setDataSourcesForSystemGeneratedReports(evaluationInfo);
-    final RoleType currentUserRole =
-        getAuthorizedRole(evaluationInfo.getUserId(), evaluationInfo.getReport())
-            .orElseThrow(
-                () ->
-                    new ForbiddenException(
-                        String.format(
-                            "User [%s] is not authorized to evaluate report [%s].",
-                            evaluationInfo.getUserId(), evaluationInfo.getReport().getName())));
-    final ReportEvaluationResult result;
-    if (evaluationInfo.getReport().isCombined()) {
-      result = evaluateCombinedReport(evaluationInfo, currentUserRole);
-    } else {
-      result = evaluateSingleReportWithErrorCheck(evaluationInfo, currentUserRole);
-    }
-    return new AuthorizedReportEvaluationResult(result, currentUserRole);
+    return ReportMetrics.recordLatency(
+        REPORT_LATENCY_METRIC,
+        evaluationInfo::getReport,
+        () -> {
+          evaluationInfo.postFetchSavedReport(reportService);
+          updateAndSetLatestReportDefinitionXml(evaluationInfo);
+          setDataSourcesForSystemGeneratedReports(evaluationInfo);
+          final RoleType currentUserRole =
+              getAuthorizedRole(evaluationInfo.getUserId(), evaluationInfo.getReport())
+                  .orElseThrow(
+                      () ->
+                          new ForbiddenException(
+                              String.format(
+                                  "User [%s] is not authorized to evaluate report [%s].",
+                                  evaluationInfo.getUserId(),
+                                  evaluationInfo.getReport().getName())));
+          final ReportEvaluationResult result;
+          if (evaluationInfo.getReport().isCombined()) {
+            result = evaluateCombinedReport(evaluationInfo, currentUserRole);
+          } else {
+            result = evaluateSingleReportWithErrorCheck(evaluationInfo, currentUserRole);
+          }
+
+          return new AuthorizedReportEvaluationResult(result, currentUserRole);
+        });
   }
 
   private void updateAndSetLatestReportDefinitionXml(

--- a/optimize/backend/src/test/java/io/camunda/optimize/ReportMetricsTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/ReportMetricsTest.java
@@ -27,7 +27,6 @@ class ReportMetricsTest {
     final SingleProcessReportDefinitionRequestDto report =
         new SingleProcessReportDefinitionRequestDto();
     report.setId("report-123");
-    report.setName("My Process Report");
 
     // when
     final Tags tags = ReportMetrics.buildTags(report, "success");

--- a/optimize/backend/src/test/java/io/camunda/optimize/ReportMetricsTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/ReportMetricsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import static io.camunda.optimize.ReportMetrics.REPORT_CATEGORY_TAG;
+import static io.camunda.optimize.ReportMetrics.REPORT_TYPE_TAG;
+import static io.camunda.optimize.ReportMetrics.SAVED_TAG;
+import static io.camunda.optimize.ReportMetrics.STATUS_TAG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportDefinitionRequestDto;
+import io.camunda.optimize.dto.optimize.query.report.single.decision.SingleDecisionReportDefinitionRequestDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
+import io.micrometer.core.instrument.Tags;
+import org.junit.jupiter.api.Test;
+
+class ReportMetricsTest {
+
+  @Test
+  void shouldBuildTagsForProcessReport() {
+    // given
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto();
+    report.setId("report-123");
+    report.setName("My Process Report");
+
+    // when
+    final Tags tags = ReportMetrics.buildTags(report, "success");
+
+    // then
+    assertThat(tags.stream().filter(t -> t.getKey().equals(REPORT_CATEGORY_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("single"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(REPORT_TYPE_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("process"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(SAVED_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("true"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(STATUS_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("success"));
+  }
+
+  @Test
+  void shouldBuildTagsForDecisionReport() {
+    // given
+    final SingleDecisionReportDefinitionRequestDto report =
+        new SingleDecisionReportDefinitionRequestDto();
+    report.setId("report-456");
+
+    // when
+    final Tags tags = ReportMetrics.buildTags(report, "success");
+
+    // then
+    assertThat(tags.stream().filter(t -> t.getKey().equals(REPORT_TYPE_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("decision"));
+  }
+
+  @Test
+  void shouldBuildTagsForUnsavedReport() {
+    // given
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto();
+    // id is null - unsaved report
+
+    // when
+    final Tags tags = ReportMetrics.buildTags(report, "success");
+
+    // then
+    assertThat(tags.stream().filter(t -> t.getKey().equals(SAVED_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("false"));
+  }
+
+  @Test
+  void shouldBuildTagsWithErrorStatus() {
+    // given
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto();
+
+    // when
+    final Tags tags = ReportMetrics.buildTags(report, "error");
+
+    // then
+    assertThat(tags.stream().filter(t -> t.getKey().equals(STATUS_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("error"));
+  }
+
+  @Test
+  void shouldBuildFallbackTagsWithUnknownValues() {
+    // when
+    final Tags tags = ReportMetrics.buildFallbackTags("error");
+
+    // then
+    assertThat(tags.stream().filter(t -> t.getKey().equals(REPORT_CATEGORY_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("unknown"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(REPORT_TYPE_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("unknown"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(SAVED_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("false"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(STATUS_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("error"));
+  }
+
+  @Test
+  void shouldBuildTagsForCombinedReport() {
+    // given
+    final CombinedReportDefinitionRequestDto report = new CombinedReportDefinitionRequestDto();
+    report.setId("combined-123");
+
+    // when
+    final Tags tags = ReportMetrics.buildTags(report, "success");
+
+    // then
+    assertThat(tags.stream().filter(t -> t.getKey().equals(REPORT_CATEGORY_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("combined"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(REPORT_TYPE_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("process"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(SAVED_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("true"));
+    assertThat(tags.stream().filter(t -> t.getKey().equals(STATUS_TAG)).findFirst())
+        .hasValueSatisfying(tag -> assertThat(tag.getValue()).isEqualTo("success"));
+  }
+}


### PR DESCRIPTION
## Description
This PR adds **Optimize report latency instrumentation** so that we can observe how long report and dashboard evaluations take in production.

**_MetricEnum.java_**

- Added REPORT_LATENCY_METRIC for tracking report evaluation duration

-Introduced nested MetricType enum to categorize metrics by domain (IMPORT vs REPORT), improving metric namespace organization (e.g., optimize.import.* vs optimize.report.*)

**_ReportMetrics.java (new file)_**

- Utility class for building report-related Micrometer metrics

- Creates Timer metrics with descriptive tags:

  - REPORT_TYPE_TAG — process or decision report
  
  - REPORT_CATEGORY_TAG — single or combined report
  
  - SAVED_TAG — whether the report is persisted
  
  - STATUS_TAG — success or error

- Provides fallback tags when report details are unavailable (e.g., early failures)

**_ReportEvaluationHandler.java_**

- Instruments evaluateReport() — the central entry point for all report and dashboard evaluations
- Records evaluation duration in milliseconds using a try/finally block to capture both successful and failed evaluations
- Centralizes instrumentation so all report types (single, combined, process, decision) are covered in one place


##Screenshots

<img width="1086" height="121" alt="Screenshot 2026-03-10 at 12 57 38 PM" src="https://github.com/user-attachments/assets/03370bf9-f5ee-4d5c-93a0-e937621969b9" />

Changes verified, metrics visible in grafana. 
<img width="2702" height="1371" alt="Screenshot 2026-03-18 at 1 58 02 PM" src="https://github.com/user-attachments/assets/d55f0c17-be8b-4312-bd22-ef15bd09ea81" />

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46867 
