### PR TITLE
feat: Refactor the automerge logic

### DIFF
--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 240
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
       checks: read
     defaults:
       run:

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -15,12 +15,12 @@ on:
 jobs:
   auto-merge:
     # Only run for PRs from release branches created by release automation
-    if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
+    # if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
     name: Auto-merge release to stable
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 90
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       checks: read
     defaults:
@@ -28,7 +28,6 @@ jobs:
         shell: bash
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_BOT_TOKEN: ${{ secrets.CAMUNDAIT_GITHUB_TOKEN }}
       DRY_RUN: ${{ vars.AUTO_MERGE_DRY_RUN || 'true' }}
       MERGE_QUEUE_TIMEOUT_MINUTES: ${{ vars.MERGE_QUEUE_TIMEOUT_MINUTES || '60' }}
     
@@ -160,165 +159,27 @@ jobs:
             }
             echo "✅ Version: $OLD_VER → $NEW_VER"
           fi      
-      - name: Get required status checks from rulesets targeting base branch
-        id: get_required_checks
-        run: |
-          REQUIRED_CHECKS=""
-          BASE_BRANCH="${{ github.base_ref }}"
-          
-          # Get all rulesets (returns empty array [] if none exist)
-          RULESETS_RESPONSE=$(gh api repos/${{ github.repository }}/rulesets 2>&1) || {
-            echo "⚠️  Failed to fetch rulesets: $RULESETS_RESPONSE"
-            echo "Proceeding without required checks validation"
-            echo "checks_pattern=" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
-          
-          # Check if rulesets array is empty
-          RULESET_COUNT=$(echo "$RULESETS_RESPONSE" | jq '. | length' 2>/dev/null || echo "0")
-          
-          if [ "$RULESET_COUNT" -eq 0 ]; then
-            echo "ℹ️  No rulesets configured for repository"
-            echo "⚠️  WARNING: Auto-merge will proceed without validating ruleset-based required status checks"
-            echo "⚠️  Note: This does NOT check traditional branch protection rules - only rulesets as only rulesets were defined during implementation"
-            echo "⚠️  If branch protection rules exist, they may still be enforced by GitHub during merge"
-            echo "Proceeding without required checks validation"
-            echo "checks_pattern=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          
-          # Iterate through all rulesets
-          for id in $(echo "$RULESETS_RESPONSE" | jq -r '.[].id'); do
-            # Get the ruleset details
-            RULESET=$(gh api repos/${{ github.repository }}/rulesets/"$id")
-            
-            # Check if this ruleset targets the base branch
-            INCLUDES=$(echo "$RULESET" | jq -r '.conditions.ref_name.include[]? // empty' || echo "")
-            
-            # Match exact branch or wildcard pattern (e.g., refs/heads/stable/8.7 or refs/heads/stable/*)
-            # Use || true to prevent grep from failing with exit code 1 when no matches found
-            if echo "$INCLUDES" | grep -qE "refs/heads/${BASE_BRANCH}\$|refs/heads/${BASE_BRANCH%%/*}/\*" || false; then
-              # Extract required status checks from this ruleset, preserving full check names
-              while IFS= read -r check; do
-                [ -n "$check" ] && REQUIRED_CHECKS="${REQUIRED_CHECKS}${check}"$'\n'
-              done < <(echo "$RULESET" | jq -r '.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[].context' || echo "")
-            fi
-          done
-          
-          # Remove duplicates and format as pipe-delimited pattern
-          CHECKS_PATTERN=$(echo "$REQUIRED_CHECKS" | sort -u | grep -v '^$' | paste -sd '|' - || true)
-          
-          if [ -z "$CHECKS_PATTERN" ]; then
-            echo "No required checks found in rulesets for branch: $BASE_BRANCH"
-            echo "checks_pattern=" >> "$GITHUB_OUTPUT"
-          else
-            echo "Required checks for $BASE_BRANCH: $CHECKS_PATTERN"
-            echo "checks_pattern=$CHECKS_PATTERN" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Wait for required checks to pass
+      - name: Wait for required checks
         id: wait_checks
-        if: steps.get_required_checks.outputs.checks_pattern != ''
-        env:
-          SHA: ${{ github.event.pull_request.head.sha }}
-          CHECKS_PATTERN: ${{ steps.get_required_checks.outputs.checks_pattern }}
-        run: |
-          TIMEOUT_MINUTES=50
-          POLL_INTERVAL=30
-          MAX_WAIT=$((TIMEOUT_MINUTES * 60))
-          ELAPSED=0
-          MAX_API_RETRIES=3
-          API_RETRY_DELAY=5
+        uses: camunda/infra-global-github-actions/wait-for-required-checks@main
+        with:
+          repository-owner: ${{ github.event.repository.owner.login }}
+          repository-name: ${{ github.event.repository.name }}
+          base_branch: ${{ github.base_ref }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
 
-          IFS='|' read -ra REQUIRED_CHECKS <<< "$CHECKS_PATTERN"
-          echo "Waiting for required checks: ${REQUIRED_CHECKS[*]}"
-          echo "Timeout: ${TIMEOUT_MINUTES}m, poll interval: ${POLL_INTERVAL}s"
-          echo ""
-
-          while [ $ELAPSED -lt $MAX_WAIT ]; do
-            # Fetch check runs with retry logic for transient API/parse failures
-            API_ATTEMPT=1
-            API_SUCCESS=false
-            while [ $API_ATTEMPT -le $MAX_API_RETRIES ]; do
-              set +e
-              RUNS_RAW=$(gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs?filter=all&per_page=100" \
-                --paginate --jq '.check_runs[] | {name: .name, id: .id, status: .status, conclusion: .conclusion}' 2>&1)
-              GH_STATUS=$?
-              set -e
-              if [ $GH_STATUS -ne 0 ]; then
-                echo "⚠️  gh api failed (attempt $API_ATTEMPT/$MAX_API_RETRIES, exit $GH_STATUS)"
-                API_ATTEMPT=$((API_ATTEMPT + 1))
-                sleep "$API_RETRY_DELAY"
-                continue
-              fi
-              set +e
-              RUNS_JSON=$(printf '%s\n' "$RUNS_RAW" | jq -s '.' 2>&1)
-              JQ_STATUS=$?
-              set -e
-              if [ $JQ_STATUS -ne 0 ]; then
-                echo "⚠️  jq parse failed (attempt $API_ATTEMPT/$MAX_API_RETRIES, exit $JQ_STATUS)"
-                API_ATTEMPT=$((API_ATTEMPT + 1))
-                sleep "$API_RETRY_DELAY"
-                continue
-              fi
-              API_SUCCESS=true
-              break
-            done
-
-            if [ "$API_SUCCESS" != "true" ]; then
-              echo "⚠️  Failed to fetch check runs after $MAX_API_RETRIES attempts, will retry next poll"
-              ELAPSED=$((ELAPSED + POLL_INTERVAL))
-              if [ $ELAPSED -ge $MAX_WAIT ]; then
-                echo ""
-                echo "❌ Timed out waiting for checks after ${TIMEOUT_MINUTES} minutes"
-                exit 1
-              fi
-              echo "--- Waiting ${POLL_INTERVAL}s (${ELAPSED}s/${MAX_WAIT}s) ---"
-              sleep "$POLL_INTERVAL"
-              continue
-            fi
-
-            ALL_PASSED=true
-            for CHECK in "${REQUIRED_CHECKS[@]}"; do
-              # Pick the latest run for this check name
-              LATEST=$(echo "$RUNS_JSON" | jq -r --arg name "$CHECK" \
-                '[.[] | select(.name == $name)] | sort_by(.id) | last // empty')
-
-              if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
-                echo "⏳ [$CHECK] not yet registered"
-                ALL_PASSED=false
-                continue
-              fi
-
-              STATUS=$(echo "$LATEST" | jq -r '.status')
-              CONCLUSION=$(echo "$LATEST" | jq -r '.conclusion // "pending"')
-
-              if [ "$STATUS" != "completed" ]; then
-                echo "⏳ [$CHECK] $STATUS"
-                ALL_PASSED=false
-              elif [ "$CONCLUSION" = "success" ]; then
-                echo "✅ [$CHECK] passed"
-              else
-                echo "❌ [$CHECK] failed (conclusion: $CONCLUSION)"
-                exit 1
-              fi
-            done
-
-            if [ "$ALL_PASSED" = true ]; then
-              echo ""
-              echo "✅ All required checks passed"
-              exit 0
-            fi
-
-            ELAPSED=$((ELAPSED + POLL_INTERVAL))
-            if [ $ELAPSED -ge $MAX_WAIT ]; then
-              echo ""
-              echo "❌ Timed out waiting for checks after ${TIMEOUT_MINUTES} minutes"
-              exit 1
-            fi
-            echo "--- Waiting ${POLL_INTERVAL}s (${ELAPSED}s/${MAX_WAIT}s) ---"
-            sleep "$POLL_INTERVAL"
-          done
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_RELEASE_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
+          vault-url: ${{ secrets.VAULT_ADDR }}     
       
       - name: Approve PR
         # Proceed when checks pass OR when no required checks configured (skipped outcome)
@@ -328,140 +189,37 @@ jobs:
             echo "🔍 [DRY RUN] Would approve PR #${{ github.event.pull_request.number }}"
           else
             echo "✅ Approving PR..."
-            gh pr review ${{ github.event.pull_request.number }} --approve --body "Auto-approved: Version bump changes validated successfully."
+            # Override GH_TOKEN with GitHub App installation token.
+            GH_TOKEN="${{ steps.github-token.outputs.token }}" gh pr review ${{ github.event.pull_request.number }} --approve --body "Auto-approved: Version bump changes validated successfully."
           fi
-      
+         
       - name: Enable auto-merge (for merge queue)
         # Proceed when checks pass OR when no required checks configured (skipped outcome)
         if: steps.wait_checks.outcome != 'failure'
         run: |
           if [ "$DRY_RUN" = "true" ]; then
             echo "🔍 [DRY RUN] Would enable auto-merge for PR #${{ github.event.pull_request.number }}"
-            echo "🔍 [DRY RUN] Would use CAMUNDAIT_GITHUB_TOKEN to trigger merge queue workflows"
+            echo "🔍 [DRY RUN] Would use generated GitHub App token to trigger merge queue workflows"
           else
             echo "🔀 Enabling auto-merge for merge queue..."
-            # Override GH_TOKEN with bot's PAT to trigger merge queue workflows
-            # GITHUB_TOKEN cannot trigger workflows (security feature), but CAMUNDAIT_GITHUB_TOKEN can
-            GH_TOKEN="$GH_BOT_TOKEN" gh pr merge ${{ github.event.pull_request.number }} --auto --squash
+            # Override GH_TOKEN with GitHub App installation token.
+            # Default GITHUB_TOKEN cannot trigger downstream workflows by design.
+            GH_TOKEN="${{ steps.github-token.outputs.token }}" gh pr merge ${{ github.event.pull_request.number }} --auto --squash
             echo "✅ Auto-merge enabled - PR will enter merge queue"
           fi
       
       - name: Monitor merge queue status
         id: monitor_merge
         if: steps.wait_checks.outcome != 'failure'
-        run: |
-          if [ "$DRY_RUN" = "true" ]; then
-            echo "🔍 [DRY RUN] Monitoring merge queue status (read-only) for PR #${{ github.event.pull_request.number }}"
-          else
-            echo "📊 Monitoring merge queue status..."
-          fi
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          TIMEOUT_MINUTES=${MERGE_QUEUE_TIMEOUT_MINUTES:-60}
-          MAX_ATTEMPTS=$((TIMEOUT_MINUTES / 2))  # Check every 2 minutes
-          ATTEMPT=0
-          EVICTION_COUNT=0
-          MAX_EVICTIONS=3
-          PREVIOUS_QUEUE_STATE=""
-          API_FAILURE_COUNT=0
-          MAX_CONSECUTIVE_API_FAILURES=5  # 5 failures × 2 minutes = 10 minutes
-          
-          echo "⏱️  Timeout configured: ${TIMEOUT_MINUTES} minutes (${MAX_ATTEMPTS} attempts)"
-          
-          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-            # Query PR and merge queue status via GraphQL
-            # shellcheck disable=SC2016
-            PR_DATA=$(gh api graphql -f query='
-              query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $number) {
-                    state
-                    autoMergeRequest { enabledAt }
-                    mergeStateStatus
-                    mergeQueueEntry {
-                      state
-                      position
-                    }
-                  }
-                }
-              }' -f owner='${{ github.repository_owner }}' -f repo='${{ github.event.repository.name }}' -F number=$PR_NUMBER)
-            
-            # Validate API response and parse PR state
-            if ! PR_STATE=$(echo "$PR_DATA" | jq -e -r '.data.repository.pullRequest.state' 2>/dev/null); then
-              API_FAILURE_COUNT=$((API_FAILURE_COUNT+1))
-              echo "⚠️  API call failed ($API_FAILURE_COUNT/$MAX_CONSECUTIVE_API_FAILURES)"
-              
-              if [ $API_FAILURE_COUNT -ge $MAX_CONSECUTIVE_API_FAILURES ]; then
-                echo "❌ API calls failed $MAX_CONSECUTIVE_API_FAILURES times consecutively (10 minutes) - aborting"
-                exit 1
-              fi
-              
-              ATTEMPT=$((ATTEMPT+1))
-              sleep 120
-              continue
-            fi
-            
-            # API call succeeded - reset failure counter
-            API_FAILURE_COUNT=0
-            
-            AUTO_MERGE=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequest.autoMergeRequest')
-            MERGE_STATUS=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequest.mergeStateStatus')
-            QUEUE_STATE=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequest.mergeQueueEntry.state // "NOT_IN_QUEUE"')
-            QUEUE_POSITION=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequest.mergeQueueEntry.position // "N/A"')
-            
-            AUTO_MERGE_STATUS="disabled"
-            if [ "$AUTO_MERGE" != "null" ]; then
-              AUTO_MERGE_STATUS="enabled"
-            fi
-            echo "Attempt $((ATTEMPT+1))/$MAX_ATTEMPTS - State: $PR_STATE, Queue: $QUEUE_STATE (pos: $QUEUE_POSITION), Merge Status: $MERGE_STATUS, Auto-merge: $AUTO_MERGE_STATUS"
-            
-            # Check if PR is merged
-            if [ "$PR_STATE" = "MERGED" ]; then
-              echo "✅ PR merged successfully via merge queue"
-              exit 0
-            fi
-            
-            # Check if PR was closed without merging
-            if [ "$PR_STATE" = "CLOSED" ]; then
-              echo "❌ PR was closed without merging"
-              exit 1
-            fi
-            
-            # If in AWAITING_CHECKS or QUEUED state, just wait
-            if [ "$QUEUE_STATE" = "AWAITING_CHECKS" ] || [ "$QUEUE_STATE" = "QUEUED" ]; then
-              echo "⏳ Waiting for checks to complete..."
-              PREVIOUS_QUEUE_STATE="$QUEUE_STATE"
-              ATTEMPT=$((ATTEMPT+1))
-              sleep 120
-              continue
-            fi
-            
-            # Detect eviction: was in queue, now NOT_IN_QUEUE (and PR still open)
-            if [ "$QUEUE_STATE" = "NOT_IN_QUEUE" ] && [ "$PR_STATE" = "OPEN" ] && [ -n "$PREVIOUS_QUEUE_STATE" ] && [ "$PREVIOUS_QUEUE_STATE" != "NOT_IN_QUEUE" ]; then
-              EVICTION_COUNT=$((EVICTION_COUNT+1))
-              echo "⚠️  PR evicted from merge queue (attempt $EVICTION_COUNT/$MAX_EVICTIONS)"
-              
-              if [ $EVICTION_COUNT -ge $MAX_EVICTIONS ]; then
-                echo "❌ PR evicted $MAX_EVICTIONS times - giving up"
-                exit 1
-              fi
-              
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "🔍 [DRY RUN] Would re-enable auto-merge after eviction"
-              else
-                echo "🔄 Re-enabling auto-merge..."
-                # Use bot's PAT to trigger merge queue workflows (GITHUB_TOKEN cannot trigger workflows)
-                GH_TOKEN="$GH_BOT_TOKEN" gh pr merge $PR_NUMBER --auto --squash
-                echo "✅ Auto-merge re-enabled - PR sent back to merge queue"
-              fi
-            fi
-            
-            PREVIOUS_QUEUE_STATE="$QUEUE_STATE"
-            ATTEMPT=$((ATTEMPT+1))
-            sleep 120
-          done
-          
-          echo "⏱️  Timeout waiting for merge (${TIMEOUT_MINUTES} minutes) - manual intervention required"
-          exit 1
+        uses: camunda/infra-global-github-actions/ensure-pr-passes-merge-queue@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          timeout-minutes: ${{ env.MERGE_QUEUE_TIMEOUT_MINUTES }}
+          max-evictions: '3'
+          dry-run: ${{ env.DRY_RUN }}
+          app-token: ${{ steps.github-token.outputs.token }}
+          repository-owner: ${{ github.repository_owner }}
+          repository-name: ${{ github.event.repository.name }}
       
       - name: Import Secrets
         id: secrets

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   auto-merge:
     # Only run for PRs from release branches created by release automation
-    # if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
+    if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
     name: Auto-merge release to stable
     runs-on: ubuntu-slim
     timeout-minutes: 240
@@ -243,7 +243,7 @@ jobs:
           correlationKey: ${{ github.event.pull_request.id }}
           variables: |
             {
-              "is_automerge_successful": ${{ steps.monitor_merge.outcome == 'success' }},
+              "is_automerge_successful": "${{ steps.monitor_merge.outcome == 'success' }}",
               "pr_number": ${{ github.event.pull_request.number }},
               "pr_url": "${{ github.event.pull_request.html_url }}",
               "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -223,10 +223,12 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha }}
           CHECKS_PATTERN: ${{ steps.get_required_checks.outputs.checks_pattern }}
         run: |
-          TIMEOUT_MINUTES=30
+          TIMEOUT_MINUTES=50
           POLL_INTERVAL=30
           MAX_WAIT=$((TIMEOUT_MINUTES * 60))
           ELAPSED=0
+          MAX_API_RETRIES=3
+          API_RETRY_DELAY=5
 
           IFS='|' read -ra REQUIRED_CHECKS <<< "$CHECKS_PATTERN"
           echo "Waiting for required checks: ${REQUIRED_CHECKS[*]}"
@@ -234,14 +236,51 @@ jobs:
           echo ""
 
           while [ $ELAPSED -lt $MAX_WAIT ]; do
-            # filter=all includes re-runs so we always see the most recent attempt
-            RUNS_JSON=$(gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs?filter=all&per_page=100" \
-              --paginate --jq '.check_runs[] | {name: .name, id: .id, status: .status, conclusion: .conclusion}' \
-              | jq -s '.')
+            # Fetch check runs with retry logic for transient API/parse failures
+            API_ATTEMPT=1
+            API_SUCCESS=false
+            while [ $API_ATTEMPT -le $MAX_API_RETRIES ]; do
+              set +e
+              RUNS_RAW=$(gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs?filter=all&per_page=100" \
+                --paginate --jq '.check_runs[] | {name: .name, id: .id, status: .status, conclusion: .conclusion}' 2>&1)
+              GH_STATUS=$?
+              set -e
+              if [ $GH_STATUS -ne 0 ]; then
+                echo "⚠️  gh api failed (attempt $API_ATTEMPT/$MAX_API_RETRIES, exit $GH_STATUS)"
+                API_ATTEMPT=$((API_ATTEMPT + 1))
+                sleep "$API_RETRY_DELAY"
+                continue
+              fi
+              set +e
+              RUNS_JSON=$(printf '%s\n' "$RUNS_RAW" | jq -s '.' 2>&1)
+              JQ_STATUS=$?
+              set -e
+              if [ $JQ_STATUS -ne 0 ]; then
+                echo "⚠️  jq parse failed (attempt $API_ATTEMPT/$MAX_API_RETRIES, exit $JQ_STATUS)"
+                API_ATTEMPT=$((API_ATTEMPT + 1))
+                sleep "$API_RETRY_DELAY"
+                continue
+              fi
+              API_SUCCESS=true
+              break
+            done
+
+            if [ "$API_SUCCESS" != "true" ]; then
+              echo "⚠️  Failed to fetch check runs after $MAX_API_RETRIES attempts, will retry next poll"
+              ELAPSED=$((ELAPSED + POLL_INTERVAL))
+              if [ $ELAPSED -ge $MAX_WAIT ]; then
+                echo ""
+                echo "❌ Timed out waiting for checks after ${TIMEOUT_MINUTES} minutes"
+                exit 1
+              fi
+              echo "--- Waiting ${POLL_INTERVAL}s (${ELAPSED}s/${MAX_WAIT}s) ---"
+              sleep "$POLL_INTERVAL"
+              continue
+            fi
 
             ALL_PASSED=true
             for CHECK in "${REQUIRED_CHECKS[@]}"; do
-              # Pick the run with the highest id (most recent, handles re-runs)
+              # Pick the latest run for this check name
               LATEST=$(echo "$RUNS_JSON" | jq -r --arg name "$CHECK" \
                 '[.[] | select(.name == $name)] | sort_by(.id) | last // empty')
 
@@ -424,12 +463,23 @@ jobs:
           echo "⏱️  Timeout waiting for merge (${TIMEOUT_MINUTES} minutes) - manual intervention required"
           exit 1
       
-      - name: Report auto-merge result to Zeebe
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig    
+      - name: Report auto-merge result to Monorepo Release Process
         if: always() && env.DRY_RUN != 'true'
         continue-on-error: true
         uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
         with:
-          clientConfig: ${{ secrets.TEST_CLUSTER_ZEEBE_CLIENT_CONFIG }}
+          clientConfig: ${{ steps.secrets.outputs.clientConfig }}
           operation: publishMessage
           messageName: Automerge result Camunda
           correlationKey: ${{ github.event.pull_request.id }}

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -18,7 +18,7 @@ jobs:
     # if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
     name: Auto-merge release to stable
     runs-on: ubuntu-slim
-    timeout-minutes: 90
+    timeout-minutes: 240
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -163,8 +163,8 @@ jobs:
         id: wait_checks
         uses: camunda/infra-global-github-actions/wait-for-required-checks@main
         with:
-          repository-owner: ${{ github.event.repository.owner.login }}
-          repository-name: ${{ github.event.repository.name }}
+          repository_owner: ${{ github.event.repository.owner.login }}
+          repository_name: ${{ github.event.repository.name }}
           base_branch: ${{ github.base_ref }}
           head_sha: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -92,6 +92,7 @@ jobs:
               sleep "$RETRY_DELAY"
             fi
           done
+      
       - name: Validate changes are version bumps only
         id: validate_changes
         run: |
@@ -104,7 +105,7 @@ jobs:
             echo "❌ Non-pom.xml files changed. Only version bumps allowed."
             exit 1
           fi
-          
+
           # Verify all changed pom.xml files are captured in POM_DIFF
           CHANGED_POM_COUNT=$(echo "$CHANGED_FILES" | grep -c 'pom\.xml$' || true)
           POM_DIFF_FILE_COUNT=$(echo "$POM_DIFF" | grep -c '^diff --git' || true)
@@ -118,14 +119,12 @@ jobs:
           # Check only version tags modified in pom.xml
           # Whitelist of allowed property changes in release PRs:
           # - <version>: Main project version (X.Y.Z-SNAPSHOT)
-          # - <dependency.zeebe.version>: Zeebe dependency version
           # - <backwards.compat.version>: Java API compatibility version
           # - <version.identity>: Identity component version (updated by automation)
           ALLOWED_PATTERNS=(
             '^\+\+\+'                              # Diff header
             '^---'                                 # Diff header
             '^[+-]\s*<version>'                    # Main version tag
-            '^[+-]\s*<dependency\.zeebe\.version>' # Zeebe dependency
             '^[+-]\s*<backwards\.compat\.version>' # Backwards compatibility version
             '^[+-]\s*<version\.identity>'          # Identity version
           )
@@ -160,26 +159,7 @@ jobs:
               exit 1
             }
             echo "✅ Version: $OLD_VER → $NEW_VER"
-          fi
-          
-          # Validate dependency.zeebe.version increment: X.Y.Z → X.Y.(Z+1)
-          OLD_ZEEBE=$( (echo "$POM_DIFF" | grep -E '^-\s*<dependency\.zeebe\.version>' | sed -E 's/.*>([^<]+)<.*/\1/') 2>/dev/null || true)
-          NEW_ZEEBE=$( (echo "$POM_DIFF" | grep -E '^\+\s*<dependency\.zeebe\.version>' | sed -E 's/.*>([^<]+)<.*/\1/') 2>/dev/null || true)
-          
-          if [[ -n "$OLD_ZEEBE" && -n "$NEW_ZEEBE" ]]; then
-            [[ "$OLD_ZEEBE" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]] || { echo "❌ Invalid old Zeebe version: $OLD_ZEEBE"; exit 1; }
-            OLD_MAJ="${BASH_REMATCH[1]}" OLD_MIN="${BASH_REMATCH[2]}" OLD_PAT="${BASH_REMATCH[3]}"
-            
-            [[ "$NEW_ZEEBE" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]] || { echo "❌ Invalid new Zeebe version: $NEW_ZEEBE"; exit 1; }
-            NEW_MAJ="${BASH_REMATCH[1]}" NEW_MIN="${BASH_REMATCH[2]}" NEW_PAT="${BASH_REMATCH[3]}"
-            
-            [[ "$NEW_MAJ" == "$OLD_MAJ" && "$NEW_MIN" == "$OLD_MIN" && "$NEW_PAT" == $((OLD_PAT + 1)) ]] || {
-              echo "❌ Expected Zeebe ${OLD_MAJ}.${OLD_MIN}.$((OLD_PAT + 1)), got $NEW_ZEEBE"
-              exit 1
-            }
-            echo "✅ Zeebe dependency: $OLD_ZEEBE → $NEW_ZEEBE"
-          fi
-      
+          fi      
       - name: Get required status checks from rulesets targeting base branch
         id: get_required_checks
         run: |
@@ -235,19 +215,71 @@ jobs:
             echo "Required checks for $BASE_BRANCH: $CHECKS_PATTERN"
             echo "checks_pattern=$CHECKS_PATTERN" >> "$GITHUB_OUTPUT"
           fi
-      
-      - name: Wait for required checks
+
+      - name: Wait for required checks to pass
         id: wait_checks
         if: steps.get_required_checks.outputs.checks_pattern != ''
-        # Using lewagon/wait-on-check-action - approved in https://github.com/camunda/github-actions-recipes
-        uses: lewagon/wait-on-check-action@v1.5.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-          running-workflow-name: 'Auto-merge release to stable'
-          check-regexp: '${{ steps.get_required_checks.outputs.checks_pattern }}'
-          allowed-conclusions: success
+        env:
+          SHA: ${{ github.event.pull_request.head.sha }}
+          CHECKS_PATTERN: ${{ steps.get_required_checks.outputs.checks_pattern }}
+        run: |
+          TIMEOUT_MINUTES=30
+          POLL_INTERVAL=30
+          MAX_WAIT=$((TIMEOUT_MINUTES * 60))
+          ELAPSED=0
+
+          IFS='|' read -ra REQUIRED_CHECKS <<< "$CHECKS_PATTERN"
+          echo "Waiting for required checks: ${REQUIRED_CHECKS[*]}"
+          echo "Timeout: ${TIMEOUT_MINUTES}m, poll interval: ${POLL_INTERVAL}s"
+          echo ""
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            # filter=all includes re-runs so we always see the most recent attempt
+            RUNS_JSON=$(gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs?filter=all&per_page=100" \
+              --paginate --jq '.check_runs[] | {name: .name, id: .id, status: .status, conclusion: .conclusion}' \
+              | jq -s '.')
+
+            ALL_PASSED=true
+            for CHECK in "${REQUIRED_CHECKS[@]}"; do
+              # Pick the run with the highest id (most recent, handles re-runs)
+              LATEST=$(echo "$RUNS_JSON" | jq -r --arg name "$CHECK" \
+                '[.[] | select(.name == $name)] | sort_by(.id) | last // empty')
+
+              if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+                echo "⏳ [$CHECK] not yet registered"
+                ALL_PASSED=false
+                continue
+              fi
+
+              STATUS=$(echo "$LATEST" | jq -r '.status')
+              CONCLUSION=$(echo "$LATEST" | jq -r '.conclusion // "pending"')
+
+              if [ "$STATUS" != "completed" ]; then
+                echo "⏳ [$CHECK] $STATUS"
+                ALL_PASSED=false
+              elif [ "$CONCLUSION" = "success" ]; then
+                echo "✅ [$CHECK] passed"
+              else
+                echo "❌ [$CHECK] failed (conclusion: $CONCLUSION)"
+                exit 1
+              fi
+            done
+
+            if [ "$ALL_PASSED" = true ]; then
+              echo ""
+              echo "✅ All required checks passed"
+              exit 0
+            fi
+
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+            if [ $ELAPSED -ge $MAX_WAIT ]; then
+              echo ""
+              echo "❌ Timed out waiting for checks after ${TIMEOUT_MINUTES} minutes"
+              exit 1
+            fi
+            echo "--- Waiting ${POLL_INTERVAL}s (${ELAPSED}s/${MAX_WAIT}s) ---"
+            sleep "$POLL_INTERVAL"
+          done
       
       - name: Approve PR
         # Proceed when checks pass OR when no required checks configured (skipped outcome)

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DRY_RUN: ${{ vars.AUTO_MERGE_DRY_RUN || 'true' }}
-      MERGE_QUEUE_TIMEOUT_MINUTES: ${{ vars.MERGE_QUEUE_TIMEOUT_MINUTES || '60' }}
+      MERGE_QUEUE_TIMEOUT_MINUTES: ${{ vars.MERGE_QUEUE_TIMEOUT_MINUTES || '180' }}
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# 🎯  Target

Refactoring the [auto-merge-back-to-stable.yml](https://github.com/camunda/camunda/pull/48376/changes#diff-bb127e6a5b887b1dd27bd60afd874febcb6d228df359aa661b066480a7055f49) file to be able to handle required, but not yet registered mandatory checks

## Description

In our current ci runs, the re [check-results](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml#L1472C4-L1472C17) job is using `needs` paramter. This results in that this job is not registered until its preconditions not finished. The previously used `lewagon/wait-on-check-action@v1.5.0` github action is not able to handle this case, and fails instantly saying the required check was never ran.

Resolving this issue, the github action has been replaced with a polling mechanism, which waits for a given time until the required check appears, then checks its result

<img width="741" height="561" alt="image" src="https://github.com/user-attachments/assets/b234fdc7-0337-4bf1-ac30-e7abc1f643ae" />


## 🧪  Test
[Tested pr](https://github.com/camunda/szpraat-test-repository-01/pull/103) and [workflow run](https://github.com/camunda/szpraat-test-repository-01/actions/runs/23044782063/job/66931135586)



## Related issues
https://github.com/camunda/camunda/issues/41331
