### PR TITLE
[Backport stable/8.7] fix: lower exporter-api Java release version from 21 to 17

### DIFF
--- a/zeebe/exporter-api/pom.xml
+++ b/zeebe/exporter-api/pom.xml
@@ -23,6 +23,7 @@
   </licenses>
 
   <properties>
+    <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
   </properties>
 


### PR DESCRIPTION
# Description
Backport of #48520 to `stable/8.7`.

relates to #48524