### PR TITLE
feat: implement the new incidents tab

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsFilter/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsFilter/index.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  availableErrorTypes,
+  getIncidentErrorName,
+} from 'modules/utils/incidents';
+import {IncidentsFilter} from './index';
+import {render, screen} from 'modules/testing-library';
+
+describe('IncidentsFilter', () => {
+  it('should render filters', async () => {
+    const {user} = render(<IncidentsFilter />);
+
+    await user.click(
+      screen.getByRole('combobox', {name: /filter by incident type/i}),
+    );
+
+    for (const errorType of availableErrorTypes) {
+      expect(
+        screen.getByRole('option', {name: getIncidentErrorName(errorType)}),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('should disable/enable clear all button depending on selected options', async () => {
+    const {user} = render(<IncidentsFilter />);
+
+    expect(screen.getByRole('button', {name: 'Reset Filters'})).toBeDisabled();
+
+    await user.click(
+      screen.getByRole('combobox', {name: /filter by incident type/i}),
+    );
+
+    await user.click(
+      screen.getByRole('option', {
+        name: 'Condition error.',
+      }),
+    );
+    expect(screen.getByRole('button', {name: 'Reset Filters'})).toBeEnabled();
+
+    expect(
+      screen.getByRole('option', {
+        name: 'Condition error.',
+        selected: true,
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Reset Filters'}));
+
+    expect(screen.getByRole('button', {name: 'Reset Filters'})).toBeDisabled();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsFilter/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsFilter/index.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Container, Stack, Layer} from './styled';
+import {observer} from 'mobx-react';
+import {tracking} from 'modules/tracking';
+import {Button, MultiSelect} from '@carbon/react';
+import {
+  availableErrorTypes,
+  getIncidentErrorName,
+} from 'modules/utils/incidents';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
+
+const IncidentsFilter: React.FC = observer(() => {
+  return (
+    <Layer>
+      <Container>
+        <Stack orientation="horizontal" gap={5}>
+          <MultiSelect
+            id="incidents-by-errorType"
+            data-testid="incidents-by-errorType"
+            items={availableErrorTypes}
+            selectedItems={incidentsPanelStore.state.selectedErrorTypes}
+            itemToString={(selectedItem) => getIncidentErrorName(selectedItem)}
+            label="Filter by Incident Type"
+            titleText="Filter by Incident Type"
+            hideLabel
+            onChange={({selectedItems}) => {
+              incidentsPanelStore.setErrorTypeSelection(selectedItems ?? []);
+            }}
+            size="sm"
+          />
+          <Button
+            kind="ghost"
+            onClick={() => {
+              incidentsPanelStore.clearSelection();
+              tracking.track({
+                eventName: 'incident-filters-cleared',
+              });
+            }}
+            disabled={!incidentsPanelStore.hasActiveFilters}
+            title="Reset Filters"
+            size="sm"
+          >
+            Reset Filters
+          </Button>
+        </Stack>
+      </Container>
+    </Layer>
+  );
+});
+
+export {IncidentsFilter};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsFilter/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsFilter/styled.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {Stack as BaseStack, Layer as BaseLayer} from '@carbon/react';
+
+const Container = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: flex-end;
+  padding: var(--cds-spacing-01) var(--cds-spacing-05);
+`;
+
+const Stack = styled(BaseStack)`
+  align-items: center;
+`;
+
+const Layer = styled(BaseLayer)`
+  margin-left: auto;
+`;
+
+export {Container, Stack, Layer};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
@@ -73,7 +73,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
         <SortableTable
           state={state}
           emptyMessage={{
-            message: 'There are no Instances matching this filter set',
+            message: 'There are no incidents matching this filter set',
           }}
           selectionType="row"
           columnsWithNoContentPadding={['operations', 'errorMessage']}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {IncidentOperation} from 'modules/components/IncidentOperation';
+import {formatDate} from 'modules/utils/date';
+import {observer} from 'mobx-react';
+import {FlexContainer, ErrorMessageCell} from './styled';
+import {Link} from 'modules/components/Link';
+import {Paths} from 'modules/Routes';
+import {tracking} from 'modules/tracking';
+import {Button} from '@carbon/react';
+import {SortableTable} from 'modules/components/SortableTable';
+import {useState} from 'react';
+import {JSONEditorModal} from 'modules/components/JSONEditorModal';
+import {
+  getIncidentErrorName,
+  isSingleIncidentSelected,
+} from 'modules/utils/incidents';
+import type {EnhancedIncident} from 'modules/hooks/incidents';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+
+type IncidentsTableProps = {
+  processInstanceKey: string;
+  incidents: EnhancedIncident[];
+  state: React.ComponentProps<typeof SortableTable>['state'];
+  onVerticalScrollStartReach?: React.ComponentProps<
+    typeof SortableTable
+  >['onVerticalScrollStartReach'];
+  onVerticalScrollEndReach?: React.ComponentProps<
+    typeof SortableTable
+  >['onVerticalScrollEndReach'];
+};
+
+const IncidentsTable: React.FC<IncidentsTableProps> = observer(
+  function IncidentsTable({
+    state,
+    incidents,
+    processInstanceKey,
+    onVerticalScrollEndReach,
+    onVerticalScrollStartReach,
+  }) {
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const [modalContent, setModalContent] = useState<string>('');
+    const [modalTitle, setModalTitle] = useState<string>('');
+
+    const handleModalClose = () => {
+      setIsModalVisible(false);
+      setModalContent('');
+      setModalTitle('');
+    };
+
+    const handleMoreButtonClick = (
+      errorMessage: string,
+      elementName: string,
+    ) => {
+      setIsModalVisible(true);
+      setModalContent(errorMessage);
+      setModalTitle(`Element "${elementName}" Error`);
+    };
+
+    const {selectElementInstance, clearSelection} =
+      useProcessInstanceElementSelection();
+
+    const isJobKeyPresent = incidents.some(({jobKey}) => !!jobKey);
+
+    return (
+      <>
+        <SortableTable
+          state={state}
+          emptyMessage={{
+            message: 'There are no Instances matching this filter set',
+          }}
+          selectionType="row"
+          columnsWithNoContentPadding={['operations', 'errorMessage']}
+          onSelect={(rowId) => {
+            const incident = incidents.find(
+              ({incidentKey}) => incidentKey === rowId,
+            );
+            if (incident === undefined) {
+              return;
+            }
+
+            if (
+              isSingleIncidentSelected(incidents, incident.elementInstanceKey)
+            ) {
+              clearSelection();
+            } else {
+              selectElementInstance({
+                elementId: incident.elementId,
+                elementInstanceKey: incident.elementInstanceKey,
+              });
+            }
+          }}
+          checkIsRowSelected={(rowId) => {
+            const incident = incidents.find(
+              ({incidentKey}) => incidentKey === rowId,
+            );
+            if (incident === undefined) {
+              return false;
+            }
+            return incident.isSelected;
+          }}
+          onSort={(sortKey: string) => {
+            tracking.track({
+              eventName: 'incidents-sorted',
+              column: sortKey,
+            });
+          }}
+          onVerticalScrollStartReach={onVerticalScrollStartReach}
+          onVerticalScrollEndReach={onVerticalScrollEndReach}
+          headerColumns={[
+            {
+              header: 'Incident Type',
+              key: 'errorType',
+            },
+            {
+              header: 'Failing Element',
+              key: 'elementName',
+              isDisabled: true,
+            },
+            {
+              header: 'Job Id',
+              key: 'jobKey',
+              isDisabled: !isJobKeyPresent,
+            },
+            {
+              header: 'Creation Date',
+              key: 'creationTime',
+              isDefault: true,
+            },
+            {
+              header: 'Error Message',
+              key: 'errorMessage',
+              isDisabled: true,
+            },
+            {
+              header: 'Operations',
+              key: 'operations',
+              isDisabled: true,
+            },
+          ]}
+          rows={incidents.map((incident) => {
+            const areOperationsVisible =
+              processInstanceKey === incident.processInstanceKey;
+
+            return {
+              id: incident.incidentKey,
+              errorType: getIncidentErrorName(incident.errorType),
+              elementName:
+                processInstanceKey === incident.processInstanceKey ? (
+                  incident.elementName
+                ) : (
+                  <Link
+                    to={{
+                      pathname: Paths.processInstance(
+                        incident.processInstanceKey,
+                      ),
+                      search: `?elementId=${incident.elementId}`,
+                    }}
+                    title={`View root cause instance ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
+                  >
+                    {`${incident.elementId} - ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
+                  </Link>
+                ),
+              jobKey: incident.jobKey || '--',
+              creationTime: formatDate(incident.creationTime),
+              errorMessage: (
+                <FlexContainer>
+                  <ErrorMessageCell>{incident.errorMessage}</ErrorMessageCell>
+                  {incident.errorMessage.length >= 58 && (
+                    <Button
+                      size="sm"
+                      kind="ghost"
+                      onClick={(event) => {
+                        event.stopPropagation();
+
+                        tracking.track({
+                          eventName:
+                            'incidents-panel-full-error-message-opened',
+                        });
+
+                        handleMoreButtonClick(
+                          incident.errorMessage,
+                          incident.elementName,
+                        );
+                      }}
+                    >
+                      More
+                    </Button>
+                  )}
+                </FlexContainer>
+              ),
+              operations: areOperationsVisible ? (
+                <IncidentOperation
+                  incidentKey={incident.incidentKey}
+                  jobKey={incident.jobKey}
+                />
+              ) : undefined,
+            };
+          })}
+        />
+        <JSONEditorModal
+          isVisible={isModalVisible}
+          title={modalTitle}
+          value={modalContent}
+          onClose={handleModalClose}
+          readOnly
+        />
+      </>
+    );
+  },
+);
+
+export {IncidentsTable};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/styled.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const ErrorMessageCell = styled.div`
+  max-width: 404px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const FlexContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export {ErrorMessageCell, FlexContainer};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
@@ -199,7 +199,7 @@ describe('IncidentsTable', () => {
     expect(withinSecondRow.getByText('More')).toBeInTheDocument();
   });
 
-  it('should open an modal when clicking on the more button', async () => {
+  it('should open a modal when clicking on the more button', async () => {
     const {user} = render(
       <IncidentsTable
         state="content"

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {IncidentsTable} from '..';
+import {formatDate} from 'modules/utils/date';
+import {render, screen, within} from 'modules/testing-library';
+import {Wrapper, incidentsMock, firstIncident, secondIncident} from './mocks';
+import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {createProcessInstance, createUser} from 'modules/testUtils';
+import {mockMe} from 'modules/mocks/api/v2/me';
+import {getIncidentErrorName} from 'modules/utils/incidents';
+
+const firstIncidentErrorName = getIncidentErrorName(firstIncident.errorType);
+const secondIncidentErrorName = getIncidentErrorName(secondIncident.errorType);
+
+describe('IncidentsTable', () => {
+  beforeEach(() => {
+    mockFetchProcessInstanceV2().withSuccess(
+      createProcessInstance({
+        hasIncident: true,
+        parentProcessInstanceKey: null,
+        parentElementInstanceKey: null,
+        rootProcessInstanceKey: null,
+        tags: [],
+      }),
+    );
+  });
+
+  it('should render incident details', async () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={incidentsMock}
+      />,
+      {wrapper: Wrapper},
+    );
+    let withinRow = within(
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
+    );
+
+    expect(withinRow.getByText(firstIncidentErrorName)).toBeInTheDocument();
+    expect(withinRow.getByText(firstIncident.elementName)).toBeInTheDocument();
+    expect(withinRow.getByText(firstIncident.jobKey!)).toBeInTheDocument();
+    expect(
+      withinRow.getByText(formatDate(firstIncident.creationTime) || '--'),
+    ).toBeInTheDocument();
+    expect(withinRow.getByText(firstIncident.errorMessage)).toBeInTheDocument();
+    expect(
+      withinRow.getByRole('button', {name: 'Retry Incident'}),
+    ).toBeInTheDocument();
+    withinRow = within(
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
+    );
+    expect(withinRow.getByText(secondIncidentErrorName)).toBeInTheDocument();
+    expect(withinRow.getByText(secondIncident.elementName)).toBeInTheDocument();
+    expect(withinRow.getByText(secondIncident.jobKey!)).toBeInTheDocument();
+    expect(
+      withinRow.getByText(formatDate(secondIncident.creationTime) || '--'),
+    ).toBeInTheDocument();
+    expect(
+      withinRow.getByText(secondIncident.errorMessage),
+    ).toBeInTheDocument();
+    expect(
+      withinRow.getByRole('button', {name: 'Retry Incident'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the right column headers', async () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={incidentsMock}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(screen.getByText('Incident Type')).toBeInTheDocument();
+    expect(screen.getByText('Failing Element')).toBeInTheDocument();
+    expect(screen.getByText('Job Id')).toBeInTheDocument();
+    expect(screen.getByText('Creation Date')).toBeInTheDocument();
+    expect(screen.getByText('Error Message')).toBeInTheDocument();
+    expect(screen.getByText('Operations')).toBeInTheDocument();
+  });
+
+  it('should render the right column headers for restricted user', async () => {
+    mockMe().withSuccess(createUser());
+
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={incidentsMock}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(screen.getByText('Incident Type')).toBeInTheDocument();
+    expect(screen.getByText('Failing Element')).toBeInTheDocument();
+    expect(screen.getByText('Job Id')).toBeInTheDocument();
+    expect(screen.getByText('Creation Date')).toBeInTheDocument();
+    expect(screen.getByText('Error Message')).toBeInTheDocument();
+    expect(screen.getByText('Operations')).toBeInTheDocument();
+  });
+
+  it('should display -- for jobKey', () => {
+    const incidentMock = {...firstIncident, jobKey: ''};
+    const incidents = [incidentMock];
+
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={incidents}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    let withinFirstRow = within(
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
+    );
+
+    expect(withinFirstRow.getByText('--')).toBeInTheDocument();
+  });
+
+  it('should provide a link for incidents in child process instances', () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="7"
+        incidents={incidentsMock}
+      />,
+      {wrapper: Wrapper},
+    );
+    let withinRow = within(
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
+    );
+
+    expect(
+      withinRow.getByRole('link', {
+        name: `${firstIncident.elementId} - ${firstIncident.processDefinitionName} - ${firstIncident.processInstanceKey}`,
+        description: `View root cause instance ${firstIncident.processDefinitionName} - ${firstIncident.processInstanceKey}`,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should provide a retry operation for incidents in the open process instance', async () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={[
+          {...firstIncident, processInstanceKey: '1'},
+          {...secondIncident, processInstanceKey: '2'},
+        ]}
+      />,
+      {wrapper: Wrapper},
+    );
+    let firstIncidentRow = within(
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
+    );
+    let secondIncidentRow = within(
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
+    );
+
+    expect(
+      await firstIncidentRow.findByRole('button', {name: 'Retry Incident'}),
+    ).toBeInTheDocument();
+    expect(
+      secondIncidentRow.queryByRole('button', {name: 'Retry Incident'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show a more button for long error messages', () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={incidentsMock}
+      />,
+      {wrapper: Wrapper},
+    );
+    let withinFirstRow = within(
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
+    );
+
+    expect(withinFirstRow.queryByText('More')).not.toBeInTheDocument();
+
+    let withinSecondRow = within(
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
+    );
+
+    expect(withinSecondRow.getByText('More')).toBeInTheDocument();
+  });
+
+  it('should open an modal when clicking on the more button', async () => {
+    const {user} = render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={incidentsMock}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    let withinSecondRow = within(
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
+    );
+
+    expect(withinSecondRow.getByText('More')).toBeInTheDocument();
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await user.click(withinSecondRow.getByText('More'));
+
+    const modal = screen.getByRole('dialog');
+
+    expect(
+      await within(modal).findByTestId('monaco-editor'),
+    ).toBeInTheDocument();
+    expect(
+      within(modal).getByText(`Element "${secondIncident.elementName}" Error`),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/mocks.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Route, MemoryRouter, Routes} from 'react-router-dom';
+import {createEnhancedIncident} from 'modules/testUtils';
+import {useEffect} from 'react';
+import {authenticationStore} from 'modules/stores/authentication';
+import {Paths} from 'modules/Routes';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {LocationLog} from 'modules/utils/LocationLog';
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+  useEffect(() => {
+    return () => {
+      authenticationStore.reset();
+    };
+  });
+  return (
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route
+              path={Paths.processInstance()}
+              element={
+                <>
+                  {children}
+                  <LocationLog />
+                </>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  );
+};
+
+const id = 'flowNodeInstanceIdB';
+const shortError = 'No data found for query $.orderId.';
+const longError =
+  'Cannot compare values of different types: INTEGER and BOOLEAN';
+
+const firstIncident = createEnhancedIncident({
+  errorType: 'IO_MAPPING_ERROR',
+  processInstanceKey: '1',
+  errorMessage: shortError,
+  elementId: 'StartEvent_1',
+  elementInstanceKey: '18239123812938',
+  processDefinitionId: 'calledInstance',
+});
+
+const secondIncident = createEnhancedIncident({
+  errorType: 'CALLED_DECISION_ERROR',
+  processInstanceKey: '1',
+  errorMessage: longError,
+  elementId: 'Event_1db567d',
+  elementInstanceKey: id,
+});
+
+const incidentsMock = [firstIncident, secondIncident];
+
+export {Wrapper, incidentsMock, firstIncident, secondIncident};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/selection.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/selection.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {IncidentsTable} from '..';
+import {createProcessInstance} from 'modules/testUtils';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {Wrapper, firstIncident, secondIncident} from './mocks';
+import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+
+describe('Selection', () => {
+  beforeEach(() => {
+    mockFetchProcessInstanceV2().withSuccess(
+      createProcessInstance({
+        hasIncident: true,
+        parentProcessInstanceKey: null,
+        parentElementInstanceKey: null,
+        rootProcessInstanceKey: null,
+        tags: [],
+      }),
+    );
+    mockFetchElementInstance('18239123812938').withSuccess({
+      elementInstanceKey: '18239123812938',
+      elementId: 'StartEvent_1',
+      elementName: 'Start Event',
+      type: 'START_EVENT',
+      state: 'COMPLETED',
+      startDate: '2020-08-18T12:07:33.953+0000',
+      endDate: '2020-08-18T12:07:34.034+0000',
+      processDefinitionId: 'calledInstance',
+      processInstanceKey: '1',
+      processDefinitionKey: '123',
+      rootProcessInstanceKey: null,
+      hasIncident: true,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+  });
+
+  it('should deselect selected incident', async () => {
+    const {user} = render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={[{...firstIncident, isSelected: true}]}
+      />,
+      {wrapper: Wrapper},
+    );
+    expect(screen.getByRole('row', {selected: true})).toBeInTheDocument();
+
+    await user.click(screen.getByRole('row', {selected: true}));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search')).toHaveTextContent('');
+    });
+  });
+
+  it('should select single incident when multiple incidents are selected', async () => {
+    const {user} = render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={[
+          {...firstIncident, isSelected: true, errorType: 'CONDITION_ERROR'},
+          {...secondIncident, isSelected: true, errorType: 'CONDITION_ERROR'},
+        ]}
+      />,
+      {wrapper: Wrapper},
+    );
+    expect(screen.getAllByRole('row', {selected: true})).toHaveLength(2);
+
+    const [firstRow] = screen.getAllByRole('row', {
+      name: /condition error/i,
+    });
+
+    expect(firstRow).toBeInTheDocument();
+    await user.click(firstRow);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search')).toHaveTextContent(
+        '?elementId=StartEvent_1&elementInstanceKey=18239123812938',
+      );
+    });
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/sorting.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/sorting.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {IncidentsTable} from '..';
+import {createProcessInstance} from 'modules/testUtils';
+import {render, screen} from 'modules/testing-library';
+import {Wrapper, firstIncident, incidentsMock} from './mocks';
+import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+
+describe('Sorting', () => {
+  beforeEach(() => {
+    mockFetchProcessInstanceV2().withSuccess(
+      createProcessInstance({
+        hasIncident: true,
+        parentProcessInstanceKey: null,
+        parentElementInstanceKey: null,
+        rootProcessInstanceKey: null,
+        tags: [],
+      }),
+    );
+  });
+
+  it('should enable sorting for all', async () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={incidentsMock}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(screen.getByText('Job Id')).toBeEnabled();
+    expect(screen.getByText('Incident Type')).toBeEnabled();
+    expect(screen.getByText('Failing Element')).toBeEnabled();
+    expect(screen.getByText('Job Id')).toBeEnabled();
+    expect(screen.getByText('Creation Date')).toBeEnabled();
+    expect(screen.getByText('Error Message')).toBeEnabled();
+    expect(await screen.findByText('Operations')).toBeInTheDocument();
+  });
+
+  it('should disable sorting for jobKey and elementName', () => {
+    const incidents = [{...firstIncident, jobKey: ''}];
+
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={incidents}
+      />,
+      {wrapper: Wrapper},
+    );
+    expect(
+      screen.getByRole('button', {name: 'Sort by Creation Date'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Sort by Job Id'}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Sort by Failing Element'}),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from 'modules/testing-library';
+import {IncidentsTab} from './index';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {Paths} from 'modules/Routes';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
+import {mockSearchIncidentsByElementInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByElementInstance';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockProcessInstance} from 'modules/mocks/api/v2/mocks/processInstance';
+import {createIncident, searchResult} from 'modules/testUtils';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
+import {getIncidentErrorName} from 'modules/utils/incidents';
+
+const PROCESS_INSTANCE_ID = mockProcessInstance.processInstanceKey;
+
+const firstIncident = createIncident({
+  errorType: 'CONDITION_ERROR',
+  creationTime: '2022-03-01T14:26:19',
+  elementId: 'flowNodeId_exclusiveGateway',
+});
+
+const secondIncident = createIncident({
+  errorType: 'EXTRACT_VALUE_ERROR',
+  elementId: 'flowNodeId_alwaysFailingTask',
+});
+
+function getWrapper(searchParams?: Record<string, string>) {
+  const params = new URLSearchParams(searchParams);
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter
+        initialEntries={[
+          `${Paths.processInstance(PROCESS_INSTANCE_ID)}?${params.toString()}`,
+        ]}
+      >
+        <Routes>
+          <Route path={Paths.processInstance()} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  return Wrapper;
+}
+
+describe('IncidentsTab', () => {
+  beforeEach(() => {
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchProcessInstances().withSuccess(
+      searchResult([mockProcessInstance]),
+    );
+  });
+
+  afterEach(() => {
+    incidentsPanelStore.clearSelection();
+  });
+
+  it('should render the incidents table with correct columns', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([firstIncident, secondIncident]),
+    );
+
+    render(<IncidentsTab />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('data-table-skeleton'),
+    );
+
+    const table = within(screen.getByRole('table'));
+    expect(table.getByText(/^Incident Type/)).toBeInTheDocument();
+    expect(table.getByText(/^Failing Element/)).toBeInTheDocument();
+    expect(table.getByText(/^Job Id/)).toBeInTheDocument();
+    expect(table.getByText(/^Creation Date/)).toBeInTheDocument();
+    expect(table.getByText(/^Error Message/)).toBeInTheDocument();
+    expect(table.getByText(/^Operations/)).toBeInTheDocument();
+  });
+
+  it('should render incident rows', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([firstIncident, secondIncident]),
+    );
+
+    render(<IncidentsTab />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('data-table-skeleton'),
+    );
+
+    const table = within(screen.getByRole('table'));
+    expect(
+      table.getByText(getIncidentErrorName(firstIncident.errorType)),
+    ).toBeInTheDocument();
+    expect(
+      table.getByText(getIncidentErrorName(secondIncident.errorType)),
+    ).toBeInTheDocument();
+  });
+
+  it('should show the result count in the panel header', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([firstIncident, secondIncident]),
+    );
+
+    render(<IncidentsTab />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText(/Incidents/)).toBeInTheDocument();
+    expect(screen.getByText(/2 results/)).toBeInTheDocument();
+  });
+
+  it('should show skeleton state while loading', () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withServerError();
+
+    render(<IncidentsTab />, {wrapper: getWrapper()});
+
+    expect(screen.getByTestId('data-table-skeleton')).toBeInTheDocument();
+  });
+
+  it('should render incidents filtered by error type', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([firstIncident]),
+    );
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([firstIncident, secondIncident]),
+    );
+
+    const {user} = render(<IncidentsTab />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText(/2 results/)).toBeInTheDocument();
+    let table = within(screen.getByRole('table'));
+    expect(
+      table.getByText(getIncidentErrorName(firstIncident.errorType)),
+    ).toBeInTheDocument();
+    expect(
+      table.getByText(getIncidentErrorName(secondIncident.errorType)),
+    ).toBeInTheDocument();
+
+    await user.click(
+      await screen.findByRole('combobox', {name: /filter by incident type/i}),
+    );
+    await user.click(
+      screen.getByRole('option', {
+        name: 'Condition error.',
+      }),
+    );
+
+    expect(await screen.findByText(/1 result/)).toBeInTheDocument();
+    table = within(screen.getByRole('table'));
+    expect(
+      table.getByText(getIncidentErrorName(firstIncident.errorType)),
+    ).toBeInTheDocument();
+    expect(
+      table.queryByText(getIncidentErrorName(secondIncident.errorType)),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should fetch incidents by element instance when scoped to an element', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([]),
+    );
+    mockSearchElementInstances().withSuccess({
+      items: [
+        {
+          elementInstanceKey: secondIncident.elementInstanceKey,
+          processInstanceKey: PROCESS_INSTANCE_ID,
+          processDefinitionKey: mockProcessInstance.processDefinitionKey,
+          processDefinitionId: mockProcessInstance.processDefinitionId,
+          startDate: '2024-01-01T00:00:00.000Z',
+          endDate: null,
+          state: 'ACTIVE',
+          incidentKey: secondIncident.incidentKey,
+          elementId: secondIncident.elementId,
+          elementName: null,
+          type: 'SERVICE_TASK',
+          tenantId: '<default>',
+          hasIncident: true,
+          rootProcessInstanceKey: null,
+        },
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockSearchIncidentsByElementInstance(':elementInstanceId').withSuccess(
+      searchResult([secondIncident]),
+    );
+
+    render(<IncidentsTab />, {
+      wrapper: getWrapper({elementId: secondIncident.elementId}),
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('data-table-skeleton'),
+    );
+
+    const table = within(screen.getByRole('table'));
+    expect(
+      table.getByText(getIncidentErrorName(secondIncident.errorType)),
+    ).toBeInTheDocument();
+  });
+
+  it('should show empty state when no incidents match', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([]),
+    );
+
+    render(<IncidentsTab />, {wrapper: getWrapper()});
+
+    expect(
+      await screen.findByText(
+        'There are no Instances matching this filter set',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
@@ -178,8 +178,8 @@ describe('IncidentsTab', () => {
   });
 
   it('should fetch incidents by element instance when scoped to an element', async () => {
-    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
-      searchResult([]),
+    mockSearchIncidentsByElementInstance(':elementInstanceId').withSuccess(
+      searchResult([secondIncident]),
     );
     mockSearchElementInstances().withSuccess({
       items: [
@@ -208,10 +208,6 @@ describe('IncidentsTab', () => {
       },
     });
 
-    mockSearchIncidentsByElementInstance(':elementInstanceId').withSuccess(
-      searchResult([secondIncident]),
-    );
-
     render(<IncidentsTab />, {
       wrapper: getWrapper({elementId: secondIncident.elementId}),
     });
@@ -235,7 +231,7 @@ describe('IncidentsTab', () => {
 
     expect(
       await screen.findByText(
-        'There are no Instances matching this filter set',
+        'There are no incidents matching this filter set',
       ),
     ).toBeInTheDocument();
   });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -15,7 +15,6 @@ import type {InfiniteData, UseInfiniteQueryResult} from '@tanstack/react-query';
 import {useEnhancedIncidents, useIncidentsSort} from 'modules/hooks/incidents';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
-import {useElementSelectionInstanceKey} from 'modules/hooks/useElementSelectionInstanceKey';
 import {useGetIncidentsByProcessInstancePaginated} from 'modules/queries/incidents/useGetIncidentsByProcessInstancePaginated';
 import {useGetIncidentsByElementInstancePaginated} from 'modules/queries/incidents/useGetIncidentsByElementInstancePaginated';
 import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
@@ -26,13 +25,17 @@ import {IncidentsFilter} from './IncidentsFilter';
 import {IncidentsTable} from './IncidentsTable';
 import {PanelHeader} from 'modules/components/PanelHeader';
 import {Container} from './styled';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 
 const ROW_HEIGHT = 32;
 
 const IncidentsTab: React.FC = observer(() => {
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const {data: processInstance} = useProcessInstance();
-  const elementInstanceKey = useElementSelectionInstanceKey();
+  const {selectedElementId, resolvedElementInstance} =
+    useProcessInstanceElementSelection();
+  const resolvedElementInstanceKey =
+    resolvedElementInstance?.elementInstanceKey;
 
   const enablePeriodicRefetch =
     processInstance !== undefined &&
@@ -42,29 +45,31 @@ const IncidentsTab: React.FC = observer(() => {
   const sort = useIncidentsSort();
   const filter = getIncidentsSearchFilter(
     incidentsPanelStore.state.selectedErrorTypes,
-    elementInstanceKey !== null && elementInstanceKey !== processInstanceId
-      ? undefined
-      : undefined,
+    selectedElementId ?? undefined,
   );
 
   const isElementInstanceSelected =
-    elementInstanceKey !== null && elementInstanceKey !== processInstanceId;
+    resolvedElementInstanceKey !== undefined &&
+    resolvedElementInstanceKey !== processInstanceId;
 
   const processInstanceResult = useGetIncidentsByProcessInstancePaginated(
     processInstanceId,
     {
-      enabled: !isElementInstanceSelected,
+      enabled: !isElementInstanceSelected && processInstance !== undefined,
       enablePeriodicRefetch,
       payload: {sort, filter},
     },
   );
 
   const elementInstanceResult = useGetIncidentsByElementInstancePaginated(
-    elementInstanceKey ?? '',
+    resolvedElementInstanceKey ?? '',
     {
-      enabled: isElementInstanceSelected,
+      enabled: isElementInstanceSelected && processInstance !== undefined,
       enablePeriodicRefetch,
-      payload: {sort, filter},
+      payload: {
+        sort,
+        filter,
+      },
     },
   );
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -32,7 +32,7 @@ const ROW_HEIGHT = 32;
 const IncidentsTab: React.FC = observer(() => {
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const {data: processInstance} = useProcessInstance();
-  const {selectedElementId, resolvedElementInstance} =
+  const {selectedElementId, resolvedElementInstance, isFetchingElement} =
     useProcessInstanceElementSelection();
   const resolvedElementInstanceKey =
     resolvedElementInstance?.elementInstanceKey;
@@ -55,7 +55,10 @@ const IncidentsTab: React.FC = observer(() => {
   const processInstanceResult = useGetIncidentsByProcessInstancePaginated(
     processInstanceId,
     {
-      enabled: !isElementInstanceSelected && processInstance !== undefined,
+      enabled:
+        !isElementInstanceSelected &&
+        processInstance !== undefined &&
+        !isFetchingElement,
       enablePeriodicRefetch,
       payload: {sort, filter},
     },

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {observer} from 'mobx-react';
+import {
+  type Incident,
+  type QueryIncidentsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.9';
+import type {InfiniteData, UseInfiniteQueryResult} from '@tanstack/react-query';
+import {useEnhancedIncidents, useIncidentsSort} from 'modules/hooks/incidents';
+import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {useElementSelectionInstanceKey} from 'modules/hooks/useElementSelectionInstanceKey';
+import {useGetIncidentsByProcessInstancePaginated} from 'modules/queries/incidents/useGetIncidentsByProcessInstancePaginated';
+import {useGetIncidentsByElementInstancePaginated} from 'modules/queries/incidents/useGetIncidentsByElementInstancePaginated';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
+import {getIncidentsSearchFilter} from 'modules/utils/incidents';
+import {isInstanceRunning} from 'modules/utils/instance';
+import {modificationsStore} from 'modules/stores/modifications';
+import {IncidentsFilter} from './IncidentsFilter';
+import {IncidentsTable} from './IncidentsTable';
+import {PanelHeader} from 'modules/components/PanelHeader';
+import {Container} from './styled';
+
+const ROW_HEIGHT = 32;
+
+const IncidentsTab: React.FC = observer(() => {
+  const {processInstanceId = ''} = useProcessInstancePageParams();
+  const {data: processInstance} = useProcessInstance();
+  const elementInstanceKey = useElementSelectionInstanceKey();
+
+  const enablePeriodicRefetch =
+    processInstance !== undefined &&
+    isInstanceRunning(processInstance) &&
+    !modificationsStore.isModificationModeEnabled;
+
+  const sort = useIncidentsSort();
+  const filter = getIncidentsSearchFilter(
+    incidentsPanelStore.state.selectedErrorTypes,
+    elementInstanceKey !== null && elementInstanceKey !== processInstanceId
+      ? undefined
+      : undefined,
+  );
+
+  const isElementInstanceSelected =
+    elementInstanceKey !== null && elementInstanceKey !== processInstanceId;
+
+  const processInstanceResult = useGetIncidentsByProcessInstancePaginated(
+    processInstanceId,
+    {
+      enabled: !isElementInstanceSelected,
+      enablePeriodicRefetch,
+      payload: {sort, filter},
+    },
+  );
+
+  const elementInstanceResult = useGetIncidentsByElementInstancePaginated(
+    elementInstanceKey ?? '',
+    {
+      enabled: isElementInstanceSelected,
+      enablePeriodicRefetch,
+      payload: {sort, filter},
+    },
+  );
+
+  const result = isElementInstanceSelected
+    ? elementInstanceResult
+    : processInstanceResult;
+
+  const {
+    incidents,
+    totalIncidentsCount,
+    displayState,
+    handleScrollStartReach,
+    handleScrollEndReach,
+  } = mapQueryResultToIncidentsHandle(result);
+
+  const enhancedIncidents = useEnhancedIncidents(incidents);
+
+  return (
+    <Container>
+      <PanelHeader title="Incidents" count={totalIncidentsCount} size="sm">
+        <IncidentsFilter />
+      </PanelHeader>
+      <IncidentsTable
+        state={displayState}
+        onVerticalScrollStartReach={handleScrollStartReach}
+        onVerticalScrollEndReach={handleScrollEndReach}
+        processInstanceKey={processInstanceId}
+        incidents={enhancedIncidents}
+      />
+    </Container>
+  );
+});
+
+function mapQueryResultToIncidentsHandle(
+  result: UseInfiniteQueryResult<InfiniteData<QueryIncidentsResponseBody>>,
+) {
+  const incidents: Incident[] =
+    result.data?.pages.flatMap((p) => p.items) ?? [];
+  const totalIncidentsCount = result.data?.pages[0]?.page.totalItems ?? 0;
+  const displayState = computeDisplayState(result, totalIncidentsCount);
+
+  return {
+    incidents,
+    totalIncidentsCount,
+    displayState,
+    handleScrollStartReach: async (scrollDown: (amount: number) => void) => {
+      if (result.hasPreviousPage && !result.isFetchingPreviousPage) {
+        await result.fetchPreviousPage();
+        const SMOOTH_SCROLL_STEP_SIZE = 5 * ROW_HEIGHT;
+        scrollDown(SMOOTH_SCROLL_STEP_SIZE);
+      }
+    },
+    handleScrollEndReach: () => {
+      if (result.hasNextPage && !result.isFetchingNextPage) {
+        result.fetchNextPage();
+      }
+    },
+  };
+}
+
+function computeDisplayState(
+  result: UseInfiniteQueryResult<InfiniteData<unknown>>,
+  totalItems: number,
+): React.ComponentProps<typeof IncidentsTable>['state'] {
+  switch (true) {
+    case result.status === 'pending': {
+      return 'skeleton';
+    }
+    case result.isFetching &&
+      !result.isRefetching &&
+      !result.isFetchingPreviousPage &&
+      !result.isFetchingNextPage: {
+      return 'loading';
+    }
+    case result.status === 'error': {
+      return 'error';
+    }
+    case result.status === 'success' && totalItems === 0: {
+      return 'empty';
+    }
+    default: {
+      return 'content';
+    }
+  }
+}
+
+export {IncidentsTab};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/styled.ts
@@ -9,7 +9,8 @@
 import styled from 'styled-components';
 
 const Container = styled.section`
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/styled.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const Container = styled.section`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding-top: var(--cds-spacing-05);
+`;
+
+export {Container};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/TabListNav/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/TabListNav/index.tsx
@@ -7,6 +7,7 @@
  */
 
 import {useLocation, useNavigate, type Path} from 'react-router-dom';
+import {Tag} from '@carbon/react';
 import {cn} from './cn';
 import {Nav, Button} from './styled';
 
@@ -20,6 +21,7 @@ type Props = {
     selected: boolean;
     to: Partial<Path>;
     visible?: boolean;
+    count?: number;
   }>;
 };
 
@@ -30,7 +32,7 @@ const TabListNav: React.FC<Props> = ({className, label, items}) => {
   return (
     <Nav className={cn(className, 'cds--tabs')}>
       <div className="cds--tab--list" aria-label={label}>
-        {items.map(({key, title, label, selected, to, visible}) => {
+        {items.map(({key, title, label, selected, to, visible, count}) => {
           const isHidden = visible === false;
           return (
             <Button
@@ -54,6 +56,11 @@ const TabListNav: React.FC<Props> = ({className, label, items}) => {
             >
               <div className="cds--tabs__nav-item-label-wrapper">
                 <span className="cds--tabs__nav-item-label">{title}</span>
+                {count !== undefined && count > 0 && (
+                  <Tag size="sm" type="high-contrast">
+                    {count}
+                  </Tag>
+                )}
               </div>
             </Button>
           );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/TabListNav/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/TabListNav/styled.tsx
@@ -17,6 +17,10 @@ const Button = styled.button`
 
 const Nav = styled.nav`
   border-bottom: 1px solid var(--cds-border-subtle);
+
+  .cds--tabs__nav-item-label:not(:last-child) {
+    margin-right: var(--cds-spacing-02);
+  }
 `;
 
 export {Nav, Button};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
@@ -15,6 +15,7 @@ import {BottomPanelTabs} from './index';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {createProcessInstance, searchResult} from 'modules/testUtils';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
 import {LocationLog} from 'modules/utils/LocationLog';
 
 const PROCESS_INSTANCE_ID = '123';
@@ -149,6 +150,9 @@ describe('<BottomPanelTabs />', () => {
   });
 
   it('should show Incidents tab when process instance has an incident', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([], 3),
+    );
     mockFetchProcessInstance().withSuccess(
       createProcessInstance({
         processInstanceKey: PROCESS_INSTANCE_ID,
@@ -165,6 +169,9 @@ describe('<BottomPanelTabs />', () => {
 
   it('should render all tabs in correct order when all are visible', async () => {
     mockSearchElementInstances().withSuccess(searchResult([]));
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([], 2),
+    );
 
     mockFetchProcessInstance().withSuccess(
       createProcessInstance({
@@ -267,6 +274,9 @@ describe('<BottomPanelTabs />', () => {
   });
 
   it('should navigate to the Incidents route when clicking the Incidents tab', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([], 1),
+    );
     mockFetchProcessInstance().withSuccess(
       createProcessInstance({
         processInstanceKey: PROCESS_INSTANCE_ID,
@@ -355,5 +365,25 @@ describe('<BottomPanelTabs />', () => {
     expect(
       screen.getByRole('link', {name: /^Variables$/i}),
     ).not.toHaveAttribute('aria-current');
+  });
+
+  it('should display incident count badge on the Incidents tab', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([], 5),
+    );
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: true,
+      }),
+    );
+
+    render(<BottomPanelTabs />, {wrapper: getWrapper()});
+
+    const incidentsTab = await screen.findByRole('link', {
+      name: /^Incidents$/i,
+    });
+    expect(incidentsTab).toBeVisible();
+    expect(await screen.findByText('5')).toBeVisible();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -14,12 +14,18 @@ import {useProcessInstancePageParams} from '../useProcessInstancePageParams';
 import {useCurrentPage} from 'modules/hooks/useCurrentPage';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/useProcessInstanceIncidentsCount';
 
 const BottomPanelTabs: React.FC = () => {
   const {hasSelection} = useProcessInstanceElementSelection();
   const {data: processInstance} = useProcessInstance();
   const {processInstanceId} = useProcessInstancePageParams();
   const {currentPage} = useCurrentPage();
+  const hasIncident = processInstance?.hasIncident === true;
+  const incidentsCount = useProcessInstanceIncidentsCount(
+    processInstanceId ?? '',
+    {enabled: hasIncident},
+  );
   const tabItems = [
     {
       label: 'Details',
@@ -43,7 +49,8 @@ const BottomPanelTabs: React.FC = () => {
       key: 'incidents',
       selected: currentPage === 'process-details-incidents',
       title: 'Incidents',
-      visible: processInstance?.hasIncident === true,
+      visible: hasIncident,
+      count: incidentsCount,
     },
     {
       label: 'Input Mappings',

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/styled.tsx
@@ -9,6 +9,10 @@
 import {styled} from 'styled-components';
 
 const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
   background-color: var(--cds-layer);
 `;
 

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -111,7 +111,11 @@ const routes = createRoutesFromElements(
             />
             <Route
               path={Paths.processInstanceIncidents({isRelative: true})}
-              element={null}
+              lazy={async () => {
+                const {IncidentsTab} =
+                  await import('./ProcessInstance/BottomPanelTabs/IncidentsTab/index');
+                return {Component: IncidentsTab};
+              }}
             />
             <Route
               path={Paths.processInstanceInputMappings({isRelative: true})}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the new incidents tab. It's better to check by commit because I copied the old incidents table, otherwise the diff is too big.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #47040
