### PR TITLE
[Backport stable/8.9] fix: cast to binary large object instead of BLOB in H2 web sessions to

### DIFF
--- a/db/rdbms/src/main/resources/mapper/PersistentWebSessionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/PersistentWebSessionMapper.xml
@@ -27,7 +27,7 @@
                     CAST(#{creationTime} AS BIGINT)                        AS CREATION_TIME,
                     CAST(#{lastAccessedTime} AS BIGINT)                    AS LAST_ACCESSED_TIME,
                     CAST(#{maxInactiveIntervalInSeconds} AS BIGINT)        AS MAX_INACTIVE_INTERVAL_IN_SECONDS,
-                    CAST(#{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler} AS BLOB) AS ATTRIBUTES
+                    CAST(#{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler} AS BINARY LARGE OBJECT) AS ATTRIBUTES
       ) source
       ON (target.SESSION_ID = source.SESSION_ID)
       WHEN MATCHED THEN


### PR DESCRIPTION
# Description
Backport of #48288 to `stable/8.9`.

relates to #48092