### PR TITLE
feat: Change the return response of an expression evaluation

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/EvaluationWarning.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/EvaluationWarning.java
@@ -15,29 +15,13 @@
  */
 package io.camunda.client.api.response;
 
-import java.util.List;
-
-/** Response for the expression evaluation command. */
-public interface EvaluateExpressionResponse {
+/** A warning generated during expression evaluation. */
+public interface EvaluationWarning {
 
   /**
-   * Returns the evaluated expression.
+   * Returns the warning message.
    *
-   * @return the expression that was evaluated
+   * @return the warning message
    */
-  String getExpression();
-
-  /**
-   * Returns the result of the expression evaluation.
-   *
-   * @return the result value. Type depends on the result type (String, Boolean, Number, or Object)
-   */
-  Object getResult();
-
-  /**
-   * Returns the list of warnings generated during expression evaluation.
-   *
-   * @return the list of warnings, or an empty list if none
-   */
-  List<EvaluationWarning> getWarnings();
+  String getMessage();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateExpressionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateExpressionResponseImpl.java
@@ -16,8 +16,8 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.client.api.response.EvaluationWarning;
 import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
-import io.camunda.client.protocol.rest.ExpressionEvaluationWarningItem;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,14 +25,14 @@ public class EvaluateExpressionResponseImpl implements EvaluateExpressionRespons
 
   private final String expression;
   private final Object result;
-  private final List<String> warnings;
+  private final List<EvaluationWarning> warnings;
 
   public EvaluateExpressionResponseImpl(final ExpressionEvaluationResult response) {
     expression = response.getExpression();
     result = response.getResult();
     warnings =
         response.getWarnings().stream()
-            .map(ExpressionEvaluationWarningItem::getMessage)
+            .map(EvaluationWarningImpl::new)
             .collect(Collectors.toList());
   }
 
@@ -47,7 +47,7 @@ public class EvaluateExpressionResponseImpl implements EvaluateExpressionRespons
   }
 
   @Override
-  public List<String> getWarnings() {
+  public List<EvaluationWarning> getWarnings() {
     return warnings;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateExpressionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateExpressionResponseImpl.java
@@ -17,8 +17,9 @@ package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
-import java.util.Collections;
+import io.camunda.client.protocol.rest.ExpressionEvaluationWarningItem;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class EvaluateExpressionResponseImpl implements EvaluateExpressionResponse {
 
@@ -29,7 +30,10 @@ public class EvaluateExpressionResponseImpl implements EvaluateExpressionRespons
   public EvaluateExpressionResponseImpl(final ExpressionEvaluationResult response) {
     expression = response.getExpression();
     result = response.getResult();
-    warnings = response.getWarnings() != null ? response.getWarnings() : Collections.emptyList();
+    warnings =
+        response.getWarnings().stream()
+            .map(ExpressionEvaluationWarningItem::getMessage)
+            .collect(Collectors.toList());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluationWarningImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluationWarningImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.EvaluationWarning;
+import io.camunda.client.protocol.rest.ExpressionEvaluationWarningItem;
+
+public class EvaluationWarningImpl implements EvaluationWarning {
+
+  private final String message;
+
+  public EvaluationWarningImpl(final ExpressionEvaluationWarningItem warningItem) {
+    message = warningItem.getMessage();
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.client.api.response.EvaluationWarning;
 import io.camunda.client.protocol.rest.ExpressionEvaluationRequest;
 import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
 import io.camunda.client.protocol.rest.ExpressionEvaluationWarningItem;
@@ -235,6 +236,8 @@ public final class EvaluateExpressionTest extends ClientRestTest {
     // then
     assertThat(response.getExpression()).isEqualTo(expression);
     assertThat(response.getResult()).isEqualTo(resultValue);
-    assertThat(response.getWarnings()).containsExactly("Warning 1", "Warning 2");
+    assertThat(response.getWarnings())
+        .extracting(EvaluationWarning::getMessage)
+        .containsExactly("Warning 1", "Warning 2");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.client.protocol.rest.ExpressionEvaluationRequest;
 import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
+import io.camunda.client.protocol.rest.ExpressionEvaluationWarningItem;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
@@ -217,7 +218,10 @@ public final class EvaluateExpressionTest extends ClientRestTest {
     // given
     final String expression = "=x + y";
     final Object resultValue = 30;
-    final List<String> warnings = Arrays.asList("Warning 1", "Warning 2");
+    final List<ExpressionEvaluationWarningItem> warnings =
+        Arrays.asList(
+            new ExpressionEvaluationWarningItem().message("Warning 1"),
+            new ExpressionEvaluationWarningItem().message("Warning 2"));
     gatewayService.onExpressionEvaluationRequest(
         new ExpressionEvaluationResult()
             .expression(expression)

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -45,6 +45,7 @@ import io.camunda.gateway.protocol.model.EvaluatedDecisionInputItem;
 import io.camunda.gateway.protocol.model.EvaluatedDecisionOutputItem;
 import io.camunda.gateway.protocol.model.EvaluatedDecisionResult;
 import io.camunda.gateway.protocol.model.ExpressionEvaluationResult;
+import io.camunda.gateway.protocol.model.ExpressionEvaluationWarningItem;
 import io.camunda.gateway.protocol.model.GroupCreateResult;
 import io.camunda.gateway.protocol.model.GroupUpdateResult;
 import io.camunda.gateway.protocol.model.JobKindEnum;
@@ -765,7 +766,10 @@ public final class ResponseMapper {
     return new ExpressionEvaluationResult()
         .expression(expressionRecord.getExpression())
         .result(expressionRecord.getResultValue())
-        .warnings(expressionRecord.getWarnings());
+        .warnings(
+            expressionRecord.getWarnings().stream()
+                .map(warning -> new ExpressionEvaluationWarningItem().message(warning))
+                .toList());
   }
 
   public static TopologyResponse toTopologyResponse(final Topology topology) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -14,6 +14,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientHttpException;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.client.api.response.EvaluationWarning;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -298,6 +299,7 @@ public class ExpressionEvaluationIT {
     // then
     assertThat(response).isNotNull();
     assertThat(response.getWarnings())
+        .extracting(EvaluationWarning::getMessage)
         .contains("No function found with name 'invalid_function' and 0 parameters");
   }
 
@@ -851,9 +853,10 @@ public class ExpressionEvaluationIT {
     assertThat(response).isNotNull();
     assertThat(response.getResult()).isNull();
     assertThat(response.getWarnings())
+        .extracting(io.camunda.client.api.response.EvaluationWarning::getMessage)
         .anySatisfy(
-            warning ->
-                assertThat(warning)
+            message ->
+                assertThat(message)
                     .contains("The context is empty")
                     .contains("No context entry found with key"));
   }

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -73,6 +73,15 @@ components:
           type: array
           description: List of warnings generated during expression evaluation
           items:
-            type: string
+            $ref: '#/components/schemas/ExpressionEvaluationWarningItem'
           example: [ ]
+    ExpressionEvaluationWarningItem:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: The warning message
+          example: "No function found with name '{}' and {} parameters"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -83,5 +83,5 @@ components:
         message:
           type: string
           description: The warning message
-          example: "No function found with name '{}' and {} parameters"
+          example: "No function found with name 'random' and 1 parameters"
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
@@ -178,6 +178,7 @@ public class ExpressionControllerTest extends RestControllerTest {
             """
             {
                 "expression": "=invalid_function()",
+                "result": null,
                 "warnings": [
                     {
                         "message": "No function found with name 'invalid_function' and 0 parameters"

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
@@ -145,6 +145,49 @@ public class ExpressionControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldEvaluateExpressionWithWarnings() {
+    // given
+    final var expressionRecord = mock(ExpressionRecord.class);
+    when(expressionRecord.getExpression()).thenReturn("=invalid_function()");
+    when(expressionRecord.getResultValue()).thenReturn(null);
+    when(expressionRecord.getWarnings())
+        .thenReturn(List.of("No function found with name 'invalid_function' and 0 parameters"));
+
+    when(expressionServices.evaluateExpression(any(ExpressionEvaluationRequest.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(expressionRecord));
+
+    final var request =
+        """
+        {
+            "expression": "=invalid_function()",
+            "tenantId": "tenant1"
+        }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(EXPRESSION_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+                "expression": "=invalid_function()",
+                "warnings": [
+                    {
+                        "message": "No function found with name 'invalid_function' and 0 parameters"
+                    }
+                ]
+            }""",
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
   void shouldRejectEvaluationWithMissingExpression() {
     // given
     final var request =


### PR DESCRIPTION
This pull request updates how expression evaluation warnings are handled and represented throughout the gateway and client layers. The main improvement is changing warnings from simple strings to structured objects, allowing for richer and more consistent warning information. Additionally, the tests and protocol definitions are updated to support this change.

Structured warning representation:

* Changed the `warnings` field in the protocol definition (`expression.yaml`) from an array of strings to an array of `ExpressionEvaluationWarningItem` objects, which contain a `message` property.
* Updated the gateway response mapping (`ResponseMapper.java`) so that warnings are mapped to `ExpressionEvaluationWarningItem` objects instead of strings.

Client-side handling:

* Modified the client implementation (`EvaluateExpressionResponseImpl.java`) to extract warning messages from `ExpressionEvaluationWarningItem` objects, ensuring compatibility with the new structure.
* Updated client tests (`EvaluateExpressionTest.java`) to use `ExpressionEvaluationWarningItem` objects for warnings instead of strings.

Testing improvements:

* Added a new test in `ExpressionControllerTest.java` to verify that warnings are returned as structured objects in the REST response.