### PR TITLE
test: enable Slack Reporting for API tests with rdbms

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -5,9 +5,13 @@
 ---
 name: C8 Orchestration Cluster E2E Tests Nightly
 
+#on:
+#  schedule:
+#    - cron: "0 0 * * *" # Run all tests at midnight UTC
+
 on:
-  schedule:
-    - cron: "0 0 * * *" # Run all tests at midnight UTC
+  pull_request:
+    types: [opened, edited, synchronize]  # Triggers on PR open, new comits on PR and when the PR description is edited
 
 permissions:
   contents: read
@@ -18,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [stable/8.6, stable/8.7, stable/8.8, stable/8.9, main]
+        branch: [test-update-api-workflow]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -221,7 +225,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [stable/8.9, main]
+        branch: [test-update-api-workflow]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions: {}
@@ -230,6 +234,20 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
 
       - uses: ./.github/actions/setup-build
         with:
@@ -341,6 +359,8 @@ jobs:
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
           DATABASE: "RDBMS"
+          INCLUDE_SLACK_REPORTER: true
+          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
         run: npm run test -- --project=api-tests
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
@@ -350,12 +370,61 @@ jobs:
           if [ -f dev-dist/camunda.pid ]; then
             kill "$(cat dev-dist/camunda.pid)" 2>/dev/null || true
           fi
+
+      - name: Publish test results to TestRail
+        if: always()
+        shell: bash
+        env:
+          TESTRAIL_HOST: "https://camunda.testrail.com/"
+          TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }} # Use the imported secret
+          TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
+          JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
+          BRANCH_NAME: ${{ matrix.branch }}
+        run: |
+          pip install trcli
+          trcli -y -h "$TESTRAIL_HOST" \
+            --project 'C8' \
+            --username "$TESTRAIL_USERNAME" \
+            --key "$TESTRAIL_KEY" \
+            parse_junit --suite-id 17050 \
+            --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME - API tests - RDBMS - $(date '+%Y-%m-%d %H:%M:%S')" \
+            --close-run \
+            -f "$JUNIT_RESULTS_FILE"
+
+      - name: Sanitize branch name for artifact names
+        id: sanitize
+        if: always()
+        shell: bash
+        run: |
+          branch="${{ matrix.branch }}"
+          # Replace invalid artifact-name characters (at least '/')
+          safe_branch="${branch//\//-}"
+          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: json-report-nightly-api-rdbms-${{ steps.sanitize.outputs.safe_branch }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "c8-orchestration-cluster-e2e-nightly-api-rdbms-tests/${{ matrix.branch }}"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
   nightly-tests:
     name: nightly-tests (${{ matrix.branch }} - Tasklist ${{ matrix.tasklist_mode }} mode)
     strategy:
       fail-fast: false
       matrix:
-        branch: [stable/8.6, stable/8.7, stable/8.8, stable/8.9, main]
+        branch: [test-update-api-workflow]
         tasklist_mode: [v1, v2]
         exclude:
           # V2 mode only supported on main branch - exclude V2 for older branches

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -5,13 +5,9 @@
 ---
 name: C8 Orchestration Cluster E2E Tests Nightly
 
-#on:
-#  schedule:
-#    - cron: "0 0 * * *" # Run all tests at midnight UTC
-
 on:
-  pull_request:
-    types: [opened, edited, synchronize]  # Triggers on PR open, new comits on PR and when the PR description is edited
+  schedule:
+    - cron: "0 0 * * *" # Run all tests at midnight UTC
 
 permissions:
   contents: read
@@ -22,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [test-update-api-workflow]
+        branch: [stable/8.6, stable/8.7, stable/8.8, stable/8.9, main]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -225,7 +221,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [test-update-api-workflow]
+        branch: [stable/8.9, main]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions: {}
@@ -361,6 +357,7 @@ jobs:
           DATABASE: "RDBMS"
           INCLUDE_SLACK_REPORTER: true
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          API_TESTS_ONLY: true
         run: npm run test -- --project=api-tests
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
@@ -424,7 +421,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [test-update-api-workflow]
+        branch: [stable/8.6, stable/8.7, stable/8.8, stable/8.9, main]
         tasklist_mode: [v1, v2]
         exclude:
           # V2 mode only supported on main branch - exclude V2 for older branches

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -44,7 +44,7 @@ const useReportersWithSlack: any[] = [
     './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
     {
       slackOAuthToken: process.env.SLACK_BOT_USER_OAUTH_TOKEN!,
-      channels: ['prj-qa-sandbox'],
+      channels: ['c8-orchestration-cluster-e2e-test-results'],
       sendResults: 'always',
       showInThread: true,
       meta: [

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -44,7 +44,7 @@ const useReportersWithSlack: any[] = [
     './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
     {
       slackOAuthToken: process.env.SLACK_BOT_USER_OAUTH_TOKEN!,
-      channels: ['c8-orchestration-cluster-e2e-test-results'],
+      channels: ['prj-qa-sandbox'],
       sendResults: 'always',
       showInThread: true,
       meta: [


### PR DESCRIPTION
## Description

Enabled Slack reporting for RDBMS.

Triggered [this run](https://github.com/camunda/camunda/actions/runs/23140634154/job/67215707541) for test purposes. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
