### PR TITLE
fix: remove redundant partition-level empty directory check during restore

### DIFF
--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Objects;
@@ -80,12 +79,6 @@ public class PartitionRestoreService {
    */
   public void restore(final long[] backupIds, final BackupValidator validator)
       throws IOException, FlushException {
-    if (!FileUtil.isEmpty(rootDirectory)) {
-      LOG.error(
-          "Partition's data directory {} is not empty. Aborting restore to avoid overwriting data. Please restart with a clean directory.",
-          rootDirectory);
-      throw new DirectoryNotEmptyException(rootDirectory.toString());
-    }
     validateAndSortBackupIds(backupIds);
 
     try (final var restoredJournal =


### PR DESCRIPTION
Removes the redundant empty-directory check in `PartitionRestoreService.restore()` that duplicates the top-level check already performed by `RestoreManager.verifyDataFolderIsEmpty()`.

When a container restarts with `ZEEBE_RESTORE=true` still set after a successful restore, the partition-level check in `PartitionRestoreService` finds the restored data in `raft-partition/partitions/N`, throws `DirectoryNotEmptyException`, which gets wrapped in an `ExecutionException` and caught by `RestoreManager` — triggering deletion of the entire data directory, including the successfully restored data. This creates a destructive succeed-restart-delete cycle.

The top-level check in `RestoreManager.verifyDataFolderIsEmpty()` already validates the data directory state with `ignoreFilesInTarget` support. The partition-level check lacked this support and served no additional purpose since `PartitionRestoreService` is only ever called from `RestoreManager` after the top-level check has already passed.