### PR TITLE
[Backport stable/8.9] fix: trim restore backups to minimum required starting point

### DIFF
--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
@@ -55,7 +55,8 @@ public class RestorePointResolver {
     final var restorableCheckpoints =
         findRestorableCheckpointsForPartition(metadataByPartition, from, exportedPositions);
     final var commonCheckpoint = findCommonCheckpoint(restorableCheckpoints, exportedPositions, to);
-    final var restorableBackups = findRequiredBackups(restorableCheckpoints, commonCheckpoint);
+    final var restorableBackups =
+        findRequiredBackups(restorableCheckpoints, commonCheckpoint, from, exportedPositions);
     LOG.atDebug().log(
         "Resolved restore point with globalCheckpointId={}",
         restorableBackups.globalCheckpointId());
@@ -65,13 +66,16 @@ public class RestorePointResolver {
   /** Finds all backup-type checkpoints that are required to cover the common checkpoint. */
   private static @NonNull RestorableBackups findRequiredBackups(
       @NonNull final List<RestorableCheckpoints> allRestorableCheckpoints,
-      final long commonCheckpoint) {
+      final long commonCheckpoint,
+      final @Nullable Instant from,
+      final @Nullable Map<Integer, Long> exportedPositions) {
     LOG.atDebug().log(
         "Finding restorable backups with commonCheckpoint={}, partitionCount={}",
         commonCheckpoint,
         allRestorableCheckpoints.size());
     final var backupsByPartitionId = new HashMap<Integer, List<CheckpointEntry>>();
     for (final var restorableCheckpoints : allRestorableCheckpoints) {
+      final var partitionId = restorableCheckpoints.partitionId();
       final var backups = new ArrayList<CheckpointEntry>();
       for (final var checkpoint : restorableCheckpoints.checkpoints()) {
         if (checkpoint.checkpointType().shouldCreateBackup()) {
@@ -80,7 +84,7 @@ public class RestorePointResolver {
           if (checkpoint.checkpointId() >= commonCheckpoint) {
             // Found the last required backup that contains the common checkpoint
             LOG.atTrace()
-                .addKeyValue("partition", restorableCheckpoints.partitionId())
+                .addKeyValue("partition", partitionId)
                 .log("Reached commonCheckpoint at checkpointId={}", checkpoint.checkpointId());
             break;
           }
@@ -90,16 +94,85 @@ public class RestorePointResolver {
         throw new IllegalStateException(
             String.format(
                 "Last restorable backup %d for partition %d does not cover the common checkpoint %d",
-                backups.getLast().checkpointId(),
-                restorableCheckpoints.partitionId(),
-                commonCheckpoint));
+                backups.getLast().checkpointId(), partitionId, commonCheckpoint));
       }
+      discardUnnecessaryBackups(
+          backups, from, exportedPositions != null ? exportedPositions.get(partitionId) : null);
       LOG.atDebug()
-          .addKeyValue("partition", restorableCheckpoints.partitionId())
+          .addKeyValue("partition", partitionId)
           .log("Found required backups: requiredBackups={}", backups.size());
-      backupsByPartitionId.put(restorableCheckpoints.partitionId(), backups);
+      backupsByPartitionId.put(partitionId, backups);
     }
     return new RestorableBackups(commonCheckpoint, backupsByPartitionId);
+  }
+
+  /**
+   * Discards backups that are not necessary for restoring. A backup is not necessary if it is from
+   * before the {@code from} timestamp or before the exported position. Retains at least one backup,
+   * even if it is unnecessary according to these rules. If both {@code from} and {@code
+   * exportedPosition} are provided, we only trim based on {@code from} because the user
+   * specifically requested it.
+   */
+  private static void discardUnnecessaryBackups(
+      final ArrayList<CheckpointEntry> backups,
+      final @Nullable Instant from,
+      final @Nullable Long exportedPosition) {
+    // For 'from': remove all backups whose timestamp is before 'from'.
+    if (from != null) {
+      discardUnnecessaryBackupsBeforeTimestamp(backups, from, exportedPosition);
+    }
+
+    // For 'exportedPosition': keep the last backup whose position is below exportedPosition and
+    // remove everything before it.
+    else if (exportedPosition != null) {
+      discardUnnecessaryBackupsBelowExporterPosition(backups, exportedPosition);
+    }
+  }
+
+  /**
+   * Retains the last backup whose position is below the exported position. Discards all previous
+   * backups because they are not needed for resuming exporting after restore.
+   */
+  private static void discardUnnecessaryBackupsBelowExporterPosition(
+      final ArrayList<CheckpointEntry> backups, final @NonNull Long exportedPosition) {
+    int lastBeforeExported = -1;
+    for (int i = 0; i < backups.size(); i++) {
+      if (backups.get(i).checkpointPosition() <= exportedPosition) {
+        lastBeforeExported = i;
+      } else {
+        break;
+      }
+    }
+    if (lastBeforeExported > 0) {
+      backups.subList(0, lastBeforeExported).clear();
+    }
+  }
+
+  /**
+   * Removes all backups before the given timestamp. Throws if the exported position is not covered
+   * by the remaining backups.
+   */
+  private static void discardUnnecessaryBackupsBeforeTimestamp(
+      final ArrayList<CheckpointEntry> backups,
+      final @NonNull Instant from,
+      final @Nullable Long exportedPosition) {
+    final var iterator = backups.iterator();
+    while (iterator.hasNext()) {
+      final var checkpoint = iterator.next();
+      if (!checkpoint.checkpointTimestamp().isBefore(from)) {
+        break;
+      }
+      // Always retain at least one backup.
+      if (iterator.hasNext()) {
+        iterator.remove();
+      }
+    }
+    if (exportedPosition != null && backups.getFirst().checkpointPosition() > exportedPosition) {
+      throw new IllegalStateException(
+          String.format(
+              "After discarding backups before %s, the exporter position %d is not covered by the first remaining backup %s",
+              from, exportedPosition, backups.getFirst()));
+    }
   }
 
   /**

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
@@ -53,9 +53,9 @@ public class RestorePointResolver {
         to,
         exportedPositions);
     final var restorableCheckpoints =
-        findRestorableCheckpoints(metadataByPartition, from, exportedPositions);
+        findRestorableCheckpointsForPartition(metadataByPartition, from, exportedPositions);
     final var commonCheckpoint = findCommonCheckpoint(restorableCheckpoints, exportedPositions, to);
-    final var restorableBackups = findRestorableBackups(restorableCheckpoints, commonCheckpoint);
+    final var restorableBackups = findRequiredBackups(restorableCheckpoints, commonCheckpoint);
     LOG.atDebug().log(
         "Resolved restore point with globalCheckpointId={}",
         restorableBackups.globalCheckpointId());
@@ -63,7 +63,7 @@ public class RestorePointResolver {
   }
 
   /** Finds all backup-type checkpoints that are required to cover the common checkpoint. */
-  private static @NonNull RestorableBackups findRestorableBackups(
+  private static @NonNull RestorableBackups findRequiredBackups(
       @NonNull final List<RestorableCheckpoints> allRestorableCheckpoints,
       final long commonCheckpoint) {
     LOG.atDebug().log(
@@ -131,7 +131,7 @@ public class RestorePointResolver {
    * Finds a list of checkpoints for each partition that start from the given timestamp or exported
    * position.
    */
-  private static @NonNull List<RestorableCheckpoints> findRestorableCheckpoints(
+  private static @NonNull List<RestorableCheckpoints> findRestorableCheckpointsForPartition(
       @NonNull final List<BackupMetadata> metadataByPartition,
       @Nullable final Instant from,
       @Nullable final Map<Integer, Long> exportedPositions) {
@@ -140,7 +140,7 @@ public class RestorePointResolver {
             entry -> {
               final var exportedPosition =
                   exportedPositions != null ? exportedPositions.get(entry.partitionId()) : null;
-              return findRestorableCheckpoints(from, exportedPosition, entry);
+              return findRestorableCheckpointsForPartition(from, exportedPosition, entry);
             })
         .toList();
   }
@@ -149,12 +149,12 @@ public class RestorePointResolver {
    * For a given partition, finds a list of checkpoints that start from the given timestamp or
    * exported position.
    */
-  private static @NonNull RestorableCheckpoints findRestorableCheckpoints(
+  private static @NonNull RestorableCheckpoints findRestorableCheckpointsForPartition(
       @Nullable final Instant from,
       @Nullable final Long exportedPosition,
       @NonNull final BackupMetadata metadata) {
     final var restorableRange = findRestorableRange(from, exportedPosition, metadata);
-    final var restorableCheckpoints = findRestorableCheckpoints(metadata, restorableRange);
+    final var restorableCheckpoints = findRestorableCheckpointsInRange(metadata, restorableRange);
     return new RestorableCheckpoints(metadata.partitionId(), restorableCheckpoints);
   }
 
@@ -227,7 +227,7 @@ public class RestorePointResolver {
   }
 
   /** Finds all checkpoints that fit within the given range. */
-  private static @NonNull List<CheckpointEntry> findRestorableCheckpoints(
+  private static @NonNull List<CheckpointEntry> findRestorableCheckpointsInRange(
       @NonNull final BackupMetadata metadata, @NonNull final RestorableRange restorableRange) {
     return metadata.checkpoints().stream()
         .filter(

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestorePointResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestorePointResolverTest.java
@@ -154,11 +154,10 @@ final class RestorePointResolverTest {
     // when – from=t2 means range start timestamp must be <= t2 (not after t2)
     final var result = RestorePointResolver.resolve(List.of(meta), t2, null, Map.of());
 
-    // then – only checkpoints from range [1,2] are usable
-    // range [1,2] start=cp1 at t1, t1.isAfter(t2)=false -> qualifies
-    // range [3,4] start=cp3 at t3, t3.isAfter(t2)=true -> filtered out
+    // then – range [3,4] is filtered out (start=t3 > from=t2), and within range [1,2],
+    // cp1 is trimmed because its timestamp (t1) is before 'from' (t2)
     assertThat(result.globalCheckpointId()).isEqualTo(2);
-    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp1, cp2);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp2);
   }
 
   @Test
@@ -402,7 +401,7 @@ final class RestorePointResolverTest {
 
   @Test
   void shouldUseFromAndToTogether() {
-    // given – from filters the range, to picks the checkpoint within that range
+    // given – single range with 4 checkpoints; from trims early ones, to limits the end
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-02-01T00:00:00Z");
     final var t3 = Instant.parse("2025-03-01T00:00:00Z");
@@ -413,19 +412,14 @@ final class RestorePointResolverTest {
     final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
     final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
 
-    // from=t2: range [1,2] start=cp1 at t1, t1.isAfter(t2)=false -> qualifies
-    //          range [3,4] start=cp3 at t3, t3.isAfter(t2)=true -> filtered out
-    // to=t1 picks checkpoint closest to t1 within range [1,2] -> checkpoint 1
-    final var meta =
-        metadata(
-            1, List.of(cp1, cp2, cp3, cp4), List.of(new RangeEntry(1, 2), new RangeEntry(3, 4)));
+    final var meta = metadata(1, List.of(cp1, cp2, cp3, cp4), List.of(new RangeEntry(1, 4)));
 
-    // when
-    final var result = RestorePointResolver.resolve(List.of(meta), t2, t1, Map.of());
+    // when – from=t2 trims cp1 (t1 < t2), to=t3 picks cp3 as common checkpoint
+    final var result = RestorePointResolver.resolve(List.of(meta), t2, t3, Map.of());
 
-    // then
-    assertThat(result.globalCheckpointId()).isOne();
-    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp1);
+    // then – cp1 trimmed by from, cp4 excluded by to → only cp2 and cp3
+    assertThat(result.globalCheckpointId()).isEqualTo(3);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp2, cp3);
   }
 
   @Test
@@ -546,32 +540,39 @@ final class RestorePointResolverTest {
 
   @Test
   void shouldFilterCommonCheckpointByPerPartitionExportedPosition() {
-    // given – two partitions share checkpoints 1 and 2; partition 2's exported position
-    // requires checkpoint position >= 200, so checkpoint 1 (position 110 on P2) is skipped
+    // given – two partitions share checkpoints 2 and 3; partition 2's exported position
+    // requires checkpoint position >= 200, so checkpoint 2 (position 110 on P2) is skipped
     final var t1 = Instant.parse("2025-01-01T00:00:00Z");
     final var t2 = Instant.parse("2025-01-02T00:00:00Z");
+    final var t3 = Instant.parse("2025-01-03T00:00:00Z");
 
     final var metadataByPartition =
         List.of(
             metadata(
                 1,
                 List.of(
-                    entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
-                    entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101))),
-                List.of(new RangeEntry(1, 2))),
+                    entry(2, 100, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50)),
+                    entry(3, 200, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101))),
+                List.of(new RangeEntry(2, 3))),
             metadata(
                 2,
                 List.of(
-                    entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(60)),
-                    entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(111))),
-                List.of(new RangeEntry(1, 2))));
+                    entry(1, 10, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(109)),
+                    entry(2, 110, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(60)),
+                    entry(3, 210, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(111))),
+                List.of(new RangeEntry(1, 3))));
 
     // when – P2 exportedPosition=200 means cp1 on P2 (checkpointPosition=110) < 200 -> skip cp1
     final var result =
         RestorePointResolver.resolve(metadataByPartition, null, null, Map.of(2, 200L));
 
-    // then – checkpoint 2 is selected (cp2 on P2 has checkpointPosition=210 >= 200)
-    assertThat(result.globalCheckpointId()).isEqualTo(2);
+    // then – checkpoint 3 is selected (cp2 on P2 has checkpointPosition=210 >= 200)
+    assertThat(result.globalCheckpointId()).isEqualTo(3);
+    // P1 has no exported position → all checkpoints kept
+    assertThat(result.backupsByPartitionId().get(1)).hasSize(2);
+    // P2 cp2 (pos=110) is kept as the safe starting snapshot (last before exportedPosition=200) but
+    // cp1 is discarded based on the exporter position.
+    assertThat(result.backupsByPartitionId().get(2)).hasSize(2);
   }
 
   @Test
@@ -819,6 +820,137 @@ final class RestorePointResolverTest {
             () -> RestorePointResolver.resolve(metadataByPartition, null, null, Map.of()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Unexpected data gaps");
+  }
+
+  @Test
+  void shouldTrimCheckpointsBeforeExportedPosition() {
+    // given – 4 checkpoints in one range, exportedPosition between cp2 and cp3
+    final var t1 = Instant.parse("2025-01-01T00:00:00Z");
+    final var t2 = Instant.parse("2025-01-02T00:00:00Z");
+    final var t3 = Instant.parse("2025-01-03T00:00:00Z");
+    final var t4 = Instant.parse("2025-01-04T00:00:00Z");
+
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
+
+    final var meta = metadata(1, List.of(cp1, cp2, cp3, cp4), List.of(new RangeEntry(1, 4)));
+
+    // when – exportedPosition=250 is between cp2(pos=200) and cp3(pos=300)
+    final var result = RestorePointResolver.resolve(List.of(meta), null, null, Map.of(1, 250L));
+
+    // then – cp1 is trimmed, but cp2 is kept as the starting snapshot because its exporter
+    // position is guaranteed to be <= the RDBMS exported position
+    assertThat(result.globalCheckpointId()).isEqualTo(4);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp2, cp3, cp4);
+  }
+
+  @Test
+  void shouldTrimCheckpointsBeforeFromTimestamp() {
+    // given – 4 checkpoints in one range, from between t2 and t3
+    final var t1 = Instant.parse("2025-01-01T00:00:00Z");
+    final var t2 = Instant.parse("2025-02-01T00:00:00Z");
+    final var t3 = Instant.parse("2025-03-01T00:00:00Z");
+    final var t4 = Instant.parse("2025-04-01T00:00:00Z");
+
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
+
+    final var meta = metadata(1, List.of(cp1, cp2, cp3, cp4), List.of(new RangeEntry(1, 4)));
+
+    // when – from=Feb 15 means cp1(Jan 1) and cp2(Feb 1) are before the requested start
+    final var from = Instant.parse("2025-02-15T00:00:00Z");
+    final var result = RestorePointResolver.resolve(List.of(meta), from, null, Map.of());
+
+    // then – cp1 and cp2 trimmed, only cp3 and cp4 are restored
+    assertThat(result.globalCheckpointId()).isEqualTo(4);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp3, cp4);
+  }
+
+  @Test
+  void shouldTrimDifferentlyPerPartitionBasedOnExportedPosition() {
+    // given – two partitions with 4 checkpoints each and different exported positions
+    final var t1 = Instant.parse("2025-01-01T00:00:00Z");
+    final var t2 = Instant.parse("2025-01-02T00:00:00Z");
+    final var t3 = Instant.parse("2025-01-03T00:00:00Z");
+    final var t4 = Instant.parse("2025-01-04T00:00:00Z");
+
+    final var cp1p1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var cp2p1 = entry(2, 200, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp3p1 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(201));
+    final var cp4p1 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
+
+    final var cp1p2 = entry(1, 110, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(60));
+    final var cp2p2 = entry(2, 210, t2, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(111));
+    final var cp3p2 = entry(3, 310, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(211));
+    final var cp4p2 = entry(4, 410, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(311));
+
+    final var metadataByPartition =
+        List.of(
+            metadata(1, List.of(cp1p1, cp2p1, cp3p1, cp4p1), List.of(new RangeEntry(1, 4))),
+            metadata(2, List.of(cp1p2, cp2p2, cp3p2, cp4p2), List.of(new RangeEntry(1, 4))));
+
+    // when – P1 exportedPosition=250 (between cp2 and cp3), P2 exportedPosition=350 (between cp3
+    // and cp4)
+    final var result =
+        RestorePointResolver.resolve(metadataByPartition, null, null, Map.of(1, 250L, 2, 350L));
+
+    // then – P1 starts from cp2 (last before 250), P2 starts from cp3 (last before 350)
+    assertThat(result.globalCheckpointId()).isEqualTo(4);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp2p1, cp3p1, cp4p1);
+    assertThat(result.backupsByPartitionId().get(2)).containsExactly(cp3p2, cp4p2);
+  }
+
+  @Test
+  void shouldNotTrimSafeBackupWhenMarkerIsInterspersedBeforeExportedPosition() {
+    // given – a MARKER sits between the last safe backup and the first backup >= exportedPosition
+    final var t1 = Instant.parse("2025-01-01T00:00:00Z");
+    final var t2 = Instant.parse("2025-01-02T00:00:00Z");
+    final var t3 = Instant.parse("2025-01-03T00:00:00Z");
+    final var t4 = Instant.parse("2025-01-04T00:00:00Z");
+
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var marker = entry(2, 200, t2, CheckpointType.MARKER, OptionalLong.empty());
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
+
+    final var meta = metadata(1, List.of(cp1, marker, cp3, cp4), List.of(new RangeEntry(1, 4)));
+
+    // when – exportedPosition=250 is between marker(pos=200) and cp3(pos=300);
+    // cp1(pos=100) is the last backup before exportedPosition and must be kept
+    final var result = RestorePointResolver.resolve(List.of(meta), null, null, Map.of(1, 250L));
+
+    // then – cp1 must not be trimmed; it is the safe starting snapshot
+    assertThat(result.globalCheckpointId()).isEqualTo(4);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp1, cp3, cp4);
+  }
+
+  @Test
+  void shouldNotTrimSafeBackupWhenMarkerIsInterspersedBeforeFromTimestamp() {
+    // given – a MARKER sits between the last backup before 'from' and the first backup >= 'from'
+    final var t1 = Instant.parse("2025-01-01T00:00:00Z");
+    final var t2 = Instant.parse("2025-01-15T00:00:00Z");
+    final var t3 = Instant.parse("2025-02-01T00:00:00Z");
+    final var t4 = Instant.parse("2025-03-01T00:00:00Z");
+
+    final var cp1 = entry(1, 100, t1, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(50));
+    final var marker = entry(2, 200, t2, CheckpointType.MARKER, OptionalLong.empty());
+    final var cp3 = entry(3, 300, t3, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(101));
+    final var cp4 = entry(4, 400, t4, CheckpointType.SCHEDULED_BACKUP, OptionalLong.of(301));
+
+    final var meta = metadata(1, List.of(cp1, marker, cp3, cp4), List.of(new RangeEntry(1, 4)));
+
+    // when – from=Jan 20 is between marker(t2=Jan 15) and cp3(t3=Feb 1);
+    // the first backup-type checkpoint at or after 'from' is cp3
+    final var from = Instant.parse("2025-01-20T00:00:00Z");
+    final var result = RestorePointResolver.resolve(List.of(meta), from, null, Map.of());
+
+    // then – cp1 is trimmed (before 'from'), marker is skipped, restore starts from cp3
+    assertThat(result.globalCheckpointId()).isEqualTo(4);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(cp3, cp4);
   }
 
   private static CheckpointEntry entry(


### PR DESCRIPTION
# Description
Backport of #48185 to `stable/8.9`.

relates to 