### PR TITLE
feat: expose process name from zeebe gateway

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -489,7 +489,8 @@ public final class ResponseMapper {
                     .processDefinitionVersion(process.getVersion())
                     .processDefinitionKey(KeyUtil.keyToString(process.getProcessDefinitionKey()))
                     .tenantId(process.getTenantId())
-                    .resourceName(process.getResourceName()))
+                    .resourceName(process.getResourceName())
+                    .processName(process.getProcessName()))
         .map(
             deploymentProcess ->
                 new DeploymentMetadataResult().processDefinition(deploymentProcess))

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -490,7 +490,7 @@ public final class ResponseMapper {
                     .processDefinitionKey(KeyUtil.keyToString(process.getProcessDefinitionKey()))
                     .tenantId(process.getTenantId())
                     .resourceName(process.getResourceName())
-                    .processName(process.getProcessName()))
+                    .name(process.getName()))
         .map(
             deploymentProcess ->
                 new DeploymentMetadataResult().processDefinition(deploymentProcess))

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
@@ -24,7 +24,7 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
   private String bpmnProcessId;
   private String tenantId;
   private String versionTag;
-  private String processName;
+  private String name;
 
   public ZeebeProcessDefinitionDataDto() {}
 
@@ -77,8 +77,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
     return this.versionTag;
   }
 
-  public String getProcessName() {
-    return this.processName;
+  public String getName() {
+    return this.name;
   }
 
   public void setResource(final byte[] resource) {
@@ -113,8 +113,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
     this.versionTag = versionTag;
   }
 
-  public void setProcessName(final String processName) {
-    this.processName = processName;
+  public void setName(final String name) {
+    this.name = name;
   }
 
   public String toString() {
@@ -134,8 +134,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         + this.getTenantId()
         + ", versionTag="
         + this.getVersionTag()
-        + ", processName="
-        + this.getProcessName()
+        + ", name="
+        + this.getName()
         + ")";
   }
 
@@ -153,7 +153,7 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(versionTag, that.versionTag)
-        && Objects.equals(processName, that.processName);
+        && Objects.equals(name, that.name);
   }
 
   @Override
@@ -167,7 +167,7 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         bpmnProcessId,
         tenantId,
         versionTag,
-        processName);
+        name);
   }
 
   protected boolean canEqual(final Object other) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
@@ -24,6 +24,7 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
   private String bpmnProcessId;
   private String tenantId;
   private String versionTag;
+  private String processName;
 
   public ZeebeProcessDefinitionDataDto() {}
 
@@ -76,6 +77,10 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
     return this.versionTag;
   }
 
+  public String getProcessName() {
+    return this.processName;
+  }
+
   public void setResource(final byte[] resource) {
     this.resource = resource;
   }
@@ -108,6 +113,10 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
     this.versionTag = versionTag;
   }
 
+  public void setProcessName(final String processName) {
+    this.processName = processName;
+  }
+
   public String toString() {
     return "ZeebeProcessDefinitionDataDto(resource="
         + java.util.Arrays.toString(this.getResource())
@@ -125,6 +134,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         + this.getTenantId()
         + ", versionTag="
         + this.getVersionTag()
+        + ", processName="
+        + this.getProcessName()
         + ")";
   }
 
@@ -141,7 +152,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         && Objects.equals(resourceName, that.resourceName)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(tenantId, that.tenantId)
-        && Objects.equals(versionTag, that.versionTag);
+        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(processName, that.processName);
   }
 
   @Override
@@ -154,7 +166,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         resourceName,
         bpmnProcessId,
         tenantId,
-        versionTag);
+        versionTag,
+        processName);
   }
 
   protected boolean canEqual(final Object other) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -208,7 +208,9 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
           .setChecksum(resourceDigest)
           .setResourceName(deploymentResource.getResourceNameBuffer())
           .setTenantId(tenantId);
+
       getOptionalVersionTag(process).ifPresent(processMetadata::setVersionTag);
+      getOptionalProcessName(process).ifPresent(processMetadata::setProcessName);
 
       final var isDuplicate =
           isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);
@@ -240,6 +242,10 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
   private Optional<String> getOptionalVersionTag(final Process process) {
     return Optional.ofNullable(process.getSingleExtensionElement(ZeebeVersionTag.class))
         .map(ZeebeVersionTag::getValue);
+  }
+
+  private Optional<String> getOptionalProcessName(final Process process) {
+    return Optional.ofNullable(process.getName());
   }
 
   private boolean isDuplicateOfLatest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -208,7 +208,6 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
           .setChecksum(resourceDigest)
           .setResourceName(deploymentResource.getResourceNameBuffer())
           .setTenantId(tenantId);
