### PR TITLE
fix: preserve query params when navigating in TaskDetailsHistory

### DIFF
--- a/tasklist/client/src/v2/TaskDetailsHistoryView/HistoryItemDetailsModal/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/HistoryItemDetailsModal/index.tsx
@@ -6,7 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type LoaderFunctionArgs, redirect, useNavigate} from 'react-router-dom';
+import {
+  type LoaderFunctionArgs,
+  redirect,
+  useNavigate,
+  useLocation,
+} from 'react-router-dom';
 import {useSuspenseQuery, type InfiniteData} from '@tanstack/react-query';
 import {t} from 'i18next';
 import type {QueryUserTaskAuditLogsResponseBody} from '@camunda/camunda-api-zod-schemas/8.9';
@@ -64,12 +69,16 @@ async function loader({params}: LoaderFunctionArgs) {
 const HistoryItemDetailsModal: React.FC = () => {
   const {id, auditLogKey} = useHistoryItemDetailsParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const {data: auditLog} = useSuspenseQuery(
     getAuditLogQueryOptions(auditLogKey),
   );
 
   const handleClose = () => {
-    navigate(pages.taskDetailsHistory(id));
+    navigate({
+      ...location,
+      pathname: pages.taskDetailsHistory(id),
+    });
   };
 
   return <DetailsModal auditLog={auditLog} onClose={handleClose} />;

--- a/tasklist/client/src/v2/TaskDetailsHistoryView/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/index.test.tsx
@@ -326,6 +326,7 @@ describe('<TaskDetailsHistoryView />', () => {
     expect(screen.getByTestId('pathname')).toHaveTextContent(
       '/0/history/test-audit-log-key',
     );
+    expect(screen.getByTestId('search')).toHaveTextContent('');
   });
 
   it('should close details modal when clicking close button', async () => {
@@ -366,6 +367,7 @@ describe('<TaskDetailsHistoryView />', () => {
     expect(screen.getByTestId('pathname')).toHaveTextContent(
       '/0/history/test-audit-log-key-2',
     );
+    expect(screen.getByTestId('search')).toHaveTextContent('');
 
     await user.click(
       within(screen.getByRole('dialog')).getByRole('button', {
@@ -378,6 +380,68 @@ describe('<TaskDetailsHistoryView />', () => {
     ).not.toBeInTheDocument();
 
     expect(screen.getByTestId('pathname')).toHaveTextContent('/0/history');
+    expect(screen.getByTestId('search')).toHaveTextContent('');
+  });
+
+  it('should preserve query string when opening and closing details modal', async () => {
+    const testAuditLog = auditLogMocks.auditLog({
+      auditLogKey: 'test-audit-log-key-3',
+      operationType: 'ASSIGN',
+    });
+
+    nodeMockServer.use(
+      http.post(
+        endpoints.queryUserTaskAuditLogs.getUrl({
+          userTaskKey: ':userTaskKey',
+        }),
+        () =>
+          HttpResponse.json(
+            auditLogMocks.getQueryUserTaskAuditLogsResponseMock([testAuditLog]),
+          ),
+      ),
+      http.get('/v2/audit-logs/:auditLogKey', () =>
+        HttpResponse.json(testAuditLog),
+      ),
+    );
+
+    const {user} = render(
+      <RouterProvider
+        router={getRouter('/0/history?sort=operationType+desc')}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    expect(
+      await screen.findByTestId('task-details-history-view'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: /open details/i}));
+
+    expect(
+      await screen.findByRole('heading', {name: /assign task/i}),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/0/history/test-audit-log-key-3',
+    );
+    expect(screen.getByTestId('search')).toHaveTextContent(
+      'sort=operationType+desc',
+    );
+
+    await user.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: /close/i,
+      }),
+    );
+
+    expect(
+      screen.queryByRole('heading', {name: /assign task/i}),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/0/history');
+    expect(screen.getByTestId('search')).toHaveTextContent(
+      'sort=operationType+desc',
+    );
   });
 
   it('should display sortable column headers for Operation, Actor, and Date', async () => {

--- a/tasklist/client/src/v2/TaskDetailsHistoryView/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/index.tsx
@@ -201,7 +201,10 @@ const TaskDetailsHistoryView: React.FC = () => {
   );
 
   const handleOpenDetails = (auditLogKey: string) => {
-    navigate(pages.taskDetailsHistoryAuditLog(id, auditLogKey));
+    navigate({
+      ...location,
+      pathname: pages.taskDetailsHistoryAuditLog(id, auditLogKey),
+    });
   };
 
   if (rows.length === 0) {


### PR DESCRIPTION
## Description

- Updated navigation logic in TaskDetailsHistoryView to retain URL query parameters when opening details or closing the modal
- Add coverage for query string preservation in TaskDetailsHistoryView

## Related issues

closes https://github.com/camunda/camunda/issues/48013
