### PR TITLE
fix: prevent npe during swim probe

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -597,7 +597,7 @@ public class SwimMembershipProtocol
     PROBE_LOGGER.trace(
         "{} - Received probe {} from {}", this.localMember.id(), localMember, remoteMember);
 
-    if (localMember.id().equals(this.localMember.id())) {
+    if (Objects.equals(this.localMember.id(), localMember.id())) {
       // id can be just the host address if the probe uses the configured initial contact points. In
       // that case do not compare nodeVersion as it will be always 0.
       if (localMember.nodeVersion() < this.localMember.nodeVersion()) {


### PR DESCRIPTION
## Description

Observed NPE when handling probe

```
java.lang.NullPointerException: Cannot invoke "io.atomix.cluster.MemberId.equals(Object)" because the return value of "io.atomix.cluster.protocol.SwimMembershipProtocol$ImmutableMember.id()" is null
	at io.atomix.cluster.protocol.SwimMembershipProtocol.handleProbe(SwimMembershipProtocol.java:600)
	at io.atomix.cluster.protocol.SwimMembershipProtocol.lambda$new$3(SwimMembershipProtocol.java:123)
	at io.atomix.cluster.messaging.impl.NettyMessagingService.lambda$registerHandler$8(NettyMessagingService.java:338)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at io.atomix.utils.concurrent.AtomixThreadFactory.lambda$newThread$0(AtomixThreadFactory.java:46)
	at java.base/java.lang.Thread.run(Unknown Source)
```

It is not clear in what cases where the member in the request contains a null ID, but it is safer to compare using the localMember.id() as we know it will never be null. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).


related to https://github.com/camunda/camunda/pull/47525