### PR TITLE
ci: temporarely disable the dependency-cycle-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,8 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   dependency-cycle-check:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    # Temporarily disabling the dependency-cycle-check as too brittle
+    if: ${{ false }} #if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "Dependency Cycle Check"
     needs: [ detect-changes ]
     runs-on: gcp-core-16-default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
 
   dependency-cycle-check:
     # Temporarily disabling the dependency-cycle-check as too brittle
-    if: ${{ false }} #if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: ${{ false }}
     name: "Dependency Cycle Check"
     needs: [ detect-changes ]
     runs-on: gcp-core-16-default


### PR DESCRIPTION
## Description

The `dependency-cycle-check` jobs take too much time and are currently unreliable to be used as a required step for the CI. 
We are disabling it to reduce the run time of the unified CI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes]

## Related issues

closes #
