### PR TITLE
deps: bump jackson-bom to 2.21.1 to fix GHSA-72hv-8253-57qq

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -67,7 +67,7 @@
     <version.identity>8.8.9</version.identity>
     <version.instancio>5.5.1</version.instancio>
     <version.surefire>3.5.5</version.surefire>
-    <version.jackson>2.19.4</version.jackson>
+    <version.jackson>2.21.1</version.jackson>
     <version.junit>5.13.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.3</version.log4j>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -140,7 +140,7 @@
     <version.validation-api>3.1.1</version.validation-api>
     <version.jackson-databind-nullable>0.2.9</version.jackson-databind-nullable>
     <version.findbugs.jsr305>3.0.2</version.findbugs.jsr305>
-    <version.jackson-annotations>2.19.4</version.jackson-annotations>
+    <version.jackson-annotations>2.21</version.jackson-annotations>
     <version.json-path>2.9.0</version.json-path>
     <version.swagger-annotations>2.2.44</version.swagger-annotations>
     <version.swagger-parser>2.1.38</version.swagger-parser>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Bump com.fasterxml.jackson:jackson-bom from 2.19.4 to 2.21.1 in parent/pom.xml on stable/8.8 to address security advisory GHSA-72hv-8253-57qq.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48238
