### PR TITLE
fix: job error stats should filter jobs by states

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -17,16 +17,59 @@ public record DbQueryPage(
 
   public record KeySetPaginationFieldEntry(String fieldName, Operator operator, Object fieldValue) {
 
-    public static Operator determineOperator(final SortOrder order, final boolean isSearchAfter) {
-      if (isSearchAfter) {
-        return order == SortOrder.ASC ? Operator.GREATER : Operator.LOWER;
+    public static Builder of(final String fieldName, final Object fieldValue) {
+      return new Builder(fieldName, fieldValue);
+    }
+
+    public static KeySetPaginationFieldEntry equality(
+        final String fieldName, final Object fieldValue) {
+      final var operator = fieldValue == null ? Operator.IS_NULL : Operator.EQUALS;
+      return new KeySetPaginationFieldEntry(fieldName, operator, fieldValue);
+    }
+
+    public static final class Builder {
+      private final String fieldName;
+      private final Object fieldValue;
+      private SortOrder order;
+      private boolean isSearchAfter;
+
+      private Builder(final String fieldName, final Object fieldValue) {
+        this.fieldName = fieldName;
+        this.fieldValue = fieldValue;
       }
 
-      return order == SortOrder.ASC ? Operator.LOWER : Operator.GREATER;
+      public Builder order(final SortOrder order) {
+        this.order = order;
+        return this;
+      }
+
+      public Builder isSearchAfter(final boolean isSearchAfter) {
+        this.isSearchAfter = isSearchAfter;
+        return this;
+      }
+
+      public KeySetPaginationFieldEntry build() {
+        final Operator operator;
+        if (isSearchAfter) {
+          operator =
+              order == SortOrder.ASC
+                  ? fieldValue == null ? Operator.IS_NOT_NULL : Operator.GREATER
+                  : fieldValue == null ? Operator.IS_NULL : Operator.LOWER;
+        } else {
+          // searchBefore: mirror of searchAfter with directions reversed
+          operator =
+              order == SortOrder.ASC
+                  ? fieldValue == null ? Operator.IS_NOT_NULL : Operator.LOWER
+                  : fieldValue == null ? Operator.IS_NULL : Operator.GREATER;
+        }
+        return new KeySetPaginationFieldEntry(fieldName, operator, fieldValue);
+      }
     }
   }
 
   public enum Operator {
+    IS_NULL("IS NULL"),
+    IS_NOT_NULL("IS NOT NULL"),
     GREATER(">"),
     LOWER("<"),
     EQUALS("=");

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -7,13 +7,10 @@
  */
 package io.camunda.db.rdbms.read.service;
 
-import static io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry.determineOperator;
-
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.DbQueryPage;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPagination;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
-import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.sql.columns.SearchColumn;
 import io.camunda.search.page.SearchQueryPage;
@@ -129,20 +126,20 @@ abstract class AbstractEntityReader<T> {
 
     for (int i = 0; i < sort.orderings().size(); i++) {
       final List<KeySetPaginationFieldEntry> fieldEntries = new ArrayList<>();
-      // add entries for equals sorting
+      // add equality entries for all preceding sort columns
       for (int j = 0; j < i; j++) {
         final SearchColumn<?> sortColumn = sort.orderings().get(j).column();
-        fieldEntries.add(
-            new KeySetPaginationFieldEntry(sortColumn.name(), Operator.EQUALS, sortValues[j]));
+        fieldEntries.add(KeySetPaginationFieldEntry.equality(sortColumn.name(), sortValues[j]));
       }
 
-      // add comparator entry
+      // add the comparator entry for the current sort column
       final var sorting = sort.orderings().get(i);
       fieldEntries.add(
-          new KeySetPaginationFieldEntry(
-              sorting.column().name(),
-              determineOperator(sorting.order(), isSearchAfter),
-              sortValues[i]));
+          KeySetPaginationFieldEntry.of(sorting.column().name(), sortValues[i])
+              .order(sorting.order())
+              .isSearchAfter(isSearchAfter)
+              .build());
+
       keySetPagination.add(new KeySetPagination(fieldEntries));
     }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -64,7 +64,7 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
 
   // Fixed sort: errorCode asc, errorMessage asc
   private static final JobErrorStatisticsSort JOB_ERROR_STATS_FIXED_SORT =
-      JobErrorStatisticsSort.of(b -> b.errorCode().asc());
+      JobErrorStatisticsSort.of(b -> b.errorCode().asc().errorMessage().asc());
 
   private final JobMetricsBatchMapper jobMetricsBatchMapper;
 

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -113,7 +113,14 @@
         close=")">
         <foreach collection="keySet.entries" item="entry" open="(" separator=" AND "
           close=")">
-            ${entry.fieldName} ${entry.operator.symbol} #{entry.fieldValue}
+          <choose>
+            <when test="entry.fieldValue != null">
+              ${entry.fieldName} ${entry.operator.symbol} #{entry.fieldValue}
+            </when>
+            <otherwise>
+              ${entry.fieldName} ${entry.operator.symbol}
+            </otherwise>
+          </choose>
         </foreach>
       </foreach>
     </if>

--- a/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
@@ -269,7 +269,7 @@
   </select>
 
   <sql id="jobErrorStatisticsFilter">
-    WHERE ERROR_CODE IS NOT NULL
+    WHERE STATE IN ('ERROR_THROWN', 'FAILED', 'CANCELED', 'TIMED_OUT')
     <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
       AND TENANT_ID IN
       <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -25,6 +25,7 @@ import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.search.sort.SortOrder;
 import java.util.List;
 import org.instancio.Instancio;
+import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 
 class AbstractEntityReaderTest {
@@ -195,5 +196,327 @@ class AbstractEntityReaderTest {
             new SortingEntry<>(ProcessInstanceSearchColumn.START_DATE, SortOrder.DESC),
             // Note: duplicated PROCESS_DEFINITION_NAME is ignored
             new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+  }
+
+  // ---- Null-value keyset pagination tests ----
+
+  @Test
+  void shouldBuildSearchAfterWithNullInFirstColumnTwoCols() {
+    // given: an entity whose first sort column (processDefinitionName) is null
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionName), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 2 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(2);
+
+    // first entry: processDefinitionName IS NOT NULL (null + ASC + searchAfter => IS_NOT_NULL)
+    final var ks0 = dbPage.keySetPagination().get(0);
+    assertThat(ks0.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry("PROCESS_DEFINITION_NAME", Operator.IS_NOT_NULL, null));
+
+    // second entry: processDefinitionName IS_NULL (null equality prefix) AND processInstanceKey >
+    // value
+    final var ks1 = dbPage.keySetPagination().get(1);
+    assertThat(ks1.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry("PROCESS_DEFINITION_NAME", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchAfterWithNullInSecondColumnThreeCols() {
+    // given: an entity whose second sort column (processDefinitionVersionTag) is null
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
+                    .addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 3 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(3);
+
+    // ks0: processDefinitionName > value  (non-null, ASC, searchAfter)
+    final var ks0 = dbPage.keySetPagination().get(0);
+    assertThat(ks0.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.GREATER, entity.processDefinitionName()));
+
+    // ks1: processDefinitionName = value AND processDefinitionVersionTag IS NOT NULL
+    //       (null + ASC + searchAfter => IS_NOT_NULL)
+    final var ks1 = dbPage.keySetPagination().get(1);
+    assertThat(ks1.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.EQUALS, entity.processDefinitionName()),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
+
+    // ks2: processDefinitionName = value AND processDefinitionVersionTag IS NULL AND
+    //       processInstanceKey > value
+    final var ks2 = dbPage.keySetPagination().get(2);
+    assertThat(ks2.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.EQUALS, entity.processDefinitionName()),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchAfterWithNullInFirstColumnThreeCols() {
+    // given: entity where the first sort column (processDefinitionVersionTag) is null
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.START_DATE, SortOrder.DESC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 3 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(3);
+
+    // ks0: processDefinitionVersionTag IS NOT NULL  (null + ASC + searchAfter => IS_NOT_NULL)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL (null equality) AND startDate < value
+    //       (DESC + searchAfter => LOWER)
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry("START_DATE", Operator.LOWER, entity.startDate()));
+
+    // ks2: processDefinitionVersionTag IS NULL AND startDate = value AND processInstanceKey > value
+    assertThat(dbPage.keySetPagination().get(2).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry("START_DATE", Operator.EQUALS, entity.startDate()),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchBeforeWithNullInFirstColumnTwoCols() {
+    // given: entity where first column (processDefinitionVersionTag) is null
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).before(result.startCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 2 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(2);
+
+    // ks0: processDefinitionVersionTag IS NOT NULL  (null + ASC + searchBefore => IS_NOT_NULL)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey < value
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.LOWER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchAfterDescWithNullInFirstColumn() {
+    // given: entity where the DESC sort column (processDefinitionVersionTag) is null
+    // null + DESC + searchAfter => IS_NULL (null rows come last in DESC, so "after null" = nothing
+    // further; but "is null" is the correct comparator for rows at the same null level)
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.DESC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 2 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(2);
+
+    // ks0: processDefinitionVersionTag IS NULL  (null + DESC + searchAfter => IS_NULL)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey > value
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchBeforeDescWithNullInFirstColumn() {
+    // given: entity where the DESC sort column (processDefinitionVersionTag) is null
+    // null + DESC + searchBefore => IS_NULL  (reverse of searchAfter+DESC+null)
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.DESC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).before(result.startCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 2 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(2);
+
+    // ks0: processDefinitionVersionTag IS NULL  (null + DESC + searchBefore => IS_NULL)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey < value
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.LOWER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchAfterWithAllNullSortColumnsThreeCols() {
+    // given: all three sort columns are null except the tiebreaker (processInstanceKey)
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionName), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 3 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(3);
+
+    // ks0: processDefinitionVersionTag IS NOT NULL  (null + ASC + searchAfter)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL AND processDefinitionName IS NOT NULL
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry("PROCESS_DEFINITION_NAME", Operator.IS_NOT_NULL, null));
+
+    // ks2: processDefinitionVersionTag IS NULL AND processDefinitionName IS NULL
+    //       AND processInstanceKey > value
+    assertThat(dbPage.keySetPagination().get(2).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry("PROCESS_DEFINITION_NAME", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1654,7 +1654,7 @@ public final class SearchQueryResponseMapper {
     }
 
     return new JobErrorStatisticsItem()
-        .errorCode(entity.errorCode())
+        .errorCode(ofNullable(entity.errorCode()).orElse(""))
         .errorMessage(entity.errorMessage())
         .workers(entity.workers());
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobErrorStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobErrorStatisticsIT.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.statistics.response.JobErrorStatisticsItem;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
@@ -45,11 +46,16 @@ public class JobErrorStatisticsIT {
   private static final String PROCESS_ID = "service_tasks_v1";
   private static final String WORKER_1 = "worker-1";
   private static final String WORKER_2 = "worker-2";
+  private static final String WORKER_3 = "worker-3";
+  private static final String WORKER_4 = "worker-4";
 
   private static final String ERROR_CODE_IO = "IO_ERROR";
   private static final String ERROR_MSG_IO = "Disk full";
   private static final String ERROR_CODE_TIMEOUT = "TIMEOUT";
   private static final String ERROR_MSG_TIMEOUT = "Connection timed out";
+  // failJob produces entries with an empty errorCode but a non-null errorMessage
+  private static final String FAIL_ERROR_MSG_1 = "Transient failure – will retry";
+  private static final String FAIL_ERROR_MSG_2 = "Database unavailable";
 
   @UserDefinition
   private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
@@ -58,35 +64,43 @@ public class JobErrorStatisticsIT {
   static void setup(@Authenticated(ADMIN) final CamundaClient adminClient) {
     deployResource(adminClient, "process/service_tasks_v1.bpmn");
 
-    // Start 3 process instances → 3 taskA jobs
+    // Start 7 process instances → 7 taskA jobs:
+    //   2 → throwError IO_ERROR (worker-1 and worker-2, to test distinct-worker counting)
+    //   1 → throwError TIMEOUT  (worker-3)
+    //   1 → failJob with FAIL_ERROR_MSG_1, retries=0  (worker-4, creates incident)
+    //   1 → failJob with FAIL_ERROR_MSG_2, retries=0  (worker-4, different message)
+    //   1 → failJob with FAIL_ERROR_MSG_1, retries=1  (worker-4, will be retried — same msg bucket)
+    //   1 → complete successfully (must NOT appear in error statistics)
+    startProcessInstance(adminClient, PROCESS_ID);
+    startProcessInstance(adminClient, PROCESS_ID);
+    startProcessInstance(adminClient, PROCESS_ID);
+    startProcessInstance(adminClient, PROCESS_ID);
     startProcessInstance(adminClient, PROCESS_ID);
     startProcessInstance(adminClient, PROCESS_ID);
     startProcessInstance(adminClient, PROCESS_ID);
 
-    waitForJobs(adminClient, f -> f.type(JOB_TYPE_A), 3);
+    waitForJobs(adminClient, f -> f.type(JOB_TYPE_A), 7);
 
-    // worker-1 throws IO_ERROR on 2 jobs
+    // worker-1 throws IO_ERROR on 1 job
     final List<ActivatedJob> jobs1 =
         adminClient
             .newActivateJobsCommand()
             .jobType(JOB_TYPE_A)
-            .maxJobsToActivate(2)
+            .maxJobsToActivate(1)
             .workerName(WORKER_1)
             .timeout(Duration.ofMinutes(5))
             .send()
             .join()
             .getJobs();
 
-    for (final ActivatedJob job : jobs1) {
-      adminClient
-          .newThrowErrorCommand(job.getKey())
-          .errorCode(ERROR_CODE_IO)
-          .errorMessage(ERROR_MSG_IO)
-          .send()
-          .join();
-    }
+    adminClient
+        .newThrowErrorCommand(jobs1.get(0).getKey())
+        .errorCode(ERROR_CODE_IO)
+        .errorMessage(ERROR_MSG_IO)
+        .send()
+        .join();
 
-    // worker-2 throws TIMEOUT on 1 job
+    // worker-2 throws IO_ERROR on 1 job (same error code, different worker → workers count = 2)
     final List<ActivatedJob> jobs2 =
         adminClient
             .newActivateJobsCommand()
@@ -98,16 +112,81 @@ public class JobErrorStatisticsIT {
             .join()
             .getJobs();
 
-    for (final ActivatedJob job : jobs2) {
-      adminClient
-          .newThrowErrorCommand(job.getKey())
-          .errorCode(ERROR_CODE_TIMEOUT)
-          .errorMessage(ERROR_MSG_TIMEOUT)
-          .send()
-          .join();
-    }
+    adminClient
+        .newThrowErrorCommand(jobs2.get(0).getKey())
+        .errorCode(ERROR_CODE_IO)
+        .errorMessage(ERROR_MSG_IO)
+        .send()
+        .join();
 
-    // Wait for error stats to be available
+    // worker-3 throws TIMEOUT on 1 job
+    final List<ActivatedJob> jobs3 =
+        adminClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE_A)
+            .maxJobsToActivate(1)
+            .workerName(WORKER_3)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+
+    adminClient
+        .newThrowErrorCommand(jobs3.get(0).getKey())
+        .errorCode(ERROR_CODE_TIMEOUT)
+        .errorMessage(ERROR_MSG_TIMEOUT)
+        .send()
+        .join();
+
+    // worker-4 fails 3 jobs via newFailCommand (no errorCode → null errorCode bucket)
+    // Two with retries=0, one with retries=1; two different error messages
+    final List<ActivatedJob> jobs4 =
+        adminClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE_A)
+            .maxJobsToActivate(3)
+            .workerName(WORKER_4)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+
+    adminClient
+        .newFailCommand(jobs4.get(0).getKey())
+        .retries(0)
+        .errorMessage(FAIL_ERROR_MSG_1)
+        .send()
+        .join();
+
+    adminClient
+        .newFailCommand(jobs4.get(1).getKey())
+        .retries(0)
+        .errorMessage(FAIL_ERROR_MSG_2)
+        .send()
+        .join();
+
+    adminClient
+        .newFailCommand(jobs4.get(2).getKey())
+        .retries(1)
+        .errorMessage(FAIL_ERROR_MSG_1)
+        .send()
+        .join();
+
+    // worker-4 also completes 1 job successfully (COMPLETED state → must NOT appear)
+    final List<ActivatedJob> jobs5 =
+        adminClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE_A)
+            .maxJobsToActivate(1)
+            .workerName(WORKER_4)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+
+    adminClient.newCompleteCommand(jobs5.get(0).getKey()).send().join();
+
+    // Wait until at least the throwError entries are visible
     waitForJobErrorStatistics(
         adminClient,
         NOW.minusDays(1),
@@ -125,7 +204,8 @@ public class JobErrorStatisticsIT {
         NOW.plusDays(1),
         JOB_TYPE_A,
         stats -> {
-          assertThat(stats.items()).isNotEmpty();
+          // 4 buckets: IO_ERROR, TIMEOUT, (null, FAIL_ERROR_MSG_1), (null, FAIL_ERROR_MSG_2)
+          assertThat(stats.items()).hasSize(4);
 
           final var ioError =
               stats.items().stream()
@@ -133,7 +213,8 @@ public class JobErrorStatisticsIT {
                   .findFirst();
           assertThat(ioError).isPresent();
           assertThat(ioError.get().getErrorMessage()).isEqualTo(ERROR_MSG_IO);
-          assertThat(ioError.get().getWorkers()).isEqualTo(1); // only worker-1
+          // IO_ERROR was thrown by both worker-1 and worker-2 → 2 distinct workers
+          assertThat(ioError.get().getWorkers()).isEqualTo(2);
         });
   }
 
@@ -145,22 +226,24 @@ public class JobErrorStatisticsIT {
         NOW.plusDays(1),
         JOB_TYPE_A,
         stats -> {
-          assertThat(stats.items()).hasSize(2); // IO_ERROR and TIMEOUT
+          // 4 buckets: IO_ERROR, TIMEOUT, (null, FAIL_ERROR_MSG_1), (null, FAIL_ERROR_MSG_2)
+          assertThat(stats.items()).hasSize(4);
 
           final var ioError =
               stats.items().stream()
                   .filter(e -> ERROR_CODE_IO.equals(e.getErrorCode()))
                   .findFirst()
                   .orElseThrow();
-          // Both IO_ERROR jobs came from worker-1 → distinct worker count is 1
-          assertThat(ioError.getWorkers()).isEqualTo(1);
+          // IO_ERROR was thrown by worker-1 and worker-2 → 2 distinct workers
+          assertThat(ioError.getWorkers()).isEqualTo(2);
 
           final var timeout =
               stats.items().stream()
                   .filter(e -> ERROR_CODE_TIMEOUT.equals(e.getErrorCode()))
                   .findFirst()
                   .orElseThrow();
-          assertThat(timeout.getWorkers()).isEqualTo(1); // worker-2
+          // TIMEOUT was thrown by worker-3 only → 1 distinct worker
+          assertThat(timeout.getWorkers()).isEqualTo(1);
         });
   }
 
@@ -218,9 +301,18 @@ public class JobErrorStatisticsIT {
 
   @Test
   void shouldSupportPagination(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    final var endCursor = new AtomicReference<>("");
+    // Page through all 4 buckets one at a time and assert each item's values.
+    // Composite aggregation sorts by (errorCode ASC, errorMessage ASC), empty/null first:
+    //   page 1: ("",        "Database unavailable")       ← FAIL_ERROR_MSG_2
+    //   page 2: ("",        "Transient failure – will retry") ← FAIL_ERROR_MSG_1
+    //   page 3: ("IO_ERROR","Disk full")
+    //   page 4: ("TIMEOUT", "Connection timed out")
+    final var cursor1 = new AtomicReference<String>();
+    final var cursor2 = new AtomicReference<String>();
+    final var cursor3 = new AtomicReference<String>();
+    final var cursor4 = new AtomicReference<String>();
 
-    // First page of size 1 — should return exactly one error bucket
+    // page 1
     waitForJobErrorStatistics(
         adminClient,
         NOW.minusDays(1),
@@ -229,17 +321,103 @@ public class JobErrorStatisticsIT {
         p -> p.limit(1),
         stats -> {
           assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().getFirst().getErrorCode()).isNullOrEmpty();
+          assertThat(stats.items().getFirst().getErrorMessage()).isEqualTo(FAIL_ERROR_MSG_2);
           assertThat(stats.page().endCursor()).isNotNull();
-          endCursor.set(stats.page().endCursor());
+          cursor1.set(stats.page().endCursor());
         });
 
-    // Second page using the cursor — should return the remaining error bucket
+    // page 2
     waitForJobErrorStatistics(
         adminClient,
         NOW.minusDays(1),
         NOW.plusDays(1),
         JOB_TYPE_A,
-        p -> p.limit(1).after(endCursor.get()),
-        stats -> assertThat(stats.items()).hasSize(1));
+        p -> p.limit(1).after(cursor1.get()),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().getFirst().getErrorCode()).isNullOrEmpty();
+          assertThat(stats.items().getFirst().getErrorMessage()).isEqualTo(FAIL_ERROR_MSG_1);
+          assertThat(stats.page().endCursor()).isNotNull();
+          cursor2.set(stats.page().endCursor());
+        });
+
+    // page 3
+    waitForJobErrorStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        p -> p.limit(1).after(cursor2.get()),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().getFirst().getErrorCode()).isEqualTo(ERROR_CODE_IO);
+          assertThat(stats.items().getFirst().getErrorMessage()).isEqualTo(ERROR_MSG_IO);
+          assertThat(stats.page().endCursor()).isNotNull();
+          cursor3.set(stats.page().endCursor());
+        });
+
+    // page 4
+    waitForJobErrorStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        p -> p.limit(1).after(cursor3.get()),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().getFirst().getErrorCode()).isEqualTo(ERROR_CODE_TIMEOUT);
+          assertThat(stats.items().getFirst().getErrorMessage()).isEqualTo(ERROR_MSG_TIMEOUT);
+          assertThat(stats.page().endCursor()).isNotNull();
+          cursor4.set(stats.page().endCursor());
+        });
+
+    // page 5 — cursor exhausted, no more results
+    waitForJobErrorStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        p -> p.limit(1).after(cursor4.get()),
+        stats -> assertThat(stats.items()).isEmpty());
+  }
+
+  @Test
+  void shouldCountFailedJobsWithEmptyErrorCode(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // Jobs failed via newFailCommand have no errorCode (stored as "") but do have an errorMessage.
+    // They must appear in the results as separate buckets (grouped by (errorCode, errorMessage)).
+    waitForJobErrorStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          // The two distinct fail messages produce two empty-errorCode buckets
+          final var failBuckets =
+              stats.items().stream()
+                  .filter(e -> e.getErrorCode() == null || e.getErrorCode().isEmpty())
+                  .toList();
+          assertThat(failBuckets).hasSize(2);
+
+          final var messages =
+              failBuckets.stream().map(JobErrorStatisticsItem::getErrorMessage).toList();
+          assertThat(messages).containsExactlyInAnyOrder(FAIL_ERROR_MSG_1, FAIL_ERROR_MSG_2);
+        });
+  }
+
+  @Test
+  void shouldNotCountCompletedJobsAsErrors(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    // Jobs that were completed successfully (COMPLETED state) must not appear in error statistics.
+    waitForJobErrorStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          // Exactly 4 buckets: IO_ERROR, TIMEOUT, and the 2 null-errorCode fail buckets.
+          // The 1 completed job must not produce any additional bucket.
+          assertThat(stats.items()).hasSize(4);
+        });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
@@ -26,6 +26,7 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtensio
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
 import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.filter.Operation;
@@ -1652,6 +1653,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("IO_ERROR")
                 .errorMessage("Disk full")
                 .worker("worker-1")
@@ -1661,6 +1663,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("IO_ERROR")
                 .errorMessage("Disk full")
                 .worker("worker-2")
@@ -1670,6 +1673,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("TIMEOUT")
                 .errorMessage("Connection timed out")
                 .worker("worker-1")
@@ -1715,6 +1719,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("IO_ERROR")
                 .errorMessage("Disk full")
                 .worker("worker-1")
@@ -1724,6 +1729,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("UNHANDLED_EXCEPTION")
                 .errorMessage("NPE")
                 .worker("worker-1")
@@ -1759,6 +1765,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(TENANT1)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("IO_ERROR")
                 .errorMessage("msg")
                 .worker("w1")
@@ -1789,6 +1796,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(TENANT1)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("IO_ERROR")
                 .errorMessage("Disk full")
                 .worker("worker-1")
@@ -1798,6 +1806,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(TENANT2)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("IO_ERROR")
                 .errorMessage("Disk full")
                 .worker("worker-2")
@@ -1819,29 +1828,42 @@ public class JobMetricsBatchIT {
   }
 
   @TestTemplate
-  public void shouldExcludeJobsWithoutErrorCode() {
-    // given — one job with an error code, one job without
+  public void shouldIncludeFailedStateAndExcludeCompletedState() {
+    // given — one ERROR_THROWN job (with errorCode), one FAILED job (no errorCode),
+    //         one COMPLETED job (must be excluded by the state filter)
     final var now = NOW;
-    final var uniqueTenant = "no-error-tenant-" + CommonFixtures.generateRandomString(8);
-    final var jobType = "no-error-job-" + CommonFixtures.generateRandomString(6);
+    final var uniqueTenant = "state-filter-tenant-" + CommonFixtures.generateRandomString(8);
+    final var jobType = "state-filter-job-" + CommonFixtures.generateRandomString(6);
 
     JobFixtures.createAndSaveJob(
         rdbmsWriters,
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("IO_ERROR")
                 .errorMessage("Disk full")
                 .worker("worker-1")
+                .creationTime(now.minusMinutes(30)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .state(JobState.FAILED)
+                .errorCode("")
+                .errorMessage("Transient failure")
+                .worker("worker-2")
                 .creationTime(now.minusMinutes(20)));
     JobFixtures.createAndSaveJob(
         rdbmsWriters,
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
-                .errorCode(null)
-                .errorMessage(null)
-                .worker("worker-2")
+                .state(JobState.COMPLETED)
+                .errorCode("")
+                .errorMessage("")
+                .worker("worker-3")
                 .creationTime(now.minusMinutes(10)));
 
     // when
@@ -1854,24 +1876,65 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(
                 AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(uniqueTenant))));
 
-    // then — only the job with an error code is returned
-    assertThat(result.items()).hasSize(1);
-    assertErrorStats(result.items().getFirst(), "IO_ERROR", "Disk full", 1);
+    // then — ERROR_THROWN and FAILED are both included; COMPLETED is excluded
+    assertThat(result.items()).hasSize(2);
+
+    final var errorThrown =
+        result.items().stream()
+            .filter(e -> "IO_ERROR".equals(e.errorCode()))
+            .findFirst()
+            .orElseThrow();
+    assertErrorStats(errorThrown, "IO_ERROR", "Disk full", 1);
+
+    final var failed =
+        result.items().stream()
+            .filter(e -> e.errorCode() == null || e.errorCode().isEmpty())
+            .findFirst()
+            .orElseThrow();
+    assertThat(failed.errorMessage()).isEqualTo("Transient failure");
+    assertThat(failed.errorCode()).isNullOrEmpty();
+    assertThat(failed.workers()).isEqualTo(1);
   }
 
   @TestTemplate
-  public void shouldReturnSecondPageOfErrorStatisticsUsingCursor() {
-    // given — 3 jobs each with a distinct errorCode so each forms its own bucket
-    // errorCodes are chosen so alphabetical order is: ERR_A < ERR_B < ERR_C
+  public void shouldReturnPagesOfErrorStatisticsUsingCursor() throws InterruptedException {
+    // given — 5 jobs: two FAILED with empty errorCode and three ERROR_THROWN with distinct codes.
+    // Sort order is errorCode ASC NULLS FIRST, then errorMessage ASC, so:
+    //   page 1 (size=2): ("", "fail-msg") and ("", "fail-msg-2")  ← both FAILED
+    //   page 2 (size=2): ("ERR_A", "msg-a") and ("ERR_B", "msg-b")
+    //   page 3 (size=2): ("ERR_C", "msg-c") — then empty on page 4
     final var now = NOW;
     final var uniqueTenant = "paging-error-tenant-" + CommonFixtures.generateRandomString(8);
     final var jobType = "paging-error-job-" + CommonFixtures.generateRandomString(6);
 
+    // FAILED job 1 — empty errorCode, message "fail-msg"
     JobFixtures.createAndSaveJob(
         rdbmsWriters,
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.FAILED)
+                .errorCode("")
+                .errorMessage("fail-msg")
+                .worker("worker-1")
+                .creationTime(now.minusMinutes(50)));
+    // FAILED job 2 — empty errorCode, message "fail-msg-2" (sorts after "fail-msg")
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .state(JobState.FAILED)
+                .errorCode("")
+                .errorMessage("fail-msg-2")
+                .worker("worker-2")
+                .creationTime(now.minusMinutes(40)));
+    JobFixtures.createAndSaveJob(
+        rdbmsWriters,
+        b ->
+            b.type(jobType)
+                .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("ERR_A")
                 .errorMessage("msg-a")
                 .worker("worker-1")
@@ -1881,6 +1944,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("ERR_B")
                 .errorMessage("msg-b")
                 .worker("worker-1")
@@ -1890,6 +1954,7 @@ public class JobMetricsBatchIT {
         b ->
             b.type(jobType)
                 .tenantId(uniqueTenant)
+                .state(JobState.ERROR_THROWN)
                 .errorCode("ERR_C")
                 .errorMessage("msg-c")
                 .worker("worker-1")
@@ -1899,7 +1964,7 @@ public class JobMetricsBatchIT {
         ResourceAccessChecks.of(
             AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(uniqueTenant)));
 
-    // fetch first page (size=2) — should return ERR_A and ERR_B
+    // fetch first page (size=2) — both FAILED buckets (empty errorCode, sorted by message)
     final var firstPage =
         jobMetricsBatchReader.getJobErrorStatistics(
             JobErrorStatisticsQuery.of(
@@ -1909,11 +1974,13 @@ public class JobMetricsBatchIT {
             accessChecks);
 
     assertThat(firstPage.items()).hasSize(2);
-    assertThat(firstPage.items().get(0).errorCode()).isEqualTo("ERR_A");
-    assertThat(firstPage.items().get(1).errorCode()).isEqualTo("ERR_B");
+    assertThat(firstPage.items().get(0).errorCode()).isNullOrEmpty();
+    assertThat(firstPage.items().get(0).errorMessage()).isEqualTo("fail-msg");
+    assertThat(firstPage.items().get(1).errorCode()).isNullOrEmpty();
+    assertThat(firstPage.items().get(1).errorMessage()).isEqualTo("fail-msg-2");
     assertThat(firstPage.endCursor()).isNotNull();
 
-    // when — fetch second page using the end cursor
+    // fetch second page — ERR_A and ERR_B
     final var secondPage =
         jobMetricsBatchReader.getJobErrorStatistics(
             JobErrorStatisticsQuery.of(
@@ -1922,8 +1989,33 @@ public class JobMetricsBatchIT {
                         .page(p -> p.size(2).after(firstPage.endCursor()))),
             accessChecks);
 
-    // then — only ERR_C is returned on the second page
-    assertThat(secondPage.items()).hasSize(1);
-    assertErrorStats(secondPage.items().getFirst(), "ERR_C", "msg-c", 1);
+    assertThat(secondPage.items()).hasSize(2);
+    assertErrorStats(secondPage.items().get(0), "ERR_A", "msg-a", 1);
+    assertErrorStats(secondPage.items().get(1), "ERR_B", "msg-b", 1);
+    assertThat(secondPage.endCursor()).isNotNull();
+
+    // fetch third page — only ERR_C remains
+    final var thirdPage =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(f -> f.from(now.minusHours(1)).to(now.plusMinutes(1)).jobType(jobType))
+                        .page(p -> p.size(2).after(secondPage.endCursor()))),
+            accessChecks);
+
+    assertThat(thirdPage.items()).hasSize(1);
+    assertErrorStats(thirdPage.items().getFirst(), "ERR_C", "msg-c", 1);
+    assertThat(thirdPage.endCursor()).isNotNull();
+
+    // fetch fourth page — cursor exhausted, no more results
+    final var fourthPage =
+        jobMetricsBatchReader.getJobErrorStatistics(
+            JobErrorStatisticsQuery.of(
+                q ->
+                    q.filter(f -> f.from(now.minusHours(1)).to(now.plusMinutes(1)).jobType(jobType))
+                        .page(p -> p.size(2).after(thirdPage.endCursor()))),
+            accessChecks);
+
+    assertThat(fourthPage.items()).isEmpty();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobErrorStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobErrorStatisticsFilterTransformer.java
@@ -11,13 +11,16 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.CREATION_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_CODE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_MESSAGE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_TYPE;
 
 import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.filter.JobErrorStatisticsFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.security.auth.Authorization;
@@ -28,6 +31,14 @@ import java.util.List;
 public class JobErrorStatisticsFilterTransformer
     extends IndexFilterTransformer<JobErrorStatisticsFilter> {
 
+  /** Only these job states are relevant for error statistics. */
+  private static final List<String> ERROR_STATES =
+      List.of(
+          JobState.ERROR_THROWN.name(),
+          JobState.FAILED.name(),
+          JobState.CANCELED.name(),
+          JobState.TIMED_OUT.name());
+
   public JobErrorStatisticsFilterTransformer(final IndexDescriptor indexDescriptor) {
     super(indexDescriptor);
   }
@@ -35,6 +46,9 @@ public class JobErrorStatisticsFilterTransformer
   @Override
   public SearchQuery toSearchQuery(final JobErrorStatisticsFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
+
+    // Always restrict to the relevant job states
+    queries.add(stringTerms(JOB_STATE, ERROR_STATES));
 
     if (filter.from() != null) {
       queries.addAll(dateTimeOperations(CREATION_TIME, List.of(Operation.gte(filter.from()))));
@@ -56,7 +70,7 @@ public class JobErrorStatisticsFilterTransformer
       queries.addAll(stringOperations(ERROR_MESSAGE, filter.errorMessageOperations()));
     }
 
-    return queries.isEmpty() ? matchAll() : and(queries);
+    return and(queries);
   }
 
   @Override


### PR DESCRIPTION
## Description

This pull request improves the accuracy and coverage of job error statistics by refining both the database query and the search query logic, and by expanding the acceptance tests to cover more scenarios. The changes ensure that only jobs in error states are considered, group failed jobs with empty error codes correctly, and verify that completed jobs are excluded from error statistics.

**Backend and Query Logic Improvements:**

* The SQL filter in `JobMetricsBatchMapper.xml` now only includes jobs in specific error states (`ERROR_THROWN`, `FAILED`, `CANCELED`, `TIMED_OUT`) with a non-null error code, ensuring error statistics are calculated from the correct set of jobs.
* The search query transformer (`JobErrorStatisticsFilterTransformer.java`) is updated to always restrict queries to relevant job states and to use an `AND` combination for all filters, improving consistency and accuracy of error statistics queries. [[1]](diffhunk://#diff-40900ab36f9c8a4bded8d9bf275b3c56f8ca09e86621f1f00099d23adda6af13R34-R41) [[2]](diffhunk://#diff-40900ab36f9c8a4bded8d9bf275b3c56f8ca09e86621f1f00099d23adda6af13R50-R52) [[3]](diffhunk://#diff-40900ab36f9c8a4bded8d9bf275b3c56f8ca09e86621f1f00099d23adda6af13L59-R73)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43048
