### PR TITLE
feat: add OffsetDateTime overloads for date-time request fields

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteUserTaskJobResultStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteUserTaskJobResultStep1.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.command;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
@@ -97,12 +98,42 @@ public interface CompleteUserTaskJobResultStep1 extends CompleteJobResult {
   CompleteUserTaskJobResultStep1 correctDueDate(final String dueDate);
 
   /**
+   * Correct the due date of the task.
+   *
+   * @param dueDate due date of the task
+   * @return this job result
+   */
+  CompleteUserTaskJobResultStep1 correctDueDate(final OffsetDateTime dueDate);
+
+  /**
+   * Clear the due date of the task, removing any previously set value.
+   *
+   * @return this job result
+   */
+  CompleteUserTaskJobResultStep1 clearDueDate();
+
+  /**
    * Correct the follow up date of the task.
    *
    * @param followUpDate follow up date of the task
    * @return this job result
    */
   CompleteUserTaskJobResultStep1 correctFollowUpDate(final String followUpDate);
+
+  /**
+   * Correct the follow up date of the task.
+   *
+   * @param followUpDate follow up date of the task
+   * @return this job result
+   */
+  CompleteUserTaskJobResultStep1 correctFollowUpDate(final OffsetDateTime followUpDate);
+
+  /**
+   * Clear the follow up date of the task, removing any previously set value.
+   *
+   * @return this job result
+   */
+  CompleteUserTaskJobResultStep1 clearFollowUpDate();
 
   /**
    * Correct the candidate groups of the task.

--- a/clients/java/src/main/java/io/camunda/client/api/command/JobResultCorrections.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/JobResultCorrections.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.client.api.command;
 
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class JobResultCorrections {
@@ -49,6 +51,27 @@ public class JobResultCorrections {
   }
 
   /**
+   * Correct the due date of the task.
+   *
+   * @param dueDate due date of the task
+   * @return this corrections
+   */
+  public JobResultCorrections dueDate(final OffsetDateTime dueDate) {
+    this.dueDate = dueDate == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate);
+    return this;
+  }
+
+  /**
+   * Clear the due date of the task, removing any previously set value.
+   *
+   * @return this corrections
+   */
+  public JobResultCorrections clearDueDate() {
+    this.dueDate = "";
+    return this;
+  }
+
+  /**
    * Correct the follow up date of the task.
    *
    * @param followUpDate follow up date of the task
@@ -56,6 +79,28 @@ public class JobResultCorrections {
    */
   public JobResultCorrections followUpDate(final String followUpDate) {
     this.followUpDate = followUpDate;
+    return this;
+  }
+
+  /**
+   * Correct the follow up date of the task.
+   *
+   * @param followUpDate follow up date of the task
+   * @return this corrections
+   */
+  public JobResultCorrections followUpDate(final OffsetDateTime followUpDate) {
+    this.followUpDate =
+        followUpDate == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(followUpDate);
+    return this;
+  }
+
+  /**
+   * Clear the follow up date of the task, removing any previously set value.
+   *
+   * @return this corrections
+   */
+  public JobResultCorrections clearFollowUpDate() {
+    this.followUpDate = "";
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateUserTaskCommandStep1.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UpdateUserTaskResponse;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserTaskResponse> {
@@ -40,6 +41,16 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 dueDate(String dueDate);
 
   /**
+   * Set the due date to set in the user task. Use {@link #clearDueDate()} to remove the due date
+   * from the task.
+   *
+   * @param dueDate the due date to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 dueDate(OffsetDateTime dueDate);
+
+  /**
    * Clear the due date in the user task.
    *
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
@@ -56,6 +67,16 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
    *     to the broker.
    */
   UpdateUserTaskCommandStep1 followUpDate(String followUpDate);
+
+  /**
+   * Set the follow-up date to set in the user task. Use {@link #clearFollowUpDate()} to remove the
+   * follow-up date from the task.
+   *
+   * @param followUpDate the follow-up date to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 followUpDate(OffsetDateTime followUpDate);
 
   /**
    * Clear the follow-up date in the user task.

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteUserTaskJobResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteUserTaskJobResultImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.command.CompleteUserTaskJobResultStep1;
 import io.camunda.client.api.command.JobResultCorrections;
 import io.camunda.client.api.command.enums.JobResultType;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
@@ -79,8 +80,32 @@ public class CompleteUserTaskJobResultImpl implements CompleteUserTaskJobResultS
   }
 
   @Override
+  public CompleteUserTaskJobResultImpl correctDueDate(final OffsetDateTime dueDate) {
+    corrections.dueDate(dueDate);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl clearDueDate() {
+    corrections.clearDueDate();
+    return this;
+  }
+
+  @Override
   public CompleteUserTaskJobResultImpl correctFollowUpDate(final String followUpDate) {
     corrections.followUpDate(followUpDate);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl correctFollowUpDate(final OffsetDateTime followUpDate) {
+    corrections.followUpDate(followUpDate);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskJobResultImpl clearFollowUpDate() {
+    corrections.clearFollowUpDate();
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserTaskCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserTaskCommandImpl.java
@@ -26,6 +26,8 @@ import io.camunda.client.impl.response.UpdateUserTaskResponseImpl;
 import io.camunda.client.protocol.rest.Changeset;
 import io.camunda.client.protocol.rest.UserTaskUpdateRequest;
 import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -81,6 +83,12 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
   }
 
   @Override
+  public UpdateUserTaskCommandStep1 dueDate(final OffsetDateTime dueDate) {
+    ArgumentUtil.ensureNotNull("dueDate", dueDate);
+    return dueDate(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate));
+  }
+
+  @Override
   public UpdateUserTaskCommandStep1 clearDueDate() {
     getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_DUE_DATE, "");
     return this;
@@ -91,6 +99,12 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
     ArgumentUtil.ensureNotNull("followUpDate", followUpDate);
     getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_FOLLOW_UP_DATE, followUpDate);
     return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 followUpDate(final OffsetDateTime followUpDate) {
+    ArgumentUtil.ensureNotNull("followUpDate", followUpDate);
+    return followUpDate(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(followUpDate));
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
@@ -33,6 +33,9 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.JobResultCorrections;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StringList;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -465,8 +468,8 @@ public final class CompleteJobTest extends ClientTest {
             r ->
                 r.forUserTask()
                     .correctAssignee(null)
-                    .correctDueDate(null)
-                    .correctFollowUpDate(null)
+                    .correctDueDate((String) null)
+                    .correctFollowUpDate((String) null)
                     .correctCandidateGroups(null)
                     .correctCandidateUsers(null)
                     .correctPriority(null))
@@ -515,7 +518,7 @@ public final class CompleteJobTest extends ClientTest {
                 r.forUserTask()
                     .deny(false)
                     .correctAssignee("Test")
-                    .correctDueDate(null)
+                    .correctDueDate((String) null)
                     .correctFollowUpDate("")
                     .correctCandidateUsers(Arrays.asList("User A", "User B"))
                     .correctPriority(80))
@@ -569,7 +572,7 @@ public final class CompleteJobTest extends ClientTest {
                     .correct(
                         c ->
                             c.assignee("Test")
-                                .dueDate(null)
+                                .dueDate((String) null)
                                 .followUpDate("")
                                 .candidateUsers(Arrays.asList("User A", "User B"))
                                 .priority(80)))
@@ -819,6 +822,108 @@ public final class CompleteJobTest extends ClientTest {
             .build();
 
     assertThat(request).isEqualTo(expectedRequest);
+  }
+
+  @Test
+  public void shouldCompleteJobWithResultCorrectionDueDateOffsetDateTime() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    final OffsetDateTime dueDate = OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult(r -> r.forUserTask().correctDueDate(dueDate))
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getResult().getCorrections().getDueDate())
+        .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate));
+  }
+
+  @Test
+  public void shouldCompleteJobWithResultCorrectionFollowUpDateOffsetDateTime() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    final OffsetDateTime followUpDate =
+        OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult(r -> r.forUserTask().correctFollowUpDate(followUpDate))
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getResult().getCorrections().getFollowUpDate())
+        .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(followUpDate));
+  }
+
+  @Test
+  public void shouldCompleteJobWithResultClearDueDate() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult(r -> r.forUserTask().correctDueDate("due date").clearDueDate())
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getResult().getCorrections().getDueDate()).isEmpty();
+  }
+
+  @Test
+  public void shouldCompleteJobWithResultClearFollowUpDate() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult(r -> r.forUserTask().correctFollowUpDate("follow up").clearFollowUpDate())
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getResult().getCorrections().getFollowUpDate()).isEmpty();
+  }
+
+  @Test
+  public void shouldCompleteJobWithResultCorrectionsObjectOffsetDateTime() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    final OffsetDateTime dueDate = OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+    final OffsetDateTime followUpDate =
+        OffsetDateTime.of(2024, 7, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult(
+            r -> r.forUserTask().correct(c -> c.dueDate(dueDate).followUpDate(followUpDate)))
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getResult().getCorrections().getDueDate())
+        .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate));
+    assertThat(request.getResult().getCorrections().getFollowUpDate())
+        .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(followUpDate));
   }
 
   public static class POJO {

--- a/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
@@ -29,6 +29,9 @@ import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.JsonUtil;
 import io.camunda.client.util.StringUtil;
 import java.io.ByteArrayInputStream;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -368,8 +371,8 @@ class CompleteJobRestTest extends ClientRestTest {
             r ->
                 r.forUserTask()
                     .correctAssignee(null)
-                    .correctDueDate(null)
-                    .correctFollowUpDate(null)
+                    .correctDueDate((String) null)
+                    .correctFollowUpDate((String) null)
                     .correctCandidateGroups(null)
                     .correctCandidateUsers(null)
                     .correctPriority(null))
@@ -410,7 +413,7 @@ class CompleteJobRestTest extends ClientRestTest {
                 r.forUserTask()
                     .deny(false)
                     .correctAssignee("Test")
-                    .correctDueDate(null)
+                    .correctDueDate((String) null)
                     .correctFollowUpDate("")
                     .correctCandidateUsers(Arrays.asList("User A", "User B"))
                     .correctPriority(80))
@@ -452,7 +455,7 @@ class CompleteJobRestTest extends ClientRestTest {
                     .correct(
                         c ->
                             c.assignee("Test")
-                                .dueDate(null)
+                                .dueDate((String) null)
                                 .followUpDate("")
                                 .candidateUsers(Arrays.asList("User A", "User B"))
                                 .priority(80)))
@@ -665,5 +668,107 @@ class CompleteJobRestTest extends ClientRestTest {
                     .isCancelRemainingInstances(true));
 
     assertThat(request).isEqualTo(expectedRequest);
+  }
+
+  @Test
+  void shouldCompleteWithResultCorrectionDueDateOffsetDateTime() {
+    // given
+    final long jobKey = 12;
+    final OffsetDateTime dueDate = OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+
+    // when
+    client
+        .newCompleteCommand(jobKey)
+        .withResult(r -> r.forUserTask().correctDueDate(dueDate))
+        .send()
+        .join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getResult()).isNotNull();
+    assertThat(request.getResult().getCorrections().getDueDate())
+        .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate));
+  }
+
+  @Test
+  void shouldCompleteWithResultCorrectionFollowUpDateOffsetDateTime() {
+    // given
+    final long jobKey = 12;
+    final OffsetDateTime followUpDate =
+        OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+
+    // when
+    client
+        .newCompleteCommand(jobKey)
+        .withResult(r -> r.forUserTask().correctFollowUpDate(followUpDate))
+        .send()
+        .join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getResult()).isNotNull();
+    assertThat(request.getResult().getCorrections().getFollowUpDate())
+        .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(followUpDate));
+  }
+
+  @Test
+  void shouldCompleteWithResultClearDueDate() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client
+        .newCompleteCommand(jobKey)
+        .withResult(r -> r.forUserTask().correctDueDate("due date").clearDueDate())
+        .send()
+        .join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getResult()).isNotNull();
+    assertThat(request.getResult().getCorrections().getDueDate()).isEmpty();
+  }
+
+  @Test
+  void shouldCompleteWithResultClearFollowUpDate() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client
+        .newCompleteCommand(jobKey)
+        .withResult(r -> r.forUserTask().correctFollowUpDate("follow up").clearFollowUpDate())
+        .send()
+        .join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getResult()).isNotNull();
+    assertThat(request.getResult().getCorrections().getFollowUpDate()).isEmpty();
+  }
+
+  @Test
+  void shouldCompleteWithResultCorrectionsObjectOffsetDateTime() {
+    // given
+    final long jobKey = 12;
+    final OffsetDateTime dueDate = OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+    final OffsetDateTime followUpDate =
+        OffsetDateTime.of(2024, 7, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+
+    // when
+    client
+        .newCompleteCommand(jobKey)
+        .withResult(
+            r -> r.forUserTask().correct(c -> c.dueDate(dueDate).followUpDate(followUpDate)))
+        .send()
+        .join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getResult()).isNotNull();
+    assertThat(request.getResult().getCorrections().getDueDate())
+        .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate));
+    assertThat(request.getResult().getCorrections().getFollowUpDate())
+        .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(followUpDate));
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/usertask/UpdateUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/UpdateUserTaskTest.java
@@ -29,13 +29,15 @@ import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public final class UpdateUserTaskTest extends ClientRestTest {
 
   private static final String TEST_TIME =
-      OffsetDateTime.of(2023, 11, 11, 11, 11, 11, 11, ZoneOffset.of("Z")).toString();
+      DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(
+          OffsetDateTime.of(2023, 11, 11, 11, 11, 11, 11, ZoneOffset.of("Z")));
 
   @Test
   void shouldUpdateUserTask() {
@@ -185,6 +187,65 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getChangeset())
         .isNotNull()
         .containsOnly(entry("candidateUsers", Arrays.asList("foo", "bar")));
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithDueDateOffsetDateTime() {
+    // given
+    final OffsetDateTime dueDate =
+        OffsetDateTime.of(2023, 11, 11, 11, 11, 11, 11, ZoneOffset.of("Z"));
+
+    // when
+    client.newUpdateUserTaskCommand(123L).dueDate(dueDate).send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .containsOnly(entry("dueDate", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate)));
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithFollowUpDateOffsetDateTime() {
+    // given
+    final OffsetDateTime followUpDate =
+        OffsetDateTime.of(2023, 11, 11, 11, 11, 11, 11, ZoneOffset.of("Z"));
+
+    // when
+    client.newUpdateUserTaskCommand(123L).followUpDate(followUpDate).send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .containsOnly(
+            entry("followUpDate", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(followUpDate)));
+  }
+
+  @Test
+  void shouldRejectNullDueDateOffsetDateTime() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client.newUpdateUserTaskCommand(123L).dueDate((OffsetDateTime) null).send().join())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectNullFollowUpDateOffsetDateTime() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateUserTaskCommand(123L)
+                    .followUpDate((OffsetDateTime) null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
@@ -120,8 +120,8 @@ public class UserTaskIT {
         .priority(99)
         .candidateUsers("demoUsers")
         .candidateGroups("demoGroup")
-        .dueDate(dateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
-        .followUpDate(dateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+        .dueDate(dateTime)
+        .followUpDate(dateTime)
         .send()
         .join();
 


### PR DESCRIPTION
## Description

Add OffsetDateTime overloads alongside existing String methods for dueDate and followUpDate in UpdateUserTaskCommand, CompleteUserTaskJobResult, and JobResultCorrections. Add clearDueDate/clearFollowUpDate to CompleteUserTaskJobResult. Existing String-based API remains unchanged.

Existing tests updated to disambiguate null calls, new tests added for OffsetDateTime overloads and clear methods.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #33678
