### PR TITLE
[Backport stable/8.8] fix: validate pagination and sorting for process definition search with isLatestVersion filter

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
@@ -99,6 +99,14 @@ public final class SearchQueryRequestMapper {
     if (request == null) {
       return Either.right(SearchQueryBuilders.processDefinitionSearchQuery().build());
     }
+
+    // Validate isLatestVersion constraints
+    final var isLatestVersionValidation =
+        validateProcessDefinitionIsLatestVersionConstraints(request);
+    if (isLatestVersionValidation.isLeft()) {
+      return Either.left(isLatestVersionValidation.getLeft());
+    }
+
     final var page = toSearchQueryPage(request.getPage());
     final var sort =
         SearchQuerySortRequestMapper.toSearchQuerySort(
@@ -631,6 +639,53 @@ public final class SearchQueryRequestMapper {
           ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
               "page.from", from, "a non-negative number"));
     }
+  }
+
+  private static Either<ProblemDetail, Void> validateProcessDefinitionIsLatestVersionConstraints(
+      final ProcessDefinitionSearchQuery request) {
+    final List<String> violations = new ArrayList<>();
+
+    // Check if isLatestVersion filter is set to true
+    final var filter = request.getFilter();
+    if (filter == null || filter.getIsLatestVersion() == null || !filter.getIsLatestVersion()) {
+      return Either.right(null);
+    }
+
+    // Validate pagination: only 'after' and 'limit' are allowed
+    final var page = request.getPage();
+    if (page != null) {
+      if (page.getBefore() != null) {
+        violations.add(
+            ERROR_MESSAGE_UNSUPPORTED_PAGINATION_WITH_IS_LATEST_VERSION.formatted("before"));
+      }
+      if (page.getFrom() != null) {
+        violations.add(
+            ERROR_MESSAGE_UNSUPPORTED_PAGINATION_WITH_IS_LATEST_VERSION.formatted("from"));
+      }
+    }
+
+    // Validate sorting: only 'processDefinitionId' and 'tenantId' are allowed
+    final var sort = request.getSort();
+    if (sort != null && !sort.isEmpty()) {
+      for (final var sortRequest : sort) {
+        final var field = sortRequest.getField();
+        if (field != null
+            && field != ProcessDefinitionSearchQuerySortRequest.FieldEnum.PROCESS_DEFINITION_ID
+            && field != ProcessDefinitionSearchQuerySortRequest.FieldEnum.TENANT_ID) {
+          violations.add(
+              ERROR_MESSAGE_UNSUPPORTED_SORT_FIELD_WITH_IS_LATEST_VERSION.formatted(field));
+        }
+      }
+    }
+
+    if (!violations.isEmpty()) {
+      final var problem = RequestValidator.createProblemDetail(violations);
+      if (problem.isPresent()) {
+        return Either.left(problem.get());
+      }
+    }
+
+    return Either.right(null);
   }
 
   private static <

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -44,4 +44,8 @@ public final class ErrorMessages {
       "The provided tag '%s' is not valid. %s";
   public static final String ERROR_MESSAGE_INVALID_TAGS_COUNT =
       "The provided number of tags '%s' is not supported. Ensure to not add more than %s tags.";
+  public static final String ERROR_MESSAGE_UNSUPPORTED_PAGINATION_WITH_IS_LATEST_VERSION =
+      "When using isLatestVersion filter, pagination is limited to forward pagination using 'after' and 'limit'. The field '%s' is not supported.";
+  public static final String ERROR_MESSAGE_UNSUPPORTED_SORT_FIELD_WITH_IS_LATEST_VERSION =
+      "When using isLatestVersion filter, sorting is limited to 'processDefinitionId' and 'tenantId' fields only. The field '%s' is not supported.";
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -28,6 +28,7 @@ import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.FormServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQuerySortRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -563,5 +565,217 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class));
+  }
+
+  @Test
+  void shouldRejectBeforePaginationWhenIsLatestVersionIsTrue() {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "page": {
+                    "before": "someCursor"
+                }
+            }""";
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "When using isLatestVersion filter, pagination is limited to forward pagination using 'after' and 'limit'. The field 'before' is not supported.",
+                  "instance": "%s"
+                }""",
+            PROCESS_DEFINITION_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class));
+  }
+
+  @Test
+  void shouldRejectFromPaginationWhenIsLatestVersionIsTrue() {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "page": {
+                    "from": 10
+                }
+            }""";
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "When using isLatestVersion filter, pagination is limited to forward pagination using 'after' and 'limit'. The field 'from' is not supported.",
+                  "instance": "%s"
+                }""",
+            PROCESS_DEFINITION_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessDefinitionSearchQuerySortRequest.FieldEnum.class,
+      names = {"PROCESS_DEFINITION_ID", "TENANT_ID"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void shouldRejectUnsupportedSortFieldWhenIsLatestVersionIsTrue(
+      final ProcessDefinitionSearchQuerySortRequest.FieldEnum unsupportedField) {
+    // given
+    final var request =
+        String.format(
+            """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "sort": [
+                    {
+                        "field": "%s",
+                        "order": "ASC"
+                    }
+                ]
+            }""",
+            unsupportedField.getValue());
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "When using isLatestVersion filter, sorting is limited to 'processDefinitionId' and 'tenantId' fields only. The field '%s' is not supported.",
+                  "instance": "%s"
+                }""",
+            unsupportedField.getValue(), PROCESS_DEFINITION_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class));
+  }
+
+  @Test
+  void shouldAllowAfterPaginationWhenIsLatestVersionIsTrue() {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "page": {
+                    "after": "someCursor",
+                    "limit": 10
+                }
+            }""";
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class)))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices).search(any(ProcessDefinitionQuery.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessDefinitionSearchQuerySortRequest.FieldEnum.class,
+      names = {"PROCESS_DEFINITION_ID", "TENANT_ID"})
+  void shouldAllowSupportedSortFieldsWhenIsLatestVersionIsTrue(
+      final ProcessDefinitionSearchQuerySortRequest.FieldEnum supportedField) {
+    // given
+    final var request =
+        String.format(
+            """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "sort": [
+                    {
+                        "field": "%s",
+                        "order": "ASC"
+                    }
+                ]
+            }""",
+            supportedField.getValue());
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class)))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices).search(any(ProcessDefinitionQuery.class));
   }
 }


### PR DESCRIPTION
# Description
Backport of #48302 to `stable/8.8`.

relates to camunda/camunda#47959