### PR TITLE
ci: add stress testing capability for Maven tests on PRs

### DIFF
--- a/.github/actions/post-ci-failure-reasons/action.yml
+++ b/.github/actions/post-ci-failure-reasons/action.yml
@@ -106,7 +106,8 @@ runs:
             break # No need to check further jobs - we will skip comment creation entirely in this case
           fi
 
-          ANNOTATION_COUNT=$(echo "$ANNOTATIONS" | jq '. | length')
+          FILTERED_ANNOTATIONS=$(echo "$ANNOTATIONS" | jq '[.[] | select(.annotation_level != "warning" or (.message | contains("Node.js 20 actions are deprecated") | not))]')
+          ANNOTATION_COUNT=$(echo "$FILTERED_ANNOTATIONS" | jq '. | length')
 
           if [ "$ANNOTATION_COUNT" -eq 0 ]; then
             echo "No GHA annotations found for this job." | tee -a "$COMMENT_FILE"
@@ -116,7 +117,7 @@ runs:
             echo "" | tee -a "$COMMENT_FILE"
 
             # Format annotations for display
-            echo "$ANNOTATIONS" | jq -r '.[] | "- **\(.annotation_level | ascii_upcase)**: \(.message)"' | tee -a "$COMMENT_FILE"
+            echo "$FILTERED_ANNOTATIONS" | jq -r '.[] | "- **\(.annotation_level | ascii_upcase)**: \(.message)"' | tee -a "$COMMENT_FILE"
 
             echo "" | tee -a "$COMMENT_FILE"
           fi

--- a/.github/maven-matcher.json
+++ b/.github/maven-matcher.json
@@ -17,6 +17,15 @@
           "message": 1
         }
       ]
