### PR TITLE
[Backport stable/8.9] fix: prevent batch operation document overwrite in multi-partition clusters

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.search.enums.BatchOperationItemState;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
 import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
+import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.protocol.Protocol;
@@ -40,12 +41,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "es")
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class ClusterMultiplePartitionsBatchOperationIT {
-
-  private static CamundaClient camundaClient;
 
   @MultiDbTestApplication
   private static final TestStandaloneApplication<?> APPLICATION =
@@ -62,7 +59,7 @@ public class ClusterMultiplePartitionsBatchOperationIT {
   private static final List<ProcessInstanceEvent> ACTIVE_PROCESS_INSTANCES = new ArrayList<>();
 
   @BeforeAll
-  public static void beforeAll() {
+  public static void beforeAll(@Authenticated final CamundaClient camundaClient) {
     Objects.requireNonNull(camundaClient);
 
     // Deploy process definitions
@@ -100,7 +97,8 @@ public class ClusterMultiplePartitionsBatchOperationIT {
   }
 
   @Test
-  void shouldCancelProcessInstancesOnSeveralPartitionsWithBatch() {
+  void shouldCancelProcessInstancesOnSeveralPartitionsWithBatch(
+      @Authenticated final CamundaClient camundaClient) {
     // when
     final var result =
         camundaClient

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -79,11 +79,15 @@ public class BatchOperationChunkCreatedHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    // also set the endDate to null to ensure that the batch operation is processed again by the
-    // BatchOperationUpdateTask
-    batchRequest.updateWithScript(
+    // Use upsertWithScript to be resilient against cross-partition ordering: if the batch operation
+    // document has not been created yet (e.g., a slow partition's CREATED event export), the upsert
+    // creates a minimal document from the entity. When the document already exists, the script
+    // atomically increments the total count and resets endDate to null so that the
+    // BatchOperationUpdateTask will re-process this batch operation to update all counts.
+    batchRequest.upsertWithScript(
         indexName,
         entity.getId(),
+        entity,
         """
             ctx._source.operationsTotalCount = ctx._source.operationsTotalCount + params.operationsTotalCount;
             ctx._source.endDate = null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.exporter.utils.ExporterUtil.map;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
@@ -24,10 +25,12 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Handles the creation of a batch operation by inserting the corresponding {@link
+ * Handles the creation of a batch operation by upserting the corresponding {@link
  * BatchOperationEntity} with the batch operation details. This handler is responsible for
  * initializing the batch operation state and type, and updating the local cache for immediate
  * access.
@@ -92,7 +95,20 @@ public class BatchOperationCreatedHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    // Use upsert instead of add (index) to prevent cross-partition document overwrites.
+    // The CREATED event is distributed to all partitions, so each partition's exporter writes to
+    // the same document. An index operation would fully replace the document, potentially
+    // overwriting operationsTotalCount increments or state transitions applied by other partitions.
+    // With upsert: if the document does not yet exist, it is created from the entity; if it
+    // already exists, only the specified fields are updated without affecting other fields.
+    // Note: STATE is intentionally excluded from updateFields because a late CREATED event from a
+    // slow partition could overwrite a state that has already advanced (e.g., ACTIVE or COMPLETED).
+    // The state is set correctly on initial document creation via the entity.
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(BatchOperationTemplate.TYPE, entity.getType());
+    updateFields.put(BatchOperationTemplate.ACTOR_TYPE, entity.getActorType());
+    updateFields.put(BatchOperationTemplate.ACTOR_ID, entity.getActorId());
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -12,7 +12,6 @@ import static io.camunda.exporter.utils.ExporterUtil.map;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
@@ -25,7 +24,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -100,23 +98,10 @@ public class BatchOperationCreatedHandler
     // the same document. An index operation would fully replace the document, potentially
     // overwriting operationsTotalCount increments or state transitions applied by other partitions.
     // With upsert: if the document does not yet exist, it is created from the entity; if it
-    // already exists, only the specified fields are updated without affecting other fields.
-    // Note: STATE is intentionally excluded from updateFields because a late CREATED event from a
-    // slow partition could overwrite a state that has already advanced (e.g., ACTIVE or COMPLETED).
-    // The state is set correctly on initial document creation via the entity.
-    final Map<String, Object> updateFields = new HashMap<>();
-    updateFields.put(BatchOperationTemplate.TYPE, entity.getType());
-
-    final var actorType = entity.getActorType();
-    if (actorType != null) {
-      updateFields.put(BatchOperationTemplate.ACTOR_TYPE, actorType);
-    }
-
-    final var actorId = entity.getActorId();
-    if (actorId != null) {
-      updateFields.put(BatchOperationTemplate.ACTOR_ID, actorId);
-    }
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    // already exists, the empty update map is a no-op — all fields in the CREATED event are
+    // idempotent across partitions (same values regardless of which partition exports), so there
+    // is nothing to update on an existing document.
+    batchRequest.upsert(indexName, entity.getId(), entity, Map.of());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -106,8 +106,16 @@ public class BatchOperationCreatedHandler
     // The state is set correctly on initial document creation via the entity.
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(BatchOperationTemplate.TYPE, entity.getType());
-    updateFields.put(BatchOperationTemplate.ACTOR_TYPE, entity.getActorType());
-    updateFields.put(BatchOperationTemplate.ACTOR_ID, entity.getActorId());
+
+    final var actorType = entity.getActorType();
+    if (actorType != null) {
+      updateFields.put(BatchOperationTemplate.ACTOR_TYPE, actorType);
+    }
+
+    final var actorId = entity.getActorId();
+    if (actorId != null) {
+      updateFields.put(BatchOperationTemplate.ACTOR_ID, actorId);
+    }
     batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandler.java
@@ -18,12 +18,21 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationInitializationRecordValue;
 import io.camunda.zeebe.util.DateUtil;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class BatchOperationInitializedHandler
     implements ExportHandler<BatchOperationEntity, BatchOperationInitializationRecordValue> {
+
+  static final String CONDITIONAL_UPDATE_SCRIPT =
+      """
+      if (ctx._source.state == null || ctx._source.state == 'CREATED') {
+          ctx._source.state = params.state;
+      }
+      if (ctx._source.startDate == null) {
+          ctx._source.startDate = params.startDate;
+      }
+      """;
 
   private final String indexName;
 
@@ -68,10 +77,20 @@ public class BatchOperationInitializedHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    final Map<String, Object> updateFields = new HashMap<>();
-    updateFields.put(BatchOperationTemplate.STATE, entity.getState());
-    updateFields.put(BatchOperationTemplate.START_DATE, entity.getStartDate());
-    batchRequest.update(indexName, entity.getId(), updateFields);
+    // Use upsertWithScript to be resilient against cross-partition ordering. Each partition
+    // independently produces an INITIALIZED event, so multiple exporters write state=ACTIVE to
+    // the same document. A late write from a slow partition could overwrite a state that has
+    // already advanced (e.g., COMPLETED). The Painless script only transitions to ACTIVE if the
+    // current state is CREATED or null, preventing state regression.
+    // If the document does not yet exist, the upsert creates it from the entity.
+    batchRequest.upsertWithScript(
+        indexName,
+        entity.getId(),
+        entity,
+        CONDITIONAL_UPDATE_SCRIPT,
+        Map.of(
+            BatchOperationTemplate.STATE, entity.getState().name(),
+            BatchOperationTemplate.START_DATE, entity.getStartDate()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
@@ -116,19 +116,21 @@ public class BatchOperationLifecycleManagementHandler
   // - If the incoming state is non-terminal (ACTIVE from RESUMED, or SUSPENDED), it is only
   //   applied when the current stored state is also non-terminal, preventing a lagging distributed
   //   event from overwriting a terminal state.
-  // endDate and errors are always updated because they are set alongside the state transition and
-  // are safe to overwrite.
+  // - endDate and errors are updated only when the state transition is applied, ensuring that
+  //   late non-terminal events cannot clear or modify the end date or errors of a terminal
+  //   operation.
   static final String CONDITIONAL_STATE_UPDATE_SCRIPT =
       """
       def terminalStates = ['COMPLETED', 'PARTIALLY_COMPLETED', 'FAILED', 'CANCELED'];
       def isNewStateTerminal = terminalStates.contains(params.state);
       def isCurrentStateTerminal = terminalStates.contains(ctx._source.state);
-      if (isNewStateTerminal || !isCurrentStateTerminal) {
+      def shouldApplyState = isNewStateTerminal || !isCurrentStateTerminal;
+      if (shouldApplyState) {
           ctx._source.state = params.state;
-      }
-      ctx._source.endDate = params.endDate;
-      if (params.containsKey('errors')) {
-          ctx._source.errors = params.errors;
+          ctx._source.endDate = params.endDate;
+          if (params.containsKey('errors')) {
+              ctx._source.errors = params.errors;
+          }
       }
       """;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
@@ -114,13 +114,19 @@ public class BatchOperationLifecycleManagementHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
+    // Use upsert instead of update to be resilient against cross-partition ordering.
+    // CANCELED, SUSPENDED, and RESUMED events are distributed to all partitions, so each
+    // partition's exporter writes to the same document. If the document does not yet exist
+    // (e.g., the CREATED event from a slow partition hasn't been exported yet), a plain update()
+    // would fail with a document_missing_exception. With upsert: if the document does not exist,
+    // it is created from the entity; if it already exists, only the specified fields are updated.
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(BatchOperationTemplate.STATE, entity.getState());
     updateFields.put(BatchOperationTemplate.END_DATE, entity.getEndDate());
     if (entity.getErrors() != null && !entity.getErrors().isEmpty()) {
       updateFields.put(BatchOperationTemplate.ERRORS, entity.getErrors());
     }
-    batchRequest.update(indexName, entity.getId(), updateFields);
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
@@ -111,22 +111,44 @@ public class BatchOperationLifecycleManagementHandler
     }
   }
 
+  // Painless script that guards against state regression in multi-partition clusters.
+  // - If the incoming state is terminal, it is always applied (terminal states take priority).
+  // - If the incoming state is non-terminal (ACTIVE from RESUMED, or SUSPENDED), it is only
+  //   applied when the current stored state is also non-terminal, preventing a lagging distributed
+  //   event from overwriting a terminal state.
+  // endDate and errors are always updated because they are set alongside the state transition and
+  // are safe to overwrite.
+  static final String CONDITIONAL_STATE_UPDATE_SCRIPT =
+      """
+      def terminalStates = ['COMPLETED', 'PARTIALLY_COMPLETED', 'FAILED', 'CANCELED'];
+      def isNewStateTerminal = terminalStates.contains(params.state);
+      def isCurrentStateTerminal = terminalStates.contains(ctx._source.state);
+      if (isNewStateTerminal || !isCurrentStateTerminal) {
+          ctx._source.state = params.state;
+      }
+      ctx._source.endDate = params.endDate;
+      if (params.containsKey('errors')) {
+          ctx._source.errors = params.errors;
+      }
+      """;
+
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    // Use upsert instead of update to be resilient against cross-partition ordering.
+    // Use upsertWithScript to be resilient against cross-partition ordering.
     // CANCELED, SUSPENDED, and RESUMED events are distributed to all partitions, so each
-    // partition's exporter writes to the same document. If the document does not yet exist
-    // (e.g., the CREATED event from a slow partition hasn't been exported yet), a plain update()
-    // would fail with a document_missing_exception. With upsert: if the document does not exist,
-    // it is created from the entity; if it already exists, only the specified fields are updated.
-    final Map<String, Object> updateFields = new HashMap<>();
-    updateFields.put(BatchOperationTemplate.STATE, entity.getState());
-    updateFields.put(BatchOperationTemplate.END_DATE, entity.getEndDate());
+    // partition's exporter writes to the same document. A conditional Painless script prevents
+    // a lagging non-terminal state (e.g., ACTIVE from RESUMED) from overwriting a terminal state
+    // (e.g., COMPLETED) that was already written by the lead partition's exporter.
+    // If the document does not yet exist, the upsert creates it from the entity.
+    final Map<String, Object> scriptParams = new HashMap<>();
+    scriptParams.put(BatchOperationTemplate.STATE, entity.getState().name());
+    scriptParams.put(BatchOperationTemplate.END_DATE, entity.getEndDate());
     if (entity.getErrors() != null && !entity.getErrors().isEmpty()) {
-      updateFields.put(BatchOperationTemplate.ERRORS, entity.getErrors());
+      scriptParams.put(BatchOperationTemplate.ERRORS, entity.getErrors());
     }
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsertWithScript(
+        indexName, entity.getId(), entity, CONDITIONAL_STATE_UPDATE_SCRIPT, scriptParams);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
@@ -37,9 +37,30 @@ import org.slf4j.LoggerFactory;
  */
 public class BatchOperationLifecycleManagementHandler
     implements ExportHandler<BatchOperationEntity, BatchOperationLifecycleManagementRecordValue> {
+  // Painless script that guards against state regression in multi-partition clusters.
+  // - If the incoming state is terminal, it is always applied (terminal states take priority).
+  // - If the incoming state is non-terminal (ACTIVE from RESUMED, or SUSPENDED), it is only
+  //   applied when the current stored state is also non-terminal, preventing a lagging distributed
+  //   event from overwriting a terminal state.
+  // - endDate and errors are updated only when the state transition is applied, ensuring that
+  //   late non-terminal events cannot clear or modify the end date or errors of a terminal
+  //   operation.
+  static final String CONDITIONAL_STATE_UPDATE_SCRIPT =
+      """
+      def terminalStates = ['COMPLETED', 'PARTIALLY_COMPLETED', 'FAILED', 'CANCELED'];
+      def isNewStateTerminal = terminalStates.contains(params.state);
+      def isCurrentStateTerminal = terminalStates.contains(ctx._source.state);
+      def shouldApplyState = isNewStateTerminal || !isCurrentStateTerminal;
+      if (shouldApplyState) {
+          ctx._source.state = params.state;
+          ctx._source.endDate = params.endDate;
+          if (params.containsKey('errors')) {
+              ctx._source.errors = params.errors;
+          }
+      }
+      """;
   private static final Logger LOGGER =
       LoggerFactory.getLogger(BatchOperationLifecycleManagementHandler.class);
-
   private static final Set<Intent> EXPORTABLE_INTENTS =
       Set.of(CANCELED, SUSPENDED, RESUMED, COMPLETED, FAILED);
   private final String indexName;
@@ -110,29 +131,6 @@ public class BatchOperationLifecycleManagementHandler
               record.getIntent());
     }
   }
-
-  // Painless script that guards against state regression in multi-partition clusters.
-  // - If the incoming state is terminal, it is always applied (terminal states take priority).
-  // - If the incoming state is non-terminal (ACTIVE from RESUMED, or SUSPENDED), it is only
-  //   applied when the current stored state is also non-terminal, preventing a lagging distributed
-  //   event from overwriting a terminal state.
-  // - endDate and errors are updated only when the state transition is applied, ensuring that
-  //   late non-terminal events cannot clear or modify the end date or errors of a terminal
-  //   operation.
-  static final String CONDITIONAL_STATE_UPDATE_SCRIPT =
-      """
-      def terminalStates = ['COMPLETED', 'PARTIALLY_COMPLETED', 'FAILED', 'CANCELED'];
-      def isNewStateTerminal = terminalStates.contains(params.state);
-      def isCurrentStateTerminal = terminalStates.contains(ctx._source.state);
-      def shouldApplyState = isNewStateTerminal || !isCurrentStateTerminal;
-      if (shouldApplyState) {
-          ctx._source.state = params.state;
-          ctx._source.endDate = params.endDate;
-          if (params.containsKey('errors')) {
-              ctx._source.errors = params.errors;
-          }
-      }
-      """;
 
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -116,7 +116,7 @@ class BatchOperationChunkCreatedHandlerTest {
   }
 
   @Test
-  void shouldUpdateEntityOnFlush() throws PersistenceException {
+  void shouldUpsertWithScriptEntityOnFlush() throws PersistenceException {
     // given
     final var entity =
         new BatchOperationEntity().setId("123").setOperationsTotalCount(123).setEndDate(null);
@@ -131,8 +131,12 @@ class BatchOperationChunkCreatedHandlerTest {
     // then
     final var scriptCaptor = ArgumentCaptor.forClass(String.class);
     verify(mockRequest, times(1))
-        .updateWithScript(
-            eq(indexName), eq(entity.getId()), scriptCaptor.capture(), eq(updateFields));
+        .upsertWithScript(
+            eq(indexName),
+            eq(entity.getId()),
+            eq(entity),
+            scriptCaptor.capture(),
+            eq(updateFields));
 
     final var script = scriptCaptor.getValue();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -207,18 +207,48 @@ class BatchOperationCreatedHandlerTest {
   }
 
   @Test
-  void shouldUpsertEntityOnFlush() throws PersistenceException {
-    // given
+  void shouldUpsertEntityOnFlushWithoutNullActorFields() throws PersistenceException {
+    // given — entity with null actorType and actorId (e.g., broker < 8.9.0)
     final var entity = new BatchOperationEntity().setId("123");
     final var mockRequest = mock(BatchRequest.class);
 
     // when
     underTest.flush(entity, mockRequest);
 
-    // then
+    // then — null actor fields must NOT be included in updateFields to avoid
+    // overwriting previously populated actor info from another partition
     @SuppressWarnings("unchecked")
     final ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
     verify(mockRequest, times(1)).upsert(eq(indexName), eq("123"), eq(entity), captor.capture());
+
+    final Map<String, Object> updateFields = captor.getValue();
+    assertThat(updateFields).containsOnlyKeys(BatchOperationTemplate.TYPE);
+    assertThat(updateFields)
+        .doesNotContainKeys(
+            BatchOperationTemplate.ACTOR_TYPE,
+            BatchOperationTemplate.ACTOR_ID,
+            BatchOperationTemplate.STATE,
+            BatchOperationTemplate.OPERATIONS_TOTAL_COUNT,
+            BatchOperationTemplate.END_DATE);
+  }
+
+  @Test
+  void shouldUpsertEntityOnFlushWithNonNullActorFields() throws PersistenceException {
+    // given — entity with populated actor info
+    final var entity =
+        new BatchOperationEntity()
+            .setId("456")
+            .setActorType(AuditLogActorType.USER)
+            .setActorId("username");
+    final var mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then — non-null actor fields must be included in updateFields
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+    verify(mockRequest, times(1)).upsert(eq(indexName), eq("456"), eq(entity), captor.capture());
 
     final Map<String, Object> updateFields = captor.getValue();
     assertThat(updateFields)
@@ -226,6 +256,9 @@ class BatchOperationCreatedHandlerTest {
             BatchOperationTemplate.TYPE,
             BatchOperationTemplate.ACTOR_TYPE,
             BatchOperationTemplate.ACTOR_ID);
+    assertThat(updateFields)
+        .containsEntry(BatchOperationTemplate.ACTOR_TYPE, AuditLogActorType.USER)
+        .containsEntry(BatchOperationTemplate.ACTOR_ID, "username");
     assertThat(updateFields)
         .doesNotContainKeys(
             BatchOperationTemplate.STATE,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class BatchOperationCreatedHandlerTest {
 
@@ -206,7 +207,7 @@ class BatchOperationCreatedHandlerTest {
   }
 
   @Test
-  void shouldAddEntityOnFlush() throws PersistenceException {
+  void shouldUpsertEntityOnFlush() throws PersistenceException {
     // given
     final var entity = new BatchOperationEntity().setId("123");
     final var mockRequest = mock(BatchRequest.class);
@@ -215,6 +216,20 @@ class BatchOperationCreatedHandlerTest {
     underTest.flush(entity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, entity);
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+    verify(mockRequest, times(1)).upsert(eq(indexName), eq("123"), eq(entity), captor.capture());
+
+    final Map<String, Object> updateFields = captor.getValue();
+    assertThat(updateFields)
+        .containsOnlyKeys(
+            BatchOperationTemplate.TYPE,
+            BatchOperationTemplate.ACTOR_TYPE,
+            BatchOperationTemplate.ACTOR_ID);
+    assertThat(updateFields)
+        .doesNotContainKeys(
+            BatchOperationTemplate.STATE,
+            BatchOperationTemplate.OPERATIONS_TOTAL_COUNT,
+            BatchOperationTemplate.END_DATE);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 class BatchOperationCreatedHandlerTest {
 
@@ -207,37 +206,12 @@ class BatchOperationCreatedHandlerTest {
   }
 
   @Test
-  void shouldUpsertEntityOnFlushWithoutNullActorFields() throws PersistenceException {
-    // given — entity with null actorType and actorId (e.g., broker < 8.9.0)
-    final var entity = new BatchOperationEntity().setId("123");
-    final var mockRequest = mock(BatchRequest.class);
-
-    // when
-    underTest.flush(entity, mockRequest);
-
-    // then — null actor fields must NOT be included in updateFields to avoid
-    // overwriting previously populated actor info from another partition
-    @SuppressWarnings("unchecked")
-    final ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
-    verify(mockRequest, times(1)).upsert(eq(indexName), eq("123"), eq(entity), captor.capture());
-
-    final Map<String, Object> updateFields = captor.getValue();
-    assertThat(updateFields).containsOnlyKeys(BatchOperationTemplate.TYPE);
-    assertThat(updateFields)
-        .doesNotContainKeys(
-            BatchOperationTemplate.ACTOR_TYPE,
-            BatchOperationTemplate.ACTOR_ID,
-            BatchOperationTemplate.STATE,
-            BatchOperationTemplate.OPERATIONS_TOTAL_COUNT,
-            BatchOperationTemplate.END_DATE);
-  }
-
-  @Test
-  void shouldUpsertEntityOnFlushWithNonNullActorFields() throws PersistenceException {
-    // given — entity with populated actor info
+  void shouldUpsertWithEmptyUpdateFieldsOnFlush() throws PersistenceException {
+    // given
     final var entity =
         new BatchOperationEntity()
-            .setId("456")
+            .setId("123")
+            .setType(OperationType.RESOLVE_INCIDENT)
             .setActorType(AuditLogActorType.USER)
             .setActorId("username");
     final var mockRequest = mock(BatchRequest.class);
@@ -245,24 +219,7 @@ class BatchOperationCreatedHandlerTest {
     // when
     underTest.flush(entity, mockRequest);
 
-    // then — non-null actor fields must be included in updateFields
-    @SuppressWarnings("unchecked")
-    final ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
-    verify(mockRequest, times(1)).upsert(eq(indexName), eq("456"), eq(entity), captor.capture());
-
-    final Map<String, Object> updateFields = captor.getValue();
-    assertThat(updateFields)
-        .containsOnlyKeys(
-            BatchOperationTemplate.TYPE,
-            BatchOperationTemplate.ACTOR_TYPE,
-            BatchOperationTemplate.ACTOR_ID);
-    assertThat(updateFields)
-        .containsEntry(BatchOperationTemplate.ACTOR_TYPE, AuditLogActorType.USER)
-        .containsEntry(BatchOperationTemplate.ACTOR_ID, "username");
-    assertThat(updateFields)
-        .doesNotContainKeys(
-            BatchOperationTemplate.STATE,
-            BatchOperationTemplate.OPERATIONS_TOTAL_COUNT,
-            BatchOperationTemplate.END_DATE);
+    // then
+    verify(mockRequest, times(1)).upsert(eq(indexName), eq("123"), eq(entity), eq(Map.of()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers.batchoperation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -98,13 +99,14 @@ class BatchOperationInitializedHandlerTest {
   }
 
   @Test
-  void shouldUpdateEntityOnFlush() throws PersistenceException {
+  void shouldUpsertWithConditionalScriptOnFlush() throws PersistenceException {
     // given
+    final var startDate = OffsetDateTime.now();
     final var entity =
         new BatchOperationEntity()
             .setId("123")
             .setState(BatchOperationState.ACTIVE)
-            .setStartDate(OffsetDateTime.now());
+            .setStartDate(startDate);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
@@ -112,11 +114,11 @@ class BatchOperationInitializedHandlerTest {
 
     // then
     verify(mockRequest, times(1))
-        .update(
-            indexName,
-            entity.getId(),
-            Map.of(
-                "state", entity.getState(),
-                "startDate", entity.getStartDate()));
+        .upsertWithScript(
+            eq(indexName),
+            eq(entity.getId()),
+            eq(entity),
+            eq(BatchOperationInitializedHandler.CONDITIONAL_UPDATE_SCRIPT),
+            eq(Map.of("state", BatchOperationState.ACTIVE.name(), "startDate", startDate)));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
@@ -282,9 +282,10 @@ class BatchOperationLifecycleManagementHandlerTest {
     handler.flush(entity, batchRequest);
 
     // then
-    final var argumentCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(batchRequest).update(eq(indexName), eq("12345"), argumentCaptor.capture());
-    final Map<String, Object> updateFields = argumentCaptor.getValue();
+    final var updateFieldsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(batchRequest)
+        .upsert(eq(indexName), eq("12345"), eq(entity), updateFieldsCaptor.capture());
+    final Map<String, Object> updateFields = updateFieldsCaptor.getValue();
     assertThat(updateFields).containsEntry("state", BatchOperationState.CANCELED);
     assertThat(updateFields).containsEntry("endDate", entity.getEndDate());
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
@@ -269,7 +269,7 @@ class BatchOperationLifecycleManagementHandlerTest {
   }
 
   @Test
-  void shouldFlushEntity() throws Exception {
+  void shouldFlushEntityWithConditionalScript() throws Exception {
     // given
     final BatchRequest batchRequest = mock(BatchRequest.class);
     final BatchOperationEntity entity =
@@ -282,11 +282,50 @@ class BatchOperationLifecycleManagementHandlerTest {
     handler.flush(entity, batchRequest);
 
     // then
-    final var updateFieldsCaptor = ArgumentCaptor.forClass(Map.class);
+    final var paramsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(batchRequest)
-        .upsert(eq(indexName), eq("12345"), eq(entity), updateFieldsCaptor.capture());
-    final Map<String, Object> updateFields = updateFieldsCaptor.getValue();
-    assertThat(updateFields).containsEntry("state", BatchOperationState.CANCELED);
-    assertThat(updateFields).containsEntry("endDate", entity.getEndDate());
+        .upsertWithScript(
+            eq(indexName),
+            eq("12345"),
+            eq(entity),
+            eq(BatchOperationLifecycleManagementHandler.CONDITIONAL_STATE_UPDATE_SCRIPT),
+            paramsCaptor.capture());
+    final Map<String, Object> params = paramsCaptor.getValue();
+    assertThat(params).containsEntry("state", "CANCELED");
+    assertThat(params).containsEntry("endDate", entity.getEndDate());
+    assertThat(params).doesNotContainKey("errors");
+  }
+
+  @Test
+  void shouldFlushEntityWithErrorsInScript() throws Exception {
+    // given
+    final BatchRequest batchRequest = mock(BatchRequest.class);
+    final var errorEntity =
+        new io.camunda.webapps.schema.entities.operation.BatchOperationErrorEntity()
+            .setPartitionId(1)
+            .setType("QUERY_FAILED")
+            .setMessage("error message");
+    final BatchOperationEntity entity =
+        new BatchOperationEntity()
+            .setId("12345")
+            .setState(BatchOperationState.FAILED)
+            .setEndDate(null)
+            .setErrors(List.of(errorEntity));
+
+    // when
+    handler.flush(entity, batchRequest);
+
+    // then - errors should be included in script params when present
+    final var paramsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(batchRequest)
+        .upsertWithScript(
+            eq(indexName),
+            eq("12345"),
+            eq(entity),
+            eq(BatchOperationLifecycleManagementHandler.CONDITIONAL_STATE_UPDATE_SCRIPT),
+            paramsCaptor.capture());
+    final Map<String, Object> params = paramsCaptor.getValue();
+    assertThat(params).containsEntry("state", "FAILED");
+    assertThat(params).containsEntry("errors", List.of(errorEntity));
   }
 }


### PR DESCRIPTION
# Description
Backport of #47635 to `stable/8.9`.

relates to #46466 #46696 #44841