### PR TITLE
[Backport main] fix: flaky BackupCompaitbilityAcceptance test

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -127,6 +127,7 @@ public interface BackupCompatibilityAcceptance {
 
       // then
       Awaitility.await("until backup is deleted")
+          .ignoreExceptions()
           .atMost(Duration.ofSeconds(30))
           .untilAsserted(() -> assertThat(backupActuator.list()).isEmpty());
     }


### PR DESCRIPTION
# Description
Backport of #48239 to `main`.

relates to camunda/camunda#48223