-
       getOptionalVersionTag(process).ifPresent(processMetadata::setVersionTag);
       getOptionalProcessName(process).ifPresent(processMetadata::setProcessName);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -209,7 +209,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
           .setResourceName(deploymentResource.getResourceNameBuffer())
           .setTenantId(tenantId);
       getOptionalVersionTag(process).ifPresent(processMetadata::setVersionTag);
-      getOptionalProcessName(process).ifPresent(processMetadata::setProcessName);
+      getOptionalProcessName(process).ifPresent(processMetadata::setName);
 
       final var isDuplicate =
           isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -26,7 +26,7 @@
                 "bpmnProcessId": {
                   "type": "keyword"
                 },
-                "processName": {
+                "name": {
                   "type": "keyword"
                 },
                 "version": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -26,6 +26,9 @@
                 "bpmnProcessId": {
                   "type": "keyword"
                 },
+                "processName": {
+                  "type": "keyword"
+                },
                 "version": {
                   "type": "long"
                 },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -22,7 +22,7 @@
             "bpmnProcessId": {
               "type": "keyword"
             },
-            "processName": {
+            "name": {
               "type": "keyword"
             },
             "version": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -22,6 +22,9 @@
             "bpmnProcessId": {
               "type": "keyword"
             },
+            "processName": {
+              "type": "keyword"
+            },
             "version": {
               "type": "long"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -56,7 +56,7 @@
                 "versionTag": {
                   "type": "keyword"
                 },
-                "processName": {
+                "name": {
                   "type": "keyword"
                 }
               }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -55,6 +55,9 @@
                 },
                 "versionTag": {
                   "type": "keyword"
+                },
+                "processName": {
+                  "type": "keyword"
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -54,6 +54,9 @@
             },
             "versionTag": {
               "type": "keyword"
+            },
+            "processName": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -28,6 +28,9 @@
             "bpmnProcessId": {
               "type": "keyword"
             },
+            "name": {
+              "type": "keyword"
+            },
             "version": {
               "type": "long"
             },
@@ -53,9 +56,6 @@
               "type": "long"
             },
             "versionTag": {
-              "type": "keyword"
-            },
-            "processName": {
               "type": "keyword"
             }
           }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -93,7 +93,8 @@ public final class ResponseMapper {
                     .setVersion(process.getVersion())
                     .setProcessDefinitionKey(process.getKey())
                     .setTenantId(process.getTenantId())
-                    .setResourceName(bufferAsString(process.getResourceNameBuffer())));
+                    .setResourceName(bufferAsString(process.getResourceNameBuffer()))
+                    .setProcessName(process.getProcessName()));
 
     return responseBuilder.build();
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -94,7 +94,7 @@ public final class ResponseMapper {
                     .setProcessDefinitionKey(process.getKey())
                     .setTenantId(process.getTenantId())
                     .setResourceName(bufferAsString(process.getResourceNameBuffer()))
-                    .setProcessName(process.getProcessName()));
+                    .setName(process.getName()));
 
     return responseBuilder.build();
   }