+    },
+    {
+      "owner": "maven-failsafe-test",
+      "pattern": [
+        {
+          "regexp": "^\\s*\\[INFO\\]\\s+\\+--\\s+\\[XX\\]\\s+(?<message>.+)$",
+          "message": 1
+        }
+      ]
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,7 @@ jobs:
       ZEEBE_IT_EXPORTER_MODULES: ${{ steps.set-constants.outputs.it_exporter }}
       # IT Engine = ZEEBE_CORE_FEATURES_MODULES + ZEEBE_PROTOCOL_MODULES + ZEEBE_GATEWAY_MODULES + ZEEBE_CLIENT_MODULES (explicit list)
       ZEEBE_IT_ENGINE_MODULES: ${{ steps.set-constants.outputs.it_engine }}
+      INTEGRATION_TESTS_MATRIX: ${{ steps.integration-tests-matrix.outputs.matrix }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: { }
@@ -418,6 +419,197 @@ jobs:
             echo "it_distributed=${IT_DISTRIBUTED}"
             echo "it_exporter=${IT_EXPORTER}"
             echo "it_engine=${IT_ENGINE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build integration tests matrix
+        id: integration-tests-matrix
+        env:
+          ZEEBE_IT_DISTRIBUTED_MODULES: ${{ steps.set-constants.outputs.it_distributed }}
+          ZEEBE_IT_ENGINE_MODULES: ${{ steps.set-constants.outputs.it_engine }}
+          ZEEBE_IT_EXPORTER_MODULES: ${{ steps.set-constants.outputs.it_exporter }}
+          # TODO: disabled until 8.9.0 minor release is out
+          ZEEBE_QA_UPDATE_ENABLED: "false"
+          # Opt-in to stress testing the integration-tests job via the PR label "ci:stress-test".
+          STRESS_ENABLED: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:stress-test') }}
+        run: |
+          # The DOLLAR variable is necessary to avoid problems with escaping in jq.
+          DOLLAR='$'
+          base_matrix=$(cat <<EOF | jq -c '.'
+          [
+            {
+              "group": "root",
+              "name": "Root Acceptance Tests",
+              "maven-modules": "'qa/acceptance-tests'",
+              "maven-build-threads": 2,
+              "maven-test-fork-count": 3,
+              "runs-on": "gcp-perf-core-8-default",
+              "docker-repository": "localhost:5000/camunda/zeebe",
+              "docker-file": "Dockerfile",
+              "owner": "QA",
+              "module": "QA",
+              "stressRun": 1
+            },
+            {
+              "group": "zeebe-ds-modules",
+              "name": "Zeebe Distributed Platform Modules",
+              "maven-modules": "${ZEEBE_IT_DISTRIBUTED_MODULES}",
+              "maven-build-threads": 2,
+              "maven-test-fork-count": 7,
+              "runs-on": "gcp-perf-core-16-longrunning",
+              "docker-repository": "localhost:5000/camunda/zeebe",
+              "docker-file": "Dockerfile",
+              "owner": "Distributed Platform",
+              "module": "Zeebe",
+              "stressRun": 1
+            },
+            {
+              "group": "zeebe-engine-modules",
+              "name": "Zeebe Engine Modules",
+              "maven-modules": "${ZEEBE_IT_ENGINE_MODULES}",
+              "maven-build-threads": 2,
+              "maven-test-fork-count": 7,
+              "runs-on": "gcp-perf-core-16-longrunning",
+              "docker-repository": "localhost:5000/camunda/zeebe",
+              "docker-file": "Dockerfile",
+              "owner": "Core Features",
+              "module": "Zeebe",
+              "stressRun": 1
+            },
+            {
+              "group": "zeebe-exporter-modules",
+              "name": "Zeebe Exporter Modules",
+              "maven-modules": "${ZEEBE_IT_EXPORTER_MODULES}",
+              "maven-build-threads": 2,
+              "maven-test-fork-count": 7,
+              "runs-on": "gcp-perf-core-16-longrunning",
+              "docker-repository": "localhost:5000/camunda/zeebe",
+              "docker-file": "Dockerfile",
+              "owner": "DataLayer",
+              "module": "Zeebe",
+              "stressRun": 1
+            },
+            {
+              "group": "schema-manager",
+              "name": "Schema Manager",
+              "maven-modules": "schema-manager",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 3,
+              "runs-on": "gcp-perf-core-8-default",
+              "docker-repository": "localhost:5000/camunda/camunda",
+              "docker-file": "camunda.Dockerfile",
+              "owner": "Data Layer",
+              "module": "Schema Manager",
+              "stressRun": 1
+            },
+            {
+              "group": "zeebe-engine-integration",
+              "name": "Zeebe Engine QA",
+              "maven-modules": "zeebe/qa/integration-tests",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 10,
+              "runs-on": "gcp-perf-core-16-default",
+              "owner": "Core Features",
+              "module": "Zeebe",
+              "test-filter": "io.camunda.zeebe.it.engine.**,!**/*${DOLLAR}*.java",
+              "allow-stress": true,
+              "stressRun": 1
+            },
+            {
+              "group": "zeebe-ds-integration",
+              "name": "Zeebe Cluster QA",
+              "maven-modules": "zeebe/qa/integration-tests",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 10,
+              "runs-on": "gcp-perf-core-16-default",
+              "docker-repository": "localhost:5000/camunda/zeebe",
+              "docker-file": "Dockerfile",
+              "owner": "Distributed Platform",
+              "module": "Zeebe",
+              "test-filter": "io.camunda.zeebe.it.cluster.**,!io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest,!**/*${DOLLAR}*.java",
+              "allow-stress": true,
+              "stressRun": 1
+            },
+            {
+              "group": "zeebe-ds-integration-scaleup",
+              "name": "Zeebe Cluster ScaleUp QA",
+              "maven-modules": "zeebe/qa/integration-tests",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 1,
+              "runs-on": "gcp-perf-core-8-default",
+              "owner": "Distributed Platform",
+              "module": "Zeebe",
+              "test-filter": "io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest",
+              "stressRun": 1
+            },
+            {
+              "group": "zeebe-shared-integration",
+              "name": "Zeebe General QA",
+              "maven-modules": "zeebe/qa/integration-tests",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 10,
+              "runs-on": "gcp-perf-core-16-default",
+              "docker-repository": "localhost:5000/camunda/zeebe",
+              "docker-file": "Dockerfile",
+              "owner": "General",
+              "module": "Zeebe",
+              "test-filter": "!io.camunda.zeebe.it.engine.**,!io.camunda.zeebe.it.cluster.**,!**/*${DOLLAR}*.java",
+              "stressRun": 1
+            },
+            {
+              "group": "qa-camunda-process-test",
+              "name": "Camunda Process",
+              "maven-modules": "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 3,
+              "runs-on": "gcp-perf-core-8-default",
+              "docker-repository": "localhost:5000/camunda/camunda",
+              "docker-file": "camunda.Dockerfile",
+              "owner": "CamundaEx",
+              "module": "Testing",
+              "stressRun": 1
+            }
+          ]
+          EOF
+          )
+
+          if [[ "${ZEEBE_QA_UPDATE_ENABLED}" == "true" ]]; then
+            base_matrix=$(jq -c '. + [
+              {
+                "group": "qa-update",
+                "name": "Zeebe QA - Update",
+                "maven-modules": "zeebe/qa/update-tests",
+                "maven-build-threads": 1,
+                "maven-test-fork-count": 10,
+                "runs-on": "gcp-perf-core-8-default",
+                "docker-repository": "localhost:5000/camunda/zeebe",
+                "docker-file": "Dockerfile",
+                "owner": "Core Features",
+                "module": "Zeebe",
+                "stressRun": 1
+              }
+            ]' <<< "${base_matrix}")
+          fi
+
+          if [[ "${STRESS_ENABLED}" == "true" ]]; then
+            zeebe_engine_template=$(jq -c '.[] | select(.group == "zeebe-engine-integration") | del(.stressRun)' <<< "${base_matrix}")
+            for run in {2..10}; do
+              base_matrix=$(jq -c --argjson entry "${zeebe_engine_template}" --argjson run "${run}" '. + [
+                $entry + {"stressRun": $run}
+              ]' <<< "${base_matrix}")
+            done
+
+            zeebe_ds_template=$(jq -c '.[] | select(.group == "zeebe-ds-integration") | del(.stressRun)' <<< "${base_matrix}")
+            for run in {2..10}; do
+              base_matrix=$(jq -c --argjson entry "${zeebe_ds_template}" --argjson run "${run}" '. + [
+                $entry + {"stressRun": $run}
+              ]' <<< "${base_matrix}")
+            done
+          fi
+
+          {
+            echo "matrix<<EOF"
+            echo "${base_matrix}"
+            echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
   # Runs unit tests for all modules that are not Operate, Optimize, Tasklist, or Zeebe. This test will run any new modules that are added and are not included in setup-tests
@@ -730,7 +922,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "[IT] RDBMS - Run ${{ matrix.stressRun }}"
+          name: "[IT] RDBMS (${{ matrix.stressRun }})"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -747,7 +939,7 @@ jobs:
 
   integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    name: "${{ matrix.module }} / Integration / ${{ matrix.name }} ITs"
+    name: "${{ matrix.module }} / Integration / ${{ matrix.name }} ITs (${{ matrix.stressRun }})"
     needs: [ detect-changes, setup-tests ]
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -755,119 +947,11 @@ jobs:
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     strategy:
+      # In case of stress testing, we want the status from all jobs.
       fail-fast: false
       matrix:
-        include:
-          - group: root
-            name: "Root Acceptance Tests"
-            maven-modules: "'qa/acceptance-tests'"
-            maven-build-threads: 2
-            maven-test-fork-count: 3
-            runs-on: gcp-perf-core-8-default
-            docker-repository: localhost:5000/camunda/zeebe
-            docker-file: Dockerfile
-            owner: "QA"
-            module: "QA"
-          - group: zeebe-ds-modules
-            name: "Zeebe Distributed Platform Modules"
-            maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_IT_DISTRIBUTED_MODULES }}
-            maven-build-threads: 2
-            maven-test-fork-count: 7
-            runs-on: gcp-perf-core-16-longrunning
-            docker-repository: localhost:5000/camunda/zeebe
-            docker-file: Dockerfile
-            owner: "Distributed Platform"
-            module: "Zeebe"
-          - group: zeebe-engine-modules
-            name: "Zeebe Engine Modules"
-            maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_IT_ENGINE_MODULES }}
-            maven-build-threads: 2
-            maven-test-fork-count: 7
-            runs-on: gcp-perf-core-16-longrunning
-            docker-repository: localhost:5000/camunda/zeebe
-            docker-file: Dockerfile
-            owner: "Core Features"
-            module: "Zeebe"
-          - group: zeebe-exporter-modules
-            name: "Zeebe Exporter Modules"
-            maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_IT_EXPORTER_MODULES }}
-            maven-build-threads: 2
-            maven-test-fork-count: 7
-            runs-on: gcp-perf-core-16-longrunning
-            docker-repository: localhost:5000/camunda/zeebe
-            docker-file: Dockerfile
-            owner: "DataLayer"
-            module: "Zeebe"
-          - group: schema-manager
-            name: "Schema Manager"
-            maven-modules: "schema-manager"
-            maven-build-threads: 1
-            maven-test-fork-count: 3
-            runs-on: gcp-perf-core-8-default
-            docker-repository: localhost:5000/camunda/camunda
-            docker-file: camunda.Dockerfile
-            owner: "Data Layer"
-            module: "Schema Manager"
-          - group: zeebe-engine-integration
-            name: "Zeebe Engine QA"
-            maven-modules: "zeebe/qa/integration-tests"
-            maven-build-threads: 1
-            maven-test-fork-count: 10
-            runs-on: gcp-perf-core-16-default
-            owner: "Core Features"
-            module: "Zeebe"
-            test-filter: "io.camunda.zeebe.it.engine.**,!**/*$*.java"
-          - group: zeebe-ds-integration
-            name: "Zeebe Cluster QA"
-            maven-modules: "zeebe/qa/integration-tests"
-            maven-build-threads: 1
-            maven-test-fork-count: 10
-            runs-on: gcp-perf-core-16-default
-            docker-repository: localhost:5000/camunda/zeebe
-            docker-file: Dockerfile
-            owner: "Distributed Platform"
-            module: "Zeebe"
-            test-filter: "io.camunda.zeebe.it.cluster.**,!io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest,!**/*$*.java"
-          - group: zeebe-ds-integration-scaleup
-            name: "Zeebe Cluster ScaleUp QA"
-            maven-modules: "zeebe/qa/integration-tests"
-            maven-build-threads: 1
-            maven-test-fork-count: 1
-            runs-on: gcp-perf-core-8-default
-            owner: "Distributed Platform"
-            module: "Zeebe"
-            test-filter: "io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest"
-          - group: zeebe-shared-integration
-            name: "Zeebe General QA"
-            maven-modules: "zeebe/qa/integration-tests"
-            maven-build-threads: 1
-            maven-test-fork-count: 10
-            runs-on: gcp-perf-core-16-default
-            docker-repository: localhost:5000/camunda/zeebe
-            docker-file: Dockerfile
-            owner: "General"
-            module: "Zeebe"
-            test-filter: "!io.camunda.zeebe.it.engine.**,!io.camunda.zeebe.it.cluster.**,!**/*$*.java"
-          # - group: qa-update
-          #   name: "Zeebe QA - Update"
-          #   maven-modules: "zeebe/qa/update-tests"
-          #   maven-build-threads: 1
-          #   maven-test-fork-count: 10
-          #   runs-on: gcp-perf-core-8-default
-          #   docker-repository: localhost:5000/camunda/zeebe
-          #   docker-file: Dockerfile
-          #   owner: "Core Features"
-          #   module: "Zeebe"
-          - group: qa-camunda-process-test
-            name: "Camunda Process"
-            maven-modules: "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example"
-            maven-build-threads: 1
-            maven-test-fork-count: 3
-            runs-on: gcp-perf-core-8-default
-            docker-repository: localhost:5000/camunda/camunda
-            docker-file: camunda.Dockerfile
-            owner: "CamundaEx"
-            module: "Testing"
+        # Opt-in to stress testing this job via the PR label "ci:stress-test".
+        include: ${{ fromJson(needs.setup-tests.outputs.INTEGRATION_TESTS_MATRIX) }}
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
@@ -942,13 +1026,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           # Propagate matrix test filters (may be empty for other matrix entries)
           TEST_FILTER: ${{ matrix.test-filter }}
