### PR TITLE
[Backport stable/8.9] fix: remove type:string from enum types

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -186,7 +186,6 @@ components:
           type: string
         resourceType:
           description: The type of resource to add permissions to.
-          type: string
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
         permissionTypes:
@@ -216,7 +215,6 @@ components:
           type: string
         resourceType:
           description: The type of resource to add permissions to.
-          type: string
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
         permissionTypes:
@@ -296,7 +294,6 @@ components:
             type: string
         resourceType:
           description: The type of resource to search permissions for.
-          type: string
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
 
@@ -318,7 +315,6 @@ components:
           $ref: '#/components/schemas/OwnerTypeEnum'
         resourceType:
           description: The type of resource that the permissions relate to.
-          type: string
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
         resourceId:


### PR DESCRIPTION
# Description
Backport of #48294 to `stable/8.9`.

relates to 