### PR TITLE
feat: AuthInfo can be "frozen" when underlying buffer is copied

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
@@ -68,7 +68,7 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
 
   @Override
   public void setAuthorization(final Map<String, Object> claims) {
-    request.setAuthorization(new AuthInfo().setClaims(claims));
+    request.setAuthorization(AuthInfo.ofClaims(claims));
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -219,7 +219,7 @@ final class InterPartitionCommandReceiverImpl {
         return;
       }
       final var offset = messageDecoder.limit() + InterPartitionMessageDecoder.authHeaderLength();
-      recordMetadata.getAuthorization().wrap(messageDecoder.buffer(), offset, length);
+      recordMetadata.authorization(messageDecoder.buffer(), offset, length);
       messageDecoder.skipAuth();
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -79,7 +79,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
             .recordVersion(recordVersion)
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("")
-            .authorization(new AuthInfo().setClaims(metadata.getClaims()))
+            .authorization(AuthInfo.ofClaims(metadata.getClaims()))
             .operationReference(metadata.getOperationReference())
             .batchOperationReference(metadata.getBatchOperationReference());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
@@ -33,7 +33,8 @@ final class ResultBuilderBackedRejectionWriter extends AbstractResultBuilderBack
         new RecordMetadata()
             .recordType(RecordType.COMMAND_REJECTION)
             .intent(command.getIntent())
-            .authorization(new AuthInfo().setClaims(command.getAuthorizations()))
+            // if authInfo is frozen no copy is done
+            .authorization(AuthInfo.of(command.getAuthInfo()))
             .rejectionType(rejectionType)
             .rejectionReason(reason)
             .operationReference(command.getOperationReference());

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.auth.JwtDecoder;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
@@ -28,9 +29,16 @@ public class AuthInfo extends UnpackedObject {
   private final StringProperty authDataProp = new StringProperty("authData", "").sanitized();
   private final DocumentProperty claimsProp = new DocumentProperty("claims").sanitized();
 
+  private transient boolean frozen;
+  private transient Map<String, Object> cachedDecodedMap;
+
   public AuthInfo() {
     super(3);
     declareProperty(formatProp).declareProperty(authDataProp).declareProperty(claimsProp);
+  }
+
+  public static AuthInfo empty() {
+    return EmptyAuthInfo.getInstance();
   }
 
   public AuthDataFormat getFormat() {
@@ -38,6 +46,7 @@ public class AuthInfo extends UnpackedObject {
   }
 
   public AuthInfo setFormat(final AuthDataFormat format) {
+    ensureMutable();
     formatProp.setValue(format);
     return this;
   }
@@ -47,6 +56,7 @@ public class AuthInfo extends UnpackedObject {
   }
 
   public AuthInfo setAuthData(final String authData) {
+    ensureMutable();
     authDataProp.setValue(authData);
     return this;
   }
@@ -56,17 +66,20 @@ public class AuthInfo extends UnpackedObject {
   }
 
   public AuthInfo setClaims(final DirectBuffer authInfo) {
+    ensureMutable();
     claimsProp.setValue(authInfo);
     return this;
   }
 
   public AuthInfo setClaims(final Map<String, Object> authInfo) {
+    ensureMutable();
     claimsProp.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(authInfo)));
     return this;
   }
 
   @Override
   public void reset() {
+    ensureMutable();
     formatProp.setValue(AuthDataFormat.UNKNOWN);
     authDataProp.setValue("");
     claimsProp.reset();
@@ -85,9 +98,38 @@ public class AuthInfo extends UnpackedObject {
   }
 
   @Override
+  public void read(final MsgPackReader reader) {
+    ensureMutable();
+    super.read(reader);
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buff, final int offset, final int length) {
+    ensureMutable();
+    super.wrap(buff, offset, length);
+  }
+
+  @Override
   @JsonIgnore
   public int getLength() {
     return super.getLength();
+  }
+
+  /** Marks this instance as frozen. A frozen AuthInfo rejects mutation and caches decoded maps. */
+  public AuthInfo freeze() {
+    frozen = true;
+    return this;
+  }
+
+  @JsonIgnore
+  public boolean isFrozen() {
+    return frozen;
+  }
+
+  private void ensureMutable() {
+    if (frozen) {
+      throw new UnsupportedOperationException("Cannot mutate a frozen AuthInfo");
+    }
   }
 
   public DirectBuffer toDirectBuffer() {
@@ -99,20 +141,32 @@ public class AuthInfo extends UnpackedObject {
   }
 
   public Map<String, Object> toDecodedMap() {
-    if (getFormat() == AuthDataFormat.JWT) {
-      final String token = getAuthData();
-      return new JwtDecoder(token).decode().getClaims();
+    if (frozen && cachedDecodedMap != null) {
+      return cachedDecodedMap;
     }
-    return getClaims();
+    final Map<String, Object> result;
+    if (getFormat() == AuthDataFormat.JWT) {
+      result = new JwtDecoder(getAuthData()).decode().getClaims();
+    } else {
+      result = getClaims();
+    }
+    if (frozen) {
+      cachedDecodedMap = result;
+    }
+    return result;
   }
 
   public static AuthInfo of(final AuthInfo info) {
     if (info == null) {
       return null;
     }
+    if (info.isFrozen()) {
+      return info;
+    }
 
     final var auth = new AuthInfo();
     auth.copyFrom(info);
+    auth.freeze();
     return auth;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -11,9 +11,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.auth.JwtDecoder;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
-import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
@@ -25,11 +25,12 @@ public class AuthInfo extends UnpackedObject {
 
   private final EnumProperty<AuthDataFormat> formatProp =
       new EnumProperty<>("format", AuthDataFormat.class, AuthDataFormat.UNKNOWN);
-
   private final StringProperty authDataProp = new StringProperty("authData", "").sanitized();
   private final DocumentProperty claimsProp = new DocumentProperty("claims").sanitized();
 
+  // fields  for caching
   private transient boolean frozen;
+  private transient int cachedLength = -1;
   private transient Map<String, Object> cachedDecodedMap;
 
   public AuthInfo() {
@@ -86,21 +87,28 @@ public class AuthInfo extends UnpackedObject {
   }
 
   @Override
+  public void read(final MsgPackReader reader) {
+    ensureMutable();
+    super.read(reader);
+  }
+
+  @Override
   @JsonIgnore
   public int getEncodedLength() {
-    return super.getEncodedLength();
+    if (frozen) {
+      if (cachedLength < 0) {
+        cachedLength = super.getEncodedLength();
+      }
+      return cachedLength;
+    } else {
+      return super.getEncodedLength();
+    }
   }
 
   @Override
   @JsonIgnore
   public boolean isEmpty() {
     return super.isEmpty();
-  }
-
-  @Override
-  public void read(final MsgPackReader reader) {
-    ensureMutable();
-    super.read(reader);
   }
 
   @Override
@@ -112,7 +120,7 @@ public class AuthInfo extends UnpackedObject {
   @Override
   @JsonIgnore
   public int getLength() {
-    return super.getLength();
+    return getEncodedLength();
   }
 
   /** Marks this instance as frozen. A frozen AuthInfo rejects mutation and caches decoded maps. */
@@ -156,6 +164,11 @@ public class AuthInfo extends UnpackedObject {
     return result;
   }
 
+  /**
+   * @param info the AuthInfo to copy if necessary
+   * @return Creates a new AuthInfo if the argument is not frozen by copying it. The returned value
+   *     is always frozen
+   */
   public static AuthInfo of(final AuthInfo info) {
     if (info == null) {
       return null;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -179,8 +179,14 @@ public class AuthInfo extends UnpackedObject {
 
     final var auth = new AuthInfo();
     auth.copyFrom(info);
-    auth.freeze();
-    return auth;
+    return auth.freeze();
+  }
+
+  public static AuthInfo ofClaims(final Map<String, Object> claims) {
+    if (claims == null || claims.isEmpty()) {
+      return empty();
+    }
+    return new AuthInfo().setClaims(Map.copyOf(claims)).freeze();
   }
 
   public boolean hasAnyClaims() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -20,8 +20,10 @@ import java.util.Collections;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-/** */
+@NullMarked
 public class AuthInfo extends UnpackedObject {
 
   private final EnumProperty<AuthDataFormat> formatProp =
@@ -32,7 +34,7 @@ public class AuthInfo extends UnpackedObject {
   // fields  for caching
   private transient boolean frozen;
   private transient int cachedLength = -1;
-  private transient Map<String, Object> cachedDecodedMap;
+  private transient @Nullable Map<String, Object> cachedDecodedMap;
 
   public AuthInfo() {
     super(3);
@@ -146,14 +148,6 @@ public class AuthInfo extends UnpackedObject {
     }
   }
 
-  public DirectBuffer toDirectBuffer() {
-    final var bytes = new byte[getLength()];
-    final var buffer = new UnsafeBuffer(bytes);
-    write(buffer, 0);
-
-    return buffer;
-  }
-
   public Map<String, Object> toDecodedMap() {
     if (frozen && cachedDecodedMap != null) {
       return cachedDecodedMap;
@@ -178,7 +172,7 @@ public class AuthInfo extends UnpackedObject {
    * @return Creates a new AuthInfo if the argument is not frozen by copying it. The returned value
    *     is always frozen
    */
-  public static AuthInfo of(final AuthInfo info) {
+  public static @Nullable AuthInfo of(final @Nullable AuthInfo info) {
     if (info == null) {
       return null;
     }
@@ -191,7 +185,7 @@ public class AuthInfo extends UnpackedObject {
     return auth.freeze();
   }
 
-  public static AuthInfo ofClaims(final Map<String, Object> claims) {
+  public static AuthInfo ofClaims(@Nullable final Map<String, Object> claims) {
     if (claims == null || claims.isEmpty()) {
       return empty();
     }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -172,10 +172,7 @@ public class AuthInfo extends UnpackedObject {
    * @return Creates a new AuthInfo if the argument is not frozen by copying it. The returned value
    *     is always frozen
    */
-  public static @Nullable AuthInfo of(final @Nullable AuthInfo info) {
-    if (info == null) {
-      return null;
-    }
+  public static AuthInfo of(final AuthInfo info) {
     if (info.isFrozen()) {
       return info;
     }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collections;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -123,7 +124,12 @@ public class AuthInfo extends UnpackedObject {
     return getEncodedLength();
   }
 
-  /** Marks this instance as frozen. A frozen AuthInfo rejects mutation and caches decoded maps. */
+  /**
+   * Marks this instance as frozen. A frozen AuthInfo rejects mutation and caches decoded maps.
+   *
+   * <p>Only freeze an instance that owns its underlying buffer: frozen instances are shared by
+   * reference, so freezing a view over foreign memory lets it outlive that memory.
+   */
   public AuthInfo freeze() {
     frozen = true;
     return this;
@@ -159,7 +165,10 @@ public class AuthInfo extends UnpackedObject {
       result = getClaims();
     }
     if (frozen) {
-      cachedDecodedMap = result;
+      // a frozen instance is shared by reference, so the cached map must not be mutable by any
+      // single holder
+      cachedDecodedMap = Collections.unmodifiableMap(result);
+      return cachedDecodedMap;
     }
     return result;
   }
@@ -186,7 +195,9 @@ public class AuthInfo extends UnpackedObject {
     if (claims == null || claims.isEmpty()) {
       return empty();
     }
-    return new AuthInfo().setClaims(Map.copyOf(claims)).freeze();
+    // no defensive copy of the map: setClaims encodes it to msgpack right away, which already
+    // snapshots it. Map.copyOf would also reject null claim values, which msgpack encodes as nil.
+    return new AuthInfo().setClaims(claims).freeze();
   }
 
   public boolean hasAnyClaims() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * An immutable, singleton-safe empty {@link AuthInfo}. This subclass is frozen at construction and
+ * caches all derived values (claims, decoded map, serialized buffer) eagerly since they never
+ * change. By overriding {@link #write}, it avoids the shared {@code MsgPackWriter} in the parent
+ * class, eliminating a data race when multiple threads call {@code write()} on the singleton.
+ */
+final class EmptyAuthInfo extends AuthInfo {
+
+  private static final EmptyAuthInfo INSTANCE = new EmptyAuthInfo();
+
+  private static final Map<String, Object> EMPTY_MAP = Map.of();
+  private final DirectBuffer cachedBuffer;
+  private final int length;
+
+  private EmptyAuthInfo() {
+    super();
+    length = super.getLength();
+    // Cannot use super.toDirectBuffer() because it calls write(buffer, 0) which dispatches
+    // to our override, but cachedBuffer is still null. Use super.write() directly instead.
+    final var bytes = new byte[length];
+    final var buf = new UnsafeBuffer(bytes);
+    super.write(buf, 0);
+    cachedBuffer = buf;
+    freeze();
+  }
+
+  static AuthInfo getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public int getLength() {
+    return length;
+  }
+
+  @Override
+  public DirectBuffer toDirectBuffer() {
+    return cachedBuffer;
+  }
+
+  @Override
+  public Map<String, Object> toDecodedMap() {
+    return EMPTY_MAP;
+  }
+
+  @Override
+  public boolean hasAnyClaims() {
+    return false;
+  }
+
+  @Override
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    buffer.putBytes(offset, cachedBuffer, 0, length);
+    return length;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/EmptyAuthInfo.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * An immutable, singleton-safe empty {@link AuthInfo}. This subclass is frozen at construction and
@@ -18,6 +19,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  * change. By overriding {@link #write}, it avoids the shared {@code MsgPackWriter} in the parent
  * class, eliminating a data race when multiple threads call {@code write()} on the singleton.
  */
+@NullMarked
 final class EmptyAuthInfo extends AuthInfo {
 
   private static final EmptyAuthInfo INSTANCE = new EmptyAuthInfo();
@@ -29,8 +31,8 @@ final class EmptyAuthInfo extends AuthInfo {
   private EmptyAuthInfo() {
     super();
     length = super.getLength();
-    // Cannot use super.toDirectBuffer() because it calls write(buffer, 0) which dispatches
-    // to our override, but cachedBuffer is still null. Use super.write() directly instead.
+    // must use super.write() directly: any helper going through write(buffer, 0) would dispatch to
+    // our override, and cachedBuffer is still null at this point.
     final var bytes = new byte[length];
     final var buf = new UnsafeBuffer(bytes);
     super.write(buf, 0);
@@ -45,11 +47,6 @@ final class EmptyAuthInfo extends AuthInfo {
   @Override
   public int getLength() {
     return length;
-  }
-
-  @Override
-  public DirectBuffer toDirectBuffer() {
-    return cachedBuffer;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -247,9 +247,17 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         .valueType(valueType)
         .intent(intent.value())
         .channelType(channelType)
-        .putValue(value, 0, value.capacity())
-        .putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength())
-        .putToolName(toolName, 0, toolName.capacity());
+        .putValue(value, 0, value.capacity());
+
+    // breaks the chain: variable-length fields must be written in schema order, and the encoder
+    // itself is needed to serialize the authorization in place
+    BufferUtil.writeLengthPrefixed(
+        authorization,
+        bodyEncoder,
+        ExecuteCommandRequestEncoder.authorizationHeaderLength(),
+        ExecuteCommandRequestEncoder.BYTE_ORDER);
+
+    bodyEncoder.putToolName(toolName, 0, toolName.capacity());
 
     return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -126,7 +126,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       if (authorization.isFrozen()) {
         authorization = new AuthInfo();
       }
-      authorization.wrap(authBuffer);
+      // the decoded buffer is only a view over memory owned by the caller (a journal segment or an
+      // inter-partition message). Freezing lets the instance be shared by reference, outliving that
+      // memory, so we must take ownership of the bytes first. One copy here replaces the per-
+      // assignment copy that AuthInfo.of() would otherwise do for every follow-up record.
+      authorization.wrap(BufferUtil.cloneBuffer(authBuffer));
       authorization.freeze();
     } else {
       decoder.skipAuthorization();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -49,7 +49,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private long requestId;
   private short intentValue = Intent.NULL_VAL;
   private int requestStreamId;
-  private final AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization = AuthInfo.empty();
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private AgentInfo agent;
@@ -123,6 +123,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     if (authorizationLength > 0) {
       final DirectBuffer authBuffer = new UnsafeBuffer();
       decoder.wrapAuthorization(authBuffer);
+      if (authorization.isFrozen()) {
+        authorization = new AuthInfo();
+      }
       authorization.wrap(authBuffer);
     } else {
       decoder.skipAuthorization();
@@ -286,13 +289,26 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata authorization(final AuthInfo authorization) {
-    this.authorization.copyFrom(authorization);
+    this.authorization = AuthInfo.of(authorization);
     return this;
   }
 
   public RecordMetadata authorization(final DirectBuffer buffer) {
-    authorization.wrap(buffer);
+    authorization(buffer, 0, buffer.capacity());
     return this;
+  }
+
+  public RecordMetadata authorization(
+      final DirectBuffer buffer, final int offset, final int length) {
+    if (authorization.isFrozen()) {
+      authorization = new AuthInfo();
+    }
+    authorization.wrap(buffer, offset, length);
+    return this;
+  }
+
+  public void emptyAuthorization() {
+    authorization = AuthInfo.empty();
   }
 
   public AuthInfo getAuthorization() {
@@ -383,7 +399,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
-    authorization.reset();
+    authorization = AuthInfo.empty();
     agent = null;
     requestChannelType = ChannelType.NULL_VAL;
     requestToolName.wrap(0, 0);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -127,6 +127,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         authorization = new AuthInfo();
       }
       authorization.wrap(authBuffer);
+      authorization.freeze();
     } else {
       decoder.skipAuthorization();
     }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -55,7 +55,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
    * Cached JSON representation of the value. Lazily computed on first call to {@link #getValue()}
    * and invalidated when the underlying value changes via {@link #setValue} or {@link #wrap}.
    */
-  private String cachedJsonValue;
+  private transient String cachedJsonValue;
 
   public VariableRecord() {
     super(9);

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -168,6 +168,27 @@ final class AuthInfoTest {
     }
 
     @Test
+    void shouldReturnEmptyWhenOfClaimsCalledWithNull() {
+      assertThat(AuthInfo.ofClaims(null)).isSameAs(AuthInfo.empty());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenOfClaimsCalledWithEmptyMap() {
+      assertThat(AuthInfo.ofClaims(Map.of())).isSameAs(AuthInfo.empty());
+    }
+
+    @Test
+    void shouldReturnFrozenAuthInfoWithClaims() {
+      final Map<String, Object> claims = Map.of("user", "admin", "role", "operator");
+
+      final AuthInfo result = AuthInfo.ofClaims(claims);
+
+      assertThat(result.isFrozen()).isTrue();
+      assertThat(result.getClaims()).isEqualTo(claims);
+      assertThat(result.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.UNKNOWN);
+    }
+
+    @Test
     void shouldCopyAuthInfoWhenOfCalledWithNonNull() {
       // given
       final AuthInfo original = new AuthInfo();

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.zeebe.protocol.impl;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -181,6 +184,199 @@ final class AuthInfoTest {
       assertThat(copy.getFormat()).isEqualTo(original.getFormat());
       assertThat(copy.getAuthData()).isEqualTo(original.getAuthData());
       assertThat(copy.getClaims()).isEqualTo(original.getClaims());
+      assertThat(copy.isFrozen()).isTrue();
+    }
+  }
+
+  @Nested
+  class FreezeTests {
+
+    @Test
+    void shouldRejectResetWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.freeze();
+
+      assertThatThrownBy(authInfo::reset).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldRejectWrapWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.freeze();
+      final var buffer = new UnsafeBuffer(new byte[10]);
+
+      assertThatThrownBy(() -> authInfo.wrap(buffer, 0, buffer.capacity()))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldRejectSetFormatWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.freeze();
+
+      assertThatThrownBy(() -> authInfo.setFormat(AuthInfo.AuthDataFormat.JWT))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldRejectSetAuthDataWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.freeze();
+
+      assertThatThrownBy(() -> authInfo.setAuthData("token"))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldRejectSetClaimsMapWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.freeze();
+
+      assertThatThrownBy(() -> authInfo.setClaims(Map.of("k", "v")))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldRejectSetClaimsBufferWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.freeze();
+
+      assertThatThrownBy(() -> authInfo.setClaims(new UnsafeBuffer(new byte[0])))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldAllowGettersWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+      authInfo.setClaims(Map.of("key", "value"));
+      authInfo.freeze();
+
+      assertThat(authInfo.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+      assertThat(authInfo.getAuthData()).isEqualTo("");
+      assertThat(authInfo.getClaims()).isEqualTo(Map.of("key", "value"));
+    }
+
+    @Test
+    void shouldAllowWriteWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setClaims(Map.of("key", "value"));
+      authInfo.freeze();
+
+      final var buffer = new UnsafeBuffer(new byte[authInfo.getLength()]);
+      authInfo.write(buffer, 0);
+
+      assertThat(buffer.capacity()).isGreaterThan(0);
+    }
+
+    @Test
+    void shouldCacheToDecodedMapWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+      authInfo.setClaims(Map.of("key", "value"));
+      authInfo.freeze();
+
+      final var first = authInfo.toDecodedMap();
+      final var second = authInfo.toDecodedMap();
+
+      assertThat(first).isSameAs(second);
+    }
+
+    @Test
+    void shouldNotCacheToDecodedMapWhenNotFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+      authInfo.setClaims(Map.of("key", "value"));
+
+      final var first = authInfo.toDecodedMap();
+      final var second = authInfo.toDecodedMap();
+
+      assertThat(first).isNotSameAs(second);
+      assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void shouldFreezeOnCopyViaOf() {
+      final AuthInfo original = new AuthInfo();
+      original.setClaims(Map.of("key", "value"));
+
+      final AuthInfo copy = AuthInfo.of(original);
+
+      assertThat(copy.isFrozen()).isTrue();
+      assertThat(original.isFrozen()).isFalse();
+    }
+  }
+
+  @Nested
+  class EmptyAuthInfoTests {
+    @Test
+    void shouldThrowOnWrap() {
+      final var empty = AuthInfo.empty();
+      final var buffer = new UnsafeBuffer(new byte[0]);
+
+      assertThatThrownBy(() -> empty.wrap(buffer, 0, 0))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldThrowOnReset() {
+      final var empty = AuthInfo.empty();
+
+      assertThatThrownBy(empty::reset).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldReturnEmptyClaims() {
+      final var empty = AuthInfo.empty();
+
+      assertThat(empty.toDecodedMap()).isEmpty();
+      assertThat(empty.hasAnyClaims()).isFalse();
+    }
+
+    @Test
+    void shouldSerializeIdenticallyToNewAuthInfo() {
+      final var empty = AuthInfo.empty();
+      final var regular = new AuthInfo();
+
+      assertThat(empty.getLength()).isEqualTo(regular.getLength());
+      assertThat(empty.toDirectBuffer()).isEqualTo(regular.toDirectBuffer());
+    }
+
+    @Test
+    void shouldWriteCorrectlyUnderConcurrentAccess() throws Exception {
+      // given — expected bytes from a single-threaded write
+      final var empty = AuthInfo.empty();
+      final var expected = new UnsafeBuffer(new byte[empty.getLength()]);
+      empty.write(expected, 0);
+
+      final int threads = 8;
+      final int iterations = 1_000;
+      final var errors = new AtomicInteger(0);
+      final var latch = new CountDownLatch(threads);
+
+      // when — write concurrently from multiple threads
+      for (int t = 0; t < threads; t++) {
+        new Thread(
+                () -> {
+                  try {
+                    for (int i = 0; i < iterations; i++) {
+                      final var buf = new UnsafeBuffer(new byte[empty.getLength()]);
+                      empty.write(buf, 0);
+                      if (!buf.equals(expected)) {
+                        errors.incrementAndGet();
+                      }
+                    }
+                  } finally {
+                    latch.countDown();
+                  }
+                })
+            .start();
+      }
+
+      latch.await();
+
+      // then — no corrupted writes
+      assertThat(errors.get()).isZero();
     }
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -305,6 +305,45 @@ final class AuthInfoTest {
       assertThat(copy.isFrozen()).isTrue();
       assertThat(original.isFrozen()).isFalse();
     }
+
+    @Test
+    void shouldCacheLengthWhenFrozen() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setClaims(Map.of("key", "value"));
+
+      final int lengthBeforeFreeze = authInfo.getLength();
+      authInfo.freeze();
+
+      // calling getLength() multiple times should return the same cached value
+      assertThat(authInfo.getLength()).isEqualTo(lengthBeforeFreeze);
+      assertThat(authInfo.getLength()).isEqualTo(lengthBeforeFreeze);
+    }
+
+    @Test
+    void shouldCacheLengthConsistentWithWrite() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
+      authInfo.setAuthData("some-token");
+      authInfo.setClaims(Map.of("a", "b", "c", "d"));
+      authInfo.freeze();
+
+      final int length = authInfo.getLength();
+      final var buffer = new UnsafeBuffer(new byte[length]);
+      final int written = authInfo.write(buffer, 0);
+      final var bb = authInfo.toDirectBuffer();
+
+      assertThat(bb.capacity()).isEqualTo(length);
+      assertThat(written).isEqualTo(length);
+    }
+
+    @Test
+    void shouldCacheLengthForEmptyFrozenAuthInfo() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.freeze();
+
+      assertThat(authInfo.getLength()).isEqualTo(new AuthInfo().getLength());
+      assertThat(authInfo.getLength()).isEqualTo(AuthInfo.empty().getLength());
+    }
   }
 
   @Nested

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -376,9 +377,7 @@ final class AuthInfoTest {
       final int length = authInfo.getLength();
       final var buffer = new UnsafeBuffer(new byte[length]);
       final int written = authInfo.write(buffer, 0);
-      final var bb = authInfo.toDirectBuffer();
 
-      assertThat(bb.capacity()).isEqualTo(length);
       assertThat(written).isEqualTo(length);
     }
 
@@ -424,7 +423,7 @@ final class AuthInfoTest {
       final var regular = new AuthInfo();
 
       assertThat(empty.getLength()).isEqualTo(regular.getLength());
-      assertThat(empty.toDirectBuffer()).isEqualTo(regular.toDirectBuffer());
+      assertThat(BufferUtil.createCopy(empty)).isEqualTo(BufferUtil.createCopy(regular));
     }
 
     @Test

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -161,15 +161,6 @@ final class AuthInfoTest {
   @Nested
   class OfTests {
     @Test
-    void shouldReturnNullWhenOfCalledWithNull() {
-      // when
-      final AuthInfo result = AuthInfo.of(null);
-
-      // then
-      assertThat(result).isNull();
-    }
-
-    @Test
     void shouldReturnEmptyWhenOfClaimsCalledWithNull() {
       assertThat(AuthInfo.ofClaims(null)).isSameAs(AuthInfo.empty());
     }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -178,6 +179,17 @@ final class AuthInfoTest {
     }
 
     @Test
+    void shouldAcceptNullClaimValueInOfClaims() {
+      // claims decoded from msgpack can carry a nil value, which becomes a Java null
+      final Map<String, Object> claims = new HashMap<>();
+      claims.put("user", null);
+
+      final AuthInfo result = AuthInfo.ofClaims(claims);
+
+      assertThat(result.getClaims()).containsEntry("user", null);
+    }
+
+    @Test
     void shouldReturnFrozenAuthInfoWithClaims() {
       final Map<String, Object> claims = Map.of("user", "admin", "role", "operator");
 
@@ -314,6 +326,19 @@ final class AuthInfoTest {
 
       assertThat(first).isNotSameAs(second);
       assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void shouldRejectMutationOfCachedDecodedMap() {
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+      authInfo.setClaims(Map.of("key", "value"));
+      authInfo.freeze();
+
+      final var claims = authInfo.toDecodedMap();
+
+      assertThatThrownBy(() -> claims.put("key", "other"))
+          .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
@@ -63,6 +63,29 @@ final class RecordMetadataTest {
     assertThat(storedAuth.getClaims()).isEqualTo(Map.of("key", "value"));
   }
 
+  @Test
+  void shouldOwnAuthInfoBufferAfterWrap() {
+    // given -- encoded metadata carrying an authorization
+    final var source = new RecordMetadata();
+    final var authInfo = new AuthInfo();
+    authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+    authInfo.setClaims(Map.of("key", "value"));
+    source.authorization(authInfo);
+    final var buffer = new UnsafeBuffer(new byte[source.getLength()]);
+    source.write(buffer, 0);
+
+    final var metadata = new RecordMetadata();
+    metadata.wrap(buffer, 0, buffer.capacity());
+
+    // when -- the memory the metadata was decoded from is recycled
+    buffer.setMemory(0, buffer.capacity(), (byte) 0);
+
+    // then -- the wrapped authorization is unaffected, so it is safe to share by reference
+    final var storedAuth = metadata.getAuthorization();
+    assertThat(storedAuth.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+    assertThat(storedAuth.getClaims()).isEqualTo(Map.of("key", "value"));
+  }
+
   private void encodeDecode(final RecordMetadata metadata) {
     // encode
     final UnsafeBuffer buffer = new UnsafeBuffer(new byte[metadata.getLength()]);

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/RecordGoldenFilesTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/RecordGoldenFilesTest.java
@@ -39,14 +39,25 @@ public class RecordGoldenFilesTest {
   private static final String RECORD_COMPONENTS_TEMPLATE = "record\\s+%s\\s*\\(([^)]*)\\)";
   private static final String NULL_CHECK_TEMPLATE = "if\\s*\\(\\s*%s\\s*==\\s*null\\s*\\)";
 
-  // FIELD_DECLARATION_PATTERN matches declarations such as:
+  // FIELD_DECLARATION_PATTERN matches private instance field declarations, both final and
+  // non-final.
+  // Fields marked `transient` or `static` are excluded — use the `transient` keyword to opt out
+  // of golden-file tracking for caching or internal bookkeeping fields.
+  //
+  // Examples of matched declarations:
   //     private final List<String> names = new ArrayList<>();
   //     private final int count;
-  //     private final SomeType<?>[] values = new SomeType[0];
+  //     private AuthInfo authorization = AuthInfo.empty();
+  //     private AgentInfo agent;
   //     private final @Nullable Map<String, Integer> map;
+  //
+  // Examples of excluded declarations:
+  //     private transient boolean frozen;       (transient — internal state)
+  //     private transient int cachedLength;      (transient — cached value)
+  //     private static final int CONST = 1;      (static — class-level constant)
   private static final Pattern FIELD_DECLARATION_PATTERN =
       Pattern.compile(
-          "private\\s+final\\s+([\\w<>,?\\s.\\[\\]@]+?)\\s+(\\w+)\\s*(=\\s*[^;]+)?;",
+          "private\\s+(?:final\\s+)?(?!static\\s|transient\\s)([\\w<>,?\\s.\\[\\]@]+?)\\s+(\\w+)\\s*(=\\s*[^;]+)?;",
           Pattern.DOTALL);
 
   // PROPERTY_CTOR_PATTERN matches constructor expressions such as:
@@ -300,6 +311,9 @@ public class RecordGoldenFilesTest {
 
         3) Golden file is missing for a new record:
            - Create the golden file after careful review.
+
+        4) You added a field that should NOT be tracked (e.g. caching, internal state):
+           - Mark it `transient`. Transient and static fields are excluded from tracking.
 
         To update the golden file, use the command printed by the test logs (see
         printGoldenFileCommand) to copy or create the golden file. Always double-check

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
@@ -49,7 +49,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private long requestId;
   private short intentValue = Intent.NULL_VAL;
   private int requestStreamId;
-  private final AuthInfo authorization = new AuthInfo();
+  private AuthInfo authorization = AuthInfo.empty();
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private AgentInfo agent;
@@ -123,6 +123,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     if (authorizationLength > 0) {
       final DirectBuffer authBuffer = new UnsafeBuffer();
       decoder.wrapAuthorization(authBuffer);
+      if (authorization.isFrozen()) {
+        authorization = new AuthInfo();
+      }
       authorization.wrap(authBuffer);
     } else {
       decoder.skipAuthorization();
@@ -286,13 +289,26 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata authorization(final AuthInfo authorization) {
-    this.authorization.copyFrom(authorization);
+    this.authorization = AuthInfo.of(authorization);
     return this;
   }
 
   public RecordMetadata authorization(final DirectBuffer buffer) {
-    authorization.wrap(buffer);
+    authorization(buffer, 0, buffer.capacity());
     return this;
+  }
+
+  public RecordMetadata authorization(
+      final DirectBuffer buffer, final int offset, final int length) {
+    if (authorization.isFrozen()) {
+      authorization = new AuthInfo();
+    }
+    authorization.wrap(buffer, offset, length);
+    return this;
+  }
+
+  public void emptyAuthorization() {
+    authorization = AuthInfo.empty();
   }
 
   public AuthInfo getAuthorization() {
@@ -383,7 +399,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
-    authorization.reset();
+    authorization = AuthInfo.empty();
     agent = null;
     requestChannelType = ChannelType.NULL_VAL;
     requestToolName.wrap(0, 0);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
@@ -46,7 +46,7 @@ public record FollowUpCommandMetadata(
     }
 
     public Builder claims(final Map<String, Object> claims) {
-      authInfo = new AuthInfo().setClaims(claims).freeze();
+      authInfo = AuthInfo.ofClaims(claims);
       return this;
     }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
@@ -28,7 +28,7 @@ public record FollowUpCommandMetadata(
   public static class Builder {
     private long operationReference = RecordMetadataDecoder.operationReferenceNullValue();
     private long batchOperationReference = RecordMetadataDecoder.batchOperationReferenceNullValue();
-    private final AuthInfo authInfo = new AuthInfo();
+    private AuthInfo authInfo = AuthInfo.empty();
 
     public Builder operationReference(final long operationReference) {
       this.operationReference = operationReference;
@@ -41,12 +41,12 @@ public record FollowUpCommandMetadata(
     }
 
     public Builder authInfo(final AuthInfo authInfo) {
-      this.authInfo.copyFrom(authInfo);
+      this.authInfo = AuthInfo.of(authInfo);
       return this;
     }
 
     public Builder claims(final Map<String, Object> claims) {
-      authInfo.setClaims(claims);
+      authInfo = new AuthInfo().setClaims(claims).freeze();
       return this;
     }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -43,7 +43,8 @@ public interface ProcessingSession {
 
   default void appendAuthInfoToFollowUps(final @Nullable AuthInfo authInfo) {
     if (authInfo != null && authInfo.hasAnyClaims()) {
-      // no explicit copy needed: RecordMetadata.authorization() already copies via copyFrom()
+      // no explicit copy needed: a frozen AuthInfo owns its buffer and is safe to share by
+      // reference; an unfrozen one is copied by RecordMetadata.authorization()
       appendMetadataToFollowUps(metadata -> metadata.authorization(authInfo));
     }
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -103,7 +103,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
             .valueType(valueType);
 
     metadataDecorators.forEach(m -> m.accept(metadata));
-    metadata.getAuthorization().reset(); // don't expose the authorization data in the response
+    metadata.emptyAuthorization(); // don't expose the authorization data in the response
 
     final var entry = RecordBatchEntry.createEntry(key, metadata, -1, value);
     processingResponse = new ProcessingResponseImpl(entry, requestId, requestStreamId);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/CopiedRecords.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/CopiedRecords.java
@@ -32,6 +32,7 @@ public final class CopiedRecords {
 
     final RecordMetadata metadata = new RecordMetadata();
     metadata.wrap(metadataBuffer, 0, metadataBuffer.capacity());
+    metadata.getAuthorization().freeze();
 
     final byte[] valueBytes = new byte[rawEvent.getValueLength()];
     contentBuffer.getBytes(rawEvent.getValueOffset(), valueBytes);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/CopiedRecords.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/CopiedRecords.java
@@ -32,7 +32,6 @@ public final class CopiedRecords {
 
     final RecordMetadata metadata = new RecordMetadata();
     metadata.wrap(metadataBuffer, 0, metadataBuffer.capacity());
-    metadata.getAuthorization().freeze();
 
     final byte[] valueBytes = new byte[rawEvent.getValueLength()];
     contentBuffer.getBytes(rawEvent.getValueOffset(), valueBytes);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -26,8 +26,10 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.StringUtil;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
   private final int partitionId;
   private @Nullable LoggedEvent rawEvent;


### PR DESCRIPTION
## Description
Freezing an AuthInfo instance makes it immutable after it's been constructed an immutable copy of the underlying buffer has been made. This allows to cache `claims` and avoids copying the buffer a reference can be taken instead.

This is particularly interesting because in `FollowUpCommandMetadata` we were taking copies of `AuthInfo` for every appended record, which was visible in the profile. 

For example in `JobCompleteProcess.processRecord`

### Before ~11.19% (from daily benchmark [here](https://github.com/camunda/camunda/actions/runs/22944796853))
<img width="2864" height="1060" alt="image" src="https://github.com/user-attachments/assets/cd6c9a50-04ac-48d0-b38c-0d55b04fbbae" />

### After  ~ 1.7% 
See last profiler in this PR
<img width="2347" height="1068" alt="image" src="https://github.com/user-attachments/assets/3133aa85-13c4-4e57-babd-8331e570ad86" />

There's is still some overhead by calling `getClaims` once for `getAuthorizedTenants` which we were not sure if it was safe to remove, so that one has to remain unfortunately. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46873
