### PR TITLE
fix: fix frontend version on 8.9

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-frontend",
-  "version": "8.10.0-SNAPSHOT",
+  "version": "8.9.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-frontend",
-      "version": "8.10.0-SNAPSHOT",
+      "version": "8.9.0-SNAPSHOT",
       "dependencies": {
         "@camunda/camunda-api-zod-schemas": "0.0.51",
         "@camunda/camunda-composite-components": "0.22.1",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "identity-frontend",
   "private": true,
-  "version": "8.10.0-SNAPSHOT",
+  "version": "8.9.0-SNAPSHOT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camunda-operate",
-  "version": "8.10.0-SNAPSHOT",
+  "version": "8.9.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "camunda-operate",
-      "version": "8.10.0-SNAPSHOT",
+      "version": "8.9.0-SNAPSHOT",
       "dependencies": {
         "@axe-core/playwright": "4.11.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-operate",
-  "version": "8.10.0-SNAPSHOT",
+  "version": "8.9.0-SNAPSHOT",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camunda-tasklist",
-  "version": "8.10.0-SNAPSHOT",
+  "version": "8.9.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "camunda-tasklist",
-      "version": "8.10.0-SNAPSHOT",
+      "version": "8.9.0-SNAPSHOT",
       "dependencies": {
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.19.0",

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-tasklist",
-  "version": "8.10.0-SNAPSHOT",
+  "version": "8.9.0-SNAPSHOT",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We use the `package.json` version to render the component version on the UI. By accident we backported the 8.10 update.

[This was reported on this thread](https://camunda.slack.com/archives/C08MRKHJ0CD/p1773330388405079)
