### PR TITLE
[Backport stable/8.8] perf: decouple CamundaExporter flushing with async CompletableFuture-based flush

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -38,7 +38,6 @@ import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE_DOCUMENT;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ConfigValidator;
 import io.camunda.exporter.config.ExporterConfiguration;
-import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.ExporterBatchWriter;
@@ -62,11 +61,16 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,6 +93,10 @@ public class CamundaExporter implements Exporter {
   private int partitionId;
   private Context context;
   private long lastFlushTimestamp = 0L;
+  private CompletableFuture<Void> pendingFlush;
+  private long pendingFlushPosition = -1;
+  private ExecutorService flushExecutor;
+  private Timer.Sample latencySample;
 
   private long flushDelayMs;
 
@@ -136,6 +144,9 @@ public class CamundaExporter implements Exporter {
       }
 
       writer = createBatchWriter();
+      flushExecutor =
+          Executors.newSingleThreadExecutor(
+              r -> new Thread(r, "camunda-exporter-flush-partition-" + partitionId));
 
       checkImportersCompletedAndReschedule();
       controller.readMetadata().ifPresent(metadata::deserialize);
@@ -154,11 +165,17 @@ public class CamundaExporter implements Exporter {
 
     if (writer != null) {
       try {
-        flush();
+        waitForCurrentFlushToComplete();
+        flushSynchronously();
         writer = null;
       } catch (final Exception e) {
         LOG.warn("Failed to flush records before closing exporter.", e);
       }
+    }
+
+    if (flushExecutor != null) {
+      flushExecutor.shutdown();
+      flushExecutor = null;
     }
 
     if (clientAdapter != null) {
@@ -224,7 +241,7 @@ public class CamundaExporter implements Exporter {
     }
 
     if (writer.getBatchSize() == 0) {
-      metrics.startFlushLatencyMeasurement();
+      latencySample = metrics.startFlushLatencyMeasurement();
     }
 
     // adding record is idempotent
@@ -389,13 +406,18 @@ public class CamundaExporter implements Exporter {
   }
 
   private void flushAndReschedule() {
-    final var now = context.clock().millis();
+    long now;
     try {
+      waitForCurrentFlushToComplete();
+      now = context.clock().millis();
       if (now - lastFlushTimestamp >= flushDelayMs) {
         flush();
       }
+    } catch (final ExporterException e) {
+      throw e;
     } catch (final Exception e) {
       LOG.warn("Unexpected exception occurred on periodically flushing bulk, will retry later.", e);
+      now = context.clock().millis();
     }
     scheduleDelayedFlush(now);
   }
@@ -444,21 +466,75 @@ public class CamundaExporter implements Exporter {
 
   private void flush() {
     if (writer.getBatchSize() > 0) {
-      try (final var ignored = metrics.measureFlushDuration()) {
-        metrics.recordBulkSize(writer.getBatchSize());
-        final BatchRequest batchRequest = clientAdapter.createBatchRequest().withMetrics(metrics);
-        writer.flush(batchRequest);
-        metrics.recordFlushOccurrence(Instant.now());
-        metrics.stopFlushLatencyMeasurement();
-        lastFlushTimestamp = context.clock().millis();
-      } catch (final PersistenceException ex) {
-        metrics.recordFailedFlush();
-        throw new ExporterException(ex.getMessage(), ex);
+      waitForCurrentFlushToComplete();
+
+      final var writerToFlush = writer;
+      final var positionToFlush = lastPosition;
+
+      writer = createBatchWriter();
+
+      // We record the flush timestamp at submission time (not after completion) because this
+      // controls the delay-based scheduling. Starting the timer here prevents excessive delays
+      // when the async flush itself takes a long time.
+      lastFlushTimestamp = context.clock().millis();
+
+      final var sampleToFlush = latencySample;
+      latencySample = null;
+
+      pendingFlushPosition = positionToFlush;
+      pendingFlush =
+          CompletableFuture.supplyAsync(
+              () -> {
+                executeBatchFlush(writerToFlush, sampleToFlush);
+                return null;
+              },
+              flushExecutor);
+    }
+  }
+
+  /**
+   * Executes the batch flush for the given writer, recording metrics and stopping the latency
+   * sample. Shared by both async and sync flush paths. On failure, records the failed flush metric
+   * and rethrows as {@link ExporterException}.
+   */
+  private void executeBatchFlush(
+      final ExporterBatchWriter writerToFlush, final Timer.Sample latencySample) {
+    try (final var ignored = metrics.measureFlushDuration()) {
+      metrics.recordBulkSize(writerToFlush.getBatchSize());
+      final BatchRequest batchRequest = clientAdapter.createBatchRequest().withMetrics(metrics);
+      writerToFlush.flush(batchRequest);
+      metrics.recordFlushOccurrence(Instant.now());
+      if (latencySample != null) {
+        latencySample.stop(metrics.getFlushLatencyTimer());
+      }
+    } catch (final Exception e) {
+      metrics.recordFailedFlush();
+      throw new ExporterException(e.getMessage(), e);
+    }
+  }
+
+  private void waitForCurrentFlushToComplete() {
+    if (pendingFlush != null) {
+      try {
+        pendingFlush.join();
+        updateLastExportedPosition(pendingFlushPosition);
+      } catch (final CompletionException e) {
+        final var cause = e.getCause();
+        throw new ExporterException(cause.getMessage(), cause);
+      } finally {
+        pendingFlush = null;
+        pendingFlushPosition = -1;
       }
     }
+  }
 
-    // Update the record counters only after the flush was successful. If the synchronous flush
-    // fails then the exporter will be invoked with the same record again.
+  private void flushSynchronously() {
+    if (writer.getBatchSize() > 0) {
+      executeBatchFlush(writer, latencySample);
+      latencySample = null;
+      lastFlushTimestamp = context.clock().millis();
+    }
+
     updateLastExportedPosition(lastPosition);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -78,7 +78,6 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private final Counter archiverDeletedDocs;
   private final Counter archiverReindexedDocs;
   private final Timer archiverReindexTimer;
-  private Timer.Sample flushLatencyMeasurement;
   private final Timer archivingDuration;
   private final DistributionSummary bulkSize;
   private final Counter bulkOperations;
@@ -274,14 +273,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
     failedFlush.increment();
   }
 
-  public void startFlushLatencyMeasurement() {
-    flushLatencyMeasurement = Timer.start(meterRegistry);
+  public Timer.Sample startFlushLatencyMeasurement() {
+    return Timer.start(meterRegistry);
   }
 
-  public void stopFlushLatencyMeasurement() {
-    if (flushLatencyMeasurement != null) {
-      flushLatencyMeasurement.stop(flushLatency);
-    }
+  public Timer getFlushLatencyTimer() {
+    return flushLatency;
   }
 
   public void recordProcessInstancesArchived(final int count) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -59,7 +59,6 @@ public class CamundaExporterAuthenticationIT {
   void afterEach() {
     if (exporter != null) {
       exporter.close();
-      exporter = null;
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.utils.ExporterThreadLeakExtension;
 import io.camunda.search.schema.exceptions.SearchEngineException;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
@@ -19,13 +20,16 @@ import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
+@ExtendWith(ExporterThreadLeakExtension.class)
 public class CamundaExporterAuthenticationIT {
 
   private static final String ELASTIC_PASSWORD = "PASSWORD";
@@ -40,6 +44,9 @@ public class CamundaExporterAuthenticationIT {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final ExporterTestController controller = new ExporterTestController();
 
+  /** Exporter under test — closed automatically after each test. */
+  private CamundaExporter exporter;
+
   @BeforeEach
   void beforeEach() throws IOException {
     CONFIG.getConnect().setUsername("elastic");
@@ -48,10 +55,18 @@ public class CamundaExporterAuthenticationIT {
     createSchemas(CONFIG);
   }
 
+  @AfterEach
+  void afterEach() {
+    if (exporter != null) {
+      exporter.close();
+      exporter = null;
+    }
+  }
+
   @Test
   void shouldConnectToElasticsearchWithUsernameAndPassword() {
     // given
-    final var exporter = new CamundaExporter();
+    exporter = new CamundaExporter();
 
     final var context =
         new ExporterTestContext()
@@ -67,7 +82,7 @@ public class CamundaExporterAuthenticationIT {
   @Test
   void shouldFailToAuthenticateForWrongCredentials() {
     // given
-    final var exporter = new CamundaExporter();
+    exporter = new CamundaExporter();
     CONFIG.getConnect().setPassword("123");
 
     final var context =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -127,11 +127,9 @@ final class CamundaExporterIT {
   private void closeExporters() {
     if (exporter != null) {
       exporter.close();
-      exporter = null;
     }
     if (secondExporter != null) {
       secondExporter.close();
-      secondExporter = null;
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -770,6 +770,8 @@ final class CamundaExporterIT {
 
       camundaExporter.export(record);
 
+      camundaExporter.close();
+
       // then
       assertThat(controller.getPosition()).isEqualTo(record.getPosition());
       verify(controller, times(1))
@@ -816,6 +818,7 @@ final class CamundaExporterIT {
 
       camundaExporter.export(record);
 
+      camundaExporter.close();
       // if importers completed this would trigger scheduled flush which would result in the
       // record being visible in ES/OS
       controller.runScheduledTasks(Duration.ofSeconds(config.getBulk().getDelay()));
@@ -858,6 +861,7 @@ final class CamundaExporterIT {
               UserIntent.CREATED);
 
       camundaExporter.export(record);
+      camundaExporter.close();
 
       // then
       assertThat(controller.getPosition()).isEqualTo(record.getPosition());
@@ -905,6 +909,7 @@ final class CamundaExporterIT {
               UserIntent.CREATED);
 
       camundaExporter.export(record);
+      camundaExporter.close();
 
       // as the importer state is ignored, this should trigger a flush still resulting in the
       // record being visible in ES/OS
@@ -964,12 +969,13 @@ final class CamundaExporterIT {
               UserIntent.CREATED);
 
       camundaExporter.export(record);
-
       final var record2 =
           factory.generateRecord(
               ValueType.USER,
               r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()),
               UserIntent.CREATED);
+
+      camundaExporter.close();
 
       // then
       assertThatThrownBy(() -> camundaExporter.export(record2))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -259,7 +259,7 @@ final class CamundaExporterIT {
 
     // the export above fails in the async supplier, and it requires a call to .join that future so
     // that the error is surfaced
-    assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(1)))
+    assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(5)))
         .isInstanceOf(ExporterException.class)
         .hasMessageContaining("Connection refused");
 
@@ -429,7 +429,7 @@ final class CamundaExporterIT {
 
     // act
     exporter.export(record);
-    assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(1)))
+    assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(5)))
         .isInstanceOf(ExporterException.class)
         .rootCause()
         .isInstanceOf(PersistenceException.class);
@@ -455,6 +455,7 @@ final class CamundaExporterIT {
 
     // when
     camundaExporter.export(record);
+    camundaExporter.close();
 
     // then
     assertThat(controller.getPosition()).isEqualTo(recordPosition);
@@ -708,6 +709,11 @@ final class CamundaExporterIT {
       controller.resetLastRanAt();
     }
 
+    @AfterEach
+    void teardown() {
+      camundaExporter.close();
+    }
+
     @TestTemplate
     void shouldMarkImportersAsCompletedEvenIfVersion88ZeebeIndicesExist(
         final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
@@ -736,10 +742,11 @@ final class CamundaExporterIT {
               UserIntent.CREATED);
 
       camundaExporter.export(record);
+      camundaExporter.close();
 
       // then
       assertThat(controller.getPosition()).isEqualTo(record.getPosition());
-      verify(controller, times(1))
+      verify(controller, atLeastOnce())
           .updateLastExportedRecordPosition(eq(record.getPosition()), any());
     }
 
@@ -774,7 +781,7 @@ final class CamundaExporterIT {
 
       // then
       assertThat(controller.getPosition()).isEqualTo(record.getPosition());
-      verify(controller, times(1))
+      verify(controller, atLeastOnce())
           .updateLastExportedRecordPosition(eq(record.getPosition()), any());
 
       final var authHandler =
@@ -818,7 +825,6 @@ final class CamundaExporterIT {
 
       camundaExporter.export(record);
 
-      camundaExporter.close();
       // if importers completed this would trigger scheduled flush which would result in the
       // record being visible in ES/OS
       controller.runScheduledTasks(Duration.ofSeconds(config.getBulk().getDelay()));
@@ -865,7 +871,7 @@ final class CamundaExporterIT {
 
       // then
       assertThat(controller.getPosition()).isEqualTo(record.getPosition());
-      verify(controller, times(1))
+      verify(controller, atLeastOnce())
           .updateLastExportedRecordPosition(eq(record.getPosition()), any());
 
       final var authHandler =
@@ -975,8 +981,6 @@ final class CamundaExporterIT {
               r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()),
               UserIntent.CREATED);
 
-      camundaExporter.close();
-
       // then
       assertThatThrownBy(() -> camundaExporter.export(record2))
           .isInstanceOf(IllegalStateException.class)
@@ -984,6 +988,8 @@ final class CamundaExporterIT {
               String.format(
                   "Reached the max bulk size amount of cached records [%d] while waiting for importers to finish",
                   config.getBulk().getSize()));
+
+      camundaExporter.close();
     }
 
     private void indexImportPositionEntity(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -37,6 +37,7 @@ import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.VariableHandler;
 import io.camunda.exporter.utils.CamundaExporterITTemplateExtension;
 import io.camunda.exporter.utils.EntitySizeEstimator;
+import io.camunda.exporter.utils.ExporterThreadLeakExtension;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -80,6 +81,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -91,6 +93,7 @@ import org.testcontainers.containers.GenericContainer;
  * export records using the configured handlers.
  */
 @TestInstance(Lifecycle.PER_CLASS)
+@ExtendWith(ExporterThreadLeakExtension.class)
 final class CamundaExporterIT {
 
   @RegisterExtension private static SearchDBExtension searchDB = SearchDBExtension.create();
@@ -101,8 +104,18 @@ final class CamundaExporterIT {
 
   private final ProtocolFactory factory = new ProtocolFactory();
 
+  /** Primary exporter under test — closed automatically after each test. */
+  private CamundaExporter exporter;
+
+  /**
+   * Secondary exporter used only when a test needs multiple exporters (e.g. different partitions) —
+   * closed automatically after each test.
+   */
+  private CamundaExporter secondExporter;
+
   @AfterEach
   public void afterEach() throws IOException {
+    closeExporters();
     final var openSearchAwsInstanceUrl =
         Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL)).orElse("");
     if (openSearchAwsInstanceUrl.isEmpty()) {
@@ -111,25 +124,36 @@ final class CamundaExporterIT {
     searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
   }
 
+  private void closeExporters() {
+    if (exporter != null) {
+      exporter.close();
+      exporter = null;
+    }
+    if (secondExporter != null) {
+      secondExporter.close();
+      secondExporter = null;
+    }
+  }
+
   @TestTemplate
   void shouldOpenDifferentPartitions(
       final ExporterConfiguration config, final SearchClientAdapter ignored) throws IOException {
     // given
     createSchemas(config);
-    final var p1Exporter = new CamundaExporter();
+    exporter = new CamundaExporter();
     final var p1Context = getContextFromConfig(config, 1);
-    p1Exporter.configure(p1Context);
+    exporter.configure(p1Context);
 
-    final var p2Exporter = new CamundaExporter();
+    secondExporter = new CamundaExporter();
     final var p2Context = getContextFromConfig(config, 2);
-    p2Exporter.configure(p2Context);
+    secondExporter.configure(p2Context);
 
     // when
     final var future =
         CompletableFuture.runAsync(
             () -> {
               final var p1ExporterController = new ExporterTestController();
-              p1Exporter.open(p1ExporterController);
+              exporter.open(p1ExporterController);
             });
 
     // then
@@ -137,7 +161,7 @@ final class CamundaExporterIT {
         .isThrownBy(
             () -> {
               final var p2ExporterController = new ExporterTestController();
-              p2Exporter.open(p2ExporterController);
+              secondExporter.open(p2ExporterController);
             });
     await("Partition one has been opened successfully")
         .atMost(Duration.ofSeconds(30))
@@ -153,7 +177,7 @@ final class CamundaExporterIT {
       final ExporterConfiguration config, final SearchClientAdapter ignored) throws IOException {
     // given
     createSchemas(config);
-    final var exporter = new CamundaExporter();
+    exporter = new CamundaExporter();
 
     final var context = getContextFromConfig(config);
     exporter.configure(context);
@@ -180,7 +204,7 @@ final class CamundaExporterIT {
     // given
     createSchemas(config);
     config.getBulk().setSize(2);
-    final var exporter = new CamundaExporter();
+    exporter = new CamundaExporter();
 
     final var context = getContextFromConfig(config);
     exporter.configure(context);
@@ -218,7 +242,7 @@ final class CamundaExporterIT {
     // given
     final var config = getConnectConfigForContainer(container);
     createSchemas(config);
-    final var exporter = new CamundaExporter();
+    exporter = new CamundaExporter();
 
     final var context = getContextFromConfig(config);
     final ExporterTestController controller = spy(new ExporterTestController());
@@ -264,7 +288,7 @@ final class CamundaExporterIT {
     final var duration = 2;
     config.getBulk().setDelay(duration);
 
-    final var exporter = new CamundaExporter();
+    exporter = new CamundaExporter();
     exporter.configure(getContextFromConfig(config));
 
     // when
@@ -300,17 +324,17 @@ final class CamundaExporterIT {
             .filter(exportHandler -> exportHandler.handlesRecord(record))
             .toList();
 
-    final CamundaExporter camundaExporter = new CamundaExporter();
+    exporter = new CamundaExporter();
     final ExporterTestContext exporterTestContext =
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("camundaExporter", config));
 
-    camundaExporter.configure(exporterTestContext);
-    camundaExporter.open(new ExporterTestController());
+    exporter.configure(exporterTestContext);
+    exporter.open(new ExporterTestController());
 
     // when
-    camundaExporter.export(record);
-    camundaExporter.close();
+    exporter.export(record);
+    exporter.close();
 
     // then
     assertThat(expectedHandlers).isNotEmpty();
@@ -361,16 +385,16 @@ final class CamundaExporterIT {
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
-    final CamundaExporter camundaExporter = new CamundaExporter();
+    exporter = new CamundaExporter();
     final ExporterTestContext exporterTestContext =
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("camundaExporter", config));
 
-    camundaExporter.configure(exporterTestContext);
-    camundaExporter.open(new ExporterTestController());
+    exporter.configure(exporterTestContext);
+    exporter.open(new ExporterTestController());
 
     // act
-    assertThatCode(() -> camundaExporter.export(record)).doesNotThrowAnyException();
+    assertThatCode(() -> exporter.export(record)).doesNotThrowAnyException();
   }
 
   @TestTemplate
@@ -396,17 +420,17 @@ final class CamundaExporterIT {
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
-    final CamundaExporter camundaExporter = new CamundaExporter();
+    exporter = new CamundaExporter();
     final ExporterTestContext exporterTestContext =
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("camundaExporter", config));
 
-    camundaExporter.configure(exporterTestContext);
+    exporter.configure(exporterTestContext);
     final var controller = new ExporterTestController();
-    camundaExporter.open(controller);
+    exporter.open(controller);
 
     // act
-    camundaExporter.export(record);
+    exporter.export(record);
     assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(1)))
         .isInstanceOf(ExporterException.class)
         .rootCause()
@@ -461,7 +485,7 @@ final class CamundaExporterIT {
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
     // Do not create schema yet
-    final var exporter = spy(new CamundaExporter());
+    exporter = spy(new CamundaExporter());
     final var context = getContextFromConfig(config);
     exporter.configure(context);
 
@@ -580,7 +604,7 @@ final class CamundaExporterIT {
       throws IOException {
     // given
     createSchemas(config);
-    final var exporter = new CamundaExporter();
+    exporter = new CamundaExporter();
 
     final var memoryLimit = 3;
     config.getBulk().setMemoryLimit(memoryLimit);
@@ -660,16 +684,16 @@ final class CamundaExporterIT {
                     .withIntent(BatchOperationChunkIntent.CREATED)
                     .withTimestamp(System.currentTimeMillis()));
 
-    final CamundaExporter camundaExporter = new CamundaExporter();
+    exporter = new CamundaExporter();
     final ExporterTestContext exporterTestContext =
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("camundaExporter", config));
 
-    camundaExporter.configure(exporterTestContext);
-    camundaExporter.open(new ExporterTestController());
+    exporter.configure(exporterTestContext);
+    exporter.open(new ExporterTestController());
 
     // act
-    assertThatCode(() -> camundaExporter.export(record)).doesNotThrowAnyException();
+    assertThatCode(() -> exporter.export(record)).doesNotThrowAnyException();
   }
 
   @Nested

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -167,6 +167,9 @@ final class CamundaExporterIT {
 
     exporter.export(record);
 
+    // flushes are now async so close() is called to force a wait for pending flushes to finish
+    exporter.close();
+
     // then
     assertThat(exporterController.getPosition()).isEqualTo(record.getPosition());
   }
@@ -191,10 +194,17 @@ final class CamundaExporterIT {
 
     exporter.export(record);
     exporter.export(record2);
+    exporter.close();
+
     // then
     verify(controllerSpy, never())
         .updateLastExportedRecordPosition(eq(record.getPosition()), any());
-    verify(controllerSpy).updateLastExportedRecordPosition(eq(record2.getPosition()), any());
+
+    // two update positions
+    // - one occurs from async flush completing and setting position
+    // - second occurs on close call which invokes a synchronous flush
+    verify(controllerSpy, times(2))
+        .updateLastExportedRecordPosition(eq(record2.getPosition()), any());
   }
 
   @ParameterizedTest
@@ -223,7 +233,11 @@ final class CamundaExporterIT {
 
     final var record = generateRecordWithSupportedBrokerVersion(ValueType.USER, UserIntent.CREATED);
 
-    assertThatThrownBy(() -> exporter.export(record))
+    exporter.export(record);
+
+    // the export above fails in the async supplier, and it requires a call to .join that future so
+    // that the error is surfaced
+    assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(1)))
         .isInstanceOf(ExporterException.class)
         .hasMessageContaining("Connection refused");
 
@@ -236,6 +250,7 @@ final class CamundaExporterIT {
     final var record2 =
         generateRecordWithSupportedBrokerVersion(ValueType.USER, UserIntent.CREATED);
     exporter.export(record2);
+    exporter.close();
 
     await()
         .untilAsserted(() -> assertThat(controller.getPosition()).isEqualTo(record2.getPosition()));
@@ -295,6 +310,7 @@ final class CamundaExporterIT {
 
     // when
     camundaExporter.export(record);
+    camundaExporter.close();
 
     // then
     assertThat(expectedHandlers).isNotEmpty();
@@ -386,12 +402,14 @@ final class CamundaExporterIT {
             .setConfiguration(new ExporterTestConfiguration<>("camundaExporter", config));
 
     camundaExporter.configure(exporterTestContext);
-    camundaExporter.open(new ExporterTestController());
+    final var controller = new ExporterTestController();
+    camundaExporter.open(controller);
 
     // act
-    assertThatThrownBy(() -> camundaExporter.export(record))
+    camundaExporter.export(record);
+    assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(1)))
         .isInstanceOf(ExporterException.class)
-        .cause()
+        .rootCause()
         .isInstanceOf(PersistenceException.class);
   }
 
@@ -473,6 +491,7 @@ final class CamundaExporterIT {
             r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()),
             UserIntent.CREATED);
     exporter.export(record);
+    exporter.close();
 
     // Position updated
     assertThat(secondController.getPosition()).isEqualTo(record.getPosition());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -9,9 +9,11 @@ package io.camunda.exporter;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -22,10 +24,12 @@ import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
@@ -148,6 +152,45 @@ final class CamundaExporterTest {
     }
   }
 
+  private static final class FailingBatchRequestClientAdapter implements ClientAdapter {
+    private final ExporterEntityCacheProvider entityCacheProvider =
+        new NoopExporterEntityCacheProvider();
+    private final SearchEngineClient client =
+        mock(
+            SearchEngineClient.class,
+            Mockito.withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+
+    @Override
+    public ObjectMapper objectMapper() {
+      return TestObjectMapper.objectMapper();
+    }
+
+    @Override
+    public SearchEngineClient getSearchEngineClient() {
+      return client;
+    }
+
+    @Override
+    public BatchRequest createBatchRequest() {
+      final var request =
+          mock(BatchRequest.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF));
+      try {
+        doThrow(new PersistenceException("simulated flush failure")).when(request).execute(any());
+      } catch (final PersistenceException e) {
+        throw new RuntimeException(e);
+      }
+      return request;
+    }
+
+    @Override
+    public ExporterEntityCacheProvider getExporterEntityCacheProvider() {
+      return entityCacheProvider;
+    }
+
+    @Override
+    public void close() {}
+  }
+
   @Nested
   final class OpenTest {
     @Test
@@ -193,7 +236,7 @@ final class CamundaExporterTest {
       // when
       exporter.configure(testContext);
       exporter.open(testController);
-      testController.runScheduledTasks(Duration.ofHours(1));
+      exporter.close();
 
       // then
       final var actual = new ExporterMetadata(TestObjectMapper.objectMapper());
@@ -294,6 +337,161 @@ final class CamundaExporterTest {
             .as("Rescheduled delay in cycle %d must not degrade", cycle)
             .isEqualTo(Duration.ofMillis(500));
       }
+    }
+  }
+
+  @Nested
+  final class AsyncFlushTest {
+
+    private final ProtocolFactory factory = new ProtocolFactory();
+
+    private Record<?> stubRecord() {
+      return factory.generateRecord(ValueType.VARIABLE);
+    }
+
+    @Test
+    void shouldUpdatePositionAfterAsyncFlushOnNextExport() {
+      // given
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      final var record = stubRecord();
+
+      // when
+      exporter.export(record);
+      final var record2 = stubRecord();
+      exporter.export(record2);
+
+      // then
+      assertThat(testController.getPosition()).isEqualTo(record.getPosition());
+    }
+
+    @Test
+    void shouldUpdatePositionAfterAsyncFlushOnClose() {
+      // given
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      final var record = stubRecord();
+
+      // when
+      exporter.export(record);
+      exporter.close();
+
+      // then
+      assertThat(testController.getPosition()).isEqualTo(record.getPosition());
+
+      exporter = null;
+    }
+
+    @Test
+    void shouldPropagateAsyncFlushErrorOnNextExport() {
+      // given
+      final var failingAdapter = new FailingBatchRequestClientAdapter();
+      mockedClientAdapterFactory
+          .when(() -> ClientAdapter.of(configuration.getConnect()))
+          .thenReturn(failingAdapter);
+
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      exporter.export(stubRecord());
+
+      // then
+      assertThatThrownBy(() -> exporter.export(stubRecord()))
+          .isInstanceOf(ExporterException.class)
+          .hasRootCauseInstanceOf(PersistenceException.class);
+    }
+
+    @Test
+    void shouldNotUpdatePositionOnFailedAsyncFlush() {
+      // given
+      final var failingAdapter = new FailingBatchRequestClientAdapter();
+      mockedClientAdapterFactory
+          .when(() -> ClientAdapter.of(configuration.getConnect()))
+          .thenReturn(failingAdapter);
+
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+      final var initialPosition = testController.getPosition();
+
+      // when
+      exporter.export(stubRecord());
+
+      // then
+      try {
+        exporter.export(stubRecord());
+      } catch (final ExporterException expected) {
+        assertThat(expected).hasRootCauseInstanceOf(PersistenceException.class);
+      }
+      assertThat(testController.getPosition()).isEqualTo(initialPosition);
+    }
+
+    @Test
+    void shouldSwapWriterOnFlushAndContinueBatching() {
+      // given
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      final var record1 = stubRecord();
+      exporter.export(record1);
+
+      final var record2 = stubRecord();
+      exporter.export(record2);
+
+      final var record3 = stubRecord();
+      exporter.export(record3);
+
+      // then
+      assertThat(testController.getPosition()).isGreaterThanOrEqualTo(record2.getPosition());
+    }
+
+    @Test
+    void shouldPropagateAsyncFlushErrorOnScheduledFlush() {
+      // given
+      final var failingAdapter = new FailingBatchRequestClientAdapter();
+      mockedClientAdapterFactory
+          .when(() -> ClientAdapter.of(configuration.getConnect()))
+          .thenReturn(failingAdapter);
+
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      exporter.export(stubRecord());
+
+      // then
+      final var initialPosition = testController.getPosition();
+      assertThatThrownBy(() -> testController.runScheduledTasks(Duration.ofHours(1)))
+          .isInstanceOf(ExporterException.class)
+          .hasRootCauseInstanceOf(PersistenceException.class);
+      assertThat(testController.getPosition()).isEqualTo(initialPosition);
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -62,6 +62,7 @@ final class CamundaExporterTest {
           .setConfiguration(new ExporterTestConfiguration<>("test", configuration));
   private final ExporterTestController testController = new ExporterTestController();
   private ClientAdapter stubbedClientAdapterInUse;
+  private final ProtocolFactory factory = new ProtocolFactory();
 
   @SuppressWarnings("FieldCanBeLocal")
   @AutoClose
@@ -80,6 +81,12 @@ final class CamundaExporterTest {
   @AfterEach
   void tearDown() {
     mockedClientAdapterFactory.close();
+  }
+
+  private Record<?> stubRecord() {
+    final var record = spy(factory.generateRecord(ValueType.VARIABLE));
+    when(record.getBrokerVersion()).thenReturn("8.8.0");
+    return record;
   }
 
   private static final class NoopExporterEntityCacheProvider
@@ -255,12 +262,6 @@ final class CamundaExporterTest {
       configuration.getIndex().setShouldWaitForImporters(false);
     }
 
-    private Record<?> stubRecord() {
-      final var record = spy(new ProtocolFactory().generateRecord(ValueType.VARIABLE));
-      when(record.getBrokerVersion()).thenReturn("8.8.0");
-      return record;
-    }
-
     @Test
     void shouldScheduleInitialFlushAtConfiguredDelay() {
       // given
@@ -342,12 +343,6 @@ final class CamundaExporterTest {
 
   @Nested
   final class AsyncFlushTest {
-
-    private final ProtocolFactory factory = new ProtocolFactory();
-
-    private Record<?> stubRecord() {
-      return factory.generateRecord(ValueType.VARIABLE);
-    }
 
     @Test
     void shouldUpdatePositionAfterAsyncFlushOnNextExport() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/ExporterThreadLeakExtension.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/ExporterThreadLeakExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import java.util.List;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension that detects leaked {@code CamundaExporter} flush executor threads after each
+ * test. The {@code CamundaExporter.open()} method creates a single-thread executor with a thread
+ * named {@code "camunda-exporter-flush-partition-<partitionId>"}. If a test opens an exporter but
+ * fails to close it, this executor thread will leak.
+ *
+ * <p>Register this extension on any test class that creates and opens {@code CamundaExporter}
+ * instances to ensure all exporters are properly closed.
+ */
+public class ExporterThreadLeakExtension implements AfterEachCallback {
+
+  private static final String FLUSH_THREAD_PREFIX = "camunda-exporter-flush-partition-";
+
+  @Override
+  public void afterEach(final ExtensionContext context) {
+    final List<String> leakedThreadNames =
+        Thread.getAllStackTraces().keySet().stream()
+            .filter(Thread::isAlive)
+            .map(Thread::getName)
+            .filter(name -> name.startsWith(FLUSH_THREAD_PREFIX))
+            .sorted()
+            .toList();
+
+    if (!leakedThreadNames.isEmpty()) {
+      throw new AssertionError(
+          String.format(
+              "Detected leaked exporter flush thread(s) after test '%s': %s. "
+                  + "Ensure all CamundaExporter instances are closed via close() after use.",
+              context.getDisplayName(), leakedThreadNames));
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #48362 to `stable/8.8`.

relates to #41206