### PR TITLE
fea: improve bottom panel responsiveness

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/styled.tsx
@@ -7,6 +7,7 @@
  */
 
 import {styled} from 'styled-components';
+import {breakpoints} from '@carbon/elements';
 
 const Container = styled.div`
   display: flex;
@@ -14,6 +15,11 @@ const Container = styled.div`
   height: 100%;
   overflow: hidden;
   background-color: var(--cds-layer);
+
+  @media (max-width: ${breakpoints.lg.width}) {
+    min-height: 250px;
+    flex: 1;
+  }
 `;
 
 export {Container};

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/styled.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/styled.ts
@@ -16,6 +16,14 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+
+  @media (max-width: 66rem) {
+    border-right: none;
+    border-bottom: solid 1px var(--cds-border-subtle-01);
+  }
 `;
 
 const PanelHeader = styled(BasePanelHeader)`

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/styled.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/styled.ts
@@ -7,6 +7,7 @@
  */
 
 import styled from 'styled-components';
+import {breakpoints} from '@carbon/elements';
 import {PanelHeader as BasePanelHeader} from 'modules/components/PanelHeader';
 import {ErrorMessage as BaseErrorMessage} from 'modules/components/ErrorMessage';
 
@@ -20,9 +21,11 @@ const Container = styled.div`
   width: 100%;
   overflow: hidden;
 
