### PR TITLE
[Backport stable/8.9] fix: add @NotNull validation for all Long key parameters in MCP tools

### DIFF
--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
@@ -54,6 +54,8 @@ public final class ToolDescriptions {
   /** Validation constraint messages */
   public static final String POSITIVE_NUMBER_MESSAGE = "must be a positive number.";
 
+  public static final String NOT_NULL_MESSAGE = "must not be null.";
+
   public static final String INCIDENT_KEY_POSITIVE_MESSAGE =
       "Incident key " + POSITIVE_NUMBER_MESSAGE;
   public static final String PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE =
@@ -64,6 +66,7 @@ public final class ToolDescriptions {
       "Process definition key " + POSITIVE_NUMBER_MESSAGE;
   public static final String USER_TASK_KEY_POSITIVE_MESSAGE =
       "User task key " + POSITIVE_NUMBER_MESSAGE;
+  public static final String USER_TASK_KEY_NOT_NULL_MESSAGE = "User task key " + NOT_NULL_MESSAGE;
 
   private ToolDescriptions() {
     // Utility class

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
@@ -58,12 +58,18 @@ public final class ToolDescriptions {
 
   public static final String INCIDENT_KEY_POSITIVE_MESSAGE =
       "Incident key " + POSITIVE_NUMBER_MESSAGE;
+  public static final String INCIDENT_KEY_NOT_NULL_MESSAGE = "Incident key " + NOT_NULL_MESSAGE;
   public static final String PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE =
       "Process instance key " + POSITIVE_NUMBER_MESSAGE;
+  public static final String PROCESS_INSTANCE_KEY_NOT_NULL_MESSAGE =
+      "Process instance key " + NOT_NULL_MESSAGE;
   public static final String VARIABLE_KEY_POSITIVE_MESSAGE =
       "Variable key " + POSITIVE_NUMBER_MESSAGE;
+  public static final String VARIABLE_KEY_NOT_NULL_MESSAGE = "Variable key " + NOT_NULL_MESSAGE;
   public static final String PROCESS_DEFINITION_KEY_POSITIVE_MESSAGE =
       "Process definition key " + POSITIVE_NUMBER_MESSAGE;
+  public static final String PROCESS_DEFINITION_KEY_NOT_NULL_MESSAGE =
+      "Process definition key " + NOT_NULL_MESSAGE;
   public static final String USER_TASK_KEY_POSITIVE_MESSAGE =
       "User task key " + POSITIVE_NUMBER_MESSAGE;
   public static final String USER_TASK_KEY_NOT_NULL_MESSAGE = "User task key " + NOT_NULL_MESSAGE;

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
@@ -38,6 +38,7 @@ public final class ToolDescriptions {
       "The assigned key of the process definition, which acts as a unique identifier for this process definition.";
 
   public static final String USER_TASK_KEY_DESCRIPTION = "The user task key.";
+  public static final String VARIABLE_KEY_DESCRIPTION = "The variable key.";
 
   /* Variable descriptions */
   public static final String VARIABLE_FILTER_FORMAT_NOTE =

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -9,6 +9,7 @@ package io.camunda.gateway.mcp.tool.incident;
 
 import static io.camunda.gateway.mcp.mapper.CallToolResultMapper.mapErrorToResult;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.INCIDENT_KEY_NOT_NULL_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.INCIDENT_KEY_POSITIVE_MESSAGE;
 
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.Either;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
@@ -81,6 +83,7 @@ public class IncidentTools {
       @McpToolParam(
               description =
                   "The assigned key of the incident, which acts as a unique identifier for this incident.")
+          @NotNull(message = INCIDENT_KEY_NOT_NULL_MESSAGE)
           @Positive(message = INCIDENT_KEY_POSITIVE_MESSAGE)
           final Long incidentKey) {
     try {
@@ -96,6 +99,7 @@ public class IncidentTools {
   @CamundaMcpTool(description = "Resolve incident by key. " + EVENTUAL_CONSISTENCY_NOTE)
   public CallToolResult resolveIncident(
       @McpToolParam(description = "Key of the incident to resolve.")
+          @NotNull(message = INCIDENT_KEY_NOT_NULL_MESSAGE)
           @Positive(message = INCIDENT_KEY_POSITIVE_MESSAGE)
           final Long incidentKey) {
     try {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionTools.java
@@ -9,6 +9,7 @@ package io.camunda.gateway.mcp.tool.process.definition;
 
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_DEFINITION_KEY_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_DEFINITION_KEY_NOT_NULL_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_DEFINITION_KEY_POSITIVE_MESSAGE;
 
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
@@ -23,6 +24,7 @@ import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
@@ -69,6 +71,7 @@ public class ProcessDefinitionTools {
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getProcessDefinition(
       @McpToolParam(description = PROCESS_DEFINITION_KEY_DESCRIPTION)
+          @NotNull(message = PROCESS_DEFINITION_KEY_NOT_NULL_MESSAGE)
           @Positive(message = PROCESS_DEFINITION_KEY_POSITIVE_MESSAGE)
           final Long processDefinitionKey) {
     try {
@@ -86,6 +89,7 @@ public class ProcessDefinitionTools {
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getProcessDefinitionXml(
       @McpToolParam(description = PROCESS_DEFINITION_KEY_DESCRIPTION)
+          @NotNull(message = PROCESS_DEFINITION_KEY_NOT_NULL_MESSAGE)
           @Positive(message = PROCESS_DEFINITION_KEY_POSITIVE_MESSAGE)
           final Long processDefinitionKey) {
     try {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mcp.tool.process.instance;
 
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_INSTANCE_KEY_NOT_NULL_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE;
 
 import io.camunda.gateway.mapping.http.ResponseMapper;
@@ -24,6 +25,7 @@ import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
@@ -74,6 +76,7 @@ public class ProcessInstanceTools {
       @McpToolParam(
               description =
                   "The assigned key of the process instance, which acts as a unique identifier for this process instance.")
+          @NotNull(message = PROCESS_INSTANCE_KEY_NOT_NULL_MESSAGE)
           @Positive(message = PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE)
           final Long processInstanceKey) {
     try {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
@@ -32,6 +32,7 @@ import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.UserTaskServices;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
@@ -166,6 +167,7 @@ public class UserTaskTools {
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult searchUserTaskVariables(
       @McpToolParam(description = USER_TASK_KEY_DESCRIPTION)
+          @NotNull(message = "User task key must not be null.")
           @Positive(message = USER_TASK_KEY_POSITIVE_MESSAGE)
           final Long userTaskKey,
       @McpToolParam(description = FILTER_DESCRIPTION, required = false)

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
@@ -82,6 +82,7 @@ public class UserTaskTools {
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getUserTask(
       @McpToolParam(description = USER_TASK_KEY_DESCRIPTION)
+          @NotNull(message = USER_TASK_KEY_NOT_NULL_MESSAGE)
           @Positive(message = USER_TASK_KEY_POSITIVE_MESSAGE)
           final Long userTaskKey) {
     try {
@@ -99,6 +100,7 @@ public class UserTaskTools {
           "Assign or unassign a user task. Provide an assignee to assign the task, or omit/provide null to unassign it.")
   public CallToolResult assignUserTask(
       @McpToolParam(description = USER_TASK_KEY_DESCRIPTION)
+          @NotNull(message = USER_TASK_KEY_NOT_NULL_MESSAGE)
           @Positive(message = USER_TASK_KEY_POSITIVE_MESSAGE)
           final Long userTaskKey,
       @McpToolParam(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
@@ -13,6 +13,7 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.PAGE_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.TRUNCATE_VARIABLES_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.USER_TASK_KEY_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.USER_TASK_KEY_NOT_NULL_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.USER_TASK_KEY_POSITIVE_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_FILTER_FORMAT_NOTE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_VALUE_RETURN_FORMAT;
@@ -167,7 +168,7 @@ public class UserTaskTools {
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult searchUserTaskVariables(
       @McpToolParam(description = USER_TASK_KEY_DESCRIPTION)
-          @NotNull(message = "User task key must not be null.")
+          @NotNull(message = USER_TASK_KEY_NOT_NULL_MESSAGE)
           @Positive(message = USER_TASK_KEY_POSITIVE_MESSAGE)
           final Long userTaskKey,
       @McpToolParam(description = FILTER_DESCRIPTION, required = false)

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/variable/VariableTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/variable/VariableTools.java
@@ -12,6 +12,7 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.FILTER_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.PAGE_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.TRUNCATE_VARIABLES_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_KEY_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_KEY_NOT_NULL_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_KEY_POSITIVE_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_VALUE_RETURN_FORMAT;
@@ -82,7 +83,7 @@ public class VariableTools {
           "Get variable by key. " + VARIABLE_VALUE_RETURN_FORMAT + " " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getVariable(
-      @McpToolParam
+      @McpToolParam(description = VARIABLE_KEY_DESCRIPTION)
           @NotNull(message = VARIABLE_KEY_NOT_NULL_MESSAGE)
           @Positive(message = VARIABLE_KEY_POSITIVE_MESSAGE)
           final Long variableKey) {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/variable/VariableTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/variable/VariableTools.java
@@ -12,6 +12,7 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.FILTER_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.PAGE_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.TRUNCATE_VARIABLES_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_KEY_NOT_NULL_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_KEY_POSITIVE_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_VALUE_RETURN_FORMAT;
 
@@ -25,6 +26,7 @@ import io.camunda.gateway.protocol.model.simple.VariableFilter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.VariableServices;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
@@ -80,7 +82,10 @@ public class VariableTools {
           "Get variable by key. " + VARIABLE_VALUE_RETURN_FORMAT + " " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getVariable(
-      @McpToolParam @Positive(message = VARIABLE_KEY_POSITIVE_MESSAGE) final Long variableKey) {
+      @McpToolParam
+          @NotNull(message = VARIABLE_KEY_NOT_NULL_MESSAGE)
+          @Positive(message = VARIABLE_KEY_POSITIVE_MESSAGE)
+          final Long variableKey) {
     try {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toVariableItem(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -49,6 +49,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -192,7 +193,7 @@ class IncidentToolsTest extends ToolsTest {
     @Test
     void shouldFailGetIncidentByKeyOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("incidentKey", null);
       final CallToolResult result =
           mcpClient.callTool(
@@ -490,7 +491,7 @@ class IncidentToolsTest extends ToolsTest {
     @Test
     void shouldFailResolveIncidentByKeyOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("incidentKey", null);
       final CallToolResult result =
           mcpClient.callTool(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -170,11 +170,33 @@ class IncidentToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailGetIncidentByKeyOnNullKey() {
+    void shouldFailGetIncidentByKeyOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
               CallToolRequest.builder().name("getIncident").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("incidentKey: Incident key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetIncidentByKeyOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("incidentKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getIncident").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -446,11 +468,33 @@ class IncidentToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailResolveIncidentByKeyOnNullKey() {
+    void shouldFailResolveIncidentByKeyOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
               CallToolRequest.builder().name("resolveIncident").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("incidentKey: Incident key must not be null."));
+    }
+
+    @Test
+    void shouldFailResolveIncidentByKeyOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("incidentKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("resolveIncident").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -170,6 +170,26 @@ class IncidentToolsTest extends ToolsTest {
     }
 
     @Test
+    void shouldFailGetIncidentByKeyOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getIncident").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("incidentKey: Incident key must not be null."));
+    }
+
+    @Test
     void shouldFailGetIncidentByKeyOnInvalidKey() {
       // when
       final CallToolResult result =
@@ -423,6 +443,26 @@ class IncidentToolsTest extends ToolsTest {
       verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null)), any());
 
       assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldFailResolveIncidentByKeyOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("resolveIncident").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("incidentKey: Incident key must not be null."));
     }
 
     @Test

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
@@ -118,11 +118,33 @@ class ProcessDefinitionToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailGetProcessDefinitionByKeyOnNullKey() {
+    void shouldFailGetProcessDefinitionByKeyOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
               CallToolRequest.builder().name("getProcessDefinition").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("processDefinitionKey: Process definition key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetProcessDefinitionByKeyOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("processDefinitionKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getProcessDefinition").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -271,13 +293,38 @@ class ProcessDefinitionToolsTest extends ToolsTest {
   class GetProcessDefinitionXml {
 
     @Test
-    void shouldFailGetProcessDefinitionXmlByKeyOnNullKey() {
+    void shouldFailGetProcessDefinitionXmlByKeyOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
               CallToolRequest.builder()
                   .name("getProcessDefinitionXml")
                   .arguments(Map.of())
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("processDefinitionKey: Process definition key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetProcessDefinitionXmlByKeyOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("processDefinitionKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessDefinitionXml")
+                  .arguments(arguments)
                   .build());
 
       // then

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
@@ -34,6 +34,7 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -140,7 +141,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
     @Test
     void shouldFailGetProcessDefinitionByKeyOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("processDefinitionKey", null);
       final CallToolResult result =
           mcpClient.callTool(
@@ -318,7 +319,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
     @Test
     void shouldFailGetProcessDefinitionXmlByKeyOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("processDefinitionKey", null);
       final CallToolResult result =
           mcpClient.callTool(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
@@ -118,6 +118,26 @@ class ProcessDefinitionToolsTest extends ToolsTest {
     }
 
     @Test
+    void shouldFailGetProcessDefinitionByKeyOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getProcessDefinition").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("processDefinitionKey: Process definition key must not be null."));
+    }
+
+    @Test
     void shouldFailGetProcessDefinitionByKeyOnInvalidKey() {
       // when
       final CallToolResult result =
@@ -249,6 +269,53 @@ class ProcessDefinitionToolsTest extends ToolsTest {
 
   @Nested
   class GetProcessDefinitionXml {
+
+    @Test
+    void shouldFailGetProcessDefinitionXmlByKeyOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessDefinitionXml")
+                  .arguments(Map.of())
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("processDefinitionKey: Process definition key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetProcessDefinitionXmlByKeyOnInvalidKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessDefinitionXml")
+                  .arguments(Map.of("processDefinitionKey", -3L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo(
+                          "processDefinitionKey: Process definition key must be a positive number."));
+    }
 
     @Test
     void shouldGetProcessDefinitionXmlByKey() {

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -179,11 +179,33 @@ class ProcessInstanceToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailGetProcessInstanceByKeyOnNullKey() {
+    void shouldFailGetProcessInstanceByKeyOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
               CallToolRequest.builder().name("getProcessInstance").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("processInstanceKey: Process instance key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetProcessInstanceByKeyOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("processInstanceKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getProcessInstance").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -46,6 +46,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -201,7 +202,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
     @Test
     void shouldFailGetProcessInstanceByKeyOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("processInstanceKey", null);
       final CallToolResult result =
           mcpClient.callTool(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -179,6 +179,26 @@ class ProcessInstanceToolsTest extends ToolsTest {
     }
 
     @Test
+    void shouldFailGetProcessInstanceByKeyOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getProcessInstance").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("processInstanceKey: Process instance key must not be null."));
+    }
+
+    @Test
     void shouldFailGetProcessInstanceByKeyOnInvalidKey() {
       // when
       final CallToolResult result =

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -223,6 +223,26 @@ class UserTaskToolsTest extends ToolsTest {
     }
 
     @Test
+    void shouldFailGetUserTaskByKeyOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getUserTask").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("userTaskKey: User task key must not be null."));
+    }
+
+    @Test
     void shouldFailGetUserTaskByKeyOnInvalidKey() {
       // when
       final CallToolResult result =
@@ -681,6 +701,29 @@ class UserTaskToolsTest extends ToolsTest {
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
 
       assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldFailAssignUserTaskOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("assignUserTask")
+                  .arguments(Map.of("assignee", "jane.doe"))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("userTaskKey: User task key must not be null."));
     }
 
     @Test

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -223,11 +223,33 @@ class UserTaskToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailGetUserTaskByKeyOnNullKey() {
+    void shouldFailGetUserTaskByKeyOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
               CallToolRequest.builder().name("getUserTask").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("userTaskKey: User task key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetUserTaskByKeyOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("userTaskKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getUserTask").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -704,7 +726,7 @@ class UserTaskToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailAssignUserTaskOnNullKey() {
+    void shouldFailAssignUserTaskOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
@@ -712,6 +734,29 @@ class UserTaskToolsTest extends ToolsTest {
                   .name("assignUserTask")
                   .arguments(Map.of("assignee", "jane.doe"))
                   .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("userTaskKey: User task key must not be null."));
+    }
+
+    @Test
+    void shouldFailAssignUserTaskOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("userTaskKey", null);
+      arguments.put("assignee", "jane.doe");
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("assignUserTask").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -906,13 +951,38 @@ class UserTaskToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailSearchUserTaskVariablesOnNullKey() {
+    void shouldFailSearchUserTaskVariablesOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
               CallToolRequest.builder()
                   .name("searchUserTaskVariables")
                   .arguments(Map.of())
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("userTaskKey: User task key must not be null."));
+    }
+
+    @Test
+    void shouldFailSearchUserTaskVariablesOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("userTaskKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchUserTaskVariables")
+                  .arguments(arguments)
                   .build());
 
       // then

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -47,6 +47,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -245,7 +246,7 @@ class UserTaskToolsTest extends ToolsTest {
     @Test
     void shouldFailGetUserTaskByKeyOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("userTaskKey", null);
       final CallToolResult result =
           mcpClient.callTool(
@@ -751,7 +752,7 @@ class UserTaskToolsTest extends ToolsTest {
     @Test
     void shouldFailAssignUserTaskOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("userTaskKey", null);
       arguments.put("assignee", "jane.doe");
       final CallToolResult result =
@@ -976,7 +977,7 @@ class UserTaskToolsTest extends ToolsTest {
     @Test
     void shouldFailSearchUserTaskVariablesOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("userTaskKey", null);
       final CallToolResult result =
           mcpClient.callTool(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -863,6 +863,29 @@ class UserTaskToolsTest extends ToolsTest {
     }
 
     @Test
+    void shouldFailSearchUserTaskVariablesOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchUserTaskVariables")
+                  .arguments(Map.of())
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("userTaskKey: User task key must not be null."));
+    }
+
+    @Test
     void shouldFailSearchUserTaskVariablesOnInvalidKey() {
       // when
       final CallToolResult result =

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -158,6 +158,26 @@ class VariableToolsTest extends ToolsTest {
     }
 
     @Test
+    void shouldFailGetVariableByKeyOnNullKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getVariable").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("variableKey: Variable key must not be null."));
+    }
+
+    @Test
     void shouldFailGetVariableByKeyOnInvalidKey() {
       // when
       final CallToolResult result =

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -36,6 +36,7 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
@@ -180,7 +181,7 @@ class VariableToolsTest extends ToolsTest {
     @Test
     void shouldFailGetVariableByKeyOnNullKey() {
       // when
-      final var arguments = new java.util.HashMap<String, Object>();
+      final var arguments = new HashMap<String, Object>();
       arguments.put("variableKey", null);
       final CallToolResult result =
           mcpClient.callTool(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -158,11 +158,33 @@ class VariableToolsTest extends ToolsTest {
     }
 
     @Test
-    void shouldFailGetVariableByKeyOnNullKey() {
+    void shouldFailGetVariableByKeyOnMissingKey() {
       // when
       final CallToolResult result =
           mcpClient.callTool(
               CallToolRequest.builder().name("getVariable").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("variableKey: Variable key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetVariableByKeyOnNullKey() {
+      // when
+      final var arguments = new java.util.HashMap<String, Object>();
+      arguments.put("variableKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getVariable").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();


### PR DESCRIPTION
# Description
Backport of #48264 to `stable/8.9`.

relates to #47954 #48197 #48195 #48196 #48201