### PR TITLE
[Backport stable/8.9] fix: ensure shutdown is completed when raft bootstrap is waiting

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftBootstrapStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftBootstrapStep.java
@@ -43,10 +43,14 @@ public final class RaftBootstrapStep implements StartupStep<PartitionStartupCont
         .bootstrap(context.partitionManagementService(), context.snapshotStore())
         .whenComplete(
             (raftPartition, throwable) -> {
-              if (throwable == null) {
-                result.complete(context);
-              } else {
-                result.completeExceptionally(throwable);
+              try {
+                if (throwable == null) {
+                  result.complete(context);
+                } else {
+                  result.completeExceptionally(throwable);
+                }
+              } catch (final Exception e) {
+                // Future is already completed due to interrupted by shutdown
               }
             });
 
@@ -74,5 +78,14 @@ public final class RaftBootstrapStep implements StartupStep<PartitionStartupCont
         });
 
     return result;
+  }
+
+  @Override
+  public boolean isInterruptible() {
+    // It is safe to interrupt the bootstrap step, as the initial setup of RaftContext is done in a
+    // blocking way and the async waiting is done to catch up the log. It is safe to interrupt the
+    // async waiting for shutdown and the RaftServer will be shutdown cleanly when shutdown is
+    // triggered.
+    return true;
   }
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupProcess.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupProcess.java
@@ -73,6 +73,8 @@ public final class StartupProcess<CONTEXT> {
   private ActorFuture<CONTEXT> shutdownFuture;
   private ActorFuture<CONTEXT> startupFuture;
   private Map<String, String> loggingContext = Map.of();
+  private StartupStep<CONTEXT> ongoingStartupStep;
+  private ActorFuture<CONTEXT> ongoingStartupStepFuture;
 
   /**
    * Constructs the startup process
@@ -189,6 +191,8 @@ public final class StartupProcess<CONTEXT> {
 
       final var before = System.nanoTime();
       final var stepStartupFuture = stepToStart.startup(context);
+      ongoingStartupStep = stepToStart;
+      ongoingStartupStepFuture = stepStartupFuture;
 
       concurrencyControl.runOnCompletion(
           stepStartupFuture,
@@ -199,6 +203,8 @@ public final class StartupProcess<CONTEXT> {
                 stepToStart.getName(),
                 error != null,
                 (completedAt - before) / 1e6);
+            ongoingStartupStep = null;
+            ongoingStartupStepFuture = null;
             if (error != null) {
               completeStartupFutureExceptionallySynchronized(startupFuture, stepToStart, error);
             } else {
@@ -232,6 +238,28 @@ public final class StartupProcess<CONTEXT> {
     clearCustomMDC();
     if (shutdownFuture == null) {
       shutdownFuture = resultFuture;
+
+      if (ongoingStartupStep != null
+          && ongoingStartupStep.isInterruptible()
+          && ongoingStartupStepFuture != null) {
+        setCustomMDC();
+        logger.info(
+            "Interrupting ongoing startup step {} due to shutdown request",
+            ongoingStartupStep.getName());
+        clearCustomMDC();
+        try {
+          ongoingStartupStepFuture.completeExceptionally(
+              new InterruptedException(
+                  "Interrupting ongoing startup step "
+                      + ongoingStartupStep.getName()
+                      + " due to shutdown request"));
+        } catch (final Exception e) {
+          logger.warn(
+              "Failed to interrupt ongoing startup step {} due to shutdown request",
+              ongoingStartupStep.getName(),
+              e);
+        }
+      }
 
       if (startupFuture != null) {
         concurrencyControl.runOnCompletion(

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupStep.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupStep.java
@@ -23,9 +23,11 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
  *   <li>Startup will be called at most once
  *   <li>Shutdown may be called more than once with the expectation that the first call will trigger
  *       the shutdown and any subsequent calls shall do nothing
- *   <li>Shutdown will not be called while startup is running
+ *   <li>Shutdown will not be called while startup is running, unless {@link
+ *       StartupStep#isInterruptible()} is true
  *   <li>Implementation classes can assume that methods of this interface are never called
- *       concurrently
+ *       concurrently, unless {@link StartupStep#isInterruptible()} is true, in which case shutdown
+ *       can be called while startup is still running.
  * </ul>
  *
  * @param <CONTEXT> context object for the startup and shutdown steps. During startup this context
@@ -56,4 +58,21 @@ public interface StartupStep<CONTEXT> {
    * @return future with the shutdown context at the end of this step.
    */
   ActorFuture<CONTEXT> shutdown(final CONTEXT context);
+
+  /**
+   * Whether the startup step is interruptible. If a startup step is interruptible, it can be
+   * interrupted by a shutdown while it is still running. In this case, the shutdown will trigger
+   * the shutdown logic of the step immediately, without waiting for the startup logic to complete.
+   * If a startup step is not interruptible, it cannot be interrupted by a shutdown while it is
+   * still running. In this case, the shutdown will wait for the startup logic to complete before
+   * triggering the shutdown logic of the step.
+   *
+   * <p>If a startup step is interruptible, it should ensure that a shutdown can be triggered at any
+   * point during the execution of the startup logic.
+   *
+   * @return {@code true} if the startup step is interruptible, {@code false} otherwise
+   */
+  default boolean isInterruptible() {
+    return false;
+  }
 }

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/startup/StartupProcessTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/startup/StartupProcessTest.java
@@ -57,6 +57,34 @@ class StartupProcessTest {
 
   private static final ConcurrencyControl TEST_CONCURRENCY_CONTROL = new TestConcurrencyControl();
 
+  private static final class InterruptibleStartupStep implements StartupStep<Object> {
+
+    private volatile boolean shutdownCalled = false;
+
+    @Override
+    public String getName() {
+      return "InterruptibleStartupStep";
+    }
+
+    @Override
+    public ActorFuture<Object> startup(final Object o) {
+      // Return a future that never completes on its own - it will be completed exceptionally
+      // when the step is interrupted by the shutdown process
+      return new TestActorFuture<>();
+    }
+
+    @Override
+    public ActorFuture<Object> shutdown(final Object o) {
+      shutdownCalled = true;
+      return completedFuture(o);
+    }
+
+    @Override
+    public boolean isInterruptible() {
+      return true;
+    }
+  }
+
   @Nested
   class MainUseCase {
 
@@ -235,6 +263,39 @@ class StartupProcessTest {
 
       assertThat(startupFuture.isCompletedExceptionally()).isTrue();
       assertThat(shutdownFuture.join()).isSameAs(SHUTDOWN_CONTEXT);
+    }
+
+    @Test
+    void shouldInterruptOngoingStartupStepWhenShutdownIsCalledAndStepIsInterruptible() {
+      // given
+      final var step1 = new InterruptibleStartupStep();
+
+      final var sut = new StartupProcess<>(List.of(step1, mockStep2));
+
+      // when
+      final var startupFuture = sut.startup(TEST_CONCURRENCY_CONTROL, STARTUP_CONTEXT);
+      // shutdown before the step is completed - this will interrupt the step
+      final var shutdownFuture = sut.shutdown(TEST_CONCURRENCY_CONTROL, SHUTDOWN_CONTEXT);
+
+      // then
+      verifyNoInteractions(mockStep2);
+
+      await().until(startupFuture::isDone);
+      await().until(shutdownFuture::isDone);
+
+      assertThat(startupFuture.isCompletedExceptionally()).isTrue();
+      assertThatThrownBy(startupFuture::join)
+          .isInstanceOf(ExecutionException.class)
+          .cause()
+          .isInstanceOf(StartupProcessException.class)
+          .hasSuppressedException(
+              new StartupProcessStepException(
+                  "InterruptibleStartupStep", new InterruptedException()));
+
+      assertThat(shutdownFuture.join()).isSameAs(SHUTDOWN_CONTEXT);
+
+      // verify that the step was interrupted
+      assertThat(step1.shutdownCalled).isTrue();
     }
   }
 


### PR DESCRIPTION
# Description
Backport of #48108 to `stable/8.9`.

relates to #48136