### PR TITLE
fix(cpt): Reduce the connector polling interval

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ConnectorsContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ConnectorsContainer.java
@@ -33,6 +33,9 @@ import org.testcontainers.utility.DockerImageName;
 public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
 
   private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
+
+  private static final String DEFAULT_CONNECTOR_POLLING_INTERVAL_IN_MILLIS = "500";
+
   private static final String CONNECTORS_READY_ENDPOINT = "/actuator/health/readiness";
 
   private static final String LOG_APPENDER_STACKDRIVER = "stackdriver";
@@ -47,6 +50,9 @@ public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
         .waitingFor(newDefaultWaitStrategy())
         .withEnv("management.endpoints.web.exposure.include", "health")
         .withEnv("management.endpoint.health.probes.enabled", "true")
+        .withEnv(
+            ContainerRuntimeEnvs.CONNECTORS_ENV_POLLING_INTERVAL,
+            DEFAULT_CONNECTOR_POLLING_INTERVAL_IN_MILLIS)
         .withEnv(ContainerRuntimeEnvs.CONNECTORS_ENV_LOG_APPENDER, LOG_APPENDER_STACKDRIVER)
         .addExposedPorts(ContainerRuntimePorts.CONNECTORS_REST_API);
   }
@@ -77,13 +83,6 @@ public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
         .withEnv(
             ContainerRuntimeEnvs.CONNECTORS_ENV_CAMUNDA_CLIENT_WORKER_DEFAULTS_TENANTIDS,
             MultiTenancyConfiguration.CAMUNDA_CLIENT_WORKER_DEFAULTS_TENANTIDS)
-        /*
-         * Basic Auth has a very limited request throughput, requiring tests with multitenancy to have an increased
-         * polling interval so as to not cause timeout exceptions.
-         */
-        .withEnv(
-            ContainerRuntimeEnvs.CONNECTORS_ENV_POLLING_INTERVAL,
-            MultiTenancyConfiguration.POLLING_INTERVAL)
         .waitingFor(newBasicAuthWaitStrategy());
 
     return this;
@@ -138,6 +137,5 @@ public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
         CamundaContainer.MultiTenancyConfiguration.MULTITENANCY_USER_PASSWORD;
     private static final String CAMUNDA_CLIENT_TENANTID = "<default>";
     private static final String CAMUNDA_CLIENT_WORKER_DEFAULTS_TENANTIDS = "<default>";
-    private static final String POLLING_INTERVAL = "1000";
   }
 }


### PR DESCRIPTION
## Description

Set the connector polling interval to 500 milliseconds to reduce the import latency.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Following a suggestion from the Connectors team. 
