### PR TITLE
fix: fix batch operation actions tooltip alignment

### DIFF
--- a/operate/client/src/App/BatchOperation/OperationActions.tsx
+++ b/operate/client/src/App/BatchOperation/OperationActions.tsx
@@ -110,7 +110,12 @@ const OperationsActions: React.FC<Props> = ({
         </Button>
       )}
       {allowedActions.includes('CANCEL') && (
-        <OverflowMenu size="md" aria-label="overflow-menu" flipped>
+        <OverflowMenu
+          size="md"
+          aria-label="overflow-menu"
+          flipped
+          align="bottom-end"
+        >
           <OverflowMenuItem
             itemText="Cancel"
             isDelete

--- a/operate/client/src/App/BatchOperation/index.tsx
+++ b/operate/client/src/App/BatchOperation/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import React, {useEffect} from 'react';
+import {useEffect} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
 import {IconButton, InlineNotification, SkeletonText} from '@carbon/react';
 import {ArrowLeft} from '@carbon/react/icons';


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes the tooltip alignment

<img width="183" height="241" alt="Screenshot 2026-03-16 at 12 35 56" src="https://github.com/user-attachments/assets/ad2872f2-4dae-41e8-bc09-218c7ae2af78" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48386
