### PR TITLE
fix: update pod names from camunda-0/1/2 to zeebe-0/1/2 in profile workflow and script

### DIFF
--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -9,7 +9,7 @@ on:
         description: 'Specifies the name of the load test to profile'
         required: true
       pod:
-        description: 'Specifies the pod name to profile. Leave empty to profile all three pods (camunda-0, camunda-1, camunda-2) with different events, or specify a pod name for CPU profiling only.'
+        description: 'Specifies the pod name to profile. Leave empty to profile all three pods (zeebe-0, zeebe-1, zeebe-2) with different events, or specify a pod name for CPU profiling only.'
         default: ''
         required: false
       profiler_options:
@@ -23,7 +23,7 @@ on:
         required: true
         type: string
       pod:
-        description: 'Specifies the pod name to profile. Leave empty to profile all three pods with different events, or specify a pod name for CPU profiling only.'
+        description: 'Specifies the pod name to profile. Leave empty to profile all three pods (zeebe-0, zeebe-1, zeebe-2) with different events, or specify a pod name for CPU profiling only.'
         default: ''
         required: false
         type: string
@@ -56,11 +56,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - pod: camunda-0
+          - pod: zeebe-0
             event: cpu
-          - pod: camunda-1
+          - pod: zeebe-1
             event: wall
-          - pod: camunda-2
+          - pod: zeebe-2
             event: alloc
     steps:
       - uses: actions/checkout@v6

--- a/zeebe/benchmarks/docs/scripts/executeProfiling.sh
+++ b/zeebe/benchmarks/docs/scripts/executeProfiling.sh
@@ -53,7 +53,7 @@ fi
 filename=flamegraph-$profiler_event-$(date +%Y-%m-%d_%H-%M-%S).html
 # Extracting the PID:
 #
-#  $ k exec camunda-0 -it -- ps -ax
+#  $ k exec zeebe-0 -it -- ps -ax
 #    PID TTY      STAT   TIME COMMAND
 #      1 ?        Ssl  570:26 /usr/lib/jvm/default-jvm/bin/java -XX:+ExitOnOutOfM
 #   5905 pts/0    Rs+    0:00 ps -ax


### PR DESCRIPTION
## Description
This pull request updates references to pod names in profiling scripts and workflow files from `camunda-*` to `zeebe-*`. The changes ensure consistency across documentation and workflow configuration, aligning pod naming with the current deployment.

Pod naming updates:

* [`.github/workflows/profile-load-test.yml`](diffhunk://#diff-979e3b0e30cac18b9f9ae3d8bcad0bb8506bf9f9d12b8447af820a54874c4015L12-R12): Changed pod descriptions and matrix entries from `camunda-0`, `camunda-1`, `camunda-2` to `zeebe-0`, `zeebe-1`, `zeebe-2` in both workflow input descriptions and job matrix configuration. [[1]](diffhunk://#diff-979e3b0e30cac18b9f9ae3d8bcad0bb8506bf9f9d12b8447af820a54874c4015L12-R12) [[2]](diffhunk://#diff-979e3b0e30cac18b9f9ae3d8bcad0bb8506bf9f9d12b8447af820a54874c4015L26-R26) [[3]](diffhunk://#diff-979e3b0e30cac18b9f9ae3d8bcad0bb8506bf9f9d12b8447af820a54874c4015L59-R63)
* [`zeebe/benchmarks/docs/scripts/executeProfiling.sh`](diffhunk://#diff-9640667d82e0dbbc3fc822f53749b3fd8940599cd5994954ef6ebe324a4ce68fL56-R56): Updated example command for extracting the PID to reference `zeebe-0` instead of `camunda-0`.

## Related issues
Same commit made here: https://github.com/camunda/camunda/pull/48089/changes/a6e6d77d355188ccbb703de6a2aca82588c78613
