### PR TITLE
fix: configure firstUser password for camunda-platform 14.x

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/secrets.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/secrets.yml
@@ -12,9 +12,9 @@ metadata:
     {{- include "commonAnnotations" $ | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.camundaPlatform.identity.firstUser.existingSecret }}
-  # Identity login.
-  {{ .Values.camundaPlatform.identity.firstUser.existingSecretKey }}: "{{ .Values.camundaPlatform.identity.firstUser.username | b64enc }}"
+  {{- if .Values.camundaPlatform.identity.firstUser.secret.existingSecret }}
+  # Identity first user password (demo user for smoke tests).
+  {{ .Values.camundaPlatform.identity.firstUser.secret.existingSecretKey }}: "{{ .Values.camundaPlatform.identity.firstUser.username | b64enc }}"
   {{- end }}
   {{- if .Values.camundaPlatform.identityKeycloak.auth.existingSecret }}
   # Identity Keycloak login.

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -259,6 +259,12 @@ camunda-platform:
     fullURL: https://{{ include "ingress.domain" . }}{{ .Values.identity.contextPath }}
     # image:
     #     repository: camunda/identity
+    firstUser:
+      enabled: true
+      username: demo
+      secret:
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-firstuser-password
     resources:
       limits:
         cpu: "1"


### PR DESCRIPTION
## Description

The camunda-platform chart 14.0.0-alpha5 removed the deprecated `identity.firstUser.password` and `identity.firstUser.existingSecret` defaults. The new secret mechanism (`identity.firstUser.secret.*`) must be explicitly configured.

Without this, the demo user is created in Keycloak without a password, causing a NullPointerException in PasswordCredentialProvider.isValid() when the smoke tests attempt to log in.

Changes:
- values.yaml: add identity.firstUser.secret config pointing to camunda-credentials secret with key identity-firstuser-password
- secrets.yml: update template to reference the new secret path

Test: https://github.com/camunda/camunda/actions/runs/23144630441

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
