### PR TITLE
[Backport stable/8.9] fix: deprecate batchOperationId and add batchOperationKey in process instance filter

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
@@ -138,13 +138,31 @@ public interface ProcessInstanceFilter extends ProcessInstanceFilterBase {
   @Override
   ProcessInstanceFilter variables(final Map<String, Object> variableValueFilters);
 
-  /** Filter by batchOperationId */
+  /**
+   * Filter by batchOperationId.
+   *
+   * @deprecated Use {@link #batchOperationKey(String)} instead.
+   */
+  @Deprecated
   @Override
   ProcessInstanceFilter batchOperationId(final String batchOperationId);
 
-  /** Filter by batchOperationId using {@link StringProperty} */
+  /**
+   * Filter by batchOperationId using {@link StringProperty}.
+   *
+   * @deprecated Use {@link #batchOperationKey(Consumer)} instead.
+   */
+  @Deprecated
   @Override
   ProcessInstanceFilter batchOperationId(final Consumer<StringProperty> fn);
+
+  /** Filter by batchOperationKey */
+  @Override
+  ProcessInstanceFilter batchOperationKey(final String batchOperationKey);
+
+  /** Filter by batchOperationKey using {@link StringProperty} */
+  @Override
+  ProcessInstanceFilter batchOperationKey(final Consumer<StringProperty> fn);
 
   /** Filter by error message */
   @Override

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
@@ -114,11 +114,27 @@ public interface ProcessInstanceFilterBase extends SearchRequestFilter {
   /** Filter by variables map */
   ProcessInstanceFilterBase variables(final Map<String, Object> variableValueFilters);
 
-  /** Filter by batchOperationId */
+  /**
+   * Filter by batchOperationId.
+   *
+   * @deprecated Use {@link #batchOperationKey(String)} instead.
+   */
+  @Deprecated
   ProcessInstanceFilterBase batchOperationId(final String batchOperationId);
 
-  /** Filter by batchOperationId using {@link StringProperty} */
+  /**
+   * Filter by batchOperationId using {@link StringProperty}.
+   *
+   * @deprecated Use {@link #batchOperationKey(Consumer)} instead.
+   */
+  @Deprecated
   ProcessInstanceFilterBase batchOperationId(final Consumer<StringProperty> fn);
+
+  /** Filter by batchOperationKey */
+  ProcessInstanceFilterBase batchOperationKey(final String batchOperationKey);
+
+  /** Filter by batchOperationKey using {@link StringProperty} */
+  ProcessInstanceFilterBase batchOperationKey(final Consumer<StringProperty> fn);
 
   /** Filter by error message */
   ProcessInstanceFilterBase errorMessage(final String errorMessage);

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilter.java
@@ -101,13 +101,31 @@ public interface ProcessDefinitionStatisticsFilter extends ProcessDefinitionStat
   @Override
   ProcessDefinitionStatisticsFilter variables(final Map<String, Object> variableValueFilters);
 
-  /** Filter by batchOperationId */
+  /**
+   * Filter by batchOperationId.
+   *
+   * @deprecated Use {@link #batchOperationKey(String)} instead.
+   */
+  @Deprecated
   @Override
   ProcessDefinitionStatisticsFilter batchOperationId(final String batchOperationId);
 
-  /** Filter by batchOperationId using {@link StringProperty} */
+  /**
+   * Filter by batchOperationId using {@link StringProperty}.
+   *
+   * @deprecated Use {@link #batchOperationKey(Consumer)} instead.
+   */
+  @Deprecated
   @Override
   ProcessDefinitionStatisticsFilter batchOperationId(final Consumer<StringProperty> fn);
+
+  /** Filter by batchOperationKey */
+  @Override
+  ProcessDefinitionStatisticsFilter batchOperationKey(final String batchOperationKey);
+
+  /** Filter by batchOperationKey using {@link StringProperty} */
+  @Override
+  ProcessDefinitionStatisticsFilter batchOperationKey(final Consumer<StringProperty> fn);
 
   /** Filter by error message */
   @Override

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilterBase.java
@@ -88,11 +88,27 @@ public interface ProcessDefinitionStatisticsFilterBase extends StatisticsRequest
   /** Filter by variables map */
   ProcessDefinitionStatisticsFilterBase variables(final Map<String, Object> variableValueFilters);
 
-  /** Filter by batchOperationId */
+  /**
+   * Filter by batchOperationId.
+   *
+   * @deprecated Use {@link #batchOperationKey(String)} instead.
+   */
+  @Deprecated
   ProcessDefinitionStatisticsFilterBase batchOperationId(final String batchOperationId);
 
-  /** Filter by batchOperationId using {@link StringProperty} */
+  /**
+   * Filter by batchOperationId using {@link StringProperty}.
+   *
+   * @deprecated Use {@link #batchOperationKey(Consumer)} instead.
+   */
+  @Deprecated
   ProcessDefinitionStatisticsFilterBase batchOperationId(final Consumer<StringProperty> fn);
+
+  /** Filter by batchOperationKey */
+  ProcessDefinitionStatisticsFilterBase batchOperationKey(final String batchOperationKey);
+
+  /** Filter by batchOperationKey using {@link StringProperty} */
+  ProcessDefinitionStatisticsFilterBase batchOperationKey(final Consumer<StringProperty> fn);
 
   /** Filter by error message */
   ProcessDefinitionStatisticsFilterBase errorMessage(final String errorMessage);

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -259,6 +259,20 @@ public class ProcessInstanceFilterImpl
   }
 
   @Override
+  public ProcessInstanceFilter batchOperationKey(final String batchOperationKey) {
+    batchOperationKey(b -> b.eq(batchOperationKey));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilter batchOperationKey(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBatchOperationKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public ProcessInstanceFilter errorMessage(final String errorMessage) {
     errorMessage(b -> b.eq(errorMessage));
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -252,6 +252,10 @@ public class ProcessInstanceFilterImpl
 
   @Override
   public ProcessInstanceFilter batchOperationId(final Consumer<StringProperty> fn) {
+    if (filter.getBatchOperationKey() != null) {
+      throw new IllegalArgumentException(
+          "Cannot set batchOperationId when batchOperationKey is already set. Use batchOperationKey instead.");
+    }
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setBatchOperationId(provideSearchRequestProperty(property));
@@ -266,6 +270,10 @@ public class ProcessInstanceFilterImpl
 
   @Override
   public ProcessInstanceFilter batchOperationKey(final Consumer<StringProperty> fn) {
+    if (filter.getBatchOperationId() != null) {
+      throw new IllegalArgumentException(
+          "Cannot set batchOperationKey when batchOperationId is already set. Use batchOperationKey instead.");
+    }
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setBatchOperationKey(provideSearchRequestProperty(property));

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
@@ -191,6 +191,20 @@ public class ProcessDefinitionStatisticsFilterImpl
   }
 
   @Override
+  public ProcessDefinitionStatisticsFilter batchOperationKey(final String batchOperationKey) {
+    batchOperationKey(b -> b.eq(batchOperationKey));
+    return this;
+  }
+
+  @Override
+  public ProcessDefinitionStatisticsFilter batchOperationKey(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBatchOperationKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public ProcessDefinitionStatisticsFilter errorMessage(final String errorMessage) {
     errorMessage(b -> b.eq(errorMessage));
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
@@ -184,6 +184,10 @@ public class ProcessDefinitionStatisticsFilterImpl
 
   @Override
   public ProcessDefinitionStatisticsFilter batchOperationId(final Consumer<StringProperty> fn) {
+    if (filter.getBatchOperationKey() != null) {
+      throw new IllegalArgumentException(
+          "Cannot set batchOperationId when batchOperationKey is already set. Use batchOperationKey instead.");
+    }
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setBatchOperationId(provideSearchRequestProperty(property));
@@ -198,6 +202,10 @@ public class ProcessDefinitionStatisticsFilterImpl
 
   @Override
   public ProcessDefinitionStatisticsFilter batchOperationKey(final Consumer<StringProperty> fn) {
+    if (filter.getBatchOperationId() != null) {
+      throw new IllegalArgumentException(
+          "Cannot set batchOperationKey when batchOperationId is already set. Use batchOperationKey instead.");
+    }
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setBatchOperationKey(provideSearchRequestProperty(property));

--- a/clients/java/src/main/java/io/camunda/client/impl/util/ProcessDefinitionStatisticsFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/ProcessDefinitionStatisticsFilterMapper.java
@@ -42,6 +42,7 @@ public final class ProcessDefinitionStatisticsFilterMapper {
     target.setParentProcessInstanceKey(filter.getParentProcessInstanceKey());
     target.setParentElementInstanceKey(filter.getParentElementInstanceKey());
     target.setBatchOperationId(filter.getBatchOperationId());
+    target.setBatchOperationKey(filter.getBatchOperationKey());
     target.setErrorMessage(filter.getErrorMessage());
     target.setHasRetriesLeft(filter.getHasRetriesLeft());
     target.setElementInstanceState(filter.getElementInstanceState());

--- a/clients/java/src/main/java/io/camunda/client/impl/util/ProcessInstanceFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/ProcessInstanceFilterMapper.java
@@ -49,6 +49,7 @@ public final class ProcessInstanceFilterMapper {
     target.setParentProcessInstanceKey(filter.getParentProcessInstanceKey());
     target.setParentElementInstanceKey(filter.getParentElementInstanceKey());
     target.setBatchOperationId(filter.getBatchOperationId());
+    target.setBatchOperationKey(filter.getBatchOperationKey());
     target.setErrorMessage(filter.getErrorMessage());
     target.setHasRetriesLeft(filter.getHasRetriesLeft());
     target.setElementInstanceState(filter.getElementInstanceState());

--- a/clients/java/src/test/java/io/camunda/client/process/ProcessDefinitionStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/ProcessDefinitionStatisticsTest.java
@@ -16,6 +16,7 @@
 package io.camunda.client.process;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
@@ -238,5 +239,35 @@ public class ProcessDefinitionStatisticsTest extends ClientRestTest {
                 .processInstanceKey(new BasicStringFilterProperty().$eq("123"))
                 .elementId(new StringFilterProperty().$eq("elementId")),
             new BaseProcessInstanceFilterFields().hasElementInstanceIncident(true));
+  }
+
+  @Test
+  void
+      shouldThrowWhenSettingBatchOperationIdAfterBatchOperationKeyInProcessDefinitionStatisticsFilter() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newProcessDefinitionElementStatisticsRequest(PROCESS_DEFINITION_KEY)
+                    .filter(f -> f.batchOperationKey("key-1").batchOperationId("id-1"))
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchOperationKey");
+  }
+
+  @Test
+  void
+      shouldThrowWhenSettingBatchOperationKeyAfterBatchOperationIdInProcessDefinitionStatisticsFilter() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newProcessDefinitionElementStatisticsRequest(PROCESS_DEFINITION_KEY)
+                    .filter(f -> f.batchOperationId("id-1").batchOperationKey("key-1"))
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchOperationId");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -18,6 +18,7 @@ package io.camunda.client.process;
 import static io.camunda.client.api.search.enums.ProcessInstanceState.ACTIVE;
 import static io.camunda.client.util.assertions.SortAssert.assertSort;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
@@ -409,5 +410,33 @@ public class QueryProcessInstanceTest extends ClientRestTest {
         .filter(m -> Modifier.isPublic(m.getModifiers()) && !m.isSynthetic())
         .map(m -> m.getName() + Arrays.toString(m.getParameterTypes()))
         .collect(Collectors.toSet());
+  }
+
+  @Test
+  void shouldThrowWhenSettingBatchOperationIdAfterBatchOperationKeyInProcessInstanceFilter() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newProcessInstanceSearchRequest()
+                    .filter(f -> f.batchOperationKey("key-1").batchOperationId("id-1"))
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchOperationKey");
+  }
+
+  @Test
+  void shouldThrowWhenSettingBatchOperationKeyAfterBatchOperationIdInProcessInstanceFilter() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newProcessInstanceSearchRequest()
+                    .filter(f -> f.batchOperationId("id-1").batchOperationKey("key-1"))
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchOperationId");
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -12,6 +12,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_NULL_VARIABLE_NAME;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_NULL_VARIABLE_VALUE;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_ONLY_ONE_FIELD;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDuration;
 import static java.util.Optional.ofNullable;
@@ -142,9 +143,18 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getTenantId())
           .map(mapToOperations(String.class))
           .ifPresent(builder::tenantIdOperations);
-      ofNullable(filter.getBatchOperationId())
-          .map(mapToOperations(String.class))
-          .ifPresent(builder::batchOperationIdOperations);
+      if (filter.getBatchOperationId() != null && filter.getBatchOperationKey() != null) {
+        validationErrors.add(
+            ERROR_MESSAGE_ONLY_ONE_FIELD.formatted("batchOperationId, batchOperationKey"));
+      } else {
+        final var batchOperationFilter =
+            filter.getBatchOperationKey() != null
+                ? filter.getBatchOperationKey()
+                : filter.getBatchOperationId();
+        ofNullable(batchOperationFilter)
+            .map(mapToOperations(String.class))
+            .ifPresent(builder::batchOperationIdOperations);
+      }
       ofNullable(filter.getErrorMessage())
           .map(mapToOperations(String.class))
           .ifPresent(builder::errorMessageOperations);
@@ -662,9 +672,18 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getTenantId())
           .map(mapToOperations(String.class))
           .ifPresent(builder::tenantIdOperations);
-      ofNullable(filter.getBatchOperationId())
-          .map(mapToOperations(String.class))
-          .ifPresent(builder::batchOperationIdOperations);
+      if (filter.getBatchOperationId() != null && filter.getBatchOperationKey() != null) {
+        validationErrors.add(
+            ERROR_MESSAGE_ONLY_ONE_FIELD.formatted("batchOperationId, batchOperationKey"));
+      } else {
+        final var batchOperationFilter =
+            filter.getBatchOperationKey() != null
+                ? filter.getBatchOperationKey()
+                : filter.getBatchOperationId();
+        ofNullable(batchOperationFilter)
+            .map(mapToOperations(String.class))
+            .ifPresent(builder::batchOperationIdOperations);
+      }
       ofNullable(filter.getErrorMessage())
           .map(mapToOperations(String.class))
           .ifPresent(builder::errorMessageOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -145,7 +145,8 @@ public class SearchQueryFilterMapper {
           .ifPresent(builder::tenantIdOperations);
       if (filter.getBatchOperationId() != null && filter.getBatchOperationKey() != null) {
         validationErrors.add(
-            ERROR_MESSAGE_ONLY_ONE_FIELD.formatted("batchOperationId, batchOperationKey"));
+            ERROR_MESSAGE_ONLY_ONE_FIELD.formatted(
+                List.of("batchOperationId", "batchOperationKey")));
       } else {
         final var batchOperationFilter =
             filter.getBatchOperationKey() != null
@@ -674,7 +675,8 @@ public class SearchQueryFilterMapper {
           .ifPresent(builder::tenantIdOperations);
       if (filter.getBatchOperationId() != null && filter.getBatchOperationKey() != null) {
         validationErrors.add(
-            ERROR_MESSAGE_ONLY_ONE_FIELD.formatted("batchOperationId, batchOperationKey"));
+            ERROR_MESSAGE_ONLY_ONE_FIELD.formatted(
+                List.of("batchOperationId", "batchOperationKey")));
       } else {
         final var batchOperationFilter =
             filter.getBatchOperationKey() != null

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -206,6 +206,9 @@ public class SimpleSearchQueryMapper {
         .map(SimpleSearchQueryMapper::getBasicStringFilter)
         .ifPresent(target::parentElementInstanceKey);
 
+    ofNullable(source.getBatchOperationKey())
+        .map(SimpleSearchQueryMapper::getStringFilter)
+        .ifPresent(target::batchOperationKey);
     ofNullable(source.getBatchOperationId())
         .map(SimpleSearchQueryMapper::getStringFilter)
         .ifPresent(target::batchOperationId);
@@ -263,6 +266,7 @@ public class SimpleSearchQueryMapper {
         .parentProcessInstanceKey(source.getParentProcessInstanceKey())
         .parentElementInstanceKey(source.getParentElementInstanceKey())
         .batchOperationId(source.getBatchOperationId())
+        .batchOperationKey(source.getBatchOperationKey())
         .errorMessage(source.getErrorMessage())
         .hasRetriesLeft(source.getHasRetriesLeft())
         .elementInstanceState(source.getElementInstanceState())

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceFilter.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceFilter.java
@@ -16,6 +16,7 @@ import io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter;
  */
 @JsonIgnoreProperties({
   "batchOperationId",
+  "batchOperationKey",
   "elementId",
   "elementInstanceState",
   "errorMessage",

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1045,7 +1045,16 @@ components:
         batchOperationId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
-          description: The batch operation id.
+          description: >
+            The batch operation id.
+
+            **Deprecated**: Use `batchOperationKey` instead. This field will be removed in a future release.
+            If both `batchOperationId` and `batchOperationKey` are provided, the request will be rejected with a 400 error.
+          deprecated: true
+        batchOperationKey:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: The batch operation key.
         errorMessage:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -381,6 +381,46 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectSearchWithBothBatchOperationIdAndBatchOperationKey() {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                    "batchOperationId": {"$eq": "id-1"},
+                    "batchOperationKey": {"$eq": "key-1"}
+                }
+            }""";
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "Only one of batchOperationId, batchOperationKey is allowed.",
+                  "instance": "%s"
+                }""",
+            PROCESS_INSTANCES_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+  }
+
+  @Test
   void shouldSearchProcessInstancessWithSorting() {
     // given
     when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
@@ -830,6 +870,10 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         streamBuilder,
         "errorMessage",
         ops -> new ProcessInstanceFilter.Builder().errorMessageOperations(ops).build());
+    stringOperationTestCases(
+        streamBuilder,
+        "batchOperationKey",
+        ops -> new ProcessInstanceFilter.Builder().batchOperationIdOperations(ops).build());
     return streamBuilder.build();
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -398,7 +398,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                   "type": "about:blank",
                   "title": "INVALID_ARGUMENT",
                   "status": 400,
-                  "detail": "Only one of batchOperationId, batchOperationKey is allowed.",
+                  "detail": "Only one of [batchOperationId, batchOperationKey] is allowed.",
                   "instance": "%s"
                 }""",
             PROCESS_INSTANCES_SEARCH_URL);
@@ -418,6 +418,45 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+  }
+
+  @Test
+  void shouldSearchProcessInstancesWithDeprecatedBatchOperationId() {
+    // given - batchOperationId is deprecated but should still be accepted for backward
+    // compatibility
+    final var request =
+        """
+            {
+                "filter": {
+                    "batchOperationId": {"$eq": "op-id-1"}
+                }
+            }""";
+    final var expectedFilter =
+        new ProcessInstanceFilter.Builder()
+            .batchOperationIdOperations(Operation.eq("op-id-1"))
+            .build();
+
+    when(processInstanceServices.search(queryCaptor.capture(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .consumeWith(
+            result -> assertJsonNonExtensible(EXPECTED_SEARCH_RESPONSE, result.getResponseBody()));
+
+    verify(processInstanceServices)
+        .search(eq(new ProcessInstanceQuery.Builder().filter(expectedFilter).build()), any());
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #48518 to `stable/8.9`.

relates to 