### PR TITLE
fix: display `entityDescription` in operations log when available

### DIFF
--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -342,7 +342,9 @@ const List: FC = () => {
                   ),
                   entityType: spaceAndCapitalize(log.entityType),
                   reference: (
-                    <CodeSnippet type="inline">{log.entityKey}</CodeSnippet>
+                    <CodeSnippet type="inline">
+                      {log.entityDescription?.trim() || log.entityKey}
+                    </CodeSnippet>
                   ),
                   property: <CellProperty item={log} />,
                   actorId: log.actorId ? (

--- a/operate/client/src/App/OperationsLog/InstancesTable/Cell/CellEntityKey.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/Cell/CellEntityKey.tsx
@@ -41,7 +41,7 @@ const CellEntityKey: React.FC<Props> = ({
           label
         )}
       </div>
-      {item.entityDescription ?? <em>{name}</em>}
+      {item.entityDescription?.trim() || <em>{name}</em>}
     </div>
   );
 };

--- a/operate/client/src/modules/components/OperationsLogDetailsModal/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsLogDetailsModal/index.test.tsx
@@ -75,6 +75,29 @@ describe('DetailsModal', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders fallback name when entityDescription is an empty string or whitespace only', () => {
+    const auditLogWithEmptyDescription: AuditLog = {
+      ...baseAuditLog,
+      entityType: 'PROCESS_INSTANCE',
+      entityKey: 'process-instance-123',
+      entityDescription: ' ',
+      processDefinitionId: 'process-def-id',
+    };
+
+    render(
+      <DetailsModal
+        isOpen
+        onClose={() => {}}
+        auditLog={auditLogWithEmptyDescription}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(screen.getByText('process-def-id')).toBeInTheDocument();
+  });
+
   it('renders batch information and link for batch audit log', () => {
     const batchAuditLog: AuditLog = {
       ...baseAuditLog,

--- a/operate/client/src/modules/components/OperationsLogDetailsModal/index.tsx
+++ b/operate/client/src/modules/components/OperationsLogDetailsModal/index.tsx
@@ -157,7 +157,7 @@ const DetailsModal: React.FC<Props> = ({isOpen, onClose, auditLog}) => {
                 entityKeyData.label
               )}
               &nbsp;
-              {auditLog.entityDescription ?? entityKeyData.name}
+              {auditLog.entityDescription?.trim() || entityKeyData.name}
             </SecondColumn>
           </VerticallyAlignedRow>
           {['USER_TASK', 'INCIDENT', 'VARIABLE'].includes(


### PR DESCRIPTION
## Description

- Fallback to `entityKey` if `entityDescription` is undefined.
- Handle empty `entityDescription` string too.

## Related issues

closes https://github.com/camunda/camunda/issues/48287
