### PR TITLE
Use fromJSON to pass ttl as number to reusable workflow

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-typical
-      ttl: ${{ fromJSON(inputs.ttl || 28) }}
+      ttl: ${{ fromJSON(inputs.ttl || '28') }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: typical
       build-frontend: true
@@ -69,7 +69,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-rdbms-realistic
-      ttl: ${{ fromJSON(inputs.ttl || 28) }}
+      ttl: ${{ fromJSON(inputs.ttl || '28') }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       secondary-storage-type: 'postgresql'
       build-frontend: true
@@ -82,7 +82,7 @@ jobs:
       - test-data
     with:
       name: ${{ needs.test-data.outputs.test }}-realistic
-      ttl: ${{ fromJSON(inputs.ttl || 28) }}
+      ttl: ${{ fromJSON(inputs.ttl || '28') }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: realistic
       build-frontend: true
@@ -94,7 +94,7 @@ jobs:
       - test-data
     with:
       name: ${{ needs.test-data.outputs.test }}-latency
-      ttl: ${{ fromJSON(inputs.ttl || 28) }}
+      ttl: ${{ fromJSON(inputs.ttl || '28') }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: latency
       build-frontend: true

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-typical
-      ttl: ${{ inputs.ttl || 28 }}
+      ttl: ${{ fromJSON(inputs.ttl || 28) }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: typical
       build-frontend: true
@@ -69,7 +69,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-rdbms-realistic
-      ttl: ${{ inputs.ttl || 28 }}
+      ttl: ${{ fromJSON(inputs.ttl || 28) }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       secondary-storage-type: 'postgresql'
       build-frontend: true
@@ -82,7 +82,7 @@ jobs:
       - test-data
     with:
       name: ${{ needs.test-data.outputs.test }}-realistic
-      ttl: ${{ inputs.ttl || 28 }}
+      ttl: ${{ fromJSON(inputs.ttl || 28) }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: realistic
       build-frontend: true
@@ -94,7 +94,7 @@ jobs:
       - test-data
     with:
       name: ${{ needs.test-data.outputs.test }}-latency
-      ttl: ${{ inputs.ttl || 28 }}
+      ttl: ${{ fromJSON(inputs.ttl || 28) }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       scenario: latency
       build-frontend: true


### PR DESCRIPTION
## Description

With https://github.com/camunda/camunda/pull/47538 we introduced the TTL input, but it has some issues.

workflow_dispatch inputs are always strings at runtime, which causes validation errors ("Unexpected value '28'") when passed to reusable workflows that declare the input as type: number.

Wrapping with fromJSON() converts the string back to a proper numeric type before the reusable workflow validates its inputs.

See https://github.com/orgs/community/discussions/67182


> [!Important]
>
> If we do not merge this today, this will break our setup next week.