### PR TITLE
[Backport stable/8.9] Exclude bpmn-related decision evaluations from the audit log

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -13,9 +13,11 @@ import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForDecisionsToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForJobs;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
+import static io.camunda.it.util.TestHelper.waitUntilJobExistsForProcessInstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
@@ -69,6 +71,7 @@ public class AuditLogProcessOperationsIT {
   private static final String INCIDENT_PROCESS_ID = "incident_process_v1";
   private static final String SERVICE_TASKS_PROCESS_ID = "service_tasks_v1";
   private static final String DECISION_ID = "decision_1";
+  private static final String PROCESS_WITH_BUSINESS_RULE_TASK_ID = "business_rule_task_process";
   private static CamundaClient adminClient;
   private static AuditLogUtils utils;
 
@@ -86,7 +89,8 @@ public class AuditLogProcessOperationsIT {
                 "process/migration-process_v2.bpmn",
                 "process/service_tasks_v1.bpmn",
                 "process/incident_process_v1.bpmn",
-                "decisions/decision_model.dmn")
+                "decisions/decision_model.dmn",
+                "process/business_rule_task_process.bpmn")
             .map(
                 resource ->
                     adminClient
@@ -95,10 +99,9 @@ public class AuditLogProcessOperationsIT {
                         .tenantId(TENANT_A)
                         .send())
             .toList();
-
     deploymentFutures.forEach(CamundaFuture::join);
 
-    waitForProcessesToBeDeployed(adminClient, 4);
+    waitForProcessesToBeDeployed(adminClient, 5);
     waitForDecisionsToBeDeployed(adminClient, 1, 1);
 
     final var sharedInstance =
@@ -517,6 +520,49 @@ public class AuditLogProcessOperationsIT {
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = auditLogItems.getFirst();
     assertDecisionAuditLog(auditLog, AuditLogOperationTypeEnum.EVALUATE);
+  }
+
+  @Test
+  void shouldNotTrackDecisionEvaluationTriggeredByBusinessRuleTask(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // given - start a process instance that evaluates the decision via a business rule task
+    final var processInstance =
+        createProcessInstance(
+            client, PROCESS_WITH_BUSINESS_RULE_TASK_ID, Map.of("age", 25, "income", 30000));
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+
+    // when - the process completes (the BRT evaluates the decision internally)
+    waitUntilJobExistsForProcessInstance(client, processInstanceKey);
+    final var activateJobsResponse =
+        client
+            .newActivateJobsCommand()
+            .jobType("milestoneJob")
+            .maxJobsToActivate(1)
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+    client.newCompleteCommand(activateJobsResponse.getJobs().getFirst()).send().join();
+    waitForProcessInstancesToBeCompleted(client, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // then - assert that no DECISION audit log entries exist for this process instance
+    final var auditLogs =
+        client
+            .newAuditLogSearchRequest()
+            .filter(
+                f ->
+                    f.entityType(
+                            filter ->
+                                filter.in(
+                                    AuditLogEntityTypeEnum.DECISION, AuditLogEntityTypeEnum.JOB))
+                        .processInstanceKey(String.valueOf(processInstanceKey)))
+            .send()
+            .join()
+            .items();
+    // We expect only a JOB audit log for the service task, but no DECISION audit log
+    // since the evaluation is triggered by a BRT internally before the job is completed.
+    assertThat(auditLogs).hasSize(1);
+    final var auditLog = auditLogs.getFirst();
+    assertThat(auditLog.getEntityType()).isEqualTo(AuditLogEntityTypeEnum.JOB);
   }
 
   // ========================================================================================

--- a/qa/acceptance-tests/src/test/resources/process/business_rule_task_process.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/business_rule_task_process.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0tkzk9f" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.45.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="business_rule_task_process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_04537cl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_04537cl" sourceRef="StartEvent_1" targetRef="brtTask" />
+    <bpmn:sequenceFlow id="Flow_1boff23" sourceRef="brtTask" targetRef="serviceTask" />
+    <bpmn:endEvent id="Event_0k90mln">
+      <bpmn:incoming>Flow_15cx3kg</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_15cx3kg" sourceRef="serviceTask" targetRef="Event_0k90mln" />
+    <bpmn:businessRuleTask id="brtTask" name="Brt task">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="decision_1" resultVariable="output" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04537cl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1boff23</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:serviceTask id="serviceTask" name="Service Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="milestoneJob" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1boff23</bpmn:incoming>
+      <bpmn:outgoing>Flow_15cx3kg</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process_with_business_rule_task">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0k90mln_di" bpmnElement="Event_0k90mln">
+        <dc:Bounds x="592" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ptwzli_di" bpmnElement="brtTask">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cspizw_di" bpmnElement="serviceTask">
+        <dc:Bounds x="430" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_04537cl_di" bpmnElement="Flow_04537cl">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1boff23_di" bpmnElement="Flow_1boff23">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="430" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15cx3kg_di" bpmnElement="Flow_15cx3kg">
+        <di:waypoint x="530" y="120" />
+        <di:waypoint x="592" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformer.java
@@ -59,7 +59,7 @@ public interface AuditLogTransformer<R extends RecordValue> {
 
   default void transform(final Record<R> record, final AuditLogEntry log) {}
 
-  default boolean supports(final Record<?> record) {
+  default boolean supports(final Record<R> record) {
     return config().supports(record);
   }
 

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
@@ -47,4 +47,11 @@ public class DecisionEvaluationAuditLogTransformer
       log.setResult(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);
     }
   }
+
+  @Override
+  public boolean supports(final Record<DecisionEvaluationRecordValue> record) {
+    final var decisionEvaluation = record.getValue();
+    final var isStandaloneDecision = decisionEvaluation.getProcessDefinitionKey() == -1L;
+    return isStandaloneDecision && AuditLogTransformer.super.supports(record);
+  }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
@@ -27,9 +27,9 @@ public class VariableAddUpdateAuditLogTransformer
   }
 
   @Override
-  public boolean supports(final Record<?> record) {
-    final VariableRecordValue value = (VariableRecordValue) record.getValue();
-    return AuditLogTransformer.super.supports(record)
-        && VariableOperationType.API.equals(value.getSource().getType());
+  public boolean supports(final Record<VariableRecordValue> record) {
+    final VariableRecordValue value = record.getValue();
+    return VariableOperationType.API.equals(value.getSource().getType())
+        && AuditLogTransformer.super.supports(record);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
@@ -287,6 +287,26 @@ class DecisionEvaluationAuditLogTransformerTest {
     assertThat(entity.getEntityDescription()).isEqualTo(RejectionType.INVALID_STATE.name());
   }
 
+  @Test
+  void shouldNotSupportDecisionEvaluationRecordWithProcessInstanceKey() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withProcessInstanceKey(123L)
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when / then
+    assertThat(transformer.supports(record)).isFalse();
+  }
+
   @ParameterizedTest
   @EnumSource(
       value = DecisionEvaluationIntent.class,

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -260,6 +260,16 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
   public DecisionEvaluationRecord setEvaluationFailureMessage(
       final String evaluationFailureMessage) {
     evaluationFailureMessageProp.setValue(evaluationFailureMessage);
@@ -333,16 +343,6 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
 
   public DecisionEvaluationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
-    return this;
-  }
-
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public DecisionEvaluationRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 }


### PR DESCRIPTION
# Description
Backport of #48349 to `stable/8.9`.

relates to #48329