### PR TITLE
[Backport stable/optimize-8.6] deps(optimize): bump jetty to 12.0.33

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -45,7 +45,7 @@
     <previous.optimize.opensearch.version>2.9.0</previous.optimize.opensearch.version>
     <awssdk.version>2.28.13</awssdk.version>
 
-    <jetty.version>12.0.25</jetty.version>
+    <jetty.version>12.0.33</jetty.version>
     <jackson.version>2.18.1</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <apache.http5-client.version>5.5</apache.http5-client.version>


### PR DESCRIPTION
# Description
Backport of #48559 to `stable/optimize-8.6`.

relates to #48558
original author: @korthout