### PR TITLE
[Backport stable/8.7] fix: backup service should run on an IO thread

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.backup.management.NoopBackupManager;
 import io.camunda.zeebe.backup.processing.CheckpointRecordsProcessor;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 
@@ -113,7 +114,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
     final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
     context
         .getActorSchedulingService()
-        .submitActor(backupManager)
+        .submitActor(backupManager, SchedulingHints.ioBound())
         .onComplete(
             (ignore, error) -> {
               if (error == null) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStepTest.java
@@ -73,7 +73,7 @@ class BackupServiceTransitionStepTest {
     lenient().when(raftPartition.dataDirectory()).thenReturn(Path.of("/tmp/zeebe").toFile());
 
     lenient()
-        .when(actorSchedulingService.submitActor(any()))
+        .when(actorSchedulingService.submitActor(any(), any()))
         .thenReturn(TEST_CONCURRENCY_CONTROL.completedFuture(null));
 
     lenient()


### PR DESCRIPTION
# Description
Backport of #48193 to `stable/8.7`.

relates to 