### PR TITLE
fix: backup service should run on an IO thread

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 
@@ -122,7 +123,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
     final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
     context
         .getActorSchedulingService()
-        .submitActor(backupManager)
+        .submitActor(backupManager, SchedulingHints.ioBound())
         .onComplete(
             (ignore, error) -> {
               if (error == null) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStepTest.java
@@ -83,7 +83,7 @@ class BackupServiceTransitionStepTest {
     lenient().when(raftPartition.dataDirectory()).thenReturn(Path.of("/tmp/zeebe").toFile());
 
     lenient()
-        .when(actorSchedulingService.submitActor(any()))
+        .when(actorSchedulingService.submitActor(any(), any()))
         .thenReturn(TEST_CONCURRENCY_CONTROL.completedFuture(null));
 
     lenient()


### PR DESCRIPTION
Given the tasks of the backup manager, IO threads are certainly the better choice. This should help a bit with keeping processing latency low.