@@ -113,6 +113,7 @@ public final class ResponseMapper {
                     .setProcessDefinitionKey(process.getKey())
                     .setResourceName(process.getResourceName())
                     .setTenantId(process.getTenantId())
+                    .setName(process.getName())
                     .build())
         .forEach(process -> responseBuilder.addDeploymentsBuilder().setProcess(process));
 

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -538,6 +538,8 @@ message ProcessMetadata {
   string resourceName = 4;
   // the tenant id of the deployed process
   string tenantId = 5;
+  // the process name as defined in BPMN; null if not defined
+  optional string processName = 6;
 }
 
 message DecisionMetadata {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -539,7 +539,7 @@ message ProcessMetadata {
   // the tenant id of the deployed process
   string tenantId = 5;
   // the process name as defined in BPMN; null if not defined
-  optional string processName = 6;
+  optional string name = 6;
 }
 
 message DecisionMetadata {

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -255,6 +255,10 @@ components:
         resourceName:
           type: string
           description: The resource name from which this process was parsed.
+        processName:
+          type: string
+          nullable: true
+          description: The name of the process.
         tenantId:
           description: The tenant ID of the deployed process.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -241,7 +241,7 @@ components:
         - resourceName
         - processDefinitionKey
         - tenantId
-        - processName
+        - name
       properties:
         processDefinitionId:
           allOf:
@@ -256,7 +256,7 @@ components:
         resourceName:
           type: string
           description: The resource name from which this process was parsed.
-        processName:
+        name:
           type: string
           nullable: true
           description: The name of the process.

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -241,6 +241,7 @@ components:
         - resourceName
         - processDefinitionKey
         - tenantId
+        - processName
       properties:
         processDefinitionId:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -399,6 +399,10 @@ components:
           description: Name of this process definition.
           nullable: true
           type: string
+        processName:
+          description: Name of this process.
+          nullable: true
+          type: string
         resourceName:
           description: Resource name for this process definition.
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -399,10 +399,6 @@ components:
           description: Name of this process definition.
           nullable: true
           type: string
-        processName:
-          description: Name of this process.
-          nullable: true
-          type: string
         resourceName:
           description: Resource name for this process definition.
           type: string

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -81,7 +81,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
-        .setProcessName("processName")
+        .setName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -123,7 +123,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
-                             "processName":"processName",
+                             "name":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -151,7 +151,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
-        .setProcessName("processName")
+        .setName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -193,7 +193,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
-                             "processName":"processName",
+                             "name":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -223,7 +223,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
-        .setProcessName("processName")
+        .setName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -267,7 +267,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
-                             "processName":"processName",
+                             "name":"processName",
                              "tenantId":"tenantId"
                           },
                           "decisionDefinition": null,
@@ -298,7 +298,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
-        .setProcessName("processName")
+        .setName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -308,7 +308,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(secondFilename)
-        .setProcessName("secondProcessName")
+        .setName("secondProcessName")
         .setBpmnProcessId("secondProcessId")
         .setDeploymentKey(456L)
         .setVersion(1)
@@ -367,7 +367,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
-                             "processName":"processName",
+                             "name":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -381,7 +381,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"7890123",
                              "resourceName":"second.bpmn",
-                             "processName":"secondProcessName",
+                             "name":"secondProcessName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -81,6 +81,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
+        .setProcessName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -122,6 +123,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
+                             "processName":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -149,6 +151,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
+        .setProcessName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -190,6 +193,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
+                             "processName":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -219,6 +223,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
+        .setProcessName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -262,6 +267,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
+                             "processName":"processName",
                              "tenantId":"tenantId"
                           },
                           "decisionDefinition": null,
@@ -292,6 +298,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
+        .setProcessName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -301,6 +308,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(secondFilename)
+        .setProcessName("secondProcessName")
         .setBpmnProcessId("secondProcessId")
         .setDeploymentKey(456L)
         .setVersion(1)
@@ -359,6 +367,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
+                             "processName":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -372,6 +381,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"7890123",
                              "resourceName":"second.bpmn",