+          IS_STRESS_ENABLED: ${{ matrix.allow-stress == true && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:stress-test') }}
         shell: bash
         run: >
           ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
           -D forkCount=${{ matrix.maven-test-fork-count }}
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }} -D flaky.test.reportDir=failsafe-reports
+          -D failsafe.rerunFailingTestsCount=${{ env.IS_STRESS_ENABLED == 'true' && '0' || env.FLAKY_TEST_RERUN_COUNT }} -D flaky.test.reportDir=failsafe-reports
           -Dio.camunda.process.test.camundaDockerImageName="${{ env.CAMUNDA_DOCKER_IMAGE_NAME }}"
           -Dio.camunda.process.test.camundaDockerImageVersion="${{ env.DOCKER_IMAGE_TAG }}"
           -Dio.camunda.process.test.camundaVersion="${{ env.DOCKER_IMAGE_TAG }}"
@@ -969,14 +1054,14 @@ jobs:
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         continue-on-error: true
         with:
-          name: "[IT] ${{ matrix.name }}"
+          name: "[IT] ${{ matrix.name }} (${{ matrix.stressRun }})"
       - name: Write matrix outputs for test analysis
         uses: cloudposse/github-action-matrix-outputs-write@v1
         id: matrix-write
         continue-on-error: true
         with:
           matrix-step-name: ${{ github.job }}
