### PR TITLE
docs: fix formatting and clarify code freeze date

### DIFF
--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -339,11 +339,17 @@ In addition to the standard steps above, recent minor releases have surfaced sev
 
 ### Feature Freeze vs Code Freeze (Minor Releases)
 
+Terminology:
+
+* **Release date**: (in scope of the Monorepo) The day on which final Monorepo artifacts should be tested and available for a release
+* **Code freeze date**: The day on which the release branch will be forked from the base branch
+* **Press release date**: (out of scope of the Monorepo) The day on which the whole C8 release train should be finished
+
 For C8 monorepo minor releases, we enforce two distinct stages to ensure quality and predictable delivery:
 
 **🔒 Feature Freeze (Minor Releases)**
 - **Purpose**: Lock in the feature scope for the upcoming minor release
-- **Timing**: Occurs with the **last alpha** before the minor release (e.g., for `8.9.0`, this would be `8.9.0-alpha5`)
+- **Timing**: Occurs with the **last alpha** before the minor release (e.g., for `8.9.0`, this would be `8.9.0-alpha5`), on the day of the code freeze of the last alpha
 - **What Changes**:
 - ✅ All cross-component features targeted for the minor must be fully implemented, documented, and working end-to-end
 - ❌ No new features, scope extensions, or risky changes after this point
@@ -367,7 +373,7 @@ Hey all,
 
 **🚫 Code Freeze (Minor Releases)**
 - **Purpose**: Minimize code changes to ensure release stability
-- **Timing**: On the day of the official minor release start date
+- **Timing**: Three weeks before the press release (e.g., release branch creation and thus code freeze for `8.9.0` is on March 24th since press release is on April 14th)
 - **What Changes**:
 - ✅ Only **critical** changes allowed (release blockers, severe regressions, security issues)
 - ❌ Non-critical changes deferred to future alphas or patch releases


### PR DESCRIPTION
## Description

We identified that we don't have a single source of truth regarding the meaning of code freeze in relation to feature freeze of C8 minor releases documented. This PR adds it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
