### PR TITLE
fix: add instance history 403 message

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.tsx
@@ -16,6 +16,7 @@ import {useVariables} from 'modules/queries/variables/useVariables';
 import {VariablesFinalForm} from './VariablesFinalForm';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 import {isRequestError} from 'modules/request';
+import {getForbiddenPermissionsError} from 'modules/constants/permissions';
 import {useVariableScopeKey} from 'modules/hooks/variables';
 
 const VariablesTab: React.FC = observer(() => {
@@ -23,19 +24,19 @@ const VariablesTab: React.FC = observer(() => {
   const scopeKey = useVariableScopeKey();
 
   if (displayStatus === 'error') {
+    const isForbidden =
+      isRequestError(error) &&
+      error?.response?.status === HTTP_STATUS_FORBIDDEN;
+    const forbidden = getForbiddenPermissionsError('Variables', 'variables');
     return (
       <EmptyMessageContainer>
         <ErrorMessage
           message={
-            isRequestError(error) &&
-            error?.response?.status === HTTP_STATUS_FORBIDDEN
-              ? 'Missing permissions to access Variables'
-              : 'Variables could not be fetched'
+            isForbidden ? forbidden.message : 'Variables could not be fetched'
           }
           additionalInfo={
-            isRequestError(error) &&
-            error?.response?.status === HTTP_STATUS_FORBIDDEN
-              ? 'Please contact your organization owner or admin to give you the necessary permissions to access variables'
+            isForbidden
+              ? forbidden.additionalInfo
               : 'Refresh the page to try again'
           }
         />

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
@@ -1036,4 +1036,62 @@ describe('elementInstancesTreeStore', () => {
 
     vi.useRealTimers();
   });
+
+  it('should stop polling when poll encounters a 403 forbidden error', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey, {
+      enablePolling: true,
+    });
+
+    expect(elementInstancesTreeStore.intervalId).not.toBe(null);
+
+    mockSearchElementInstances().withServerError(403);
+
+    vi.advanceTimersByTime(5000);
+
+    await waitFor(() => {
+      expect(elementInstancesTreeStore.isPollRequestRunning).toBe(false);
+    });
+
+    expect(elementInstancesTreeStore.intervalId).toBe(null);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.status).toBe('error-permissions');
+
+    vi.useRealTimers();
+  });
+
+  it('should continue polling when poll encounters a non-403 error', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey, {
+      enablePolling: true,
+    });
+
+    expect(elementInstancesTreeStore.intervalId).not.toBe(null);
+
+    mockSearchElementInstances().withServerError(500);
+
+    vi.advanceTimersByTime(5000);
+
+    await waitFor(() => {
+      expect(elementInstancesTreeStore.isPollRequestRunning).toBe(false);
+    });
+
+    expect(elementInstancesTreeStore.intervalId).not.toBe(null);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.status).toBe('error');
+
+    vi.useRealTimers();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
@@ -248,6 +248,36 @@ describe('elementInstancesTreeStore', () => {
     });
   });
 
+  it('should set status to error-permissions when expansion fails with forbidden', async () => {
+    mockSearchElementInstances().withServerError(403);
+
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    const nodeData =
+      elementInstancesTreeStore.state.nodes.get(mockChildScopeKey1);
+
+    expect(nodeData?.status).toBe('error-permissions');
+  });
+
+  it('should clear error-permissions status after successful fetch', async () => {
+    mockSearchElementInstances().withServerError(403);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.nodes.get(mockChildScopeKey1)?.status,
+    ).toBe('error-permissions');
+
+    elementInstancesTreeStore.collapseNode(mockChildScopeKey1);
+
+    mockSearchElementInstances().withSuccess(mockChildResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    const nodeData =
+      elementInstancesTreeStore.state.nodes.get(mockChildScopeKey1);
+
+    expect(nodeData?.status).toBe('loaded');
+  });
+
   it('should collapse node and remove from expandedNodes set', async () => {
     mockSearchElementInstances().withSuccess(mockEmptyResponse);
     await elementInstancesTreeStore.expandNode(mockChildScopeKey1);

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
@@ -11,6 +11,8 @@ import {makeObservable, observable, action, override} from 'mobx';
 import {searchElementInstances} from 'modules/api/v2/elementInstances/searchElementInstances';
 import {logger} from 'modules/logger';
 import {NetworkReconnectionHandler} from 'modules/stores/networkReconnectionHandler';
+import type {RequestError} from 'modules/request';
+import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 
 const PAGE_SIZE = 50;
 const POLLING_INTERVAL = 5000;
@@ -24,7 +26,7 @@ type PageMetadata = {
 type NodeData = {
   items: ElementInstance[];
   pageMetadata: PageMetadata;
-  status: 'idle' | 'loading' | 'error' | 'loaded';
+  status: 'idle' | 'loading' | 'error' | 'error-permissions' | 'loaded';
 };
 
 type State = {
@@ -154,7 +156,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
         status: 'loaded',
       });
     } else {
-      this.setNodeStatus(scopeKey, 'error');
+      this.setNodeStatus(scopeKey, 'error', error);
       logger.error('Failed to fetch element instances', error);
     }
   };
