### PR TITLE
fix: remove type:string from enum types

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -186,7 +186,6 @@ components:
           type: string
         resourceType:
           description: The type of resource to add permissions to.
-          type: string
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
         permissionTypes:
@@ -216,7 +215,6 @@ components:
           type: string
         resourceType:
           description: The type of resource to add permissions to.
-          type: string
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
         permissionTypes:
@@ -296,7 +294,6 @@ components:
             type: string
         resourceType:
           description: The type of resource to search permissions for.
-          type: string
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
 
@@ -318,7 +315,6 @@ components:
           $ref: '#/components/schemas/OwnerTypeEnum'
         resourceType:
           description: The type of resource that the permissions relate to.
-          type: string
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
         resourceId:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR removes `type: string` from enums declared using `allOf` composition with enums. The contradictory declaration is unconventional with the rest of the specification and causes issues with code generation.

Relates to https://github.com/camunda/camunda/issues/48123#issuecomment-4041126665

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
