### PR TITLE
ci: add sharding to Operate visual regression tests

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -341,7 +341,7 @@ jobs:
       - name: Start server
         run: npm run start:visual-regression &
       - name: Run Visual regression tests
-        run: npm run test:visual -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob --reporter=github
+        run: npm run test:visual -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Upload blob report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -371,9 +371,6 @@ jobs:
     env:
       TEST_TYPE: visual-regression
       TEST_OWNER: Core Features
-    container:
-      image: mcr.microsoft.com/playwright:v1.58.2
-      options: --user 1001:1000
     defaults:
       run:
         working-directory: operate/client

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -307,10 +307,15 @@ jobs:
 
   operate-fe-visual-regression-tests:
     if: inputs.runFeTests
-    name: "Unit / Front End - Visual Regression"
+    name: "Unit / Front End - Visual Regression [${{ matrix.shardIndex }}/${{ matrix.shardTotal }}]"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions: {} # GITHUB_TOKEN unused in this job
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     env:
       TEST_TYPE: visual-regression
       TEST_OWNER: Core Features
@@ -336,9 +341,63 @@ jobs:
       - name: Start server
         run: npm run start:visual-regression &
       - name: Run Visual regression tests
-        run: npm run test:visual
-      - uses: actions/upload-artifact@v7
+        run: npm run test:visual -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob --reporter=github
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: operate-visual-regression-blob-report-${{ matrix.shardIndex }}
+          path: operate/client/blob-report
+          retention-days: 1
+      - name: Observe build status
         if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "operate-ci/operate-fe-visual-regression-tests-${{ matrix.shardIndex }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          user_description: "team-core-features"
+
+  operate-fe-visual-regression-merge:
+    if: ${{ !cancelled() && inputs.runFeTests }}
+    needs: [operate-fe-visual-regression-tests]
+    name: "Unit / Front End - Visual Regression - Merge Reports"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {} # GITHUB_TOKEN unused in this job
+    env:
+      TEST_TYPE: visual-regression
+      TEST_OWNER: Core Features
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2
+      options: --user 1001:1000
+    defaults:
+      run:
+        working-directory: operate/client
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v6
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+      - name: Setup NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Install node dependencies
+        run: npm ci
+      - name: Download blob reports
+        uses: actions/download-artifact@v8
+        with:
+          path: operate/client/all-blob-reports
+          pattern: operate-visual-regression-blob-report-*
+          merge-multiple: true
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v7
         with:
           name: operate-visual-regression-report
           path: operate/client/playwright-report/

--- a/operate/client/playwright.config.ts
+++ b/operate/client/playwright.config.ts
@@ -27,6 +27,7 @@ const config = defineConfig({
   workers: IS_CI || IS_E2E ? 1 : undefined,
   reporter: IS_CI
     ? [
+        ['blob'],
         ['github'],
         ['html'],
         [


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I'm also sharding the Operate visual regression tests. We added more tests recently and they're timing out like in [here](https://github.com/camunda/camunda/actions/runs/23011986991/job/66846965732?pr=48281)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48394
