### PR TITLE
fix: change the selective indices on 'active' to 'ACTIVE' to have an …

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -1177,11 +1177,11 @@
     <sql dbms="postgresql,mssql">
       CREATE INDEX ${prefix}IDX_PROCESS_INSTANCE_STATE_ACTIVE
         ON ${prefix}PROCESS_INSTANCE (STATE)
-        WHERE STATE = 'active'
+        WHERE STATE = 'ACTIVE'
     </sql>
     <sql dbms="oracle">
       CREATE INDEX ${prefix}IDX_PROCESS_INSTANCE_STATE_ACTIVE
-        ON ${prefix}PROCESS_INSTANCE (CASE WHEN STATE = 'active' THEN STATE END)
+        ON ${prefix}PROCESS_INSTANCE (CASE WHEN STATE = 'ACTIVE' THEN STATE END)
     </sql>
   </changeSet>
 
@@ -1202,11 +1202,11 @@
     <sql dbms="postgresql,mssql">
       CREATE INDEX ${prefix}IDX_FNI_STATE_ACTIVE
         ON ${prefix}FLOW_NODE_INSTANCE (STATE)
-        WHERE STATE = 'active'
+        WHERE STATE = 'ACTIVE'
     </sql>
     <sql dbms="oracle">
       CREATE INDEX ${prefix}IDX_FNI_STATE_ACTIVE
-        ON ${prefix}FLOW_NODE_INSTANCE (CASE WHEN STATE = 'active' THEN STATE END)
+        ON ${prefix}FLOW_NODE_INSTANCE (CASE WHEN STATE = 'ACTIVE' THEN STATE END)
     </sql>
   </changeSet>
 
@@ -1219,11 +1219,11 @@
     <sql dbms="postgresql,mssql">
       CREATE INDEX ${prefix}IDX_INCIDENT_STATE_ACTIVE
         ON ${prefix}INCIDENT (STATE)
-        WHERE STATE = 'active'
+        WHERE STATE = 'ACTIVE'
     </sql>
     <sql dbms="oracle">
       CREATE INDEX ${prefix}IDX_INCIDENT_STATE_ACTIVE
-        ON ${prefix}INCIDENT (CASE WHEN STATE = 'active' THEN STATE END)
+        ON ${prefix}INCIDENT (CASE WHEN STATE = 'ACTIVE' THEN STATE END)
     </sql>
   </changeSet>
 


### PR DESCRIPTION
## Description

This PR fixes wrong index definitions for the selective indices on `PROCESS_INSTANCE`, `FLOW_NODE_INSTANCE` and `INCIDENT` on the `STATE` column. They were defined for only the value `active`. This is wrong, the enum value translates to the capitalised `ACTIVE`.

The change is done in the same changeset instead of adding a migration script because 8.9.0 is still not released.