### PR TITLE
fix: fix jvm config

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -7,3 +7,5 @@
 --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
 --add-opens=java.base/java.text=ALL-UNNAMED
 --add-opens=java.desktop/java.awt.font=ALL-UNNAMED
+--add-opens=java.base/java.io=ALL-UNNAMED
+--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -7,5 +7,3 @@
 --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
 --add-opens=java.base/java.text=ALL-UNNAMED
 --add-opens=java.desktop/java.awt.font=ALL-UNNAMED
---add-opens=java.base/java.io=ALL-UNNAMED
---add-opens=java.base/jdk.internal.misc=ALL-UNNAMED

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -16,6 +16,7 @@
   <name>Zeebe Distribution</name>
 
   <properties>
+    <spring-boot.run.mainClass>io.camunda.application.StandaloneCamunda</spring-boot.run.mainClass>
     <spring-boot.run.jvmArguments>${jvm.module.opens}</spring-boot.run.jvmArguments>
   </properties>
 
@@ -1138,6 +1139,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
+          <mainClass>${spring-boot.run.mainClass}</mainClass>
           <jvmArguments>${spring-boot.run.jvmArguments}</jvmArguments>
         </configuration>
         <executions>

--- a/operate/Makefile
+++ b/operate/Makefile
@@ -14,9 +14,9 @@ env-h2-up:
 	CAMUNDA_DATABASE_URL=jdbc:h2:mem:camunda \
 	CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=rdbms \
 	ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME=io.camunda.exporter.rdbms.RdbmsExporter \
-	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java \
-	  -Dexec.mainClass="io.camunda.application.StandaloneCamunda" \
-	  -Dspring.profiles.active=operate,broker,dev,dev-data,admin,consolidated-auth
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run \
+	  -Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
+	  -Dspring-boot.run.profiles=operate,broker,dev,dev-data,admin,consolidated-auth
 
 .PHONY: env-up
 env-up:
@@ -43,9 +43,9 @@ env-up:
 	CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://localhost:9200 \
 	CAMUNDA_DATABASE_URL=http://localhost:9200 \
 	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS=false \
-	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java \
-	  -Dexec.mainClass="io.camunda.application.StandaloneCamunda" \
-	  -Dspring.profiles.active=operate,broker,dev,dev-data,consolidated-auth
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run \
+	  -Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
+	  -Dspring-boot.run.profiles=operate,broker,dev,dev-data,consolidated-auth
 
 env-os-up:
 	docker compose -f docker-compose.yml up -d opensearch zeebe-opensearch \
@@ -64,7 +64,8 @@ env-os-up:
       CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0=demo \
       CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=true \
       CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=false \
-         mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate" -Dspring.profiles.active=dev,dev-data,auth -Dcamunda.operate.zeebe.compatibility.enabled=true
+      CAMUNDA_OPERATE_ZEEBE_COMPATIBILITY_ENABLED=true \
+         mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run -Dspring-boot.run.mainClass="io.camunda.application.StandaloneOperate" -Dspring-boot.run.profiles=dev,dev-data,auth
 
 # Look up for users (bender/bender etc) in: https://github.com/rroemhild/docker-test-openldap
 .PHONY: env-ldap-up
@@ -77,7 +78,8 @@ env-ldap-up:
        CAMUNDA_OPERATE_LDAP_MANAGERDN=cn=admin,dc=planetexpress,dc=com \
        CAMUNDA_OPERATE_LDAP_MANAGERPASSWORD=GoodNewsEveryone \
        CAMUNDA_OPERATE_LDAP_USERSEARCHFILTER=uid={0} \
-	   mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate" -Dspring.profiles.active=dev,dev-data,ldap-auth -Dcamunda.operate.zeebe.compatibility.enabled=true
+       CAMUNDA_OPERATE_ZEEBE_COMPATIBILITY_ENABLED=true \
+	   mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run -Dspring-boot.run.mainClass="io.camunda.application.StandaloneOperate" -Dspring-boot.run.profiles=dev,dev-data,ldap-auth
 
 # Set the env var CAMUNDA_OPERATE_AUTH0_CLIENTSECRET in your shell please, eg: export CAMUNDA_OPERATE_AUTH0_CLIENTSECRET=<client-secret>
 .PHONY: env-sso-up
@@ -94,7 +96,8 @@ env-sso-up:
        CAMUNDA_OPERATE_AUTH0_ORGANIZATION=6ff582aa-a62e-4a28-aac7-4d2224d8c58a \
        CAMUNDA_OPERATE_AUTH0_ORGANIZATIONSKEY=https://camunda.com/orgs \
        CAMUNDA_OPERATE_CLOUD_CONSOLE_URL=https://console.cloud.ultrawombat.com/ \
