### PR TITLE
Rocksdb: Improve start up validation.

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -81,6 +81,9 @@ public class RocksDbSharedCache {
       // for strategies other than FRACTION which are static sizes, we check if maxMemoryFraction is
       // correctly set, and if so, we validate the allocated memory does not go above the threshold.
       validateMaxMemoryFraction(rocksdbCfg, totalMemorySize, blockCacheBytes);
+      // validate that the allocated memory does not exceed total system memory.
+      validateMemoryDoesNotExceedSystemMemory(
+          rocksdbCfg, totalMemorySize, blockCacheBytes, partitionsCount);
     }
 
     // validate that each partition has at least the minimum required memory
@@ -119,6 +122,36 @@ public class RocksDbSharedCache {
               "Expected the allocated memory for RocksDB to be below or "
                   + "equal %.2f %% of ram memory, but was %.2f %%.",
               maxMemoryFraction * 100, ((double) blockCacheBytes / totalMemorySize * 100)));
+    }
+  }
+
+  static void validateMemoryDoesNotExceedSystemMemory(
+      final RocksdbCfg rocksdbCfg,
+      final long totalMemorySize,
+      final long blockCacheBytes,
+      final int partitionsCount) {
+    if (blockCacheBytes > totalMemorySize) {
+      final String configHint =
+          switch (rocksdbCfg.getMemoryAllocationStrategy()) {
+            case BROKER ->
+                "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.";
+            case PARTITION ->
+                "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT or the number of partitions.";
+            case FRACTION ->
+                throw new IllegalStateException(
+                    "Unexpected value: FRACTION should be within [0,1]");
+          };
+      throw new IllegalArgumentException(
+          String.format(
+              "Requested RocksDB memory (%d bytes / %d MB) exceeds total system memory (%d bytes / %d MB). "
+                  + "Memory allocation strategy: %s. Partitions count: %d. %s",
+              blockCacheBytes,
+              blockCacheBytes / (1024 * 1024),
+              totalMemorySize,
+              totalMemorySize / (1024 * 1024),
+              rocksdbCfg.getMemoryAllocationStrategy(),
+              partitionsCount,
+              configHint));
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -133,10 +133,8 @@ public class RocksDbSharedCache {
     if (blockCacheBytes > totalMemorySize) {
       final String configHint =
           switch (rocksdbCfg.getMemoryAllocationStrategy()) {
-            case BROKER ->
+            case BROKER, PARTITION ->
                 "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.";
-            case PARTITION ->
-                "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT or the number of partitions.";
             case FRACTION ->
                 throw new IllegalStateException(
                     "Unexpected value: FRACTION should be within [0,1]");

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -29,11 +29,18 @@ public class RocksDbSharedCache {
     final var rocksdbCfg = brokerCfg.getExperimental().getRocksdb();
     final long blockCacheBytes = getBlockCacheBytes(rocksdbCfg, partitionsCount);
     final var memoryAllocationStrategy = rocksdbCfg.getMemoryAllocationStrategy();
+    final long totalMemorySize =
+        ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
 
-    LOGGER.debug(
-        "Allocating {} bytes for RocksDB, with memory allocation strategy: {}",
+    LOGGER.info(
+        "Allocating {} bytes ({} MB) for RocksDB block cache, with memory allocation strategy: {}. "
+            + "Total system memory: {} bytes ({} MB). Partitions count: {}",
         blockCacheBytes,
-        memoryAllocationStrategy);
+        blockCacheBytes / (1024 * 1024),
+        memoryAllocationStrategy,
+        totalMemorySize,
+        totalMemorySize / (1024 * 1024),
+        partitionsCount);
 
     RocksDbSharedCacheMetrics.registerAllocationStrategy(meterRegistry, memoryAllocationStrategy);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -360,97 +360,62 @@ class RocksDbSharedCacheTest {
             0.0);
   }
 
-  @Test
-  void shouldThrowIfRequestedMemoryExceedsTotalSystemMemory() {
-    // given - configure 512MB for RocksDB with only 256MB total system memory
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryLimit(DataSize.ofBytes(512L * 1024 * 1024)); // 512MB
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
-
-    // when/then
-    try (final var ignored = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB total
-      final var throwable =
-          catchThrowable(
-              () ->
-                  RocksDbSharedCache.validateRocksDbMemory(
-                      brokerCfg.getExperimental().getRocksdb(), DEFAULT_PARTITION_COUNT));
-
-      assertThat(throwable)
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("Requested RocksDB memory")
-          .hasMessageContaining("exceeds total system memory")
-          .hasMessageContaining("512 MB")
-          .hasMessageContaining("256 MB")
-          .hasMessageContaining("PARTITION")
-          .hasMessageContaining(
-              "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT");
-    }
+  static Stream<Arguments> provideExceedsTotalSystemMemoryScenarios() {
+    return Stream.of(
+        // 512MB limit with PARTITION strategy, 1 partition, 256MB total system memory
+        Arguments.of(
+            512L * 1024 * 1024,
+            MemoryAllocationStrategy.PARTITION,
+            1,
+            256L * 1024 * 1024,
+            new String[] {"512 MB", "256 MB", "PARTITION"}),
+        // 512MB limit with BROKER strategy, 1 partition, 256MB total system memory
+        Arguments.of(
+            512L * 1024 * 1024,
+            MemoryAllocationStrategy.BROKER,
+            1,
+            256L * 1024 * 1024,
+            new String[] {"BROKER"}),
+        // 128MB per partition with 4 partitions = 512MB, 256MB total system memory
+        Arguments.of(
+            128L * 1024 * 1024,
+            MemoryAllocationStrategy.PARTITION,
+            4,
+            256L * 1024 * 1024,
+            new String[] {"512 MB", "256 MB", "Partitions count: 4"}));
   }
 
-  @Test
-  void shouldThrowIfRequestedMemoryExceedsTotalSystemMemoryWithBrokerStrategy() {
-    // given - configure 512MB for RocksDB with only 256MB total system memory using BROKER strategy
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryLimit(DataSize.ofBytes(512L * 1024 * 1024)); // 512MB
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryAllocationStrategy(MemoryAllocationStrategy.BROKER);
+  @ParameterizedTest
+  @MethodSource("provideExceedsTotalSystemMemoryScenarios")
+  void shouldThrowIfRequestedMemoryExceedsTotalSystemMemory(
+      final long memoryLimitBytes,
+      final MemoryAllocationStrategy strategy,
+      final int partitionsCount,
+      final long totalSystemMemory,
+      final String[] expectedMessageParts) {
+    // given
+    brokerCfg.getExperimental().getRocksdb().setMemoryLimit(DataSize.ofBytes(memoryLimitBytes));
+    brokerCfg.getExperimental().getRocksdb().setMemoryAllocationStrategy(strategy);
 
     // when/then
-    try (final var ignored = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB total
-      final var throwable =
-          catchThrowable(
-              () ->
-                  RocksDbSharedCache.validateRocksDbMemory(
-                      brokerCfg.getExperimental().getRocksdb(), DEFAULT_PARTITION_COUNT));
-
-      assertThat(throwable)
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("Requested RocksDB memory")
-          .hasMessageContaining("exceeds total system memory")
-          .hasMessageContaining("BROKER")
-          .hasMessageContaining(
-              "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT");
-    }
-  }
-
-  @Test
-  void shouldThrowIfRequestedMemoryExceedsTotalSystemMemoryWithMultiplePartitions() {
-    // given - configure 128MB per partition with 4 partitions = 512MB, but only 256MB total
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryLimit(DataSize.ofBytes(128L * 1024 * 1024)); // 128MB per partition
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
-    final int partitionsCount = 4;
-
-    // when/then
-    try (final var ignored = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB total
+    try (final var ignored = mockMemoryEnvironment(totalSystemMemory)) {
       final var throwable =
           catchThrowable(
               () ->
                   RocksDbSharedCache.validateRocksDbMemory(
                       brokerCfg.getExperimental().getRocksdb(), partitionsCount));
 
-      assertThat(throwable)
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("Requested RocksDB memory")
-          .hasMessageContaining("exceeds total system memory")
-          .hasMessageContaining("512 MB") // 128MB * 4 partitions
-          .hasMessageContaining("256 MB")
-          .hasMessageContaining("Partitions count: 4")
-          .hasMessageContaining("or the number of partitions");
+      var assertion =
+          assertThat(throwable)
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessageContaining("Requested RocksDB memory")
+              .hasMessageContaining("exceeds total system memory")
+              .hasMessageContaining(
+                  "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT");
+
+      for (final String part : expectedMessageParts) {
+        assertion = assertion.hasMessageContaining(part);
+      }
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -359,4 +359,98 @@ class RocksDbSharedCacheTest {
             "Expected the memoryFraction for RocksDB FRACTION memory allocation strategy to be between 0 and 1, but was %s.",
             0.0);
   }
+
+  @Test
+  void shouldThrowIfRequestedMemoryExceedsTotalSystemMemory() {
+    // given - configure 512MB for RocksDB with only 256MB total system memory
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryLimit(DataSize.ofBytes(512L * 1024 * 1024)); // 512MB
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
+
+    // when/then
+    try (final var ignored = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB total
+      final var throwable =
+          catchThrowable(
+              () ->
+                  RocksDbSharedCache.validateRocksDbMemory(
+                      brokerCfg.getExperimental().getRocksdb(), DEFAULT_PARTITION_COUNT));
+
+      assertThat(throwable)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Requested RocksDB memory")
+          .hasMessageContaining("exceeds total system memory")
+          .hasMessageContaining("512 MB")
+          .hasMessageContaining("256 MB")
+          .hasMessageContaining("PARTITION")
+          .hasMessageContaining(
+              "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT");
+    }
+  }
+
+  @Test
+  void shouldThrowIfRequestedMemoryExceedsTotalSystemMemoryWithBrokerStrategy() {
+    // given - configure 512MB for RocksDB with only 256MB total system memory using BROKER strategy
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryLimit(DataSize.ofBytes(512L * 1024 * 1024)); // 512MB
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.BROKER);
+
+    // when/then
+    try (final var ignored = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB total
+      final var throwable =
+          catchThrowable(
+              () ->
+                  RocksDbSharedCache.validateRocksDbMemory(
+                      brokerCfg.getExperimental().getRocksdb(), DEFAULT_PARTITION_COUNT));
+
+      assertThat(throwable)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Requested RocksDB memory")
+          .hasMessageContaining("exceeds total system memory")
+          .hasMessageContaining("BROKER")
+          .hasMessageContaining(
+              "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT");
+    }
+  }
+
+  @Test
+  void shouldThrowIfRequestedMemoryExceedsTotalSystemMemoryWithMultiplePartitions() {
+    // given - configure 128MB per partition with 4 partitions = 512MB, but only 256MB total
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryLimit(DataSize.ofBytes(128L * 1024 * 1024)); // 128MB per partition
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
+    final int partitionsCount = 4;
+
+    // when/then
+    try (final var ignored = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB total
+      final var throwable =
+          catchThrowable(
+              () ->
+                  RocksDbSharedCache.validateRocksDbMemory(
+                      brokerCfg.getExperimental().getRocksdb(), partitionsCount));
+
+      assertThat(throwable)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Requested RocksDB memory")
+          .hasMessageContaining("exceeds total system memory")
+          .hasMessageContaining("512 MB") // 128MB * 4 partitions
+          .hasMessageContaining("256 MB")
+          .hasMessageContaining("Partitions count: 4")
+          .hasMessageContaining("or the number of partitions");
+    }
+  }
 }


### PR DESCRIPTION
## Description

Log improvement, now we can see what the total RAM was, and add validation at startup that we don't exceed the total RAM.

Related with this issue found in [saas int](https://github.com/camunda/camunda/issues/46626).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/46626
