### PR TITLE
[Backport stable/8.8] fix: set application/json content-type for 207 responses

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/ResponseMapper.java
@@ -327,7 +327,7 @@ public final class ResponseMapper {
               response.addFailedDocumentsItem(detail);
             });
     return ResponseEntity.status(HttpStatus.MULTI_STATUS)
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
         .body(response);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -639,4 +639,67 @@ public class DocumentControllerTest extends RestControllerTest {
 
     verify(documentServices, never()).createDocumentBatch(any());
   }
+
+  @Test
+  void shouldReturn207WithApplicationJsonWhenSomeDocumentsFail() throws Exception {
+    // given
+    final var filename1 = "file.txt";
+    final var filename2 = "file2.txt";
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var content1 = new byte[] {1, 2, 3};
+    final var content2 = new byte[] {4, 5};
+    final var timestamp = OffsetDateTime.now();
+
+    final var successfulRef =
+        new DocumentReferenceResponse(
+            "documentId1",
+            "default",
+            "dummy_hash_1",
+            new DocumentMetadataModel(
+                contentType.toString(), filename1, timestamp, 0L, null, null, Map.of()));
+
+    final var failedError =
+        new DocumentServices.DocumentErrorResponse(
+            new DocumentServices.DocumentCreateRequest(
+                null,
+                null,
+                new ByteArrayInputStream(content2),
+                new DocumentMetadataModel(
+                    contentType.toString(),
+                    filename2,
+                    null,
+                    (long) content2.length,
+                    null,
+                    null,
+                    Map.of())),
+            ErrorMapper.mapDocumentError(new DocumentHashMismatch("doc2", "expected")));
+
+    when(documentServices.createDocumentBatch(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(Either.right(successfulRef), Either.left(failedError))));
+
+    final var mapper = new ObjectMapper();
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder.part("files", content1).filename(filename1).contentType(contentType);
+    multipartBodyBuilder.part("files", content2).filename(filename2).contentType(contentType);
+
+    // when/then
+    webClient
+        .post()
+        .uri(DOCUMENTS_BASE_URL + "/batch")
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(multipartBodyBuilder.build())
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(207)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("$.createdDocuments.length()")
+        .isEqualTo(1)
+        .jsonPath("$.failedDocuments.length()")
+        .isEqualTo(1);
+  }
 }


### PR DESCRIPTION
# Description
Backport of #48363 to `stable/8.8`.

relates to #43633 camunda/camunda#43633