-	   mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate" -Dspring.profiles.active=dev,dev-data,sso-auth -Dcamunda.operate.zeebe.compatibility.enabled=true
+       CAMUNDA_OPERATE_ZEEBE_COMPATIBILITY_ENABLED=true \
+	   mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run -Dspring-boot.run.mainClass="io.camunda.application.StandaloneOperate" -Dspring-boot.run.profiles=dev,dev-data,sso-auth
 
 .PHONY: env-identity-up
 env-identity-up:
@@ -124,9 +127,9 @@ env-identity-up:
   CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0=demo \
   CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=true \
   CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=false \
-	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java \
-	  -Dexec.mainClass="io.camunda.application.StandaloneCamunda" \
-	  -Dspring.profiles.active=operate,broker,dev,dev-data,consolidated-auth,admin
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run \
+	  -Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
+	  -Dspring-boot.run.profiles=operate,broker,dev,dev-data,consolidated-auth,admin
 
 
 .PHONY: env-down
@@ -180,6 +183,6 @@ start-e2e:
   CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=false \
 	SERVER_PORT=8081 \
 	MANAGEMENT_SERVER_PORT=9601 \
-	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java \
-	  -Dexec.mainClass="io.camunda.application.StandaloneCamunda" \
-	  -Dspring.profiles.active=operate,broker,consolidated-auth
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run \
+	  -Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
+	  -Dspring-boot.run.profiles=operate,broker,consolidated-auth

--- a/tasklist/Makefile
+++ b/tasklist/Makefile
@@ -24,9 +24,9 @@ env-h2-up:
 	CAMUNDA_DATABASE_URL=jdbc:h2:mem:camunda \
 	CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=rdbms \
 	ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME=io.camunda.exporter.rdbms.RdbmsExporter \
-	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java \
-	  -Dexec.mainClass="io.camunda.application.StandaloneCamunda" \
-	  -Dspring.profiles.active=tasklist,broker,dev,dev-data,admin,consolidated-auth
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run \
+	  -Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
+	  -Dspring-boot.run.profiles=tasklist,broker,dev,dev-data,admin,consolidated-auth
 
 .PHONY: env-up
 env-up: $(DATABASE) setup-maven-context
@@ -184,6 +184,6 @@ define run-env
 	@DATABASE=$(DATABASE) docker compose -f $(COMPOSE_FILE) up -d $(SERVICES)
 	@../mvnw clean install -B -T1C -DskipTests=true -DskipChecks -Dskip.fe.build=false -DskipQaBuild
 	@set -o allexport && source $(MAVEN_CONTEXT) && set +o allexport && rm -rf $(MAVEN_CONTEXT) && \
-        ../mvnw -f ../dist/pom.xml exec:java -Dexec.mainClass="$(MAIN_CLASS)" -Dspring.profiles.active=$(SPRING_PROFILES_ACTIVE)
+        ../mvnw -f ../dist/pom.xml spring-boot:run -Dspring-boot.run.mainClass="$(MAIN_CLASS)" -Dspring-boot.run.profiles=$(SPRING_PROFILES_ACTIVE)
 endef
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Since this PR was merged https://github.com/camunda/camunda/pull/45515 I started getting errors when trying to run `make env-up` on the `operate/` folder

I'm not sure if this is the best fix but it fixes the issue for me

The error is here below:

