### PR TITLE
[Backport stable/8.9] feat: add Playwright E2E tests for Identity audit log UI

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -37,6 +37,7 @@ import {IdentityMappingRulesPage} from '@pages/IdentityMappingRulesPage';
 import {IdentityRolesPage} from '@pages/IdentityRolesPage';
 import {IdentityTenantsPage} from '@pages/IdentityTenantsPage';
 import {IdentityRolesDetailsPage} from '@pages/IdentityRolesDetailsPage';
+import {IdentityAuditLogPage} from '@pages/IdentityAuditLogPage';
 import {OperateOperationsDetailsPage} from '@pages/OperateOperationsDetailsPage';
 
 import {sleep} from 'utils/sleep';
@@ -74,6 +75,7 @@ type PlaywrightFixtures = {
   identityRolesPage: IdentityRolesPage;
   identityTenantsPage: IdentityTenantsPage;
   identityRolesDetailsPage: IdentityRolesDetailsPage;
+  identityAuditLogPage: IdentityAuditLogPage;
 };
 
 const test = base.extend<PlaywrightFixtures>({
@@ -198,6 +200,9 @@ const test = base.extend<PlaywrightFixtures>({
 
   identityRolesDetailsPage: async ({page}, use) => {
     await use(new IdentityRolesDetailsPage(page));
+  },
+  identityAuditLogPage: async ({page}, use) => {
+    await use(new IdentityAuditLogPage(page));
   },
   taskPanelPageV1: async ({page}, use) => {
     await use(new TaskPanelPageV1(page));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuditLogPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuditLogPage.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+import {relativizePath, Paths} from 'utils/relativizePath';
+
+export class IdentityAuditLogPage {
+  private page: Page;
+  readonly auditLogTable: Locator;
+  readonly auditLogHeading: Locator;
+  readonly actorFilter: Locator;
+  readonly resetFiltersButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.auditLogTable = page.getByRole('table');
+    this.auditLogHeading = page.getByRole('heading', {
+      name: /operations log/i,
+    });
+    this.actorFilter = page.getByRole('textbox', {name: /^actor$/i});
+    this.resetFiltersButton = page.getByRole('button', {
+      name: /reset filters/i,
+    });
+  }
+
+  async navigateToAuditLog(): Promise<void> {
+    await this.page.goto(relativizePath(Paths.operationsLog()));
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/audit-log.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/audit-log.spec.ts
@@ -76,7 +76,7 @@ test.describe('Identity Audit Log', () => {
           await identityAuditLogPage.auditLogTable.getByRole('row').count(),
         {timeout: 60000},
       )
-      .toBe(2);
+      .toBeGreaterThan(1);
 
     await expect(identityAuditLogPage.resetFiltersButton).toBeEnabled();
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/audit-log.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/audit-log.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {relativizePath, Paths} from 'utils/relativizePath';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {LOGIN_CREDENTIALS} from 'utils/constants';
+
+test.describe('Identity Audit Log', () => {
+  test.beforeEach(async ({page, loginPage}) => {
+    await navigateToApp(page, 'admin');
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.users()));
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Audit log page is accessible and shows table headers', async ({
+    page,
+    identityAuditLogPage,
+  }) => {
+    await identityAuditLogPage.navigateToAuditLog();
+
+    await expect(page).toHaveURL(relativizePath(Paths.operationsLog()));
+
+    await expect(identityAuditLogPage.auditLogHeading).toBeVisible();
+
+    await expect(
+      page.getByRole('columnheader', {name: 'Operation type'}),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('columnheader', {name: 'Entity type'}),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('columnheader', {name: 'Reference to entity'}),
+    ).toBeVisible();
+    await expect(page.getByRole('columnheader', {name: 'Actor'})).toBeVisible();
+    await expect(page.getByRole('columnheader', {name: 'Date'})).toBeVisible();
+  });
+
+  test('Audit log entries are visible in the Identity audit log UI', async ({
+    identityAuditLogPage,
+  }) => {
+    await identityAuditLogPage.navigateToAuditLog();
+
+    await expect
+      .poll(
+        async () =>
+          await identityAuditLogPage.auditLogTable.getByRole('row').count(),
+        {timeout: 60000},
+      )
+      .toBeGreaterThan(1);
+  });
+
+  test('Audit log can be filtered by actor', async ({identityAuditLogPage}) => {
+    await identityAuditLogPage.navigateToAuditLog();
+
+    await identityAuditLogPage.actorFilter.fill(LOGIN_CREDENTIALS.username);
+
+    await expect
+      .poll(
+        async () =>
+          await identityAuditLogPage.auditLogTable.getByRole('row').count(),
+        {timeout: 60000},
+      )
+      .toBe(2);
+
+    await expect(identityAuditLogPage.resetFiltersButton).toBeEnabled();
+
+    await identityAuditLogPage.resetFiltersButton.click();
+
+    await expect(identityAuditLogPage.actorFilter).toHaveValue('');
+    await expect(identityAuditLogPage.resetFiltersButton).toBeDisabled();
+  });
+
+  test('Audit log navigation link is visible in the Identity UI', async ({
+    page,
+    identityAuditLogPage,
+  }) => {
+    await identityAuditLogPage.navigateToAuditLog();
+
+    await expect(
+      page.locator('nav a').filter({hasText: /^Operations Log$/}),
+    ).toBeVisible();
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
@@ -39,6 +39,9 @@ export const Paths = {
   authorizations() {
     return '/admin/authorizations';
   },
+  operationsLog() {
+    return '/admin/operations-log';
+  },
   operateDashboard() {
     return '/operate';
   },


### PR DESCRIPTION
# Description
Backport of #48228 to `stable/8.9`.

relates to camunda/camunda#41212 #41212