### PR TITLE
refactor: improve type safety, readability, and error handling in batch operation scheduling

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -85,7 +85,6 @@ public final class BatchOperationSetupProcessors {
             new ItemProviderFactory(searchClientsProxy, batchOperationMetrics, partitionId),
             new BatchOperationChunkAppender(engineConfiguration.getBatchOperationChunkSize()),
             new BatchOperationCommands(partitionId),
-            engineConfiguration.getBatchOperationQueryPageSize(),
             batchOperationMetrics);
 
     final var retryHandler =
@@ -184,6 +183,7 @@ public final class BatchOperationSetupProcessors {
                 scheduledTaskStateFactory,
                 batchOperationInitializer,
                 retryHandler,
-                engineConfiguration.getBatchOperationSchedulerInterval()));
+                engineConfiguration.getBatchOperationSchedulerInterval(),
+                engineConfiguration.getBatchOperationQueryPageSize()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperatio
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationCommandAppender;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationExecutionScheduler;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -89,7 +89,7 @@ public final class BatchOperationSetupProcessors {
             batchOperationMetrics);
 
     final var retryHandler =
-        new BatchOperationRetryHandler(
+        new BatchOperationRetryPolicy(
             engineConfiguration.getBatchOperationQueryRetryInitialDelay(),
             engineConfiguration.getBatchOperationQueryRetryMaxDelay(),
             engineConfiguration.getBatchOperationQueryRetryMax(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.handlers.ModifyProcessI
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.ResolveIncidentBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationCommandAppender;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationCommands;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationExecutionScheduler;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy;
@@ -84,7 +84,7 @@ public final class BatchOperationSetupProcessors {
         new BatchOperationInitializationBehavior(
             new ItemProviderFactory(searchClientsProxy, batchOperationMetrics, partitionId),
             new BatchOperationChunkAppender(engineConfiguration.getBatchOperationChunkSize()),
-            new BatchOperationCommandAppender(partitionId),
+            new BatchOperationCommands(partitionId),
             engineConfiguration.getBatchOperationQueryPageSize(),
             batchOperationMetrics);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -18,10 +18,10 @@ import io.camunda.zeebe.engine.processing.batchoperation.handlers.MigrateProcess
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.ModifyProcessInstanceBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.ResolveIncidentBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationCommandAppender;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationExecutionScheduler;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -83,7 +83,7 @@ public final class BatchOperationSetupProcessors {
     final var batchOperationInitializer =
         new BatchOperationInitializationBehavior(
             new ItemProviderFactory(searchClientsProxy, batchOperationMetrics, partitionId),
-            new BatchOperationPageProcessor(engineConfiguration.getBatchOperationChunkSize()),
+            new BatchOperationChunkAppender(engineConfiguration.getBatchOperationChunkSize()),
             new BatchOperationCommandAppender(partitionId),
             engineConfiguration.getBatchOperationQueryPageSize(),
             batchOperationMetrics);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.handlers.ResolveInciden
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationCommandAppender;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationExecutionScheduler;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -81,7 +81,7 @@ public final class BatchOperationSetupProcessors {
                 writers.command(), brokerRequestAuthorizationConverter));
 
     final var batchOperationInitializer =
-        new BatchOperationInitializationHelper(
+        new BatchOperationInitializationBehavior(
             new ItemProviderFactory(searchClientsProxy, batchOperationMetrics, partitionId),
             new BatchOperationPageProcessor(engineConfiguration.getBatchOperationChunkSize()),
             new BatchOperationCommandAppender(partitionId),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
@@ -72,7 +72,7 @@ public class BatchOperationChunkAppender {
     final boolean appendedChunks = appendChunks(taskResultBuilder, batchOperationKey, page.items());
 
     if (!appendedChunks) {
-      return new ChunkingOutcome.BufferFull(page.items().size());
+      return new ChunkingOutcome.BufferFull();
     }
     if (page.isLastPage()) {
       return new ChunkingOutcome.Finished(page.endCursor(), page.items().size());
@@ -178,7 +178,7 @@ public class BatchOperationChunkAppender {
     record Finished(String endCursor, int itemsProcessed) implements ChunkingOutcome {}
 
     /** Chunks could not fit in the result buffer. */
-    record BufferFull(int itemsProcessed) implements ChunkingOutcome {}
+    record BufferFull() implements ChunkingOutcome {}
 
     /** Fetching the page from the item provider failed. */
     record FetchFailed(Exception cause) implements ChunkingOutcome {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
@@ -65,32 +65,32 @@ public class BatchOperationChunkAppender {
    * @return a result indicating whether chunks were appended, the end cursor, number of items
    *     processed, and if it was the last page
    */
-  private PageProcessingResult chunkAndAppend(
+  private ChunkingOutcome chunkAndAppend(
       final long batchOperationKey,
       final ItemPage page,
       final TaskResultBuilder taskResultBuilder) {
     final boolean appendedChunks = appendChunks(taskResultBuilder, batchOperationKey, page.items());
 
     if (!appendedChunks) {
-      return new PageProcessingResult.BufferFull(page.items().size());
+      return new ChunkingOutcome.BufferFull(page.items().size());
     }
     if (page.isLastPage()) {
-      return new PageProcessingResult.Finished(page.endCursor(), page.items().size());
+      return new ChunkingOutcome.Finished(page.endCursor(), page.items().size());
     }
-    return new PageProcessingResult.Continue(page.endCursor(), page.items().size());
+    return new ChunkingOutcome.Continue(page.endCursor(), page.items().size());
   }
 
   /**
    * Fetches the next page of items and chunks them into the result buffer. If the fetch fails, a
-   * {@link PageProcessingResult.FetchFailed} is returned instead of throwing an exception.
+   * {@link ChunkingOutcome.FetchFailed} is returned instead of throwing an exception.
    *
    * @param itemProvider the item provider to fetch the page from
    * @param context the current initialization context (cursor, page size)
    * @param taskResultBuilder the builder to append command records to
-   * @return the result of processing the page, or a {@link PageProcessingResult.FetchFailed} if the
+   * @return the result of processing the page, or a {@link ChunkingOutcome.FetchFailed} if the
    *     fetch fails
    */
-  public PageProcessingResult fetchAndChunkNextPage(
+  public ChunkingOutcome fetchAndChunkNextPage(
       final ItemProvider itemProvider,
       final InitializationContext context,
       final TaskResultBuilder taskResultBuilder) {
@@ -98,7 +98,7 @@ public class BatchOperationChunkAppender {
     try {
       page = itemProvider.fetchItemPage(context.currentCursor(), context.pageSize());
     } catch (final Exception e) {
-      return new PageProcessingResult.FetchFailed(e);
+      return new ChunkingOutcome.FetchFailed(e);
     }
     return chunkAndAppend(context.operation().getKey(), page, taskResultBuilder);
   }
@@ -161,7 +161,7 @@ public class BatchOperationChunkAppender {
   }
 
   /**
-   * Represents the outcome of processing a page of batch operation items.
+   * Represents the outcome of fetching and chunking a page of batch operation items.
    *
    * <ul>
    *   <li>{@link Continue} — chunks were appended, more pages remain
@@ -170,17 +170,17 @@ public class BatchOperationChunkAppender {
    *   <li>{@link FetchFailed} — fetching the page failed with an exception
    * </ul>
    */
-  public sealed interface PageProcessingResult {
+  public sealed interface ChunkingOutcome {
     /** Chunks were appended and more pages remain. */
-    record Continue(String endCursor, int itemsProcessed) implements PageProcessingResult {}
+    record Continue(String endCursor, int itemsProcessed) implements ChunkingOutcome {}
 
     /** Chunks were appended and this was the last page. */
-    record Finished(String endCursor, int itemsProcessed) implements PageProcessingResult {}
+    record Finished(String endCursor, int itemsProcessed) implements ChunkingOutcome {}
 
     /** Chunks could not fit in the result buffer. */
-    record BufferFull(int itemsProcessed) implements PageProcessingResult {}
+    record BufferFull(int itemsProcessed) implements ChunkingOutcome {}
 
     /** Fetching the page from the item provider failed. */
-    record FetchFailed(Exception cause) implements PageProcessingResult {}
+    record FetchFailed(Exception cause) implements ChunkingOutcome {}
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
@@ -32,8 +32,8 @@ import org.slf4j.LoggerFactory;
  * the task result builder. It handles the logic for chunking items and ensuring that the task
  * result can accommodate the new records.
  */
-public class BatchOperationPageProcessor {
-  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationPageProcessor.class);
+public class BatchOperationChunkAppender {
+  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationChunkAppender.class);
   // These empty records are used only for size checking in canAppendChunks,
   // to ensure that the size check accounts for the largest possible record types
   // that may be appended. They are not used for actual data processing.
@@ -47,7 +47,7 @@ public class BatchOperationPageProcessor {
 
   private final int chunkSize;
 
-  public BatchOperationPageProcessor(final int chunkSize) {
+  public BatchOperationChunkAppender(final int chunkSize) {
     this.chunkSize = chunkSize;
   }
 
@@ -149,7 +149,7 @@ public class BatchOperationPageProcessor {
     final var command = new BatchOperationChunkRecord();
     command.setBatchOperationKey(batchOperationKey);
     command.setItems(
-        chunkItems.stream().map(BatchOperationPageProcessor::mapItem).collect(Collectors.toSet()));
+        chunkItems.stream().map(BatchOperationChunkAppender::mapItem).collect(Collectors.toSet()));
     return command;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
@@ -65,7 +65,7 @@ public class BatchOperationChunkAppender {
    * @return a result indicating whether chunks were appended, the end cursor, number of items
    *     processed, and if it was the last page
    */
-  private PageProcessingResult processPage(
+  private PageProcessingResult chunkAndAppend(
       final long batchOperationKey,
       final ItemPage page,
       final TaskResultBuilder taskResultBuilder) {
@@ -81,8 +81,8 @@ public class BatchOperationChunkAppender {
   }
 
   /**
-   * Fetches the next page of items and processes it into chunks. If the fetch fails, a {@link
-   * PageProcessingResult.FetchFailed} is returned instead of throwing an exception.
+   * Fetches the next page of items and chunks them into the result buffer. If the fetch fails, a
+   * {@link PageProcessingResult.FetchFailed} is returned instead of throwing an exception.
    *
    * @param itemProvider the item provider to fetch the page from
    * @param context the current initialization context (cursor, page size)
@@ -90,7 +90,7 @@ public class BatchOperationChunkAppender {
    * @return the result of processing the page, or a {@link PageProcessingResult.FetchFailed} if the
    *     fetch fails
    */
-  public PageProcessingResult processNextPage(
+  public PageProcessingResult fetchAndChunkNextPage(
       final ItemProvider itemProvider,
       final InitializationContext context,
       final TaskResultBuilder taskResultBuilder) {
@@ -100,7 +100,7 @@ public class BatchOperationChunkAppender {
     } catch (final Exception e) {
       return new PageProcessingResult.FetchFailed(e);
     }
-    return processPage(context.operation().getKey(), page, taskResultBuilder);
+    return chunkAndAppend(context.operation().getKey(), page, taskResultBuilder);
   }
 
   private boolean appendChunks(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationCommands.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationCommands.java
@@ -21,15 +21,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is responsible for appending commands related to batch operations, such as
- * initialization, execution, and failure handling. It provides methods to append these commands to
- * a {@link TaskResultBuilder}.
+ * Utility class for creating and appending batch operation commands to a {@link TaskResultBuilder}.
  */
-public class BatchOperationCommandAppender {
-  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationCommandAppender.class);
+public class BatchOperationCommands {
+  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationCommands.class);
   private final int partitionId;
 
-  public BatchOperationCommandAppender(final int partitionId) {
+  public BatchOperationCommands(final int partitionId) {
     this.partitionId = partitionId;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
-import com.google.common.base.Strings;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.ReducePageSize;
@@ -23,7 +22,6 @@ import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -73,7 +71,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   private final BatchOperationInitializationBehavior batchOperationInitializer;
   private final BatchOperationRetryPolicy retryPolicy;
   private final AtomicBoolean executing = new AtomicBoolean(false);
-  private final AtomicReference<ExecutionLoopState> executionState = new AtomicReference<>();
+  private final AtomicReference<SchedulerExecutionState> executionState = new AtomicReference<>();
 
   private ReadonlyStreamProcessorContext processingContext;
 
@@ -188,7 +186,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   private Duration handleRetry(
       final TaskResultBuilder taskResultBuilder,
       final PersistedBatchOperation batchOperation,
-      final ExecutionLoopState currentState,
+      final SchedulerExecutionState currentState,
       final String cursor,
       final Throwable cause) {
 
@@ -221,115 +219,12 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
    *   <li>The batch operation key changed (switched to a different BO)
    * </ul>
    */
-  private ExecutionLoopState getOrCreateState(final PersistedBatchOperation batchOperation) {
+  private SchedulerExecutionState getOrCreateState(final PersistedBatchOperation batchOperation) {
     var state = executionState.get();
-    if (state == null || state.batchOperationKey != batchOperation.getKey()) {
-      state = ExecutionLoopState.from(batchOperation);
+    if (state == null || state.batchOperationKey() != batchOperation.getKey()) {
+      state = SchedulerExecutionState.from(batchOperation);
       executionState.set(state);
     }
     return state;
-  }
-
-  /**
-   * Tracks the in-flight state of a batch operation being initialized.
-   *
-   * <p>This class exists to prevent re-initialization of a batch operation before the stream
-   * processor has processed our previous INITIALIZE command. Without this guard, the scheduler
-   * could fire multiple INITIALIZE commands for the same cursor position, causing duplicate work.
-   *
-   * <p>The key invariant: after we successfully initialize a page and append an INITIALIZE command,
-   * the persisted state's cursor will be updated asynchronously by the command processor. Until
-   * that happens, our in-memory cursor differs from the persisted cursor. We use this difference to
-   * detect "command in flight" and skip re-initialization.
-   *
-   * <p>However, if retries are in flight ({@code numAttempts > 0}), we should NOT skip — retries
-   * are intentional re-executions after transient failures.
-   *
-   * <p>The state also tracks a reduced page size when buffer-full scenarios require smaller
-   * fetches. This avoids writing INITIALIZE commands just to persist the page size change.
-   */
-  static final class ExecutionLoopState {
-    private final long batchOperationKey;
-    private final String cursor;
-    private final int pageSize; // 0 means use default
-    private final int numAttempts;
-
-    private ExecutionLoopState(
-        final long batchOperationKey,
-        final String cursor,
-        final int pageSize,
-        final int numAttempts) {
-      this.batchOperationKey = batchOperationKey;
-      this.cursor = cursor;
-      this.pageSize = pageSize;
-      this.numAttempts = numAttempts;
-    }
-
-    /** Creates initial state from a persisted batch operation. */
-    static ExecutionLoopState from(final PersistedBatchOperation batchOperation) {
-      return new ExecutionLoopState(
-          batchOperation.getKey(),
-          Strings.nullToEmpty(batchOperation.getInitializationSearchCursor()),
-          0,
-          0);
-    }
-
-    /**
-     * Advances to a new cursor after successful page processing. Resets page size and retry count.
-     */
-    ExecutionLoopState advanceTo(final String newCursor) {
-      return new ExecutionLoopState(batchOperationKey, newCursor, 0, 0);
-    }
-
-    /**
-     * Prepares for a retry attempt with the given cursor and attempt count. Preserves page size.
-     */
-    ExecutionLoopState retryWith(final String newCursor, final int attempts) {
-      return new ExecutionLoopState(batchOperationKey, newCursor, pageSize, attempts);
-    }
-
-    /** Reduces page size for next attempt due to buffer full. */
-    ExecutionLoopState withReducedPageSize(final int newPageSize) {
-      return new ExecutionLoopState(batchOperationKey, cursor, newPageSize, 0);
-    }
-
-    /**
-     * Builds an {@link InitializationContext} using in-memory overrides where applicable.
-     *
-     * <p>Uses:
-     *
-     * <ul>
-     *   <li>In-memory cursor when retrying ({@code numAttempts > 0}) to avoid stale cursor race
-     *   <li>In-memory page size when reduced ({@code pageSize > 0}) to avoid stale page size race
-     *   <li>Persisted values otherwise
-     * </ul>
-     */
-    InitializationContext buildContext(
-        final PersistedBatchOperation batchOperation, final int defaultPageSize) {
-      final String effectiveCursor =
-          numAttempts > 0 ? cursor : batchOperation.getInitializationSearchCursor();
-      final int effectivePageSize =
-          pageSize > 0
-              ? pageSize
-              : batchOperation.getInitializationSearchQueryPageSize(defaultPageSize);
-      return new InitializationContext(
-          batchOperation, effectiveCursor, effectivePageSize, 0, false);
-    }
-
-    /**
-     * Determines whether initialization should be skipped for the given batch operation.
-     *
-     * <p>We skip when our in-memory cursor differs from the persisted cursor AND we're not in a
-     * retry. This means we appended an INITIALIZE command that hasn't been processed yet.
-     */
-    boolean shouldSkipInitialization(final PersistedBatchOperation batchOperation) {
-      return batchOperationKey == batchOperation.getKey()
-          && numAttempts == 0
-          && !Objects.equals(cursor, batchOperation.getInitializationSearchCursor());
-    }
-
-    int numAttempts() {
-      return numAttempts;
-    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -11,7 +11,8 @@ import com.google.common.base.Strings;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryDecision;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy.RetryDecision.Fail;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy.RetryDecision.Retry;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
@@ -60,7 +61,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see StreamProcessorLifecycleAware
  * @see BatchOperationInitializationBehavior
- * @see BatchOperationRetryHandler
+ * @see BatchOperationRetryPolicy
  */
 public class BatchOperationExecutionScheduler implements StreamProcessorLifecycleAware {
   private static final Logger LOG = LoggerFactory.getLogger(BatchOperationExecutionScheduler.class);
@@ -68,7 +69,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   private final Duration initialPollingInterval;
   private final BatchOperationState batchOperationState;
   private final BatchOperationInitializationBehavior batchOperationInitializer;
-  private final BatchOperationRetryHandler retryHandler;
+  private final BatchOperationRetryPolicy retryPolicy;
   private final AtomicBoolean executing = new AtomicBoolean(false);
   private final AtomicReference<ExecutionLoopState> executionState = new AtomicReference<>();
 
@@ -77,14 +78,14 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   public BatchOperationExecutionScheduler(
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final BatchOperationInitializationBehavior batchOperationInitializer,
-      final BatchOperationRetryHandler retryHandler,
+      final BatchOperationRetryPolicy retryPolicy,
       final Duration batchOperationSchedulerInterval) {
 
     batchOperationState = scheduledTaskStateFactory.get().getBatchOperationState();
     initialPollingInterval = batchOperationSchedulerInterval;
 
     this.batchOperationInitializer = batchOperationInitializer;
-    this.retryHandler = retryHandler;
+    this.retryPolicy = retryPolicy;
   }
 
   @Override
@@ -177,18 +178,18 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
       final String cursor,
       final Throwable cause) {
 
-    final var decision = retryHandler.evaluate(cursor, cause, currentState.numAttempts());
+    final var decision = retryPolicy.evaluate(cursor, cause, currentState.numAttempts());
 
     return switch (decision) {
-      case RetryDecision.Fail(final var message, final var errorType) -> {
+      case Fail(final var message, final var errorType) -> {
         batchOperationInitializer.appendFailedCommand(
             taskResultBuilder, batchOperation.getKey(), message, errorType);
         yield initialPollingInterval;
       }
-      case RetryDecision.Retry(final var delay, final int numAttempts, final String retryCursor) -> {
+      case Retry(final var delay, final int numAttempts, final String retryCursor) -> {
         LOG.warn(
             "Retryable operation failed, retries left: {}, retrying in {} ms",
-            retryHandler.getMaxRetries() - numAttempts,
+            retryPolicy.getMaxRetries() - numAttempts,
             delay.toMillis());
         executionState.set(currentState.retryWith(retryCursor, numAttempts));
         yield delay;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -69,7 +69,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   private final BatchOperationInitializationBehavior batchOperationInitializer;
   private final BatchOperationRetryHandler retryHandler;
   private final AtomicBoolean executing = new AtomicBoolean(false);
-  private final AtomicReference<ExecutionLoopState> initializing = new AtomicReference<>();
+  private final AtomicReference<ExecutionLoopState> executionState = new AtomicReference<>();
 
   private ReadonlyStreamProcessorContext processingContext;
 
@@ -143,7 +143,11 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   private Duration executeRetrying(
       final PersistedBatchOperation batchOperation, final TaskResultBuilder taskResultBuilder) {
 
-    if (!validateNoReInitialization(batchOperation)) {
+    final var currentState = getOrCreateState(batchOperation);
+    if (currentState.shouldSkipInitialization(batchOperation)) {
+      LOG.trace(
+          "Batch operation {} initialization already in progress, skipping.",
+          batchOperation.getKey());
       return initialPollingInterval;
     }
 
@@ -152,11 +156,11 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
             () ->
                 batchOperationInitializer.initializeBatchOperation(
                     batchOperation, taskResultBuilder),
-            initializing.get().numAttempts);
+            currentState.numAttempts());
 
     return switch (retryResult) {
       case Success(final var cursor) -> {
-        initializing.set(new ExecutionLoopState(batchOperation.getKey(), cursor, 0));
+        executionState.set(currentState.advanceTo(cursor));
         yield initialPollingInterval;
       }
       case Failure(final var exception) -> {
@@ -169,35 +173,105 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
             "Retryable operation failed, retries left: {}, retrying in {} ms",
             retryHandler.getMaxRetries() - numAttempts,
             delay.toMillis());
-        initializing.set(new ExecutionLoopState(batchOperation.getKey(), endCursor, numAttempts));
+        executionState.set(currentState.retryWith(endCursor, numAttempts));
         yield delay;
       }
     };
   }
 
-  private boolean validateNoReInitialization(final PersistedBatchOperation batchOperation) {
-    final var initializingBO = initializing.get();
-    if (initializingBO != null
-        && initializingBO.batchOperationKey == batchOperation.getKey()
-        && !Objects.equals(
-            initializingBO.searchResultCursor, batchOperation.getInitializationSearchCursor())
-        && initializingBO.numAttempts == 0) {
-      LOG.trace(
-          "Batch operation {} is already being executed, skipping re-initialization.",
-          batchOperation.getKey());
-      return false;
-    } else if (initializingBO == null) {
-      initializing.set(new ExecutionLoopState(batchOperation));
+  /**
+   * Returns existing execution state or creates fresh state from the batch operation.
+   *
+   * <p>We reset state when:
+   *
+   * <ul>
+   *   <li>No state exists (first run), or
+   *   <li>The batch operation key changed (switched to a different BO)
+   * </ul>
+   */
+  private ExecutionLoopState getOrCreateState(final PersistedBatchOperation batchOperation) {
+    var state = executionState.get();
+    if (state == null || state.batchOperationKey != batchOperation.getKey()) {
+      state = ExecutionLoopState.from(batchOperation);
+      executionState.set(state);
     }
-    return true;
+    return state;
   }
 
-  record ExecutionLoopState(long batchOperationKey, String searchResultCursor, int numAttempts) {
-    public ExecutionLoopState(final PersistedBatchOperation batchOperation) {
-      this(
+  /**
+   * Tracks the in-flight state of a batch operation being initialized.
+   *
+   * <p>This class exists to prevent re-initialization of a batch operation before the stream
+   * processor has processed our previous INITIALIZE command. Without this guard, the scheduler
+   * could fire multiple INITIALIZE commands for the same cursor position, causing duplicate work.
+   *
+   * <p>The key invariant: after we successfully initialize a page and append an INITIALIZE command,
+   * the persisted state's cursor will be updated asynchronously by the command processor. Until
+   * that happens, our in-memory cursor differs from the persisted cursor. We use this difference to
+   * detect "command in flight" and skip re-initialization.
+   *
+   * <p>However, if retries are in flight ({@code numAttempts > 0}), we should NOT skip — retries
+   * are intentional re-executions after transient failures.
+   */
+  static final class ExecutionLoopState {
+    private final long batchOperationKey;
+    private final String lastKnownCursor;
+    private final int numAttempts;
+
+    private ExecutionLoopState(
+        final long batchOperationKey, final String lastKnownCursor, final int numAttempts) {
+      this.batchOperationKey = batchOperationKey;
+      this.lastKnownCursor = lastKnownCursor;
+      this.numAttempts = numAttempts;
+    }
+
+    /** Creates initial state from a persisted batch operation. */
+    static ExecutionLoopState from(final PersistedBatchOperation batchOperation) {
+      return new ExecutionLoopState(
           batchOperation.getKey(),
           Strings.nullToEmpty(batchOperation.getInitializationSearchCursor()),
           0);
+    }
+
+    /** Advances to a new cursor after successful page processing. Resets retry count. */
+    ExecutionLoopState advanceTo(final String newCursor) {
+      return new ExecutionLoopState(batchOperationKey, newCursor, 0);
+    }
+
+    /** Prepares for a retry attempt with the given cursor and attempt count. */
+    ExecutionLoopState retryWith(final String cursor, final int attempts) {
+      return new ExecutionLoopState(batchOperationKey, cursor, attempts);
+    }
+
+    /**
+     * Determines whether initialization should be skipped for the given batch operation.
+     *
+     * <p>Precondition: This method assumes the state tracks the same batch operation as the one
+     * passed in (same key). This is guaranteed by {@link
+     * BatchOperationExecutionScheduler#getOrCreateState}, which resets state when the key changes.
+     *
+     * <p>We skip if BOTH of the following are true:
+     *
+     * <ul>
+     *   <li>Our in-memory cursor differs from the persisted cursor — this means we already appended
+     *       an INITIALIZE command that advanced our cursor, but the stream processor has NOT yet
+     *       processed it to update the persisted state. We're "ahead" and waiting for it to catch
+     *       up.
+     *   <li>No retries are in flight ({@code numAttempts == 0}) — retries are intentional
+     *       re-executions after transient failures and should proceed even if cursors differ.
+     * </ul>
+     *
+     * <p>Once the stream processor processes our command, the persisted cursor will match our
+     * in-memory cursor, and the next scheduler run will proceed (cursors equal → don't skip).
+     */
+    boolean shouldSkipInitialization(final PersistedBatchOperation batchOperation) {
+      return batchOperationKey == batchOperation.getKey()
+          && !Objects.equals(lastKnownCursor, batchOperation.getInitializationSearchCursor())
+          && numAttempts == 0;
+    }
+
+    int numAttempts() {
+      return numAttempts;
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
  * processing.
  *
  * @see StreamProcessorLifecycleAware
- * @see BatchOperationInitializationHelper
+ * @see BatchOperationInitializationBehavior
  * @see BatchOperationRetryHandler
  */
 public class BatchOperationExecutionScheduler implements StreamProcessorLifecycleAware {
@@ -66,7 +66,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
 
   private final Duration initialPollingInterval;
   private final BatchOperationState batchOperationState;
-  private final BatchOperationInitializationHelper batchOperationInitializer;
+  private final BatchOperationInitializationBehavior batchOperationInitializer;
   private final BatchOperationRetryHandler retryHandler;
   private final AtomicBoolean executing = new AtomicBoolean(false);
   private final AtomicReference<ExecutionLoopState> initializing = new AtomicReference<>();
@@ -75,7 +75,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
 
   public BatchOperationExecutionScheduler(
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
-      final BatchOperationInitializationHelper batchOperationInitializer,
+      final BatchOperationInitializationBehavior batchOperationInitializer,
       final BatchOperationRetryHandler retryHandler,
       final Duration batchOperationSchedulerInterval) {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -155,8 +155,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
       return initialPollingInterval;
     }
 
-    // Build context with in-memory overrides (cursor for retries, page size for buffer-full)
-    final var context = currentState.buildContext(batchOperation, defaultPageSize);
+    final var context = InitializationContext.fromBatchOperation(batchOperation, defaultPageSize);
     final var outcome =
         batchOperationInitializer.initializeBatchOperation(context, taskResultBuilder);
 
@@ -176,7 +175,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
             batchOperation.getKey(),
             newPageSize);
         executionState.set(currentState.withReducedPageSize(newPageSize));
-        yield Duration.ZERO; // Retry immediately with smaller page size
+        yield initialPollingInterval;
       }
       case NeedsRetry(final var cursor, final var cause) ->
           handleRetry(taskResultBuilder, batchOperation, currentState, cursor, cause);
@@ -222,7 +221,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   private SchedulerExecutionState getOrCreateState(final PersistedBatchOperation batchOperation) {
     var state = executionState.get();
     if (state == null || state.batchOperationKey() != batchOperation.getKey()) {
-      state = SchedulerExecutionState.from(batchOperation);
+      state = SchedulerExecutionState.from(batchOperation, defaultPageSize);
       executionState.set(state);
     }
     return state;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -163,9 +163,9 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
         executionState.set(currentState.advanceTo(cursor));
         yield initialPollingInterval;
       }
-      case Failure(final var exception) -> {
+      case Failure(final var message, final var errorType) -> {
         batchOperationInitializer.appendFailedCommand(
-            taskResultBuilder, batchOperation.getKey(), exception);
+            taskResultBuilder, batchOperation.getKey(), message, errorType);
         yield initialPollingInterval;
       }
       case Retry(final var delay, final int numAttempts, final String endCursor) -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import com.google.common.base.Strings;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.ReducePageSize;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy.RetryDecision.Fail;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy.RetryDecision.Retry;
@@ -67,6 +68,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   private static final Logger LOG = LoggerFactory.getLogger(BatchOperationExecutionScheduler.class);
 
   private final Duration initialPollingInterval;
+  private final int defaultPageSize;
   private final BatchOperationState batchOperationState;
   private final BatchOperationInitializationBehavior batchOperationInitializer;
   private final BatchOperationRetryPolicy retryPolicy;
@@ -79,10 +81,12 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final BatchOperationInitializationBehavior batchOperationInitializer,
       final BatchOperationRetryPolicy retryPolicy,
-      final Duration batchOperationSchedulerInterval) {
+      final Duration batchOperationSchedulerInterval,
+      final int defaultPageSize) {
 
     batchOperationState = scheduledTaskStateFactory.get().getBatchOperationState();
     initialPollingInterval = batchOperationSchedulerInterval;
+    this.defaultPageSize = defaultPageSize;
 
     this.batchOperationInitializer = batchOperationInitializer;
     this.retryPolicy = retryPolicy;
@@ -153,8 +157,10 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
       return initialPollingInterval;
     }
 
+    // Build context with in-memory overrides (cursor for retries, page size for buffer-full)
+    final var context = currentState.buildContext(batchOperation, defaultPageSize);
     final var outcome =
-        batchOperationInitializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+        batchOperationInitializer.initializeBatchOperation(context, taskResultBuilder);
 
     return switch (outcome) {
       case Success(final var cursor) -> {
@@ -165,6 +171,14 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
         batchOperationInitializer.appendFailedCommand(
             taskResultBuilder, batchOperation.getKey(), message, errorType);
         yield initialPollingInterval;
+      }
+      case ReducePageSize(final int newPageSize) -> {
+        LOG.debug(
+            "Buffer full for batch operation {}, reducing page size to {}",
+            batchOperation.getKey(),
+            newPageSize);
+        executionState.set(currentState.withReducedPageSize(newPageSize));
+        yield Duration.ZERO; // Retry immediately with smaller page size
       }
       case NeedsRetry(final var cursor, final var cause) ->
           handleRetry(taskResultBuilder, batchOperation, currentState, cursor, cause);
@@ -230,16 +244,24 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
    *
    * <p>However, if retries are in flight ({@code numAttempts > 0}), we should NOT skip — retries
    * are intentional re-executions after transient failures.
+   *
+   * <p>The state also tracks a reduced page size when buffer-full scenarios require smaller
+   * fetches. This avoids writing INITIALIZE commands just to persist the page size change.
    */
   static final class ExecutionLoopState {
     private final long batchOperationKey;
-    private final String lastKnownCursor;
+    private final String cursor;
+    private final int pageSize; // 0 means use default
     private final int numAttempts;
 
     private ExecutionLoopState(
-        final long batchOperationKey, final String lastKnownCursor, final int numAttempts) {
+        final long batchOperationKey,
+        final String cursor,
+        final int pageSize,
+        final int numAttempts) {
       this.batchOperationKey = batchOperationKey;
-      this.lastKnownCursor = lastKnownCursor;
+      this.cursor = cursor;
+      this.pageSize = pageSize;
       this.numAttempts = numAttempts;
     }
 
@@ -248,44 +270,62 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
       return new ExecutionLoopState(
           batchOperation.getKey(),
           Strings.nullToEmpty(batchOperation.getInitializationSearchCursor()),
+          0,
           0);
     }
 
-    /** Advances to a new cursor after successful page processing. Resets retry count. */
+    /**
+     * Advances to a new cursor after successful page processing. Resets page size and retry count.
+     */
     ExecutionLoopState advanceTo(final String newCursor) {
-      return new ExecutionLoopState(batchOperationKey, newCursor, 0);
+      return new ExecutionLoopState(batchOperationKey, newCursor, 0, 0);
     }
 
-    /** Prepares for a retry attempt with the given cursor and attempt count. */
-    ExecutionLoopState retryWith(final String cursor, final int attempts) {
-      return new ExecutionLoopState(batchOperationKey, cursor, attempts);
+    /**
+     * Prepares for a retry attempt with the given cursor and attempt count. Preserves page size.
+     */
+    ExecutionLoopState retryWith(final String newCursor, final int attempts) {
+      return new ExecutionLoopState(batchOperationKey, newCursor, pageSize, attempts);
+    }
+
+    /** Reduces page size for next attempt due to buffer full. */
+    ExecutionLoopState withReducedPageSize(final int newPageSize) {
+      return new ExecutionLoopState(batchOperationKey, cursor, newPageSize, 0);
+    }
+
+    /**
+     * Builds an {@link InitializationContext} using in-memory overrides where applicable.
+     *
+     * <p>Uses:
+     *
+     * <ul>
+     *   <li>In-memory cursor when retrying ({@code numAttempts > 0}) to avoid stale cursor race
+     *   <li>In-memory page size when reduced ({@code pageSize > 0}) to avoid stale page size race
+     *   <li>Persisted values otherwise
+     * </ul>
+     */
+    InitializationContext buildContext(
+        final PersistedBatchOperation batchOperation, final int defaultPageSize) {
+      final String effectiveCursor =
+          numAttempts > 0 ? cursor : batchOperation.getInitializationSearchCursor();
+      final int effectivePageSize =
+          pageSize > 0
+              ? pageSize
+              : batchOperation.getInitializationSearchQueryPageSize(defaultPageSize);
+      return new InitializationContext(
+          batchOperation, effectiveCursor, effectivePageSize, 0, false);
     }
 
     /**
      * Determines whether initialization should be skipped for the given batch operation.
      *
-     * <p>Precondition: This method assumes the state tracks the same batch operation as the one
-     * passed in (same key). This is guaranteed by {@link
-     * BatchOperationExecutionScheduler#getOrCreateState}, which resets state when the key changes.
-     *
-     * <p>We skip if BOTH of the following are true:
-     *
-     * <ul>
-     *   <li>Our in-memory cursor differs from the persisted cursor — this means we already appended
-     *       an INITIALIZE command that advanced our cursor, but the stream processor has NOT yet
-     *       processed it to update the persisted state. We're "ahead" and waiting for it to catch
-     *       up.
-     *   <li>No retries are in flight ({@code numAttempts == 0}) — retries are intentional
-     *       re-executions after transient failures and should proceed even if cursors differ.
-     * </ul>
-     *
-     * <p>Once the stream processor processes our command, the persisted cursor will match our
-     * in-memory cursor, and the next scheduler run will proceed (cursors equal → don't skip).
+     * <p>We skip when our in-memory cursor differs from the persisted cursor AND we're not in a
+     * retry. This means we appended an INITIALIZE command that hasn't been processed yet.
      */
     boolean shouldSkipInitialization(final PersistedBatchOperation batchOperation) {
       return batchOperationKey == batchOperation.getKey()
-          && !Objects.equals(lastKnownCursor, batchOperation.getInitializationSearchCursor())
-          && numAttempts == 0;
+          && numAttempts == 0
+          && !Objects.equals(cursor, batchOperation.getInitializationSearchCursor());
     }
 
     int numAttempts() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -43,6 +43,16 @@ import org.slf4j.LoggerFactory;
  *   <li>Handling initialization and re-initialization scenarios
  * </ul>
  *
+ * <p><b>Design decision — serial scheduling:</b> Only one batch operation is processed at a time.
+ * This is intentional for two reasons:
+ *
+ * <ul>
+ *   <li>batch operations have lower priority than normal Zeebe record processing, so we limit their
+ *       resource footprint to avoid impacting stream processing throughput; and
+ *   <li>two concurrent batch operations could target overlapping process instances, leading to
+ *       write conflicts on the same records. Serial execution eliminates both problems.
+ * </ul>
+ *
  * <p>The scheduler uses an atomic execution flag to ensure only one batch operation execution cycle
  * runs at a time, and maintains state about currently initializing operations to prevent duplicate
  * processing.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -8,9 +8,10 @@
 package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import com.google.common.base.Strings;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult.Failure;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult.Retry;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult.Success;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryDecision;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
@@ -151,29 +152,45 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
       return initialPollingInterval;
     }
 
-    final var retryResult =
-        retryHandler.executeWithRetry(
-            () ->
-                batchOperationInitializer.initializeBatchOperation(
-                    batchOperation, taskResultBuilder),
-            currentState.numAttempts());
+    final var outcome =
+        batchOperationInitializer.initializeBatchOperation(batchOperation, taskResultBuilder);
 
-    return switch (retryResult) {
+    return switch (outcome) {
       case Success(final var cursor) -> {
         executionState.set(currentState.advanceTo(cursor));
         yield initialPollingInterval;
       }
-      case Failure(final var message, final var errorType) -> {
+      case Failed(final var message, final var errorType) -> {
         batchOperationInitializer.appendFailedCommand(
             taskResultBuilder, batchOperation.getKey(), message, errorType);
         yield initialPollingInterval;
       }
-      case Retry(final var delay, final int numAttempts, final String endCursor) -> {
+      case NeedsRetry(final var cursor, final var cause) ->
+          handleRetry(taskResultBuilder, batchOperation, currentState, cursor, cause);
+    };
+  }
+
+  private Duration handleRetry(
+      final TaskResultBuilder taskResultBuilder,
+      final PersistedBatchOperation batchOperation,
+      final ExecutionLoopState currentState,
+      final String cursor,
+      final Throwable cause) {
+
+    final var decision = retryHandler.evaluate(cursor, cause, currentState.numAttempts());
+
+    return switch (decision) {
+      case RetryDecision.Fail(final var message, final var errorType) -> {
+        batchOperationInitializer.appendFailedCommand(
+            taskResultBuilder, batchOperation.getKey(), message, errorType);
+        yield initialPollingInterval;
+      }
+      case RetryDecision.Retry(final var delay, final int numAttempts, final String retryCursor) -> {
         LOG.warn(
             "Retryable operation failed, retries left: {}, retrying in {} ms",
             retryHandler.getMaxRetries() - numAttempts,
             delay.toMillis());
-        executionState.set(currentState.retryWith(endCursor, numAttempts));
+        executionState.set(currentState.retryWith(retryCursor, numAttempts));
         yield delay;
       }
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -94,10 +94,6 @@ public class BatchOperationInitializationBehavior {
   public InitializationOutcome initializeBatchOperation(
       final InitializationContext initialContext, final TaskResultBuilder taskResultBuilder) {
     final var batchOperation = initialContext.operation();
-    if (batchOperation.isSuspended()) {
-      LOG.trace("Batch operation {} is suspended.", batchOperation.getKey());
-      return new Success(batchOperation.getInitializationSearchCursor());
-    }
 
     final var itemProvider = itemProviderFactory.fromBatchOperation(batchOperation);
     var context = initialContext;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -101,29 +101,33 @@ public class BatchOperationInitializationBehavior {
     final var itemProvider = itemProviderFactory.fromBatchOperation(batchOperation);
     var context = InitializationContext.fromBatchOperation(batchOperation, queryPageSize);
 
-    while (true) {
-      final var result = pageProcessor.processNextPage(itemProvider, context, taskResultBuilder);
-
-      switch (result) {
-        case Continue(final var endCursor, final int itemsProcessed) ->
-            context = context.withNextPage(endCursor, itemsProcessed, true);
-        case Finished(final var endCursor, final int itemsProcessed) -> {
-          context = context.withNextPage(endCursor, itemsProcessed, true);
-          finishInitialization(batchOperation, taskResultBuilder);
-          startExecutionPhase(taskResultBuilder, context);
-          return new BatchOperationInitializationResult(batchOperation.getKey(), "finished");
-        }
-        case BufferFull(final int itemCount) -> {
-          return handleFailedChunkAppend(taskResultBuilder, context, itemCount);
-        }
-        case FetchFailed(final var cause) -> {
-          if (context.hasAppendedChunks()) {
-            continueInitialization(taskResultBuilder, context);
-          }
-          throw new BatchOperationInitializationException(cause, context.currentCursor());
-        }
-      }
+    var result = pageProcessor.processNextPage(itemProvider, context, taskResultBuilder);
+    while (result instanceof Continue(final var endCursor, final int itemsProcessed)) {
+      context = context.withNextPage(endCursor, itemsProcessed, true);
+      result = pageProcessor.processNextPage(itemProvider, context, taskResultBuilder);
     }
+
+    return switch (result) {
+      case Continue(final var endCursor, final int ignored) ->
+          throw new BatchOperationInitializationException(
+              "Unexpected Continue result after loop exit",
+              BatchOperationErrorType.UNKNOWN,
+              endCursor);
+      case Finished(final var endCursor, final int itemsProcessed) -> {
+        context = context.withNextPage(endCursor, itemsProcessed, true);
+        finishInitialization(batchOperation, taskResultBuilder);
+        startExecutionPhase(taskResultBuilder, context);
+        yield new BatchOperationInitializationResult(batchOperation.getKey(), "finished");
+      }
+      case BufferFull(final int itemCount) ->
+          handleFailedChunkAppend(taskResultBuilder, context, itemCount);
+      case FetchFailed(final var cause) -> {
+        if (context.hasAppendedChunks()) {
+          continueInitialization(taskResultBuilder, context);
+        }
+        throw new BatchOperationInitializationException(cause, context.currentCursor());
+      }
+    };
   }
 
   private BatchOperationInitializationResult handleFailedChunkAppend(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -10,10 +10,10 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import com.google.common.base.Strings;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.BufferFull;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.Continue;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.FetchFailed;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.Finished;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.BufferFull;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.Continue;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.FetchFailed;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.Finished;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
@@ -35,11 +35,11 @@ import org.slf4j.LoggerFactory;
  * <p>The initialization process creates an {@link
  * io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider} once per batch
  * operation via {@link ItemProviderFactory}, then fetches and processes items in pages via {@link
- * BatchOperationPageProcessor}, and builds commands through {@link BatchOperationCommandAppender}.
+ * BatchOperationChunkAppender}, and builds commands through {@link BatchOperationCommandAppender}.
  * If chunk appending fails, it attempts to reduce the page size and retry, or marks the operation
  * as failed if the minimum page size is reached.
  *
- * @see BatchOperationPageProcessor
+ * @see BatchOperationChunkAppender
  * @see BatchOperationCommandAppender
  * @see ItemProviderFactory
  * @see PersistedBatchOperation
@@ -53,18 +53,18 @@ public class BatchOperationInitializationBehavior {
   private final ItemProviderFactory itemProviderFactory;
   private final BatchOperationMetrics metrics;
   private final BatchOperationCommandAppender commandAppender;
-  private final BatchOperationPageProcessor pageProcessor;
+  private final BatchOperationChunkAppender chunkAppender;
   private final int queryPageSize;
 
   public BatchOperationInitializationBehavior(
       final ItemProviderFactory itemProviderFactory,
-      final BatchOperationPageProcessor pageProcessor,
+      final BatchOperationChunkAppender chunkAppender,
       final BatchOperationCommandAppender commandAppender,
       final int queryPageSize,
       final BatchOperationMetrics metrics) {
     this.itemProviderFactory = itemProviderFactory;
     this.commandAppender = commandAppender;
-    this.pageProcessor = pageProcessor;
+    this.chunkAppender = chunkAppender;
     this.queryPageSize = queryPageSize;
     this.metrics = metrics;
   }
@@ -101,10 +101,10 @@ public class BatchOperationInitializationBehavior {
     final var itemProvider = itemProviderFactory.fromBatchOperation(batchOperation);
     var context = InitializationContext.fromBatchOperation(batchOperation, queryPageSize);
 
-    var result = pageProcessor.processNextPage(itemProvider, context, taskResultBuilder);
+    var result = chunkAppender.processNextPage(itemProvider, context, taskResultBuilder);
     while (result instanceof Continue(final var endCursor, final int itemsProcessed)) {
       context = context.withNextPage(endCursor, itemsProcessed);
-      result = pageProcessor.processNextPage(itemProvider, context, taskResultBuilder);
+      result = chunkAppender.processNextPage(itemProvider, context, taskResultBuilder);
     }
 
     return switch (result) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -113,9 +113,9 @@ public class BatchOperationInitializationBehavior {
         context = context.withNextPage(endCursor, itemsProcessed);
         finishInitialization(batchOperation, taskResultBuilder);
         startExecutionPhase(taskResultBuilder, context);
-        yield new Success("finished");
+        yield new Success(endCursor);
       }
-      case BufferFull ignored -> handleFailedChunkAppend(taskResultBuilder, context);
+      case final BufferFull ignored -> handleFailedChunkAppend(taskResultBuilder, context);
       case FetchFailed(final var cause) -> {
         if (context.hasAppendedChunks()) {
           continueInitialization(taskResultBuilder, context);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -11,10 +11,10 @@ import com.google.common.base.Strings;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.BufferFull;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.Continue;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.FetchFailed;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.Finished;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.ChunkingOutcome.BufferFull;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.ChunkingOutcome.Continue;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.ChunkingOutcome.FetchFailed;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.ChunkingOutcome.Finished;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
@@ -124,8 +124,8 @@ public class BatchOperationInitializationBehavior {
         yield new NeedsRetry(context.currentCursor(), cause);
       }
       default ->
-          new InitializationOutcome.Failed(
-              "Unexpected InitializationOutcome result: " + result.getClass().getSimpleName(),
+          new Failed(
+              "Unexpected ChunkingOutcome:" + result.getClass().getSimpleName(),
               BatchOperationErrorType.UNKNOWN);
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -10,6 +10,9 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import com.google.common.base.Strings;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.BufferFull;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.Continue;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.Finished;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
@@ -99,18 +102,20 @@ public class BatchOperationInitializationBehavior {
       try {
         final var page = itemProvider.fetchItemPage(context.currentCursor(), context.pageSize());
         final var result =
-            pageProcessor.processPage(batchOperation.getKey(), page, taskResultBuilder);
+            pageProcessor.processPage(context.operation().getKey(), page, taskResultBuilder);
 
-        if (result.chunksAppended()) {
-          context = context.withNextPage(result.endCursor(), result.itemsProcessed(), true);
-
-          if (result.isLastPage()) {
+        switch (result) {
+          case Continue(final var endCursor, final int itemsProcessed) ->
+              context = context.withNextPage(endCursor, itemsProcessed, true);
+          case Finished(final var endCursor, final int itemsProcessed) -> {
+            context = context.withNextPage(endCursor, itemsProcessed, true);
             finishInitialization(batchOperation, taskResultBuilder);
             startExecutionPhase(taskResultBuilder, context);
             return new BatchOperationInitializationResult(batchOperation.getKey(), "finished");
           }
-        } else {
-          return handleFailedChunkAppend(taskResultBuilder, context, result.itemsProcessed());
+          case BufferFull(final int itemCount) -> {
+            return handleFailedChunkAppend(taskResultBuilder, context, itemCount);
+          }
         }
       } catch (final BatchOperationInitializationException e) {
         throw e;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -187,10 +187,6 @@ public class BatchOperationInitializationBehavior {
     commandAppender.appendFailureCommand(taskResultBuilder, batchOperationKey, message, errorType);
   }
 
-  public record BatchOperationInitializationResult(
-      long batchOperationKey, String searchResultCursor) {}
-
-
   /**
    * Represents the outcome of a batch operation initialization attempt.
    *

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -38,11 +38,11 @@ import org.slf4j.LoggerFactory;
  * @see ItemProviderFactory
  * @see PersistedBatchOperation
  */
-public class BatchOperationInitializationHelper {
+public class BatchOperationInitializationBehavior {
   public static final String ERROR_MSG_FAILED_FIRST_CHUNK_APPEND =
       "Unable to append first chunk of batch operation items. Number of items: %d";
   private static final Logger LOG =
-      LoggerFactory.getLogger(BatchOperationInitializationHelper.class);
+      LoggerFactory.getLogger(BatchOperationInitializationBehavior.class);
 
   private final ItemProviderFactory itemProviderFactory;
   private final BatchOperationMetrics metrics;
@@ -50,7 +50,7 @@ public class BatchOperationInitializationHelper {
   private final BatchOperationPageProcessor pageProcessor;
   private final int queryPageSize;
 
-  public BatchOperationInitializationHelper(
+  public BatchOperationInitializationBehavior(
       final ItemProviderFactory itemProviderFactory,
       final BatchOperationPageProcessor pageProcessor,
       final BatchOperationCommandAppender commandAppender,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -101,10 +101,10 @@ public class BatchOperationInitializationBehavior {
     final var itemProvider = itemProviderFactory.fromBatchOperation(batchOperation);
     var context = InitializationContext.fromBatchOperation(batchOperation, queryPageSize);
 
-    var result = chunkAppender.processNextPage(itemProvider, context, taskResultBuilder);
+    var result = chunkAppender.fetchAndChunkNextPage(itemProvider, context, taskResultBuilder);
     while (result instanceof Continue(final var endCursor, final int itemsProcessed)) {
       context = context.withNextPage(endCursor, itemsProcessed);
-      result = chunkAppender.processNextPage(itemProvider, context, taskResultBuilder);
+      result = chunkAppender.fetchAndChunkNextPage(itemProvider, context, taskResultBuilder);
     }
 
     return switch (result) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -103,7 +103,7 @@ public class BatchOperationInitializationBehavior {
 
     var result = pageProcessor.processNextPage(itemProvider, context, taskResultBuilder);
     while (result instanceof Continue(final var endCursor, final int itemsProcessed)) {
-      context = context.withNextPage(endCursor, itemsProcessed, true);
+      context = context.withNextPage(endCursor, itemsProcessed);
       result = pageProcessor.processNextPage(itemProvider, context, taskResultBuilder);
     }
 
@@ -114,7 +114,7 @@ public class BatchOperationInitializationBehavior {
               BatchOperationErrorType.UNKNOWN,
               endCursor);
       case Finished(final var endCursor, final int itemsProcessed) -> {
-        context = context.withNextPage(endCursor, itemsProcessed, true);
+        context = context.withNextPage(endCursor, itemsProcessed);
         finishInitialization(batchOperation, taskResultBuilder);
         startExecutionPhase(taskResultBuilder, context);
         yield new BatchOperationInitializationResult(batchOperation.getKey(), "finished");

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -9,11 +9,15 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import com.google.common.base.Strings;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.BufferFull;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.Continue;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.FetchFailed;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult.Finished;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
@@ -32,9 +36,8 @@ import org.slf4j.LoggerFactory;
  *   <li>Recording metrics for batch operation performance
  * </ul/>
  *
- * <p>The initialization process creates an {@link
- * io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider} once per batch
- * operation via {@link ItemProviderFactory}, then fetches and processes items in pages via {@link
+ * <p>The initialization process creates an {@link ItemProvider} once per batch operation via {@link
+ * ItemProviderFactory}, then fetches and processes items in pages via {@link
  * BatchOperationChunkAppender}, and builds commands through {@link BatchOperationCommandAppender}.
  * If chunk appending fails, it attempts to reduce the page size and retry, or marks the operation
  * as failed if the minimum page size is reached.
@@ -80,22 +83,20 @@ public class BatchOperationInitializationBehavior {
    *   <li>Handling chunk appending failures with retries and page size reduction
    *   <li>Transitioning to the execution phase once initialization is complete
    *   <li>Recording metrics for the operation
-   *   <li>Returning a result containing the batch operation key and search result cursor
    * </ul>
    *
-   * This method is designed to be resilient against failures during the initialization phase,
-   * allowing for retries and adjustments to the page size if necessary.
+   * <p>This method returns an {@link InitializationOutcome} indicating success, need for retry, or
+   * terminal failure. It does not throw exceptions for control flow.
    *
    * @param batchOperation the batch operation to initialize
    * @param taskResultBuilder the builder to append task results
-   * @return a result containing the batch operation key and search result cursor
+   * @return the outcome of the initialization attempt
    */
-  public BatchOperationInitializationResult initializeBatchOperation(
+  public InitializationOutcome initializeBatchOperation(
       final PersistedBatchOperation batchOperation, final TaskResultBuilder taskResultBuilder) {
     if (batchOperation.isSuspended()) {
       LOG.trace("Batch operation {} is suspended.", batchOperation.getKey());
-      return new BatchOperationInitializationResult(
-          batchOperation.getKey(), batchOperation.getInitializationSearchCursor());
+      return new Success(batchOperation.getInitializationSearchCursor());
     }
 
     final var itemProvider = itemProviderFactory.fromBatchOperation(batchOperation);
@@ -108,16 +109,11 @@ public class BatchOperationInitializationBehavior {
     }
 
     return switch (result) {
-      case Continue(final var endCursor, final int ignored) ->
-          throw new BatchOperationInitializationException(
-              "Unexpected Continue result after loop exit",
-              BatchOperationErrorType.UNKNOWN,
-              endCursor);
       case Finished(final var endCursor, final int itemsProcessed) -> {
         context = context.withNextPage(endCursor, itemsProcessed);
         finishInitialization(batchOperation, taskResultBuilder);
         startExecutionPhase(taskResultBuilder, context);
-        yield new BatchOperationInitializationResult(batchOperation.getKey(), "finished");
+        yield new Success("finished");
       }
       case BufferFull(final int itemCount) ->
           handleFailedChunkAppend(taskResultBuilder, context, itemCount);
@@ -125,12 +121,17 @@ public class BatchOperationInitializationBehavior {
         if (context.hasAppendedChunks()) {
           continueInitialization(taskResultBuilder, context);
         }
-        throw new BatchOperationInitializationException(cause, context.currentCursor());
+        yield new NeedsRetry(context.currentCursor(), cause);
       }
+      default ->
+          new InitializationOutcome.Failed(
+              "Unexpected InitializationOutcome result: " + result.getClass().getSimpleName(),
+              BatchOperationErrorType.UNKNOWN,
+              context.currentCursor());
     };
   }
 
-  private BatchOperationInitializationResult handleFailedChunkAppend(
+  private InitializationOutcome handleFailedChunkAppend(
       final TaskResultBuilder taskResultBuilder,
       final InitializationContext context,
       final int itemCount) {
@@ -138,17 +139,17 @@ public class BatchOperationInitializationBehavior {
       if (context.pageSize() > 1) {
         final var reducedContext = context.withHalvedPageSize();
         continueInitialization(taskResultBuilder, reducedContext);
+        return new Success(Strings.nullToEmpty(reducedContext.currentCursor()));
       } else {
-        throw new BatchOperationInitializationException(
+        return new Failed(
             String.format(ERROR_MSG_FAILED_FIRST_CHUNK_APPEND, itemCount),
             BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED,
             context.currentCursor());
       }
     } else {
       continueInitialization(taskResultBuilder, context);
+      return new Success(Strings.nullToEmpty(context.currentCursor()));
     }
-    return new BatchOperationInitializationResult(
-        context.operation().getKey(), Strings.nullToEmpty(context.currentCursor()));
   }
 
   private void startExecutionPhase(
@@ -219,5 +220,28 @@ public class BatchOperationInitializationBehavior {
     public String getEndCursor() {
       return endCursor;
     }
+  }
+
+  /**
+   * Represents the outcome of a batch operation initialization attempt.
+   *
+   * <p>This sealed interface provides explicit outcomes without using exceptions for control flow:
+   *
+   * <ul>
+   *   <li>{@link Success} - initialization completed successfully or made progress
+   *   <li>{@link NeedsRetry} - a transient failure occurred, retry is possible
+   *   <li>{@link Failed} - a terminal failure occurred, no retry possible
+   * </ul>
+   */
+  public sealed interface InitializationOutcome {
+    /** Initialization succeeded or made progress. Contains the cursor for the next page. */
+    record Success(String cursor) implements InitializationOutcome {}
+
+    /** A transient failure occurred. Contains the cursor to resume from and the cause. */
+    record NeedsRetry(String cursor, Throwable cause) implements InitializationOutcome {}
+
+    /** A terminal failure occurred. Contains the error message and type. */
+    record Failed(String message, BatchOperationErrorType errorType, String cursor)
+        implements InitializationOutcome {}
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -38,12 +38,12 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The initialization process creates an {@link ItemProvider} once per batch operation via {@link
  * ItemProviderFactory}, then fetches and processes items in pages via {@link
- * BatchOperationChunkAppender}, and builds commands through {@link BatchOperationCommandAppender}.
- * If chunk appending fails, it attempts to reduce the page size and retry, or marks the operation
- * as failed if the minimum page size is reached.
+ * BatchOperationChunkAppender}, and builds commands through {@link BatchOperationCommands}. If
+ * chunk appending fails, it attempts to reduce the page size and retry, or marks the operation as
+ * failed if the minimum page size is reached.
  *
  * @see BatchOperationChunkAppender
- * @see BatchOperationCommandAppender
+ * @see BatchOperationCommands
  * @see ItemProviderFactory
  * @see PersistedBatchOperation
  */
@@ -55,18 +55,18 @@ public class BatchOperationInitializationBehavior {
 
   private final ItemProviderFactory itemProviderFactory;
   private final BatchOperationMetrics metrics;
-  private final BatchOperationCommandAppender commandAppender;
+  private final BatchOperationCommands commands;
   private final BatchOperationChunkAppender chunkAppender;
   private final int queryPageSize;
 
   public BatchOperationInitializationBehavior(
       final ItemProviderFactory itemProviderFactory,
       final BatchOperationChunkAppender chunkAppender,
-      final BatchOperationCommandAppender commandAppender,
+      final BatchOperationCommands commands,
       final int queryPageSize,
       final BatchOperationMetrics metrics) {
     this.itemProviderFactory = itemProviderFactory;
-    this.commandAppender = commandAppender;
+    this.commands = commands;
     this.chunkAppender = chunkAppender;
     this.queryPageSize = queryPageSize;
     this.metrics = metrics;
@@ -152,7 +152,7 @@ public class BatchOperationInitializationBehavior {
 
   private void startExecutionPhase(
       final TaskResultBuilder resultBuilder, final InitializationContext context) {
-    commandAppender.appendExecutionCommand(resultBuilder, context.operation().getKey());
+    commands.appendExecutionCommand(resultBuilder, context.operation().getKey());
 
     metrics.recordItemsPerPartition(
         context.operation().getNumTotalItems() + context.itemsProcessed(),
@@ -165,14 +165,14 @@ public class BatchOperationInitializationBehavior {
 
   private void finishInitialization(
       final PersistedBatchOperation batchOperation, final TaskResultBuilder resultBuilder) {
-    commandAppender.appendFinishInitializationCommand(resultBuilder, batchOperation.getKey());
+    commands.appendFinishInitializationCommand(resultBuilder, batchOperation.getKey());
     metrics.recordInitialized(batchOperation.getBatchOperationType());
   }
 
   private void continueInitialization(
       final TaskResultBuilder taskResultBuilder, final InitializationContext context) {
 
-    commandAppender.appendInitializationCommand(
+    commands.appendInitializationCommand(
         taskResultBuilder,
         context.operation().getKey(),
         context.currentCursor(),
@@ -184,7 +184,7 @@ public class BatchOperationInitializationBehavior {
       final long batchOperationKey,
       final String message,
       final BatchOperationErrorType errorType) {
-    commandAppender.appendFailureCommand(taskResultBuilder, batchOperationKey, message, errorType);
+    commands.appendFailureCommand(taskResultBuilder, batchOperationKey, message, errorType);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -49,8 +49,8 @@ import org.slf4j.LoggerFactory;
  * @see PersistedBatchOperation
  */
 public class BatchOperationInitializationBehavior {
-  public static final String ERROR_MSG_FAILED_FIRST_CHUNK_APPEND =
-      "Unable to append first chunk of batch operation items. Number of items: %d";
+  private static final String ERROR_MSG_BUFFER_CAPACITY_EXCEEDED =
+      "Result buffer too small: cannot fit even a single item after reducing page size to minimum";
   private static final Logger LOG =
       LoggerFactory.getLogger(BatchOperationInitializationBehavior.class);
 
@@ -115,8 +115,7 @@ public class BatchOperationInitializationBehavior {
         startExecutionPhase(taskResultBuilder, context);
         yield new Success("finished");
       }
-      case BufferFull(final int itemCount) ->
-          handleFailedChunkAppend(taskResultBuilder, context, itemCount);
+      case BufferFull ignored -> handleFailedChunkAppend(taskResultBuilder, context);
       case FetchFailed(final var cause) -> {
         if (context.hasAppendedChunks()) {
           continueInitialization(taskResultBuilder, context);
@@ -131,9 +130,7 @@ public class BatchOperationInitializationBehavior {
   }
 
   private InitializationOutcome handleFailedChunkAppend(
-      final TaskResultBuilder taskResultBuilder,
-      final InitializationContext context,
-      final int itemCount) {
+      final TaskResultBuilder taskResultBuilder, final InitializationContext context) {
     if (!context.hasAppendedChunks()) {
       if (context.pageSize() > 1) {
         final var reducedContext = context.withHalvedPageSize();
@@ -141,7 +138,7 @@ public class BatchOperationInitializationBehavior {
         return new ReducePageSize(reducedContext.pageSize());
       } else {
         return new Failed(
-            String.format(ERROR_MSG_FAILED_FIRST_CHUNK_APPEND, itemCount),
+            ERROR_MSG_BUFFER_CAPACITY_EXCEEDED,
             BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED);
       }
     } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -126,8 +126,7 @@ public class BatchOperationInitializationBehavior {
       default ->
           new InitializationOutcome.Failed(
               "Unexpected InitializationOutcome result: " + result.getClass().getSimpleName(),
-              BatchOperationErrorType.UNKNOWN,
-              context.currentCursor());
+              BatchOperationErrorType.UNKNOWN);
     };
   }
 
@@ -143,8 +142,7 @@ public class BatchOperationInitializationBehavior {
       } else {
         return new Failed(
             String.format(ERROR_MSG_FAILED_FIRST_CHUNK_APPEND, itemCount),
-            BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED,
-            context.currentCursor());
+            BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED);
       }
     } else {
       continueInitialization(taskResultBuilder, context);
@@ -184,43 +182,14 @@ public class BatchOperationInitializationBehavior {
   public void appendFailedCommand(
       final TaskResultBuilder taskResultBuilder,
       final long batchOperationKey,
-      final BatchOperationInitializationException exception) {
-    commandAppender.appendFailureCommand(
-        taskResultBuilder, batchOperationKey, exception.getMessage(), exception.getErrorType());
+      final String message,
+      final BatchOperationErrorType errorType) {
+    commandAppender.appendFailureCommand(taskResultBuilder, batchOperationKey, message, errorType);
   }
 
   public record BatchOperationInitializationResult(
       long batchOperationKey, String searchResultCursor) {}
 
-  public static class BatchOperationInitializationException extends RuntimeException {
-    private final String endCursor;
-    private final BatchOperationErrorType errorType;
-
-    public BatchOperationInitializationException(final Throwable e, final String endCursor) {
-      super(
-          String.format(
-              "Failed to initialize batch operation with end cursor: %s. Reason: %s",
-              endCursor, e.getMessage()),
-          e);
-      this.endCursor = endCursor;
-      errorType = BatchOperationErrorType.QUERY_FAILED;
-    }
-
-    public BatchOperationInitializationException(
-        final String message, final BatchOperationErrorType errorType, final String endCursor) {
-      super(message);
-      this.endCursor = endCursor;
-      this.errorType = errorType;
-    }
-
-    public BatchOperationErrorType getErrorType() {
-      return errorType;
-    }
-
-    public String getEndCursor() {
-      return endCursor;
-    }
-  }
 
   /**
    * Represents the outcome of a batch operation initialization attempt.
@@ -241,7 +210,7 @@ public class BatchOperationInitializationBehavior {
     record NeedsRetry(String cursor, Throwable cause) implements InitializationOutcome {}
 
     /** A terminal failure occurred. Contains the error message and type. */
-    record Failed(String message, BatchOperationErrorType errorType, String cursor)
+    record Failed(String message, BatchOperationErrorType errorType)
         implements InitializationOutcome {}
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.BufferFull;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.Continue;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.FetchFailed;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult.Finished;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
@@ -31,10 +32,12 @@ import org.slf4j.LoggerFactory;
  *   <li>Recording metrics for batch operation performance
  * </ul/>
  *
- * <p>The initialization process fetches items using an {@link ItemProviderFactory}, processes them
- * in pages via {@link BatchOperationPageProcessor}, and builds commands through {@link
- * BatchOperationCommandAppender}. If chunk appending fails, it attempts to reduce the page size and
- * retry, or marks the operation as failed if the minimum page size is reached.
+ * <p>The initialization process creates an {@link
+ * io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider} once per batch
+ * operation via {@link ItemProviderFactory}, then fetches and processes items in pages via {@link
+ * BatchOperationPageProcessor}, and builds commands through {@link BatchOperationCommandAppender}.
+ * If chunk appending fails, it attempts to reduce the page size and retry, or marks the operation
+ * as failed if the minimum page size is reached.
  *
  * @see BatchOperationPageProcessor
  * @see BatchOperationCommandAppender
@@ -99,31 +102,26 @@ public class BatchOperationInitializationBehavior {
     var context = InitializationContext.fromBatchOperation(batchOperation, queryPageSize);
 
     while (true) {
-      try {
-        final var page = itemProvider.fetchItemPage(context.currentCursor(), context.pageSize());
-        final var result =
-            pageProcessor.processPage(context.operation().getKey(), page, taskResultBuilder);
+      final var result = pageProcessor.processNextPage(itemProvider, context, taskResultBuilder);
 
-        switch (result) {
-          case Continue(final var endCursor, final int itemsProcessed) ->
-              context = context.withNextPage(endCursor, itemsProcessed, true);
-          case Finished(final var endCursor, final int itemsProcessed) -> {
+      switch (result) {
+        case Continue(final var endCursor, final int itemsProcessed) ->
             context = context.withNextPage(endCursor, itemsProcessed, true);
-            finishInitialization(batchOperation, taskResultBuilder);
-            startExecutionPhase(taskResultBuilder, context);
-            return new BatchOperationInitializationResult(batchOperation.getKey(), "finished");
-          }
-          case BufferFull(final int itemCount) -> {
-            return handleFailedChunkAppend(taskResultBuilder, context, itemCount);
-          }
+        case Finished(final var endCursor, final int itemsProcessed) -> {
+          context = context.withNextPage(endCursor, itemsProcessed, true);
+          finishInitialization(batchOperation, taskResultBuilder);
+          startExecutionPhase(taskResultBuilder, context);
+          return new BatchOperationInitializationResult(batchOperation.getKey(), "finished");
         }
-      } catch (final BatchOperationInitializationException e) {
-        throw e;
-      } catch (final Exception e) {
-        if (context.hasAppendedChunks()) {
-          continueInitialization(taskResultBuilder, context);
+        case BufferFull(final int itemCount) -> {
+          return handleFailedChunkAppend(taskResultBuilder, context, itemCount);
         }
-        throw new BatchOperationInitializationException(e, context.currentCursor());
+        case FetchFailed(final var cause) -> {
+          if (context.hasAppendedChunks()) {
+            continueInitialization(taskResultBuilder, context);
+          }
+          throw new BatchOperationInitializationException(cause, context.currentCursor());
+        }
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperatio
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.ChunkingOutcome.Finished;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.ReducePageSize;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
@@ -57,18 +58,15 @@ public class BatchOperationInitializationBehavior {
   private final BatchOperationMetrics metrics;
   private final BatchOperationCommands commands;
   private final BatchOperationChunkAppender chunkAppender;
-  private final int queryPageSize;
 
   public BatchOperationInitializationBehavior(
       final ItemProviderFactory itemProviderFactory,
       final BatchOperationChunkAppender chunkAppender,
       final BatchOperationCommands commands,
-      final int queryPageSize,
       final BatchOperationMetrics metrics) {
     this.itemProviderFactory = itemProviderFactory;
     this.commands = commands;
     this.chunkAppender = chunkAppender;
-    this.queryPageSize = queryPageSize;
     this.metrics = metrics;
   }
 
@@ -88,19 +86,21 @@ public class BatchOperationInitializationBehavior {
    * <p>This method returns an {@link InitializationOutcome} indicating success, need for retry, or
    * terminal failure. It does not throw exceptions for control flow.
    *
-   * @param batchOperation the batch operation to initialize
+   * @param initialContext the initialization context (cursor, page size, etc.) built by the
+   *     scheduler
    * @param taskResultBuilder the builder to append task results
    * @return the outcome of the initialization attempt
    */
   public InitializationOutcome initializeBatchOperation(
-      final PersistedBatchOperation batchOperation, final TaskResultBuilder taskResultBuilder) {
+      final InitializationContext initialContext, final TaskResultBuilder taskResultBuilder) {
+    final var batchOperation = initialContext.operation();
     if (batchOperation.isSuspended()) {
       LOG.trace("Batch operation {} is suspended.", batchOperation.getKey());
       return new Success(batchOperation.getInitializationSearchCursor());
     }
 
     final var itemProvider = itemProviderFactory.fromBatchOperation(batchOperation);
-    var context = InitializationContext.fromBatchOperation(batchOperation, queryPageSize);
+    var context = initialContext;
 
     var result = chunkAppender.fetchAndChunkNextPage(itemProvider, context, taskResultBuilder);
     while (result instanceof Continue(final var endCursor, final int itemsProcessed)) {
@@ -138,7 +138,7 @@ public class BatchOperationInitializationBehavior {
       if (context.pageSize() > 1) {
         final var reducedContext = context.withHalvedPageSize();
         continueInitialization(taskResultBuilder, reducedContext);
-        return new Success(Strings.nullToEmpty(reducedContext.currentCursor()));
+        return new ReducePageSize(reducedContext.pageSize());
       } else {
         return new Failed(
             String.format(ERROR_MSG_FAILED_FIRST_CHUNK_APPEND, itemCount),
@@ -195,6 +195,7 @@ public class BatchOperationInitializationBehavior {
    * <ul>
    *   <li>{@link Success} - initialization completed successfully or made progress
    *   <li>{@link NeedsRetry} - a transient failure occurred, retry is possible
+   *   <li>{@link ReducePageSize} - buffer was full, retry with smaller page size
    *   <li>{@link Failed} - a terminal failure occurred, no retry possible
    * </ul>
    */
@@ -204,6 +205,12 @@ public class BatchOperationInitializationBehavior {
 
     /** A transient failure occurred. Contains the cursor to resume from and the cause. */
     record NeedsRetry(String cursor, Throwable cause) implements InitializationOutcome {}
+
+    /**
+     * Buffer was full before any chunks were appended. Retry immediately with reduced page size. No
+     * command is written — the scheduler tracks the reduced page size in memory.
+     */
+    record ReducePageSize(int newPageSize) implements InitializationOutcome {}
 
     /** A terminal failure occurred. Contains the error message and type. */
     record Failed(String message, BatchOperationErrorType errorType)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import com.google.common.collect.Lists;
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -64,7 +65,7 @@ public class BatchOperationPageProcessor {
    * @return a result indicating whether chunks were appended, the end cursor, number of items
    *     processed, and if it was the last page
    */
-  public PageProcessingResult processPage(
+  private PageProcessingResult processPage(
       final long batchOperationKey,
       final ItemPage page,
       final TaskResultBuilder taskResultBuilder) {
@@ -77,6 +78,29 @@ public class BatchOperationPageProcessor {
       return new PageProcessingResult.Finished(page.endCursor(), page.items().size());
     }
     return new PageProcessingResult.Continue(page.endCursor(), page.items().size());
+  }
+
+  /**
+   * Fetches the next page of items and processes it into chunks. If the fetch fails, a {@link
+   * PageProcessingResult.FetchFailed} is returned instead of throwing an exception.
+   *
+   * @param itemProvider the item provider to fetch the page from
+   * @param context the current initialization context (cursor, page size)
+   * @param taskResultBuilder the builder to append command records to
+   * @return the result of processing the page, or a {@link PageProcessingResult.FetchFailed} if the
+   *     fetch fails
+   */
+  public PageProcessingResult processNextPage(
+      final ItemProvider itemProvider,
+      final InitializationContext context,
+      final TaskResultBuilder taskResultBuilder) {
+    final ItemPage page;
+    try {
+      page = itemProvider.fetchItemPage(context.currentCursor(), context.pageSize());
+    } catch (final Exception e) {
+      return new PageProcessingResult.FetchFailed(e);
+    }
+    return processPage(context.operation().getKey(), page, taskResultBuilder);
   }
 
   private boolean appendChunks(
@@ -143,6 +167,7 @@ public class BatchOperationPageProcessor {
    *   <li>{@link Continue} — chunks were appended, more pages remain
    *   <li>{@link Finished} — chunks were appended and this was the last page
    *   <li>{@link BufferFull} — chunks could not fit in the result buffer
+   *   <li>{@link FetchFailed} — fetching the page failed with an exception
    * </ul>
    */
   public sealed interface PageProcessingResult {
@@ -154,5 +179,8 @@ public class BatchOperationPageProcessor {
 
     /** Chunks could not fit in the result buffer. */
     record BufferFull(int itemsProcessed) implements PageProcessingResult {}
+
+    /** Fetching the page from the item provider failed. */
+    record FetchFailed(Exception cause) implements PageProcessingResult {}
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessor.java
@@ -69,8 +69,14 @@ public class BatchOperationPageProcessor {
       final ItemPage page,
       final TaskResultBuilder taskResultBuilder) {
     final boolean appendedChunks = appendChunks(taskResultBuilder, batchOperationKey, page.items());
-    return new PageProcessingResult(
-        appendedChunks, page.endCursor(), page.items().size(), page.isLastPage());
+
+    if (!appendedChunks) {
+      return new PageProcessingResult.BufferFull(page.items().size());
+    }
+    if (page.isLastPage()) {
+      return new PageProcessingResult.Finished(page.endCursor(), page.items().size());
+    }
+    return new PageProcessingResult.Continue(page.endCursor(), page.items().size());
   }
 
   private boolean appendChunks(
@@ -130,6 +136,23 @@ public class BatchOperationPageProcessor {
         .setRootProcessInstanceKey(Optional.ofNullable(item.rootProcessInstanceKey()).orElse(-1L));
   }
 
-  public record PageProcessingResult(
-      boolean chunksAppended, String endCursor, int itemsProcessed, boolean isLastPage) {}
+  /**
+   * Represents the outcome of processing a page of batch operation items.
+   *
+   * <ul>
+   *   <li>{@link Continue} — chunks were appended, more pages remain
+   *   <li>{@link Finished} — chunks were appended and this was the last page
+   *   <li>{@link BufferFull} — chunks could not fit in the result buffer
+   * </ul>
+   */
+  public sealed interface PageProcessingResult {
+    /** Chunks were appended and more pages remain. */
+    record Continue(String endCursor, int itemsProcessed) implements PageProcessingResult {}
+
+    /** Chunks were appended and this was the last page. */
+    record Finished(String endCursor, int itemsProcessed) implements PageProcessingResult {}
+
+    /** Chunks could not fit in the result buffer. */
+    record BufferFull(int itemsProcessed) implements PageProcessingResult {}
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationException;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationResult;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import java.time.Duration;
 import java.util.Set;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
@@ -9,11 +9,11 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
+import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import java.time.Duration;
 import java.util.Set;
 
@@ -67,17 +67,22 @@ public class BatchOperationRetryHandler {
     final var outcome = operation.execute();
     return switch (outcome) {
       case Success(final var cursor) -> RetryResult.success(cursor);
-      case Failed(final var message, final var errorType, final var cursor) ->
-          RetryResult.failure(
-              new BatchOperationInitializationException(message, errorType, cursor));
+      case Failed(final var message, final var errorType) ->
+          RetryResult.failure(message, errorType);
       case NeedsRetry(final var cursor, final var cause) -> {
         if (shouldFailImmediately(cause) || numAttempts >= maxRetries) {
-          yield RetryResult.failure(new BatchOperationInitializationException(cause, cursor));
+          yield RetryResult.failure(formatErrorMessage(cursor, cause), BatchOperationErrorType.QUERY_FAILED);
         }
         final Duration nextDelay = calculateNextDelay(numAttempts);
         yield RetryResult.retry(nextDelay, numAttempts + 1, cursor);
       }
     };
+  }
+
+  private String formatErrorMessage(final String cursor, final Throwable cause) {
+    return String.format(
+        "Failed to initialize batch operation with end cursor: %s. Reason: %s",
+        cursor, cause.getMessage());
   }
 
   private boolean shouldFailImmediately(final Throwable cause) {
@@ -107,8 +112,8 @@ public class BatchOperationRetryHandler {
       return new Success(searchResultCursor);
     }
 
-    static Failure failure(final BatchOperationInitializationException exception) {
-      return new Failure(exception);
+    static Failure failure(final String message, final BatchOperationErrorType errorType) {
+      return new Failure(message, errorType);
     }
 
     static Retry retry(final Duration delay, final int numAttempts, final String endCursor) {
@@ -117,7 +122,7 @@ public class BatchOperationRetryHandler {
 
     record Success(String searchResultCursor) implements RetryResult {}
 
-    record Failure(BatchOperationInitializationException exception) implements RetryResult {}
+    record Failure(String message, BatchOperationErrorType errorType) implements RetryResult {}
 
     record Retry(Duration delay, int numAttempts, String endCursor) implements RetryResult {}
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
@@ -9,26 +9,21 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import java.time.Duration;
 import java.util.Set;
 
 /**
- * Handles retry logic for batch operations with configurable retry policies.
+ * Evaluates retry policy for batch operation failures.
  *
  * <p>This handler implements exponential backoff retry strategy with configurable parameters for
- * initial delay, maximum delay, maximum retries, and backoff factor. It also supports immediate
- * failure for certain types of exceptions that should not be retried.
+ * initial delay, maximum delay, maximum retries, and backoff factor. It determines whether a
+ * failure should be retried or should fail immediately.
  *
  * <p>The handler will immediately fail operations that encounter exceptions with specific reasons
  * such as NOT_FOUND, NOT_UNIQUE, SECONDARY_STORAGE_NOT_SET, or FORBIDDEN.
  *
- * @see RetryableOperation
- * @see RetryResult
+ * @see RetryDecision
  */
 public class BatchOperationRetryHandler {
   private static final Set<Reason> FAIL_IMMEDIATELY_REASONS =
@@ -52,31 +47,19 @@ public class BatchOperationRetryHandler {
   }
 
   /**
-   * Executes a retryable operation with retry logic.
+   * Evaluates whether a transient failure should be retried or should fail permanently.
    *
-   * <p>This method will execute the provided operation and evaluate its outcome. If the operation
-   * returns a {@link NeedsRetry} outcome with a recoverable failure, it will return a {@link
-   * RetryResult.Retry} indicating the next delay. If the operation fails irrecoverably or exceeds
-   * the maximum number of retries, it will return a {@link RetryResult.Failure}.
-   *
-   * @param operation the operation to execute
-   * @param numAttempts the current number of attempts made to execute the operation
-   * @return the result of the retry operation
+   * @param cursor the cursor to resume from if retrying
+   * @param cause the exception that caused the failure
+   * @param numAttempts the current number of attempts made
+   * @return a decision indicating whether to retry (with delay) or fail permanently
    */
-  public RetryResult executeWithRetry(final RetryableOperation operation, final int numAttempts) {
-    final var outcome = operation.execute();
-    return switch (outcome) {
-      case Success(final var cursor) -> RetryResult.success(cursor);
-      case Failed(final var message, final var errorType) ->
-          RetryResult.failure(message, errorType);
-      case NeedsRetry(final var cursor, final var cause) -> {
-        if (shouldFailImmediately(cause) || numAttempts >= maxRetries) {
-          yield RetryResult.failure(formatErrorMessage(cursor, cause), BatchOperationErrorType.QUERY_FAILED);
-        }
-        final Duration nextDelay = calculateNextDelay(numAttempts);
-        yield RetryResult.retry(nextDelay, numAttempts + 1, cursor);
-      }
-    };
+  public RetryDecision evaluate(final String cursor, final Throwable cause, final int numAttempts) {
+    if (shouldFailImmediately(cause) || numAttempts >= maxRetries) {
+      return RetryDecision.fail(formatErrorMessage(cursor, cause), BatchOperationErrorType.QUERY_FAILED);
+    }
+    final Duration nextDelay = calculateNextDelay(numAttempts);
+    return RetryDecision.retry(nextDelay, numAttempts + 1, cursor);
   }
 
   private String formatErrorMessage(final String cursor, final Throwable cause) {
@@ -101,40 +84,19 @@ public class BatchOperationRetryHandler {
   }
 
   /**
-   * Represents the result of a retry operation.
-   *
-   * <p>This interface defines three possible outcomes: success, failure, and retry. Each outcome
-   * carries relevant data such as batch operation key, search result cursor, or exception details.
+   * Represents the decision of whether to retry or fail permanently.
    */
-  public sealed interface RetryResult
-      permits RetryResult.Success, RetryResult.Failure, RetryResult.Retry {
-    static Success success(final String searchResultCursor) {
-      return new Success(searchResultCursor);
+  public sealed interface RetryDecision {
+    static Fail fail(final String message, final BatchOperationErrorType errorType) {
+      return new Fail(message, errorType);
     }
 
-    static Failure failure(final String message, final BatchOperationErrorType errorType) {
-      return new Failure(message, errorType);
+    static Retry retry(final Duration delay, final int numAttempts, final String cursor) {
+      return new Retry(delay, numAttempts, cursor);
     }
 
-    static Retry retry(final Duration delay, final int numAttempts, final String endCursor) {
-      return new Retry(delay, numAttempts, endCursor);
-    }
+    record Fail(String message, BatchOperationErrorType errorType) implements RetryDecision {}
 
-    record Success(String searchResultCursor) implements RetryResult {}
-
-    record Failure(String message, BatchOperationErrorType errorType) implements RetryResult {}
-
-    record Retry(Duration delay, int numAttempts, String endCursor) implements RetryResult {}
-  }
-
-  /**
-   * Represents a retryable operation that can be executed with retry logic.
-   *
-   * <p>This functional interface allows defining operations that return an {@link
-   * InitializationOutcome} indicating success, need for retry, or terminal failure.
-   */
-  @FunctionalInterface
-  public interface RetryableOperation {
-    InitializationOutcome execute();
+    record Retry(Duration delay, int numAttempts, String cursor) implements RetryDecision {}
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationResult;
-import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Failed;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.NeedsRetry;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome.Success;
 import java.time.Duration;
 import java.util.Set;
 
@@ -52,36 +54,35 @@ public class BatchOperationRetryHandler {
   /**
    * Executes a retryable operation with retry logic.
    *
-   * <p>This method will attempt to execute the provided operation, handling retries according to
-   * the configured parameters. If the operation fails with a recoverable exception, it will return
-   * a {@link RetryResult.Retry} indicating the next delay and updated context. If the operation
-   * fails irrecoverably or exceeds the maximum number of retries, it will return a {@link
-   * RetryResult.Failure}.
+   * <p>This method will execute the provided operation and evaluate its outcome. If the operation
+   * returns a {@link NeedsRetry} outcome with a recoverable failure, it will return a {@link
+   * RetryResult.Retry} indicating the next delay. If the operation fails irrecoverably or exceeds
+   * the maximum number of retries, it will return a {@link RetryResult.Failure}.
    *
    * @param operation the operation to execute
    * @param numAttempts the current number of attempts made to execute the operation
    * @return the result of the retry operation
    */
   public RetryResult executeWithRetry(final RetryableOperation operation, final int numAttempts) {
-    try {
-      final var result = operation.execute();
-      return RetryResult.success(result.searchResultCursor());
-    } catch (final BatchOperationInitializationException e) {
-      if (shouldFailImmediately(e) || numAttempts >= maxRetries) {
-        return RetryResult.failure(e);
+    final var outcome = operation.execute();
+    return switch (outcome) {
+      case Success(final var cursor) -> RetryResult.success(cursor);
+      case Failed(final var message, final var errorType, final var cursor) ->
+          RetryResult.failure(
+              new BatchOperationInitializationException(message, errorType, cursor));
+      case NeedsRetry(final var cursor, final var cause) -> {
+        if (shouldFailImmediately(cause) || numAttempts >= maxRetries) {
+          yield RetryResult.failure(new BatchOperationInitializationException(cause, cursor));
+        }
+        final Duration nextDelay = calculateNextDelay(numAttempts);
+        yield RetryResult.retry(nextDelay, numAttempts + 1, cursor);
       }
-      final Duration nextDelay = calculateNextDelay(numAttempts);
-      return RetryResult.retry(nextDelay, numAttempts + 1, e.getEndCursor());
-    }
+    };
   }
 
-  private boolean shouldFailImmediately(final BatchOperationInitializationException exception) {
-    if (BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED.equals(exception.getErrorType())) {
-      return true;
-    }
-    return exception.getCause() instanceof CamundaSearchException
-        && FAIL_IMMEDIATELY_REASONS.contains(
-            ((CamundaSearchException) exception.getCause()).getReason());
+  private boolean shouldFailImmediately(final Throwable cause) {
+    return cause instanceof final CamundaSearchException searchException
+        && FAIL_IMMEDIATELY_REASONS.contains(searchException.getReason());
   }
 
   private Duration calculateNextDelay(final int attemptNumber) {
@@ -124,11 +125,11 @@ public class BatchOperationRetryHandler {
   /**
    * Represents a retryable operation that can be executed with retry logic.
    *
-   * <p>This functional interface allows defining operations that may require retries due to
-   * transient failures or other conditions.
+   * <p>This functional interface allows defining operations that return an {@link
+   * InitializationOutcome} indicating success, need for retry, or terminal failure.
    */
   @FunctionalInterface
   public interface RetryableOperation {
-    BatchOperationInitializationResult execute() throws BatchOperationInitializationException;
+    InitializationOutcome execute();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicy.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicy.java
@@ -75,9 +75,15 @@ public class BatchOperationRetryPolicy {
   }
 
   private Duration calculateNextDelay(final int attemptNumber) {
-    final var calculatedDelay =
-        initialRetryDelay.multipliedBy((int) Math.pow(backoffFactor, attemptNumber));
-    return maxRetryDelay.compareTo(calculatedDelay) < 0 ? maxRetryDelay : calculatedDelay;
+    // Use iterative multiplication with early-cap to avoid overflow from Math.pow
+    Duration delay = initialRetryDelay;
+    for (int i = 0; i < attemptNumber; i++) {
+      delay = delay.multipliedBy(backoffFactor);
+      if (delay.compareTo(maxRetryDelay) >= 0) {
+        return maxRetryDelay;
+      }
+    }
+    return delay;
   }
 
   public int getMaxRetries() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicy.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicy.java
@@ -16,16 +16,16 @@ import java.util.Set;
 /**
  * Evaluates retry policy for batch operation failures.
  *
- * <p>This handler implements exponential backoff retry strategy with configurable parameters for
+ * <p>This policy implements exponential backoff retry strategy with configurable parameters for
  * initial delay, maximum delay, maximum retries, and backoff factor. It determines whether a
  * failure should be retried or should fail immediately.
  *
- * <p>The handler will immediately fail operations that encounter exceptions with specific reasons
+ * <p>The policy will immediately fail operations that encounter exceptions with specific reasons
  * such as NOT_FOUND, NOT_UNIQUE, SECONDARY_STORAGE_NOT_SET, or FORBIDDEN.
  *
  * @see RetryDecision
  */
-public class BatchOperationRetryHandler {
+public class BatchOperationRetryPolicy {
   private static final Set<Reason> FAIL_IMMEDIATELY_REASONS =
       Set.of(
           Reason.NOT_FOUND, Reason.NOT_UNIQUE, Reason.SECONDARY_STORAGE_NOT_SET, Reason.FORBIDDEN);
@@ -35,7 +35,7 @@ public class BatchOperationRetryHandler {
   private final int maxRetries;
   private final int backoffFactor;
 
-  public BatchOperationRetryHandler(
+  public BatchOperationRetryPolicy(
       final Duration initialRetryDelay,
       final Duration maxRetryDelay,
       final int maxRetries,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicy.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicy.java
@@ -56,7 +56,8 @@ public class BatchOperationRetryPolicy {
    */
   public RetryDecision evaluate(final String cursor, final Throwable cause, final int numAttempts) {
     if (shouldFailImmediately(cause) || numAttempts >= maxRetries) {
-      return RetryDecision.fail(formatErrorMessage(cursor, cause), BatchOperationErrorType.QUERY_FAILED);
+      return RetryDecision.fail(
+          formatErrorMessage(cursor, cause), BatchOperationErrorType.QUERY_FAILED);
     }
     final Duration nextDelay = calculateNextDelay(numAttempts);
     return RetryDecision.retry(nextDelay, numAttempts + 1, cursor);
@@ -83,9 +84,7 @@ public class BatchOperationRetryPolicy {
     return maxRetries;
   }
 
-  /**
-   * Represents the decision of whether to retry or fail permanently.
-   */
+  /** Represents the decision of whether to retry or fail permanently. */
   public sealed interface RetryDecision {
     static Fail fail(final String message, final BatchOperationErrorType errorType) {
       return new Fail(message, errorType);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/InitializationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/InitializationContext.java
@@ -32,10 +32,9 @@ public record InitializationContext(
         false);
   }
 
-  public InitializationContext withNextPage(
-      final String newCursor, final int newItems, final boolean appended) {
+  public InitializationContext withNextPage(final String newCursor, final int newItems) {
     return new InitializationContext(
-        operation, newCursor, pageSize, itemsProcessed + newItems, appended);
+        operation, newCursor, pageSize, itemsProcessed + newItems, true);
   }
 
   public InitializationContext withHalvedPageSize() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionState.java
@@ -73,26 +73,29 @@ record SchedulerExecutionState(
   /**
    * Determines whether initialization should be skipped for the given batch operation.
    *
-   * <p>We skip when our in-memory state differs from the persisted state, which means we appended
-   * an INITIALIZE command that hasn't been processed yet by the stream processor. In that case, the
-   * engine is still catching up, and since batch operations are lower priority than normal record
-   * processing, we back off and wait for the next scheduler tick.
-   *
-   * <p>We detect in-flight commands by comparing:
+   * <p>We skip in three cases:
    *
    * <ul>
-   *   <li><b>Cursor:</b> differs when a page was successfully initialized and a
-   *       continueInitialization command was written
-   *   <li><b>Page size:</b> differs when a buffer-full scenario triggered a page size reduction and
-   *       a continueInitialization command was written with the new size
+   *   <li><b>Suspended:</b> the batch operation has been suspended and should not be processed
+   *       until resumed
+   *   <li><b>Cursor differs:</b> a page was successfully initialized and a continueInitialization
+   *       command was written, but hasn't been processed yet by the stream processor
+   *   <li><b>Page size differs:</b> a buffer-full scenario triggered a page size reduction and a
+   *       continueInitialization command was written with the new size, but hasn't been processed
+   *       yet
    * </ul>
    *
-   * <p>This applies equally to retries: if a retry wrote a {@code continueInitialization} command,
-   * we wait for it to be processed before scheduling more work.
+   * <p>The last two cases provide natural back-pressure: batch operations are lower priority than
+   * normal record processing, so we wait rather than adding more commands to a busy pipeline. This
+   * applies equally to retries — if a retry wrote a {@code continueInitialization} command, we wait
+   * for it to be processed before scheduling more work.
    */
   boolean shouldSkipInitialization(final PersistedBatchOperation batchOperation) {
     if (batchOperationKey != batchOperation.getKey()) {
       return false;
+    }
+    if (batchOperation.isSuspended()) {
+      return true;
     }
     if (!Objects.equals(cursor, emptyToNull(batchOperation.getInitializationSearchCursor()))) {
       return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionState.java
@@ -20,75 +20,83 @@ import java.util.Objects;
  * fire multiple INITIALIZE commands for the same cursor position, causing duplicate work.
  *
  * <p>The key invariant: after we successfully initialize a page and append an INITIALIZE command,
- * the persisted state's cursor will be updated asynchronously by the command processor. Until that
- * happens, our in-memory cursor differs from the persisted cursor. We use this difference to detect
- * "command in flight" and skip re-initialization.
+ * the persisted state's cursor and/or page size will be updated asynchronously by the command
+ * processor. Until that happens, our in-memory state differs from the persisted state. We use this
+ * difference to detect "command in flight" and skip the current scheduler tick — regardless of
+ * whether a retry is pending. This provides natural back-pressure: if the stream processor is busy,
+ * batch operations (which are lower priority) wait rather than adding more commands to the
+ * pipeline.
  *
- * <p>However, if retries are in flight ({@code numAttempts > 0}), we should NOT skip — retries are
- * intentional re-executions after transient failures.
+ * <p>Because we only proceed when persisted state has caught up, the scheduler can always use
+ * persisted values directly via {@link InitializationContext#fromBatchOperation} — no in-memory
+ * overrides are needed.
  *
- * <p>The state also tracks a reduced page size when buffer-full scenarios require smaller fetches.
- * This avoids writing INITIALIZE commands just to persist the page size change.
- *
- * @param pageSize 0 means use default
+ * @param defaultPageSize stored at creation to resolve persisted page size (which uses {@code -1}
+ *     as sentinel for "unset") in {@link #shouldSkipInitialization} comparisons
+ * @param pageSize the resolved page size; eagerly set from persisted state at creation, then
+ *     updated by {@link #withReducedPageSize} when buffer-full scenarios occur
  */
 record SchedulerExecutionState(
-    long batchOperationKey, String cursor, int pageSize, int numAttempts) {
+    long batchOperationKey, String cursor, int defaultPageSize, int pageSize, int numAttempts) {
 
   /** Creates initial state from a persisted batch operation. */
-  static SchedulerExecutionState from(final PersistedBatchOperation batchOperation) {
+  static SchedulerExecutionState from(
+      final PersistedBatchOperation batchOperation, final int defaultPageSize) {
     return new SchedulerExecutionState(
-        batchOperation.getKey(), batchOperation.getInitializationSearchCursor(), 0, 0);
+        batchOperation.getKey(),
+        emptyToNull(batchOperation.getInitializationSearchCursor()),
+        defaultPageSize,
+        batchOperation.getInitializationSearchQueryPageSize(defaultPageSize),
+        0);
   }
 
   /**
-   * Advances to a new cursor after successful page processing. Resets page size and retry count.
+   * Advances to a new cursor after successful page processing. Resets retry count but preserves
+   * page size.
    */
   SchedulerExecutionState advanceTo(final String newCursor) {
-    return new SchedulerExecutionState(batchOperationKey, newCursor, 0, 0);
+    return new SchedulerExecutionState(batchOperationKey, newCursor, defaultPageSize, pageSize, 0);
   }
 
   /** Prepares for a retry attempt with the given cursor and attempt count. Preserves page size. */
   SchedulerExecutionState retryWith(final String newCursor, final int attempts) {
-    return new SchedulerExecutionState(batchOperationKey, newCursor, pageSize, attempts);
+    return new SchedulerExecutionState(
+        batchOperationKey, newCursor, defaultPageSize, pageSize, attempts);
   }
 
   /** Reduces page size for next attempt due to buffer full. */
   SchedulerExecutionState withReducedPageSize(final int newPageSize) {
-    return new SchedulerExecutionState(batchOperationKey, cursor, newPageSize, numAttempts);
-  }
-
-  /**
-   * Builds an {@link InitializationContext} using in-memory overrides where applicable.
-   *
-   * <p>Uses:
-   *
-   * <ul>
-   *   <li>In-memory cursor when retrying ({@code numAttempts > 0}) to avoid stale cursor race
-   *   <li>In-memory page size when reduced ({@code pageSize > 0}) to avoid stale page size race
-   *   <li>Persisted values otherwise
-   * </ul>
-   */
-  InitializationContext buildContext(
-      final PersistedBatchOperation batchOperation, final int defaultPageSize) {
-    final String effectiveCursor =
-        emptyToNull(numAttempts > 0 ? cursor : batchOperation.getInitializationSearchCursor());
-    final int effectivePageSize =
-        pageSize > 0
-            ? pageSize
-            : batchOperation.getInitializationSearchQueryPageSize(defaultPageSize);
-    return new InitializationContext(batchOperation, effectiveCursor, effectivePageSize, 0, false);
+    return new SchedulerExecutionState(
+        batchOperationKey, cursor, defaultPageSize, newPageSize, numAttempts);
   }
 
   /**
    * Determines whether initialization should be skipped for the given batch operation.
    *
-   * <p>We skip when our in-memory cursor differs from the persisted cursor AND we're not in a
-   * retry. This means we appended an INITIALIZE command that hasn't been processed yet.
+   * <p>We skip when our in-memory state differs from the persisted state, which means we appended
+   * an INITIALIZE command that hasn't been processed yet by the stream processor. In that case, the
+   * engine is still catching up, and since batch operations are lower priority than normal record
+   * processing, we back off and wait for the next scheduler tick.
+   *
+   * <p>We detect in-flight commands by comparing:
+   *
+   * <ul>
+   *   <li><b>Cursor:</b> differs when a page was successfully initialized and a
+   *       continueInitialization command was written
+   *   <li><b>Page size:</b> differs when a buffer-full scenario triggered a page size reduction and
+   *       a continueInitialization command was written with the new size
+   * </ul>
+   *
+   * <p>This applies equally to retries: if a retry wrote a {@code continueInitialization} command,
+   * we wait for it to be processed before scheduling more work.
    */
   boolean shouldSkipInitialization(final PersistedBatchOperation batchOperation) {
-    return batchOperationKey == batchOperation.getKey()
-        && numAttempts == 0
-        && !Objects.equals(cursor, batchOperation.getInitializationSearchCursor());
+    if (batchOperationKey != batchOperation.getKey()) {
+      return false;
+    }
+    if (!Objects.equals(cursor, emptyToNull(batchOperation.getInitializationSearchCursor()))) {
+      return true;
+    }
+    return pageSize != batchOperation.getInitializationSearchQueryPageSize(defaultPageSize);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionState.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
+
+import static com.google.common.base.Strings.emptyToNull;
+
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import java.util.Objects;
+
+/**
+ * Tracks the in-flight state of a batch operation being initialized.
+ *
+ * <p>This class exists to prevent re-initialization of a batch operation before the stream
+ * processor has processed our previous INITIALIZE command. Without this guard, the scheduler could
+ * fire multiple INITIALIZE commands for the same cursor position, causing duplicate work.
+ *
+ * <p>The key invariant: after we successfully initialize a page and append an INITIALIZE command,
+ * the persisted state's cursor will be updated asynchronously by the command processor. Until that
+ * happens, our in-memory cursor differs from the persisted cursor. We use this difference to detect
+ * "command in flight" and skip re-initialization.
+ *
+ * <p>However, if retries are in flight ({@code numAttempts > 0}), we should NOT skip — retries are
+ * intentional re-executions after transient failures.
+ *
+ * <p>The state also tracks a reduced page size when buffer-full scenarios require smaller fetches.
+ * This avoids writing INITIALIZE commands just to persist the page size change.
+ *
+ * @param pageSize 0 means use default
+ */
+record SchedulerExecutionState(
+    long batchOperationKey, String cursor, int pageSize, int numAttempts) {
+
+  /** Creates initial state from a persisted batch operation. */
+  static SchedulerExecutionState from(final PersistedBatchOperation batchOperation) {
+    return new SchedulerExecutionState(
+        batchOperation.getKey(), batchOperation.getInitializationSearchCursor(), 0, 0);
+  }
+
+  /**
+   * Advances to a new cursor after successful page processing. Resets page size and retry count.
+   */
+  SchedulerExecutionState advanceTo(final String newCursor) {
+    return new SchedulerExecutionState(batchOperationKey, newCursor, 0, 0);
+  }
+
+  /** Prepares for a retry attempt with the given cursor and attempt count. Preserves page size. */
+  SchedulerExecutionState retryWith(final String newCursor, final int attempts) {
+    return new SchedulerExecutionState(batchOperationKey, newCursor, pageSize, attempts);
+  }
+
+  /** Reduces page size for next attempt due to buffer full. */
+  SchedulerExecutionState withReducedPageSize(final int newPageSize) {
+    return new SchedulerExecutionState(batchOperationKey, cursor, newPageSize, numAttempts);
+  }
+
+  /**
+   * Builds an {@link InitializationContext} using in-memory overrides where applicable.
+   *
+   * <p>Uses:
+   *
+   * <ul>
+   *   <li>In-memory cursor when retrying ({@code numAttempts > 0}) to avoid stale cursor race
+   *   <li>In-memory page size when reduced ({@code pageSize > 0}) to avoid stale page size race
+   *   <li>Persisted values otherwise
+   * </ul>
+   */
+  InitializationContext buildContext(
+      final PersistedBatchOperation batchOperation, final int defaultPageSize) {
+    final String effectiveCursor =
+        emptyToNull(numAttempts > 0 ? cursor : batchOperation.getInitializationSearchCursor());
+    final int effectivePageSize =
+        pageSize > 0
+            ? pageSize
+            : batchOperation.getInitializationSearchQueryPageSize(defaultPageSize);
+    return new InitializationContext(batchOperation, effectiveCursor, effectivePageSize, 0, false);
+  }
+
+  /**
+   * Determines whether initialization should be skipped for the given batch operation.
+   *
+   * <p>We skip when our in-memory cursor differs from the persisted cursor AND we're not in a
+   * retry. This means we appended an INITIALIZE command that hasn't been processed yet.
+   */
+  boolean shouldSkipInitialization(final PersistedBatchOperation batchOperation) {
+    return batchOperationKey == batchOperation.getKey()
+        && numAttempts == 0
+        && !Objects.equals(cursor, batchOperation.getInitializationSearchCursor());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
@@ -48,7 +48,7 @@ class BatchOperationChunkAppenderTest {
   }
 
   @Test
-  void shouldProcessPageWithSingleChunk() {
+  void shouldChunkAndAppendWithSingleChunk() {
     // given
     final var item1 = new Item(100L, 200L, null);
     final var item2 = new Item(101L, 201L, null);
@@ -59,7 +59,8 @@ class BatchOperationChunkAppenderTest {
     when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
 
     // when
-    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+    final var result =
+        processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.Continue.class);
@@ -76,7 +77,7 @@ class BatchOperationChunkAppenderTest {
   }
 
   @Test
-  void shouldProcessPageWithMultipleChunks() {
+  void shouldChunkAndAppendWithMultipleChunks() {
     // given - 5 items with chunk size 2 should create 3 chunks (2+2+1)
     final var items =
         List.of(
@@ -92,7 +93,8 @@ class BatchOperationChunkAppenderTest {
     when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
 
     // when
-    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+    final var result =
+        processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.Finished.class);
@@ -122,7 +124,8 @@ class BatchOperationChunkAppenderTest {
         .thenReturn(false);
 
     // when
-    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+    final var result =
+        processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.BufferFull.class);
@@ -149,7 +152,8 @@ class BatchOperationChunkAppenderTest {
         .thenReturn(true);
 
     // when
-    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+    final var result =
+        processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.Finished.class);
@@ -180,7 +184,7 @@ class BatchOperationChunkAppenderTest {
     when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
 
     // when
-    processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+    processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     final var chunkCaptor = ArgumentCaptor.forClass(BatchOperationChunkRecord.class);
@@ -220,7 +224,7 @@ class BatchOperationChunkAppenderTest {
 
     // when
     final var result =
-        largeChunkProcessor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+        largeChunkProcessor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.Continue.class);
@@ -245,7 +249,8 @@ class BatchOperationChunkAppenderTest {
     when(mockItemProvider.fetchItemPage("cursor1", 50)).thenThrow(exception);
 
     // when
-    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+    final var result =
+        processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.FetchFailed.class);
@@ -266,7 +271,7 @@ class BatchOperationChunkAppenderTest {
     when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
 
     // when
-    processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+    processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     verify(mockItemProvider).fetchItemPage("specific-cursor", 25);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationItem;
@@ -31,18 +31,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-class BatchOperationPageProcessorTest {
+class BatchOperationChunkAppenderTest {
 
   private static final long BATCH_OPERATION_KEY = 123L;
   private static final int CHUNK_SIZE = 2;
 
-  private BatchOperationPageProcessor processor;
+  private BatchOperationChunkAppender processor;
   private ItemProvider mockItemProvider;
   private TaskResultBuilder mockTaskResultBuilder;
 
   @BeforeEach
   void setUp() {
-    processor = new BatchOperationPageProcessor(CHUNK_SIZE);
+    processor = new BatchOperationChunkAppender(CHUNK_SIZE);
     mockItemProvider = mock(ItemProvider.class);
     mockTaskResultBuilder = mock(TaskResultBuilder.class);
   }
@@ -209,7 +209,7 @@ class BatchOperationPageProcessorTest {
   @Test
   void shouldHandleDifferentChunkSizes() {
     // given
-    final var largeChunkProcessor = new BatchOperationPageProcessor(10);
+    final var largeChunkProcessor = new BatchOperationChunkAppender(10);
     final var items =
         List.of(new Item(100L, 200L, null), new Item(101L, 201L, null), new Item(102L, 202L, null));
     final var page = new ItemPage(items, "cursor", 3L, false);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.ChunkingOutcome;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationItem;
@@ -63,8 +63,8 @@ class BatchOperationChunkAppenderTest {
         processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
-    assertThat(result).isInstanceOf(PageProcessingResult.Continue.class);
-    final var continueResult = (PageProcessingResult.Continue) result;
+    assertThat(result).isInstanceOf(ChunkingOutcome.Continue.class);
+    final var continueResult = (ChunkingOutcome.Continue) result;
     assertThat(continueResult.endCursor()).isEqualTo("cursor123");
     assertThat(continueResult.itemsProcessed()).isEqualTo(2);
 
@@ -97,8 +97,8 @@ class BatchOperationChunkAppenderTest {
         processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
-    assertThat(result).isInstanceOf(PageProcessingResult.Finished.class);
-    final var finishedResult = (PageProcessingResult.Finished) result;
+    assertThat(result).isInstanceOf(ChunkingOutcome.Finished.class);
+    final var finishedResult = (ChunkingOutcome.Finished) result;
     assertThat(finishedResult.endCursor()).isEqualTo("cursor456");
     assertThat(finishedResult.itemsProcessed()).isEqualTo(5);
 
@@ -128,8 +128,8 @@ class BatchOperationChunkAppenderTest {
         processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
-    assertThat(result).isInstanceOf(PageProcessingResult.BufferFull.class);
-    final var bufferFullResult = (PageProcessingResult.BufferFull) result;
+    assertThat(result).isInstanceOf(ChunkingOutcome.BufferFull.class);
+    final var bufferFullResult = (ChunkingOutcome.BufferFull) result;
     assertThat(bufferFullResult.itemsProcessed()).isEqualTo(2);
 
     verify(mockTaskResultBuilder, never())
@@ -156,8 +156,8 @@ class BatchOperationChunkAppenderTest {
         processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
-    assertThat(result).isInstanceOf(PageProcessingResult.Finished.class);
-    final var finishedResult = (PageProcessingResult.Finished) result;
+    assertThat(result).isInstanceOf(ChunkingOutcome.Finished.class);
+    final var finishedResult = (ChunkingOutcome.Finished) result;
     assertThat(finishedResult.endCursor()).isNull();
     assertThat(finishedResult.itemsProcessed()).isZero();
 
@@ -227,8 +227,8 @@ class BatchOperationChunkAppenderTest {
         largeChunkProcessor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
-    assertThat(result).isInstanceOf(PageProcessingResult.Continue.class);
-    final var continueResult = (PageProcessingResult.Continue) result;
+    assertThat(result).isInstanceOf(ChunkingOutcome.Continue.class);
+    final var continueResult = (ChunkingOutcome.Continue) result;
     assertThat(continueResult.itemsProcessed()).isEqualTo(3);
 
     // Should create only 1 chunk since all items fit in chunk size 10
@@ -253,8 +253,8 @@ class BatchOperationChunkAppenderTest {
         processor.fetchAndChunkNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
-    assertThat(result).isInstanceOf(PageProcessingResult.FetchFailed.class);
-    final var fetchFailedResult = (PageProcessingResult.FetchFailed) result;
+    assertThat(result).isInstanceOf(ChunkingOutcome.FetchFailed.class);
+    final var fetchFailedResult = (ChunkingOutcome.FetchFailed) result;
     assertThat(fetchFailedResult.cause()).isSameAs(exception);
 
     verify(mockTaskResultBuilder, never())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
@@ -129,8 +129,6 @@ class BatchOperationChunkAppenderTest {
 
     // then
     assertThat(result).isInstanceOf(ChunkingOutcome.BufferFull.class);
-    final var bufferFullResult = (ChunkingOutcome.BufferFull) result;
-    assertThat(bufferFullResult.itemsProcessed()).isEqualTo(2);
 
     verify(mockTaskResultBuilder, never())
         .appendCommandRecord(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationCommandsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationCommandsTest.java
@@ -25,17 +25,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-class BatchOperationCommandAppenderTest {
+class BatchOperationCommandsTest {
 
   private static final int PARTITION_ID = 1;
   private static final long BATCH_OPERATION_KEY = 123L;
 
-  private BatchOperationCommandAppender appender;
+  private BatchOperationCommands appender;
   private TaskResultBuilder mockBuilder;
 
   @BeforeEach
   void setUp() {
-    appender = new BatchOperationCommandAppender(PARTITION_ID);
+    appender = new BatchOperationCommands(PARTITION_ID);
     mockBuilder = mock(TaskResultBuilder.class);
   }
 
@@ -177,7 +177,7 @@ class BatchOperationCommandAppenderTest {
   void shouldUseCorrectPartitionIdInFailureCommand() {
     // given
     final int differentPartitionId = 5;
-    final var differentAppender = new BatchOperationCommandAppender(differentPartitionId);
+    final var differentAppender = new BatchOperationCommands(differentPartitionId);
     final String errorMessage = "Partition specific error";
     final BatchOperationErrorType errorType = BatchOperationErrorType.UNKNOWN;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import static io.camunda.zeebe.protocol.record.value.BatchOperationType.CANCEL_PROCESS_INSTANCE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
@@ -142,26 +143,32 @@ public class BatchOperationExecutionSchedulerTest {
   }
 
   @Test
-  public void shouldReducePageSizeAndRetryImmediatelyOnBufferFull() {
-    // given
-    final var batchOperation = createBatchOperation();
-    when(batchOperationState.getNextPendingBatchOperation())
-        .thenReturn(Optional.of(batchOperation));
-
+  public void shouldReducePageSizeAndRetryOnNextSchedulerTick() {
+    // given - two separate instances: first has original page size, second has reduced
+    // (simulating the continueInitialization command being processed between ticks)
+    final var bo1 = createBatchOperation();
     final int reducedPageSize = 50;
+    final var bo2 = createBatchOperation().setInitializationSearchQueryPageSize(reducedPageSize);
+
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(bo1))
+        .thenReturn(Optional.of(bo2));
+
     when(batchOperationInitializer.initializeBatchOperation(any(), any()))
         .thenReturn(new InitializationOutcome.ReducePageSize(reducedPageSize))
         .thenReturn(new InitializationOutcome.Success("cursor"));
 
-    // when - first execution returns ReducePageSize, second succeeds
+    // when - first execution returns ReducePageSize, second succeeds after persisted state caught
+    // up
     execute();
     execute();
 
     // then - initializer should be called twice
-    verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
-    // First call scheduled with SCHEDULER_INTERVAL (initial), second with Duration.ZERO (immediate
-    // retry)
-    verify(scheduleService).runDelayedAsync(eq(Duration.ZERO), any(), any());
+    final var contextCapture = ArgumentCaptor.forClass(InitializationContext.class);
+    verify(batchOperationInitializer, times(2))
+        .initializeBatchOperation(contextCapture.capture(), any());
+
+    assertThat(contextCapture.getAllValues().getLast().pageSize()).isEqualTo(reducedPageSize);
   }
 
   @Test
@@ -298,32 +305,33 @@ public class BatchOperationExecutionSchedulerTest {
 
   @Test
   public void shouldPassCorrectNumAttemptsToRetryHandlerOnSubsequentRetries() {
-    // given
-    final var batchOperation = createBatchOperation();
+    // given - NeedsRetry with same cursor (no continueInit command written, e.g. fetch failed
+    // before any chunks appended) so retries proceed without waiting for command processing
+    final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation));
 
     final var cause = new RuntimeException("Transient failure");
     when(batchOperationInitializer.initializeBatchOperation(any(), any()))
-        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", cause));
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor1", cause));
 
     // First call returns retry with numAttempts=1, second call returns retry with numAttempts=2
     when(retryPolicy.evaluate(any(), any(), eq(0)))
-        .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor"));
+        .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor1"));
     when(retryPolicy.evaluate(any(), any(), eq(1)))
-        .thenReturn(RetryDecision.retry(Duration.ofMillis(200), 2, "cursor"));
+        .thenReturn(RetryDecision.retry(Duration.ofMillis(200), 2, "cursor1"));
 
     // when - execute twice (simulating retry)
     execute();
     execute();
 
     // then - verify numAttempts increments
-    verify(retryPolicy).evaluate("cursor", cause, 0); // first execution
-    verify(retryPolicy).evaluate("cursor", cause, 1); // second execution after retry
+    verify(retryPolicy).evaluate("cursor1", cause, 0); // first execution
+    verify(retryPolicy).evaluate("cursor1", cause, 1); // second execution after retry
   }
 
   @Test
-  public void shouldNotSkipWhenRetryInProgress() {
+  public void shouldSkipRetryWhenCommandInFlight() {
     // given - batch operation with cursor "cursor1"
     final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
     when(batchOperationState.getNextPendingBatchOperation())
@@ -338,7 +346,57 @@ public class BatchOperationExecutionSchedulerTest {
     // First retry decision advances cursor to "cursor2" with numAttempts=1
     when(retryPolicy.evaluate(any(), any(), eq(0)))
         .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor2"));
-    // Second call should still proceed because numAttempts > 0
+
+    // when - execute twice: first initializes, second should skip (command in-flight)
+    execute();
+    execute();
+
+    // then - only one initialization (second tick skipped because persisted cursor
+    // hasn't caught up, indicating the engine is still processing the previous command)
+    verify(batchOperationInitializer, times(1)).initializeBatchOperation(any(), any());
+  }
+
+  @Test
+  public void shouldProceedWithRetryAfterCommandProcessed() {
+    // given - batch operation with cursor "cursor1"
+    final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation))
+        // Second call: cursor advanced to "cursor2" (command was processed)
+        .thenReturn(Optional.of(batchOperation.setInitializationSearchCursor("cursor2")));
+
+    final var cause = new RuntimeException("Transient failure");
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor2", cause));
+
+    when(retryPolicy.evaluate(any(), any(), eq(0)))
+        .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor2"));
+    when(retryPolicy.evaluate(any(), any(), eq(1)))
+        .thenReturn(
+            RetryDecision.fail("Max retries exceeded", BatchOperationErrorType.QUERY_FAILED));
+
+    // when - first execution triggers retry, second proceeds because persisted state caught up
+    execute();
+    execute();
+
+    // then - both executions should call initializer
+    verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
+  }
+
+  @Test
+  public void shouldRetryImmediatelyWhenNoContinueCommandWritten() {
+    // given - NeedsRetry with same cursor (no chunks were appended, no command written)
+    final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation))
+        .thenReturn(Optional.of(batchOperation)); // cursor unchanged — no command to process
+
+    final var cause = new RuntimeException("Fetch failed, no chunks appended");
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor1", cause));
+
+    when(retryPolicy.evaluate(any(), any(), eq(0)))
+        .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor1"));
     when(retryPolicy.evaluate(any(), any(), eq(1)))
         .thenReturn(
             RetryDecision.fail("Max retries exceeded", BatchOperationErrorType.QUERY_FAILED));
@@ -347,18 +405,20 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
     execute();
 
-    // then - both executions should call initializer (not skipped due to retry in progress)
+    // then - both calls proceed: cursors match (no command in-flight)
     verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
   }
 
   @Test
   public void shouldResetNumAttemptsOnSuccess() {
-    // given
-    final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
+    // given - three separate instances to avoid mutable cursor aliasing
+    final var bo1 = createBatchOperation().setInitializationSearchCursor("cursor1");
+    final var bo2 = createBatchOperation().setInitializationSearchCursor("cursor2");
+    final var bo3 = createBatchOperation().setInitializationSearchCursor("cursor3");
     when(batchOperationState.getNextPendingBatchOperation())
-        .thenReturn(Optional.of(batchOperation))
-        .thenReturn(Optional.of(batchOperation.setInitializationSearchCursor("cursor2")))
-        .thenReturn(Optional.of(batchOperation.setInitializationSearchCursor("cursor3")));
+        .thenReturn(Optional.of(bo1))
+        .thenReturn(Optional.of(bo2))
+        .thenReturn(Optional.of(bo3));
 
     final var cause = new RuntimeException("Transient failure");
     // First call: needs retry (numAttempts goes to 1)
@@ -372,7 +432,7 @@ public class BatchOperationExecutionSchedulerTest {
     when(retryPolicy.evaluate(any(), any(), eq(0)))
         .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor2"));
 
-    // when - first needs retry, second succeeds, third needs retry again
+    // when - first needs retry, second succeeds (persisted caught up), third needs retry again
     execute();
     execute();
     execute();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -142,6 +142,29 @@ public class BatchOperationExecutionSchedulerTest {
   }
 
   @Test
+  public void shouldReducePageSizeAndRetryImmediatelyOnBufferFull() {
+    // given
+    final var batchOperation = createBatchOperation();
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation));
+
+    final int reducedPageSize = 50;
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.ReducePageSize(reducedPageSize))
+        .thenReturn(new InitializationOutcome.Success("cursor"));
+
+    // when - first execution returns ReducePageSize, second succeeds
+    execute();
+    execute();
+
+    // then - initializer should be called twice
+    verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
+    // First call scheduled with SCHEDULER_INTERVAL (initial), second with Duration.ZERO (immediate
+    // retry)
+    verify(scheduleService).runDelayedAsync(eq(Duration.ZERO), any(), any());
+  }
+
+  @Test
   public void shouldDelegateToRetryHandlerOnNeedsRetry() {
     // given
     final var batchOperation = createBatchOperation();
@@ -194,8 +217,11 @@ public class BatchOperationExecutionSchedulerTest {
   }
 
   @Test
-  public void shouldSkipReInitializationForSameBatchOperationWithDifferentCursor() {
-    // given
+  public void shouldSkipWhenCommandInFlight() {
+    // given - first execution advances in-memory cursor to "cursor1"
+    // second execution sees persisted cursor changed to "cursor2" (command was processed)
+    // but our in-memory cursor is still "cursor1" (different from persisted)
+    // this indicates a command is in-flight, so we skip
     final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation))
@@ -208,13 +234,13 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
     execute();
 
-    // then - should only process the first one, skip the second due to cursor change
+    // then - should only process the first one, skip the second (command in-flight)
     verify(batchOperationInitializer, times(1)).initializeBatchOperation(any(), any());
   }
 
   @Test
-  public void shouldProcessSameBatchOperationWithSameCursor() {
-    // given
+  public void shouldContinueWhenPersistedStateCaughtUp() {
+    // given - both executions see the same cursor (persisted state caught up with in-memory)
     final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation))
@@ -227,7 +253,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
     execute();
 
-    // then - should process both since cursor is the same
+    // then - should process both since cursors match (no command in-flight)
     verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
   }
 
@@ -331,25 +357,29 @@ public class BatchOperationExecutionSchedulerTest {
     final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation))
-        .thenReturn(Optional.of(batchOperation.setInitializationSearchCursor("cursor2")));
+        .thenReturn(Optional.of(batchOperation.setInitializationSearchCursor("cursor2")))
+        .thenReturn(Optional.of(batchOperation.setInitializationSearchCursor("cursor3")));
 
     final var cause = new RuntimeException("Transient failure");
-    // First call: needs retry
+    // First call: needs retry (numAttempts goes to 1)
+    // Second call: success (numAttempts should reset to 0)
+    // Third call: needs retry again (should use numAttempts=0, not 1)
     when(batchOperationInitializer.initializeBatchOperation(any(), any()))
         .thenReturn(new InitializationOutcome.NeedsRetry("cursor2", cause))
-        .thenReturn(new InitializationOutcome.Success("cursor3"));
+        .thenReturn(new InitializationOutcome.Success("cursor3"))
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor4", cause));
 
     when(retryPolicy.evaluate(any(), any(), eq(0)))
         .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor2"));
 
-    // when - first execution triggers retry, second succeeds
+    // when - first needs retry, second succeeds, third needs retry again
+    execute();
     execute();
     execute();
 
-    // then - initializer should be called twice
-    verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
-    // And retry handler only once (success doesn't call retry handler)
-    verify(retryPolicy, times(1)).evaluate(any(), any(), anyInt());
+    // then - retry policy should be called twice, both times with numAttempts=0
+    // (proving that success reset the counter)
+    verify(retryPolicy, times(2)).evaluate(any(), any(), eq(0));
   }
 
   /** Bypasses the scheduling mechanism and executes the task directly */

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import static io.camunda.zeebe.protocol.record.value.BatchOperationType.CANCEL_PROCESS_INSTANCE;
 import static org.mockito.Mockito.*;
 
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
@@ -43,7 +43,7 @@ public class BatchOperationExecutionSchedulerTest {
   @Mock private ReadonlyStreamProcessorContext streamProcessorContext;
   @Mock private ProcessingScheduleService scheduleService;
   @Mock private BatchOperationState batchOperationState;
-  @Mock private BatchOperationInitializationHelper batchOperationInitializer;
+  @Mock private BatchOperationInitializationBehavior batchOperationInitializer;
   @Mock private BatchOperationRetryHandler retryHandler;
 
   @Captor private ArgumentCaptor<Task> taskCaptor;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -67,6 +67,21 @@ public class BatchOperationExecutionSchedulerTest {
   }
 
   @Test
+  public void shouldSkipWhenBatchOperationIsSuspended() {
+    // given
+    final var batchOperation = createBatchOperation().setStatus(BatchOperationStatus.SUSPENDED);
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation));
+
+    // when
+    execute();
+
+    // then - initializer should not be called for suspended operations
+    verifyNoInteractions(batchOperationInitializer, retryPolicy);
+    verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
+  }
+
+  @Test
   public void shouldDoNothingWhenNoBatchOperation() {
     // given
     when(batchOperationState.getNextPendingBatchOperation()).thenReturn(Optional.empty());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import static io.camunda.zeebe.protocol.record.value.BatchOperationType.CANCEL_PROCESS_INSTANCE;
 import static org.mockito.Mockito.*;
 
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
@@ -116,10 +115,10 @@ public class BatchOperationExecutionSchedulerTest {
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation));
 
-    final var exception =
-        new BatchOperationInitializationException(
-            "Test error", BatchOperationErrorType.QUERY_FAILED, "cursor");
-    when(retryHandler.executeWithRetry(any(), anyInt())).thenReturn(RetryResult.failure(exception));
+    final var errorMessage = "Test error";
+    final var errorType = BatchOperationErrorType.QUERY_FAILED;
+    when(retryHandler.executeWithRetry(any(), anyInt()))
+        .thenReturn(RetryResult.failure(errorMessage, errorType));
 
     // when
     execute();
@@ -127,7 +126,7 @@ public class BatchOperationExecutionSchedulerTest {
     // then
     verify(retryHandler).executeWithRetry(any(), anyInt());
     verify(batchOperationInitializer)
-        .appendFailedCommand(taskResultBuilder, BATCH_OPERATION_KEY, exception);
+        .appendFailedCommand(taskResultBuilder, BATCH_OPERATION_KEY, errorMessage, errorType);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -10,7 +10,8 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import static io.camunda.zeebe.protocol.record.value.BatchOperationType.CANCEL_PROCESS_INSTANCE;
 import static org.mockito.Mockito.*;
 
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryDecision;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
@@ -73,43 +74,46 @@ public class BatchOperationExecutionSchedulerTest {
   }
 
   @Test
-  public void shouldDelegateToRetryHandlerWhenBatchOperationExists() {
+  public void shouldCallInitializerDirectlyWhenBatchOperationExists() {
     // given
     final var batchOperation = createBatchOperation();
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation));
 
-    when(retryHandler.executeWithRetry(any(), anyInt())).thenReturn(RetryResult.success("cursor"));
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.Success("cursor"));
 
     // when
     execute();
 
     // then
     verify(batchOperationState).getNextPendingBatchOperation();
-    verify(retryHandler).executeWithRetry(any(), anyInt());
+    verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
+    verifyNoInteractions(retryHandler);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 
   @Test
-  public void shouldHandleRetryResultSuccess() {
+  public void shouldHandleInitializationSuccess() {
     // given
     final var batchOperation = createBatchOperation();
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation));
 
-    when(retryHandler.executeWithRetry(any(), anyInt()))
-        .thenReturn(RetryResult.success("new-cursor"));
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.Success("new-cursor"));
 
     // when
     execute();
 
     // then
-    verify(retryHandler).executeWithRetry(any(), anyInt());
+    verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
+    verifyNoInteractions(retryHandler);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 
   @Test
-  public void shouldHandleRetryResultFailure() {
+  public void shouldHandleInitializationFailed() {
     // given
     final var batchOperation = createBatchOperation();
     when(batchOperationState.getNextPendingBatchOperation())
@@ -117,38 +121,70 @@ public class BatchOperationExecutionSchedulerTest {
 
     final var errorMessage = "Test error";
     final var errorType = BatchOperationErrorType.QUERY_FAILED;
-    when(retryHandler.executeWithRetry(any(), anyInt()))
-        .thenReturn(RetryResult.failure(errorMessage, errorType));
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.Failed(errorMessage, errorType));
 
     // when
     execute();
 
     // then
-    verify(retryHandler).executeWithRetry(any(), anyInt());
+    verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
     verify(batchOperationInitializer)
         .appendFailedCommand(taskResultBuilder, BATCH_OPERATION_KEY, errorMessage, errorType);
+    verifyNoInteractions(retryHandler);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 
   @Test
-  public void shouldHandleRetryResultRetry() {
+  public void shouldDelegateToRetryHandlerOnNeedsRetry() {
     // given
     final var batchOperation = createBatchOperation();
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation));
 
+    final var cause = new RuntimeException("Transient failure");
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", cause));
+
     final var retryDelay = Duration.ofMillis(500);
-    when(retryHandler.executeWithRetry(any(), anyInt()))
-        .thenReturn(RetryResult.retry(retryDelay, 1, "cursor"));
+    when(retryHandler.evaluate(eq("cursor"), eq(cause), eq(0)))
+        .thenReturn(RetryDecision.retry(retryDelay, 1, "cursor"));
 
     // when
     execute();
 
     // then
-    verify(retryHandler).executeWithRetry(any(), anyInt());
+    verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
+    verify(retryHandler).evaluate("cursor", cause, 0);
     verify(scheduleService)
         .runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any()); // initial schedule
     verify(scheduleService).runDelayedAsync(eq(retryDelay), any(), any()); // retry schedule
+  }
+
+  @Test
+  public void shouldHandleRetryDecisionFail() {
+    // given
+    final var batchOperation = createBatchOperation();
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation));
+
+    final var cause = new RuntimeException("Non-retryable failure");
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", cause));
+
+    final var errorMessage = "Failed after retries";
+    final var errorType = BatchOperationErrorType.QUERY_FAILED;
+    when(retryHandler.evaluate(any(), any(), anyInt()))
+        .thenReturn(RetryDecision.fail(errorMessage, errorType));
+
+    // when
+    execute();
+
+    // then
+    verify(retryHandler).evaluate("cursor", cause, 0);
+    verify(batchOperationInitializer)
+        .appendFailedCommand(taskResultBuilder, BATCH_OPERATION_KEY, errorMessage, errorType);
+    verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 
   @Test
@@ -159,14 +195,15 @@ public class BatchOperationExecutionSchedulerTest {
         .thenReturn(Optional.of(batchOperation))
         .thenReturn(Optional.of(batchOperation.setInitializationSearchCursor("cursor2")));
 
-    when(retryHandler.executeWithRetry(any(), anyInt())).thenReturn(RetryResult.success("cursor1"));
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.Success("cursor1"));
 
     // when - execute twice
     execute();
     execute();
 
     // then - should only process the first one, skip the second due to cursor change
-    verify(retryHandler, times(1)).executeWithRetry(any(), anyInt());
+    verify(batchOperationInitializer, times(1)).initializeBatchOperation(any(), any());
   }
 
   @Test
@@ -177,14 +214,15 @@ public class BatchOperationExecutionSchedulerTest {
         .thenReturn(Optional.of(batchOperation))
         .thenReturn(Optional.of(batchOperation));
 
-    when(retryHandler.executeWithRetry(any(), anyInt())).thenReturn(RetryResult.success("cursor1"));
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.Success("cursor1"));
 
     // when - execute twice
     execute();
     execute();
 
     // then - should process both since cursor is the same
-    verify(retryHandler, times(2)).executeWithRetry(any(), anyInt());
+    verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
   }
 
   @Test
@@ -197,16 +235,16 @@ public class BatchOperationExecutionSchedulerTest {
         .thenReturn(Optional.of(batchOperation1))
         .thenReturn(Optional.of(batchOperation2));
 
-    when(retryHandler.executeWithRetry(any(), anyInt()))
-        .thenReturn(RetryResult.success("cursor1"))
-        .thenReturn(RetryResult.success("cursor2"));
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.Success("cursor1"))
+        .thenReturn(new InitializationOutcome.Success("cursor2"));
 
     // when
     execute();
     execute();
 
     // then - should process both operations
-    verify(retryHandler, times(2)).executeWithRetry(any(), anyInt());
+    verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
   }
 
   @Test
@@ -216,13 +254,96 @@ public class BatchOperationExecutionSchedulerTest {
     when(batchOperationState.getNextPendingBatchOperation())
         .thenReturn(Optional.of(batchOperation));
 
-    when(retryHandler.executeWithRetry(any(), anyInt())).thenReturn(RetryResult.success("cursor"));
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.Success("cursor"));
 
     // when
     execute();
 
     // then
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
+  }
+
+  @Test
+  public void shouldPassCorrectNumAttemptsToRetryHandlerOnSubsequentRetries() {
+    // given
+    final var batchOperation = createBatchOperation();
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation));
+
+    final var cause = new RuntimeException("Transient failure");
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", cause));
+
+    // First call returns retry with numAttempts=1, second call returns retry with numAttempts=2
+    when(retryHandler.evaluate(any(), any(), eq(0)))
+        .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor"));
+    when(retryHandler.evaluate(any(), any(), eq(1)))
+        .thenReturn(RetryDecision.retry(Duration.ofMillis(200), 2, "cursor"));
+
+    // when - execute twice (simulating retry)
+    execute();
+    execute();
+
+    // then - verify numAttempts increments
+    verify(retryHandler).evaluate("cursor", cause, 0); // first execution
+    verify(retryHandler).evaluate("cursor", cause, 1); // second execution after retry
+  }
+
+  @Test
+  public void shouldNotSkipWhenRetryInProgress() {
+    // given - batch operation with cursor "cursor1"
+    final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation))
+        // Second call: cursor still "cursor1" (command not yet processed)
+        .thenReturn(Optional.of(batchOperation));
+
+    final var cause = new RuntimeException("Transient failure");
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor2", cause));
+
+    // First retry decision advances cursor to "cursor2" with numAttempts=1
+    when(retryHandler.evaluate(any(), any(), eq(0)))
+        .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor2"));
+    // Second call should still proceed because numAttempts > 0
+    when(retryHandler.evaluate(any(), any(), eq(1)))
+        .thenReturn(
+            RetryDecision.fail("Max retries exceeded", BatchOperationErrorType.QUERY_FAILED));
+
+    // when - execute twice
+    execute();
+    execute();
+
+    // then - both executions should call initializer (not skipped due to retry in progress)
+    verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
+  }
+
+  @Test
+  public void shouldResetNumAttemptsOnSuccess() {
+    // given
+    final var batchOperation = createBatchOperation().setInitializationSearchCursor("cursor1");
+    when(batchOperationState.getNextPendingBatchOperation())
+        .thenReturn(Optional.of(batchOperation))
+        .thenReturn(Optional.of(batchOperation.setInitializationSearchCursor("cursor2")));
+
+    final var cause = new RuntimeException("Transient failure");
+    // First call: needs retry
+    when(batchOperationInitializer.initializeBatchOperation(any(), any()))
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor2", cause))
+        .thenReturn(new InitializationOutcome.Success("cursor3"));
+
+    when(retryHandler.evaluate(any(), any(), eq(0)))
+        .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor2"));
+
+    // when - first execution triggers retry, second succeeds
+    execute();
+    execute();
+
+    // then - initializer should be called twice
+    verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
+    // And retry handler only once (success doesn't call retry handler)
+    verify(retryHandler, times(1)).evaluate(any(), any(), anyInt());
   }
 
   /** Bypasses the scheduling mechanism and executes the task directly */

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -37,11 +37,13 @@ public class BatchOperationExecutionSchedulerTest {
 
   public static final Duration SCHEDULER_INTERVAL = Duration.ofSeconds(1);
   public static final long BATCH_OPERATION_KEY = 123456789L;
+  private static final int DEFAULT_PAGE_SIZE = 100;
 
   @Mock private Supplier<ScheduledTaskState> scheduledTaskStateFactory;
   @Mock private TaskResultBuilder taskResultBuilder;
   @Mock private ReadonlyStreamProcessorContext streamProcessorContext;
   @Mock private ProcessingScheduleService scheduleService;
+
   @Mock private BatchOperationState batchOperationState;
   @Mock private BatchOperationInitializationBehavior batchOperationInitializer;
   @Mock private BatchOperationRetryPolicy retryPolicy;
@@ -56,7 +58,11 @@ public class BatchOperationExecutionSchedulerTest {
 
     scheduler =
         new BatchOperationExecutionScheduler(
-            scheduledTaskStateFactory, batchOperationInitializer, retryPolicy, SCHEDULER_INTERVAL);
+            scheduledTaskStateFactory,
+            batchOperationInitializer,
+            retryPolicy,
+            SCHEDULER_INTERVAL,
+            DEFAULT_PAGE_SIZE);
   }
 
   @Test
@@ -88,7 +94,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     // then
     verify(batchOperationState).getNextPendingBatchOperation();
-    verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
+    verify(batchOperationInitializer).initializeBatchOperation(any(), eq(taskResultBuilder));
     verifyNoInteractions(retryPolicy);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
@@ -107,7 +113,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
-    verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
+    verify(batchOperationInitializer).initializeBatchOperation(any(), eq(taskResultBuilder));
     verifyNoInteractions(retryPolicy);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
@@ -128,7 +134,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
-    verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
+    verify(batchOperationInitializer).initializeBatchOperation(any(), eq(taskResultBuilder));
     verify(batchOperationInitializer)
         .appendFailedCommand(taskResultBuilder, BATCH_OPERATION_KEY, errorMessage, errorType);
     verifyNoInteractions(retryPolicy);
@@ -154,7 +160,7 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then
-    verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
+    verify(batchOperationInitializer).initializeBatchOperation(any(), eq(taskResultBuilder));
     verify(retryPolicy).evaluate("cursor", cause, 0);
     verify(scheduleService)
         .runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any()); // initial schedule

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.protocol.record.value.BatchOperationType.CANCEL_P
 import static org.mockito.Mockito.*;
 
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryDecision;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy.RetryDecision;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
@@ -44,7 +44,7 @@ public class BatchOperationExecutionSchedulerTest {
   @Mock private ProcessingScheduleService scheduleService;
   @Mock private BatchOperationState batchOperationState;
   @Mock private BatchOperationInitializationBehavior batchOperationInitializer;
-  @Mock private BatchOperationRetryHandler retryHandler;
+  @Mock private BatchOperationRetryPolicy retryPolicy;
 
   @Captor private ArgumentCaptor<Task> taskCaptor;
 
@@ -56,7 +56,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     scheduler =
         new BatchOperationExecutionScheduler(
-            scheduledTaskStateFactory, batchOperationInitializer, retryHandler, SCHEDULER_INTERVAL);
+            scheduledTaskStateFactory, batchOperationInitializer, retryPolicy, SCHEDULER_INTERVAL);
   }
 
   @Test
@@ -69,7 +69,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     // then
     verify(batchOperationState).getNextPendingBatchOperation();
-    verifyNoInteractions(batchOperationInitializer, retryHandler);
+    verifyNoInteractions(batchOperationInitializer, retryPolicy);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 
@@ -89,7 +89,7 @@ public class BatchOperationExecutionSchedulerTest {
     // then
     verify(batchOperationState).getNextPendingBatchOperation();
     verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
-    verifyNoInteractions(retryHandler);
+    verifyNoInteractions(retryPolicy);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 
@@ -108,7 +108,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     // then
     verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
-    verifyNoInteractions(retryHandler);
+    verifyNoInteractions(retryPolicy);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 
@@ -131,7 +131,7 @@ public class BatchOperationExecutionSchedulerTest {
     verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
     verify(batchOperationInitializer)
         .appendFailedCommand(taskResultBuilder, BATCH_OPERATION_KEY, errorMessage, errorType);
-    verifyNoInteractions(retryHandler);
+    verifyNoInteractions(retryPolicy);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
   }
 
@@ -147,7 +147,7 @@ public class BatchOperationExecutionSchedulerTest {
         .thenReturn(new InitializationOutcome.NeedsRetry("cursor", cause));
 
     final var retryDelay = Duration.ofMillis(500);
-    when(retryHandler.evaluate(eq("cursor"), eq(cause), eq(0)))
+    when(retryPolicy.evaluate(eq("cursor"), eq(cause), eq(0)))
         .thenReturn(RetryDecision.retry(retryDelay, 1, "cursor"));
 
     // when
@@ -155,7 +155,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     // then
     verify(batchOperationInitializer).initializeBatchOperation(batchOperation, taskResultBuilder);
-    verify(retryHandler).evaluate("cursor", cause, 0);
+    verify(retryPolicy).evaluate("cursor", cause, 0);
     verify(scheduleService)
         .runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any()); // initial schedule
     verify(scheduleService).runDelayedAsync(eq(retryDelay), any(), any()); // retry schedule
@@ -174,14 +174,14 @@ public class BatchOperationExecutionSchedulerTest {
 
     final var errorMessage = "Failed after retries";
     final var errorType = BatchOperationErrorType.QUERY_FAILED;
-    when(retryHandler.evaluate(any(), any(), anyInt()))
+    when(retryPolicy.evaluate(any(), any(), anyInt()))
         .thenReturn(RetryDecision.fail(errorMessage, errorType));
 
     // when
     execute();
 
     // then
-    verify(retryHandler).evaluate("cursor", cause, 0);
+    verify(retryPolicy).evaluate("cursor", cause, 0);
     verify(batchOperationInitializer)
         .appendFailedCommand(taskResultBuilder, BATCH_OPERATION_KEY, errorMessage, errorType);
     verify(scheduleService, times(2)).runDelayedAsync(eq(SCHEDULER_INTERVAL), any(), any());
@@ -276,9 +276,9 @@ public class BatchOperationExecutionSchedulerTest {
         .thenReturn(new InitializationOutcome.NeedsRetry("cursor", cause));
 
     // First call returns retry with numAttempts=1, second call returns retry with numAttempts=2
-    when(retryHandler.evaluate(any(), any(), eq(0)))
+    when(retryPolicy.evaluate(any(), any(), eq(0)))
         .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor"));
-    when(retryHandler.evaluate(any(), any(), eq(1)))
+    when(retryPolicy.evaluate(any(), any(), eq(1)))
         .thenReturn(RetryDecision.retry(Duration.ofMillis(200), 2, "cursor"));
 
     // when - execute twice (simulating retry)
@@ -286,8 +286,8 @@ public class BatchOperationExecutionSchedulerTest {
     execute();
 
     // then - verify numAttempts increments
-    verify(retryHandler).evaluate("cursor", cause, 0); // first execution
-    verify(retryHandler).evaluate("cursor", cause, 1); // second execution after retry
+    verify(retryPolicy).evaluate("cursor", cause, 0); // first execution
+    verify(retryPolicy).evaluate("cursor", cause, 1); // second execution after retry
   }
 
   @Test
@@ -304,10 +304,10 @@ public class BatchOperationExecutionSchedulerTest {
         .thenReturn(new InitializationOutcome.NeedsRetry("cursor2", cause));
 
     // First retry decision advances cursor to "cursor2" with numAttempts=1
-    when(retryHandler.evaluate(any(), any(), eq(0)))
+    when(retryPolicy.evaluate(any(), any(), eq(0)))
         .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor2"));
     // Second call should still proceed because numAttempts > 0
-    when(retryHandler.evaluate(any(), any(), eq(1)))
+    when(retryPolicy.evaluate(any(), any(), eq(1)))
         .thenReturn(
             RetryDecision.fail("Max retries exceeded", BatchOperationErrorType.QUERY_FAILED));
 
@@ -333,7 +333,7 @@ public class BatchOperationExecutionSchedulerTest {
         .thenReturn(new InitializationOutcome.NeedsRetry("cursor2", cause))
         .thenReturn(new InitializationOutcome.Success("cursor3"));
 
-    when(retryHandler.evaluate(any(), any(), eq(0)))
+    when(retryPolicy.evaluate(any(), any(), eq(0)))
         .thenReturn(RetryDecision.retry(Duration.ofMillis(100), 1, "cursor2"));
 
     // when - first execution triggers retry, second succeeds
@@ -343,7 +343,7 @@ public class BatchOperationExecutionSchedulerTest {
     // then - initializer should be called twice
     verify(batchOperationInitializer, times(2)).initializeBatchOperation(any(), any());
     // And retry handler only once (success doesn't call retry handler)
-    verify(retryHandler, times(1)).evaluate(any(), any(), anyInt());
+    verify(retryPolicy, times(1)).evaluate(any(), any(), anyInt());
   }
 
   /** Bypasses the scheduling mechanism and executes the task directly */

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -69,10 +69,6 @@ class BatchOperationInitializationBehaviorTest {
     return new InitializationContext(batchOperation, SEARCH_CURSOR, PAGE_SIZE, 0, false);
   }
 
-  /** Creates an InitializationContext with custom page size. */
-  private InitializationContext createContextWithPageSize(final int pageSize) {
-    return new InitializationContext(batchOperation, SEARCH_CURSOR, pageSize, 0, false);
-  }
 
   @Test
   void shouldReturnEarlyWhenBatchOperationIsSuspended() {
@@ -140,7 +136,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldHandleFailedChunkAppendWithoutPreviousChunks() {
     // given
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new ChunkingOutcome.BufferFull(2));
+        .thenReturn(new ChunkingOutcome.BufferFull());
 
     // when
     final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
@@ -163,16 +159,17 @@ class BatchOperationInitializationBehaviorTest {
     // given - First page succeeds, second page fails to fit in buffer
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new ChunkingOutcome.Continue("cursor1", 2))
-        .thenReturn(new ChunkingOutcome.BufferFull(2));
+        .thenReturn(new ChunkingOutcome.BufferFull());
 
     // when
     final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
-    // then
+    // then - returns Success (meaning "progress made, continue later") with cursor at last successful page
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
     final var success = (InitializationOutcome.Success) result;
     assertThat(success.cursor()).isEqualTo("cursor1");
 
+    // INITIALIZE command written to persist progress
     verify(commandBuilder)
         .appendInitializationCommand(
             eq(taskResultBuilder), eq(BATCH_OPERATION_KEY), eq("cursor1"), eq(PAGE_SIZE));
@@ -293,5 +290,29 @@ class BatchOperationInitializationBehaviorTest {
     verify(metrics)
         .startTotalExecutionLatencyMeasure(
             BATCH_OPERATION_KEY, BatchOperationType.DELETE_PROCESS_INSTANCE);
+  }
+
+  @Test
+  void shouldFailWhenBufferFullAndPageSizeAlreadyMinimum() {
+    // given - page size is already 1, cannot reduce further
+    final var minPageSizeContext =
+        new InitializationContext(batchOperation, SEARCH_CURSOR, 1, 0, false);
+
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new ChunkingOutcome.BufferFull());
+
+    // when
+    final var result = initializer.initializeBatchOperation(minPageSizeContext, taskResultBuilder);
+
+    // then - terminal failure since we can't reduce page size below 1
+    assertThat(result).isInstanceOf(InitializationOutcome.Failed.class);
+    final var failed = (InitializationOutcome.Failed) result;
+    assertThat(failed.message()).contains("Result buffer too small");
+    assertThat(failed.errorType())
+        .isEqualTo(BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED);
+
+    // No INITIALIZE command should be written for terminal failure
+    verify(commandBuilder, never())
+        .appendInitializationCommand(any(), anyLong(), anyString(), anyInt());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -22,9 +22,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
-import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider;
-import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
-import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult;
@@ -32,7 +29,6 @@ import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +40,6 @@ class BatchOperationInitializationBehaviorTest {
   private static final int PAGE_SIZE = 100;
 
   private final ItemProviderFactory itemProviderFactory = mock(ItemProviderFactory.class);
-  private final ItemProvider itemProvider = mock(ItemProvider.class);
   private final BatchOperationPageProcessor pageProcessor = mock(BatchOperationPageProcessor.class);
   private final BatchOperationCommandAppender commandBuilder =
       mock(BatchOperationCommandAppender.class);
@@ -69,8 +64,6 @@ class BatchOperationInitializationBehaviorTest {
             .setInitializationSearchQueryPageSize(PAGE_SIZE)
             .setNumTotalItems(0)
             .setStatus(CREATED);
-
-    when(itemProviderFactory.fromBatchOperation(batchOperation)).thenReturn(itemProvider);
   }
 
   @Test
@@ -84,20 +77,14 @@ class BatchOperationInitializationBehaviorTest {
     // then
     assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
     assertThat(result.searchResultCursor()).isEqualTo(SEARCH_CURSOR);
-    verify(itemProvider, never()).fetchItemPage(anyString(), any(Integer.class));
-    verify(pageProcessor, never()).processPage(anyLong(), any(), any());
+    verify(pageProcessor, never()).processNextPage(any(), any(), any());
   }
 
   @Test
   void shouldInitializeSuccessfullyWithSinglePageAndFinish() {
     // given
-    final var items = List.of(createItem(1L), createItem(2L));
-    final var itemPage = new ItemPage(items, NEXT_SEARCH_CURSOR, 2L, true);
-    final var pageResult = new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2);
-
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(itemPage);
-    when(pageProcessor.processPage(batchOperation.getKey(), itemPage, taskResultBuilder))
-        .thenReturn(pageResult);
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -121,20 +108,9 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleMultiplePagesSuccessfully() {
     // given
-    final var firstPageItems = List.of(createItem(1L), createItem(2L));
-    final var firstPage = new ItemPage(firstPageItems, "cursor1", 4L, false);
-    final var firstPageResult = new PageProcessingResult.Continue("cursor1", 2);
-
-    final var secondPageItems = List.of(createItem(3L), createItem(4L));
-    final var secondPage = new ItemPage(secondPageItems, "cursor2", 4L, true);
-    final var secondPageResult = new PageProcessingResult.Finished("cursor2", 2);
-
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(firstPage);
-    when(itemProvider.fetchItemPage("cursor1", PAGE_SIZE)).thenReturn(secondPage);
-    when(pageProcessor.processPage(batchOperation.getKey(), firstPage, taskResultBuilder))
-        .thenReturn(firstPageResult);
-    when(pageProcessor.processPage(batchOperation.getKey(), secondPage, taskResultBuilder))
-        .thenReturn(secondPageResult);
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
+        .thenReturn(new PageProcessingResult.Finished("cursor2", 2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -152,13 +128,8 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleFailedChunkAppendWithoutPreviousChunks() {
     // given
-    final var items = List.of(createItem(1L), createItem(2L));
-    final var itemPage = new ItemPage(items, NEXT_SEARCH_CURSOR, 2L, false);
-    final var pageResult = new PageProcessingResult.BufferFull(2);
-
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(itemPage);
-    when(pageProcessor.processPage(batchOperation.getKey(), itemPage, taskResultBuilder))
-        .thenReturn(pageResult);
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.BufferFull(2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -177,21 +148,10 @@ class BatchOperationInitializationBehaviorTest {
 
   @Test
   void shouldHandleFailedChunkAppendWithPreviousChunks() {
-    // given - First page succeeds, second page fails
-    final var firstPageItems = List.of(createItem(1L), createItem(2L));
-    final var firstPage = new ItemPage(firstPageItems, "cursor1", 4L, false);
-    final var firstPageResult = new PageProcessingResult.Continue("cursor1", 2);
-
-    final var secondPageItems = List.of(createItem(3L), createItem(4L));
-    final var secondPage = new ItemPage(secondPageItems, "cursor2", 4L, false);
-    final var secondPageResult = new PageProcessingResult.BufferFull(2);
-
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(firstPage);
-    when(itemProvider.fetchItemPage("cursor1", PAGE_SIZE)).thenReturn(secondPage);
-    when(pageProcessor.processPage(batchOperation.getKey(), firstPage, taskResultBuilder))
-        .thenReturn(firstPageResult);
-    when(pageProcessor.processPage(batchOperation.getKey(), secondPage, taskResultBuilder))
-        .thenReturn(secondPageResult);
+    // given - First page succeeds, second page fails to fit in buffer
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
+        .thenReturn(new PageProcessingResult.BufferFull(2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -206,10 +166,11 @@ class BatchOperationInitializationBehaviorTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenItemProviderFailsWithoutPreviousChunks() {
+  void shouldThrowExceptionWhenFetchFailsWithoutPreviousChunks() {
     // given
     final var exception = new RuntimeException("Database connection failed");
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenThrow(exception);
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.FetchFailed(exception));
 
     // when & then
     assertThatThrownBy(
@@ -224,18 +185,12 @@ class BatchOperationInitializationBehaviorTest {
   }
 
   @Test
-  void shouldContinueInitializationWhenItemProviderFailsWithPreviousChunks() {
-    // given - First page succeeds, second page throws exception
-    final var firstPageItems = List.of(createItem(1L), createItem(2L));
-    final var firstPage = new ItemPage(firstPageItems, "cursor1", 4L, false);
-    final var firstPageResult = new PageProcessingResult.Continue("cursor1", 2);
-
+  void shouldContinueInitializationWhenFetchFailsWithPreviousChunks() {
+    // given - First page succeeds, second page fetch fails
     final var exception = new RuntimeException("Database connection failed");
-
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(firstPage);
-    when(itemProvider.fetchItemPage("cursor1", PAGE_SIZE)).thenThrow(exception);
-    when(pageProcessor.processPage(batchOperation.getKey(), firstPage, taskResultBuilder))
-        .thenReturn(firstPageResult);
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
+        .thenReturn(new PageProcessingResult.FetchFailed(exception));
 
     // when & then
     assertThatThrownBy(
@@ -268,12 +223,8 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleEmptyPageSuccessfully() {
     // given
-    final var emptyPage = new ItemPage(List.of(), NEXT_SEARCH_CURSOR, 0L, true);
-    final var pageResult = new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 0);
-
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(emptyPage);
-    when(pageProcessor.processPage(batchOperation.getKey(), emptyPage, taskResultBuilder))
-        .thenReturn(pageResult);
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 0));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -292,14 +243,8 @@ class BatchOperationInitializationBehaviorTest {
   void shouldUpdateTotalItemsCountCorrectly() {
     // given
     batchOperation.setNumTotalItems(5);
-
-    final var items = List.of(createItem(1L), createItem(2L), createItem(3L));
-    final var itemPage = new ItemPage(items, NEXT_SEARCH_CURSOR, 3L, true);
-    final var pageResult = new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 3);
-
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(itemPage);
-    when(pageProcessor.processPage(batchOperation.getKey(), itemPage, taskResultBuilder))
-        .thenReturn(pageResult);
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 3));
 
     // when
     initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -312,13 +257,8 @@ class BatchOperationInitializationBehaviorTest {
   void shouldInitializeDeleteProcessInstanceBatchOperation() {
     // given
     batchOperation.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
-    final var items = List.of(createItem(10L), createItem(11L));
-    final var itemPage = new ItemPage(items, NEXT_SEARCH_CURSOR, 2L, true);
-    final var pageResult = new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2);
-
-    when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(itemPage);
-    when(pageProcessor.processPage(batchOperation.getKey(), itemPage, taskResultBuilder))
-        .thenReturn(pageResult);
+    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+        .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -336,9 +276,5 @@ class BatchOperationInitializationBehaviorTest {
     verify(metrics)
         .startTotalExecutionLatencyMeasure(
             BATCH_OPERATION_KEY, BatchOperationType.DELETE_PROCESS_INSTANCE);
-  }
-
-  private Item createItem(final long key) {
-    return new Item(key, key + 1000, null);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import static io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus.CREATED;
 import static io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus.SUSPENDED;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -23,8 +22,9 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
@@ -75,8 +75,9 @@ class BatchOperationInitializationBehaviorTest {
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
 
     // then
-    assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
-    assertThat(result.searchResultCursor()).isEqualTo(SEARCH_CURSOR);
+    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
+    final var success = (InitializationOutcome.Success) result;
+    assertThat(success.cursor()).isEqualTo(SEARCH_CURSOR);
     verify(chunkAppender, never()).fetchAndChunkNextPage(any(), any(), any());
   }
 
@@ -90,8 +91,9 @@ class BatchOperationInitializationBehaviorTest {
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
 
     // then
-    assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
-    assertThat(result.searchResultCursor()).isEqualTo("finished");
+    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
+    final var success = (InitializationOutcome.Success) result;
+    assertThat(success.cursor()).isEqualTo("finished");
 
     verify(commandBuilder)
         .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
@@ -116,8 +118,9 @@ class BatchOperationInitializationBehaviorTest {
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
 
     // then
-    assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
-    assertThat(result.searchResultCursor()).isEqualTo("finished");
+    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
+    final var success = (InitializationOutcome.Success) result;
+    assertThat(success.cursor()).isEqualTo("finished");
 
     verify(commandBuilder)
         .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
@@ -135,8 +138,9 @@ class BatchOperationInitializationBehaviorTest {
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
 
     // then
-    assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
-    assertThat(result.searchResultCursor()).isEqualTo(SEARCH_CURSOR);
+    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
+    final var success = (InitializationOutcome.Success) result;
+    assertThat(success.cursor()).isEqualTo(SEARCH_CURSOR);
 
     verify(commandBuilder)
         .appendInitializationCommand(
@@ -157,8 +161,9 @@ class BatchOperationInitializationBehaviorTest {
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
 
     // then
-    assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
-    assertThat(result.searchResultCursor()).isEqualTo("cursor1");
+    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
+    final var success = (InitializationOutcome.Success) result;
+    assertThat(success.cursor()).isEqualTo("cursor1");
 
     verify(commandBuilder)
         .appendInitializationCommand(
@@ -166,19 +171,20 @@ class BatchOperationInitializationBehaviorTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenFetchFailsWithoutPreviousChunks() {
+  void shouldReturnNeedsRetryWhenFetchFailsWithoutPreviousChunks() {
     // given
     final var exception = new RuntimeException("Database connection failed");
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.FetchFailed(exception));
 
-    // when & then
-    assertThatThrownBy(
-            () -> initializer.initializeBatchOperation(batchOperation, taskResultBuilder))
-        .isInstanceOf(BatchOperationInitializationException.class)
-        .hasMessageContaining(
-            "Failed to initialize batch operation with end cursor: " + SEARCH_CURSOR)
-        .hasCause(exception);
+    // when
+    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+
+    // then
+    assertThat(result).isInstanceOf(InitializationOutcome.NeedsRetry.class);
+    final var needsRetry = (InitializationOutcome.NeedsRetry) result;
+    assertThat(needsRetry.cursor()).isEqualTo(SEARCH_CURSOR);
+    assertThat(needsRetry.cause()).isSameAs(exception);
 
     verify(commandBuilder, never())
         .appendInitializationCommand(any(), anyLong(), anyString(), anyInt());
@@ -192,12 +198,14 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
         .thenReturn(new PageProcessingResult.FetchFailed(exception));
 
-    // when & then
-    assertThatThrownBy(
-            () -> initializer.initializeBatchOperation(batchOperation, taskResultBuilder))
-        .isInstanceOf(BatchOperationInitializationException.class)
-        .hasMessageContaining("Failed to initialize batch operation with end cursor: cursor1")
-        .hasCause(exception);
+    // when
+    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+
+    // then
+    assertThat(result).isInstanceOf(InitializationOutcome.NeedsRetry.class);
+    final var needsRetry = (InitializationOutcome.NeedsRetry) result;
+    assertThat(needsRetry.cursor()).isEqualTo("cursor1");
+    assertThat(needsRetry.cause()).isSameAs(exception);
 
     verify(commandBuilder)
         .appendInitializationCommand(
@@ -230,8 +238,9 @@ class BatchOperationInitializationBehaviorTest {
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
 
     // then
-    assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
-    assertThat(result.searchResultCursor()).isEqualTo("finished");
+    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
+    final var success = (InitializationOutcome.Success) result;
+    assertThat(success.cursor()).isEqualTo("finished");
 
     verify(commandBuilder)
         .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
@@ -264,8 +273,9 @@ class BatchOperationInitializationBehaviorTest {
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
 
     // then
-    assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
-    assertThat(result.searchResultCursor()).isEqualTo("finished");
+    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
+    final var success = (InitializationOutcome.Success) result;
+    assertThat(success.cursor()).isEqualTo("finished");
     verify(commandBuilder)
         .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
     verify(commandBuilder).appendExecutionCommand(taskResultBuilder, BATCH_OPERATION_KEY);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -93,7 +93,7 @@ class BatchOperationInitializationBehaviorTest {
     // given
     final var items = List.of(createItem(1L), createItem(2L));
     final var itemPage = new ItemPage(items, NEXT_SEARCH_CURSOR, 2L, true);
-    final var pageResult = new PageProcessingResult(true, NEXT_SEARCH_CURSOR, 2, true);
+    final var pageResult = new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2);
 
     when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(itemPage);
     when(pageProcessor.processPage(batchOperation.getKey(), itemPage, taskResultBuilder))
@@ -123,11 +123,11 @@ class BatchOperationInitializationBehaviorTest {
     // given
     final var firstPageItems = List.of(createItem(1L), createItem(2L));
     final var firstPage = new ItemPage(firstPageItems, "cursor1", 4L, false);
-    final var firstPageResult = new PageProcessingResult(true, "cursor1", 2, false);
+    final var firstPageResult = new PageProcessingResult.Continue("cursor1", 2);
 
     final var secondPageItems = List.of(createItem(3L), createItem(4L));
     final var secondPage = new ItemPage(secondPageItems, "cursor2", 4L, true);
-    final var secondPageResult = new PageProcessingResult(true, "cursor2", 2, true);
+    final var secondPageResult = new PageProcessingResult.Finished("cursor2", 2);
 
     when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(firstPage);
     when(itemProvider.fetchItemPage("cursor1", PAGE_SIZE)).thenReturn(secondPage);
@@ -154,7 +154,7 @@ class BatchOperationInitializationBehaviorTest {
     // given
     final var items = List.of(createItem(1L), createItem(2L));
     final var itemPage = new ItemPage(items, NEXT_SEARCH_CURSOR, 2L, false);
-    final var pageResult = new PageProcessingResult(false, NEXT_SEARCH_CURSOR, 2, false);
+    final var pageResult = new PageProcessingResult.BufferFull(2);
 
     when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(itemPage);
     when(pageProcessor.processPage(batchOperation.getKey(), itemPage, taskResultBuilder))
@@ -180,11 +180,11 @@ class BatchOperationInitializationBehaviorTest {
     // given - First page succeeds, second page fails
     final var firstPageItems = List.of(createItem(1L), createItem(2L));
     final var firstPage = new ItemPage(firstPageItems, "cursor1", 4L, false);
-    final var firstPageResult = new PageProcessingResult(true, "cursor1", 2, false);
+    final var firstPageResult = new PageProcessingResult.Continue("cursor1", 2);
 
     final var secondPageItems = List.of(createItem(3L), createItem(4L));
     final var secondPage = new ItemPage(secondPageItems, "cursor2", 4L, false);
-    final var secondPageResult = new PageProcessingResult(false, "cursor2", 2, false);
+    final var secondPageResult = new PageProcessingResult.BufferFull(2);
 
     when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(firstPage);
     when(itemProvider.fetchItemPage("cursor1", PAGE_SIZE)).thenReturn(secondPage);
@@ -228,7 +228,7 @@ class BatchOperationInitializationBehaviorTest {
     // given - First page succeeds, second page throws exception
     final var firstPageItems = List.of(createItem(1L), createItem(2L));
     final var firstPage = new ItemPage(firstPageItems, "cursor1", 4L, false);
-    final var firstPageResult = new PageProcessingResult(true, "cursor1", 2, false);
+    final var firstPageResult = new PageProcessingResult.Continue("cursor1", 2);
 
     final var exception = new RuntimeException("Database connection failed");
 
@@ -269,7 +269,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldHandleEmptyPageSuccessfully() {
     // given
     final var emptyPage = new ItemPage(List.of(), NEXT_SEARCH_CURSOR, 0L, true);
-    final var pageResult = new PageProcessingResult(true, NEXT_SEARCH_CURSOR, 0, true);
+    final var pageResult = new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 0);
 
     when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(emptyPage);
     when(pageProcessor.processPage(batchOperation.getKey(), emptyPage, taskResultBuilder))
@@ -295,7 +295,7 @@ class BatchOperationInitializationBehaviorTest {
 
     final var items = List.of(createItem(1L), createItem(2L), createItem(3L));
     final var itemPage = new ItemPage(items, NEXT_SEARCH_CURSOR, 3L, true);
-    final var pageResult = new PageProcessingResult(true, NEXT_SEARCH_CURSOR, 3, true);
+    final var pageResult = new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 3);
 
     when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(itemPage);
     when(pageProcessor.processPage(batchOperation.getKey(), itemPage, taskResultBuilder))
@@ -314,7 +314,7 @@ class BatchOperationInitializationBehaviorTest {
     batchOperation.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
     final var items = List.of(createItem(10L), createItem(11L));
     final var itemPage = new ItemPage(items, NEXT_SEARCH_CURSOR, 2L, true);
-    final var pageResult = new PageProcessingResult(true, NEXT_SEARCH_CURSOR, 2, true);
+    final var pageResult = new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2);
 
     when(itemProvider.fetchItemPage(SEARCH_CURSOR, PAGE_SIZE)).thenReturn(itemPage);
     when(pageProcessor.processPage(batchOperation.getKey(), itemPage, taskResultBuilder))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
@@ -217,11 +216,10 @@ class BatchOperationInitializationBehaviorTest {
     // given
     final var errorMessage = "Test error message";
     final var errorType = BatchOperationErrorType.QUERY_FAILED;
-    final var exception =
-        new BatchOperationInitializationException(errorMessage, errorType, "test-cursor");
 
     // when
-    initializer.appendFailedCommand(taskResultBuilder, batchOperation.getKey(), exception);
+    initializer.appendFailedCommand(
+        taskResultBuilder, batchOperation.getKey(), errorMessage, errorType);
 
     // then
     verify(commandBuilder)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.ChunkingOutcome;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
@@ -83,7 +83,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldInitializeSuccessfullyWithSinglePageAndFinish() {
     // given
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2));
+        .thenReturn(new ChunkingOutcome.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -109,8 +109,8 @@ class BatchOperationInitializationBehaviorTest {
   void shouldHandleMultiplePagesSuccessfully() {
     // given
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
-        .thenReturn(new PageProcessingResult.Finished("cursor2", 2));
+        .thenReturn(new ChunkingOutcome.Continue("cursor1", 2))
+        .thenReturn(new ChunkingOutcome.Finished("cursor2", 2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -130,7 +130,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldHandleFailedChunkAppendWithoutPreviousChunks() {
     // given
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.BufferFull(2));
+        .thenReturn(new ChunkingOutcome.BufferFull(2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -152,8 +152,8 @@ class BatchOperationInitializationBehaviorTest {
   void shouldHandleFailedChunkAppendWithPreviousChunks() {
     // given - First page succeeds, second page fails to fit in buffer
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
-        .thenReturn(new PageProcessingResult.BufferFull(2));
+        .thenReturn(new ChunkingOutcome.Continue("cursor1", 2))
+        .thenReturn(new ChunkingOutcome.BufferFull(2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -173,7 +173,7 @@ class BatchOperationInitializationBehaviorTest {
     // given
     final var exception = new RuntimeException("Database connection failed");
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.FetchFailed(exception));
+        .thenReturn(new ChunkingOutcome.FetchFailed(exception));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -193,8 +193,8 @@ class BatchOperationInitializationBehaviorTest {
     // given - First page succeeds, second page fetch fails
     final var exception = new RuntimeException("Database connection failed");
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
-        .thenReturn(new PageProcessingResult.FetchFailed(exception));
+        .thenReturn(new ChunkingOutcome.Continue("cursor1", 2))
+        .thenReturn(new ChunkingOutcome.FetchFailed(exception));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -229,7 +229,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldHandleEmptyPageSuccessfully() {
     // given
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 0));
+        .thenReturn(new ChunkingOutcome.Finished(NEXT_SEARCH_CURSOR, 0));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -250,7 +250,7 @@ class BatchOperationInitializationBehaviorTest {
     // given
     batchOperation.setNumTotalItems(5);
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 3));
+        .thenReturn(new ChunkingOutcome.Finished(NEXT_SEARCH_CURSOR, 3));
 
     // when
     initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
@@ -264,7 +264,7 @@ class BatchOperationInitializationBehaviorTest {
     // given
     batchOperation.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
     when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
-        .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2));
+        .thenReturn(new ChunkingOutcome.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when
     final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvid
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
@@ -36,7 +36,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class BatchOperationInitializationHelperTest {
+class BatchOperationInitializationBehaviorTest {
 
   private static final long BATCH_OPERATION_KEY = 12345L;
   private static final String SEARCH_CURSOR = "test-cursor";
@@ -52,12 +52,12 @@ class BatchOperationInitializationHelperTest {
   private final TaskResultBuilder taskResultBuilder = mock(TaskResultBuilder.class);
   private PersistedBatchOperation batchOperation;
 
-  private BatchOperationInitializationHelper initializer;
+  private BatchOperationInitializationBehavior initializer;
 
   @BeforeEach
   void setUp() {
     initializer =
-        new BatchOperationInitializationHelper(
+        new BatchOperationInitializationBehavior(
             itemProviderFactory, pageProcessor, commandBuilder, PAGE_SIZE, metrics);
 
     // Default batch operation setup

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -77,13 +77,13 @@ class BatchOperationInitializationBehaviorTest {
     // then
     assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
     assertThat(result.searchResultCursor()).isEqualTo(SEARCH_CURSOR);
-    verify(chunkAppender, never()).processNextPage(any(), any(), any());
+    verify(chunkAppender, never()).fetchAndChunkNextPage(any(), any(), any());
   }
 
   @Test
   void shouldInitializeSuccessfullyWithSinglePageAndFinish() {
     // given
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when
@@ -108,7 +108,7 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleMultiplePagesSuccessfully() {
     // given
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
         .thenReturn(new PageProcessingResult.Finished("cursor2", 2));
 
@@ -128,7 +128,7 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleFailedChunkAppendWithoutPreviousChunks() {
     // given
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.BufferFull(2));
 
     // when
@@ -149,7 +149,7 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleFailedChunkAppendWithPreviousChunks() {
     // given - First page succeeds, second page fails to fit in buffer
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
         .thenReturn(new PageProcessingResult.BufferFull(2));
 
@@ -169,7 +169,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldThrowExceptionWhenFetchFailsWithoutPreviousChunks() {
     // given
     final var exception = new RuntimeException("Database connection failed");
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.FetchFailed(exception));
 
     // when & then
@@ -188,7 +188,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldContinueInitializationWhenFetchFailsWithPreviousChunks() {
     // given - First page succeeds, second page fetch fails
     final var exception = new RuntimeException("Database connection failed");
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
         .thenReturn(new PageProcessingResult.FetchFailed(exception));
 
@@ -223,7 +223,7 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleEmptyPageSuccessfully() {
     // given
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 0));
 
     // when
@@ -243,7 +243,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldUpdateTotalItemsCountCorrectly() {
     // given
     batchOperation.setNumTotalItems(5);
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 3));
 
     // when
@@ -257,7 +257,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldInitializeDeleteProcessInstanceBatchOperation() {
     // given
     batchOperation.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
-    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.fetchAndChunkNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.PageProcessingResult;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
@@ -40,7 +40,7 @@ class BatchOperationInitializationBehaviorTest {
   private static final int PAGE_SIZE = 100;
 
   private final ItemProviderFactory itemProviderFactory = mock(ItemProviderFactory.class);
-  private final BatchOperationPageProcessor pageProcessor = mock(BatchOperationPageProcessor.class);
+  private final BatchOperationChunkAppender chunkAppender = mock(BatchOperationChunkAppender.class);
   private final BatchOperationCommandAppender commandBuilder =
       mock(BatchOperationCommandAppender.class);
   private final BatchOperationMetrics metrics = mock(BatchOperationMetrics.class);
@@ -53,7 +53,7 @@ class BatchOperationInitializationBehaviorTest {
   void setUp() {
     initializer =
         new BatchOperationInitializationBehavior(
-            itemProviderFactory, pageProcessor, commandBuilder, PAGE_SIZE, metrics);
+            itemProviderFactory, chunkAppender, commandBuilder, PAGE_SIZE, metrics);
 
     // Default batch operation setup
     batchOperation =
@@ -77,13 +77,13 @@ class BatchOperationInitializationBehaviorTest {
     // then
     assertThat(result.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
     assertThat(result.searchResultCursor()).isEqualTo(SEARCH_CURSOR);
-    verify(pageProcessor, never()).processNextPage(any(), any(), any());
+    verify(chunkAppender, never()).processNextPage(any(), any(), any());
   }
 
   @Test
   void shouldInitializeSuccessfullyWithSinglePageAndFinish() {
     // given
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when
@@ -108,7 +108,7 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleMultiplePagesSuccessfully() {
     // given
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
         .thenReturn(new PageProcessingResult.Finished("cursor2", 2));
 
@@ -128,7 +128,7 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleFailedChunkAppendWithoutPreviousChunks() {
     // given
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.BufferFull(2));
 
     // when
@@ -149,7 +149,7 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleFailedChunkAppendWithPreviousChunks() {
     // given - First page succeeds, second page fails to fit in buffer
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
         .thenReturn(new PageProcessingResult.BufferFull(2));
 
@@ -169,7 +169,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldThrowExceptionWhenFetchFailsWithoutPreviousChunks() {
     // given
     final var exception = new RuntimeException("Database connection failed");
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.FetchFailed(exception));
 
     // when & then
@@ -188,7 +188,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldContinueInitializationWhenFetchFailsWithPreviousChunks() {
     // given - First page succeeds, second page fetch fails
     final var exception = new RuntimeException("Database connection failed");
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Continue("cursor1", 2))
         .thenReturn(new PageProcessingResult.FetchFailed(exception));
 
@@ -223,7 +223,7 @@ class BatchOperationInitializationBehaviorTest {
   @Test
   void shouldHandleEmptyPageSuccessfully() {
     // given
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 0));
 
     // when
@@ -243,7 +243,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldUpdateTotalItemsCountCorrectly() {
     // given
     batchOperation.setNumTotalItems(5);
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 3));
 
     // when
@@ -257,7 +257,7 @@ class BatchOperationInitializationBehaviorTest {
   void shouldInitializeDeleteProcessInstanceBatchOperation() {
     // given
     batchOperation.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
-    when(pageProcessor.processNextPage(any(), any(), eq(taskResultBuilder)))
+    when(chunkAppender.processNextPage(any(), any(), eq(taskResultBuilder)))
         .thenReturn(new PageProcessingResult.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -40,8 +40,7 @@ class BatchOperationInitializationBehaviorTest {
 
   private final ItemProviderFactory itemProviderFactory = mock(ItemProviderFactory.class);
   private final BatchOperationChunkAppender chunkAppender = mock(BatchOperationChunkAppender.class);
-  private final BatchOperationCommandAppender commandBuilder =
-      mock(BatchOperationCommandAppender.class);
+  private final BatchOperationCommandAppender commandBuilder = mock(BatchOperationCommandAppender.class);
   private final BatchOperationMetrics metrics = mock(BatchOperationMetrics.class);
   private final TaskResultBuilder taskResultBuilder = mock(TaskResultBuilder.class);
   private PersistedBatchOperation batchOperation;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -69,7 +69,6 @@ class BatchOperationInitializationBehaviorTest {
     return new InitializationContext(batchOperation, SEARCH_CURSOR, PAGE_SIZE, 0, false);
   }
 
-
   @Test
   void shouldReturnEarlyWhenBatchOperationIsSuspended() {
     // given
@@ -97,7 +96,7 @@ class BatchOperationInitializationBehaviorTest {
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
     final var success = (InitializationOutcome.Success) result;
-    assertThat(success.cursor()).isEqualTo("finished");
+    assertThat(success.cursor()).isEqualTo(NEXT_SEARCH_CURSOR);
 
     verify(commandBuilder)
         .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
@@ -124,7 +123,7 @@ class BatchOperationInitializationBehaviorTest {
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
     final var success = (InitializationOutcome.Success) result;
-    assertThat(success.cursor()).isEqualTo("finished");
+    assertThat(success.cursor()).isEqualTo("cursor2");
 
     verify(commandBuilder)
         .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
@@ -164,7 +163,8 @@ class BatchOperationInitializationBehaviorTest {
     // when
     final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
-    // then - returns Success (meaning "progress made, continue later") with cursor at last successful page
+    // then - returns Success (meaning "progress made, continue later") with cursor at last
+    // successful page
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
     final var success = (InitializationOutcome.Success) result;
     assertThat(success.cursor()).isEqualTo("cursor1");
@@ -244,7 +244,7 @@ class BatchOperationInitializationBehaviorTest {
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
     final var success = (InitializationOutcome.Success) result;
-    assertThat(success.cursor()).isEqualTo("finished");
+    assertThat(success.cursor()).isEqualTo(NEXT_SEARCH_CURSOR);
 
     verify(commandBuilder)
         .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
@@ -279,7 +279,7 @@ class BatchOperationInitializationBehaviorTest {
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
     final var success = (InitializationOutcome.Success) result;
-    assertThat(success.cursor()).isEqualTo("finished");
+    assertThat(success.cursor()).isEqualTo(NEXT_SEARCH_CURSOR);
     verify(commandBuilder)
         .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
     verify(commandBuilder).appendExecutionCommand(taskResultBuilder, BATCH_OPERATION_KEY);
@@ -308,8 +308,7 @@ class BatchOperationInitializationBehaviorTest {
     assertThat(result).isInstanceOf(InitializationOutcome.Failed.class);
     final var failed = (InitializationOutcome.Failed) result;
     assertThat(failed.message()).contains("Result buffer too small");
-    assertThat(failed.errorType())
-        .isEqualTo(BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED);
+    assertThat(failed.errorType()).isEqualTo(BatchOperationErrorType.RESULT_BUFFER_SIZE_EXCEEDED);
 
     // No INITIALIZE command should be written for terminal failure
     verify(commandBuilder, never())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -40,7 +40,7 @@ class BatchOperationInitializationBehaviorTest {
 
   private final ItemProviderFactory itemProviderFactory = mock(ItemProviderFactory.class);
   private final BatchOperationChunkAppender chunkAppender = mock(BatchOperationChunkAppender.class);
-  private final BatchOperationCommandAppender commandBuilder = mock(BatchOperationCommandAppender.class);
+  private final BatchOperationCommands commandBuilder = mock(BatchOperationCommands.class);
   private final BatchOperationMetrics metrics = mock(BatchOperationMetrics.class);
   private final TaskResultBuilder taskResultBuilder = mock(TaskResultBuilder.class);
   private PersistedBatchOperation batchOperation;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import static io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus.CREATED;
-import static io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus.SUSPENDED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -67,21 +66,6 @@ class BatchOperationInitializationBehaviorTest {
   /** Creates an InitializationContext from the batch operation for testing. */
   private InitializationContext createContext() {
     return new InitializationContext(batchOperation, SEARCH_CURSOR, PAGE_SIZE, 0, false);
-  }
-
-  @Test
-  void shouldReturnEarlyWhenBatchOperationIsSuspended() {
-    // given
-    batchOperation.setStatus(SUSPENDED);
-
-    // when
-    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
-
-    // then
-    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
-    final var success = (InitializationOutcome.Success) result;
-    assertThat(success.cursor()).isEqualTo(SEARCH_CURSOR);
-    verify(chunkAppender, never()).fetchAndChunkNextPage(any(), any(), any());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -51,7 +51,7 @@ class BatchOperationInitializationBehaviorTest {
   void setUp() {
     initializer =
         new BatchOperationInitializationBehavior(
-            itemProviderFactory, chunkAppender, commandBuilder, PAGE_SIZE, metrics);
+            itemProviderFactory, chunkAppender, commandBuilder, metrics);
 
     // Default batch operation setup
     batchOperation =
@@ -64,13 +64,23 @@ class BatchOperationInitializationBehaviorTest {
             .setStatus(CREATED);
   }
 
+  /** Creates an InitializationContext from the batch operation for testing. */
+  private InitializationContext createContext() {
+    return new InitializationContext(batchOperation, SEARCH_CURSOR, PAGE_SIZE, 0, false);
+  }
+
+  /** Creates an InitializationContext with custom page size. */
+  private InitializationContext createContextWithPageSize(final int pageSize) {
+    return new InitializationContext(batchOperation, SEARCH_CURSOR, pageSize, 0, false);
+  }
+
   @Test
   void shouldReturnEarlyWhenBatchOperationIsSuspended() {
     // given
     batchOperation.setStatus(SUSPENDED);
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
@@ -86,7 +96,7 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
@@ -113,7 +123,7 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.Finished("cursor2", 2));
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
@@ -133,19 +143,19 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.BufferFull(2));
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
-    assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
-    final var success = (InitializationOutcome.Success) result;
-    assertThat(success.cursor()).isEqualTo(SEARCH_CURSOR);
+    assertThat(result).isInstanceOf(InitializationOutcome.ReducePageSize.class);
+    final var reducePageSize = (InitializationOutcome.ReducePageSize) result;
+    assertThat(reducePageSize.newPageSize()).isEqualTo(PAGE_SIZE / 2);
 
     verify(commandBuilder)
         .appendInitializationCommand(
             eq(taskResultBuilder),
             eq(BATCH_OPERATION_KEY),
             anyString(),
-            eq(PAGE_SIZE / 2)); // Should reduce page size
+            eq(PAGE_SIZE / 2)); // Should write INITIALIZE with reduced page size
   }
 
   @Test
@@ -156,7 +166,7 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.BufferFull(2));
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
@@ -176,7 +186,7 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.FetchFailed(exception));
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.NeedsRetry.class);
@@ -197,7 +207,7 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.FetchFailed(exception));
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.NeedsRetry.class);
@@ -232,7 +242,7 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.Finished(NEXT_SEARCH_CURSOR, 0));
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);
@@ -253,7 +263,7 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.Finished(NEXT_SEARCH_CURSOR, 3));
 
     // when
-    initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     verify(metrics).recordItemsPerPartition(8, BatchOperationType.CANCEL_PROCESS_INSTANCE); // 5 + 3
@@ -267,7 +277,7 @@ class BatchOperationInitializationBehaviorTest {
         .thenReturn(new ChunkingOutcome.Finished(NEXT_SEARCH_CURSOR, 2));
 
     // when
-    final var result = initializer.initializeBatchOperation(batchOperation, taskResultBuilder);
+    final var result = initializer.initializeBatchOperation(createContext(), taskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(InitializationOutcome.Success.class);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessorTest.java
@@ -16,9 +16,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationItem;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
@@ -35,11 +37,13 @@ class BatchOperationPageProcessorTest {
   private static final int CHUNK_SIZE = 2;
 
   private BatchOperationPageProcessor processor;
+  private ItemProvider mockItemProvider;
   private TaskResultBuilder mockTaskResultBuilder;
 
   @BeforeEach
   void setUp() {
     processor = new BatchOperationPageProcessor(CHUNK_SIZE);
+    mockItemProvider = mock(ItemProvider.class);
     mockTaskResultBuilder = mock(TaskResultBuilder.class);
   }
 
@@ -49,11 +53,13 @@ class BatchOperationPageProcessorTest {
     final var item1 = new Item(100L, 200L, null);
     final var item2 = new Item(101L, 201L, null);
     final var page = new ItemPage(List.of(item1, item2), "cursor123", 2L, false);
+    final var context = createContext("cursor0", 10);
 
+    when(mockItemProvider.fetchItemPage("cursor0", 10)).thenReturn(page);
     when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
 
     // when
-    final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
+    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.Continue.class);
@@ -80,11 +86,13 @@ class BatchOperationPageProcessorTest {
             new Item(103L, 203L, null),
             new Item(104L, 204L, null));
     final var page = new ItemPage(items, "cursor456", 5L, true);
+    final var context = createContext("cursor0", 10);
 
+    when(mockItemProvider.fetchItemPage("cursor0", 10)).thenReturn(page);
     when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
 
     // when
-    final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
+    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.Finished.class);
@@ -106,13 +114,15 @@ class BatchOperationPageProcessorTest {
     // given
     final var items = List.of(new Item(100L, 200L, null), new Item(101L, 201L, null));
     final var page = new ItemPage(items, "cursor789", 2L, false);
+    final var context = createContext("cursor0", 10);
 
+    when(mockItemProvider.fetchItemPage("cursor0", 10)).thenReturn(page);
     when(mockTaskResultBuilder.canAppendRecords(
             any(List.class), any(FollowUpCommandMetadata.class)))
         .thenReturn(false);
 
     // when
-    final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
+    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.BufferFull.class);
@@ -131,13 +141,15 @@ class BatchOperationPageProcessorTest {
   void shouldProcessEmptyPage() {
     // given
     final var page = new ItemPage(List.of(), null, 0L, true);
+    final var context = createContext("cursor0", 10);
 
+    when(mockItemProvider.fetchItemPage("cursor0", 10)).thenReturn(page);
     when(mockTaskResultBuilder.canAppendRecords(
             any(List.class), any(FollowUpCommandMetadata.class)))
         .thenReturn(true);
 
     // when
-    final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
+    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.Finished.class);
@@ -162,11 +174,13 @@ class BatchOperationPageProcessorTest {
     final var item3 = new Item(102L, 202L, 112L);
     final var items = List.of(item1, item2, item3);
     final var page = new ItemPage(items, "cursor", 3L, false);
+    final var context = createContext("cursor0", 10);
 
+    when(mockItemProvider.fetchItemPage("cursor0", 10)).thenReturn(page);
     when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
 
     // when
-    processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
+    processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     final var chunkCaptor = ArgumentCaptor.forClass(BatchOperationChunkRecord.class);
@@ -199,12 +213,14 @@ class BatchOperationPageProcessorTest {
     final var items =
         List.of(new Item(100L, 200L, null), new Item(101L, 201L, null), new Item(102L, 202L, null));
     final var page = new ItemPage(items, "cursor", 3L, false);
+    final var context = createContext("cursor0", 10);
 
+    when(mockItemProvider.fetchItemPage("cursor0", 10)).thenReturn(page);
     when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
 
     // when
     final var result =
-        largeChunkProcessor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
+        largeChunkProcessor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
 
     // then
     assertThat(result).isInstanceOf(PageProcessingResult.Continue.class);
@@ -218,5 +234,46 @@ class BatchOperationPageProcessorTest {
             eq(BatchOperationChunkIntent.CREATE),
             any(BatchOperationChunkRecord.class),
             any(FollowUpCommandMetadata.class));
+  }
+
+  @Test
+  void shouldReturnFetchFailedWhenItemProviderThrows() {
+    // given
+    final var context = createContext("cursor1", 50);
+    final var exception = new RuntimeException("Database connection failed");
+
+    when(mockItemProvider.fetchItemPage("cursor1", 50)).thenThrow(exception);
+
+    // when
+    final var result = processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+
+    // then
+    assertThat(result).isInstanceOf(PageProcessingResult.FetchFailed.class);
+    final var fetchFailedResult = (PageProcessingResult.FetchFailed) result;
+    assertThat(fetchFailedResult.cause()).isSameAs(exception);
+
+    verify(mockTaskResultBuilder, never())
+        .appendCommandRecord(any(Long.class), any(), any(), any(FollowUpCommandMetadata.class));
+  }
+
+  @Test
+  void shouldUseCursorAndPageSizeFromContext() {
+    // given
+    final var context = createContext("specific-cursor", 25);
+    final var page = new ItemPage(List.of(), null, 0L, true);
+
+    when(mockItemProvider.fetchItemPage("specific-cursor", 25)).thenReturn(page);
+    when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
+
+    // when
+    processor.processNextPage(mockItemProvider, context, mockTaskResultBuilder);
+
+    // then
+    verify(mockItemProvider).fetchItemPage("specific-cursor", 25);
+  }
+
+  private static InitializationContext createContext(final String cursor, final int pageSize) {
+    final var batchOperation = new PersistedBatchOperation().setKey(BATCH_OPERATION_KEY);
+    return new InitializationContext(batchOperation, cursor, pageSize, 0, false);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationItem;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
@@ -55,10 +56,10 @@ class BatchOperationPageProcessorTest {
     final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
 
     // then
-    assertThat(result.chunksAppended()).isTrue();
-    assertThat(result.endCursor()).isEqualTo("cursor123");
-    assertThat(result.itemsProcessed()).isEqualTo(2);
-    assertThat(result.isLastPage()).isFalse();
+    assertThat(result).isInstanceOf(PageProcessingResult.Continue.class);
+    final var continueResult = (PageProcessingResult.Continue) result;
+    assertThat(continueResult.endCursor()).isEqualTo("cursor123");
+    assertThat(continueResult.itemsProcessed()).isEqualTo(2);
 
     verify(mockTaskResultBuilder, times(1))
         .appendCommandRecord(
@@ -86,10 +87,10 @@ class BatchOperationPageProcessorTest {
     final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
 
     // then
-    assertThat(result.chunksAppended()).isTrue();
-    assertThat(result.endCursor()).isEqualTo("cursor456");
-    assertThat(result.itemsProcessed()).isEqualTo(5);
-    assertThat(result.isLastPage()).isTrue();
+    assertThat(result).isInstanceOf(PageProcessingResult.Finished.class);
+    final var finishedResult = (PageProcessingResult.Finished) result;
+    assertThat(finishedResult.endCursor()).isEqualTo("cursor456");
+    assertThat(finishedResult.itemsProcessed()).isEqualTo(5);
 
     // Should create 3 chunks: [2 items], [2 items], [1 item]
     verify(mockTaskResultBuilder, times(3))
@@ -114,10 +115,9 @@ class BatchOperationPageProcessorTest {
     final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
 
     // then
-    assertThat(result.chunksAppended()).isFalse();
-    assertThat(result.endCursor()).isEqualTo("cursor789");
-    assertThat(result.itemsProcessed()).isEqualTo(2);
-    assertThat(result.isLastPage()).isFalse();
+    assertThat(result).isInstanceOf(PageProcessingResult.BufferFull.class);
+    final var bufferFullResult = (PageProcessingResult.BufferFull) result;
+    assertThat(bufferFullResult.itemsProcessed()).isEqualTo(2);
 
     verify(mockTaskResultBuilder, never())
         .appendCommandRecord(
@@ -140,10 +140,10 @@ class BatchOperationPageProcessorTest {
     final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
 
     // then
-    assertThat(result.chunksAppended()).isTrue();
-    assertThat(result.endCursor()).isNull();
-    assertThat(result.itemsProcessed()).isZero();
-    assertThat(result.isLastPage()).isTrue();
+    assertThat(result).isInstanceOf(PageProcessingResult.Finished.class);
+    final var finishedResult = (PageProcessingResult.Finished) result;
+    assertThat(finishedResult.endCursor()).isNull();
+    assertThat(finishedResult.itemsProcessed()).isZero();
 
     // Should not append any chunks for empty page
     verify(mockTaskResultBuilder, never())
@@ -207,8 +207,9 @@ class BatchOperationPageProcessorTest {
         largeChunkProcessor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
 
     // then
-    assertThat(result.chunksAppended()).isTrue();
-    assertThat(result.itemsProcessed()).isEqualTo(3);
+    assertThat(result).isInstanceOf(PageProcessingResult.Continue.class);
+    final var continueResult = (PageProcessingResult.Continue) result;
+    assertThat(continueResult.itemsProcessed()).isEqualTo(3);
 
     // Should create only 1 chunk since all items fit in chunk size 10
     verify(mockTaskResultBuilder, times(1))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
@@ -88,7 +88,8 @@ class BatchOperationRetryHandlerTest {
     // then
     assertThat(result).isInstanceOf(RetryResult.Failure.class);
     final var failure = (RetryResult.Failure) result;
-    assertThat(failure.exception().getCause()).isEqualTo(retryableException);
+    assertThat(failure.message()).contains("Temporary failure");
+    assertThat(failure.errorType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
   }
 
   @ParameterizedTest
@@ -107,7 +108,8 @@ class BatchOperationRetryHandlerTest {
     // then
     assertThat(result).isInstanceOf(RetryResult.Failure.class);
     final var failure = (RetryResult.Failure) result;
-    assertThat(failure.exception().getCause()).isEqualTo(nonRetryableException);
+    assertThat(failure.message()).contains("Non-retryable");
+    assertThat(failure.errorType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
   }
 
   @Test
@@ -130,7 +132,7 @@ class BatchOperationRetryHandlerTest {
     when(operation.execute())
         .thenReturn(
             new InitializationOutcome.Failed(
-                "Terminal failure", BatchOperationErrorType.QUERY_FAILED, "cursor"));
+                "Terminal failure", BatchOperationErrorType.QUERY_FAILED));
 
     // when
     final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
@@ -138,6 +140,7 @@ class BatchOperationRetryHandlerTest {
     // then
     assertThat(result).isInstanceOf(RetryResult.Failure.class);
     final var failure = (RetryResult.Failure) result;
-    assertThat(failure.exception().getMessage()).isEqualTo("Terminal failure");
+    assertThat(failure.message()).isEqualTo("Terminal failure");
+    assertThat(failure.errorType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
@@ -8,14 +8,10 @@
 package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryableOperation;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryDecision;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,66 +26,79 @@ class BatchOperationRetryHandlerTest {
   private static final int MAX_RETRIES = 3;
   private static final int BACKOFF_FACTOR = 2;
   private static final int NUM_ATTEMPTS = 0;
+  private static final String CURSOR = "test-cursor";
+
   private BatchOperationRetryHandler retryHandler;
-  private RetryableOperation operation;
 
   @BeforeEach
   void setUp() {
     retryHandler =
         new BatchOperationRetryHandler(
             INITIAL_RETRY_DELAY, MAX_RETRY_DELAY, MAX_RETRIES, BACKOFF_FACTOR);
-    operation = mock(RetryableOperation.class);
   }
 
   @Test
-  void shouldReturnSuccessWhenOperationSucceeds() {
-    // given
-    when(operation.execute()).thenReturn(new InitializationOutcome.Success("new-cursor"));
-
-    // when
-    final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
-
-    // then
-    assertThat(result).isInstanceOf(RetryResult.Success.class);
-    final var success = (RetryResult.Success) result;
-    assertThat(success.searchResultCursor()).isEqualTo("new-cursor");
-  }
-
-  @Test
-  void shouldRetryWhenOperationReturnsNeedsRetryWithRetryableCause() {
+  void shouldRetryWithInitialDelayOnFirstAttempt() {
     // given
     final var retryableException =
         new CamundaSearchException("Temporary failure", Reason.CONNECTION_FAILED);
-    when(operation.execute())
-        .thenReturn(new InitializationOutcome.NeedsRetry("test-end-cursor", retryableException));
 
     // when
-    final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
+    final var decision = retryHandler.evaluate(CURSOR, retryableException, NUM_ATTEMPTS);
 
     // then
-    assertThat(result).isInstanceOf(RetryResult.Retry.class);
-    final var retry = (RetryResult.Retry) result;
+    assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
+    final var retry = (RetryDecision.Retry) decision;
     assertThat(retry.delay()).isEqualTo(INITIAL_RETRY_DELAY);
-    assertThat(retry.endCursor()).isEqualTo("test-end-cursor");
+    assertThat(retry.cursor()).isEqualTo(CURSOR);
     assertThat(retry.numAttempts()).isEqualTo(1);
   }
 
   @Test
-  void shouldFailImmediatelyWhenMaxRetriesExceeded() {
+  void shouldRetryWithExponentialBackoff() {
+    // given
+    final var exception = new RuntimeException("Transient failure");
+
+    // when - second attempt (after first retry)
+    final var decision = retryHandler.evaluate(CURSOR, exception, 1);
+
+    // then - delay should be doubled (100ms * 2^1 = 200ms)
+    assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
+    final var retry = (RetryDecision.Retry) decision;
+    assertThat(retry.delay()).isEqualTo(Duration.ofMillis(200));
+    assertThat(retry.numAttempts()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldCapDelayAtMaxRetryDelay() {
+    // given
+    final var exception = new RuntimeException("Transient failure");
+    // With initial 100ms and backoff factor 2, attempt 10 would give 100 * 2^10 = 102400ms
+    // But max is 5000ms
+
+    // when
+    final var decision = retryHandler.evaluate(CURSOR, exception, 2);
+
+    // then - delay should be capped at max (100ms * 2^2 = 400ms, which is still under max)
+    assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
+    final var retry = (RetryDecision.Retry) decision;
+    assertThat(retry.delay()).isEqualTo(Duration.ofMillis(400));
+  }
+
+  @Test
+  void shouldFailWhenMaxRetriesExceeded() {
     // given
     final var retryableException =
         new CamundaSearchException("Temporary failure", Reason.CONNECTION_FAILED);
-    when(operation.execute())
-        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", retryableException));
 
     // when
-    final var result = retryHandler.executeWithRetry(operation, MAX_RETRIES);
+    final var decision = retryHandler.evaluate(CURSOR, retryableException, MAX_RETRIES);
 
     // then
-    assertThat(result).isInstanceOf(RetryResult.Failure.class);
-    final var failure = (RetryResult.Failure) result;
-    assertThat(failure.message()).contains("Temporary failure");
-    assertThat(failure.errorType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
+    assertThat(decision).isInstanceOf(RetryDecision.Fail.class);
+    final var fail = (RetryDecision.Fail) decision;
+    assertThat(fail.message()).contains("Temporary failure");
+    assertThat(fail.errorType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
   }
 
   @ParameterizedTest
@@ -99,48 +108,26 @@ class BatchOperationRetryHandlerTest {
   void shouldFailImmediatelyForNonRetryableReasons(final Reason reason) {
     // given
     final var nonRetryableException = new CamundaSearchException("Non-retryable", reason);
-    when(operation.execute())
-        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", nonRetryableException));
 
     // when
-    final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
+    final var decision = retryHandler.evaluate(CURSOR, nonRetryableException, NUM_ATTEMPTS);
 
     // then
-    assertThat(result).isInstanceOf(RetryResult.Failure.class);
-    final var failure = (RetryResult.Failure) result;
-    assertThat(failure.message()).contains("Non-retryable");
-    assertThat(failure.errorType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
+    assertThat(decision).isInstanceOf(RetryDecision.Fail.class);
+    final var fail = (RetryDecision.Fail) decision;
+    assertThat(fail.message()).contains("Non-retryable");
+    assertThat(fail.errorType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
   }
 
   @Test
   void shouldRetryForNonCamundaSearchExceptions() {
     // given
     final var genericException = new RuntimeException("Generic error");
-    when(operation.execute())
-        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", genericException));
 
     // when
-    final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
+    final var decision = retryHandler.evaluate(CURSOR, genericException, NUM_ATTEMPTS);
 
     // then
-    assertThat(result).isInstanceOf(RetryResult.Retry.class);
-  }
-
-  @Test
-  void shouldReturnFailureWhenOperationReturnsFailed() {
-    // given
-    when(operation.execute())
-        .thenReturn(
-            new InitializationOutcome.Failed(
-                "Terminal failure", BatchOperationErrorType.QUERY_FAILED));
-
-    // when
-    final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
-
-    // then
-    assertThat(result).isInstanceOf(RetryResult.Failure.class);
-    final var failure = (RetryResult.Failure) result;
-    assertThat(failure.message()).isEqualTo("Terminal failure");
-    assertThat(failure.errorType()).isEqualTo(BatchOperationErrorType.QUERY_FAILED);
+    assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
@@ -13,8 +13,8 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationException;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationResult;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryableOperation;
 import java.time.Duration;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
@@ -13,10 +13,10 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationException;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.BatchOperationInitializationResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationBehavior.InitializationOutcome;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryableOperation;
+import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,6 @@ class BatchOperationRetryHandlerTest {
   private static final Duration MAX_RETRY_DELAY = Duration.ofSeconds(5);
   private static final int MAX_RETRIES = 3;
   private static final int BACKOFF_FACTOR = 2;
-  private static final long BATCH_OPERATION_KEY = 12345L;
   private static final int NUM_ATTEMPTS = 0;
   private BatchOperationRetryHandler retryHandler;
   private RetryableOperation operation;
@@ -45,9 +44,7 @@ class BatchOperationRetryHandlerTest {
   @Test
   void shouldReturnSuccessWhenOperationSucceeds() {
     // given
-    final var expectedResult =
-        new BatchOperationInitializationResult(BATCH_OPERATION_KEY, "new-cursor");
-    when(operation.execute()).thenReturn(expectedResult);
+    when(operation.execute()).thenReturn(new InitializationOutcome.Success("new-cursor"));
 
     // when
     final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
@@ -59,13 +56,12 @@ class BatchOperationRetryHandlerTest {
   }
 
   @Test
-  void shouldRetryWhenOperationFailsWithRetryableException() {
+  void shouldRetryWhenOperationReturnsNeedsRetryWithRetryableCause() {
     // given
     final var retryableException =
         new CamundaSearchException("Temporary failure", Reason.CONNECTION_FAILED);
-    final var initException =
-        new BatchOperationInitializationException(retryableException, "test-end-cursor");
-    when(operation.execute()).thenThrow(initException);
+    when(operation.execute())
+        .thenReturn(new InitializationOutcome.NeedsRetry("test-end-cursor", retryableException));
 
     // when
     final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
@@ -83,9 +79,8 @@ class BatchOperationRetryHandlerTest {
     // given
     final var retryableException =
         new CamundaSearchException("Temporary failure", Reason.CONNECTION_FAILED);
-    final var initException =
-        new BatchOperationInitializationException(retryableException, "cursor");
-    when(operation.execute()).thenThrow(initException);
+    when(operation.execute())
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", retryableException));
 
     // when
     final var result = retryHandler.executeWithRetry(operation, MAX_RETRIES);
@@ -93,7 +88,7 @@ class BatchOperationRetryHandlerTest {
     // then
     assertThat(result).isInstanceOf(RetryResult.Failure.class);
     final var failure = (RetryResult.Failure) result;
-    assertThat(failure.exception()).isEqualTo(initException);
+    assertThat(failure.exception().getCause()).isEqualTo(retryableException);
   }
 
   @ParameterizedTest
@@ -103,9 +98,8 @@ class BatchOperationRetryHandlerTest {
   void shouldFailImmediatelyForNonRetryableReasons(final Reason reason) {
     // given
     final var nonRetryableException = new CamundaSearchException("Non-retryable", reason);
-    final var initException =
-        new BatchOperationInitializationException(nonRetryableException, "cursor");
-    when(operation.execute()).thenThrow(initException);
+    when(operation.execute())
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", nonRetryableException));
 
     // when
     final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
@@ -113,20 +107,37 @@ class BatchOperationRetryHandlerTest {
     // then
     assertThat(result).isInstanceOf(RetryResult.Failure.class);
     final var failure = (RetryResult.Failure) result;
-    assertThat(failure.exception()).isEqualTo(initException);
+    assertThat(failure.exception().getCause()).isEqualTo(nonRetryableException);
   }
 
   @Test
   void shouldRetryForNonCamundaSearchExceptions() {
     // given
     final var genericException = new RuntimeException("Generic error");
-    final var initException = new BatchOperationInitializationException(genericException, "cursor");
-    when(operation.execute()).thenThrow(initException);
+    when(operation.execute())
+        .thenReturn(new InitializationOutcome.NeedsRetry("cursor", genericException));
 
     // when
     final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
 
     // then
     assertThat(result).isInstanceOf(RetryResult.Retry.class);
+  }
+
+  @Test
+  void shouldReturnFailureWhenOperationReturnsFailed() {
+    // given
+    when(operation.execute())
+        .thenReturn(
+            new InitializationOutcome.Failed(
+                "Terminal failure", BatchOperationErrorType.QUERY_FAILED, "cursor"));
+
+    // when
+    final var result = retryHandler.executeWithRetry(operation, NUM_ATTEMPTS);
+
+    // then
+    assertThat(result).isInstanceOf(RetryResult.Failure.class);
+    final var failure = (RetryResult.Failure) result;
+    assertThat(failure.exception().getMessage()).isEqualTo("Terminal failure");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicyTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryDecision;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy.RetryDecision;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-class BatchOperationRetryHandlerTest {
+class BatchOperationRetryPolicyTest {
 
   private static final Duration INITIAL_RETRY_DELAY = Duration.ofMillis(100);
   private static final Duration MAX_RETRY_DELAY = Duration.ofSeconds(5);
@@ -28,12 +28,12 @@ class BatchOperationRetryHandlerTest {
   private static final int NUM_ATTEMPTS = 0;
   private static final String CURSOR = "test-cursor";
 
-  private BatchOperationRetryHandler retryHandler;
+  private BatchOperationRetryPolicy retryPolicy;
 
   @BeforeEach
   void setUp() {
-    retryHandler =
-        new BatchOperationRetryHandler(
+    retryPolicy =
+        new BatchOperationRetryPolicy(
             INITIAL_RETRY_DELAY, MAX_RETRY_DELAY, MAX_RETRIES, BACKOFF_FACTOR);
   }
 
@@ -44,7 +44,7 @@ class BatchOperationRetryHandlerTest {
         new CamundaSearchException("Temporary failure", Reason.CONNECTION_FAILED);
 
     // when
-    final var decision = retryHandler.evaluate(CURSOR, retryableException, NUM_ATTEMPTS);
+    final var decision = retryPolicy.evaluate(CURSOR, retryableException, NUM_ATTEMPTS);
 
     // then
     assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
@@ -60,7 +60,7 @@ class BatchOperationRetryHandlerTest {
     final var exception = new RuntimeException("Transient failure");
 
     // when - second attempt (after first retry)
-    final var decision = retryHandler.evaluate(CURSOR, exception, 1);
+    final var decision = retryPolicy.evaluate(CURSOR, exception, 1);
 
     // then - delay should be doubled (100ms * 2^1 = 200ms)
     assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
@@ -77,7 +77,7 @@ class BatchOperationRetryHandlerTest {
     // But max is 5000ms
 
     // when
-    final var decision = retryHandler.evaluate(CURSOR, exception, 2);
+    final var decision = retryPolicy.evaluate(CURSOR, exception, 2);
 
     // then - delay should be capped at max (100ms * 2^2 = 400ms, which is still under max)
     assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
@@ -92,7 +92,7 @@ class BatchOperationRetryHandlerTest {
         new CamundaSearchException("Temporary failure", Reason.CONNECTION_FAILED);
 
     // when
-    final var decision = retryHandler.evaluate(CURSOR, retryableException, MAX_RETRIES);
+    final var decision = retryPolicy.evaluate(CURSOR, retryableException, MAX_RETRIES);
 
     // then
     assertThat(decision).isInstanceOf(RetryDecision.Fail.class);
@@ -110,7 +110,7 @@ class BatchOperationRetryHandlerTest {
     final var nonRetryableException = new CamundaSearchException("Non-retryable", reason);
 
     // when
-    final var decision = retryHandler.evaluate(CURSOR, nonRetryableException, NUM_ATTEMPTS);
+    final var decision = retryPolicy.evaluate(CURSOR, nonRetryableException, NUM_ATTEMPTS);
 
     // then
     assertThat(decision).isInstanceOf(RetryDecision.Fail.class);
@@ -125,7 +125,7 @@ class BatchOperationRetryHandlerTest {
     final var genericException = new RuntimeException("Generic error");
 
     // when
-    final var decision = retryHandler.evaluate(CURSOR, genericException, NUM_ATTEMPTS);
+    final var decision = retryPolicy.evaluate(CURSOR, genericException, NUM_ATTEMPTS);
 
     // then
     assertThat(decision).isInstanceOf(RetryDecision.Retry.class);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryPolicyTest.java
@@ -71,18 +71,37 @@ class BatchOperationRetryPolicyTest {
 
   @Test
   void shouldCapDelayAtMaxRetryDelay() {
-    // given
+    // given - a policy where the delay exceeds max before retries are exhausted
+    final var policyWithLowMaxDelay =
+        new BatchOperationRetryPolicy(Duration.ofMillis(100), Duration.ofMillis(500), 20, 2);
     final var exception = new RuntimeException("Transient failure");
-    // With initial 100ms and backoff factor 2, attempt 10 would give 100 * 2^10 = 102400ms
-    // But max is 5000ms
+    // With initial 100ms and backoff factor 2, attempt 5 would give 100 * 2^5 = 3200ms
+    // But max is 500ms
 
     // when
-    final var decision = retryPolicy.evaluate(CURSOR, exception, 2);
+    final var decision = policyWithLowMaxDelay.evaluate(CURSOR, exception, 5);
 
-    // then - delay should be capped at max (100ms * 2^2 = 400ms, which is still under max)
+    // then - delay should be capped at max
     assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
     final var retry = (RetryDecision.Retry) decision;
-    assertThat(retry.delay()).isEqualTo(Duration.ofMillis(400));
+    assertThat(retry.delay()).isEqualTo(Duration.ofMillis(500));
+  }
+
+  @Test
+  void shouldHandleLargeAttemptNumbersWithoutOverflow() {
+    // given - a policy that allows many retries to test overflow protection
+    final var policyWithManyRetries =
+        new BatchOperationRetryPolicy(Duration.ofMillis(100), Duration.ofSeconds(10), 100, 2);
+    final var exception = new RuntimeException("Transient failure");
+
+    // when - attempt number that would overflow with Math.pow(2, 50)
+    final var decision = policyWithManyRetries.evaluate(CURSOR, exception, 50);
+
+    // then - should safely cap at max delay, not overflow
+    assertThat(decision).isInstanceOf(RetryDecision.Retry.class);
+    final var retry = (RetryDecision.Retry) decision;
+    assertThat(retry.delay()).isEqualTo(Duration.ofSeconds(10));
+    assertThat(retry.delay().isNegative()).isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/InitializationContextTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/InitializationContextTest.java
@@ -81,7 +81,7 @@ class InitializationContextTest {
     final var originalContext = new InitializationContext(operation, "cursor1", 50, 10, false);
 
     // when
-    final var nextPageContext = originalContext.withNextPage("cursor2", 5, true);
+    final var nextPageContext = originalContext.withNextPage("cursor2", 5);
 
     // then
     assertThat(nextPageContext.operation()).isEqualTo(operation);
@@ -115,7 +115,7 @@ class InitializationContextTest {
     final var originalContext = new InitializationContext(operation, "cursor1", 50, 10, false);
 
     // when
-    final var nextPageContext = originalContext.withNextPage("cursor2", 5, true);
+    final var nextPageContext = originalContext.withNextPage("cursor2", 5);
     final var halvedContext = originalContext.withHalvedPageSize();
 
     // then - original context should remain unchanged

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionStateTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
+import org.junit.jupiter.api.Test;
+
+class SchedulerExecutionStateTest {
+
+  private static final long BATCH_OPERATION_KEY = 123L;
+  private static final int DEFAULT_PAGE_SIZE = 100;
+
+  @Test
+  void shouldCreateFromBatchOperation() {
+    // given
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("cursor1");
+
+    // when
+    final var state = SchedulerExecutionState.from(batchOperation);
+
+    // then
+    assertThat(state.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
+    assertThat(state.cursor()).isEqualTo("cursor1");
+    assertThat(state.pageSize()).isZero();
+    assertThat(state.numAttempts()).isZero();
+  }
+
+  @Test
+  void shouldAdvanceToCursor() {
+    // given
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", 50, 2);
+
+    // when
+    final var advanced = state.advanceTo("cursor2");
+
+    // then - cursor updated, pageSize and numAttempts reset
+    assertThat(advanced.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
+    assertThat(advanced.cursor()).isEqualTo("cursor2");
+    assertThat(advanced.pageSize()).isZero();
+    assertThat(advanced.numAttempts()).isZero();
+  }
+
+  @Test
+  void shouldRetryWithCursorAndAttempts() {
+    // given
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", 50, 0);
+
+    // when
+    final var retrying = state.retryWith("cursor2", 3);
+
+    // then - cursor and attempts updated, pageSize preserved
+    assertThat(retrying.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
+    assertThat(retrying.cursor()).isEqualTo("cursor2");
+    assertThat(retrying.pageSize()).isEqualTo(50);
+    assertThat(retrying.numAttempts()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldReducePageSize() {
+    // given
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", 100, 1);
+
+    // when
+    final var reduced = state.withReducedPageSize(50);
+
+    // then - pageSize updated, cursor and numAttempts preserved
+    assertThat(reduced.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
+    assertThat(reduced.cursor()).isEqualTo("cursor1");
+    assertThat(reduced.pageSize()).isEqualTo(50);
+    assertThat(reduced.numAttempts()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldBuildContextWithPersistedValuesWhenNoOverrides() {
+    // given
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("persisted-cursor")
+            .setInitializationSearchQueryPageSize(75);
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "persisted-cursor", 0, 0);
+
+    // when
+    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
+
+    // then - uses persisted values
+    assertThat(context.currentCursor()).isEqualTo("persisted-cursor");
+    assertThat(context.pageSize()).isEqualTo(75);
+  }
+
+  @Test
+  void shouldBuildContextWithInMemoryCursorWhenRetrying() {
+    // given - numAttempts > 0 indicates retry in progress
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("old-persisted-cursor")
+            .setInitializationSearchQueryPageSize(75);
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "in-memory-cursor", 0, 1);
+
+    // when
+    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
+
+    // then - uses in-memory cursor (not persisted) to avoid stale cursor
+    assertThat(context.currentCursor()).isEqualTo("in-memory-cursor");
+    assertThat(context.pageSize()).isEqualTo(75);
+  }
+
+  @Test
+  void shouldBuildContextWithInMemoryPageSizeWhenReduced() {
+    // given - pageSize > 0 indicates reduced page size
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("cursor")
+            .setInitializationSearchQueryPageSize(100);
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", 50, 0);
+
+    // when
+    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
+
+    // then - uses in-memory page size (not persisted)
+    assertThat(context.currentCursor()).isEqualTo("cursor");
+    assertThat(context.pageSize()).isEqualTo(50);
+  }
+
+  @Test
+  void shouldBuildContextWithDefaultPageSizeWhenNotSet() {
+    // given - batch operation has no page size set
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("cursor");
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", 0, 0);
+
+    // when
+    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
+
+    // then - uses default page size
+    assertThat(context.pageSize()).isEqualTo(DEFAULT_PAGE_SIZE);
+  }
+
+  @Test
+  void shouldSkipWhenCursorsDifferAndNoRetryInProgress() {
+    // given - in-memory cursor differs from persisted (command in-flight)
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("persisted-cursor");
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "in-memory-cursor", 0, 0);
+
+    // when
+    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
+
+    // then - skip because command is in-flight
+    assertThat(shouldSkip).isTrue();
+  }
+
+  @Test
+  void shouldNotSkipWhenCursorsMatch() {
+    // given - cursors match (persisted state caught up)
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("same-cursor");
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "same-cursor", 0, 0);
+
+    // when
+    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
+
+    // then - don't skip, we can continue processing
+    assertThat(shouldSkip).isFalse();
+  }
+
+  @Test
+  void shouldNotSkipWhenRetryInProgress() {
+    // given - cursors differ BUT retry in progress (numAttempts > 0)
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("persisted-cursor");
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "in-memory-cursor", 0, 1);
+
+    // when
+    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
+
+    // then - don't skip, retries are intentional
+    assertThat(shouldSkip).isFalse();
+  }
+
+  @Test
+  void shouldNotSkipWhenDifferentBatchOperationKey() {
+    // given - different batch operation
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(999L) // Different key
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("cursor");
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "different-cursor", 0, 0);
+
+    // when
+    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
+
+    // then - don't skip, it's a different batch operation
+    assertThat(shouldSkip).isFalse();
+  }
+
+  @Test
+  void shouldHandleNullCursorsInShouldSkipInitialization() {
+    // given - both cursors are null/empty
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("");
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "", 0, 0);
+
+    // when
+    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
+
+    // then - don't skip, cursors match (both empty)
+    assertThat(shouldSkip).isFalse();
+  }
+
+  @Test
+  void shouldConvertEmptyCursorToNullInBuildContext() {
+    // given - empty cursor in persisted state
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("")
+            .setInitializationSearchQueryPageSize(50);
+    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "", 0, 0);
+
+    // when
+    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
+
+    // then - empty string converted to null
+    assertThat(context.currentCursor()).isNull();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionStateTest.java
@@ -199,7 +199,20 @@ class SchedulerExecutionStateTest {
     assertThat(state.shouldSkipInitialization(batchOperation)).isFalse();
   }
 
-  // --- shouldSkipInitialization: page size comparison ---
+  @Test
+  void shouldSkipWhenSuspended() {
+    // given - batch operation is suspended
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.SUSPENDED)
+            .setInitializationSearchCursor("cursor");
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", DEFAULT_PAGE_SIZE, 100, 0);
+
+    // when / then - skip because operation is suspended
+    assertThat(state.shouldSkipInitialization(batchOperation)).isTrue();
+  }
 
   @Test
   void shouldSkipWhenPageSizeDiffers() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/SchedulerExecutionStateTest.java
@@ -25,44 +25,66 @@ class SchedulerExecutionStateTest {
         new PersistedBatchOperation()
             .setKey(BATCH_OPERATION_KEY)
             .setStatus(BatchOperationStatus.CREATED)
-            .setInitializationSearchCursor("cursor1");
+            .setInitializationSearchCursor("cursor1")
+            .setInitializationSearchQueryPageSize(75);
 
     // when
-    final var state = SchedulerExecutionState.from(batchOperation);
+    final var state = SchedulerExecutionState.from(batchOperation, DEFAULT_PAGE_SIZE);
 
     // then
     assertThat(state.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
     assertThat(state.cursor()).isEqualTo("cursor1");
-    assertThat(state.pageSize()).isZero();
+    assertThat(state.defaultPageSize()).isEqualTo(DEFAULT_PAGE_SIZE);
+    assertThat(state.pageSize()).isEqualTo(75);
     assertThat(state.numAttempts()).isZero();
+  }
+
+  @Test
+  void shouldCreateFromBatchOperationWithDefaultPageSize() {
+    // given - page size not set (-1), should resolve to default
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("cursor1");
+
+    // when
+    final var state = SchedulerExecutionState.from(batchOperation, DEFAULT_PAGE_SIZE);
+
+    // then
+    assertThat(state.pageSize()).isEqualTo(DEFAULT_PAGE_SIZE);
   }
 
   @Test
   void shouldAdvanceToCursor() {
     // given
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", 50, 2);
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", DEFAULT_PAGE_SIZE, 50, 2);
 
     // when
     final var advanced = state.advanceTo("cursor2");
 
-    // then - cursor updated, pageSize and numAttempts reset
+    // then - cursor updated, numAttempts reset, pageSize and defaultPageSize preserved
     assertThat(advanced.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
     assertThat(advanced.cursor()).isEqualTo("cursor2");
-    assertThat(advanced.pageSize()).isZero();
+    assertThat(advanced.defaultPageSize()).isEqualTo(DEFAULT_PAGE_SIZE);
+    assertThat(advanced.pageSize()).isEqualTo(50);
     assertThat(advanced.numAttempts()).isZero();
   }
 
   @Test
   void shouldRetryWithCursorAndAttempts() {
     // given
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", 50, 0);
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", DEFAULT_PAGE_SIZE, 50, 0);
 
     // when
     final var retrying = state.retryWith("cursor2", 3);
 
-    // then - cursor and attempts updated, pageSize preserved
+    // then - cursor and attempts updated, pageSize and defaultPageSize preserved
     assertThat(retrying.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
     assertThat(retrying.cursor()).isEqualTo("cursor2");
+    assertThat(retrying.defaultPageSize()).isEqualTo(DEFAULT_PAGE_SIZE);
     assertThat(retrying.pageSize()).isEqualTo(50);
     assertThat(retrying.numAttempts()).isEqualTo(3);
   }
@@ -70,107 +92,34 @@ class SchedulerExecutionStateTest {
   @Test
   void shouldReducePageSize() {
     // given
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", 100, 1);
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor1", DEFAULT_PAGE_SIZE, 100, 1);
 
     // when
     final var reduced = state.withReducedPageSize(50);
 
-    // then - pageSize updated, cursor and numAttempts preserved
+    // then - pageSize updated, cursor, defaultPageSize, and numAttempts preserved
     assertThat(reduced.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
     assertThat(reduced.cursor()).isEqualTo("cursor1");
+    assertThat(reduced.defaultPageSize()).isEqualTo(DEFAULT_PAGE_SIZE);
     assertThat(reduced.pageSize()).isEqualTo(50);
     assertThat(reduced.numAttempts()).isEqualTo(1);
   }
 
   @Test
-  void shouldBuildContextWithPersistedValuesWhenNoOverrides() {
-    // given
-    final var batchOperation =
-        new PersistedBatchOperation()
-            .setKey(BATCH_OPERATION_KEY)
-            .setStatus(BatchOperationStatus.CREATED)
-            .setInitializationSearchCursor("persisted-cursor")
-            .setInitializationSearchQueryPageSize(75);
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "persisted-cursor", 0, 0);
-
-    // when
-    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
-
-    // then - uses persisted values
-    assertThat(context.currentCursor()).isEqualTo("persisted-cursor");
-    assertThat(context.pageSize()).isEqualTo(75);
-  }
-
-  @Test
-  void shouldBuildContextWithInMemoryCursorWhenRetrying() {
-    // given - numAttempts > 0 indicates retry in progress
-    final var batchOperation =
-        new PersistedBatchOperation()
-            .setKey(BATCH_OPERATION_KEY)
-            .setStatus(BatchOperationStatus.CREATED)
-            .setInitializationSearchCursor("old-persisted-cursor")
-            .setInitializationSearchQueryPageSize(75);
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "in-memory-cursor", 0, 1);
-
-    // when
-    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
-
-    // then - uses in-memory cursor (not persisted) to avoid stale cursor
-    assertThat(context.currentCursor()).isEqualTo("in-memory-cursor");
-    assertThat(context.pageSize()).isEqualTo(75);
-  }
-
-  @Test
-  void shouldBuildContextWithInMemoryPageSizeWhenReduced() {
-    // given - pageSize > 0 indicates reduced page size
-    final var batchOperation =
-        new PersistedBatchOperation()
-            .setKey(BATCH_OPERATION_KEY)
-            .setStatus(BatchOperationStatus.CREATED)
-            .setInitializationSearchCursor("cursor")
-            .setInitializationSearchQueryPageSize(100);
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", 50, 0);
-
-    // when
-    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
-
-    // then - uses in-memory page size (not persisted)
-    assertThat(context.currentCursor()).isEqualTo("cursor");
-    assertThat(context.pageSize()).isEqualTo(50);
-  }
-
-  @Test
-  void shouldBuildContextWithDefaultPageSizeWhenNotSet() {
-    // given - batch operation has no page size set
-    final var batchOperation =
-        new PersistedBatchOperation()
-            .setKey(BATCH_OPERATION_KEY)
-            .setStatus(BatchOperationStatus.CREATED)
-            .setInitializationSearchCursor("cursor");
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", 0, 0);
-
-    // when
-    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
-
-    // then - uses default page size
-    assertThat(context.pageSize()).isEqualTo(DEFAULT_PAGE_SIZE);
-  }
-
-  @Test
-  void shouldSkipWhenCursorsDifferAndNoRetryInProgress() {
+  void shouldSkipWhenCursorsDiffer() {
     // given - in-memory cursor differs from persisted (command in-flight)
     final var batchOperation =
         new PersistedBatchOperation()
             .setKey(BATCH_OPERATION_KEY)
             .setStatus(BatchOperationStatus.CREATED)
             .setInitializationSearchCursor("persisted-cursor");
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "in-memory-cursor", 0, 0);
+    final var state =
+        new SchedulerExecutionState(
+            BATCH_OPERATION_KEY, "in-memory-cursor", DEFAULT_PAGE_SIZE, 100, 0);
 
-    // when
-    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
-
-    // then - skip because command is in-flight
-    assertThat(shouldSkip).isTrue();
+    // when / then
+    assertThat(state.shouldSkipInitialization(batchOperation)).isTrue();
   }
 
   @Test
@@ -181,30 +130,42 @@ class SchedulerExecutionStateTest {
             .setKey(BATCH_OPERATION_KEY)
             .setStatus(BatchOperationStatus.CREATED)
             .setInitializationSearchCursor("same-cursor");
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "same-cursor", 0, 0);
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "same-cursor", DEFAULT_PAGE_SIZE, 100, 0);
 
-    // when
-    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
-
-    // then - don't skip, we can continue processing
-    assertThat(shouldSkip).isFalse();
+    // when / then
+    assertThat(state.shouldSkipInitialization(batchOperation)).isFalse();
   }
 
   @Test
-  void shouldNotSkipWhenRetryInProgress() {
-    // given - cursors differ BUT retry in progress (numAttempts > 0)
+  void shouldSkipWhenRetryInProgressAndCommandInFlight() {
+    // given - cursors differ AND retry in progress (numAttempts > 0)
     final var batchOperation =
         new PersistedBatchOperation()
             .setKey(BATCH_OPERATION_KEY)
             .setStatus(BatchOperationStatus.CREATED)
             .setInitializationSearchCursor("persisted-cursor");
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "in-memory-cursor", 0, 1);
+    final var state =
+        new SchedulerExecutionState(
+            BATCH_OPERATION_KEY, "in-memory-cursor", DEFAULT_PAGE_SIZE, 100, 1);
 
-    // when
-    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
+    // when / then - skip because command is in-flight, even during retries
+    assertThat(state.shouldSkipInitialization(batchOperation)).isTrue();
+  }
 
-    // then - don't skip, retries are intentional
-    assertThat(shouldSkip).isFalse();
+  @Test
+  void shouldNotSkipRetryWhenCursorsMatch() {
+    // given - retry in progress but cursors match (no command was written)
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("same-cursor");
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "same-cursor", DEFAULT_PAGE_SIZE, 100, 2);
+
+    // when / then - cursors match means no command in-flight, retry can proceed
+    assertThat(state.shouldSkipInitialization(batchOperation)).isFalse();
   }
 
   @Test
@@ -212,50 +173,98 @@ class SchedulerExecutionStateTest {
     // given - different batch operation
     final var batchOperation =
         new PersistedBatchOperation()
-            .setKey(999L) // Different key
+            .setKey(999L)
             .setStatus(BatchOperationStatus.CREATED)
             .setInitializationSearchCursor("cursor");
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "different-cursor", 0, 0);
+    final var state =
+        new SchedulerExecutionState(
+            BATCH_OPERATION_KEY, "different-cursor", DEFAULT_PAGE_SIZE, 100, 0);
 
-    // when
-    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
-
-    // then - don't skip, it's a different batch operation
-    assertThat(shouldSkip).isFalse();
+    // when / then
+    assertThat(state.shouldSkipInitialization(batchOperation)).isFalse();
   }
 
   @Test
-  void shouldHandleNullCursorsInShouldSkipInitialization() {
-    // given - both cursors are null/empty
+  void shouldHandleEmptyCursorsInShouldSkipInitialization() {
+    // given - both cursors are empty; from() normalizes "" to null via emptyToNull
     final var batchOperation =
         new PersistedBatchOperation()
             .setKey(BATCH_OPERATION_KEY)
             .setStatus(BatchOperationStatus.CREATED)
             .setInitializationSearchCursor("");
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "", 0, 0);
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, null, DEFAULT_PAGE_SIZE, 100, 0);
 
-    // when
-    final var shouldSkip = state.shouldSkipInitialization(batchOperation);
-
-    // then - don't skip, cursors match (both empty)
-    assertThat(shouldSkip).isFalse();
+    // when / then - both normalize to null, so they match
+    assertThat(state.shouldSkipInitialization(batchOperation)).isFalse();
   }
 
+  // --- shouldSkipInitialization: page size comparison ---
+
   @Test
-  void shouldConvertEmptyCursorToNullInBuildContext() {
-    // given - empty cursor in persisted state
+  void shouldSkipWhenPageSizeDiffers() {
+    // given - cursor matches but in-memory page size differs from persisted
+    // (continueInitialization command with reduced page size not yet processed)
     final var batchOperation =
         new PersistedBatchOperation()
             .setKey(BATCH_OPERATION_KEY)
             .setStatus(BatchOperationStatus.CREATED)
-            .setInitializationSearchCursor("")
+            .setInitializationSearchCursor("cursor")
+            .setInitializationSearchQueryPageSize(100);
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", DEFAULT_PAGE_SIZE, 50, 0);
+
+    // when / then
+    assertThat(state.shouldSkipInitialization(batchOperation)).isTrue();
+  }
+
+  @Test
+  void shouldSkipWhenPageSizeDiffersAndPersistedIsUnset() {
+    // given - persisted page size is unset (-1), resolves to defaultPageSize (100)
+    // but in-memory was reduced to 50 — command not yet processed
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("cursor");
+    // persisted raw is -1 (default), resolves to DEFAULT_PAGE_SIZE=100
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", DEFAULT_PAGE_SIZE, 50, 0);
+
+    // when / then - 50 != 100, skip
+    assertThat(state.shouldSkipInitialization(batchOperation)).isTrue();
+  }
+
+  @Test
+  void shouldNotSkipWhenPageSizeMatchesPersisted() {
+    // given - cursor matches and in-memory page size matches persisted
+    // (continueInitialization command has been processed)
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("cursor")
             .setInitializationSearchQueryPageSize(50);
-    final var state = new SchedulerExecutionState(BATCH_OPERATION_KEY, "", 0, 0);
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", DEFAULT_PAGE_SIZE, 50, 0);
 
-    // when
-    final var context = state.buildContext(batchOperation, DEFAULT_PAGE_SIZE);
+    // when / then
+    assertThat(state.shouldSkipInitialization(batchOperation)).isFalse();
+  }
 
-    // then - empty string converted to null
-    assertThat(context.currentCursor()).isNull();
+  @Test
+  void shouldNotSkipWhenPageSizesMatchFromDefault() {
+    // given - both in-memory and persisted resolve to the same page size
+    final var batchOperation =
+        new PersistedBatchOperation()
+            .setKey(BATCH_OPERATION_KEY)
+            .setStatus(BatchOperationStatus.CREATED)
+            .setInitializationSearchCursor("cursor")
+            .setInitializationSearchQueryPageSize(100);
+    final var state =
+        new SchedulerExecutionState(BATCH_OPERATION_KEY, "cursor", DEFAULT_PAGE_SIZE, 100, 0);
+
+    // when / then - no override pending, page sizes agree
+    assertThat(state.shouldSkipInitialization(batchOperation)).isFalse();
   }
 }


### PR DESCRIPTION
## Description

Refactor the batch operation scheduling and initialization subsystem to improve type safety, readability, separation of concerns, and error handling. This is a pure refactor with no behavioral changes, except for one deliberate improvement: the scheduler now provides natural **back-pressure** by skipping initialization ticks whenever a previously written `INITIALIZE` command has not yet been processed by the stream processor.

### Key changes

**1. Rename classes to follow engine conventions**
- `BatchOperationInitializationHelper` → `BatchOperationInitializationBehavior` — aligns with the `*Behavior` naming convention used throughout the engine.
- `BatchOperationPageProcessor` → `BatchOperationChunkAppender` — better reflects the class's responsibility (chunking items and appending them to the result buffer).
- `BatchOperationCommandAppender` → `BatchOperationCommands` — shorter, more descriptive utility name.
- `BatchOperationRetryHandler` → `BatchOperationRetryPolicy` — now a pure policy evaluator rather than an operation executor.

**2. Replace exceptions with sealed result types for control flow**
- `BatchOperationInitializationException` (thrown for both retryable and terminal failures) is replaced by a sealed `InitializationOutcome` interface with four explicit variants: `Success`, `NeedsRetry`, `ReducePageSize`, and `Failed`.
- The retry handler no longer wraps and executes the initialization as a `RetryableOperation`; instead, the scheduler calls the initializer directly and delegates to `RetryPolicy.evaluate()` only when the outcome is `NeedsRetry`.
- `PageProcessingResult` is converted from a flat record with boolean flags (`chunksAppended`, `isLastPage`) into a sealed `ChunkingOutcome` interface with four variants: `Continue`, `Finished`, `BufferFull`, and `FetchFailed`. Control flow is now exhaustively checked by the compiler via pattern matching.
- `BatchOperationInitializationResult` and `BatchOperationInitializationException` are removed entirely.

**3. Move item fetching into `BatchOperationChunkAppender`**
- Introduce `fetchAndChunkNextPage(itemProvider, context, taskResultBuilder)` which encapsulates both fetching and chunking in a single call.
- Fetch failures are modeled as a `FetchFailed` result variant instead of relying on try/catch with conditional side-effects, eliminating the buried `continueInitialization` call inside the old catch block.
- The old public `processPage()` method is now private (`chunkAndAppend()`).

**4. Simplify `InitializationBehavior` loop**
- Replace `while(true)` with a conditional loop that continues only while the result is `Continue`, making the termination condition immediately visible.
- Terminal cases (`Finished`, `BufferFull`, `FetchFailed`) are handled in a switch expression after the loop exits.
- Simplify `InitializationContext.withNextPage()` by removing the `appended` boolean parameter (always `true` when called).

**5. Restructure `BatchOperationExecutionScheduler` with in-flight command back-pressure**
- The scheduler now calls the initializer directly and pattern-matches on `InitializationOutcome`, only consulting `RetryPolicy` for `NeedsRetry` outcomes. This inverts the previous design where the retry handler wrapped the entire initialization call.
- Extract `SchedulerExecutionState` as a top-level record with named factory method (`from`), named transitions (`advanceTo`, `retryWith`, `withReducedPageSize`), and a documented predicate (`shouldSkipInitialization`).
- `shouldSkipInitialization` compares in-memory cursor and page size against persisted state. When they differ, a command is in-flight and the scheduler skips the tick — **regardless of whether a retry is pending**. This provides natural back-pressure: batch operations (lower priority) wait rather than piling commands onto a busy stream processor pipeline.
- On broker restart/recovery, the scheduler state is re-created from `PersistedBatchOperation` via `onRecovered()`. All in-flight commands are processed and events replayed before that, so the scheduler continues from the correct persisted cursor.
- Move the suspension check from `InitializationBehavior` to `SchedulerExecutionState.shouldSkipInitialization`, consolidating all "should I process this?" logic in one place.
- Rename `initializing` field → `executionState`, `searchResultCursor` → cursor tracked via `SchedulerExecutionState`.
- Replace `validateNoReInitialization` (double-negative, mixed concerns) with `getOrCreateState` + `shouldSkipInitialization`.
- Add Javadoc explaining the serial scheduling design decision: lower priority than normal stream processing, and avoiding write conflicts on overlapping process instances.

**6. Decouple retry policy from initialization internals**
- `BatchOperationRetryPolicy` is now a stateless evaluator: given a cursor, cause, and attempt count, it returns a `RetryDecision` (either `Retry` with delay or `Fail` with error details).
- It no longer depends on `BatchOperationInitializationException` or `BatchOperationInitializationResult` — it operates purely on `Throwable` and primitive parameters.
- Fix potential overflow in `calculateNextDelay`: replace `Math.pow` with iterative multiplication and early-cap at `maxRetryDelay`.

**7. Simplify `BufferFull` handling**
- `BufferFull` is now a marker type (no item count field) — the count was always 1 in the terminal failure case.
- `BufferFull` is surfaced as a `ReducePageSize` outcome to the scheduler, making the page-size-reduction flow explicit in the scheduler's switch expression.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48391