### PR TITLE
feat: make process-instance bottom panel horizontally resizable

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {IS_NEW_PROCESS_INSTANCE_PAGE} from 'modules/feature-flags';
+import {BottomPanelGrid, ResizableBottomPanelContainer} from './styled';
+import {ElementInstanceLog} from './ElementInstanceLog';
+import {VariablePanel} from './BottomPanel/VariablePanel';
+import {useEffect, useRef, useState} from 'react';
+import {
+  ResizablePanel,
+  SplitDirection,
+} from 'modules/components/ResizablePanel';
+import {BottomPanelTabs} from './BottomPanelTabs';
+
+type Props = {
+  isListenerTabSelected: boolean;
+  setListenerTabVisibility: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const BottomPanel: React.FC<Props> = (props) => {
+  if (!IS_NEW_PROCESS_INSTANCE_PAGE) {
+    return (
+      <BottomPanelGrid $shouldExpandPanel={props.isListenerTabSelected}>
+        <ElementInstanceLog />
+        <VariablePanel
+          setListenerTabVisibility={props.setListenerTabVisibility}
+        />
+      </BottomPanelGrid>
+    );
+  }
+
+  // TODO: Static conditional. Reenable rule of hooks once the feature is removed.
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const [clientWidth, setClientWidth] = useState(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const panelMinWidth = clientWidth / 4;
+
+  useEffect(() => setClientWidth(containerRef?.current?.clientWidth ?? 0), []);
+  /* eslint-enable react-hooks/rules-of-hooks */
+
+  return (
+    <ResizableBottomPanelContainer ref={containerRef}>
+      <ResizablePanel
+        panelId="process-instance-bottom-horizontal-panel"
+        direction={SplitDirection.Horizontal}
+        minWidths={[panelMinWidth, panelMinWidth]}
+      >
+        <ElementInstanceLog />
+        <BottomPanelTabs />
+      </ResizablePanel>
+    </ResizableBottomPanelContainer>
+  );
+};
+
+export {BottomPanel};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/IOMappingInfoBanner.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/IOMappingInfoBanner.tsx
@@ -6,8 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ActionableNotification} from '@carbon/react';
 import {storeStateLocally} from 'modules/utils/localStorage';
+import {FullSizeActionableNotification} from './styled';
 
 type Props = {
   type: 'Input' | 'Output';
@@ -17,7 +17,7 @@ type Props = {
 
 const IOMappingInfoBanner: React.FC<Props> = ({type, text, onClose}) => {
   return (
-    <ActionableNotification
+    <FullSizeActionableNotification
       kind="info"
       inline
       lowContrast

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/styled.ts
@@ -8,6 +8,7 @@
 
 import styled, {css} from 'styled-components';
 import {EmptyMessage as BaseEmptyMessage} from 'modules/components/EmptyMessage';
+import {ActionableNotification} from '@carbon/react';
 
 type ContentProps = {
   $isInfoBannerVisible: boolean;
@@ -28,9 +29,17 @@ const Content = styled.div<ContentProps>`
   }}
 `;
 
+const FullSizeActionableNotification = styled(ActionableNotification)`
+  max-inline-size: unset;
+
+  .cds--actionable-notification__text-wrapper {
+    max-inline-size: 80ch; // Keep text at a readable length
+  }
+`;
+
 const EmptyMessage = styled(BaseEmptyMessage)`
   align-self: center;
   margin: auto;
 `;
 
-export {Content, EmptyMessage};
+export {Content, EmptyMessage, FullSizeActionableNotification};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/styled.tsx
@@ -11,9 +11,10 @@ import {styled} from 'styled-components';
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  min-height: 0;
   height: 100%;
   overflow: hidden;
-  background-color: var(--cds-layer);
+  background-color: var(--cds-layer-01);
 `;
 
 export {Container};

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/styled.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/styled.ts
@@ -16,6 +16,8 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 0;
+  height: 100%;
+  overflow: hidden;
 `;
 
 const PanelHeader = styled(BasePanelHeader)`

--- a/operate/client/src/App/ProcessInstance/index.tsx
+++ b/operate/client/src/App/ProcessInstance/index.tsx
@@ -19,15 +19,13 @@ import {elementTimeStampStore} from 'modules/stores/elementTimeStamp';
 import {ProcessInstanceHeader} from './ProcessInstanceHeader';
 import {ProcessInstanceHeader as ProcessInstanceHeaderNext} from './ProcessInstanceHeaderNext';
 import {TopPanel} from './TopPanel';
-import {BottomPanel, ModificationFooter, Buttons} from './styled';
-import {ElementInstanceLog} from './ElementInstanceLog';
+import {ModificationFooter, Buttons} from './styled';
 import {Button, Modal} from '@carbon/react';
 import {tracking} from 'modules/tracking';
 import {ModalStateManager} from 'modules/components/ModalStateManager';
 import {ModificationSummaryModal} from './ModificationSummaryModal';
 import {useCallbackPrompt} from 'modules/hooks/useCallbackPrompt';
 import {LastModification} from './LastModification';
-import {VariablePanel} from './BottomPanel/VariablePanel';
 import {Forbidden} from 'modules/components/Forbidden';
 import {Frame} from 'modules/components/Frame';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
@@ -41,7 +39,7 @@ import {useNavigate, matchPath, type Location} from 'react-router-dom';
 import {Locations, Paths} from 'modules/Routes';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {IS_NEW_PROCESS_INSTANCE_PAGE} from 'modules/feature-flags';
-import {BottomPanelTabs} from './BottomPanelTabs';
+import {BottomPanel} from './BottomPanel';
 
 const onProcessInstanceTabTransition = ({
   currentLocation,
@@ -195,19 +193,9 @@ const ProcessInstance: React.FC = observer(() => {
             topPanel={<TopPanel />}
             bottomPanel={
               <BottomPanel
-                $shouldExpandPanel={
-                  IS_NEW_PROCESS_INSTANCE_PAGE ? false : isListenerTabSelected
-                }
-              >
-                <ElementInstanceLog />
-                {IS_NEW_PROCESS_INSTANCE_PAGE ? (
-                  <BottomPanelTabs />
-                ) : (
-                  <VariablePanel
-                    setListenerTabVisibility={setListenerTabVisibility}
-                  />
-                )}
-              </BottomPanel>
+                isListenerTabSelected={isListenerTabSelected}
+                setListenerTabVisibility={setListenerTabVisibility}
+              />
             }
             footer={
               isModificationModeEnabled ? (

--- a/operate/client/src/App/ProcessInstance/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/styled.tsx
@@ -9,10 +9,14 @@
 import styled from 'styled-components';
 import {Stack} from '@carbon/react';
 
-const BottomPanel = styled.div<{$shouldExpandPanel?: boolean}>`
+const BottomPanelGrid = styled.div<{$shouldExpandPanel?: boolean}>`
   display: grid;
   grid-template-columns: ${({$shouldExpandPanel}) =>
     $shouldExpandPanel ? '1.1fr 1.9fr' : '1fr 1fr'};
+  height: 100%;
+`;
+
+const ResizableBottomPanelContainer = styled.div`
   height: 100%;
 `;
 
@@ -28,4 +32,9 @@ const Buttons = styled(Stack)`
   margin-left: auto;
 `;
 
-export {BottomPanel, ModificationFooter, Buttons};
+export {
+  BottomPanelGrid,
+  ResizableBottomPanelContainer,
+  ModificationFooter,
+  Buttons,
+};


### PR DESCRIPTION
## Description

This PR makes the PI bottom panels vertically resizable. It serves as a starting point for the bottom panel responsiveness. Certainly, not all panel tabs look good yet when they get compressed...

## Related issues

closes #47044
