### PR TITLE
fix: throttle backup creation in listManyBackups

### DIFF
--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -80,6 +81,7 @@ public interface ListingBackups {
   default void canListManyBackups() throws IOException {
     // given
     final int backupCount = 2_000;
+    final var semaphore = new Semaphore(200);
     final var ids =
         IntStream.rangeClosed(1, backupCount)
             .mapToObj(i -> new BackupIdentifierImpl(1, 1, i))
@@ -89,14 +91,17 @@ public interface ListingBackups {
     CompletableFuture.allOf(
             ids.stream()
                 .map(
-                    id ->
-                        getStore()
-                            .save(
-                                new BackupImpl(
-                                    id,
-                                    backupTemplate.descriptor(),
-                                    backupTemplate.snapshot(),
-                                    backupTemplate.segments())))
+                    id -> {
+                      semaphore.acquireUninterruptibly();
+                      return getStore()
+                          .save(
+                              new BackupImpl(
+                                  id,
+                                  backupTemplate.descriptor(),
+                                  backupTemplate.snapshot(),
+                                  backupTemplate.segments()))
+                          .whenComplete((v, e) -> semaphore.release());
+                    })
                 .toArray(CompletableFuture[]::new))
         .join();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Use a `semaphore` to throttle backup creation in the `ListingBackups#canListManyBackups`. The amount of backups created saturate the GCS container causing it to timeout requests from other tests since the tests run in parallel the GCS container is a shared resource.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
