### PR TITLE
fix: handle NULL cursor based pagination

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -17,16 +17,59 @@ public record DbQueryPage(
 
   public record KeySetPaginationFieldEntry(String fieldName, Operator operator, Object fieldValue) {
 
-    public static Operator determineOperator(final SortOrder order, final boolean isSearchAfter) {
-      if (isSearchAfter) {
-        return order == SortOrder.ASC ? Operator.GREATER : Operator.LOWER;
+    public static Builder of(final String fieldName, final Object fieldValue) {
+      return new Builder(fieldName, fieldValue);
+    }
+
+    public static KeySetPaginationFieldEntry equality(
+        final String fieldName, final Object fieldValue) {
+      final var operator = fieldValue == null ? Operator.IS_NULL : Operator.EQUALS;
+      return new KeySetPaginationFieldEntry(fieldName, operator, fieldValue);
+    }
+
+    public static final class Builder {
+      private final String fieldName;
+      private final Object fieldValue;
+      private SortOrder order;
+      private boolean isSearchAfter;
+
+      private Builder(final String fieldName, final Object fieldValue) {
+        this.fieldName = fieldName;
+        this.fieldValue = fieldValue;
       }
 
-      return order == SortOrder.ASC ? Operator.LOWER : Operator.GREATER;
+      public Builder order(final SortOrder order) {
+        this.order = order;
+        return this;
+      }
+
+      public Builder isSearchAfter(final boolean isSearchAfter) {
+        this.isSearchAfter = isSearchAfter;
+        return this;
+      }
+
+      public KeySetPaginationFieldEntry build() {
+        final Operator operator;
+        if (isSearchAfter) {
+          operator =
+              order == SortOrder.ASC
+                  ? fieldValue == null ? Operator.IS_NOT_NULL : Operator.GREATER
+                  : fieldValue == null ? Operator.IS_NULL : Operator.LOWER;
+        } else {
+          // searchBefore: mirror of searchAfter with directions reversed
+          operator =
+              order == SortOrder.ASC
+                  ? fieldValue == null ? Operator.IS_NOT_NULL : Operator.LOWER
+                  : fieldValue == null ? Operator.IS_NULL : Operator.GREATER;
+        }
+        return new KeySetPaginationFieldEntry(fieldName, operator, fieldValue);
+      }
     }
   }
 
   public enum Operator {
+    IS_NULL("IS NULL"),
+    IS_NOT_NULL("IS NOT NULL"),
     GREATER(">"),
     LOWER("<"),
     EQUALS("=");

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -7,13 +7,10 @@
  */
 package io.camunda.db.rdbms.read.service;
 
-import static io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry.determineOperator;
-
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.DbQueryPage;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPagination;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
-import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.sql.columns.SearchColumn;
 import io.camunda.search.page.SearchQueryPage;
@@ -129,20 +126,20 @@ abstract class AbstractEntityReader<T> {
 
     for (int i = 0; i < sort.orderings().size(); i++) {
       final List<KeySetPaginationFieldEntry> fieldEntries = new ArrayList<>();
-      // add entries for equals sorting
+      // add equality entries for all preceding sort columns
       for (int j = 0; j < i; j++) {
         final SearchColumn<?> sortColumn = sort.orderings().get(j).column();
-        fieldEntries.add(
-            new KeySetPaginationFieldEntry(sortColumn.name(), Operator.EQUALS, sortValues[j]));
+        fieldEntries.add(KeySetPaginationFieldEntry.equality(sortColumn.name(), sortValues[j]));
       }
 
-      // add comparator entry
+      // add the comparator entry for the current sort column
       final var sorting = sort.orderings().get(i);
       fieldEntries.add(
-          new KeySetPaginationFieldEntry(
-              sorting.column().name(),
-              determineOperator(sorting.order(), isSearchAfter),
-              sortValues[i]));
+          KeySetPaginationFieldEntry.of(sorting.column().name(), sortValues[i])
+              .order(sorting.order())
+              .isSearchAfter(isSearchAfter)
+              .build());
+
       keySetPagination.add(new KeySetPagination(fieldEntries));
     }
 

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -113,7 +113,14 @@
         close=")">
         <foreach collection="keySet.entries" item="entry" open="(" separator=" AND "
           close=")">
-            ${entry.fieldName} ${entry.operator.symbol} #{entry.fieldValue}
+          <choose>
+            <when test="entry.fieldValue != null">
+              ${entry.fieldName} ${entry.operator.symbol} #{entry.fieldValue}
+            </when>
+            <otherwise>
+              ${entry.fieldName} ${entry.operator.symbol}
+            </otherwise>
+          </choose>
         </foreach>
       </foreach>
     </if>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -25,6 +25,7 @@ import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.search.sort.SortOrder;
 import java.util.List;
 import org.instancio.Instancio;
+import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 
 class AbstractEntityReaderTest {
@@ -195,5 +196,327 @@ class AbstractEntityReaderTest {
             new SortingEntry<>(ProcessInstanceSearchColumn.START_DATE, SortOrder.DESC),
             // Note: duplicated PROCESS_DEFINITION_NAME is ignored
             new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+  }
+
+  // ---- Null-value keyset pagination tests ----
+
+  @Test
+  void shouldBuildSearchAfterWithNullInFirstColumnTwoCols() {
+    // given: an entity whose first sort column (processDefinitionName) is null
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionName), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 2 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(2);
+
+    // first entry: processDefinitionName IS NOT NULL (null + ASC + searchAfter => IS_NOT_NULL)
+    final var ks0 = dbPage.keySetPagination().get(0);
+    assertThat(ks0.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry("PROCESS_DEFINITION_NAME", Operator.IS_NOT_NULL, null));
+
+    // second entry: processDefinitionName IS_NULL (null equality prefix) AND processInstanceKey >
+    // value
+    final var ks1 = dbPage.keySetPagination().get(1);
+    assertThat(ks1.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry("PROCESS_DEFINITION_NAME", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchAfterWithNullInSecondColumnThreeCols() {
+    // given: an entity whose second sort column (processDefinitionVersionTag) is null
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
+                    .addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 3 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(3);
+
+    // ks0: processDefinitionName > value  (non-null, ASC, searchAfter)
+    final var ks0 = dbPage.keySetPagination().get(0);
+    assertThat(ks0.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.GREATER, entity.processDefinitionName()));
+
+    // ks1: processDefinitionName = value AND processDefinitionVersionTag IS NOT NULL
+    //       (null + ASC + searchAfter => IS_NOT_NULL)
+    final var ks1 = dbPage.keySetPagination().get(1);
+    assertThat(ks1.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.EQUALS, entity.processDefinitionName()),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
+
+    // ks2: processDefinitionName = value AND processDefinitionVersionTag IS NULL AND
+    //       processInstanceKey > value
+    final var ks2 = dbPage.keySetPagination().get(2);
+    assertThat(ks2.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.EQUALS, entity.processDefinitionName()),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchAfterWithNullInFirstColumnThreeCols() {
+    // given: entity where the first sort column (processDefinitionVersionTag) is null
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.START_DATE, SortOrder.DESC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 3 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(3);
+
+    // ks0: processDefinitionVersionTag IS NOT NULL  (null + ASC + searchAfter => IS_NOT_NULL)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL (null equality) AND startDate < value
+    //       (DESC + searchAfter => LOWER)
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry("START_DATE", Operator.LOWER, entity.startDate()));
+
+    // ks2: processDefinitionVersionTag IS NULL AND startDate = value AND processInstanceKey > value
+    assertThat(dbPage.keySetPagination().get(2).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry("START_DATE", Operator.EQUALS, entity.startDate()),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchBeforeWithNullInFirstColumnTwoCols() {
+    // given: entity where first column (processDefinitionVersionTag) is null
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).before(result.startCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 2 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(2);
+
+    // ks0: processDefinitionVersionTag IS NOT NULL  (null + ASC + searchBefore => IS_NOT_NULL)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey < value
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.LOWER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchAfterDescWithNullInFirstColumn() {
+    // given: entity where the DESC sort column (processDefinitionVersionTag) is null
+    // null + DESC + searchAfter => IS_NULL (null rows come last in DESC, so "after null" = nothing
+    // further; but "is null" is the correct comparator for rows at the same null level)
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.DESC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 2 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(2);
+
+    // ks0: processDefinitionVersionTag IS NULL  (null + DESC + searchAfter => IS_NULL)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey > value
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchBeforeDescWithNullInFirstColumn() {
+    // given: entity where the DESC sort column (processDefinitionVersionTag) is null
+    // null + DESC + searchBefore => IS_NULL  (reverse of searchAfter+DESC+null)
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.DESC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).before(result.startCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 2 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(2);
+
+    // ks0: processDefinitionVersionTag IS NULL  (null + DESC + searchBefore => IS_NULL)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey < value
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.LOWER, entity.processInstanceKey()));
+  }
+
+  @Test
+  void shouldBuildSearchAfterWithAllNullSortColumnsThreeCols() {
+    // given: all three sort columns are null except the tiebreaker (processInstanceKey)
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
+            .set(Select.field(ProcessInstanceEntity::processDefinitionName), null)
+            .create();
+
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(
+                        ProcessInstanceSearchColumn.PROCESS_DEFINITION_VERSION_TAG, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final SearchQueryResult result = reader.buildSearchQueryResult(1L, List.of(entity), sort);
+
+    // when
+    final SearchQueryPage page =
+        SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
+    final DbQueryPage dbPage = reader.convertPaging(sort, page);
+
+    // then: 3 keyset entries
+    assertThat(dbPage.keySetPagination()).hasSize(3);
+
+    // ks0: processDefinitionVersionTag IS NOT NULL  (null + ASC + searchAfter)
+    assertThat(dbPage.keySetPagination().get(0).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
+
+    // ks1: processDefinitionVersionTag IS NULL AND processDefinitionName IS NOT NULL
+    assertThat(dbPage.keySetPagination().get(1).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry("PROCESS_DEFINITION_NAME", Operator.IS_NOT_NULL, null));
+
+    // ks2: processDefinitionVersionTag IS NULL AND processDefinitionName IS NULL
+    //       AND processInstanceKey > value
+    assertThat(dbPage.keySetPagination().get(2).entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry("PROCESS_DEFINITION_NAME", Operator.IS_NULL, null),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_INSTANCE_KEY", Operator.GREATER, entity.processInstanceKey()));
   }
 }


### PR DESCRIPTION
## Description

This pull request significantly improves keyset pagination support in the RDBMS layer, especially for cases where one or more sort columns are `null`. It introduces a more flexible and expressive way to build keyset pagination predicates, adds support for `IS NULL` and `IS NOT NULL` operators, and ensures correct SQL generation and thorough testing for these scenarios.

Key changes include:

### Keyset Pagination Logic Enhancements

* Refactored the construction of `KeySetPaginationFieldEntry` by replacing the static `determineOperator` method with a builder pattern, allowing for more flexible and readable creation of pagination predicates, including handling of `null` values. Added static methods for equality and a nested `Builder` class supporting sort order and search direction.
* Added support for `IS NULL` and `IS NOT NULL` operators in the `Operator` enum, enabling correct SQL predicate generation when sort columns are `null`.

### Pagination SQL Generation

* Updated the SQL mapping in `Commons.xml` to correctly generate predicates for `null` values, using the new operators to avoid binding parameters when unnecessary.

### Refactoring and Cleanup

* Refactored `AbstractEntityReader` to use the new builder-based API for constructing keyset pagination entries, simplifying and clarifying the logic for handling equality and comparator entries in pagination.
* Removed the now-obsolete `determineOperator` import and usage.

### Testing

* Added comprehensive tests in `AbstractEntityReaderTest` to verify keyset pagination behavior with `null` values in various positions and sort orders, ensuring correctness for both `searchAfter` and `searchBefore` pagination directions.

These changes make keyset pagination more robust and reliable, especially for edge cases involving `null` values in sort columns.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/48350
