### PR TITLE
[Backport stable/8.9] feat: add audit log configuration for `unknown` actors

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/AuditLog.java
+++ b/configuration/src/main/java/io/camunda/configuration/AuditLog.java
@@ -16,6 +16,7 @@ public class AuditLog {
 
   @NestedConfigurationProperty private AuditLogEntry user = AuditLogEntry.logAll();
   @NestedConfigurationProperty private AuditLogEntry client = AuditLogEntry.logNone();
+  @NestedConfigurationProperty private AuditLogEntry unknown = AuditLogEntry.logNone();
 
   public boolean isEnabled() {
     return enabled;
@@ -41,6 +42,14 @@ public class AuditLog {
     this.user = user;
   }
 
+  public AuditLogEntry getUnknown() {
+    return unknown;
+  }
+
+  public void setUnknown(final AuditLogEntry unknown) {
+    this.unknown = unknown;
+  }
+
   /** Converts this configuration to an {@link AuditLogConfiguration} for the exporter. */
   public AuditLogConfiguration toConfiguration() {
     final AuditLogConfiguration auditLogConfiguration = new AuditLogConfiguration();
@@ -53,6 +62,10 @@ public class AuditLog {
         .getUser()
         .setCategories(getUser().getCategories())
         .setExcludes(getUser().getExcludes());
+    auditLogConfiguration
+        .getUnknown()
+        .setCategories(getUnknown().getCategories())
+        .setExcludes(getUnknown().getExcludes());
     return auditLogConfiguration;
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/AuditLogTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/AuditLogTest.java
@@ -61,6 +61,18 @@ class AuditLogTest {
   }
 
   @Test
+  void shouldHaveUnknownDefaults() {
+    final AuditLog auditLog = new AuditLog();
+
+    assertThat(auditLog.getUnknown().getCategories())
+        .as("Unknown categories should be empty by default (opt-in logging)")
+        .isEmpty();
+    assertThat(auditLog.getUnknown().getExcludes())
+        .as("No excludes should be set for unknown by default")
+        .isEmpty();
+  }
+
+  @Test
   void shouldConvertToAuditLogConfiguration() {
     final AuditLog auditLog = new AuditLog();
 
@@ -75,12 +87,18 @@ class AuditLogTest {
     assertThat(config.getUser().getCategories())
         .as("User categories should match")
         .isEqualTo(auditLog.getUser().getCategories());
+    assertThat(config.getUnknown().getCategories())
+        .as("Unknown categories should match")
+        .isEqualTo(auditLog.getUnknown().getCategories());
     assertThat(config.getClient().getExcludes())
         .as("Client excludes should match")
         .isEqualTo(auditLog.getClient().getExcludes());
     assertThat(config.getUser().getExcludes())
         .as("User excludes should match")
         .isEqualTo(auditLog.getUser().getExcludes());
+    assertThat(config.getUnknown().getExcludes())
+        .as("Unknown excludes should match")
+        .isEqualTo(auditLog.getUnknown().getExcludes());
   }
 
   @Nested
@@ -98,7 +116,9 @@ class AuditLogTest {
         "camunda.data.audit-log.user.categories[1]=USER_TASKS",
         "camunda.data.audit-log.user.excludes[0]=VARIABLE",
         "camunda.data.audit-log.client.categories[0]=ADMIN",
-        "camunda.data.audit-log.client.excludes[0]=PROCESS_INSTANCE"
+        "camunda.data.audit-log.client.excludes[0]=PROCESS_INSTANCE",
+        "camunda.data.audit-log.unknown.categories[0]=USER_TASKS",
+        "camunda.data.audit-log.unknown.excludes[0]=VARIABLE"
       })
   class RDBMSExporterTest {
     @Test
@@ -119,6 +139,10 @@ class AuditLogTest {
           .containsExactlyInAnyOrder(AuditLogOperationCategory.ADMIN);
       assertThat(config.getAuditLog().getClient().getExcludes())
           .containsExactlyInAnyOrder(AuditLogEntityType.PROCESS_INSTANCE);
+      assertThat(config.getAuditLog().getUnknown().getCategories())
+          .containsExactlyInAnyOrder(AuditLogOperationCategory.USER_TASKS);
+      assertThat(config.getAuditLog().getUnknown().getExcludes())
+          .containsExactlyInAnyOrder(AuditLogEntityType.VARIABLE);
     }
   }
 
@@ -137,7 +161,9 @@ class AuditLogTest {
         "camunda.data.audit-log.user.categories[1]=ADMIN",
         "camunda.data.audit-log.user.excludes[0]=INCIDENT",
         "camunda.data.audit-log.client.categories[0]=USER_TASKS",
-        "camunda.data.audit-log.client.excludes[0]=USER"
+        "camunda.data.audit-log.client.excludes[0]=USER",
+        "camunda.data.audit-log.unknown.categories[0]=DEPLOYED_RESOURCES",
+        "camunda.data.audit-log.unknown.excludes[0]=PROCESS_INSTANCE"
       })
   class CamundaExporterTest {
     @Test
@@ -158,6 +184,10 @@ class AuditLogTest {
           .containsExactlyInAnyOrder(AuditLogOperationCategory.USER_TASKS);
       assertThat(config.getAuditLog().getClient().getExcludes())
           .containsExactlyInAnyOrder(AuditLogEntityType.USER);
+      assertThat(config.getAuditLog().getUnknown().getCategories())
+          .containsExactlyInAnyOrder(AuditLogOperationCategory.DEPLOYED_RESOURCES);
+      assertThat(config.getAuditLog().getUnknown().getExcludes())
+          .containsExactlyInAnyOrder(AuditLogEntityType.PROCESS_INSTANCE);
     }
   }
 }

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-auth</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -44,6 +44,7 @@ import io.camunda.search.query.UserQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
@@ -1409,6 +1410,7 @@ class RdbmsExporterIT {
             .from(RecordFixtures.FACTORY.generateRecord(ValueType.PROCESS_INSTANCE_CREATION))
             .withRecordType(RecordType.EVENT)
             .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withAuthorizations(Map.of(Authorization.AUTHORIZED_USERNAME, "user"))
             .withPosition(1L)
             .withPartitionId(1)
             .withTimestamp(System.currentTimeMillis())

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfiguration.java
@@ -17,6 +17,7 @@ public final class AuditLogConfiguration implements AuditLogCheck {
 
   private ActorAuditLogConfiguration user = ActorAuditLogConfiguration.logAll();
   private ActorAuditLogConfiguration client = ActorAuditLogConfiguration.logNone();
+  private ActorAuditLogConfiguration unknown = ActorAuditLogConfiguration.logNone();
 
   public ActorAuditLogConfiguration getUser() {
     return user;
@@ -36,6 +37,15 @@ public final class AuditLogConfiguration implements AuditLogCheck {
     return this;
   }
 
+  public ActorAuditLogConfiguration getUnknown() {
+    return unknown;
+  }
+
+  public AuditLogConfiguration setUnknown(final ActorAuditLogConfiguration unknown) {
+    this.unknown = unknown;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "AuditLogConfiguration{"
@@ -45,12 +55,16 @@ public final class AuditLogConfiguration implements AuditLogCheck {
         + user
         + ", client="
         + client
+        + ", unknown="
+        + unknown
         + '}';
   }
 
   public boolean isEnabled() {
     return enabled
-        && !(getUser().getCategories().isEmpty() && getClient().getCategories().isEmpty());
+        && !(getUser().getCategories().isEmpty()
+            && getClient().getCategories().isEmpty()
+            && getUnknown().getCategories().isEmpty());
   }
 
   public void setEnabled(final boolean enabled) {
@@ -64,9 +78,7 @@ public final class AuditLogConfiguration implements AuditLogCheck {
           case USER -> getUser();
           case CLIENT -> getClient();
           case ANONYMOUS -> AuditLogCheck.DISABLED;
-          // UNKNOWN actor types are logged by default to avoid missing events or when the insecure
-          // profile is used
-          case UNKNOWN -> AuditLogCheck.ENABLED;
+          case UNKNOWN -> getUnknown();
         };
 
     return isEnabled() && check.isEnabled(auditLog);

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
@@ -38,7 +38,7 @@ class AuditLogConfigurationTest {
   }
 
   @Test
-  void shouldHaveDefaultUserAndClientConfigurations() {
+  void shouldHaveDefaultConfigurations() {
     final var config = new AuditLogConfiguration();
 
     assertThat(config.getUser()).isNotNull();

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
@@ -43,6 +43,7 @@ class AuditLogConfigurationTest {
 
     assertThat(config.getUser()).isNotNull();
     assertThat(config.getClient()).isNotNull();
+    assertThat(config.getUnknown()).isNotNull();
     assertThat(config.getUser().getCategories())
         .as("User categories should include all categories by default")
         .containsExactlyInAnyOrder(
@@ -52,6 +53,9 @@ class AuditLogConfigurationTest {
     assertThat(config.getClient().getCategories())
         .as("Client categories should be empty by default (opt-in logging)")
         .isEmpty();
+    assertThat(config.getUnknown().getCategories())
+        .as("Unknown categories should be empty by default (opt-in logging)")
+        .isEmpty();
   }
 
   @Test
@@ -59,6 +63,7 @@ class AuditLogConfigurationTest {
     final var config = new AuditLogConfiguration();
     config.getUser().setCategories(Set.of());
     config.getClient().setCategories(Set.of());
+    config.getUnknown().setCategories(Set.of());
 
     assertThat(config.isEnabled()).isFalse();
   }
@@ -82,6 +87,16 @@ class AuditLogConfigurationTest {
   }
 
   @Test
+  void shouldBeEnabledWhenUnknownCategoryConfigured() {
+    final var config = new AuditLogConfiguration();
+    config.getUnknown().setCategories(Set.of(AuditLogOperationCategory.DEPLOYED_RESOURCES));
+    config.getUser().setCategories(Set.of());
+    config.getClient().setCategories(Set.of());
+
+    assertThat(config.isEnabled()).isTrue();
+  }
+
+  @Test
   void shouldBeDisabledForAnonymousActors() {
     final var config = new AuditLogConfiguration();
 
@@ -97,8 +112,27 @@ class AuditLogConfigurationTest {
   }
 
   @Test
-  void shouldBeEnabledForUnknownActors() {
+  void shouldBeDisabledForUnknownActorsByDefault() {
     final var config = new AuditLogConfiguration();
+
+    final var auditLog =
+        new AuditLogInfo(
+            AuditLogOperationCategory.DEPLOYED_RESOURCES,
+            AuditLogEntityType.PROCESS_INSTANCE,
+            AuditLogOperationType.MODIFY,
+            AuditLogActor.unknown(),
+            Optional.empty());
+
+    assertThat(config.isEnabled(auditLog)).isFalse();
+  }
+
+  @Test
+  void shouldBeEnabledForUnknownActorsWhenCategoryConfigured() {
+    final var config = new AuditLogConfiguration();
+    config
+        .getUnknown()
+        .setCategories(Set.of(AuditLogOperationCategory.DEPLOYED_RESOURCES))
+        .setExcludes(Set.of());
 
     final var auditLog =
         new AuditLogInfo(


### PR DESCRIPTION
# Description
Backport of #48364 to `stable/8.9`.

relates to camunda/camunda#48339