### PR TITLE
fix: remove -Dmaven.test.skip=true from load test build workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -263,7 +263,7 @@ jobs:
         name: Build Zeebe
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
+          maven-extra-args: -PskipFrontendBuild -P\!include-optimize
       - uses: ./.github/actions/build-platform-docker
         name: Build Zeebe Docker Image
         with:


### PR DESCRIPTION
## Summary

Fixes the load test build workflow on 8.7 by removing `-Dmaven.test.skip=true` from the `build-zeebe-image` job's maven extra args.

**Root cause:** The `zeebe-snapshots` module depends on `zeebe-scheduler:test-jar` (test scope). Using `-Dmaven.test.skip=true` prevents test jars from being compiled entirely, so the dependency cannot be resolved and the build fails with:

```
Could not resolve dependencies for project io.camunda:zeebe-snapshots
  dependency: io.camunda:zeebe-scheduler:jar:tests:8.6.39-SNAPSHOT (test)
  Could not find artifact io.camunda:zeebe-scheduler:jar:tests
```

The `build-zeebe` action already passes `-DskipTests`, which skips *running* tests but still *compiles* them (including test jars). The additional `-Dmaven.test.skip=true` was both redundant and harmful.

**Related PRs:** #48089 (same fix on 8.6), #48088 (original 8.7 load test backport, already merged)

## Test plan

- [x] Verify `build-zeebe` action already includes `-DskipTests` (confirmed in `.github/actions/build-zeebe/action.yml`)
- [ ] Verify PR benchmark build succeeds after this fix (apply `benchmark` label to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)