### PR TITLE
fix: flaky core features UserTaskIt and GlobalListenersInitializerIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
@@ -56,7 +56,9 @@ public class UserTaskIT {
 
     final var processInstanceId = startProcessInstance(client, "test-process-id");
 
-    waitForProcessTasks(client, processInstanceId);
+    waitForTask(
+        client,
+        f -> f.processInstanceKey(processInstanceId).assignee("demo").state(UserTaskState.CREATED));
 
     final var userTasks = fetchUserTasks(client, processInstanceId);
     // then
@@ -386,20 +388,7 @@ public class UserTaskIT {
 
   public static void waitForProcessTasks(
       final CamundaClient client, final Long processInstanceKey) {
-
-    Awaitility.await()
-        .ignoreExceptions()
-        .timeout(Duration.ofSeconds(30))
-        .until(
-            () ->
-                !client
-                    .newUserTaskSearchRequest()
-                    .filter(
-                        f -> f.processInstanceKey(processInstanceKey).state(UserTaskState.CREATED))
-                    .send()
-                    .join()
-                    .items()
-                    .isEmpty());
+    waitForTask(client, f -> f.processInstanceKey(processInstanceKey).state(UserTaskState.CREATED));
   }
 
   public static Long startProcessInstance(final CamundaClient client, final String processId) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -304,7 +303,7 @@ final class GlobalListenersInitializerIT {
   }
 
   private void waitForConfigurationDistributionComplete(final String expectedListenerId) {
-    Awaitility.await()
+    RecordingExporter.await(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
               // Wait for configuration to be applied on all partitions


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix flaky/broken tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/48223