-  @media (max-width: 66rem) {
+  @media (max-width: ${breakpoints.lg.width}) {
     border-right: none;
     border-bottom: solid 1px var(--cds-border-subtle-01);
+    min-height: 250px;
+    flex: 1;
   }
 `;
 

--- a/operate/client/src/App/ProcessInstance/index.tsx
+++ b/operate/client/src/App/ProcessInstance/index.tsx
@@ -11,7 +11,7 @@ import {InstanceDetail} from '../Layout/InstanceDetail';
 import {Breadcrumb} from './Breadcrumb';
 import {observer} from 'mobx-react';
 import {useProcessInstancePageParams} from './useProcessInstancePageParams';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {modificationsStore} from 'modules/stores/modifications';
 import {reaction, when} from 'mobx';
 import {instanceHistoryModificationStore} from 'modules/stores/instanceHistoryModification';
@@ -19,7 +19,13 @@ import {elementTimeStampStore} from 'modules/stores/elementTimeStamp';
 import {ProcessInstanceHeader} from './ProcessInstanceHeader';
 import {ProcessInstanceHeader as ProcessInstanceHeaderNext} from './ProcessInstanceHeaderNext';
 import {TopPanel} from './TopPanel';
-import {BottomPanel, ModificationFooter, Buttons} from './styled';
+import {
+  BottomPanel,
+  BottomPanelNew,
+  BottomPanelStacked,
+  ModificationFooter,
+  Buttons,
+} from './styled';
 import {ElementInstanceLog} from './ElementInstanceLog';
 import {Button, Modal} from '@carbon/react';
 import {tracking} from 'modules/tracking';
@@ -42,6 +48,14 @@ import {Locations, Paths} from 'modules/Routes';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {IS_NEW_PROCESS_INSTANCE_PAGE} from 'modules/feature-flags';
 import {BottomPanelTabs} from './BottomPanelTabs';
+import {
+  ResizablePanel,
+  SplitDirection,
+} from 'modules/components/ResizablePanel';
+import {
+  useMatchMedia,
+  isWidthAboveBreakpoint,
+} from 'modules/hooks/useMatchMedia';
 
 const onProcessInstanceTabTransition = ({
   currentLocation,
@@ -65,6 +79,40 @@ const onProcessInstanceTabTransition = ({
     nextProcessInstance !== null &&
     currentProcessInstance.params.processInstanceId ===
       nextProcessInstance.params.processInstanceId
+  );
+};
+
+const BottomPanelContent: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDesktop = useMatchMedia(isWidthAboveBreakpoint('lg'));
+
+  if (isDesktop) {
+    const panelMinWidth =
+      (containerRef.current?.clientWidth ?? 0) / 4 || undefined;
+
+    return (
+      <BottomPanelNew ref={containerRef}>
+        <ResizablePanel
+          panelId="process-instance-bottom-panel"
+          direction={SplitDirection.Horizontal}
+          minWidths={
+            panelMinWidth !== undefined
+              ? [panelMinWidth, panelMinWidth]
+              : undefined
+          }
+        >
+          <ElementInstanceLog />
+          <BottomPanelTabs />
+        </ResizablePanel>
+      </BottomPanelNew>
+    );
+  }
+
+  return (
+    <BottomPanelStacked>
+      <ElementInstanceLog />
+      <BottomPanelTabs />
+    </BottomPanelStacked>
   );
 };
 
@@ -199,20 +247,16 @@ const ProcessInstance: React.FC = observer(() => {
             }
             topPanel={<TopPanel />}
             bottomPanel={
-              <BottomPanel
-                $shouldExpandPanel={
-                  IS_NEW_PROCESS_INSTANCE_PAGE ? false : isListenerTabSelected
-                }
-              >
-                <ElementInstanceLog />
-                {IS_NEW_PROCESS_INSTANCE_PAGE ? (
-                  <BottomPanelTabs />
-                ) : (
+              IS_NEW_PROCESS_INSTANCE_PAGE ? (
+                <BottomPanelContent />
+              ) : (
+                <BottomPanel $shouldExpandPanel={isListenerTabSelected}>
+                  <ElementInstanceLog />
                   <VariablePanel
                     setListenerTabVisibility={setListenerTabVisibility}
                   />
-                )}
-              </BottomPanel>
+                </BottomPanel>
+              )
             }
             footer={
               isModificationModeEnabled ? (

--- a/operate/client/src/App/ProcessInstance/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/styled.tsx
@@ -16,6 +16,23 @@ const BottomPanel = styled.div<{$shouldExpandPanel?: boolean}>`
   height: 100%;
 `;
 
+const BottomPanelNew = styled.div`
+  height: 100%;
+  width: 100%;
+  position: relative;
+  z-index: 1;
+  border-top: 1px solid var(--cds-border-subtle-01);
+`;
+
+const BottomPanelStacked = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
+  border-top: 1px solid var(--cds-border-subtle-01);
+`;
+
 const ModificationFooter = styled.div`
   display: flex;
   justify-content: space-between;
@@ -28,4 +45,10 @@ const Buttons = styled(Stack)`
   margin-left: auto;
 `;
 
-export {BottomPanel, ModificationFooter, Buttons};
+export {
+  BottomPanel,
+  BottomPanelNew,
+  BottomPanelStacked,
+  ModificationFooter,
+  Buttons,
+};

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,6 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_NEW_PROCESS_INSTANCE_PAGE = false;
+const IS_NEW_PROCESS_INSTANCE_PAGE = true;
 
 export {IS_NEW_PROCESS_INSTANCE_PAGE};

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,6 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_NEW_PROCESS_INSTANCE_PAGE = true;
+const IS_NEW_PROCESS_INSTANCE_PAGE = false;
 
 export {IS_NEW_PROCESS_INSTANCE_PAGE};


### PR DESCRIPTION
## Description

 - Implement responsive bottom panel for the new process instance page                                                                       
  - On desktop (>=1056px / Carbon lg breakpoint): Instance History and Tabs are side-by-side with a resizable horizontal splitter                                                                        
  - On tablet (<1056px): panels stack vertically                                                                                                                                                         
  - Reduce app min-width from 960px to 672px for the new page, enabling tablet viewport support                                                                                                          
  - Add `useMatchMedia` hook with Carbon breakpoint utilities (aligned with https://github.com/camunda/camunda/pull/48281)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48164 
