### PR TITLE
[Backport stable/8.9] fix: remove errorMessage from incident sort fields

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -672,7 +672,6 @@ public class SearchQuerySortRequestMapper {
         case PROCESS_DEFINITION_ID -> builder.processDefinitionId();
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
         case ERROR_TYPE -> builder.errorType();
-        case ERROR_MESSAGE -> builder.errorMessage();
         case ELEMENT_ID -> builder.flowNodeId();
         case ELEMENT_INSTANCE_KEY -> builder.flowNodeInstanceKey();
         case CREATION_TIME -> builder.creationTime();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSortIT.java
@@ -95,14 +95,6 @@ public class IncidentSortIT {
   }
 
   @TestTemplate
-  public void shouldSortByErrorMessageAsc(final CamundaRdbmsTestApplication testApplication) {
-    testSorting(
-        testApplication.getRdbmsService(),
-        b -> b.errorMessage().asc(),
-        Comparator.comparing(IncidentEntity::errorMessage));
-  }
-
-  @TestTemplate
   public void shouldSortByStateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/IncidentFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/IncidentFieldSortingTransformer.java
@@ -10,7 +10,6 @@ package io.camunda.search.clients.transformers.sort;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.CREATION_TIME;
-import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.ERROR_MSG;
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.ERROR_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.FLOW_NODE_ID;
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.FLOW_NODE_INSTANCE_KEY;
@@ -30,7 +29,6 @@ public class IncidentFieldSortingTransformer implements FieldSortingTransformer 
       case "processDefinitionId" -> BPMN_PROCESS_ID;
       case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
       case "errorType" -> ERROR_TYPE;
-      case "errorMessage" -> ERROR_MSG;
       case "flowNodeId" -> FLOW_NODE_ID;
       case "flowNodeInstanceKey" -> FLOW_NODE_INSTANCE_KEY;
       case "creationTime" -> CREATION_TIME;

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/IncidentSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/IncidentSortTest.java
@@ -29,7 +29,6 @@ public class IncidentSortTest extends AbstractSortTransformerTest {
         new TestArguments("bpmnProcessId", SortOrder.ASC, s -> s.processDefinitionId().asc()),
         new TestArguments("processInstanceKey", SortOrder.ASC, s -> s.processInstanceKey().asc()),
         new TestArguments("errorType", SortOrder.ASC, s -> s.errorType().asc()),
-        new TestArguments("errorMessage", SortOrder.ASC, s -> s.errorMessage().asc()),
         new TestArguments("flowNodeId", SortOrder.ASC, s -> s.flowNodeId().asc()),
         new TestArguments("flowNodeInstanceKey", SortOrder.ASC, s -> s.flowNodeInstanceKey().asc()),
         new TestArguments("tenantId", SortOrder.ASC, s -> s.tenantId().asc()),

--- a/search/search-domain/src/main/java/io/camunda/search/sort/IncidentSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/IncidentSort.java
@@ -50,11 +50,6 @@ public record IncidentSort(List<FieldSorting> orderings) implements SortOption {
       return this;
     }
 
-    public Builder errorMessage() {
-      currentOrdering = new FieldSorting("errorMessage", null);
-      return this;
-    }
-
     public Builder flowNodeId() {
       currentOrdering = new FieldSorting("flowNodeId", null);
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -372,7 +372,6 @@ components:
             - processDefinitionId
             - processInstanceKey
             - errorType
-            - errorMessage
             - elementId
             - elementInstanceKey
             - creationTime


### PR DESCRIPTION
# Description
Backport of #48574 to `stable/8.9`.

relates to camunda/camunda#46661