### PR TITLE
feat: support parallel upload of segment/snapshot for azure

### DIFF
--- a/zeebe/backup-stores/azure/pom.xml
+++ b/zeebe/backup-stores/azure/pom.xml
@@ -122,5 +122,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -52,8 +52,8 @@ public final class AzureBackupStore implements BackupStore {
   public static final String SNAPSHOT_FILESET_NAME = "snapshot";
   public static final String SEGMENTS_FILESET_NAME = "segments";
   public static final String METADATA_OBJECT_NAME = "metadata.json";
+  static final int MAX_CONCURRENT_SAVES = 128;
   private static final Logger LOG = LoggerFactory.getLogger(AzureBackupStore.class);
-  private static final int MAX_CONCURRENT_SAVES = 128;
   private final ExecutorService executor;
   private final Semaphore saveSemaphore = new Semaphore(MAX_CONCURRENT_SAVES);
   private final ReentrantLock containerCreationLock = new ReentrantLock();
@@ -138,28 +138,54 @@ public final class AzureBackupStore implements BackupStore {
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
     return CompletableFuture.runAsync(
-        () -> {
-          try {
-            saveSemaphore.acquire();
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while waiting to save backup", e);
-          }
-          try {
-            final var persistedManifest = manifestManager.createInitialManifest(backup);
-            try {
-              fileSetManager.save(backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot());
-              fileSetManager.save(backup.id(), SEGMENTS_FILESET_NAME, backup.segments());
-              manifestManager.completeManifest(persistedManifest);
-            } catch (final Exception e) {
-              manifestManager.markAsFailed(persistedManifest.manifest().id(), e.getMessage());
-              throw e;
-            }
-          } finally {
-            saveSemaphore.release();
-          }
-        },
-        executor);
+            () -> {
+              try {
+                saveSemaphore.acquire();
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting to save backup", e);
+              }
+            },
+            executor)
+        .thenApplyAsync(ignored -> manifestManager.createInitialManifest(backup), executor)
+        .thenComposeAsync(
+            persistedManifest -> {
+              final var snapshotFuture =
+                  CompletableFuture.runAsync(
+                      () ->
+                          fileSetManager.save(
+                              backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot()),
+                      executor);
+              final var segmentsFuture =
+                  CompletableFuture.runAsync(
+                      () ->
+                          fileSetManager.save(
+                              backup.id(), SEGMENTS_FILESET_NAME, backup.segments()),
+                      executor);
+
+              return CompletableFuture.allOf(snapshotFuture, segmentsFuture)
+                  .whenCompleteAsync(
+                      (ignored, error) -> {
+                        if (error != null) {
+                          manifestManager.markAsFailed(
+                              persistedManifest.manifest().id(), error.getMessage());
+                        }
+                      },
+                      executor)
+                  .thenApplyAsync(ignored -> persistedManifest, executor);
+            },
+            executor)
+        .thenAcceptAsync(
+            persistedManifest -> {
+              try {
+                manifestManager.completeManifest(persistedManifest);
+              } catch (final Exception e) {
+                manifestManager.markAsFailed(persistedManifest.manifest().id(), e.getMessage());
+                throw e;
+              }
+            },
+            executor)
+        .whenComplete((ignored, error) -> saveSemaphore.release());
   }
 
   @Override

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStoreException.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStoreException.java
@@ -28,4 +28,10 @@ public abstract class AzureBackupStoreException extends RuntimeException {
       super(message);
     }
   }
+
+  public static class UploadException extends AzureBackupStoreException {
+    public UploadException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
 }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStoreException.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStoreException.java
@@ -28,10 +28,4 @@ public abstract class AzureBackupStoreException extends RuntimeException {
       super(message);
     }
   }
-
-  public static class UploadException extends AzureBackupStoreException {
-    public UploadException(final String message, final Throwable cause) {
-      super(message, cause);
-    }
-  }
 }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -11,10 +11,12 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.models.ParallelTransferOptions;
 import com.azure.storage.blob.specialized.BlockBlobClient;
