### PR TITLE
fix: use OffsetDateTime for AuditLogResult.getTimestamp()

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AuditLogResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AuditLogResult.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.search.enums.AuditLogEntityTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogResultEnum;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import java.time.OffsetDateTime;
 
 public interface AuditLogResult {
   String getAuditLogKey();
@@ -35,7 +36,7 @@ public interface AuditLogResult {
 
   BatchOperationType getBatchOperationType();
 
-  String getTimestamp();
+  OffsetDateTime getTimestamp();
 
   String getActorId();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AuditLogResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AuditLogResultImpl.java
@@ -23,6 +23,8 @@ import io.camunda.client.api.search.enums.AuditLogResultEnum;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.response.AuditLogResult;
 import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.impl.util.ParseUtil;
+import java.time.OffsetDateTime;
 
 public class AuditLogResultImpl implements AuditLogResult {
 
@@ -32,7 +34,7 @@ public class AuditLogResultImpl implements AuditLogResult {
   private AuditLogOperationTypeEnum operationType;
   private String batchOperationKey;
   private BatchOperationType batchOperationType;
-  private String timestamp;
+  private OffsetDateTime timestamp;
   private String actorId;
   private AuditLogActorTypeEnum actorType;
   private String agentElementId;
@@ -66,7 +68,7 @@ public class AuditLogResultImpl implements AuditLogResult {
     operationType = EnumUtil.convert(item.getOperationType(), AuditLogOperationTypeEnum.class);
     batchOperationKey = item.getBatchOperationKey();
     batchOperationType = EnumUtil.convert(item.getBatchOperationType(), BatchOperationType.class);
-    timestamp = item.getTimestamp();
+    timestamp = ParseUtil.parseOffsetDateTimeOrNull(item.getTimestamp());
     actorId = item.getActorId();
     actorType = EnumUtil.convert(item.getActorType(), AuditLogActorTypeEnum.class);
     agentElementId = item.getAgentElementId();
@@ -145,11 +147,11 @@ public class AuditLogResultImpl implements AuditLogResult {
   }
 
   @Override
-  public String getTimestamp() {
+  public OffsetDateTime getTimestamp() {
     return timestamp;
   }
 
-  public void setTimestamp(final String timestamp) {
+  public void setTimestamp(final OffsetDateTime timestamp) {
     this.timestamp = timestamp;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/auditlog/GetAuditLogTest.java
+++ b/clients/java/src/test/java/io/camunda/client/auditlog/GetAuditLogTest.java
@@ -26,6 +26,7 @@ import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import org.instancio.Instancio;
+import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 
 public class GetAuditLogTest extends ClientRestTest {
@@ -36,7 +37,11 @@ public class GetAuditLogTest extends ClientRestTest {
   void shouldGetAuditLog() {
     // given
     gatewayService.onGetAuditLogRequest(
-        AUDIT_LOG_KEY, Instancio.create(AuditLogResult.class).auditLogKey(AUDIT_LOG_KEY));
+        AUDIT_LOG_KEY,
+        Instancio.of(AuditLogResult.class)
+            .set(Select.field(AuditLogResult.class, "timestamp"), "2024-01-15T10:30:00+00:00")
+            .create()
+            .auditLogKey(AUDIT_LOG_KEY));
     // when
     client.newAuditLogGetRequest(AUDIT_LOG_KEY).send().join();
 

--- a/clients/java/src/test/java/io/camunda/client/auditlog/SearchAuditLogTest.java
+++ b/clients/java/src/test/java/io/camunda/client/auditlog/SearchAuditLogTest.java
@@ -28,6 +28,7 @@ import io.camunda.client.api.search.enums.AuditLogResultEnum;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
 import io.camunda.client.protocol.rest.AuditLogFilter;
+import io.camunda.client.protocol.rest.AuditLogResult;
 import io.camunda.client.protocol.rest.AuditLogSearchQueryRequest;
 import io.camunda.client.protocol.rest.AuditLogSearchQueryResult;
 import io.camunda.client.protocol.rest.SortOrderEnum;
@@ -38,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.instancio.Instancio;
+import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 
 public class SearchAuditLogTest extends ClientRestTest {
@@ -45,7 +47,10 @@ public class SearchAuditLogTest extends ClientRestTest {
   @Test
   public void shouldSearchAuditLogsWithEmptyQuery() {
     // when
-    gatewayService.onSearchAuditLogRequest(Instancio.create(AuditLogSearchQueryResult.class));
+    gatewayService.onSearchAuditLogRequest(
+        Instancio.of(AuditLogSearchQueryResult.class)
+            .set(Select.field(AuditLogResult.class, "timestamp"), "2024-01-15T10:30:00+00:00")
+            .create());
     client.newAuditLogSearchRequest().send().join();
 
     // then

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskAuditLogTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskAuditLogTest.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogResultEnum;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
+import io.camunda.client.protocol.rest.AuditLogResult;
 import io.camunda.client.protocol.rest.AuditLogSearchQueryResult;
 import io.camunda.client.protocol.rest.SortOrderEnum;
 import io.camunda.client.protocol.rest.UserTaskAuditLogFilter;
@@ -35,6 +36,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import org.instancio.Instancio;
+import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 
 public class SearchUserTaskAuditLogTest extends ClientRestTest {
@@ -45,7 +47,10 @@ public class SearchUserTaskAuditLogTest extends ClientRestTest {
   public void shouldSearchUserTaskAuditLogsWithEmptyQuery() {
     // when
     gatewayService.onSearchUserTaskAuditLogRequest(
-        USER_TASK_KEY, Instancio.create(AuditLogSearchQueryResult.class));
+        USER_TASK_KEY,
+        Instancio.of(AuditLogSearchQueryResult.class)
+            .set(Select.field(AuditLogResult.class, "timestamp"), "2024-01-15T10:30:00+00:00")
+            .create());
     client.newUserTaskAuditLogSearchRequest(USER_TASK_KEY).send().join();
 
     // then

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
@@ -620,8 +620,7 @@ public class AuditLogSearchClientIT {
     assertThat(auditLogItems)
         .allSatisfy(
             auditLogResult -> {
-              assertThat(OffsetDateTime.parse(auditLogResult.getTimestamp()))
-                  .isAfter(OffsetDateTime.now().minusHours(1));
+              assertThat(auditLogResult.getTimestamp()).isAfter(OffsetDateTime.now().minusHours(1));
 
               assertThat(auditLogResult.getDecisionDefinitionKey())
                   .isEqualTo(String.valueOf(decision.getDecisionKey()));
@@ -746,7 +745,7 @@ public class AuditLogSearchClientIT {
     assertThat(auditLog.getResult()).isEqualTo(AuditLogResultEnum.SUCCESS);
     assertThat(auditLog.getActorId()).isEqualTo(DEFAULT_USERNAME);
     assertThat(auditLog.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
-    assertThat(auditLog.getTimestamp()).isNotBlank();
+    assertThat(auditLog.getTimestamp()).isNotNull();
   }
 
   private List<AuditLogResult> awaitAuditLogEntryWithFilters(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
@@ -80,7 +80,7 @@ public class AuditLogUserTaskOperationsIT {
     for (int i = 0; i < auditLogItems.items().size() - 1; i++) {
       final var current = auditLogItems.items().get(i);
       final var next = auditLogItems.items().get(i + 1);
-      assertThat(current.getTimestamp()).isGreaterThanOrEqualTo(next.getTimestamp());
+      assertThat(current.getTimestamp()).isAfterOrEqualTo(next.getTimestamp());
     }
   }
 


### PR DESCRIPTION
## Description

Change the return type of AuditLogResult.getTimestamp() from String to OffsetDateTime to provide type-safe date-time handling in the Java client. The protocol layer remains unchanged (String), with conversion via ParseUtil.parseOffsetDateTimeOrNull() in AuditLogResultImpl.

This aligns the response with other response types which moved to OffsetDatetime with https://github.com/camunda/camunda/pull/38428 on 8.8

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Part of #33678
