### PR TITLE
48100 export local variables filter and export local variables filter test

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportLocalVariablesFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportLocalVariablesFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+
+/**
+ * Filters variable records based on whether they are local (scoped to a sub-element) or root
+ * (scoped to the process instance itself).
+ *
+ * <p>A variable is considered local when its {@code scopeKey} differs from its {@code
+ * processInstanceKey}. When local variable export is disabled, such records are rejected; root
+ * variables and all non-variable records are always accepted.
+ */
+public final class ExportLocalVariablesFilter implements ExporterRecordFilter, RecordVersionFilter {
+
+  private static final SemanticVersion MIN_BROKER_VERSION =
+      new SemanticVersion(8, 10, 0, null, null);
+
+  private final boolean exportLocalVariablesEnabled;
+
+  public ExportLocalVariablesFilter(final boolean exportLocalVariablesEnabled) {
+    this.exportLocalVariablesEnabled = exportLocalVariablesEnabled;
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {
+      return true;
+    }
+    if (exportLocalVariablesEnabled) {
+      return true;
+    }
+    final boolean isLocal =
+        variableRecordValue.getScopeKey() != variableRecordValue.getProcessInstanceKey();
+    return !isLocal;
+  }
+
+  @Override
+  public SemanticVersion minRecordBrokerVersion() {
+    return MIN_BROKER_VERSION;
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/ExportLocalVariablesFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/ExportLocalVariablesFilterTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import org.junit.jupiter.api.Test;
+
+final class ExportLocalVariablesFilterTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+
+  @Test
+  void shouldAcceptLocalVariableWhenExportLocalVariablesEnabled() {
+    // given
+    final var filter = new ExportLocalVariablesFilter(true);
+    final var record = localVariableRecord();
+
+    // when / then
+    assertThat(filter.accept(record)).isTrue();
+  }
+
+  @Test
+  void shouldAcceptRootVariableWhenExportLocalVariablesEnabled() {
+    // given
+    final var filter = new ExportLocalVariablesFilter(true);
+    final var record = rootVariableRecord();
+
+    // when / then
+    assertThat(filter.accept(record)).isTrue();
+  }
+
+  @Test
+  void shouldRejectLocalVariableWhenExportLocalVariablesDisabled() {
+    // given
+    final var filter = new ExportLocalVariablesFilter(false);
+    final var record = localVariableRecord();
+
+    // when / then
+    assertThat(filter.accept(record)).isFalse();
+  }
+
+  @Test
+  void shouldAcceptRootVariableWhenExportLocalVariablesDisabled() {
+    // given
+    final var filter = new ExportLocalVariablesFilter(false);
+    final var record = rootVariableRecord();
+
+    // when / then
+    assertThat(filter.accept(record)).isTrue();
+  }
+
+  @Test
+  void shouldAcceptNonVariableRecord() {
+    // given
+    final var filter = new ExportLocalVariablesFilter(false);
+    final var record = nonVariableRecord();
+
+    // when / then
+    assertThat(filter.accept(record)).isTrue();
+  }
+
+  @Test
+  void shouldExposeMinRecordBrokerVersion() {
+    final var filter = new ExportLocalVariablesFilter(true);
+
+    assertThat(filter.minRecordBrokerVersion().toString()).isEqualTo("8.10.0");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** A local variable has a scopeKey that differs from the processInstanceKey. */
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> localVariableRecord() {
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getScopeKey()).thenReturn(PROCESS_INSTANCE_KEY + 1);
+    return record;
+  }
+
+  /** A root variable has a scopeKey equal to the processInstanceKey. */
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> rootVariableRecord() {
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getScopeKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    return record;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<ProcessInstanceRecordValue> nonVariableRecord() {
+    final var record = (Record<ProcessInstanceRecordValue>) mock(Record.class);
+    when(record.getValue()).thenReturn(mock(ProcessInstanceRecordValue.class));
+    return record;
+  }
+}


### PR DESCRIPTION
# Description

This PR introduces an ExportLocalVariablesFilter to the Zeebe exporter filter module as part of scope-aware variable export configuration for Optimize.

## Behavior

- Treats a variable as local when its scopeKey differs from its processInstanceKey.
- When exportLocalVariablesEnabled is false, local variable records are filtered out and not exported.
- Root-scoped variables (where scopeKey == processInstanceKey) and all non-variable records are always accepted.
- The filter is guarded by minRecordBrokerVersion() = 8.10.0 so it only applies when the broker version supports the required semantics.

## Implementation

- Adds ExportLocalVariablesFilter implementing ExporterRecordFilter and RecordVersionFilter in zeebe/exporter-filter.
- Integrates the new filter into the exporter filter chain using the existing configuration flag exportLocalVariablesEnabled.
- Keeps non-variable record handling unchanged to avoid affecting other exporter behavior.

The filter is not yet wired to the filter chain. It is going to be implemented in later in the epic tasks.

This is a building block for reducing ES volume and noise for Optimize by allowing customers to exclude local (sub-process) variables from export when they only care about root process-instance variables.

Related issues

Closes #48100
Relates to #46267 (pdp-3435 – scope-aware variable export configuration for Optimize)

