### PR TITLE
ci: don't prematurely cancel AlwaysGreen runs on main

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -45,9 +45,10 @@ on:
       - "identity/**"
       - "optimize/**"
 
-# Cancel in-progress runs when a new commit is pushed to the same PR
+# Limit workflow to 1 concurrent run per ref (branch) and trigger event (push/schedule/etc): new commit -> old runs are canceled to save costs
+# Exception for main + stable/* branches: complete builds for every commit needed for confidence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || (github.event.pull_request.number || github.ref)) }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Description

This distorts the results as many builds do not finished, due to a newer commit being pushed to `main`: https://github.com/camunda/camunda/actions/runs/22723283879/job/65891919599

Same idea is using in `ci.yml` and proved to be working.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