@@ -257,7 +259,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
 
       return Math.max(0, response.items.length - PAGE_SIZE);
     } else {
-      this.setNodeStatus(scopeKey, 'error');
+      this.setNodeStatus(scopeKey, 'error', error);
       logger.error('Failed to fetch next page', error);
       return -1;
     }
@@ -312,18 +314,28 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
 
       return Math.min(PAGE_SIZE, response.items.length);
     } else {
-      this.setNodeStatus(scopeKey, 'error');
+      this.setNodeStatus(scopeKey, 'error', error);
       logger.error('Failed to fetch previous page', error);
       return -1;
     }
   };
 
-  private setNodeStatus = (scopeKey: string, status: NodeData['status']) => {
+  private setNodeStatus = (
+    scopeKey: string,
+    status: NodeData['status'],
+    error?: RequestError | null,
+  ) => {
+    const resolvedStatus =
+      status === 'error' &&
+      error?.variant === 'failed-response' &&
+      error.response.status === HTTP_STATUS_FORBIDDEN
+        ? 'error-permissions'
+        : status;
     const nodeData = this.state.nodes.get(scopeKey);
     if (nodeData) {
       this.setNodeData(scopeKey, {
         ...nodeData,
-        status,
+        status: resolvedStatus,
       });
     } else {
       this.setNodeData(scopeKey, {
@@ -333,7 +345,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
           windowStart: 0,
           windowEnd: 0,
         },
-        status,
+        status: resolvedStatus,
       });
     }
   };
@@ -463,7 +475,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
             });
           } else {
             if (!signal.aborted) {
-              this.setNodeStatus(scopeKey, 'error');
+              this.setNodeStatus(scopeKey, 'error', error);
               logger.error('Failed to poll element instances', error);
             }
           }

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
@@ -156,7 +156,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
         status: 'loaded',
       });
     } else {
-      this.setNodeStatus(scopeKey, 'error', error);
+      this.setNodeStatus(scopeKey, this.resolveErrorStatus(error));
       logger.error('Failed to fetch element instances', error);
     }
   };
@@ -259,7 +259,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
 
       return Math.max(0, response.items.length - PAGE_SIZE);
     } else {
-      this.setNodeStatus(scopeKey, 'error', error);
+      this.setNodeStatus(scopeKey, this.resolveErrorStatus(error));
       logger.error('Failed to fetch next page', error);
       return -1;
     }
@@ -314,28 +314,30 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
 
       return Math.min(PAGE_SIZE, response.items.length);
     } else {
-      this.setNodeStatus(scopeKey, 'error', error);
+      this.setNodeStatus(scopeKey, this.resolveErrorStatus(error));
       logger.error('Failed to fetch previous page', error);
       return -1;
     }
   };
 
-  private setNodeStatus = (
-    scopeKey: string,
-    status: NodeData['status'],
+  private resolveErrorStatus = (
     error?: RequestError | null,
-  ) => {
-    const resolvedStatus =
-      status === 'error' &&
+  ): 'error' | 'error-permissions' => {
+    if (
       error?.variant === 'failed-response' &&
       error.response.status === HTTP_STATUS_FORBIDDEN
-        ? 'error-permissions'
-        : status;
+    ) {
+      return 'error-permissions';
+    }
+    return 'error';
+  };
+
+  private setNodeStatus = (scopeKey: string, status: NodeData['status']) => {
     const nodeData = this.state.nodes.get(scopeKey);
     if (nodeData) {
       this.setNodeData(scopeKey, {
         ...nodeData,
-        status: resolvedStatus,
+        status,
       });
     } else {
       this.setNodeData(scopeKey, {
@@ -345,7 +347,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
           windowStart: 0,
           windowEnd: 0,
         },
-        status: resolvedStatus,
+        status,
       });
     }
   };
