### PR TITLE
fix: simplify the processInstanceStatistics select 

### DIFF
--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -366,12 +366,10 @@
     SELECT pi.PROCESS_DEFINITION_ID,
     pi.TENANT_ID,
     (SELECT pd.NAME
-      FROM ${prefix}PROCESS_INSTANCE pi2
-      JOIN ${prefix}PROCESS_DEFINITION pd ON pd.PROCESS_DEFINITION_KEY = pi2.PROCESS_DEFINITION_KEY
-      <where>
-        pi2.PROCESS_DEFINITION_ID = pi.PROCESS_DEFINITION_ID AND pi2.TENANT_ID = pi.TENANT_ID
-      </where>
-      ORDER BY pi2.VERSION DESC
+        FROM ${prefix}PROCESS_DEFINITION pd
+        WHERE pd.PROCESS_DEFINITION_ID = pi.PROCESS_DEFINITION_ID
+            AND pd.TENANT_ID = pi.TENANT_ID
+        ORDER BY pd.VERSION DESC
       <choose>
         <when test="_databaseId == 'mssql'">
           <!-- MSSQL needs an OFFSET when sorting in subselects -->


### PR DESCRIPTION
## Description

In load tests it turned out, that the current `processInstanceStatistics` query caused multiple scans on `PROCESS_INSTANCE` table to get the latest process definition name. This PR simplifies the SQL to a scan only on the `PROCESS_DEFINITION` table which is much smaller.