### PR TITLE
fix: flaky BackupCompaitbilityAcceptance test

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -127,6 +127,7 @@ public interface BackupCompatibilityAcceptance {
 
       // then
       Awaitility.await("until backup is deleted")
+          .ignoreExceptions()
           .atMost(Duration.ofSeconds(30))
           .untilAsserted(() -> assertThat(backupActuator.list()).isEmpty());
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This test was marked as flaky and relates to this error: https://github.com/camunda/camunda/actions/runs/22921321485/attempts/1#summary-66520287869

I didn't see any other problem with it other than the timeout, but would be happy to hear other improvement ideas if the waiting duration is unexpected at this point.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/48223
