### PR TITLE
[Backport stable/8.9] fix: validate pagination and sorting for process definition search with isLatestVersion filter

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -182,6 +182,14 @@ public final class SearchQueryRequestMapper {
     if (request == null) {
       return Either.right(SearchQueryBuilders.processDefinitionSearchQuery().build());
     }
+
+    // Validate isLatestVersion constraints
+    final var isLatestVersionValidation =
+        validateProcessDefinitionIsLatestVersionConstraints(request);
+    if (isLatestVersionValidation.isLeft()) {
+      return Either.left(isLatestVersionValidation.getLeft());
+    }
+
     final var page = toSearchQueryPage(request.getPage());
     final var sort =
         SearchQuerySortRequestMapper.toSearchQuerySort(
@@ -956,6 +964,56 @@ public final class SearchQueryRequestMapper {
 
   private static SearchQueryPage innerToSearchQueryPage(final LimitPagination requestedPage) {
     return SearchQueryPage.of((p) -> p.size(requestedPage.getLimit()));
+  }
+
+  private static Either<ProblemDetail, Void> validateProcessDefinitionIsLatestVersionConstraints(
+      final ProcessDefinitionSearchQuery request) {
+    final List<String> violations = new ArrayList<>();
+
+    // Check if isLatestVersion filter is set to true
+    final var filter = request.getFilter();
+    if (filter == null || filter.getIsLatestVersion() == null || !filter.getIsLatestVersion()) {
+      return Either.right(null);
+    }
+
+    // Validate pagination: only 'after' and 'limit' are allowed
+    final var page = request.getPage();
+    if (page != null) {
+      if (page instanceof CursorBackwardPagination) {
+        violations.add(
+            ERROR_MESSAGE_UNSUPPORTED_PAGINATION_WITH_IS_LATEST_VERSION.formatted("before"));
+      } else if (page instanceof OffsetPagination) {
+        violations.add(
+            ERROR_MESSAGE_UNSUPPORTED_PAGINATION_WITH_IS_LATEST_VERSION.formatted("from"));
+      }
+    }
+
+    // Validate sorting: only 'processDefinitionId' and 'tenantId' are allowed
+    final var sort = request.getSort();
+    if (sort != null && !sort.isEmpty()) {
+      for (final var sortRequest : sort) {
+        final var field = sortRequest.getField();
+        if (field != null
+            && field
+                != io.camunda.gateway.protocol.model.ProcessDefinitionSearchQuerySortRequest
+                    .FieldEnum.PROCESS_DEFINITION_ID
+            && field
+                != io.camunda.gateway.protocol.model.ProcessDefinitionSearchQuerySortRequest
+                    .FieldEnum.TENANT_ID) {
+          violations.add(
+              ERROR_MESSAGE_UNSUPPORTED_SORT_FIELD_WITH_IS_LATEST_VERSION.formatted(field));
+        }
+      }
+    }
+
+    if (!violations.isEmpty()) {
+      final var problem = RequestValidator.createProblemDetail(violations);
+      if (problem.isPresent()) {
+        return Either.left(problem.get());
+      }
+    }
+
+    return Either.right(null);
   }
 
   private static Either<List<String>, SearchQueryPage> toOffsetPagination(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
@@ -46,4 +46,8 @@ public final class ErrorMessages {
       "The provided tag '%s' is not valid. %s";
   public static final String ERROR_MESSAGE_INVALID_TAGS_COUNT =
       "The provided number of tags '%s' is not supported. Ensure to not add more than %s tags.";
+  public static final String ERROR_MESSAGE_UNSUPPORTED_PAGINATION_WITH_IS_LATEST_VERSION =
+      "When using isLatestVersion filter, pagination is limited to forward pagination using 'after' and 'limit'. The field '%s' is not supported.";
+  public static final String ERROR_MESSAGE_UNSUPPORTED_SORT_FIELD_WITH_IS_LATEST_VERSION =
+      "When using isLatestVersion filter, sorting is limited to 'processDefinitionId' and 'tenantId' fields only. The field '%s' is not supported.";
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.gateway.protocol.model.simple.ProcessDefinitionSearchQuerySortRequest;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -905,5 +907,217 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class), any());
+  }
+
+  @Test
+  void shouldRejectBeforePaginationWhenIsLatestVersionIsTrue() {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "page": {
+                    "before": "someCursor"
+                }
+            }""";
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "When using isLatestVersion filter, pagination is limited to forward pagination using 'after' and 'limit'. The field 'before' is not supported.",
+                  "instance": "%s"
+                }""",
+            PROCESS_DEFINITION_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class), any());
+  }
+
+  @Test
+  void shouldRejectFromPaginationWhenIsLatestVersionIsTrue() {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "page": {
+                    "from": 10
+                }
+            }""";
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "When using isLatestVersion filter, pagination is limited to forward pagination using 'after' and 'limit'. The field 'from' is not supported.",
+                  "instance": "%s"
+                }""",
+            PROCESS_DEFINITION_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class), any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessDefinitionSearchQuerySortRequest.FieldEnum.class,
+      names = {"PROCESS_DEFINITION_ID", "TENANT_ID"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void shouldRejectUnsupportedSortFieldWhenIsLatestVersionIsTrue(
+      final ProcessDefinitionSearchQuerySortRequest.FieldEnum unsupportedField) {
+    // given
+    final var request =
+        String.format(
+            """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "sort": [
+                    {
+                        "field": "%s",
+                        "order": "ASC"
+                    }
+                ]
+            }""",
+            unsupportedField.getValue());
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "When using isLatestVersion filter, sorting is limited to 'processDefinitionId' and 'tenantId' fields only. The field '%s' is not supported.",
+                  "instance": "%s"
+                }""",
+            unsupportedField.getValue(), PROCESS_DEFINITION_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class), any());
+  }
+
+  @Test
+  void shouldAllowAfterPaginationWhenIsLatestVersionIsTrue() {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "page": {
+                    "after": "someCursor",
+                    "limit": 10
+                }
+            }""";
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices).search(any(ProcessDefinitionQuery.class), any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessDefinitionSearchQuerySortRequest.FieldEnum.class,
+      names = {"PROCESS_DEFINITION_ID", "TENANT_ID"})
+  void shouldAllowSupportedSortFieldsWhenIsLatestVersionIsTrue(
+      final ProcessDefinitionSearchQuerySortRequest.FieldEnum supportedField) {
+    // given
+    final var request =
+        String.format(
+            """
+            {
+                "filter": {
+                    "isLatestVersion": true
+                },
+                "sort": [
+                    {
+                        "field": "%s",
+                        "order": "ASC"
+                    }
+                ]
+            }""",
+            supportedField.getValue());
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices).search(any(ProcessDefinitionQuery.class), any());
   }
 }


### PR DESCRIPTION
# Description
Backport of #48302 to `stable/8.9`.

relates to camunda/camunda#47959