### PR TITLE
test: mapping rule tenant api tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-mapping-rule-api-tests.spec.ts
@@ -1,0 +1,339 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+  assertStatusCode,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assertMappingRulesInResponse,
+  assignMappingRulesToTenant,
+  createMappingRule,
+  createTenant,
+  mappingRuleIdFromState,
+} from '@requestHelpers';
+import {MAPPING_RULES_EXPECTED_BODY} from '../../../../utils/beans/requestBeans';
+import { validateResponse } from 'json-body-assertions';
+
+test.describe.serial('Tenant Mapping Rule API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createTenant(request, state, '1');
+    await createTenant(request, state, '2');
+    await createTenant(request, state, '3');
+    await assignMappingRulesToTenant(request, 2, 'tenantId1', state);
+    await assignMappingRulesToTenant(request, 1, 'tenantId2', state);
+    await assignMappingRulesToTenant(request, 3, 'tenantId3', state);
+  });
+
+  test('Assign Mapping Rule To Tenant', async ({request}) => {
+    const ruleBody = await createMappingRule(request);
+    const p = {
+      mappingRuleId: ruleBody.mappingRuleId as string,
+      tenantId: state['tenantId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(res, 204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Mapping Rule To Tenant Non Existent Mapping Rule Not Found', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      mappingRuleId: 'invalidMappingRuleId',
+      tenantId: state['tenantId1'] as string,
+    };
+
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Mapping Rule To Tenant Non Existent Tenant Not Found', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      mappingRuleId: mappingRuleIdFromState('tenantId1', state) as string,
+      tenantId: 'invalidTenantId',
+    };
+
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Mapping Rule To Tenant Unauthorized', async ({request}) => {
+    const stateParams: Record<string, string> = {
+      mappingRuleId: mappingRuleIdFromState('tenantId1', state) as string,
+      tenantId: state['tenantId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl(
+          '/tenants/{tenantId}/mapping-rules/{mappingRuleId}',
+          stateParams,
+        ),
+        {
+          headers: {},
+        },
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Mapping Rule To Tenant Conflict', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      mappingRuleId: mappingRuleIdFromState('tenantId1', state) as string,
+      tenantId: state['tenantId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl(
+          '/tenants/{tenantId}/mapping-rules/{mappingRuleId}',
+          stateParams,
+        ),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Unassign Mapping Rule From Tenant', async ({request}) => {
+    const p = {
+      mappingRuleId: mappingRuleIdFromState('tenantId2', state) as string,
+      tenantId: state['tenantId2'] as string,
+    };
+    await test.step('Unassign Mapping Rule From Tenant', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', p),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(res, 204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step(
+      'Search Tenant Mapping Rules After Deletion',
+      async () => {
+        await expect(async () => {
+          const res = await request.post(
+            buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
+            {
+              headers: jsonHeaders(),
+              data: {},
+            },
+          );
+
+          await assertStatusCode(res, 200);
+          await validateResponse(
+            {
+                path: '/tenants/{tenantId}/mapping-rules/search',
+                method: 'POST',
+                status: '200',
+            },
+            res,
+          );
+          const json = await res.json();
+          expect(json.page.totalItems).toBe(0);
+        }).toPass(defaultAssertionOptions);
+      },
+    );
+  });
+
+  test('Unassign Mapping Rule From Tenant Unauthorized', async ({request}) => {
+    const p = {
+      mappingRuleId: mappingRuleIdFromState('tenantId2', state) as string,
+      tenantId: state['tenantId2'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Mapping Rule From Tenant Non Existent Mapping Rule Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      mappingRuleId: 'invalidMappingRuleId',
+      tenantId: state['tenantId2'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Mapping Rule From Tenant Non Existent Tenant Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      mappingRuleId: mappingRuleIdFromState('tenantId2', state) as string,
+      tenantId: 'invalidTenantId',
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Search Tenant Mapping Rules', async ({request}) => {
+    const p = {tenantId: state['tenantId3'] as string};
+    const rule1 = mappingRuleIdFromState('tenantId3', state, 1);
+    const rule2 = mappingRuleIdFromState('tenantId3', state, 2);
+    const rule3 = mappingRuleIdFromState('tenantId3', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+            path: '/tenants/{tenantId}/mapping-rules/search',
+            method: 'POST',
+            status: '200',
+        },
+        res,
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 3,
+        totalItemsEqualTo: 3,
+      });
+      const json = await res.json();
+      assertMappingRulesInResponse(
+        json,
+        MAPPING_RULES_EXPECTED_BODY(rule1),
+        rule1,
+      );
+      assertMappingRulesInResponse(
+        json,
+        MAPPING_RULES_EXPECTED_BODY(rule2),
+        rule2,
+      );
+      assertMappingRulesInResponse(
+        json,
+        MAPPING_RULES_EXPECTED_BODY(rule3),
+        rule3,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenant Mapping Rules Tenant With No Assignments Returns Empty', async ({
+    request,
+  }) => {
+    const tenant = await createTenant(request);
+    const p = {tenantId: tenant.tenantId as string};
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+            path: '/tenants/{tenantId}/mapping-rules/search',
+            method: 'POST',
+            status: '200',
+        },
+        res,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenant Mapping Rules Unauthorized', async ({request}) => {
+    const p = {tenantId: state['tenantId3'] as string};
+    const res = await request.post(
+      buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Tenant Mapping Rules Tenant Not Found', async ({request}) => {
+    const p = {tenantId: 'invalid-tenant-id'};
+    const res = await request.post(
+      buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+          path: '/tenants/{tenantId}/mapping-rules/search',
+          method: 'POST',
+          status: '200',
+      },
+      res,
+    );
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-mapping-rule-api-tests.spec.ts
@@ -25,7 +25,7 @@ import {
   mappingRuleIdFromState,
 } from '@requestHelpers';
 import {MAPPING_RULES_EXPECTED_BODY} from '../../../../utils/beans/requestBeans';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 test.describe.serial('Tenant Mapping Rule API Tests', () => {
   const state: Record<string, unknown> = {};
@@ -66,7 +66,10 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     };
 
     const res = await request.put(
-      buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', stateParams),
+      buildUrl(
+        '/tenants/{tenantId}/mapping-rules/{mappingRuleId}',
+        stateParams,
+      ),
       {
         headers: jsonHeaders(),
       },
@@ -86,7 +89,10 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     };
 
     const res = await request.put(
-      buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', stateParams),
+      buildUrl(
+        '/tenants/{tenantId}/mapping-rules/{mappingRuleId}',
+        stateParams,
+      ),
       {
         headers: jsonHeaders(),
       },
@@ -145,6 +151,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
       mappingRuleId: mappingRuleIdFromState('tenantId2', state) as string,
       tenantId: state['tenantId2'] as string,
     };
+
     await test.step('Unassign Mapping Rule From Tenant', async () => {
       await expect(async () => {
         const res = await request.delete(
@@ -157,35 +164,34 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
       }).toPass(defaultAssertionOptions);
     });
 
-    await test.step(
-      'Search Tenant Mapping Rules After Deletion',
-      async () => {
-        await expect(async () => {
-          const res = await request.post(
-            buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
-            {
-              headers: jsonHeaders(),
-              data: {},
-            },
-          );
+    await test.step('Search Tenant Mapping Rules After Deletion', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
+          {
+            headers: jsonHeaders(),
+            data: {},
+          },
+        );
 
-          await assertStatusCode(res, 200);
-          await validateResponse(
-            {
-                path: '/tenants/{tenantId}/mapping-rules/search',
-                method: 'POST',
-                status: '200',
-            },
-            res,
-          );
-          const json = await res.json();
-          expect(json.page.totalItems).toBe(0);
-        }).toPass(defaultAssertionOptions);
-      },
-    );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/tenants/{tenantId}/mapping-rules/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        expect(json.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
   });
 
-  test('Unassign Mapping Rule From Tenant - Unauthorized', async ({request}) => {
+  test('Unassign Mapping Rule From Tenant - Unauthorized', async ({
+    request,
+  }) => {
     const p = {
       mappingRuleId: mappingRuleIdFromState('tenantId2', state) as string,
       tenantId: state['tenantId2'] as string,
@@ -251,9 +257,9 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
       await assertStatusCode(res, 200);
       await validateResponse(
         {
-            path: '/tenants/{tenantId}/mapping-rules/search',
-            method: 'POST',
-            status: '200',
+          path: '/tenants/{tenantId}/mapping-rules/search',
+          method: 'POST',
+          status: '200',
         },
         res,
       );
@@ -298,9 +304,9 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
       await assertStatusCode(res, 200);
       await validateResponse(
         {
-            path: '/tenants/{tenantId}/mapping-rules/search',
-            method: 'POST',
-            status: '200',
+          path: '/tenants/{tenantId}/mapping-rules/search',
+          method: 'POST',
+          status: '200',
         },
         res,
       );
@@ -316,7 +322,9 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  test('Search Tenant Mapping Rules Tenant Not Found - Not Found', async ({request}) => {
+  test('Search Tenant Mapping Rules Tenant Not Found - Not Found', async ({
+    request,
+  }) => {
     const p = {tenantId: 'invalid-tenant-id'};
     const res = await request.post(
       buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
@@ -325,9 +333,9 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     await assertStatusCode(res, 200);
     await validateResponse(
       {
-          path: '/tenants/{tenantId}/mapping-rules/search',
-          method: 'POST',
-          status: '200',
+        path: '/tenants/{tenantId}/mapping-rules/search',
+        method: 'POST',
+        status: '200',
       },
       res,
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-mapping-rule-api-tests.spec.ts
@@ -39,7 +39,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     await assignMappingRulesToTenant(request, 3, 'tenantId3', state);
   });
 
-  test('Assign Mapping Rule To Tenant', async ({request}) => {
+  test('Assign Mapping Rule To Tenant - Success', async ({request}) => {
     const ruleBody = await createMappingRule(request);
     const p = {
       mappingRuleId: ruleBody.mappingRuleId as string,
@@ -57,7 +57,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Assign Mapping Rule To Tenant Non Existent Mapping Rule Not Found', async ({
+  test('Assign Mapping Rule To Tenant Non Existent Mapping Rule - Not Found', async ({
     request,
   }) => {
     const stateParams: Record<string, string> = {
@@ -77,7 +77,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     );
   });
 
-  test('Assign Mapping Rule To Tenant Non Existent Tenant Not Found', async ({
+  test('Assign Mapping Rule To Tenant Non Existent Tenant - Not Found', async ({
     request,
   }) => {
     const stateParams: Record<string, string> = {
@@ -97,7 +97,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     );
   });
 
-  test('Assign Mapping Rule To Tenant Unauthorized', async ({request}) => {
+  test('Assign Mapping Rule To Tenant - Unauthorized', async ({request}) => {
     const stateParams: Record<string, string> = {
       mappingRuleId: mappingRuleIdFromState('tenantId1', state) as string,
       tenantId: state['tenantId1'] as string,
@@ -117,7 +117,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Assign Already Added Mapping Rule To Tenant Conflict', async ({
+  test('Assign Already Added Mapping Rule To Tenant - Conflict', async ({
     request,
   }) => {
     const stateParams: Record<string, string> = {
@@ -140,7 +140,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Unassign Mapping Rule From Tenant', async ({request}) => {
+  test('Unassign Mapping Rule From Tenant - Success', async ({request}) => {
     const p = {
       mappingRuleId: mappingRuleIdFromState('tenantId2', state) as string,
       tenantId: state['tenantId2'] as string,
@@ -185,7 +185,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     );
   });
 
-  test('Unassign Mapping Rule From Tenant Unauthorized', async ({request}) => {
+  test('Unassign Mapping Rule From Tenant - Unauthorized', async ({request}) => {
     const p = {
       mappingRuleId: mappingRuleIdFromState('tenantId2', state) as string,
       tenantId: state['tenantId2'] as string,
@@ -199,7 +199,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  test('Unassign Mapping Rule From Tenant Non Existent Mapping Rule Not Found', async ({
+  test('Unassign Mapping Rule From Tenant Non Existent Mapping Rule - Not Found', async ({
     request,
   }) => {
     const p = {
@@ -218,7 +218,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     );
   });
 
-  test('Unassign Mapping Rule From Tenant Non Existent Tenant Not Found', async ({
+  test('Unassign Mapping Rule From Tenant Non Existent Tenant - Not Found', async ({
     request,
   }) => {
     const p = {
@@ -237,7 +237,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     );
   });
 
-  test('Search Tenant Mapping Rules', async ({request}) => {
+  test('Search Tenant Mapping Rules - Success', async ({request}) => {
     const p = {tenantId: state['tenantId3'] as string};
     const rule1 = mappingRuleIdFromState('tenantId3', state, 1);
     const rule2 = mappingRuleIdFromState('tenantId3', state, 2);
@@ -280,7 +280,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Tenant Mapping Rules Tenant With No Assignments Returns Empty', async ({
+  test('Search Tenant Mapping Rules Tenant With No Assignments Returns Empty - Success', async ({
     request,
   }) => {
     const tenant = await createTenant(request);
@@ -307,7 +307,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Tenant Mapping Rules Unauthorized', async ({request}) => {
+  test('Search Tenant Mapping Rules - Unauthorized', async ({request}) => {
     const p = {tenantId: state['tenantId3'] as string};
     const res = await request.post(
       buildUrl('/tenants/{tenantId}/mapping-rules/search', p),
@@ -316,7 +316,7 @@ test.describe.serial('Tenant Mapping Rule API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  test('Search Tenant Mapping Rules Tenant Not Found', async ({request}) => {
+  test('Search Tenant Mapping Rules Tenant Not Found - Not Found', async ({request}) => {
     const p = {tenantId: 'invalid-tenant-id'};
     const res = await request.post(
       buildUrl('/tenants/{tenantId}/mapping-rules/search', p),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -667,6 +667,12 @@ export function ROLES_EXPECTED_BODY(roleId: string) {
   };
 }
 
+export function MAPPING_RULES_EXPECTED_BODY(mappingRuleId: string) {
+  return {
+    mappingRuleId: mappingRuleId,
+  };
+}
+
 export function CREATE_COMPONENT_AUTHORIZATION(
   ownerType: 'ROLE' | 'USER' | 'GROUP',
   ownerId: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -20,6 +20,8 @@ export {createTenantAndStoreResponseFields} from './tenant-requestHelpers';
 export {assignGroupsToTenant} from './tenant-requestHelpers';
 export {assignRolesToTenant} from './tenant-requestHelpers';
 export {assertRolesInResponse} from './tenant-requestHelpers';
+export {assignMappingRulesToTenant} from './tenant-requestHelpers';
+export {assertMappingRulesInResponse} from './tenant-requestHelpers';
 export {createTenant} from './tenant-requestHelpers';
 export {assignClientsToTenant} from './tenant-requestHelpers';
 export {assignUsersToTenant} from './tenant-requestHelpers';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
@@ -10,6 +10,7 @@ import type {APIRequestContext} from 'playwright-core';
 import {
   groupIdFromState,
   roleIdValueUsingKey,
+  mappingRuleIdFromState,
 } from './get-value-from-state-requestHelpers';
 import {
   assertEqualsForKeys,
@@ -24,12 +25,14 @@ import {
   CREATE_NEW_TENANT,
   roleRequiredFields,
   tenantRequiredFields,
+  mappingRuleRequiredFields,
 } from '../beans/requestBeans';
 import {Serializable} from 'playwright-core/types/structs';
 import {createGroupAndStoreResponseFields} from './group-requestHelpers';
 import {createUser} from './user-requestHelpers';
 import {validateResponse} from 'json-body-assertions';
 import {createRole} from './role-requestHelpers';
+import {createMappingRule} from './role-requestHelpers';
 
 export async function assignUsersToTenant(
   request: APIRequestContext,
@@ -163,6 +166,29 @@ export async function assignRolesToTenant(
   }
 }
 
+export async function assignMappingRulesToTenant(
+  request: APIRequestContext,
+  numberOfMappingRules: number,
+  tenantIdKey: string,
+  state: Record<string, unknown>,
+) {
+  const tenantId = state[tenantIdKey] as string;
+  for (let i = 1; i <= numberOfMappingRules; i++) {
+    await createMappingRule(request, state, `${tenantId}${i}`);
+    const p = {
+      mappingRuleId: mappingRuleIdFromState(tenantIdKey, state, i) as string,
+      tenantId: tenantId as string,
+    };
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertStatusCode(res, 204);
+  }
+}
+
 export function assertRolesInResponse(
   json: Serializable,
   expectedBody: Serializable,
@@ -174,6 +200,19 @@ export function assertRolesInResponse(
   expect(matchingItem).toBeDefined();
   assertRequiredFields(matchingItem, roleRequiredFields);
   assertEqualsForKeys(matchingItem, expectedBody, ['roleId']);
+}
+
+export function assertMappingRulesInResponse(
+  json: Serializable,
+  expectedBody: Serializable,
+  mappingRuleId: string,
+) {
+  const matchingItem = json.items.find(
+    (it: {mappingRuleId: string}) => it.mappingRuleId === mappingRuleId,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, mappingRuleRequiredFields);
+  assertEqualsForKeys(matchingItem, expectedBody, ['mappingRuleId']);
 }
 
 export function assertTenantInResponse(


### PR DESCRIPTION
## Description

Added E2E API tests for the Tenant Mapping Rule endpoints `/tenants/{tenantId}/mapping-rules/*`, covering assign, unassign, and search operations:

- Assign mapping-rule To Tenant (success, not found for invalid mapping-rule/tenant, unauthorized, conflict for duplicate)
- Unassign mapping-rule From Tenant (success with search verification, unauthorized, not found for invalid mapping-rule/tenant)
- Search Tenant mapping-rule

Helper functions added: `assignMappingRulesToTenant()`, `assertMappingRulesInResponse()`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/62)

## On demand workflow
[Was all green](https://github.com/camunda/camunda/actions/runs/23210715793)
