### PR TITLE
[Backport stable/8.9] fix: use unicode-aware patterns for BPMN/DMN identifier constraints

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/EvaluateDecisionRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/EvaluateDecisionRequestValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mapping.http.validator;
 
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDecisionDefinitionId;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
 
 import io.camunda.gateway.protocol.model.DecisionEvaluationById;
@@ -40,6 +41,7 @@ public class EvaluateDecisionRequestValidator {
                   ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(
                       "[decisionDefinitionId, decisionDefinitionKey]"));
             }
+            validateDecisionDefinitionId(byId.getDecisionDefinitionId(), violations);
           });
     }
     return Optional.empty();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
@@ -34,7 +34,7 @@ public final class RequestValidator {
 
   /** Compiled pattern for a valid BPMN process definition ID, matching the OpenAPI spec. */
   public static final Pattern PROCESS_DEFINITION_ID_PATTERN =
-      Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_\\-.]*$");
+      Pattern.compile("^[\\p{L}_][\\p{L}\\p{N}_\\-.]*$");
 
   /** Maximum allowed length for a business ID, matching the engine-side constraint. */
   public static final int MAX_BUSINESS_ID_LENGTH = 256;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
@@ -32,9 +32,8 @@ import org.springframework.http.ProblemDetail;
 
 public final class RequestValidator {
 
-  /** Compiled pattern for a valid BPMN process definition ID, matching the OpenAPI spec. */
-  public static final Pattern PROCESS_DEFINITION_ID_PATTERN =
-      Pattern.compile("^[\\p{L}_][\\p{L}\\p{N}_\\-.]*$");
+  /** Compiled pattern for a valid XML ID (xsd:ID / NCName), used for BPMN and DMN identifiers. */
+  public static final Pattern XML_ID_PATTERN = Pattern.compile("^[\\p{L}_][\\p{L}\\p{N}_\\-.]*$");
 
   /** Maximum allowed length for a business ID, matching the engine-side constraint. */
   public static final int MAX_BUSINESS_ID_LENGTH = 256;
@@ -127,11 +126,25 @@ public final class RequestValidator {
    */
   public static void validateProcessDefinitionId(
       final String processDefinitionId, final List<String> violations) {
-    if (processDefinitionId != null
-        && !PROCESS_DEFINITION_ID_PATTERN.matcher(processDefinitionId).matches()) {
+    if (processDefinitionId != null && !XML_ID_PATTERN.matcher(processDefinitionId).matches()) {
       violations.add(
           ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted(
-              "processDefinitionId", PROCESS_DEFINITION_ID_PATTERN.pattern()));
+              "processDefinitionId", XML_ID_PATTERN.pattern()));
+    }
+  }
+
+  /**
+   * Validates that a decision definition ID matches the XML ID (NCName) pattern.
+   *
+   * @param decisionDefinitionId the value to validate (may be null; null is not validated)
+   * @param violations the list to add validation errors to
+   */
+  public static void validateDecisionDefinitionId(
+      final String decisionDefinitionId, final List<String> violations) {
+    if (decisionDefinitionId != null && !XML_ID_PATTERN.matcher(decisionDefinitionId).matches()) {
+      violations.add(
+          ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted(
+              "decisionDefinitionId", XML_ID_PATTERN.pattern()));
     }
   }
 

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/EvaluateDecisionRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/EvaluateDecisionRequestValidatorTest.java
@@ -138,4 +138,54 @@ class EvaluateDecisionRequestValidatorTest {
 
     assertThat(result).isEmpty();
   }
+
+  @Test
+  @DisplayName("Should accept valid decisionDefinitionId format")
+  void shouldAcceptValidDecisionDefinitionId() {
+    // given
+    final var request = new DecisionEvaluationById();
+    request.setDecisionDefinitionId("my-decision_v1.0");
+
+    // when
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should accept Unicode decisionDefinitionId")
+  void shouldAcceptUnicodeDecisionDefinitionId() {
+    // given
+    final var request = new DecisionEvaluationById();
+    request.setDecisionDefinitionId("üöäßÜÖÄ");
+
+    // when
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"9invalid", "-dash-start", ".dot-start", "has space"})
+  @DisplayName("Should reject invalid decisionDefinitionId format")
+  void shouldRejectInvalidDecisionDefinitionIdFormat(final String invalidId) {
+    // given
+    final var request = new DecisionEvaluationById();
+    request.setDecisionDefinitionId(invalidId);
+
+    // when
+    final Optional<ProblemDetail> result =
+        EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest(request);
+
+    // then
+    assertThat(result).isPresent();
+    final ProblemDetail problem = result.get();
+    assertThat(problem.getTitle()).isEqualTo("INVALID_ARGUMENT");
+    assertThat(problem.getDetail()).contains("decisionDefinitionId");
+    assertThat(problem.getDetail()).contains("illegal characters");
+  }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/RequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/RequestValidatorTest.java
@@ -171,4 +171,57 @@ class RequestValidatorTest {
     // then
     assertThat(violations).isEmpty();
   }
+
+  // --- validateDecisionDefinitionId tests ---
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "my-decision",
+        "_internal",
+        "Decision_v2.1",
+        "üöäßÜÖÄ",
+        "中文决策",
+        "процесс",
+        "café-workflow"
+      })
+  @DisplayName("Should accept valid decision definition IDs including Unicode")
+  void shouldAcceptValidDecisionDefinitionIds(final String validId) {
+    // given
+    final List<String> violations = new ArrayList<>();
+
+    // when
+    RequestValidator.validateDecisionDefinitionId(validId, violations);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"9invalid", "-dash-start", ".dot-start", "has space", "has\ttab"})
+  @DisplayName("Should reject invalid decision definition IDs")
+  void shouldRejectInvalidDecisionDefinitionIds(final String invalidId) {
+    // given
+    final List<String> violations = new ArrayList<>();
+
+    // when
+    RequestValidator.validateDecisionDefinitionId(invalidId, violations);
+
+    // then
+    assertThat(violations).hasSize(1);
+    assertThat(violations.getFirst()).contains("decisionDefinitionId");
+  }
+
+  @Test
+  @DisplayName("Should accept null decision definition ID without violations")
+  void shouldAcceptNullDecisionDefinitionId() {
+    // given
+    final List<String> violations = new ArrayList<>();
+
+    // when
+    RequestValidator.validateDecisionDefinitionId(null, violations);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/RequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/RequestValidatorTest.java
@@ -118,4 +118,57 @@ class RequestValidatorTest {
     assertThat(violations.get(0)).contains("testField");
     assertThat(violations.get(0)).contains("is not a valid key");
   }
+
+  // --- validateProcessDefinitionId tests ---
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "my-process",
+        "_internal",
+        "Process_v2.1",
+        "üöäßÜÖÄ",
+        "中文流程",
+        "процесс",
+        "café-workflow"
+      })
+  @DisplayName("Should accept valid process definition IDs including Unicode")
+  void shouldAcceptValidProcessDefinitionIds(final String validId) {
+    // given
+    final List<String> violations = new ArrayList<>();
+
+    // when
+    RequestValidator.validateProcessDefinitionId(validId, violations);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"9invalid", "-dash-start", ".dot-start", "has space", "has\ttab"})
+  @DisplayName("Should reject invalid process definition IDs")
+  void shouldRejectInvalidProcessDefinitionIds(final String invalidId) {
+    // given
+    final List<String> violations = new ArrayList<>();
+
+    // when
+    RequestValidator.validateProcessDefinitionId(invalidId, violations);
+
+    // then
+    assertThat(violations).hasSize(1);
+    assertThat(violations.getFirst()).contains("processDefinitionId");
+  }
+
+  @Test
+  @DisplayName("Should accept null process definition ID without violations")
+  void shouldAcceptNullProcessDefinitionId() {
+    // given
+    final List<String> violations = new ArrayList<>();
+
+    // when
+    RequestValidator.validateProcessDefinitionId(null, violations);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/util/patternMismatch.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/util/patternMismatch.ts
@@ -16,7 +16,10 @@ export function buildGuaranteedPatternMismatch(
 ): string | undefined {
   let rx: RegExp | undefined;
   try {
-    rx = new RegExp(pattern);
+    // Use the Unicode flag when the pattern contains Unicode property escapes (\p{...})
+    // so that JS can compile patterns like \p{L}, \p{N} from the OpenAPI specs.
+    const flags = /\\p\{/.test(pattern) ? 'u' : '';
+    rx = new RegExp(pattern, flags);
   } catch {
     return undefined;
   }

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -14,15 +14,18 @@ functionsDir: ./spectral-functions
 rules:
   # Tag validation
   operation-tag-defined: error
-  
-  # Enforce strict schema validation (catches issues like `required: false` at property level)
-  # The oas3-valid-schema-example rule validates that schemas are valid according to the 
-  # OpenAPI 3.0 JSON Schema specifications. This will catch structural issues like:
-  # - Using `required: false` as a boolean at property level (should be array at object level)
-  # - Invalid schema property combinations
-  # - Type mismatches in schema definitions
-  oas3-valid-schema-example: error
-  
+
+  # Schema example validation rules.
+  # Downgraded from error → warn because Spectral does not support Unicode regex
+  # (\p{L}, \p{N}) in pattern validation. Our identifier schemas use Unicode-aware
+  # patterns (e.g. ProcessDefinitionId, DecisionDefinitionId, Tag), which causes
+  # false-positive failures on all example values.
+  # Upstream issue: https://github.com/stoplightio/spectral/issues/2419
+  # Upstream fix:   https://github.com/stoplightio/spectral/pull/2809
+  # TODO: Restore to error once Spectral ships the unicodeRegExp option.
+  oas3-valid-schema-example: warn
+  oas3-valid-media-example: warn
+
   # Custom validation rules migrated from Vacuum
   no-period-in-summary:
     description: Path summary must not include period
@@ -33,7 +36,7 @@ rules:
       functionOptions:
         notMatch: ^.*\.$
     message: Summaries are short descriptions often used in navigation bars, they must not contain periods at the end. Please remove the period at the end of the summary text.
-  
+
   no-flow-node-in-path-summary:
     description: Path summary must not include term "flow node"
     severity: error
@@ -43,7 +46,7 @@ rules:
       functionOptions:
         notMatch: .*(flow-node|flownode|flowNode|flow node).*
     message: Please replace the term "flow node" with "element".
-  
+
   no-flow-node-in-path-description:
     description: Path description must not include term "flow node"
     severity: error
@@ -53,7 +56,7 @@ rules:
       functionOptions:
         notMatch: .*(flow-node|flownode|flowNode|flow node).*
     message: Please replace the term "flow node" with "element".
-  
+
   no-flow-node-in-operation-id:
     description: Path operation ID must not include term "flow node"
     severity: error
@@ -63,7 +66,7 @@ rules:
       functionOptions:
         notMatch: .*(flow-node|flownode|flowNode|FlowNode|Flownode).*
     message: Please replace the term "flow node" with "element".
-  
+
   no-flow-node-in-path:
     description: Paths must not include term "flow node"
     severity: error
@@ -73,7 +76,7 @@ rules:
       functionOptions:
         notMatch: .*(flow-node|flownode|flowNode).*
     message: Please replace the term "flow node" with "element".
-  
+
   no-flow-node-in-component-property:
     description: Component properties must not include term "flow node"
     severity: error
@@ -83,7 +86,7 @@ rules:
       functionOptions:
         notMatch: .*(flownode|flowNode).*
     message: Please replace the term "flow node" with "element".
-  
+
   require-property-descriptions:
     description: Schema properties must have a description.
     severity: error
@@ -91,7 +94,7 @@ rules:
     then:
       field: description
       function: truthy
-  
+
   operation-key-properties-must-be-strings:
     description: "`...Key` parameters must be of type `string`."
     severity: warn
@@ -99,7 +102,7 @@ rules:
     then:
       function: verifyKeyTypesPaths
     message: Make the `...Key` property a `string`.
-  
+
   schema-key-properties-must-be-strings:
     description: "`...Key` properties must be of type `string`."
     severity: warn
@@ -107,7 +110,7 @@ rules:
     then:
       function: verifyKeyTypesSchemas
     message: Make the `...Key` property a `string`.
-  
+
   required-properties-must-exist:
     description: "Every entry in `required` must match a key in `properties`."
     severity: error

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -30,8 +30,7 @@ components:
       x-semantic-type: DecisionDefinitionId
       type: string
       minLength: 1
-      maxLength: 256
-      pattern: ^[\p{L}\p{N}_@.+-]+$
+      pattern: ^[\p{L}_][\p{L}\p{N}_\-\.]*$
       example: new-hire-onboarding-workflow
 
     GlobalListenerId:

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -7,7 +7,7 @@ components:
       type: string
       x-semantic-type: ProcessDefinitionId
       minLength: 1
-      pattern: ^[a-zA-Z_][a-zA-Z0-9_\-\.]*$
+      pattern: ^[\p{L}_][\p{L}\p{N}_\-\.]*$
       example: new-account-onboarding-workflow
 
     ElementId:
@@ -31,7 +31,7 @@ components:
       type: string
       minLength: 1
       maxLength: 256
-      pattern: ^[A-Za-z0-9_@.+-]+$
+      pattern: ^[\p{L}\p{N}_@.+-]+$
       example: new-hire-onboarding-workflow
 
     GlobalListenerId:
@@ -69,7 +69,7 @@ components:
       type: string
       minLength: 1
       maxLength: 100
-      pattern: ^[A-Za-z][A-Za-z0-9_\-:.]{0,99}$
+      pattern: ^[\p{L}][\p{L}\p{N}_\-:.]{0,99}$
 
     TagSet:
       description: List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -69,7 +69,7 @@ components:
       type: string
       minLength: 1
       maxLength: 100
-      pattern: ^[\p{L}][\p{L}\p{N}_\-:.]{0,99}$
+      pattern: ^[A-Za-z][A-Za-z0-9_\-:.]{0,99}$
 
     TagSet:
       description: List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -463,7 +463,7 @@ public class DocumentControllerTest extends RestControllerTest {
   @Test
   void shouldRejectDocumentWithInvalidProcessDefinitionId() {
     // given — a processDefinitionId starting with a digit is invalid per the
-    // BPMN identifier pattern ^[a-zA-Z_][a-zA-Z0-9_\-.]*$
+    // BPMN identifier pattern ^[\p{L}_][\p{L}\p{N}_\-.]*$
     final var content = new byte[] {1, 2, 3};
     final var contentType = MediaType.APPLICATION_OCTET_STREAM;
 
@@ -489,7 +489,7 @@ public class DocumentControllerTest extends RestControllerTest {
         .jsonPath("$.detail")
         .isEqualTo(
             "The provided processDefinitionId contains illegal characters. "
-                + "It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\-.]*$'.");
+                + "It must match the pattern '^[\\p{L}_][\\p{L}\\p{N}_\\-.]*$'.");
 
     verify(documentServices, never()).createDocument(any(), any());
   }
@@ -682,7 +682,7 @@ public class DocumentControllerTest extends RestControllerTest {
   @Test
   void shouldRejectBatchDocumentWithInvalidProcessDefinitionId() throws Exception {
     // given — a processDefinitionId starting with a digit is invalid per the
-    // BPMN identifier pattern ^[a-zA-Z_][a-zA-Z0-9_\-.]*$
+    // BPMN identifier pattern ^[\p{L}_][\p{L}\p{N}_\-.]*$
     final var content = new byte[] {1, 2, 3};
     final var contentType = MediaType.APPLICATION_OCTET_STREAM;
     final var mapper = new ObjectMapper();
@@ -711,7 +711,7 @@ public class DocumentControllerTest extends RestControllerTest {
         .jsonPath("$.detail")
         .isEqualTo(
             "The provided processDefinitionId contains illegal characters. "
-                + "It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\-.]*$'.");
+                + "It must match the pattern '^[\\p{L}_][\\p{L}\\p{N}_\\-.]*$'.");
 
     verify(documentServices, never()).createDocumentBatch(any(), any());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -3162,7 +3162,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
                 "type":"about:blank",
                 "title":"INVALID_ARGUMENT",
                 "status":400,
-                "detail":"The provided processDefinitionId contains illegal characters. It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\\\-.]*$'.",
+                "detail":"The provided processDefinitionId contains illegal characters. It must match the pattern '^[\\\\p{L}_][\\\\p{L}\\\\p{N}_\\\\-.]*$'.",
                 "instance":"/v2/process-instances"
              }""";
 


### PR DESCRIPTION
# Description
Backport of #48299 to `stable/8.9`.

relates to #46782 #46787