@@ -475,8 +477,12 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
             });
           } else {
             if (!signal.aborted) {
-              this.setNodeStatus(scopeKey, 'error', error);
+              const errorStatus = this.resolveErrorStatus(error);
+              this.setNodeStatus(scopeKey, errorStatus);
               logger.error('Failed to poll element instances', error);
+              if (errorStatus === 'error-permissions') {
+                this.stopPolling();
+              }
             }
           }
         }),

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -20,6 +20,7 @@ import {
   NodeContainer,
   TreeNode,
 } from './styled';
+import {ErrorMessage} from '../styled';
 import {Bar} from './Bar';
 import {InfiniteScroller} from 'modules/components/InfiniteScroller';
 import {useSearchElementInstancesByScope} from 'modules/queries/elementInstances/useSearchElementInstancesByScope';
@@ -822,11 +823,20 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
       return elementInstancesTreeStore.reset;
     }, []);
 
-    if (
-      elementInstancesTreeStore.state.nodes.get(
-        processInstance.processInstanceKey,
-      )?.status === 'error'
-    ) {
+    const rootNodeData = elementInstancesTreeStore.state.nodes.get(
+      processInstance.processInstanceKey,
+    );
+
+    if (rootNodeData?.status === 'error-permissions') {
+      return (
+        <ErrorMessage
+          message="Missing permissions to access Instance History"
+          additionalInfo="Please contact your organization owner or admin to give you the necessary permissions to access this instance history"
+        />
+      );
+    }
+
+    if (rootNodeData?.status === 'error') {
       return errorMessage;
     }
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -41,6 +41,10 @@ import {TreeView} from '@carbon/react';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 
 const TREE_NODE_HEIGHT = 32;
+const INSTANCE_HISTORY_FORBIDDEN = getForbiddenPermissionsError(
+  'Instance History',
+  'this instance history',
+);
 const FOLDABLE_ELEMENT_TYPES: ElementInstance['type'][] = [
   'PROCESS',
   'MULTI_INSTANCE_BODY',
@@ -829,14 +833,10 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
     );
 
     if (rootNodeData?.status === 'error-permissions') {
-      const forbidden = getForbiddenPermissionsError(
-        'Instance History',
-        'this instance history',
-      );
       return (
         <ErrorMessage
-          message={forbidden.message}
-          additionalInfo={forbidden.additionalInfo}
+          message={INSTANCE_HISTORY_FORBIDDEN.message}
+          additionalInfo={INSTANCE_HISTORY_FORBIDDEN.additionalInfo}
         />
       );
     }

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -21,6 +21,7 @@ import {
   TreeNode,
 } from './styled';
 import {ErrorMessage} from '../styled';
+import {getForbiddenPermissionsError} from 'modules/constants/permissions';
 import {Bar} from './Bar';
 import {InfiniteScroller} from 'modules/components/InfiniteScroller';
 import {useSearchElementInstancesByScope} from 'modules/queries/elementInstances/useSearchElementInstancesByScope';
@@ -828,10 +829,14 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
     );
 
     if (rootNodeData?.status === 'error-permissions') {
+      const forbidden = getForbiddenPermissionsError(
+        'Instance History',
+        'this instance history',
+      );
       return (
         <ErrorMessage
-          message="Missing permissions to access Instance History"
-          additionalInfo="Please contact your organization owner or admin to give you the necessary permissions to access this instance history"
+          message={forbidden.message}
+          additionalInfo={forbidden.additionalInfo}
         />
       );
     }

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.test.tsx
@@ -193,8 +193,43 @@ describe('ElementInstanceLog', () => {
     ).toBeInTheDocument();
   });
 
