### PR TITLE
[Backport stable/8.9] perf: in CamundaExporter schedule flush based on last flushed timestamp

### DIFF
--- a/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
+++ b/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
@@ -30,6 +30,7 @@ public final class ExporterTestContext implements Context {
   private RecordFilter recordFilter;
   private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private int partitionId;
+  private InstantSource clock = InstantSource.system();
 
   @Override
   public MeterRegistry getMeterRegistry() {
@@ -43,7 +44,7 @@ public final class ExporterTestContext implements Context {
 
   @Override
   public InstantSource clock() {
-    return InstantSource.system();
+    return clock;
   }
 
   @Override
@@ -63,6 +64,11 @@ public final class ExporterTestContext implements Context {
 
   public ExporterTestContext setPartitionId(final int partitionId) {
     this.partitionId = partitionId;
+    return this;
+  }
+
+  public ExporterTestContext setClock(final InstantSource clock) {
+    this.clock = Objects.requireNonNull(clock, "must specify a clock");
     return this;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -136,7 +136,7 @@ public class CamundaExporter implements Exporter {
       writer = createBatchWriter();
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
-      scheduleDelayedFlush(System.currentTimeMillis());
+      scheduleDelayedFlush(context.clock().millis());
 
       LOG.info("Exporter opened");
     } catch (final Exception e) {
@@ -309,19 +309,16 @@ public class CamundaExporter implements Exporter {
   }
 
   private void scheduleDelayedFlush(final long now) {
-    long delta = configuration.getBulk().getDelay();
+    long delayMs = configuration.getBulk().getDelay() * 1000L;
     if (lastFlushTimestamp > 0) {
-      delta =
-          Math.min(
-              configuration.getBulk().getDelay() * 1000L - (now - lastFlushTimestamp),
-              configuration.getBulk().getDelay() * 1000L);
+      delayMs = Math.max(0, delayMs - (now - lastFlushTimestamp));
     }
 
-    controller.scheduleCancellableTask(Duration.ofMillis(delta), this::flushAndReschedule);
+    controller.scheduleCancellableTask(Duration.ofMillis(delayMs), this::flushAndReschedule);
   }
 
   private void flushAndReschedule() {
-    final var now = System.currentTimeMillis();
+    final var now = context.clock().millis();
     try {
       if (now - lastFlushTimestamp >= configuration.getBulk().getDelay() * 1000L) {
         flush();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -89,6 +89,7 @@ public class CamundaExporter implements Exporter {
   private SearchEngineClient searchEngineClient;
   private int partitionId;
   private Context context;
+  private long lastFlushTimestamp = 0L;
 
   public CamundaExporter() {
     // the metadata will be initialized on open
@@ -135,7 +136,7 @@ public class CamundaExporter implements Exporter {
       writer = createBatchWriter();
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
-      scheduleDelayedFlush();
+      scheduleDelayedFlush(System.currentTimeMillis());
 
       LOG.info("Exporter opened");
     } catch (final Exception e) {
@@ -307,18 +308,28 @@ public class CamundaExporter implements Exporter {
     return builder.build();
   }
 
-  private void scheduleDelayedFlush() {
-    controller.scheduleCancellableTask(
-        Duration.ofSeconds(configuration.getBulk().getDelay()), this::flushAndReschedule);
+  private void scheduleDelayedFlush(final long now) {
+    long delta = configuration.getBulk().getDelay();
+    if (lastFlushTimestamp > 0) {
+      delta =
+          Math.min(
+              configuration.getBulk().getDelay() * 1000L - (now - lastFlushTimestamp),
+              configuration.getBulk().getDelay() * 1000L);
+    }
+
+    controller.scheduleCancellableTask(Duration.ofMillis(delta), this::flushAndReschedule);
   }
 
   private void flushAndReschedule() {
+    final var now = System.currentTimeMillis();
     try {
-      flush();
+      if (now - lastFlushTimestamp >= configuration.getBulk().getDelay() * 1000L) {
+        flush();
+      }
     } catch (final Exception e) {
       LOG.warn("Unexpected exception occurred on periodically flushing bulk, will retry later.", e);
     }
-    scheduleDelayedFlush();
+    scheduleDelayedFlush(now);
   }
 
   private void flush() {
@@ -329,12 +340,15 @@ public class CamundaExporter implements Exporter {
         writer.flush(batchRequest);
         metrics.recordFlushOccurrence(Instant.now());
         metrics.stopFlushLatencyMeasurement();
+        lastFlushTimestamp = System.currentTimeMillis();
       } catch (final PersistenceException ex) {
         metrics.recordFailedFlush();
         throw new ExporterException(ex.getMessage(), ex);
       }
     }
 
+    // Update the record counters only after the flush was successful. If the synchronous flush
+    // fails then the exporter will be invoked with the same record again.
     updateLastExportedPosition(lastPosition);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -91,6 +91,8 @@ public class CamundaExporter implements Exporter {
   private Context context;
   private long lastFlushTimestamp = 0L;
 
+  private long delayMs;
+
   public CamundaExporter() {
     // the metadata will be initialized on open
     this(new DefaultExporterResourceProvider(), null);
@@ -111,6 +113,7 @@ public class CamundaExporter implements Exporter {
   public void configure(final Context context) {
     this.context = context;
     configuration = context.getConfiguration().instantiate(ExporterConfiguration.class);
+    delayMs = configuration.getBulk().getDelay() * 1000L;
     partitionId = context.getPartitionId();
 
     LOG.info("Configuring exporter with {}", configuration);
@@ -309,7 +312,6 @@ public class CamundaExporter implements Exporter {
   }
 
   private void scheduleDelayedFlush(final long now) {
-    long delayMs = configuration.getBulk().getDelay() * 1000L;
     if (lastFlushTimestamp > 0) {
       delayMs = Math.max(0, delayMs - (now - lastFlushTimestamp));
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -337,7 +337,7 @@ public class CamundaExporter implements Exporter {
         writer.flush(batchRequest);
         metrics.recordFlushOccurrence(Instant.now());
         metrics.stopFlushLatencyMeasurement();
-        lastFlushTimestamp = System.currentTimeMillis();
+        lastFlushTimestamp = context.clock().millis();
       } catch (final PersistenceException ex) {
         metrics.recordFailedFlush();
         throw new ExporterException(ex.getMessage(), ex);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -33,7 +33,12 @@ import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
@@ -168,8 +173,7 @@ final class CamundaExporterTest {
 
     @Override
     public BatchRequest createBatchRequest() {
-      return mock(
-          BatchRequest.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+      return mock(BatchRequest.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF));
     }
 
     @Override
@@ -179,6 +183,23 @@ final class CamundaExporterTest {
 
     @Override
     public void close() {}
+  }
+
+  private static final class MutableClock implements InstantSource {
+    private long millis;
+
+    MutableClock(final long initialMillis) {
+      millis = initialMillis;
+    }
+
+    @Override
+    public Instant instant() {
+      return Instant.ofEpochMilli(millis);
+    }
+
+    void advance(final long addMillis) {
+      millis += addMillis;
+    }
   }
 
   @Nested
@@ -231,6 +252,61 @@ final class CamundaExporterTest {
       assertThat(actual.getLastIncidentUpdatePosition()).isEqualTo(5);
       assertThat(actual.getFirstUserTaskKey(TaskImplementation.JOB_WORKER)).isEqualTo(10);
       assertThat(actual.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK)).isEqualTo(10);
+    }
+  }
+
+  @Nested
+  final class ScheduledFlushTest {
+
+    private Record<?> stubRecord() {
+      return new ProtocolFactory().generateRecord(ValueType.VARIABLE);
+    }
+
+    @Test
+    void shouldScheduleInitialFlushAtConfiguredDelay() {
+      // given
+      configuration.getBulk().setDelay(5);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+
+      // when
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // then — delay(5) means 5 seconds, not 5 milliseconds
+      final var tasks = testController.getScheduledTasks();
+      assertThat(tasks).hasSize(1);
+      assertThat(tasks.getFirst().getDelay()).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldNotFlushBeforeDelayElapses() {
+      // given — use a controllable clock so we can verify timing
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      // bulk size = 1 so that export() triggers an immediate size-based flush,
+      // which sets lastFlushTimestamp without needing the scheduled task to flush
+      configuration.getBulk().setSize(1);
+      configuration.getBulk().setDelay(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // export at t=500 — triggers immediate size-based flush, setting lastFlushTimestamp=500
+      clock.advance(500);
+      exporter.export(stubRecord());
+
+      // run the scheduled task at t=800 — only 300ms since last flush, guard should skip
+      clock.advance(300);
+      testController.runScheduledTasks(Duration.ofSeconds(2));
+
+      // then — the rescheduled task should have the remaining 700ms delay
+      final var tasks = testController.getScheduledTasks();
+      final var lastTask = tasks.getLast();
+      assertThat(lastTask.getDelay()).isEqualTo(Duration.ofMillis(700));
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #48251 to `stable/8.9`.

relates to 