+                             "processName":"secondProcessName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
@@ -19,13 +19,15 @@ public class ProcessMetadata extends UnpackedObject {
   private final IntegerProperty versionProp = new IntegerProperty("version", -1);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   public ProcessMetadata() {
-    super(4);
+    super(5);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(versionProp)
         .declareProperty(bpmnProcessIdProp)
-        .declareProperty(resourceNameProp);
+        .declareProperty(resourceNameProp)
+        .declareProperty(processNameProp);
   }
 
   public long getProcessDefinitionKey() {
@@ -71,6 +73,20 @@ public class ProcessMetadata extends UnpackedObject {
 
   public ProcessMetadata setResourceName(final String resourceName) {
     resourceNameProp.setValue(resourceName);
+    return this;
+  }
+
+  public DirectBuffer getProcessName() {
+    return processNameProp.getValue();
+  }
+
+  public ProcessMetadata setProcessName(final DirectBuffer processName) {
+    processNameProp.setValue(processName);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final String processName) {
+    processNameProp.setValue(processName);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
@@ -19,7 +19,7 @@ public class ProcessMetadata extends UnpackedObject {
   private final IntegerProperty versionProp = new IntegerProperty("version", -1);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
-  private final StringProperty processNameProp = new StringProperty("processName", "");
+  private final StringProperty nameProp = new StringProperty("name", "");
 
   public ProcessMetadata() {
     super(5);
@@ -27,7 +27,7 @@ public class ProcessMetadata extends UnpackedObject {
         .declareProperty(versionProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(resourceNameProp)
-        .declareProperty(processNameProp);
+        .declareProperty(nameProp);
   }
 
   public long getProcessDefinitionKey() {
@@ -76,17 +76,17 @@ public class ProcessMetadata extends UnpackedObject {
     return this;
   }
 
-  public DirectBuffer getProcessName() {
-    return processNameProp.getValue();
+  public DirectBuffer getName() {
+    return nameProp.getValue();
   }
 
-  public ProcessMetadata setProcessName(final DirectBuffer processName) {
-    processNameProp.setValue(processName);
+  public ProcessMetadata setName(final DirectBuffer name) {
+    nameProp.setValue(name);
     return this;
   }
 
-  public ProcessMetadata setProcessName(final String processName) {
-    processNameProp.setValue(processName);
+  public ProcessMetadata setName(final String name) {
+    nameProp.setValue(name);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -34,7 +34,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final LongProperty keyProp = new LongProperty(PROCESS_DEFINITION_KEY_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
-  private final StringProperty processNameProp = new StringProperty("processName", "");
+  private final StringProperty nameProp = new StringProperty("name", "");
 
   // should be set to true if the process was already deployed - property should not be exported
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
@@ -54,7 +54,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
-        .declareProperty(processNameProp);
+        .declareProperty(nameProp);
   }
 
   @Override
@@ -88,8 +88,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   }
 
   @Override
-  public String getProcessName() {
-    return bufferAsString(processNameProp.getValue());
+  public String getName() {
+    return bufferAsString(nameProp.getValue());
   }
 
   @Override
@@ -122,13 +122,13 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
     return this;
   }
 
-  public ProcessMetadata setProcessName(final String processName) {
-    processNameProp.setValue(processName);
+  public ProcessMetadata setName(final String name) {
+    nameProp.setValue(name);
     return this;
   }
 
-  public ProcessMetadata setProcessName(final DirectBuffer processName) {
-    processNameProp.setValue(processName);
+  public ProcessMetadata setName(final DirectBuffer name) {
+    nameProp.setValue(name);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -34,6 +34,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final LongProperty keyProp = new LongProperty(PROCESS_DEFINITION_KEY_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   // should be set to true if the process was already deployed - property should not be exported
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
@@ -43,7 +44,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
 
   public ProcessMetadata() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -52,7 +53,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
         .declareProperty(isDuplicateProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
-        .declareProperty(versionTagProp);
+        .declareProperty(versionTagProp)
+        .declareProperty(processNameProp);
   }
 
   @Override
@@ -86,6 +88,11 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   }
 
   @Override
+  public String getProcessName() {
+    return bufferAsString(processNameProp.getValue());
+  }
+
+  @Override
   public byte[] getChecksum() {
     return BufferUtil.bufferAsArray(checksumProp.getValue());
   }
@@ -112,6 +119,16 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   public ProcessMetadata setDeploymentKey(final long deploymentKey) {
     deploymentKeyProp.setValue(deploymentKey);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final String processName) {
+    processNameProp.setValue(processName);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final DirectBuffer processName) {
+    processNameProp.setValue(processName);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -34,7 +34,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
-  private final StringProperty processNameProp = new StringProperty("processName", "");
+  private final StringProperty nameProp = new StringProperty("name", "");
 
   public ProcessRecord() {
     super(10);
@@ -47,7 +47,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
-        .declareProperty(processNameProp);
+        .declareProperty(nameProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -60,7 +60,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     tenantIdProp.setValue(metadata.getTenantId());
     deploymentKeyProp.setValue(metadata.getDeploymentKey());
     versionTagProp.setValue(metadata.getVersionTag());
-    processNameProp.setValue(metadata.getProcessName());
+    nameProp.setValue(metadata.getName());
     return this;
   }
 
@@ -95,8 +95,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   @Override
-  public String getProcessName() {
-    return BufferUtil.bufferAsString(processNameProp.getValue());
+  public String getName() {
+    return BufferUtil.bufferAsString(nameProp.getValue());
   }
 
   @Override
@@ -124,13 +124,13 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     return this;
   }
 
-  public ProcessRecord setProcessName(final String processName) {
-    processNameProp.setValue(processName);
+  public ProcessRecord setName(final String name) {
+    nameProp.setValue(name);
     return this;
   }
 
-  public ProcessRecord setProcessName(final DirectBuffer processName) {
-    processNameProp.setValue(processName);
+  public ProcessRecord setName(final DirectBuffer name) {
+    nameProp.setValue(name);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -34,9 +34,10 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   public ProcessRecord() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -45,7 +46,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(resourceProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
-        .declareProperty(versionTagProp);
+        .declareProperty(versionTagProp)
+        .declareProperty(processNameProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -58,6 +60,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     tenantIdProp.setValue(metadata.getTenantId());
     deploymentKeyProp.setValue(metadata.getDeploymentKey());
     versionTagProp.setValue(metadata.getVersionTag());
+    processNameProp.setValue(metadata.getProcessName());
     return this;
   }
 
@@ -92,6 +95,11 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   @Override
+  public String getProcessName() {
+    return BufferUtil.bufferAsString(processNameProp.getValue());
+  }
+
+  @Override
   public byte[] getChecksum() {
     return BufferUtil.bufferAsArray(checksumProp.getValue());
   }
@@ -113,6 +121,16 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
 
   public ProcessRecord setChecksum(final DirectBuffer checksumBuffer) {
     checksumProp.setValue(checksumBuffer);
+    return this;
+  }
+
+  public ProcessRecord setProcessName(final String processName) {
+    processNameProp.setValue(processName);
+    return this;
+  }
+
+  public ProcessRecord setProcessName(final DirectBuffer processName) {
+    processNameProp.setValue(processName);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -209,6 +209,7 @@ final class JsonSerializableToJsonTest {
                   .batchOperationReference(5678);
 
               final String resourceName = "resource";
+              final String processName = "Test Process";
               final DirectBuffer resource = wrapString("contents");
               final String bpmnProcessId = "testProcess";
               final long processDefinitionKey = 123;
@@ -227,6 +228,7 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setKey(processDefinitionKey)
                   .setResourceName(wrapString(resourceName))
+                  .setProcessName(wrapString(processName))
                   .setVersion(processVersion)
                   .setChecksum(checksum);
 
@@ -266,6 +268,7 @@ final class JsonSerializableToJsonTest {
                         "version": 12,
                         "bpmnProcessId": "testProcess",
                         "resourceName": "resource",
+                        "processName": "Test Process",
                         "checksum": "Y2hlY2tzdW0=",
                         "processDefinitionKey": 123,
                         "duplicate": false,
@@ -357,6 +360,7 @@ final class JsonSerializableToJsonTest {
               final DirectBuffer checksum = wrapString("checksum");
               final long deploymentKey = 1234;
               final String versionTag = "v1.0";
+              final String processName = "Test Process";
               final DeploymentRecord record = new DeploymentRecord();
               record
                   .setDeploymentKey(deploymentKey)
@@ -370,6 +374,7 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setKey(processDefinitionKey)
                   .setResourceName(wrapString(resourceName))
+                  .setProcessName(wrapString(processName))
                   .setVersion(processVersion)
                   .setChecksum(checksum)
                   .setDuplicate(true)
@@ -428,6 +433,7 @@ final class JsonSerializableToJsonTest {
                       "version": 12,
                       "processDefinitionKey": 123,
                       "resourceName": "resource",
+                      "processName": "Test Process",
                       "duplicate": true,
                       "tenantId": "<default>",
                       "deploymentKey": 1234,
@@ -559,6 +565,7 @@ final class JsonSerializableToJsonTest {
                   "resource": "Y29udGVudHM=",
                   "checksum": "Y2hlY2tzdW0=",
                   "bpmnProcessId": "testProcess",
+                  "processName": "",
                   "version": 12,
                   "processDefinitionKey": 123,
                   "resourceName": "resource",
@@ -598,6 +605,7 @@ final class JsonSerializableToJsonTest {
                   "resource": "Y29udGVudHM=",
                   "checksum": "Y2hlY2tzdW0=",
                   "bpmnProcessId": "testProcess",
+                  "processName": "",
                   "version": 12,
                   "processDefinitionKey": 123,
                   "resourceName": "resource",
@@ -2739,6 +2747,69 @@ final class JsonSerializableToJsonTest {
                       "bpmnProcessId": "my_first_process",
                       "resourceName": "my_first_bpmn.bpmn",
                       "checksum": "c2hhMQ==",
+                      "processName": "",
+                      "duplicate": false,
+                      "tenantId": "<default>",
+                      "deploymentKey": -1,
+                      "versionTag": ""
+                    }],
+                    "decisionsMetadata": [],
+                    "decisionRequirementsMetadata": [],
+                    "formMetadata": [],
+                    "resourceMetadata":[],
+                    "tenantId": "<default>",
+                    "deploymentKey": -1
+                  },
+                  "authInfo":{"format":"UNKNOWN","claims":{"claim-a": "foo"},"authData":""}
+                }
+                """
+      },
+      {
+        "CommandDistributionRecord with ProcessName",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var deploymentRecord = new DeploymentRecord();
+              deploymentRecord
+                  .resources()
+                  .add()
+                  .setResourceName("my_first_bpmn.bpmn")
+                  .setResource(wrapString("This is the contents of the BPMN"));
+              deploymentRecord
+                  .processesMetadata()
+                  .add()
+                  .setKey(123)
+                  .setVersion(1)
+                  .setBpmnProcessId("my_first_process")
+                  .setResourceName("my_first_bpmn.bpmn")
+                  .setProcessName("Test Process")
+                  .setChecksum(wrapString("sha1"));
+
+              return new CommandDistributionRecord()
+                  .setPartitionId(1)
+                  .setQueueId("totally-random-queue-id")
+                  .setValueType(ValueType.DEPLOYMENT)
+                  .setIntent(DeploymentIntent.CREATE)
+                  .setCommandValue(deploymentRecord)
+                  .setAuthInfo(new AuthInfo().setClaims(Map.of("claim-a", "foo")));
+            },
+        """
+                {
+                  "partitionId": 1,
+                  "queueId": "totally-random-queue-id",
+                  "valueType": "DEPLOYMENT",
+                  "intent": "CREATE",
+                  "commandValue": {
+                    "resources": [{
+                      "resource": "VGhpcyBpcyB0aGUgY29udGVudHMgb2YgdGhlIEJQTU4=",
+                      "resourceName": "my_first_bpmn.bpmn"
+                    }],
+                    "processesMetadata": [{
+                      "processDefinitionKey": 123,
+                      "version": 1,
+                      "bpmnProcessId": "my_first_process",
+                      "resourceName": "my_first_bpmn.bpmn",
+                      "checksum": "c2hhMQ==",
+                      "processName": "Test Process",
                       "duplicate": false,
                       "tenantId": "<default>",
                       "deploymentKey": -1,
@@ -4652,6 +4723,57 @@ final class JsonSerializableToJsonTest {
       "configKey": -1
     }
     """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////// ProcessRecord with ProcessName
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // ///////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      new Object[] {
+        "ProcessRecord with ProcessName",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String resourceName = "resource";
+              final String processName = "Test Process";
+              final DirectBuffer resource = wrapString("contents");
+              final String bpmnProcessId = "testProcess";
+              final long processDefinitionKey = 123;
+              final int processVersion = 12;
+              final DirectBuffer checksum = wrapString("checksum");
+              final long deploymentKey = 1234;
+              final String versionTag = "v1.0";
+
+              final ProcessRecord record = new ProcessRecord();
+              record
+                  .setResourceName(wrapString(resourceName))
+                  .setResource(resource)
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setKey(processDefinitionKey)
+                  .setResourceName(wrapString(resourceName))
+                  .setProcessName(wrapString(processName))
+                  .setVersion(processVersion)
+                  .setChecksum(checksum)
+                  .setDeploymentKey(deploymentKey)
+                  .setVersionTag(versionTag);
+
+              return record;
+            },
+        """
+                {
+                  "resourceName": "resource",
+                  "resource": "Y29udGVudHM=",
+                  "checksum": "Y2hlY2tzdW0=",
+                  "bpmnProcessId": "testProcess",
+                  "version": 12,
+                  "processDefinitionKey": 123,
+                  "resourceName": "resource",
+                  "processName": "Test Process",
+                  "duplicate": false,
+                  "tenantId": "<default>",
+                  "deploymentKey": 1234,
+                  "versionTag": "v1.0"
+                }
+                """
       }
     };
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -228,7 +228,7 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setKey(processDefinitionKey)
                   .setResourceName(wrapString(resourceName))
-                  .setProcessName(wrapString(processName))
+                  .setName(wrapString(processName))
                   .setVersion(processVersion)
                   .setChecksum(checksum);
 
@@ -268,7 +268,7 @@ final class JsonSerializableToJsonTest {
                         "version": 12,
                         "bpmnProcessId": "testProcess",
                         "resourceName": "resource",
-                        "processName": "Test Process",
+                        "name": "Test Process",
                         "checksum": "Y2hlY2tzdW0=",
                         "processDefinitionKey": 123,
                         "duplicate": false,
@@ -374,7 +374,7 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setKey(processDefinitionKey)
                   .setResourceName(wrapString(resourceName))
-                  .setProcessName(wrapString(processName))
+                  .setName(wrapString(processName))
                   .setVersion(processVersion)
                   .setChecksum(checksum)
                   .setDuplicate(true)
@@ -433,7 +433,7 @@ final class JsonSerializableToJsonTest {
                       "version": 12,
                       "processDefinitionKey": 123,
                       "resourceName": "resource",
-                      "processName": "Test Process",
+                      "name": "Test Process",
                       "duplicate": true,
                       "tenantId": "<default>",
                       "deploymentKey": 1234,
@@ -565,7 +565,7 @@ final class JsonSerializableToJsonTest {
                   "resource": "Y29udGVudHM=",
                   "checksum": "Y2hlY2tzdW0=",
                   "bpmnProcessId": "testProcess",
-                  "processName": "",
+                  "name": "",
                   "version": 12,
                   "processDefinitionKey": 123,
                   "resourceName": "resource",
@@ -605,7 +605,7 @@ final class JsonSerializableToJsonTest {
                   "resource": "Y29udGVudHM=",
                   "checksum": "Y2hlY2tzdW0=",
                   "bpmnProcessId": "testProcess",
-                  "processName": "",
+                  "name": "",
                   "version": 12,
                   "processDefinitionKey": 123,
                   "resourceName": "resource",
@@ -2747,7 +2747,7 @@ final class JsonSerializableToJsonTest {
                       "bpmnProcessId": "my_first_process",
                       "resourceName": "my_first_bpmn.bpmn",
                       "checksum": "c2hhMQ==",
-                      "processName": "",
+                      "name": "",
                       "duplicate": false,
                       "tenantId": "<default>",
                       "deploymentKey": -1,
@@ -2765,7 +2765,7 @@ final class JsonSerializableToJsonTest {
                 """
       },
       {
-        "CommandDistributionRecord with ProcessName",
+        "CommandDistributionRecord with Process Name",
         (Supplier<UnifiedRecordValue>)
             () -> {
               final var deploymentRecord = new DeploymentRecord();
@@ -2781,7 +2781,7 @@ final class JsonSerializableToJsonTest {
                   .setVersion(1)
                   .setBpmnProcessId("my_first_process")
                   .setResourceName("my_first_bpmn.bpmn")
-                  .setProcessName("Test Process")
+                  .setName("Test Process")
                   .setChecksum(wrapString("sha1"));
 
               return new CommandDistributionRecord()
@@ -2809,7 +2809,7 @@ final class JsonSerializableToJsonTest {
                       "bpmnProcessId": "my_first_process",
                       "resourceName": "my_first_bpmn.bpmn",
                       "checksum": "c2hhMQ==",
-                      "processName": "Test Process",
+                      "name": "Test Process",
                       "duplicate": false,
                       "tenantId": "<default>",
                       "deploymentKey": -1,
@@ -4725,12 +4725,12 @@ final class JsonSerializableToJsonTest {
     """
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
-      //////////////////////////////////// ProcessRecord with ProcessName
+      //////////////////////////////////// ProcessRecord with Process Name
       /////////////////////////////////////////////////////////////////////////////////////////////
       // ///////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       new Object[] {
-        "ProcessRecord with ProcessName",
+        "ProcessRecord with Process Name",
         (Supplier<UnifiedRecordValue>)
             () -> {
               final String resourceName = "resource";
@@ -4750,7 +4750,7 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setKey(processDefinitionKey)
                   .setResourceName(wrapString(resourceName))
-                  .setProcessName(wrapString(processName))
+                  .setName(wrapString(processName))
                   .setVersion(processVersion)
                   .setChecksum(checksum)
                   .setDeploymentKey(deploymentKey)
@@ -4767,7 +4767,7 @@ final class JsonSerializableToJsonTest {
                   "version": 12,
                   "processDefinitionKey": 123,
                   "resourceName": "resource",
-                  "processName": "Test Process",
+                  "name": "Test Process",
                   "duplicate": false,
                   "tenantId": "<default>",
                   "deploymentKey": 1234,

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMetadata.golden
@@ -34,7 +34,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final LongProperty keyProp = new LongProperty(PROCESS_DEFINITION_KEY_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
-  private final StringProperty processNameProp = new StringProperty("processName", "");
+  private final StringProperty nameProp = new StringProperty("name", "");
 
   // should be set to true if the process was already deployed - property should not be exported
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
@@ -54,7 +54,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
-        .declareProperty(processNameProp);
+        .declareProperty(nameProp);
   }
 
   @Override
@@ -88,8 +88,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   }
 
   @Override
-  public String getProcessName() {
-    return bufferAsString(processNameProp.getValue());
+  public String getName() {
+    return bufferAsString(nameProp.getValue());
   }
 
   @Override
@@ -122,13 +122,13 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
     return this;
   }
 
-  public ProcessMetadata setProcessName(final String processName) {
-    processNameProp.setValue(processName);
+  public ProcessMetadata setName(final String name) {
+    nameProp.setValue(name);
     return this;
   }
 
-  public ProcessMetadata setProcessName(final DirectBuffer processName) {
-    processNameProp.setValue(processName);
+  public ProcessMetadata setName(final DirectBuffer name) {
+    nameProp.setValue(name);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMetadata.golden
@@ -34,6 +34,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final LongProperty keyProp = new LongProperty(PROCESS_DEFINITION_KEY_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   // should be set to true if the process was already deployed - property should not be exported
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
@@ -43,7 +44,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
 
   public ProcessMetadata() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -52,7 +53,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
         .declareProperty(isDuplicateProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
-        .declareProperty(versionTagProp);
+        .declareProperty(versionTagProp)
+        .declareProperty(processNameProp);
   }
 
   @Override
@@ -86,6 +88,11 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   }
 
   @Override
+  public String getProcessName() {
+    return bufferAsString(processNameProp.getValue());
+  }
+
+  @Override
   public byte[] getChecksum() {
     return BufferUtil.bufferAsArray(checksumProp.getValue());
   }
@@ -112,6 +119,16 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   public ProcessMetadata setDeploymentKey(final long deploymentKey) {
     deploymentKeyProp.setValue(deploymentKey);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final String processName) {
+    processNameProp.setValue(processName);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final DirectBuffer processName) {
+    processNameProp.setValue(processName);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
@@ -34,9 +34,10 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   public ProcessRecord() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -45,7 +46,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(resourceProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
-        .declareProperty(versionTagProp);
+        .declareProperty(versionTagProp)
+        .declareProperty(processNameProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -58,6 +60,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     tenantIdProp.setValue(metadata.getTenantId());
     deploymentKeyProp.setValue(metadata.getDeploymentKey());
     versionTagProp.setValue(metadata.getVersionTag());
+    processNameProp.setValue(metadata.getProcessName());
     return this;
   }
 
@@ -92,6 +95,11 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   @Override
+  public String getProcessName() {
+    return BufferUtil.bufferAsString(processNameProp.getValue());
+  }
+
+  @Override
   public byte[] getChecksum() {
     return BufferUtil.bufferAsArray(checksumProp.getValue());
   }
@@ -113,6 +121,16 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
 
   public ProcessRecord setChecksum(final DirectBuffer checksumBuffer) {
     checksumProp.setValue(checksumBuffer);
+    return this;
+  }
+
+  public ProcessRecord setProcessName(final String processName) {
+    processNameProp.setValue(processName);
+    return this;
+  }
+
+  public ProcessRecord setProcessName(final DirectBuffer processName) {
+    processNameProp.setValue(processName);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
@@ -34,7 +34,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
-  private final StringProperty processNameProp = new StringProperty("processName", "");
+  private final StringProperty nameProp = new StringProperty("name", "");
 
   public ProcessRecord() {
     super(10);
@@ -47,7 +47,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
         .declareProperty(versionTagProp)
-        .declareProperty(processNameProp);
+        .declareProperty(nameProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -60,7 +60,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     tenantIdProp.setValue(metadata.getTenantId());
     deploymentKeyProp.setValue(metadata.getDeploymentKey());
     versionTagProp.setValue(metadata.getVersionTag());
-    processNameProp.setValue(metadata.getProcessName());
+    nameProp.setValue(metadata.getName());
     return this;
   }
 
@@ -95,8 +95,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   @Override
-  public String getProcessName() {
-    return BufferUtil.bufferAsString(processNameProp.getValue());
+  public String getName() {
+    return BufferUtil.bufferAsString(nameProp.getValue());
   }
 
   @Override
@@ -124,16 +124,6 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     return this;
   }
 
-  public ProcessRecord setProcessName(final String processName) {
-    processNameProp.setValue(processName);
-    return this;
-  }
-
-  public ProcessRecord setProcessName(final DirectBuffer processName) {
-    processNameProp.setValue(processName);
-    return this;
-  }
-
   public ProcessRecord setResourceName(final String resourceName) {
     resourceNameProp.setValue(resourceName);
     return this;
@@ -156,6 +146,16 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
 
   public ProcessRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public ProcessRecord setName(final String name) {
+    nameProp.setValue(name);
+    return this;
+  }
+
+  public ProcessRecord setName(final DirectBuffer name) {
+    nameProp.setValue(name);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
@@ -50,6 +50,11 @@ public interface ProcessMetadataValue extends RecordValue, TenantOwned {
   String getResourceName();
 
   /**
+   * @return the BPMN process name, or {@code null} if none is set
+   */
+  String getProcessName();
+
+  /**
    * @return the checksum of the process (MD5)
    */
   byte[] getChecksum();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
@@ -52,7 +52,7 @@ public interface ProcessMetadataValue extends RecordValue, TenantOwned {
   /**
    * @return the BPMN process name, or {@code null} if none is set
    */
-  String getProcessName();
+  String getName();
 
   /**
    * @return the checksum of the process (MD5)


### PR DESCRIPTION
## Description

The goal is to provide Zeebe Gateway users with the name of the process as defined in the BPMN model when a deployment occurs. This is achieved by:

- Storing the process name in the process metadata.
- Exposing the process name in the deployment results.
- Updating the response mapper to include the new field.

The `name` field is now included in the deployment response.

<img width="1615" height="864" alt="test_case_47173_resp" src="https://github.com/user-attachments/assets/3cadc279-163c-493e-9672-b16829e5752a" />

[deployment-response-47173.json](https://github.com/user-attachments/files/26538637/deployment-response-47173.json)
[test_case_47173.bpmn.xml](https://github.com/user-attachments/files/25873548/test_case_47173.bpmn.xml)

## Related issues

ref #47173
