### PR TITLE
Document timeout responses

### DIFF
--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CancelProcessInstanceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CancelProcessInstanceTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.api.process;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
@@ -15,6 +16,9 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstance
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceResponse;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
 public final class CancelProcessInstanceTest extends GatewayTest {
@@ -38,5 +42,28 @@ public final class CancelProcessInstanceTest extends GatewayTest {
     assertThat(brokerRequest.getKey()).isEqualTo(123);
     assertThat(brokerRequest.getIntent()).isEqualTo(ProcessInstanceIntent.CANCEL);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.PROCESS_INSTANCE);
+  }
+
+  @Test
+  public void shouldMapTimeoutToDeadlineExceeded() {
+    // given
+    brokerClient.registerHandler(
+        BrokerCancelProcessInstanceRequest.class,
+        request -> {
+          throw new TimeoutException("request timeout");
+        });
+
+    final CancelProcessInstanceRequest request =
+        CancelProcessInstanceRequest.newBuilder().setProcessInstanceKey(123).build();
+
+    // when / then
+    assertThatThrownBy(() -> client.cancelProcessInstance(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.THROWABLE)
+        .extracting(
+            t -> ((StatusRuntimeException) t).getStatus().getCode(),
+            t -> ((StatusRuntimeException) t).getStatus().getDescription())
+        .containsExactly(
+            Status.Code.DEADLINE_EXCEEDED, "Time out between gateway and broker: request timeout");
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/SetVariablesTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/SetVariablesTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.api.process;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
@@ -19,7 +20,10 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.test.util.JsonUtil;
 import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import java.util.Collections;
+import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
 public final class SetVariablesTest extends GatewayTest {
@@ -56,5 +60,31 @@ public final class SetVariablesTest extends GatewayTest {
     final VariableDocumentRecord brokerRequestValue = brokerRequest.getRequestWriter();
     MsgPackUtil.assertEqualityExcluding(brokerRequestValue.getVariablesBuffer(), variables);
     assertThat(brokerRequestValue.getScopeKey()).isEqualTo(elementInstanceKey);
+  }
+
+  @Test
+  public void shouldMapTimeoutToDeadlineExceeded() {
+    // given
+    brokerClient.registerHandler(
+        BrokerSetVariablesRequest.class,
+        request -> {
+          throw new TimeoutException("request timeout");
+        });
+
+    final SetVariablesRequest request =
+        SetVariablesRequest.newBuilder()
+            .setElementInstanceKey(Protocol.encodePartitionId(1, 1))
+            .setVariables("{\"key\":\"value\"}")
+            .build();
+
+    // when / then
+    assertThatThrownBy(() -> client.setVariables(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.THROWABLE)
+        .extracting(
+            t -> ((StatusRuntimeException) t).getStatus().getCode(),
+            t -> ((StatusRuntimeException) t).getStatus().getDescription())
+        .containsExactly(
+            Status.Code.DEADLINE_EXCEEDED, "Time out between gateway and broker: request timeout");
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -1163,6 +1163,14 @@ service Gateway {
       INVALID_ARGUMENT:
         - the given variables document is not a valid JSON document; valid documents are expected to
           be JSON documents where the root node is an object.
+      DEADLINE_EXCEEDED:
+        - the request timed out between the gateway and the broker. This can happen for general
+          timeout reasons (for example transient communication delays). On user-task-listener-
+          related operations, this can additionally happen when the corresponding listener job is
+          not completed within the request timeout.
+
+    If this happens repeatedly, retry with backoff and check listener worker availability and
+    health.
    */
   rpc SetVariables (SetVariablesRequest) returns (SetVariablesResponse) {
   }

--- a/zeebe/gateway-protocol/src/main/proto/v2/common-responses.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/common-responses.yaml
@@ -45,6 +45,34 @@ components:
           schema:
             $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
 
+    GatewayTimeoutTaskListenerBlocking:
+      description: >
+        The request timed out between the gateway and the broker. For these endpoints, this often
+        happens when user task listeners are configured and the corresponding listener job is not
+        completed within the request timeout. Common causes include no available job workers for
+        the listener type, busy or crashed job workers, or delayed job completion. As with any
+        gateway timeout, general timeout causes (for example transient network issues) can also
+        result in a 504 response.
+
+        Troubleshooting:
+        - verify that job workers for the listener type are running and healthy
+        - check worker logs for crashes, retries, and completion failures
+        - check network connectivity between workers, gateway, and broker
+        - retry with backoff after transient failures
+        - fail without retries if a problem persists
+      content:
+        application/problem+json:
+          schema:
+            $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+          examples:
+            taskListenerTimeout:
+              value:
+                type: about:blank
+                title: DEADLINE_EXCEEDED
+                status: 504
+                detail: Expected to handle request, but request timed out between gateway and broker
+                instance: /v2/user-tasks/123/completion
+
     UnsupportedMediaType:
       description: |
         The server cannot process the request because the media type (Content-Type) of the request payload is not supported

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -80,6 +80,8 @@ paths:
       description: |
         Updates all the variables of a particular scope (for example, process instance, element instance) with the given variable data.
         Specify the element instance in the `elementInstanceKey` parameter.
+        Variable updates can be delayed by listener-related processing; if processing exceeds the
+        request timeout, this endpoint can return 504.
       parameters:
         - name: elementInstanceKey
           in: path
@@ -105,6 +107,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+        "504":
+          $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
 
   /element-instances/{elementInstanceKey}/incidents/search:
     post:

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -81,7 +81,9 @@ paths:
         Updates all the variables of a particular scope (for example, process instance, element instance) with the given variable data.
         Specify the element instance in the `elementInstanceKey` parameter.
         Variable updates can be delayed by listener-related processing; if processing exceeds the
-        request timeout, this endpoint can return 504.
+        request timeout, this endpoint can return 504. Other gateway timeout causes are also
+        possible. Retry with backoff and inspect listener worker availability and logs when this
+        repeats.
       parameters:
         - name: elementInstanceKey
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -283,7 +283,8 @@ paths:
         Cancels a running process instance. As a cancellation includes more than just the removal
         of the process instance resource, the cancellation resource must be posted. Cancellation
         can wait on listener-related processing; when that processing does not complete in time,
-        this endpoint can return 504.
+        this endpoint can return 504. Other gateway timeout causes are also possible. Retry with
+        backoff and inspect listener worker availability and logs when this repeats.
       parameters:
         - name: processInstanceKey
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -279,7 +279,11 @@ paths:
         - Process instance
       operationId: cancelProcessInstance
       summary: Cancel process instance
-      description: Cancels a running process instance. As a cancellation includes more than just the removal of the process instance resource, the cancellation resource must be posted.
+      description: >
+        Cancels a running process instance. As a cancellation includes more than just the removal
+        of the process instance resource, the cancellation resource must be posted. Cancellation
+        can wait on listener-related processing; when that processing does not complete in time,
+        this endpoint can return 504.
       parameters:
         - name: processInstanceKey
           in: path
@@ -308,6 +312,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+        "504":
+          $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
 
   /process-instances/cancellation:
     post:

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -8,7 +8,10 @@ paths:
         - User task
       operationId: completeUserTask
       summary: Complete user task
-      description: Completes a user task with the given key.
+      description: >
+        Completes a user task with the given key. Completion waits for blocking task listeners on
+        this lifecycle transition. If listener processing is delayed beyond the request timeout,
+        this endpoint can return 504.
       parameters:
         - name: userTaskKey
           in: path
@@ -45,6 +48,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+        "504":
+          $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
 
   /user-tasks/{userTaskKey}/assignment:
     post:
@@ -53,7 +58,10 @@ paths:
         - User task
       operationId: assignUserTask
       summary: Assign user task
-      description: Assigns a user task with the given key to the given assignee.
+      description: >
+        Assigns a user task with the given key to the given assignee. Assignment waits for
+        blocking task listeners on this lifecycle transition. If listener processing is delayed
+        beyond the request timeout, this endpoint can return 504.
       parameters:
         - name: userTaskKey
           in: path
@@ -90,6 +98,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+        "504":
+          $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
 
   /user-tasks/{userTaskKey}:
     get:
@@ -134,7 +144,10 @@ paths:
         - User task
       operationId: updateUserTask
       summary: Update user task
-      description: Update a user task with the given key.
+      description: >
+        Update a user task with the given key. Updates wait for blocking task listeners on this
+        lifecycle transition. If listener processing is delayed beyond the request timeout, this
+        endpoint can return 504.
       parameters:
         - name: userTaskKey
           in: path
@@ -171,6 +184,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+        "504":
+          $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
 
   /user-tasks/{userTaskKey}/form:
     get:
@@ -220,7 +235,10 @@ paths:
         - User task
       operationId: unassignUserTask
       summary: Unassign user task
-      description: Removes the assignee of a task with the given key.
+      description: >
+        Removes the assignee of a task with the given key. Unassignment waits for blocking task
+        listeners on this lifecycle transition. If listener processing is delayed beyond the
+        request timeout, this endpoint can return 504.
       parameters:
         - name: userTaskKey
           in: path
@@ -251,6 +269,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+        "504":
+          $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
 
   /user-tasks/search:
     post:

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -11,7 +11,8 @@ paths:
       description: >
         Completes a user task with the given key. Completion waits for blocking task listeners on
         this lifecycle transition. If listener processing is delayed beyond the request timeout,
-        this endpoint can return 504.
+        this endpoint can return 504. Other gateway timeout causes are also possible. Retry with
+        backoff and inspect listener worker availability and logs when this repeats.
       parameters:
         - name: userTaskKey
           in: path
@@ -61,7 +62,9 @@ paths:
       description: >
         Assigns a user task with the given key to the given assignee. Assignment waits for
         blocking task listeners on this lifecycle transition. If listener processing is delayed
-        beyond the request timeout, this endpoint can return 504.
+        beyond the request timeout, this endpoint can return 504. Other gateway timeout causes are
+        also possible. Retry with backoff and inspect listener worker availability and logs when
+        this repeats.
       parameters:
         - name: userTaskKey
           in: path
@@ -147,7 +150,8 @@ paths:
       description: >
         Update a user task with the given key. Updates wait for blocking task listeners on this
         lifecycle transition. If listener processing is delayed beyond the request timeout, this
-        endpoint can return 504.
+        endpoint can return 504. Other gateway timeout causes are also possible. Retry with
+        backoff and inspect listener worker availability and logs when this repeats.
       parameters:
         - name: userTaskKey
           in: path
@@ -238,7 +242,9 @@ paths:
       description: >
         Removes the assignee of a task with the given key. Unassignment waits for blocking task
         listeners on this lifecycle transition. If listener processing is delayed beyond the
-        request timeout, this endpoint can return 504.
+        request timeout, this endpoint can return 504. Other gateway timeout causes are also
+        possible. Retry with backoff and inspect listener worker availability and logs when this
+        repeats.
       parameters:
         - name: userTaskKey
           in: path

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
@@ -14,10 +14,12 @@ import static org.mockito.Mockito.when;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +28,7 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -187,5 +190,42 @@ public class ElementInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnGatewayTimeoutWhenSetVariablesTimesOut() {
+    // given
+    when(elementInstanceServices.setVariables(any(SetVariablesRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked set variables"))));
+
+    final var request =
+        """
+            {
+              "variables": {
+                "key": "value"
+              }
+            }""";
+
+    // when / then
+    webClient
+        .put()
+        .uri(ELEMENTS_BASE_URL + "/123/variables")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -31,6 +31,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOpe
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
@@ -51,6 +52,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,6 +62,7 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -993,6 +996,34 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnGatewayTimeoutWhenCancelProcessInstanceTimesOut() {
+    // given
+    when(processInstanceServices.cancelProcessInstance(
+            any(ProcessInstanceCancelRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked cancellation"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri(CANCEL_PROCESS_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -27,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
@@ -829,6 +830,34 @@ public class UserTaskControllerTest extends RestControllerTest {
 
   @ParameterizedTest
   @MethodSource("urls")
+  void shouldReturnGatewayTimeoutWhenCompleteTaskTimesOut(final String baseUrl) {
+    // given
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked completion"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl + "/1/completion")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
   void shouldYieldConflictWhenInvalidState(final String baseUrl) {
     // given
     Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
@@ -1188,6 +1217,82 @@ public class UserTaskControllerTest extends RestControllerTest {
 
   @ParameterizedTest
   @MethodSource("urls")
+  void shouldReturnGatewayTimeoutWhenAssignTaskTimesOut(final String baseUrl) {
+    // given
+    Mockito.when(
+            userTaskServices.assignUserTask(
+                anyLong(), anyString(), anyString(), anyBoolean(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked assignment"))));
+
+    final var request =
+        """
+            {
+              "assignee": "Test Assignee"
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl + "/1/assignment")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
+  void shouldReturnGatewayTimeoutWhenUpdateTaskTimesOut(final String baseUrl) {
+    // given
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked update"))));
+
+    final var request =
+        """
+            {
+              "changeset": {
+                "priority": 50
+              }
+            }""";
+
+    // when / then
+    webClient
+        .patch()
+        .uri(baseUrl + "/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
   void shouldUnassignTask(final String baseUrl) {
     // given
     Mockito.when(userTaskServices.unassignUserTask(anyLong(), anyString(), any()))
@@ -1203,5 +1308,33 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices).unassignUserTask(eq(2251799813685732L), eq("unassign"), any());
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
+  void shouldReturnGatewayTimeoutWhenUnassignTaskTimesOut(final String baseUrl) {
+    // given
+    Mockito.when(userTaskServices.unassignUserTask(anyLong(), anyString(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked unassignment"))));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(baseUrl + "/1/assignee")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public final class StubbedBrokerClient implements BrokerClient {
@@ -110,6 +111,9 @@ public final class StubbedBrokerClient implements BrokerClient {
       } catch (final RuntimeException e) {
         throwableConsumer.accept(new BrokerResponseException(e));
       }
+    } catch (final TimeoutException e) {
+      // Preserve timeout semantics so endpoint tests can assert gateway timeout mappings.
+      throwableConsumer.accept(e);
     } catch (final Exception e) {
       throwableConsumer.accept(new BrokerResponseException(e));
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UserTaskListenersTest.java
@@ -61,7 +61,10 @@ public class UserTaskListenersTest {
 
   @TestZeebe
   private static final TestStandaloneBroker ZEEBE =
-      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withUnauthenticatedAccess()
+          .withProperty("zeebe.broker.gateway.cluster.requestTimeout", "1s");
 
   @AutoClose private CamundaClient client;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UserTaskListenersTest.java
@@ -1049,6 +1049,51 @@ public class UserTaskListenersTest {
                 .isEqualTo(createdUserTask));
   }
 
+  @Test
+  void shouldReturnGatewayTimeoutWhenUpdatingTaskListenerBlocksVariableUpdate() {
+    // given
+    final var listenerType = "blocking_updating_listener";
+    final var userTaskKey =
+        resourcesHelper.createSingleUserTask(
+            t -> t.zeebeTaskListener(l -> l.updating().type(listenerType)));
+    final var createdUserTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withRecordKey(userTaskKey)
+            .getFirst()
+            .getValue();
+
+    try (final var restClient =
+        ZEEBE
+            .newClientBuilder()
+            .preferRestOverGrpc(false)
+            .defaultRequestTimeout(Duration.ofSeconds(60))
+            .build()) {
+      final var updateTaskVariablesFuture =
+          restClient
+              .newSetVariablesCommand(createdUserTask.getElementInstanceKey())
+              .useRest()
+              .variables(Map.of("approvalStatus", "APPROVED"))
+              .local(true)
+              .send();
+
+      // when: the listener job is created but not completed by any worker
+      await().untilAsserted(() -> ZeebeAssertHelper.assertJobCreated(listenerType));
+
+      // then
+      assertThatExceptionOfType(ProblemException.class)
+          .isThrownBy(updateTaskVariablesFuture::join)
+          .extracting(ProblemException::details)
+          .satisfies(
+              details -> {
+                assertThat(details.getStatus()).isEqualTo(HttpStatus.SC_GATEWAY_TIMEOUT);
+                assertThat(details.getTitle()).isEqualTo("DEADLINE_EXCEEDED");
+                assertThat(details.getDetail())
+                    .isEqualTo(
+                        "Expected to handle request, but request timed out between gateway and broker");
+              });
+    }
+  }
+
   private void waitForJobRetriesToBeExhausted(final RecordingJobHandler recordingHandler) {
     await("until all retries are exhausted")
         .untilAsserted(


### PR DESCRIPTION
## Summary

This PR updates the API documentation to explicitly include timeout responses for relevant endpoints.

## Motivation

Timeouts can occur in normal operation. Additionally, some user task and process APIs can time out when task listener jobs are not completed in time. These timeout responses were possible in practice but not clearly documented.

## Changes

- Added timeout responses to the endpoint documentation
- Updated OpenAPI/gRPC docs so timeout behavior is represented consistently
- Kept existing documentation structure while extending response coverage

## Impact

- **No runtime behavior changes**
- Documentation and test-only update
- Improves clarity for client-side timeout handling

## Testing

- Verified the documentation changes render correctly
- Confirmed timeout responses are reflected in the generated API docs

## Related

closes #44179