### PR TITLE
perf: cache variable names by scope in `DbVariableState` to avoid rocksDB iterator

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
@@ -19,6 +19,9 @@ public final class CachesCfg implements ConfigurationEntry {
   private int authorizationsCacheCapacity =
       EngineConfiguration.DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY;
   private Duration authorizationsCacheTtl = EngineConfiguration.DEFAULT_AUTHORIZATIONS_CACHE_TTL;
+  private int variableNamesCacheCapacity =
+      EngineConfiguration.DEFAULT_VARIABLE_NAMES_CACHE_CAPACITY;
+  private Duration variableNamesCacheTtl = EngineConfiguration.DEFAULT_VARIABLE_NAMES_CACHE_TTL;
 
   public int getDrgCacheCapacity() {
     return drgCacheCapacity;
@@ -68,6 +71,22 @@ public final class CachesCfg implements ConfigurationEntry {
     this.authorizationsCacheTtl = authorizationsCacheTtl;
   }
 
+  public int getVariableNamesCacheCapacity() {
+    return variableNamesCacheCapacity;
+  }
+
+  public void setVariableNamesCacheCapacity(final int variableNamesCacheCapacity) {
+    this.variableNamesCacheCapacity = variableNamesCacheCapacity;
+  }
+
+  public Duration getVariableNamesCacheTtl() {
+    return variableNamesCacheTtl;
+  }
+
+  public void setVariableNamesCacheTtl(final Duration variableNamesCacheTtl) {
+    this.variableNamesCacheTtl = variableNamesCacheTtl;
+  }
+
   @Override
   public String toString() {
     return "CachesCfg{"
@@ -83,6 +102,10 @@ public final class CachesCfg implements ConfigurationEntry {
         + authorizationsCacheCapacity
         + ", authorizationsCacheTtl="
         + authorizationsCacheTtl
+        + ", variableNamesCacheCapacity="
+        + variableNamesCacheCapacity
+        + ", variableNamesCacheTtl="
+        + variableNamesCacheTtl
         + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -177,6 +177,8 @@ public final class EngineCfg implements ConfigurationEntry {
         .setProcessCacheCapacity(caches.getProcessCacheCapacity())
         .setAuthorizationsCacheCapacity(caches.getAuthorizationsCacheCapacity())
         .setAuthorizationsCacheTtl(caches.getAuthorizationsCacheTtl())
+        .setVariableNamesCacheCapacity(caches.getVariableNamesCacheCapacity())
+        .setVariableNamesCacheTtl(caches.getVariableNamesCacheTtl())
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
         .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
         .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize())

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -67,6 +67,10 @@ final class EngineCfgTest {
     assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(5));
     assertThat(configuration.isBusinessIdUniquenessEnabled())
         .isEqualTo(EngineConfiguration.DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED);
+    assertThat(configuration.getVariableNamesCacheCapacity())
+        .isEqualTo(EngineConfiguration.DEFAULT_VARIABLE_NAMES_CACHE_CAPACITY);
+    assertThat(configuration.getVariableNamesCacheTtl())
+        .isEqualTo(EngineConfiguration.DEFAULT_VARIABLE_NAMES_CACHE_TTL);
   }
 
   @Test
@@ -105,6 +109,8 @@ final class EngineCfgTest {
         taskListeners.get(1), "test2", new String[] {"assigning", "canceling"}, "2", true);
     assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(2));
     assertThat(configuration.isBusinessIdUniquenessEnabled()).isTrue();
+    assertThat(configuration.getVariableNamesCacheCapacity()).isEqualTo(5000);
+    assertThat(configuration.getVariableNamesCacheTtl()).isEqualTo(Duration.ofMinutes(10));
   }
 
   void assertListenerCfg(

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -9,6 +9,8 @@ zeebe:
           drgCacheCapacity: 2000
           formCacheCapacity: 2000
           processCacheCapacity: 2000
+          variableNamesCacheCapacity: 5000
+          variableNamesCacheTtl: 10m
         jobs:
           timeoutCheckerPollingInterval: 15s
           timeoutCheckerBatchLimit: 1000

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -63,6 +63,8 @@ public final class EngineConfiguration {
   public static final boolean DEFAULT_ENABLE_IDENTITY_SETUP = true;
   public static final Duration DEFAULT_EXPRESSION_EVALUATION_TIMEOUT = Duration.ofSeconds(5);
   public static final boolean DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED = false;
+  public static final int DEFAULT_VARIABLE_NAMES_CACHE_CAPACITY = 1000;
+  public static final Duration DEFAULT_VARIABLE_NAMES_CACHE_TTL = Duration.ofMinutes(5);
 
   private int maxIdFieldLength = DEFAULT_MAX_ID_FIELD_LENGTH;
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
@@ -119,6 +121,9 @@ public final class EngineConfiguration {
    * </ul>
    */
   private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
+
+  private int variableNamesCacheCapacity = DEFAULT_VARIABLE_NAMES_CACHE_CAPACITY;
+  private Duration variableNamesCacheTtl = DEFAULT_VARIABLE_NAMES_CACHE_TTL;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -485,6 +490,23 @@ public final class EngineConfiguration {
   public EngineConfiguration setIncludeVariablesInJobCompletedEvent(
       final boolean includeVariablesInJobCompletedEvent) {
     this.includeVariablesInJobCompletedEvent = includeVariablesInJobCompletedEvent;
+  }
+
+  public int getVariableNamesCacheCapacity() {
+    return variableNamesCacheCapacity;
+  }
+
+  public EngineConfiguration setVariableNamesCacheCapacity(final int variableNamesCacheCapacity) {
+    this.variableNamesCacheCapacity = variableNamesCacheCapacity;
+    return this;
+  }
+
+  public Duration getVariableNamesCacheTtl() {
+    return variableNamesCacheTtl;
+  }
+
+  public EngineConfiguration setVariableNamesCacheTtl(final Duration variableNamesCacheTtl) {
+    this.variableNamesCacheTtl = variableNamesCacheTtl;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -162,7 +162,12 @@ public class ProcessingDbState implements MutableProcessingState {
     this.zeebeDb = zeebeDb;
     this.keyGenerator = Objects.requireNonNull(keyGenerator);
 
-    variableState = new DbVariableState(zeebeDb, transactionContext);
+    variableState =
+        new DbVariableState(
+            zeebeDb,
+            transactionContext,
+            config.getVariableNamesCacheCapacity(),
+            config.getVariableNamesCacheTtl());
     clusterVariableState = new DbClusterVariableState(zeebeDb, transactionContext);
     processState =
         new DbProcessState(zeebeDb, transactionContext, config, clock, expressionLanguageMetrics);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.variable;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -22,8 +24,10 @@ import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentReco
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -35,6 +39,8 @@ import org.agrona.collections.ObjectHashSet;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class DbVariableState implements MutableVariableState {
+
+  private static final int VARIABLE_NAME_CACHE_MAX_SIZE = 10_000;
 
   private final MsgPackWriter writer = new MsgPackWriter();
   private final ExpandableArrayBuffer documentResultBuffer = new ExpandableArrayBuffer();
@@ -62,6 +68,10 @@ public class DbVariableState implements MutableVariableState {
 
   private final VariableInstance newVariable = new VariableInstance();
   private final DirectBuffer variableNameView = new UnsafeBuffer(0, 0);
+
+  // (scope key) => (set of variable names on that scope) — LRU cache for fast removeAllVariables
+  private final Cache<Long, Set<String>> variableNameCache =
+      Caffeine.newBuilder().maximumSize(VARIABLE_NAME_CACHE_MAX_SIZE).build();
 
   // collecting variables
   private final ObjectHashSet<DirectBuffer> collectedVariables = new ObjectHashSet<>();
@@ -127,6 +137,11 @@ public class DbVariableState implements MutableVariableState {
     variableName.wrapBuffer(variableNameView);
 
     variablesColumnFamily.upsert(scopeKeyVariableNameKey, newVariable);
+
+    final Set<String> cachedNames = variableNameCache.getIfPresent(scopeKey);
+    if (cachedNames != null) {
+      cachedNames.add(BufferUtil.bufferAsString(variableNameView));
+    }
   }
 
   @Override
@@ -135,6 +150,8 @@ public class DbVariableState implements MutableVariableState {
     this.parentKey.set(parentKey);
 
     childParentColumnFamily.insert(this.childKey, this.parentKey);
+
+    variableNameCache.put(childKey, new HashSet<>());
   }
 
   @Override
@@ -142,6 +159,7 @@ public class DbVariableState implements MutableVariableState {
     this.scopeKey.wrapLong(scopeKey);
 
     removeAllVariables(scopeKey);
+    variableNameCache.invalidate(scopeKey);
 
     childKey.wrapLong(scopeKey);
     // TODO: Could be deleteExisting except for tests
@@ -150,11 +168,24 @@ public class DbVariableState implements MutableVariableState {
 
   @Override
   public void removeAllVariables(final long scopeKey) {
-    visitVariablesLocal(
-        scopeKey,
-        dbString -> true,
-        (dbString, variable1) -> variablesColumnFamily.deleteExisting(scopeKeyVariableNameKey),
-        () -> false);
+    final Set<String> cachedNames = variableNameCache.getIfPresent(scopeKey);
+    if (cachedNames != null) {
+      try {
+        this.scopeKey.wrapLong(scopeKey);
+        for (final String name : cachedNames) {
+          variableName.wrapString(name);
+          variablesColumnFamily.deleteExisting(scopeKeyVariableNameKey);
+        }
+      } finally {
+        cachedNames.clear();
+      }
+    } else {
+      visitVariablesLocal(
+          scopeKey,
+          dbString -> true,
+          (dbString, variable1) -> variablesColumnFamily.deleteExisting(scopeKeyVariableNameKey),
+          () -> false);
+    }
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,6 +42,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 public class DbVariableState implements MutableVariableState {
 
   private static final int VARIABLE_NAME_CACHE_MAX_SIZE = 10_000;
+  private static final Duration VARIABLE_NAME_CACHE_EXPIRY = Duration.ofMinutes(5);
 
   private final MsgPackWriter writer = new MsgPackWriter();
   private final ExpandableArrayBuffer documentResultBuffer = new ExpandableArrayBuffer();
@@ -71,7 +73,10 @@ public class DbVariableState implements MutableVariableState {
 
   // (scope key) => (set of variable names on that scope) — LRU cache for fast removeAllVariables
   private final Cache<Long, Set<String>> variableNameCache =
-      Caffeine.newBuilder().maximumSize(VARIABLE_NAME_CACHE_MAX_SIZE).build();
+      Caffeine.newBuilder()
+          .maximumSize(VARIABLE_NAME_CACHE_MAX_SIZE)
+          .expireAfterAccess(VARIABLE_NAME_CACHE_EXPIRY)
+          .build();
 
   // collecting variables
   private final ObjectHashSet<DirectBuffer> collectedVariables = new ObjectHashSet<>();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -72,7 +72,7 @@ public class DbVariableState implements MutableVariableState {
   private final DirectBuffer variableNameView = new UnsafeBuffer(0, 0);
 
   // (scope key) => (set of variable names on that scope) — LRU cache for fast removeAllVariables
-  private final Cache<Long, Set<String>> variableNameCache =
+  private final Cache<Long, Set<DirectBuffer>> variableNameCache =
       Caffeine.newBuilder()
           .maximumSize(VARIABLE_NAME_CACHE_MAX_SIZE)
           .expireAfterAccess(VARIABLE_NAME_CACHE_EXPIRY)
@@ -143,10 +143,9 @@ public class DbVariableState implements MutableVariableState {
 
     variablesColumnFamily.upsert(scopeKeyVariableNameKey, newVariable);
 
-    final Set<String> cachedNames = variableNameCache.getIfPresent(scopeKey);
-    if (cachedNames != null) {
-      cachedNames.add(BufferUtil.bufferAsString(variableNameView));
-    }
+    variableNameCache
+        .get(scopeKey, k -> new HashSet<>())
+        .add(BufferUtil.cloneBuffer(variableNameView));
   }
 
   @Override
@@ -155,8 +154,6 @@ public class DbVariableState implements MutableVariableState {
     this.parentKey.set(parentKey);
 
     childParentColumnFamily.insert(this.childKey, this.parentKey);
-
-    variableNameCache.put(childKey, new HashSet<>());
   }
 
   @Override
@@ -173,12 +170,12 @@ public class DbVariableState implements MutableVariableState {
 
   @Override
   public void removeAllVariables(final long scopeKey) {
-    final Set<String> cachedNames = variableNameCache.getIfPresent(scopeKey);
+    final Set<DirectBuffer> cachedNames = variableNameCache.getIfPresent(scopeKey);
     if (cachedNames != null) {
       try {
         this.scopeKey.wrapLong(scopeKey);
-        for (final String name : cachedNames) {
-          variableName.wrapString(name);
+        for (final DirectBuffer name : cachedNames) {
+          variableName.wrapBuffer(name);
           variablesColumnFamily.deleteExisting(scopeKeyVariableNameKey);
         }
       } finally {
@@ -191,6 +188,19 @@ public class DbVariableState implements MutableVariableState {
           (dbString, variable1) -> variablesColumnFamily.deleteExisting(scopeKeyVariableNameKey),
           () -> false);
     }
+  }
+
+  @Override
+  public void storeVariableDocumentState(final long key, final VariableDocumentRecord record) {
+    scopeKey.wrapLong(record.getScopeKey());
+    variableDocumentStateToWrite.setKey(key).setRecord(record);
+    variableDocumentStateByScopeKeyColumnFamily.insert(scopeKey, variableDocumentStateToWrite);
+  }
+
+  @Override
+  public void removeVariableDocumentState(final long scopeKey) {
+    this.scopeKey.wrapLong(scopeKey);
+    variableDocumentStateByScopeKeyColumnFamily.deleteIfExists(this.scopeKey);
   }
 
   @Override
@@ -359,19 +369,6 @@ public class DbVariableState implements MutableVariableState {
 
     final ParentScopeKey parentScopeKey = childParentColumnFamily.get(childKey);
     return parentScopeKey != null ? parentScopeKey.get() : NO_PARENT;
-  }
-
-  @Override
-  public void storeVariableDocumentState(final long key, final VariableDocumentRecord record) {
-    scopeKey.wrapLong(record.getScopeKey());
-    variableDocumentStateToWrite.setKey(key).setRecord(record);
-    variableDocumentStateByScopeKeyColumnFamily.insert(scopeKey, variableDocumentStateToWrite);
-  }
-
-  @Override
-  public void removeVariableDocumentState(final long scopeKey) {
-    this.scopeKey.wrapLong(scopeKey);
-    variableDocumentStateByScopeKeyColumnFamily.deleteIfExists(this.scopeKey);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.state.variable;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
@@ -41,8 +43,6 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public class DbVariableState implements MutableVariableState {
 
-  private static final int VARIABLE_NAME_CACHE_MAX_SIZE = 10_000;
-  private static final Duration VARIABLE_NAME_CACHE_EXPIRY = Duration.ofMinutes(5);
 
   private final MsgPackWriter writer = new MsgPackWriter();
   private final ExpandableArrayBuffer documentResultBuffer = new ExpandableArrayBuffer();
@@ -72,18 +72,33 @@ public class DbVariableState implements MutableVariableState {
   private final DirectBuffer variableNameView = new UnsafeBuffer(0, 0);
 
   // (scope key) => (set of variable names on that scope) — LRU cache for fast removeAllVariables
-  private final Cache<Long, Set<DirectBuffer>> variableNameCache =
-      Caffeine.newBuilder()
-          .maximumSize(VARIABLE_NAME_CACHE_MAX_SIZE)
-          .expireAfterAccess(VARIABLE_NAME_CACHE_EXPIRY)
-          .build();
+  private final Cache<Long, Set<DirectBuffer>> variableNameCache;
 
   // collecting variables
   private final ObjectHashSet<DirectBuffer> collectedVariables = new ObjectHashSet<>();
   private final ObjectHashSet<DirectBuffer> variablesToCollect = new ObjectHashSet<>();
 
+  @VisibleForTesting
   public DbVariableState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    this(
+        zeebeDb,
+        transactionContext,
+        EngineConfiguration.DEFAULT_VARIABLE_NAMES_CACHE_CAPACITY,
+        EngineConfiguration.DEFAULT_VARIABLE_NAMES_CACHE_TTL);
+  }
+
+  public DbVariableState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final TransactionContext transactionContext,
+      final int variableNamesCacheCapacity,
+      final Duration variableNamesCacheTtl) {
+    variableNameCache =
+        Caffeine.newBuilder()
+            .maximumSize(variableNamesCacheCapacity)
+            .expireAfterAccess(variableNamesCacheTtl)
+            .build();
+
     childKey = new DbLong();
     childParentColumnFamily =
         zeebeDb.createColumnFamily(


### PR DESCRIPTION
## Description
Variable names are cached per scope in `DbElementInstanceState` with a Caffeine LRU cache.
On cache hit, this avoids using a rocksDB iterator to iterate over all variables. 
The content of the variables is not cached, this is just to avoid the iteration. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
