### PR TITLE
fix: cast to binary large object instead of BLOB in H2 web sessions to

### DIFF
--- a/db/rdbms/src/main/resources/mapper/PersistentWebSessionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/PersistentWebSessionMapper.xml
@@ -27,7 +27,7 @@
                     CAST(#{creationTime} AS BIGINT)                        AS CREATION_TIME,
                     CAST(#{lastAccessedTime} AS BIGINT)                    AS LAST_ACCESSED_TIME,
                     CAST(#{maxInactiveIntervalInSeconds} AS BIGINT)        AS MAX_INACTIVE_INTERVAL_IN_SECONDS,
-                    CAST(#{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler} AS BLOB) AS ATTRIBUTES
+                    CAST(#{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler} AS BINARY LARGE OBJECT) AS ATTRIBUTES
       ) source
       ON (target.SESSION_ID = source.SESSION_ID)
       WHEN MATCHED THEN


### PR DESCRIPTION
## Description

This pull request updates the SQL type used for storing session attributes in the `PersistentWebSessionMapper.xml` file. The change replaces the use of `BLOB` with the more explicit `BINARY LARGE OBJECT` type for the `ATTRIBUTES` column.

- Database schema update:
  * Changed the SQL type for the `ATTRIBUTES` field from `BLOB` to `BINARY LARGE OBJECT` in the session persistence mapping to improve clarity and compatibility.
## Checklist

## Related issues

closes #48092 