-          matrix-key: ${{ matrix.module }} - [IT] ${{ matrix.name }} - ${{ matrix.owner }}
+          matrix-key: ${{ matrix.module }} - [IT] ${{ matrix.name }} - ${{ matrix.owner }} (${{ matrix.stressRun }})
           outputs: |-
             flakyTests: ${{ toJson(steps.analyze-test-run.outputs.flakyTests) }}
             hasFlaky: ${{ steps.analyze-test-run.outputs.flakyTests != '' }}
@@ -985,7 +1070,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "integration-tests/${{ matrix.group }}"
+          job_name: ${{ format('integration-tests/{0}{1}', matrix.group, matrix.stressRun != 1 && format('/{0}', matrix.stressRun) || '') }}
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           user_description: ${{ matrix.owner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,6 +684,12 @@ jobs:
     name: "General / Integration / RDBMS ITs"
     timeout-minutes: 30
     runs-on: gcp-perf-core-8-default
+    strategy:
+      # In case of stress testing, we want the status from all jobs.
+      fail-fast: false
+      matrix:
+        # Opt-in to stress testing this job via the PR label "ci:stress-test".
+        include: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:stress-test') && fromJson('[{"stressRun":1},{"stressRun":2},{"stressRun":3},{"stressRun":4},{"stressRun":5},{"stressRun":6},{"stressRun":7},{"stressRun":8},{"stressRun":9},{"stressRun":10}]') || fromJson('[{"stressRun":1}]') }}
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     permissions: { }  # no GITHUB_TOKEN is needed
@@ -709,7 +715,7 @@ jobs:
           -D forkCount=1
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }} -D flaky.test.reportDir=failsafe-reports
+          -D failsafe.rerunFailingTestsCount=${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:stress-test') && '0' || env.FLAKY_TEST_RERUN_COUNT }} -D flaky.test.reportDir=failsafe-reports
           -P rdbms,extract-flaky-tests
           -pl qa/acceptance-tests
           verify
@@ -724,12 +730,13 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "[IT] RDBMS"
+          name: "[IT] RDBMS - Run ${{ matrix.stressRun }}"
       - name: Observe build status
         if: always()
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          job_name: ${{ format('rdbms-integration-tests{0}', matrix.stressRun != 1 && format('/{0}', matrix.stressRun) || '') }}
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           user_description: "General"

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -665,15 +665,15 @@ Available commands:
 
 ## Flaky tests
 
-Tests can be viewed as "flaky" when they are not consistenly passing although neither the source code, nor the test code, nor the environment has been meaningfully changed.
-
-We should aim to have all tests consistently passing, avoid introducing new flaky tests and implement our [observability tooling](#ci-health-metrics) to detect and improve existing flaky tests. This allows for better developer experience and smoother processes like [automated dependency updates](#renovate).
+Tests are called "flaky" when they are not consistenly passing, while the circumstances (source code, test code, execution environment) remain the same. Flaky tests are caused by some inherent unreliability in the system. This needs to be avoided by improving the source code or test code, to improve developer experience and allow smooth [automated dependency updates](#renovate).
 
 GitHub Action workflows with Maven testing Java code should use the [flaky-test-extractor-maven-plugin](#flaky-test-extractor-maven-plugin) and report the resulting [detailed flaky test statistics](https://github.com/camunda/camunda/issues/26930) to our [CI health](#ci-health-metrics) database.
 
+Please use the [CI stress testing functionality](#stress-testing) to avoid introducing new flaky tests.
+
 Related resources:
 
-* [the Flaky tests dashboard (internal)](https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo)
+* [Flaky tests dashboard (internal)](https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo)
 
 ### flaky-test-extractor-maven-plugin
 
@@ -685,6 +685,22 @@ Some Maven modules in the monorepo [rerun failing Java tests multiple times](htt
 * if a test fails on all retries, it is classified as "failed"
   * this will cause the whole build to fail
   * see [the FAQ](#faq) on how to deal with such cases
+
+To reduce friction, we rerun failing tests up to 4 times on Pull Requests and up to 7 times in the merge queue and on `main` and `stable/*` branches.
+
+### Stress Testing
+
+There are a few jobs in the [Unified CI](#unified-ci) which frequently contain flaky tests. You need to run a CI stress test on your PR to avoid introducing new flaky tests, if you modify Java source or test code used by these CI jobs:
+
+* Zeebe Engine QA
+* Zeebe Cluster QA
+* RDBMS ITs
+
+To run a CI stress test, put the `ci:stress-test` label on any Pull Request and push e.g. a new code change or re-run the [Unified CI](#unified-ci) `ci.yml` workflow manually.
+
+This will lead to 10 concurrent instances of each of the above CI jobs being started. During a CI stress test, failed tests are not retried so ensure that flakiness is visible as failures.
+
+The results are visible via the usual Pull Request comment featuring the "CI failure summary": as soon as there is any failed CI job like `RDBMS ITs (x)` showing up, the stress test found an unreliability that must be fixed before merging.
 
 ## License Checks
 


### PR DESCRIPTION
## Description

This PR introduces **stress testing** capabilities for two Unified CI jobs that are **known flaky test hotspots: integration tests and RDBMS tests.** It also improves the CI failure summary by filtering out noisy annotations, and adding tests run via Maven failsafe (relevant for RDBMS job).

The key idea is to leverage GHA **matrix jobs** to run identical copies of the same job in **multiple parallel runs** (currently 10), thus giving a statistically relevant sample of failed vs successful runs. As part of the stress test, there will be **no reruns of failed tests** (which would constitute flakiness) to avoid masking the raw data.

Users can **opt-in to stress testing** via PR labels for the supported jobs (integration tests and RDBMS tests).

The existing [CI failure summary](https://github.com/camunda/camunda/pull/48191#issuecomment-4032082916) can be reused to view results of the stress test: As soon as there are **any failed runs** like `RDBMS ITs (x)` showing up, the stress test **revealed an unreliability** that needs fixing. Rationale here is that 1 failure in 10 parallel runs means ~10% error rate -> these errors are usually masked by retries, but are still errors.

Demo: https://github.com/camunda/camunda/pull/48712

Key changes:

**CI Workflow Enhancements and Stress Testing:**

* Added a new step to dynamically build the integration tests matrix in the `ci.yml` workflow, allowing for flexible and scalable configuration of integration test jobs. The matrix can now generate multiple runs for stress testing when the `ci:stress-test` label is present on a pull request. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR424-R467) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR360) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL753-R808)
* Updated job and artifact names to include the `stressRun` index, improving traceability and clarity in test reporting and artifact collection. This affects both the general RDBMS integration tests and the broader integration-tests job. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR732-R740) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL727-R787) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL743-R798) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL965-R918) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL981-R927)
* Modified the Maven test execution to disable flaky test reruns during stress runs (when stress testing is enabled via PR label), ensuring that all failures are reported for flakiness analysis. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL712-R766) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR883-R890)

**CI Annotation and Failure Reporting Improvements:**

* Updated the post-CI failure reasons action to filter out specific warning annotations (e.g., "Node.js 20 actions are deprecated") and only count/display relevant annotations, reducing noise in failure reports. [[1]](diffhunk://#diff-7592e81ad106aee8cf8dc474a1d063ddb05380bf93f5009411a1941271d89d86L109-R110) [[2]](diffhunk://#diff-7592e81ad106aee8cf8dc474a1d063ddb05380bf93f5009411a1941271d89d86L119-R120)

**Test Failure Pattern Matching:**

* Added a new matcher for Maven Failsafe test failures to `.github/maven-matcher.json`, improving the ability to extract and report relevant test failure messages.

(Note2self: debug link in case of GHA syntax errors is https://github.com/camunda/camunda/actions/workflows/ci.yml?query=branch%3Apoc-pr-ci-stress-test )

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not in scope of the POC, but possible later

## Related issues

None
