### PR TITLE
ci: find more flakes for daily stats

### DIFF
--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -101,7 +101,7 @@ jobs:
 
               # Try to find GH issues about related flaky tests:
               # First, search specifically by test class name + test name + "flaky"
-              GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND in:title $TEST_NAME AND in:title flaky" --json number --jq '.[].number' | head -n 1)
+              GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND in:title $TEST_NAME AND (label:kind/flake OR in:title flaky)" --json number --jq '.[].number' | head -n 1)
               if [ -z "$GH_ISSUE_ID" ]; then
                 # If nothing found, search by test class name + "flaky"
                 GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND (label:kind/flake OR in:title flaky)" --json number --jq '.[].number' | head -n 1)

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -104,7 +104,7 @@ jobs:
               GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND in:title $TEST_NAME AND in:title flaky" --json number --jq '.[].number' | head -n 1)
               if [ -z "$GH_ISSUE_ID" ]; then
                 # If nothing found, search by test class name + "flaky"
-                GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND in:title flaky" --json number --jq '.[].number' | head -n 1)
+                GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND (label:kind/flake OR in:title flaky)" --json number --jq '.[].number' | head -n 1)
               fi
               if [ -n "$GH_ISSUE_ID" ]; then
                 SUFFIX=" (<https://github.com/camunda/camunda/issues/$GH_ISSUE_ID|GH issue>)"


### PR DESCRIPTION
## Description

Extends daily CI flakes stats suffix labeling by including "kind/flake" issues.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

[Internal discussion](https://camunda.slack.com/archives/C071KP5BTHB/p1773308760415939?thread_ts=1773296768.962799&cid=C071KP5BTHB)
