### PR TITLE
[Backport stable/8.9] Don't check business-id uniqueness on instance migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -133,8 +133,7 @@ public final class BpmnProcessors {
         partitionId,
         routingInfo,
         authCheckBehavior,
-        keyGenerator,
-        config);
+        keyGenerator);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
     addAdHocSubProcessActivityStreamProcessors(
         typedRecordProcessors, processingState, writers, authCheckBehavior, bpmnBehaviors);
@@ -320,8 +319,7 @@ public final class BpmnProcessors {
       final int partitionId,
       final RoutingInfo routingInfo,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final KeyGenerator keyGenerator,
-      final EngineConfiguration config) {
+      final KeyGenerator keyGenerator) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         ProcessInstanceMigrationIntent.MIGRATE,
@@ -333,8 +331,7 @@ public final class BpmnProcessors {
             partitionId,
             routingInfo,
             authCheckBehavior,
-            keyGenerator,
-            config.isBusinessIdUniquenessEnabled()));
+            keyGenerator));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -12,7 +12,6 @@ import static io.camunda.zeebe.engine.state.immutable.IncidentState.MISSING_INCI
 import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.AD_HOC_SUB_PROCESS_ELEMENTS;
 import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
 
-import com.google.common.base.Predicates;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
@@ -184,17 +183,6 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireNonNullTargetProcessDefinition(targetProcessDefinition, targetProcessDefinitionKey);
     requireNoStartEventInstanceForTargetProcess(
         processInstance, targetProcessDefinition, messageState);