-  it.skip('should display permissions error when access to the process definition is forbidden', async () => {
+  it('should display permissions error when access to the process definition is forbidden', async () => {
     mockFetchProcessDefinitionXml().withServerError(403);
+    mockSearchElementInstances().withSuccess(mockElementInstances);
+    mockQueryBatchOperationItems().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<ElementInstanceLog />, {wrapper: Wrapper});
+
+    expect(
+      await screen.findByText('Missing permissions to access Instance History'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Please contact your organization owner or admin to give you the necessary permissions to access this instance history',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should display permissions error when element instances search returns 403', async () => {
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockSearchElementInstances().withServerError(403);
+    mockQueryBatchOperationItems().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
 
     render(<ElementInstanceLog />, {wrapper: Wrapper});
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.tsx
@@ -18,6 +18,7 @@ import {useProcessInstance} from 'modules/queries/processInstance/useProcessInst
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {isRequestError} from 'modules/request';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
+import {getForbiddenPermissionsError} from 'modules/constants/permissions';
 
 const Layout: React.FC<{children: React.ReactNode}> = observer(({children}) => {
   return (
@@ -35,9 +36,10 @@ const Layout: React.FC<{children: React.ReactNode}> = observer(({children}) => {
   );
 });
 
-const FORBIDDEN_MESSAGE = 'Missing permissions to access Instance History';
-const FORBIDDEN_ADDITIONAL_INFO =
-  'Please contact your organization owner or admin to give you the necessary permissions to access this instance history';
+const INSTANCE_HISTORY_FORBIDDEN = getForbiddenPermissionsError(
+  'Instance History',
+  'this instance history',
+);
 
 const ElementInstanceLog: React.FC = observer(() => {
   const {
@@ -71,12 +73,12 @@ const ElementInstanceLog: React.FC = observer(() => {
         <ErrorMessage
           message={
             isForbidden
-              ? FORBIDDEN_MESSAGE
+              ? INSTANCE_HISTORY_FORBIDDEN.message
               : 'Instance History could not be fetched'
           }
           additionalInfo={
             isForbidden
-              ? FORBIDDEN_ADDITIONAL_INFO
+              ? INSTANCE_HISTORY_FORBIDDEN.additionalInfo
               : 'Refresh the page to try again'
           }
         />

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.tsx
@@ -16,6 +16,8 @@ import {ExecutionCountToggle} from './ExecutionCountToggle';
 import {ElementInstancesTree} from './ElementInstancesTree';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
+import {isRequestError} from 'modules/request';
+import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 
 const Layout: React.FC<{children: React.ReactNode}> = observer(({children}) => {
   return (
@@ -33,11 +35,21 @@ const Layout: React.FC<{children: React.ReactNode}> = observer(({children}) => {
   );
 });
 
+const FORBIDDEN_MESSAGE = 'Missing permissions to access Instance History';
+const FORBIDDEN_ADDITIONAL_INFO =
+  'Please contact your organization owner or admin to give you the necessary permissions to access this instance history';
+
 const ElementInstanceLog: React.FC = observer(() => {
-  const {data: processInstance, status: processInstanceStatus} =
-    useProcessInstance();
-  const {data: businessObjects, status: businessObjectsStatus} =
-    useBusinessObjects();
+  const {
+    data: processInstance,
+    status: processInstanceStatus,
+    error: processInstanceError,
+  } = useProcessInstance();
+  const {
+    data: businessObjects,
+    status: businessObjectsStatus,
+    error: businessObjectsError,
+  } = useBusinessObjects();
 
   if ([processInstanceStatus, businessObjectsStatus].includes('pending')) {
     return (
@@ -48,10 +60,26 @@ const ElementInstanceLog: React.FC = observer(() => {
   }
 
   if ([processInstanceStatus, businessObjectsStatus].includes('error')) {
+    const isForbidden =
+      (isRequestError(processInstanceError) &&
+        processInstanceError?.response?.status === HTTP_STATUS_FORBIDDEN) ||
+      (isRequestError(businessObjectsError) &&
+        businessObjectsError?.response?.status === HTTP_STATUS_FORBIDDEN);
+
     return (
       <Layout>
-        {/* TODO update the message with 403 related error during v2 endpoint integration #33542 */}
-        <ErrorMessage message="Instance History could not be fetched" />
+        <ErrorMessage
+          message={
+            isForbidden
+              ? FORBIDDEN_MESSAGE
+              : 'Instance History could not be fetched'
+          }
+          additionalInfo={
+            isForbidden
+              ? FORBIDDEN_ADDITIONAL_INFO
+              : 'Refresh the page to try again'
+          }
+        />
       </Layout>
     );
   }

--- a/operate/client/src/modules/constants/permissions.ts
+++ b/operate/client/src/modules/constants/permissions.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+function getForbiddenPermissionsError(
+  resource: string,
+  resourceDescription: string,
+) {
+  return {
+    message: `Missing permissions to access ${resource}`,
+    additionalInfo: `Please contact your organization owner or admin to give you the necessary permissions to access ${resourceDescription}`,
+  } as const;
+}
+
+export {getForbiddenPermissionsError};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds lack of permissions error message to process instance history

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48728