```
13:54:50.932 [] [io.camunda.application.StandaloneCamunda.main()] [] WARN  io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride - The following legacy property is no longer supported and should be removed in favor of 'camunda.data.exporters': zeebe.broker.exporters
13:54:51.129 [] [io.camunda.application.StandaloneCamunda.main()] [] WARN  org.springframework.boot.web.server.servlet.context.AnnotationConfigServletWebServerApplicationContext - Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'operateModuleConfiguration': Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'brokerModuleConfiguration': Unsatisfied dependency expressed through constructor parameter 3: Error creating bean with name 'scheduler' defined in class path resource [io/camunda/application/commons/actor/ActorSchedulerConfiguration.class]: Failed to instantiate [io.camunda.zeebe.scheduler.ActorScheduler]: Factory method 'scheduler' threw exception with message: class org.agrona.UnsafeApi (in unnamed module @0x7c0f20e5) cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @0x7c0f20e5
13:54:51.132 [] [io.camunda.application.StandaloneCamunda.main()] [] INFO  org.apache.catalina.core.StandardService - Stopping service [Tomcat]
13:54:51.143 [Broker-0] [netty-messaging-event-epoll-server-0] [] WARN  io.atomix.utils.concurrent.SingleThreadContext - Execution of io.atomix.utils.concurrent.SingleThreadContext$WrappedRunnable@5eff0a3a was rejected!
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@195d38bf[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@1948f85a[Wrapped task = io.atomix.utils.concurrent.SingleThreadContext$WrappedRunnable@5eff0a3a]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@647ffedf[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 6]
	at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2081)
	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:841)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:340)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:562)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.execute(ScheduledThreadPoolExecutor.java:705)
	at io.atomix.utils.concurrent.SingleThreadContext$1.execute(SingleThreadContext.java:58)
	at io.atomix.utils.concurrent.SingleThreadContext.execute(SingleThreadContext.java:133)
	at java.base/java.util.concurrent.CompletableFuture$UniCompletion.claim(CompletableFuture.java:572)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1147)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2179)
	at io.atomix.cluster.messaging.impl.NettyMessagingService.bind(NettyMessagingService.java:951)
	at io.atomix.cluster.messaging.impl.NettyMessagingService.lambda$bind$41(NettyMessagingService.java:943)
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:604)
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:571)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:506)
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:650)
	at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:639)
	at io.netty.util.concurrent.DefaultPromise.trySuccess(DefaultPromise.java:119)
	at io.netty.channel.DefaultChannelPromise.trySuccess(DefaultChannelPromise.java:84)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetSuccess(AbstractChannel.java:853)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.bind(AbstractChannel.java:447)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.bind(DefaultChannelPipeline.java:1353)
	at io.netty.channel.AbstractChannelHandlerContext.bind(AbstractChannelHandlerContext.java:500)
	at io.netty.channel.DefaultChannelPipeline.bind(DefaultChannelPipeline.java:994)
	at io.netty.channel.Channel.bind(Channel.java:302)
	at io.netty.bootstrap.AbstractBootstrap$1.run(AbstractBootstrap.java:381)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.atomix.utils.concurrent.AtomixThreadFactory.lambda$newThread$0(AtomixThreadFactory.java:46)
	at java.base/java.lang.Thread.run(Thread.java:1583)
13:54:51.186 [] [io.camunda.application.StandaloneCamunda.main()] [] WARN  org.apache.catalina.loader.WebappClassLoaderBase - The web application [ROOT] appears to have started a thread named [AWS Advanced JDBC Wrapper bep-1] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:
 java.base/jdk.internal.misc.Unsafe.park(Native Method)
 java.base/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:269)
 java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:1797)
 java.base/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1182)
 java.base/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:899)
 java.base/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1070)
 java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
 java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
 java.base/java.lang.Thread.run(Thread.java:1583)
13:54:51.186 [] [io.camunda.application.StandaloneCamunda.main()] [] WARN  org.apache.catalina.loader.WebappClassLoaderBase - The web application [ROOT] appears to have started a thread named [AWS Advanced JDBC Wrapper ssi-1] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:
 java.base/jdk.internal.misc.Unsafe.park(Native Method)
 java.base/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:269)
 java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:1797)
 java.base/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1182)
 java.base/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:899)
 java.base/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1070)
 java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
 java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
 java.base/java.lang.Thread.run(Thread.java:1583)
13:54:51.186 [] [io.camunda.application.StandaloneCamunda.main()] [] WARN  org.apache.catalina.loader.WebappClassLoaderBase - The web application [ROOT] appears to have started a thread named [AWS Advanced JDBC Wrapper msi-1] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:
 java.base/jdk.internal.misc.Unsafe.park(Native Method)
 java.base/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:269)
 java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:1797)
 java.base/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1182)
 java.base/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:899)
 java.base/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1070)
 java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
 java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
 java.base/java.lang.Thread.run(Thread.java:1583)
13:54:51.188 [] [io.camunda.application.StandaloneCamunda.main()] [] ERROR io.camunda.application - Failed to start application with message: Error creating bean with name 'operateModuleConfiguration': Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'brokerModuleConfiguration': Unsatisfied dependency expressed through constructor parameter 3: Error creating bean with name 'scheduler' defined in class path resource [io/camunda/application/commons/actor/ActorSchedulerConfiguration.class]: Failed to instantiate [io.camunda.zeebe.scheduler.ActorScheduler]: Factory method 'scheduler' threw exception with message: class org.agrona.UnsafeApi (in unnamed module @0x7c0f20e5) cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @0x7c0f20e5
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'operateModuleConfiguration': Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'brokerModuleConfiguration': Unsatisfied dependency expressed through constructor parameter 3: Error creating bean with name 'scheduler' defined in class path resource [io/camunda/application/commons/actor/ActorSchedulerConfiguration.class]: Failed to instantiate [io.camunda.zeebe.scheduler.ActorScheduler]: Factory method 'scheduler' threw exception with message: class org.agrona.UnsafeApi (in unnamed module @0x7c0f20e5) cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @0x7c0f20e5
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:804)
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:240)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1382)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1221)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:565)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:525)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:371)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:331)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:196)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.instantiateSingleton(DefaultListableBeanFactory.java:1218)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingleton(DefaultListableBeanFactory.java:1184)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:1121)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:994)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:621)
	at org.springframework.boot.web.server.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:143)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:756)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:445)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:321)
	at io.camunda.application.StandaloneCamunda.main(StandaloneCamunda.java:98)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.mojo.exec.AbstractExecJavaBase.executeMainMethod(AbstractExecJavaBase.java:402)
	at org.codehaus.mojo.exec.ExecJavaMojo.executeMainMethod(ExecJavaMojo.java:142)
	at org.codehaus.mojo.exec.AbstractExecJavaBase.doExecClassLoader(AbstractExecJavaBase.java:377)
	at org.codehaus.mojo.exec.AbstractExecJavaBase.lambda$execute$0(AbstractExecJavaBase.java:287)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'brokerModuleConfiguration': Unsatisfied dependency expressed through constructor parameter 3: Error creating bean with name 'scheduler' defined in class path resource [io/camunda/application/commons/actor/ActorSchedulerConfiguration.class]: Failed to instantiate [io.camunda.zeebe.scheduler.ActorScheduler]: Factory method 'scheduler' threw exception with message: class org.agrona.UnsafeApi (in unnamed module @0x7c0f20e5) cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @0x7c0f20e5
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:804)
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:240)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1382)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1221)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:565)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:525)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:371)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:331)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:196)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:413)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1362)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1194)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:565)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:525)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:371)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:331)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:201)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveBean(DefaultListableBeanFactory.java:1225)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1704)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1651)
	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:912)
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:791)
	... 26 more
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'scheduler' defined in class path resource [io/camunda/application/commons/actor/ActorSchedulerConfiguration.class]: Failed to instantiate [io.camunda.zeebe.scheduler.ActorScheduler]: Factory method 'scheduler' threw exception with message: class org.agrona.UnsafeApi (in unnamed module @0x7c0f20e5) cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @0x7c0f20e5
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:657)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:489)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1362)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1194)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:565)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:525)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:371)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:331)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:201)
	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:229)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1762)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1651)
	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:912)
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:791)
	... 49 more
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.camunda.zeebe.scheduler.ActorScheduler]: Factory method 'scheduler' threw exception with message: class org.agrona.UnsafeApi (in unnamed module @0x7c0f20e5) cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @0x7c0f20e5
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:183)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiateWithFactoryMethod(SimpleInstantiationStrategy.java:72)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:152)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:653)
	... 63 more
Caused by: java.lang.IllegalAccessError: class org.agrona.UnsafeApi (in unnamed module @0x7c0f20e5) cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @0x7c0f20e5
	at org.agrona.UnsafeApi.getUnsafe(UnsafeApi.java)
	at org.agrona.UnsafeApi.<clinit>(UnsafeApi.java)
	at io.camunda.zeebe.scheduler.ActorTaskQueuePadding1.<clinit>(ActorTaskQueue.java:175)
	at io.camunda.zeebe.scheduler.WorkStealingGroup.<init>(WorkStealingGroup.java:23)
	at io.camunda.zeebe.scheduler.ActorThreadGroup.<init>(ActorThreadGroup.java:35)
	at io.camunda.zeebe.scheduler.CpuThreadGroup.<init>(CpuThreadGroup.java:16)
	at io.camunda.zeebe.scheduler.ActorScheduler$ActorSchedulerBuilder.initCpuBoundActorThreadGroup(ActorScheduler.java:250)
	at io.camunda.zeebe.scheduler.ActorScheduler$ActorSchedulerBuilder.build(ActorScheduler.java:262)
	at io.camunda.application.commons.actor.ActorSchedulerConfiguration.scheduler(ActorSchedulerConfiguration.java:55)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:155)
	... 66 more
make: *** [Makefile:23: env-up] Error 255 ****
```