### PR TITLE
[Backport stable/8.9] ci: only retry vitest tests on the CI

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "start": "vite",
     "build": "npm run ts-check && vite build && node ./renameProdIndex.js && node license-build.js",
-    "test": "vitest run --project=unit --retry=3",
+    "test": "vitest run --project=unit",
     "test:browser": "vitest run --project=browser",
     "ts-check": "tsc -b",
     "eslint": "eslint .",

--- a/operate/client/vite.config.ts
+++ b/operate/client/vite.config.ts
@@ -95,6 +95,7 @@ export default defineConfig(({mode}) => ({
     clearMocks: true,
     resetMocks: true,
     unstubEnvs: true,
+    retry: process.env.CI ? 3 : 0,
     dangerouslyIgnoreUnhandledErrors: Boolean(process.env.CI),
     ...getReporters(),
     server: {

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build && node ./renameProdIndex.mjs",
-    "test": "TZ=utc vitest run --retry=3",
+    "test": "TZ=utc vitest run",
     "test:ci": "CI=true npm run test",
     "test:visual": "playwright test --project=visual",
     "test:a11y": "IS_A11Y=true playwright test --project=a11y",

--- a/tasklist/client/vite.config.ts
+++ b/tasklist/client/vite.config.ts
@@ -80,6 +80,7 @@ export default defineConfig(({mode}) => ({
     setupFiles: ['./src/setupTests.ts'],
     restoreMocks: true,
     mockReset: true,
+    retry: process.env.CI ? 3 : 0,
     server: {
       deps: {
         // this was necessary due to some issues with styled-components which appeared when bumping C3 on this https://github.com/camunda/camunda/pull/46171


### PR DESCRIPTION
# Description
Backport of #48357 to `stable/8.9`.

relates to 