### PR TITLE
40846 enhance docker tags on main

### DIFF
--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -10,7 +10,9 @@ fi
 
 if [ "${IS_MAIN}" = "true" ]; then
     tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8-SNAPSHOT")
-elif [ -n "${DOCKER_HUB_SNAPSHOT_TAG}" ]; then
+fi
+
+if [ -n "${DOCKER_HUB_SNAPSHOT_TAG}" ]; then
     tags+=("${DOCKER_IMAGE_DOCKER_HUB}:${DOCKER_HUB_SNAPSHOT_TAG}")
 fi
 

--- a/.github/skills/act-testing/SKILL.md
+++ b/.github/skills/act-testing/SKILL.md
@@ -12,6 +12,7 @@ Use this skill when a workflow change needs local validation with `act`.
 
 After creating or editing a workflow:
 1. Assess if the workflow is Tier 1, Tier 2, or Tier 3 (see `references/workflow-tiers.md`).
+   - Re-assess tier after every major scope change during iteration (e.g., removed jobs/branches/options).
 2. If Tier 1 or Tier 2, create a temporary `test-<workflow>.yml` harness and run drift guard:
    - `bash .github/skills/act-testing/scripts/check-drift.sh <production-workflow> <test-workflow>`
 3. Assess whether `act` execution is possible in the current environment.
@@ -35,6 +36,19 @@ Decision rule:
 - If internal logic is a primary risk, prepare harness + scenario matrix (Tier 1/2).
 - If external orchestration is the primary risk and internal logic is minimal, Tier 3 rationale is acceptable.
 - For multi-workflow changes, classify each workflow explicitly; do not infer one workflow's tier from another.
+
+## Mocked-Signal Gate (mandatory)
+
+Before committing to Tier 1/2 harnessing, estimate how much critical behavior is mocked in the harness:
+
+- If >=70% of critical path steps are mocked, do **not** default to Tier 1/2.
+- In that case, either:
+   - classify as Tier 3, or
+   - provide a written justification why remaining unmocked logic still gives high-confidence signal.
+
+Required statement for Tier 1/2: "What risk is actually tested by act in this harness?"
+
+If this statement cannot be answered clearly, classify as Tier 3.
 
 ## Harness Rules
 
@@ -115,6 +129,7 @@ For Tier 3 workflows, the final user message must still include:
 - `tier: 3`
 - `non-applicability rationale: <why external orchestration dominates>`
 - `act-scenarios: not required`
+- `harness: not created (or removed) because mocked signal is insufficient`
 
 ## Success Metrics for Act Readiness
 

--- a/.github/skills/act-testing/references/event-payloads/push-stable.json
+++ b/.github/skills/act-testing/references/event-payloads/push-stable.json
@@ -1,0 +1,14 @@
+{
+  "ref": "refs/heads/stable/1.0",
+  "repository": {
+    "html_url": "https://github.com/camunda/camunda"
+  },
+  "pusher": {
+    "name": "test-user"
+  },
+  "head_commit": {
+    "id": "1234567890abcdef",
+    "message": "CI update on stable/1.0",
+    "url": "https://github.com/camunda/camunda/commit/1234567890abcdef"
+  }
+}

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -444,7 +444,9 @@ jobs:
         id: build-zeebe-docker
         with:
           repository: camunda/zeebe
-          version: ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.version_tag }}
+          version: |
+            ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.version_tag }}
+            ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.snapshot_tag }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1643,7 +1643,9 @@ jobs:
         id: build-camunda-docker
         with:
           repository: camunda/camunda
-          version: ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.version_tag }}
+          version: |
+            ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.version_tag }}
+            ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.snapshot_tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: camunda.Dockerfile

--- a/.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
+++ b/.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
@@ -23,6 +23,9 @@ on:
       version_tag:
         description: "Generated Docker version tag"
         value: ${{  jobs.get-snapshot-docker-version-tag.outputs.tag }}
+      snapshot_tag:
+        description: "Generated Docker SNAPSHOT tag for main branch"
+        value: ${{ jobs.get-snapshot-docker-version-tag.outputs.snapshot_tag }}
       concurrency_group_name:
         description: "Concurrency group name for the workflow"
         value: ${{ jobs.get-concurrency-group-dynamically.outputs.result }}