-    requireNoBusinessIdConflictForTargetProcess(
-        processInstance,
-        targetProcessDefinitionKey,
-        BufferUtil.bufferAsString(targetProcessDefinition.getBpmnProcessId()),
-        elementInstanceState,
-        businessIdUniquenessEnabled,
-        Predicates.or(
-            // ignore the current instance as we expect it to be active during version migration
-            Predicates.equalTo(processInstanceKey),
-            // ignore banned instances as well, as we don't consider them active
-            key -> key != null && bannedInstanceState.isProcessInstanceBanned(key)));
     requireReferredElementsExist(
         sourceProcessDefinition, targetProcessDefinition, mappingInstructions, processInstanceKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
@@ -93,8 +92,6 @@ public class ProcessInstanceMigrationMigrateProcessor
   private final BpmnBehaviors bpmnBehaviors;
   private final ProcessInstanceMigrationCatchEventBehaviour migrationCatchEventBehaviour;
   private final KeyGenerator keyGenerator;
-  private final boolean businessIdUniquenessEnabled;
-  private final BannedInstanceState bannedInstanceState;
 
   public ProcessInstanceMigrationMigrateProcessor(
       final Writers writers,
@@ -104,8 +101,7 @@ public class ProcessInstanceMigrationMigrateProcessor
       final int partitionId,
       final RoutingInfo routingInfo,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final KeyGenerator keyGenerator,
-      final boolean businessIdUniquenessEnabled) {
+      final KeyGenerator keyGenerator) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
@@ -117,11 +113,9 @@ public class ProcessInstanceMigrationMigrateProcessor
     incidentState = processingState.getIncidentState();
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
     messageState = processingState.getMessageState();
-    bannedInstanceState = processingState.getBannedInstanceState();
     this.authCheckBehavior = authCheckBehavior;
     this.bpmnBehaviors = bpmnBehaviors;
     this.keyGenerator = keyGenerator;
-    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
 
     migrationCatchEventBehaviour =
         new ProcessInstanceMigrationCatchEventBehaviour(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -209,11 +209,6 @@ public final class ProcessInstanceMigrationPreconditions {
       but joining gateway with id '%s' has a taken sequence flow with id '%s'. \
       Taken sequence flows must be mapped to a sequence flow in the target process definition.""";
 
-  private static final String ERROR_BUSINESS_ID_ALREADY_EXISTS_FOR_TARGET =
-      """
-      Expected to migrate instance '%s' with business id '%s' to process definition key '%s', \
-      but an active instance with this business id already exists for the target process definition""";
-
   private static final String ZEEBE_USER_TASK_IMPLEMENTATION = "zeebe user task";
   private static final String JOB_WORKER_IMPLEMENTATION = "job worker";
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
@@ -299,48 +298,6 @@ public final class ProcessInstanceMigrationPreconditions {
               processInstance.getKey(),
               targetProcessDefinition.getKey(),
               BufferUtil.bufferAsString(correlationKey));
-      throw new ProcessInstanceMigrationPreconditionFailedException(
-          reason, RejectionType.INVALID_STATE);
-    }
-  }
-
-  /**
-   * Checks whether the target process definition already has an active process instance with the
-   * same business id. Throws an exception if a conflict is found.
-   *
-   * @param processInstance the process instance being migrated
-   * @param targetProcessDefinitionKey the key of the target process definition
-   * @param targetProcessDefinitionId the BPMN process id of the target process definition
-   * @param elementInstanceState the element instance state to query for active instances
-   * @param businessIdUniquenessEnabled whether business id uniqueness checking is enabled
-   * @param ignoreWhen a predicate to ignore certain process instances (e.g. banned ones)
-   */
-  public static void requireNoBusinessIdConflictForTargetProcess(
-      final ElementInstance processInstance,
-      final long targetProcessDefinitionKey,
-      final String targetProcessDefinitionId,
-      final ElementInstanceState elementInstanceState,
-      final boolean businessIdUniquenessEnabled,
-      final Predicate<Long> ignoreWhen) {
-    if (!businessIdUniquenessEnabled) {
-      return;
-    }
-
-    final var processInstanceRecord = processInstance.getValue();
-    final String businessId = processInstanceRecord.getBusinessId();
-    if (businessId.isEmpty()) {
-      return;
-    }
-
-    final String tenantId = processInstanceRecord.getTenantId();
-    if (elementInstanceState.hasActiveProcessInstanceWithBusinessId(
-        businessId, targetProcessDefinitionId, tenantId, ignoreWhen)) {
-      final String reason =
-          String.format(
-              ERROR_BUSINESS_ID_ALREADY_EXISTS_FOR_TARGET,
-              processInstance.getKey(),
-              businessId,
-              targetProcessDefinitionKey);
       throw new ProcessInstanceMigrationPreconditionFailedException(
           reason, RejectionType.INVALID_STATE);
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -674,7 +674,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
 
   @Test
   public void
-      shouldRejectMigrationWhenTargetProcessDefinitionAlreadyHasActiveInstanceWithSameBusinessId() {
+      shouldAllowMigrationWhenTargetProcessDefinitionAlreadyHasActiveInstanceWithSameBusinessId() {
     final String sourceProcessId = helper.getBpmnProcessId() + "_source";
     final String targetProcessId = helper.getBpmnProcessId() + "_target";
     final String businessId = "biz-123";
@@ -714,27 +714,43 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             .withBusinessId(businessId)
             .create();
 
-    // when - try to migrate the source instance to the target process definition
-    final var rejection =
+    // when - migrate the source instance to the target process definition
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task", "task")
+        .migrate();
+
+    // then - migration should succeed even though the target already has an instance with the
+    // same business id
+    assertThat(
+            RecordingExporter.processInstanceMigrationRecords()
+                .withIntent(ProcessInstanceMigrationIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst())
+        .isNotNull();
+
+    // and - creating a new instance of the source process with the same business id should succeed
+    // since the business id is no longer associated with the source process definition
+    final var newProcessInstanceKey =
         ENGINE
             .processInstance()
-            .withInstanceKey(processInstanceKey)
-            .migration()
-            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-            .addMappingInstruction("task", "task")
-            .expectRejection()
-            .migrate();
+            .ofBpmnProcessId(sourceProcessId)
+            .withBusinessId(businessId)
+            .withTags("newInstance")
+            .create();
 
-    // then - should be rejected because the target process definition already has an active
-    // instance with the same business id
-    assertThat(rejection)
-        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
-        .hasRejectionType(RejectionType.INVALID_STATE)
-        .hasRejectionReason(
-            """
-            Expected to migrate instance '%s' with business id '%s' to process definition key '%s', \
-            but an active instance with this business id already exists for the target process definition"""
-                .formatted(processInstanceKey, businessId, targetProcessDefinitionKey));
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withBpmnProcessId(sourceProcessId)
+                .withTags("newInstance")
+                .getFirst()
+                .getValue())
+        .hasBusinessId(businessId)
+        .hasProcessInstanceKey(newProcessInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -828,7 +828,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
   }
 
   @Test
-  public void shouldRejectVersionMigrationWhenAnotherInstanceOfSameProcessHasSameBusinessId() {
+  public void shouldAllowVersionMigrationWhenAnotherInstanceOfSameProcessHasSameBusinessId() {
     final String processId = helper.getBpmnProcessId();
     final String businessId = "biz-123";
 
@@ -883,26 +883,46 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
     ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
     ENGINE.start();
 
-    // when - try to migrate the v1 instance to v2
-    final var rejection =
-        ENGINE
-            .processInstance()
-            .withInstanceKey(v1ProcessInstanceKey)
-            .migration()
-            .withTargetProcessDefinitionKey(v2ProcessDefinitionKey)
-            .addMappingInstruction("task", "task")
-            .expectRejection()
-            .migrate();
+    // when - migrate the v1 instance to v2
+    ENGINE
+        .processInstance()
+        .withInstanceKey(v1ProcessInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(v2ProcessDefinitionKey)
+        .addMappingInstruction("task", "task")
+        .migrate();
 
-    // then - should be rejected because the v2 instance already holds the business id
-    // for the same process definition
-    assertThat(rejection)
-        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
-        .hasRejectionType(RejectionType.INVALID_STATE)
+    // then - migration should succeed because uniqueness is only checked on instance creation,
+    // not during migration
+    assertThat(
+            RecordingExporter.processInstanceMigrationRecords()
+                .withIntent(ProcessInstanceMigrationIntent.MIGRATED)
+                .withProcessInstanceKey(v1ProcessInstanceKey)
+                .getFirst())
+        .isNotNull();
+
+    // and - creating a new instance with the same business id should still be rejected because
+    // both instances still hold the business id for this process definition
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVersion(1)
+        .withBusinessId(businessId)
+        .withTags("rejectedInstance")
+        .expectRejection()
+        .create();
+
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .onlyCommandRejections()
+                .withTags("rejectedInstance")
+                .withBpmnProcessId(processId)
+                .getFirst())
+        .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
             """
-            Expected to migrate instance '%s' with business id '%s' to process definition key '%s', \
-            but an active instance with this business id already exists for the target process definition"""
-                .formatted(v1ProcessInstanceKey, businessId, v2ProcessDefinitionKey));
+            Expected to create instance of process with business id '%s', \
+            but an instance with this business id already exists for process definition '%s'"""
+                .formatted(businessId, processId));
   }
 }


### PR DESCRIPTION
# Description
Backport of #48245 to `stable/8.9`.

relates to #48015