### PR TITLE
test: client side load balancing config for load test

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -44,6 +44,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManagerFactory;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.config.RequestConfig.Builder;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
@@ -120,6 +121,11 @@ public class HttpClientFactory {
 
     if (config.useClientSideLoadBalancing()) {
       connectionManagerBuilder.setDnsResolver(new RandomizedDnsResolver());
+      // Use a short connection TTL to force frequent re-resolution of DNS. Without this,
+      // pooled connections are reused indefinitely, and the randomized DNS resolver would
+      // only take effect when a new connection is created — defeating load balancing.
+      connectionManagerBuilder.setDefaultConnectionConfig(
+          ConnectionConfig.custom().setTimeToLive(TimeValue.ofSeconds(1)).build());
     }
 
     return connectionManagerBuilder.build();

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -43,12 +43,14 @@ saas:
     # Saas.credentials.clientSecret to define the clientSecret to connect
     clientSecret: "__SECRET__"
     # Saas.credentials.zeebeRestAddress to define the rest address of the cluster (including port)
-    zeebeRestAddress: "http://camunda-gateway:8080"
+    # Use headless service so DNS returns all pod IPs for client-side load balancing.
+    zeebeRestAddress: "http://camunda:8080"
     # SaaS.credentials.authServer to define the authentication server to retrieve JWT tokens
     authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
     # Saas.credentials.authType to define the authentication type for the starter and workers
     authType: "OAUTH"
     # Saas.credentials.zeebeGrpcAddress to define the grpc address of the cluster (including port)
-    zeebeGrpcAddress: "http://camunda-gateway:26500"
+    # Use headless service so DNS returns all pod IPs for gRPC round_robin client-side load balancing.
+    zeebeGrpcAddress: "http://camunda:26500"
     # Saas.credentials.authorizationAudience to define the auth audience of the cluster
     authorizationAudience: "orchestration-api"

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
@@ -175,7 +175,8 @@ abstract class App implements Runnable {
             .restAddress(URI.create(config.getBrokerRestUrl()))
             .preferRestOverGrpc(config.isPreferRest())
             .withProperties(System.getProperties())
-            .withInterceptors(monitoringInterceptor);
+            .withInterceptors(monitoringInterceptor)
+            .useClientSideLoadBalancing(config.isClientSideLoadBalancing());
 
     final var auth = config.getAuth();
     final var credentialsProvider =

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -23,7 +23,7 @@ public class AppCfg {
   private boolean monitorDataAvailability = true;
   private Duration monitorDataAvailabilityInterval = Duration.ofMillis(250);
   private boolean performReadBenchmarks = false;
-  private boolean clientSideLoadBalancing = false;
+  private boolean clientSideLoadBalancing = true;
 
   private String disabledQueries = "";
 

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -23,6 +23,7 @@ public class AppCfg {
   private boolean monitorDataAvailability = true;
   private Duration monitorDataAvailabilityInterval = Duration.ofMillis(250);
   private boolean performReadBenchmarks = false;
+  private boolean clientSideLoadBalancing = false;
 
   private String disabledQueries = "";
 
@@ -122,5 +123,13 @@ public class AppCfg {
         .map(String::trim)
         .filter(s -> !s.isBlank())
         .toList();
+  }
+
+  public boolean isClientSideLoadBalancing() {
+    return clientSideLoadBalancing;
+  }
+
+  public void setClientSideLoadBalancing(final boolean clientSideLoadBalancing) {
+    this.clientSideLoadBalancing = clientSideLoadBalancing;
   }
 }

--- a/load-tests/load-tester/src/main/resources/application.conf
+++ b/load-tests/load-tester/src/main/resources/application.conf
@@ -12,7 +12,7 @@ app {
   performReadBenchmarks = false
   disabledQueries = ""
   disabledQueries = ${?ZEEBE_DISABLED_QUERIES}
-  clientSideLoadBalancing = false
+  clientSideLoadBalancing = true
 
   auth {
     type = "NONE" # NONE, BASIC

--- a/load-tests/load-tester/src/main/resources/application.conf
+++ b/load-tests/load-tester/src/main/resources/application.conf
@@ -12,6 +12,7 @@ app {
   performReadBenchmarks = false
   disabledQueries = ""
   disabledQueries = ${?ZEEBE_DISABLED_QUERIES}
+  clientSideLoadBalancing = false
 
   auth {
     type = "NONE" # NONE, BASIC

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -31,6 +31,7 @@ public class ConfigTest {
     assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(250);
     assertThat(appCfg.isPerformReadBenchmarks()).isFalse();
     assertThat(appCfg.getDisabledQueriesList()).isEmpty();
+    assertThat(appCfg.isClientSideLoadBalancing()).isFalse();
 
     // authentication
     final var authCfg = appCfg.getAuth();
@@ -90,6 +91,7 @@ public class ConfigTest {
     assertThat(appCfg.isPerformReadBenchmarks()).isTrue();
     assertThat(appCfg.getDisabledQueriesList())
         .containsExactlyInAnyOrder("process_instances_active", "audit_log_by_category");
+    assertThat(appCfg.isClientSideLoadBalancing()).isTrue();
 
     // authentication
     final var authCfg = appCfg.getAuth();

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -31,7 +31,7 @@ public class ConfigTest {
     assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(250);
     assertThat(appCfg.isPerformReadBenchmarks()).isFalse();
     assertThat(appCfg.getDisabledQueriesList()).isEmpty();
-    assertThat(appCfg.isClientSideLoadBalancing()).isFalse();
+    assertThat(appCfg.isClientSideLoadBalancing()).isTrue();
 
     // authentication
     final var authCfg = appCfg.getAuth();
@@ -91,7 +91,7 @@ public class ConfigTest {
     assertThat(appCfg.isPerformReadBenchmarks()).isTrue();
     assertThat(appCfg.getDisabledQueriesList())
         .containsExactlyInAnyOrder("process_instances_active", "audit_log_by_category");
-    assertThat(appCfg.isClientSideLoadBalancing()).isTrue();
+    assertThat(appCfg.isClientSideLoadBalancing()).isFalse();
 
     // authentication
     final var authCfg = appCfg.getAuth();

--- a/load-tests/load-tester/src/test/resources/different-application.conf
+++ b/load-tests/load-tester/src/test/resources/different-application.conf
@@ -9,7 +9,7 @@ app {
   monitorDataAvailabilityInterval = 50ms
   performReadBenchmarks = true
   disabledQueries = "process_instances_active,audit_log_by_category"
-  clientSideLoadBalancing = true
+  clientSideLoadBalancing = false
 
   auth {
     type = "BASIC" # NONE, BASIC

--- a/load-tests/load-tester/src/test/resources/different-application.conf
+++ b/load-tests/load-tester/src/test/resources/different-application.conf
@@ -9,6 +9,7 @@ app {
   monitorDataAvailabilityInterval = 50ms
   performReadBenchmarks = true
   disabledQueries = "process_instances_active,audit_log_by_category"
+  clientSideLoadBalancing = true
 
   auth {
     type = "BASIC" # NONE, BASIC


### PR DESCRIPTION
## Description

Exposes new client feat added with https://github.com/camunda/camunda/pull/47644 in load test config and enables it by default for the load tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).


closes #9870