@@ -41,20 +44,37 @@ jobs:
       (inputs.job_to_run == 'all' || inputs.job_to_run == 'snapshot-tag')
     outputs:
       tag: ${{ steps.set_docker_snapshot_version_tag.outputs.tag }}
+      snapshot_tag: ${{ steps.set_docker_snapshot_version_tag.outputs.snapshot_tag }}
     steps:
+      - name: Checkout repository
+        if: github.ref == 'refs/heads/main'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            pom.xml
       - name: Determine Snapshot Docker Version Tag
         id: set_docker_snapshot_version_tag
         run: |
           BRANCH="${GITHUB_REF#refs/heads/}"
           if [[ "$BRANCH" == "main" ]]; then
-            TAG="SNAPSHOT"
+            PROJECT_VERSION="$(grep -m1 '<version>' pom.xml | sed -E 's|.*<version>([^<]+)</version>.*|\1|')"
+            if [[ "$PROJECT_VERSION" =~ ^([0-9]+)\.([0-9]+)\..*$ ]]; then
+              TAG="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}-SNAPSHOT"
+            else
+              echo "Unsupported project version: $PROJECT_VERSION"
+              exit 1
+            fi
+            SNAPSHOT_TAG="SNAPSHOT"
           elif [[ "$BRANCH" == stable/* ]]; then
             TAG="${BRANCH#stable/}-SNAPSHOT"
+            SNAPSHOT_TAG=""
           else
             echo "Unsupported branch: $BRANCH"
             exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "snapshot_tag=$SNAPSHOT_TAG" >> "$GITHUB_OUTPUT"
 
   get-concurrency-group-dynamically:
     runs-on: ubuntu-latest

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -144,7 +144,9 @@ jobs:
         uses: ./.github/actions/build-platform-docker
         with:
           repository: camunda/operate
-          version: ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.version_tag }}
+          version: |
+            ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.version_tag }}
+            ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.snapshot_tag }}
           push: true
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: operate.Dockerfile

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -129,7 +129,9 @@ jobs:
         uses: ./.github/actions/build-platform-docker
         with:
           repository: camunda/tasklist
-          version: ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.version_tag }}
+          version: |
+            ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.version_tag }}
+            ${{ needs.utils-get-snapshot-docker-tag-and-concurrency-group.outputs.snapshot_tag }}
           push: true
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: tasklist.Dockerfile

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -15,8 +15,8 @@ Maven artifacts are available on [Artifactory](https://artifacts.camunda.com/) a
 
 * Pushed commits to `main` branch produce:
   * Maven artifacts with version `8.10.0-SNAPSHOT` for all C8 components
-  * Docker images with tag `SNAPSHOT` for [Operate](https://hub.docker.com/r/camunda/operate/tags?name=SNAPSHOT), [Tasklist](https://hub.docker.com/r/camunda/tasklist/tags?name=SNAPSHOT), [Zeebe](https://hub.docker.com/r/camunda/zeebe/tags?name=SNAPSHOT)
-  * Docker images with tag `8-SNAPSHOT` for [Optimize](https://hub.docker.com/r/camunda/optimize/tags?name=8-SNAPSHOT)
+  * Docker images with tags `X.Y-SNAPSHOT` and `SNAPSHOT` for [Camunda](https://hub.docker.com/r/camunda/camunda), [Operate](https://hub.docker.com/r/camunda/operate), [Tasklist](https://hub.docker.com/r/camunda/tasklist), and [Zeebe](https://hub.docker.com/r/camunda/zeebe)
+  * Docker images with tags `X.Y-SNAPSHOT` and `8-SNAPSHOT` for [Optimize](https://hub.docker.com/r/camunda/optimize)
 * Pushed commits to `stable/8.9` branch produce:
   * Maven artifacts with version `8.9.0-SNAPSHOT` for Optimize, Operate, Tasklist, Zeebe
   * Docker images with tag `8.9-SNAPSHOT` for [Optimize](https://hub.docker.com/r/camunda/optimize/tags?name=8.9-SNAPSHOT), [Operate](https://hub.docker.com/r/camunda/operate/tags?name=8.9-SNAPSHOT), [Tasklist](https://hub.docker.com/r/camunda/tasklist/tags?name=8.9-SNAPSHOT), [Zeebe](https://hub.docker.com/r/camunda/zeebe/tags?name=8.9-SNAPSHOT)


### PR DESCRIPTION
## Description

This pull request introduces several improvements to the CI workflows and documentation, primarily focusing on enhanced Docker image tagging for main and stable branches, like described on #40846. It is working like an extension of https://github.com/camunda/camunda/pull/34498 for the `main` branch.

**Docker Image Tagging and CI Workflow Enhancements:**

* Updated the Docker build workflows (`ci.yml`, `ci-zeebe.yml`, `operate-ci-build-reusable.yml`, `tasklist-ci-build-reusable.yml`) to support multiple Docker image tags, including both `${version_tag}` and `${snapshot_tag}` outputs, ensuring that images are tagged with both `X.Y-SNAPSHOT` and `SNAPSHOT` (or `8-SNAPSHOT` for Optimize) for main branches. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1646-R1648) [[2]](diffhunk://#diff-3551c281180b31caeb72c73964907be7d02d64d790e0dde0b2560144516a8718L447-R449) [[3]](diffhunk://#diff-e7d4a22f6abf3c43f1da92e310b217ed392077d18ebb15cbcb70754aa78ec12dL147-R149) [[4]](diffhunk://#diff-9837da5d8632a6befb37fc6a47b7a0969c743ce0ce6d4eb2cb9613caca140c33L132-R134)
* Enhanced the `generate-snapshot-docker-tag-and-concurrency-group.yml` workflow to generate and output both a version-specific and a generic SNAPSHOT tag, with logic to extract the version from `pom.xml` for main branch builds. [[1]](diffhunk://#diff-7e9c3917196264221d46d246da796e6aa88d2ca7717e0b9e1bccb33626278183R26-R28) [[2]](diffhunk://#diff-7e9c3917196264221d46d246da796e6aa88d2ca7717e0b9e1bccb33626278183R47-R77)
* Tested  `generate-snapshot-docker-tag-and-concurrency-group.yml` though act:
<img width="804" height="841" alt="image" src="https://github.com/user-attachments/assets/c279cae7-b5fc-4452-b533-73e988492e17" />
<img width="868" height="841" alt="image" src="https://github.com/user-attachments/assets/f8bb7879-7ccb-4c86-89f6-16d55eeb2413" />
<img width="822" height="782" alt="image" src="https://github.com/user-attachments/assets/2456ce72-36d9-442c-8fa7-af434818c17a" />

* Modified the Docker build script (`build-docker-image.sh`) to append the `DOCKER_HUB_SNAPSHOT_TAG` if present, regardless of branch, improving tag assignment flexibility.

**Documentation Updates:**

* Updated CI documentation to reflect the new Docker tagging scheme for main and stable branches, clarifying which tags are published for which components.

**Workflow Testing Guidance Improvements:**

* Expanded the `act-testing` skill documentation to require tier reassessment after major workflow changes, introduced a "Mocked-Signal Gate" to ensure harnesses provide meaningful test coverage, and mandated explicit statements about what risks are tested by `act`. Also added requirements for Tier 3 workflows to document when a harness is not created due to insufficient signal. [[1]](diffhunk://#diff-3873d761d0cfb36e54bb67a494298ed8d1048b5483184f68c49cb7fb26db5bcfR15) [[2]](diffhunk://#diff-3873d761d0cfb36e54bb67a494298ed8d1048b5483184f68c49cb7fb26db5bcfR40-R52) [[3]](diffhunk://#diff-3873d761d0cfb36e54bb67a494298ed8d1048b5483184f68c49cb7fb26db5bcfR132)

**Test Data Additions:**

* Added a new sample event payload (`push-stable.json`) for stable branch push events to support local workflow testing.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
