### PR TITLE
ci: build frontends in dedicated steps before the testbench maven build

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -85,8 +85,24 @@ jobs:
           echo "image-tag=$version-$branch-${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
         env:
           BRANCH: ${{ inputs.branch }}
+      - name: Build optimize frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./optimize/client
+      - name: Build operate frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./operate/client
+          package-manager: npm
+      - name: Build tasklist frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./tasklist/client
+          package-manager: npm
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
+        with:
+          maven-extra-args: -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         id: build-zeebe-docker
         with:

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -99,6 +99,11 @@ jobs:
         with:
           directory: ./tasklist/client
           package-manager: npm
+      - name: Build identity frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./identity/client
+          package-manager: npm
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:


### PR DESCRIPTION
Moves frontend builds out of the Maven install phase and into dedicated steps using the `.github/actions/build-frontend` action, then passes `-PskipFrontendBuild` to skip the `frontend-maven-plugin` executions during `mvn install`. This follows the same pattern already established in other CI workflows across the monorepo.

Closes #48153