+import com.azure.storage.common.implementation.Constants;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.azure.AzureBackupStoreException.BlobAlreadyExists;
@@ -26,16 +28,19 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 final class FileSetManager {
-  static final ParallelTransferOptions SNAPSHOT_FILES_OPTS =
+  private static final long MB = 1024 * 1024;
+  private static final ParallelTransferOptions SNAPSHOT_FILES_OPTS =
       new ParallelTransferOptions()
-          .setBlockSizeLong(1 * 1024L * 1024L)
-          .setMaxSingleUploadSizeLong(1 * 1024L * 1024L)
+          .setBlockSizeLong(MB)
+          .setMaxSingleUploadSizeLong(MB)
           .setMaxConcurrency(1);
-  static final ParallelTransferOptions SEGMENT_FILES_OPTS =
+  private static final ParallelTransferOptions SEGMENT_FILES_OPTS =
       new ParallelTransferOptions()
-          .setBlockSizeLong(4 * 1024L * 1024L)
-          .setMaxSingleUploadSizeLong(8 * 1024L * 1024L)
+          .setBlockSizeLong(4 * MB)
+          .setMaxSingleUploadSizeLong(8 * MB)
           .setMaxConcurrency(2);
+  private static final BlobRequestConditions NO_OVERWRITE_CONDITION =
+      new BlobRequestConditions().setIfNoneMatch(Constants.HeaderConstants.ETAG_WILDCARD);
 
   // The path format is constructed by contents/partitionId/checkpointId/nodeId/nameOfFile
   private static final String PATH_FORMAT = "contents/%s/%s/%s/%s/";
@@ -58,16 +63,7 @@ final class FileSetManager {
       final BlobClient blobClient = containerClient.getBlobClient(fileSetPath + fileName);
 
       try {
-        blobClient.uploadFromFile(
-            filePath.toString(),
-            fileSetName.equals(AzureBackupStore.SNAPSHOT_FILESET_NAME)
-                ? SNAPSHOT_FILES_OPTS
-                : SEGMENT_FILES_OPTS,
-            new BlobHttpHeaders(),
-            null,
-            null,
-            null,
-            null);
+        upload(blobClient, filePath, fileSetPath);
       } catch (final BlobStorageException e) {
         if (e.getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
           throw new BlobAlreadyExists("File already exists.", e.getCause());
@@ -123,6 +119,19 @@ final class FileSetManager {
         containerCreationLock.unlock();
       }
     }
+  }
+
+  private void upload(final BlobClient blobClient, final Path filePath, final String fileSetName) {
+    blobClient.uploadFromFile(
+        filePath.toString(),
+        fileSetName.equals(AzureBackupStore.SNAPSHOT_FILESET_NAME)
+            ? SNAPSHOT_FILES_OPTS
+            : SEGMENT_FILES_OPTS,
+        new BlobHttpHeaders(),
+        null,
+        null,
+        NO_OVERWRITE_CONDITION,
+        null);
   }
 
   private String fileSetPath(final BackupIdentifier id, final String fileSetName) {

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -63,7 +63,7 @@ final class FileSetManager {
       final BlobClient blobClient = containerClient.getBlobClient(fileSetPath + fileName);
 
       try {
-        upload(blobClient, filePath, fileSetPath);
+        upload(blobClient, filePath, fileSetName);
       } catch (final BlobStorageException e) {
         if (e.getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
           throw new BlobAlreadyExists("File already exists.", e.getCause());

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -7,12 +7,13 @@
  */
 package io.camunda.zeebe.backup.azure;
 
-import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobHttpHeaders;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.ListBlobsOptions;
+import com.azure.storage.blob.models.ParallelTransferOptions;
 import com.azure.storage.blob.specialized.BlockBlobClient;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.NamedFileSet;
@@ -25,6 +26,17 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 final class FileSetManager {
+  static final ParallelTransferOptions SNAPSHOT_FILES_OPTS =
+      new ParallelTransferOptions()
+          .setBlockSizeLong(1 * 1024L * 1024L)
+          .setMaxSingleUploadSizeLong(1 * 1024L * 1024L)
+          .setMaxConcurrency(1);
+  static final ParallelTransferOptions SEGMENT_FILES_OPTS =
+      new ParallelTransferOptions()
+          .setBlockSizeLong(4 * 1024L * 1024L)
+          .setMaxSingleUploadSizeLong(8 * 1024L * 1024L)
+          .setMaxConcurrency(2);
+
   // The path format is constructed by contents/partitionId/checkpointId/nodeId/nameOfFile
   private static final String PATH_FORMAT = "contents/%s/%s/%s/%s/";
   private final BlobContainerClient containerClient;
@@ -46,8 +58,16 @@ final class FileSetManager {
       final BlobClient blobClient = containerClient.getBlobClient(fileSetPath + fileName);
 
       try {
-        final BinaryData binaryData = BinaryData.fromFile(filePath);
-        blobClient.upload(binaryData, false);
+        blobClient.uploadFromFile(
+            filePath.toString(),
+            fileSetName.equals(AzureBackupStore.SNAPSHOT_FILESET_NAME)
+                ? SNAPSHOT_FILES_OPTS
+                : SEGMENT_FILES_OPTS,
+            new BlobHttpHeaders(),
+            null,
+            null,
+            null,
+            null);
       } catch (final BlobStorageException e) {
         if (e.getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
           throw new BlobAlreadyExists("File already exists.", e.getCause());

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -29,12 +29,7 @@ import java.util.stream.Collectors;
 
 final class FileSetManager {
   private static final long MB = 1024 * 1024;
-  private static final ParallelTransferOptions SNAPSHOT_FILES_OPTS =
-      new ParallelTransferOptions()
-          .setBlockSizeLong(MB)
-          .setMaxSingleUploadSizeLong(MB)
-          .setMaxConcurrency(1);
-  private static final ParallelTransferOptions SEGMENT_FILES_OPTS =
+  private static final ParallelTransferOptions CHUNKED_FILE_OPTS =
       new ParallelTransferOptions()
           .setBlockSizeLong(4 * MB)
           .setMaxSingleUploadSizeLong(8 * MB)
@@ -63,7 +58,7 @@ final class FileSetManager {
       final BlobClient blobClient = containerClient.getBlobClient(fileSetPath + fileName);
 
       try {
-        upload(blobClient, filePath, fileSetName);
+        upload(blobClient, filePath);
       } catch (final BlobStorageException e) {
         if (e.getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
           throw new BlobAlreadyExists("File already exists.", e.getCause());
@@ -121,12 +116,10 @@ final class FileSetManager {
     }
   }
 
-  private void upload(final BlobClient blobClient, final Path filePath, final String fileSetName) {
+  private void upload(final BlobClient blobClient, final Path filePath) {
     blobClient.uploadFromFile(
         filePath.toString(),
-        fileSetName.equals(AzureBackupStore.SNAPSHOT_FILESET_NAME)
-            ? SNAPSHOT_FILES_OPTS
-            : SEGMENT_FILES_OPTS,
+        CHUNKED_FILE_OPTS,
         new BlobHttpHeaders(),
         null,
         null,

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreSaveTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreSaveTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.azure.ManifestManager.PersistedManifest;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class AzureBackupStoreSaveTest {
+
+  @Mock private FileSetManager fileSetManager;
+  @Mock private ManifestManager manifestManager;
+  @Mock private BlobServiceClient blobServiceClient;
+
+  private AzureBackupStore store;
+  private Backup backup;
+  private PersistedManifest persistedManifest;
+  private Semaphore saveSemaphore;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    final AzureBackupConfig config =
+        new AzureBackupConfig.Builder()
+            .withCreateContainer(false)
+            .withContainerName("test")
+            .build();
+    final var containerClient = mock(BlobContainerClient.class);
+    when(blobServiceClient.getBlobContainerClient(anyString())).thenReturn(containerClient);
+    when(containerClient.exists()).thenReturn(true);
+    final var realStore = new AzureBackupStore(config, blobServiceClient);
+
+    /* Inject mocks */
+    final Field manifestManagerField = AzureBackupStore.class.getDeclaredField("manifestManager");
+    manifestManagerField.setAccessible(true);
+    manifestManagerField.set(realStore, manifestManager);
+
+    final Field fileSetManagerField = AzureBackupStore.class.getDeclaredField("fileSetManager");
+    fileSetManagerField.setAccessible(true);
+    fileSetManagerField.set(realStore, fileSetManager);
+
+    final Field semaphoreField = AzureBackupStore.class.getDeclaredField("saveSemaphore");
+    semaphoreField.setAccessible(true);
+    saveSemaphore = (Semaphore) semaphoreField.get(realStore);
+
+    store = spy(realStore);
+
+    final var id = new BackupIdentifierImpl(1, 0, 1L);
+    final var descriptor =
+        new BackupDescriptorImpl(1L, 2, "1.2.0", Instant.now(), CheckpointType.MANUAL_BACKUP);
+    backup =
+        new BackupImpl(
+            id, descriptor, new NamedFileSetImpl(Map.of()), new NamedFileSetImpl(Map.of()));
+
+    final var manifest = Manifest.createInProgress(backup);
+    persistedManifest = new PersistedManifest("etag-1", manifest);
+  }
+
+  @AfterEach
+  void tearDown() {
+    store.closeAsync().join();
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenSnapshotUploadFails() {
+    // given
+    when(manifestManager.createInitialManifest(any())).thenReturn(persistedManifest);
+    final var uploadError = new RuntimeException("snapshot upload failed");
+    doThrow(uploadError).when(fileSetManager).save(any(), anyString(), any());
+
+    // when
+    final var future = store.save(backup);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(RuntimeException.class);
+    // whenCompleteAsync receives a CompletionException wrapping the original error
+    final var expectedFailureMessage = new CompletionException(uploadError).getMessage();
+    verify(manifestManager).markAsFailed(backup.id(), expectedFailureMessage);
+  }
+
+  @Test
+  void shouldAcquireAndReleaseTheSemaphoreOnSuccess() {
+    // given
+    when(manifestManager.createInitialManifest(any())).thenReturn(persistedManifest);
+    final int permitsBefore = saveSemaphore.availablePermits();
+
+    // when
+    store.save(backup).join();
+
+    // then
+    assertThat(saveSemaphore.availablePermits())
+        .as("semaphore permits should be fully restored after a successful save")
+        .isEqualTo(permitsBefore);
+  }
+
+  @Test
+  void shouldAcquireAndReleaseTheSemaphoreWhenUploadFails() {
+    // given
+
+    lenient()
+        .doThrow(new RuntimeException("upload failed"))
+        .when(fileSetManager)
+        .save(any(), anyString(), any());
+    final int permitsBefore = saveSemaphore.availablePermits();
+
+    // when
+    store.save(backup).exceptionally(e -> null).join();
+
+    // then
+    assertThat(saveSemaphore.availablePermits())
+        .as("semaphore permits should be fully restored after a failed upload")
+        .isEqualTo(permitsBefore);
+  }
+
+  @Test
+  void shouldAcquireAndReleaseTheSemaphoreWhenCreateInitialManifestFails() {
+    // given
+    Mockito.lenient()
+        .when(manifestManager.createInitialManifest(any()))
+        .thenThrow(new RuntimeException("manifest creation failed"));
+    final int permitsBefore = saveSemaphore.availablePermits();
+
+    // when
+    store.save(backup).exceptionally(e -> null).join();
+
+    // then
+    assertThat(saveSemaphore.availablePermits())
+        .as("semaphore permits should be fully restored after a failed manifest creation")
+        .isEqualTo(permitsBefore);
+  }
+
+  @Test
+  void shouldDecrementPermitWhileSaveIsInFlight() throws Exception {
+    // given – block the upload so the save is still in progress when we sample the semaphore
+    when(manifestManager.createInitialManifest(any())).thenReturn(persistedManifest);
+    final var uploadStarted = new CountDownLatch(1);
+    final var releaseUpload = new CountDownLatch(1);
+    Mockito.doAnswer(
+            inv -> {
+              uploadStarted.countDown();
+              releaseUpload.await();
+              return null;
+            })
+        .when(fileSetManager)
+        .save(any(), anyString(), any());
+
+    // when
+    final var future = store.save(backup);
+    uploadStarted.await();
+
+    // then – one permit must be held while the save is in progress
+    assertThat(saveSemaphore.availablePermits())
+        .as("one permit should be held while a save is in progress")
+        .isEqualTo(AzureBackupStore.MAX_CONCURRENT_SAVES - 1);
+
+    // cleanup – let the upload finish and confirm the permit is restored
+    releaseUpload.countDown();
+    future.join();
+
+    assertThat(saveSemaphore.availablePermits())
+        .as("permit should be restored after the in-flight save completes")
+        .isEqualTo(AzureBackupStore.MAX_CONCURRENT_SAVES);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Azure backup store is still the slowest of the 3 blob storage providers we currently support. It will need revisit sometime soon.

Slightly improve performance on backup uploading in Azure blob storage by parallelized uploads of segments & snapshots. Also, enable chunked uploads for **segment** uploads.

Chunked uploads also address a buffer reservation in Netty channels:
```
	Suppressed: java.lang.Exception: #block terminated with an error
		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
		at reactor.core.publisher.Mono.block(Mono.java:1773)
		at com.azure.storage.common.implementation.StorageImplUtils.blockWithOptionalTimeout(StorageImplUtils.java:147)
		at com.azure.storage.blob.BlobClient.uploadWithResponse(BlobClient.java:398)
		at com.azure.storage.blob.BlobClient.upload(BlobClient.java:325)
		at io.camunda.zeebe.backup.azure.FileSetManager.save(FileSetManager.java:48)
		at io.camunda.zeebe.backup.azure.AzureBackupStore.lambda$save$0(AzureBackupStore.java:141)
		at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
		at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(Unknown Source)
		at java.base/java.lang.VirtualThread.run(Unknown Source)
Caused by: java.lang.OutOfMemoryError: Cannot reserve 540672 bytes of direct buffer memory (allocated: 536860521, limit: 536870912)
	at java.base/java.nio.Bits.reserveMemory(Unknown Source)
	at java.base/java.nio.DirectByteBuffer.<init>(Unknown Source)
	at java.base/java.nio.ByteBuffer.allocateDirect(Unknown Source)
	at io.netty.util.internal.CleanerJava9.allocate(CleanerJava9.java:86)
	at io.netty.util.internal.PlatformDependent.allocateDirect(PlatformDependent.java:600)
	at io.netty.buffer.UnpooledDirectByteBuf.allocateDirectBuffer(UnpooledDirectByteBuf.java:121)
	at io.netty.buffer.UnpooledDirectByteBuf.<init>(UnpooledDirectByteBuf.java:66)
	at io.netty.buffer.UnpooledUnsafeDirectByteBuf.<init>(UnpooledUnsafeDirectByteBuf.java:43)
```

# After - Before

## 300MB SST files
<img width="1696" height="363" alt="image" src="https://github.com/user-attachments/assets/d72344c5-46e4-4188-aead-69f02efbd827" />

## 600MB SST files
<img width="1696" height="363" alt="image" src="https://github.com/user-attachments/assets/8ee7a550-4dfd-4633-ae0e-48fd14a31ab9" />

## 800MB SST files

Missed the before screenshot but it's upwards of 1 minute

<img width="808" height="353" alt="image" src="https://github.com/user-attachments/assets/880fb34e-1fd6-4e4c-8bbe-ec1126e72247" />



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
