### PR TITLE
feat: Scope aware variable filter properties

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
@@ -30,6 +30,8 @@ public interface FilterConfiguration {
   IndexConfig filterIndexConfig();
 
   interface IndexConfig {
+
+    // Global variable filters
     List<String> getVariableNameInclusionExact();
 
     List<String> getVariableNameInclusionStartWith();
@@ -46,10 +48,83 @@ public interface FilterConfiguration {
 
     List<String> getVariableValueTypeExclusion();
 
+    // Root variable filters
+    default List<String> getRootVariableNameInclusionExact() {
+      return List.of();
+    }
+
+    default List<String> getRootVariableNameInclusionStartWith() {
+      return List.of();
+    }
+
+    default List<String> getRootVariableNameInclusionEndWith() {
+      return List.of();
+    }
+
+    default List<String> getRootVariableNameExclusionExact() {
+      return List.of();
+    }
+
+    default List<String> getRootVariableNameExclusionStartWith() {
+      return List.of();
+    }
+
+    default List<String> getRootVariableNameExclusionEndWith() {
+      return List.of();
+    }
+
+    default List<String> getRootVariableValueTypeInclusion() {
+      return List.of();
+    }
+
+    default List<String> getRootVariableValueTypeExclusion() {
+      return List.of();
+    }
+
+    // Local variable filters
+    default List<String> getLocalVariableNameInclusionExact() {
+      return List.of();
+    }
+
+    default List<String> getLocalVariableNameInclusionStartWith() {
+      return List.of();
+    }
+
+    default List<String> getLocalVariableNameInclusionEndWith() {
+      return List.of();
+    }
+
+    default List<String> getLocalVariableNameExclusionExact() {
+      return List.of();
+    }
+
+    default List<String> getLocalVariableNameExclusionStartWith() {
+      return List.of();
+    }
+
+    default List<String> getLocalVariableNameExclusionEndWith() {
+      return List.of();
+    }
+
+    default List<String> getLocalVariableValueTypeInclusion() {
+      return List.of();
+    }
+
+    default List<String> getLocalVariableValueTypeExclusion() {
+      return List.of();
+    }
+
+    // Filter local variables
+    default boolean isExportLocalVariablesEnabled() {
+      return true;
+    }
+
+    // BPMN process filters
     List<String> getBpmnProcessIdInclusion();
 
     List<String> getBpmnProcessIdExclusion();
 
+    // Optimize mode
     boolean isOptimizeModeEnabled();
   }
 }


### PR DESCRIPTION
New scope specific properties for variable name and type filters. Boolean flag to enable or disable local variables exporting, with default to true.

## Related issues

closes #
https://github.com/camunda/camunda/issues/48099https://github.com/camunda/camunda/issues/48099
