### PR TITLE
fix: handle API conversion errors as validation errors

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -7,7 +7,10 @@
  */
 package io.camunda.gateway.mapping.http.search;
 
-import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToOperations;
+import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToIntegerOperations;
+import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToKeyOperations;
+import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToOffsetDateTimeOperations;
+import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToStringOperations;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_NULL_VARIABLE_NAME;
@@ -122,26 +125,27 @@ public class SearchQueryFilterMapper {
     final List<String> validationErrors = new ArrayList<>();
     if (filter != null) {
       ofNullable(filter.getProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeyOperations);
       ofNullable(filter.getParentProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("parentProcessInstanceKey", validationErrors))
           .ifPresent(builder::parentProcessInstanceKeyOperations);
       ofNullable(filter.getParentElementInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("parentElementInstanceKey", validationErrors))
           .ifPresent(builder::parentFlowNodeInstanceKeyOperations);
       ofNullable(filter.getStartDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("startDate", validationErrors))
           .ifPresent(builder::startDateOperations);
       ofNullable(filter.getEndDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("endDate", validationErrors))
           .ifPresent(builder::endDateOperations);
       ofNullable(filter.getState())
-          .map(mapToOperations(String.class, new ProcessInstanceStateConverter()))
+          .map(
+              mapToStringOperations("state", validationErrors, new ProcessInstanceStateConverter()))
           .ifPresent(builder::stateOperations);
       ofNullable(filter.getHasIncident()).ifPresent(builder::hasIncident);
       ofNullable(filter.getTenantId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);
       if (filter.getBatchOperationId() != null && filter.getBatchOperationKey() != null) {
         validationErrors.add(
@@ -153,23 +157,23 @@ public class SearchQueryFilterMapper {
                 ? filter.getBatchOperationKey()
                 : filter.getBatchOperationId();
         ofNullable(batchOperationFilter)
-            .map(mapToOperations(String.class))
+            .map(mapToStringOperations())
             .ifPresent(builder::batchOperationIdOperations);
       }
       ofNullable(filter.getErrorMessage())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::errorMessageOperations);
       ofNullable(filter.getHasRetriesLeft()).ifPresent(builder::hasRetriesLeft);
       ofNullable(filter.getElementId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::flowNodeIdOperations);
       ofNullable(filter.getHasElementInstanceIncident())
           .ifPresent(builder::hasFlowNodeInstanceIncident);
       ofNullable(filter.getElementInstanceState())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::flowNodeInstanceStateOperations);
       ofNullable(filter.getIncidentErrorHashCode())
-          .map(mapToOperations(Integer.class))
+          .map(mapToIntegerOperations())
           .ifPresent(builder::incidentErrorHashCodeOperations);
       if (!CollectionUtils.isEmpty(filter.getVariables())) {
         final Either<List<String>, List<VariableValueFilter>> either =
@@ -184,93 +188,96 @@ public class SearchQueryFilterMapper {
     return validationErrors.isEmpty() ? Either.right(builder) : Either.left(validationErrors);
   }
 
-  static JobFilter toJobFilter(final io.camunda.gateway.protocol.model.JobFilter filter) {
+  static Either<List<String>, JobFilter> toJobFilter(
+      final io.camunda.gateway.protocol.model.JobFilter filter) {
     final var builder = FilterBuilders.job();
+    final List<String> validationErrors = new ArrayList<>();
     if (filter != null) {
       ofNullable(filter.getJobKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("jobKey", validationErrors))
           .ifPresent(builder::jobKeyOperations);
-      ofNullable(filter.getType())
-          .map(mapToOperations(String.class))
-          .ifPresent(builder::typeOperations);
+      ofNullable(filter.getType()).map(mapToStringOperations()).ifPresent(builder::typeOperations);
       ofNullable(filter.getWorker())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::workerOperations);
       ofNullable(filter.getState())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::stateOperations);
-      ofNullable(filter.getKind())
-          .map(mapToOperations(String.class))
-          .ifPresent(builder::kindOperations);
+      ofNullable(filter.getKind()).map(mapToStringOperations()).ifPresent(builder::kindOperations);
       ofNullable(filter.getListenerEventType())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::listenerEventTypeOperations);
       ofNullable(filter.getProcessDefinitionId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionIdOperations);
       ofNullable(filter.getProcessDefinitionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeyOperations);
       ofNullable(filter.getProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeyOperations);
       ofNullable(filter.getElementId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::elementIdOperations);
       ofNullable(filter.getElementInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("elementInstanceKey", validationErrors))
           .ifPresent(builder::elementInstanceKeyOperations);
       ofNullable(filter.getTenantId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);
       ofNullable(filter.getDeadline())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("deadline", validationErrors))
           .ifPresent(builder::deadlineOperations);
       ofNullable(filter.getDeniedReason())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::deniedReasonOperations);
       ofNullable(filter.getIsDenied()).ifPresent(builder::isDenied);
       ofNullable(filter.getEndTime())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("endTime", validationErrors))
           .ifPresent(builder::endTimeOperations);
       ofNullable(filter.getErrorCode())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::errorCodeOperations);
       ofNullable(filter.getErrorMessage())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::errorMessageOperations);
       ofNullable(filter.getHasFailedWithRetriesLeft()).ifPresent(builder::hasFailedWithRetriesLeft);
       ofNullable(filter.getRetries())
-          .map(mapToOperations(Integer.class))
+          .map(mapToIntegerOperations())
           .ifPresent(builder::retriesOperations);
       ofNullable(filter.getCreationTime())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("creationTime", validationErrors))
           .ifPresent(builder::creationTimeOperations);
       ofNullable(filter.getLastUpdateTime())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("lastUpdateTime", validationErrors))
           .ifPresent(builder::lastUpdateTimeOperations);
     }
 
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
-  static DecisionInstanceFilter toDecisionInstanceFilter(
+  static Either<List<String>, DecisionInstanceFilter> toDecisionInstanceFilter(
       final io.camunda.gateway.protocol.model.DecisionInstanceFilter filter) {
     final var builder = FilterBuilders.decisionInstance();
+    final List<String> validationErrors = new ArrayList<>();
 
     if (filter != null) {
       ofNullable(filter.getDecisionEvaluationKey())
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::decisionInstanceKeys);
       ofNullable(filter.getDecisionEvaluationInstanceKey())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::decisionInstanceIdOperations);
       ofNullable(filter.getState())
-          .map(mapToOperations(String.class, new DecisionInstanceStateConverter()))
+          .map(
+              mapToStringOperations(
+                  "state", validationErrors, new DecisionInstanceStateConverter()))
           .ifPresent(builder::stateOperations);
       ofNullable(filter.getEvaluationFailure()).ifPresent(builder::evaluationFailures);
       ofNullable(filter.getEvaluationDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("evaluationDate", validationErrors))
           .ifPresent(builder::evaluationDateOperations);
       ofNullable(filter.getProcessDefinitionKey())
           .map(KeyUtil::keyToLong)
@@ -279,10 +286,10 @@ public class SearchQueryFilterMapper {
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::processInstanceKeys);
       ofNullable(filter.getElementInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("elementInstanceKey", validationErrors))
           .ifPresent(builder::flowNodeInstanceKeyOperations);
       ofNullable(filter.getDecisionDefinitionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("decisionDefinitionKey", validationErrors))
           .ifPresent(builder::decisionDefinitionKeyOperations);
       ofNullable(filter.getDecisionDefinitionId()).ifPresent(builder::decisionDefinitionIds);
       ofNullable(filter.getDecisionDefinitionName()).ifPresent(builder::decisionDefinitionNames);
@@ -292,14 +299,16 @@ public class SearchQueryFilterMapper {
           .map(t -> convertEnum(t, DecisionDefinitionType.class))
           .ifPresent(builder::decisionTypes);
       ofNullable(filter.getRootDecisionDefinitionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("rootDecisionDefinitionKey", validationErrors))
           .ifPresent(builder::rootDecisionDefinitionKeyOperations);
       ofNullable(filter.getDecisionRequirementsKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("decisionRequirementsKey", validationErrors))
           .ifPresent(builder::decisionRequirementsKeyOperations);
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
     }
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
   private static <Q extends Enum<Q>, E extends Enum<E>> E convertEnum(
@@ -307,33 +316,32 @@ public class SearchQueryFilterMapper {
     return Enum.valueOf(targetEnumType, sourceEnum.name());
   }
 
-  static VariableFilter toVariableFilter(
+  static Either<List<String>, VariableFilter> toVariableFilter(
       final io.camunda.gateway.protocol.model.VariableFilter filter) {
     if (filter == null) {
-      return FilterBuilders.variable().build();
+      return Either.right(FilterBuilders.variable().build());
     }
 
     final var builder = FilterBuilders.variable();
+    final List<String> validationErrors = new ArrayList<>();
 
     ofNullable(filter.getProcessInstanceKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("processInstanceKey", validationErrors))
         .ifPresent(builder::processInstanceKeyOperations);
     ofNullable(filter.getScopeKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("scopeKey", validationErrors))
         .ifPresent(builder::scopeKeyOperations);
     ofNullable(filter.getVariableKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("variableKey", validationErrors))
         .ifPresent(builder::variableKeyOperations);
     ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
     ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
-    ofNullable(filter.getName())
-        .map(mapToOperations(String.class))
-        .ifPresent(builder::nameOperations);
-    ofNullable(filter.getValue())
-        .map(mapToOperations(String.class))
-        .ifPresent(builder::valueOperations);
+    ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
+    ofNullable(filter.getValue()).map(mapToStringOperations()).ifPresent(builder::valueOperations);
 
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
   static ClusterVariableFilter toClusterVariableFilter(
@@ -345,17 +353,11 @@ public class SearchQueryFilterMapper {
 
     final var builder = FilterBuilders.clusterVariable();
 
-    ofNullable(filter.getName())
-        .map(mapToOperations(String.class))
-        .ifPresent(builder::nameOperations);
-    ofNullable(filter.getValue())
-        .map(mapToOperations(String.class))
-        .ifPresent(builder::valueOperations);
-    ofNullable(filter.getScope())
-        .map(mapToOperations(String.class))
-        .ifPresent(builder::scopeOperations);
+    ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
+    ofNullable(filter.getValue()).map(mapToStringOperations()).ifPresent(builder::valueOperations);
+    ofNullable(filter.getScope()).map(mapToStringOperations()).ifPresent(builder::scopeOperations);
     ofNullable(filter.getTenantId())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::tenantIdOperations);
     ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
 
@@ -368,49 +370,53 @@ public class SearchQueryFilterMapper {
 
     if (filter != null) {
       ofNullable(filter.getBatchOperationKey())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::batchOperationKeyOperations);
       ofNullable(filter.getState())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::stateOperations);
       ofNullable(filter.getOperationType())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::operationTypeOperations);
       ofNullable(filter.getActorType())
           .map(io.camunda.gateway.protocol.model.AuditLogActorTypeEnum::getValue)
           .map(String::toUpperCase)
           .ifPresent(builder::actorTypes);
       ofNullable(filter.getActorId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::actorIdOperations);
     }
 
     return builder.build();
   }
 
-  static io.camunda.search.filter.BatchOperationItemFilter toBatchOperationItemFilter(
-      final io.camunda.gateway.protocol.model.BatchOperationItemFilter filter) {
+  static Either<List<String>, io.camunda.search.filter.BatchOperationItemFilter>
+      toBatchOperationItemFilter(
+          final io.camunda.gateway.protocol.model.BatchOperationItemFilter filter) {
     final var builder = FilterBuilders.batchOperationItem();
+    final List<String> validationErrors = new ArrayList<>();
 
     if (filter != null) {
       ofNullable(filter.getBatchOperationKey())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::batchOperationKeyOperations);
       ofNullable(filter.getState())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::stateOperations);
       ofNullable(filter.getItemKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("itemKey", validationErrors))
           .ifPresent(builder::itemKeyOperations);
       ofNullable(filter.getProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeyOperations);
       ofNullable(filter.getOperationType())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::operationTypeOperations);
     }
 
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
   public static Either<List<String>, GlobalJobStatisticsFilter> toGlobalJobStatisticsFilter(
@@ -454,7 +460,7 @@ public class SearchQueryFilterMapper {
     Optional.ofNullable(to).ifPresent(builder::to);
 
     Optional.ofNullable(filter.getJobType())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::jobTypeOperations);
 
     return validationErrors.isEmpty()
@@ -542,10 +548,10 @@ public class SearchQueryFilterMapper {
     }
 
     Optional.ofNullable(filter.getErrorCode())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::errorCodeOperations);
     Optional.ofNullable(filter.getErrorMessage())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::errorMessageOperations);
 
     return validationErrors.isEmpty()
@@ -564,13 +570,13 @@ public class SearchQueryFilterMapper {
                   .map(KeyUtil::keyToLong)
                   .ifPresent(builder::processDefinitionKeys);
               Optional.ofNullable(f.getName())
-                  .map(mapToOperations(String.class))
+                  .map(mapToStringOperations())
                   .ifPresent(builder::nameOperations);
               Optional.ofNullable(f.getResourceName()).ifPresent(builder::resourceNames);
               Optional.ofNullable(f.getVersion()).ifPresent(builder::versions);
               Optional.ofNullable(f.getVersionTag()).ifPresent(builder::versionTags);
               Optional.ofNullable(f.getProcessDefinitionId())
-                  .map(mapToOperations(String.class))
+                  .map(mapToStringOperations())
                   .ifPresent(builder::processDefinitionIdOperations);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
               Optional.ofNullable(f.getHasStartForm()).ifPresent(builder::hasStartForm);
@@ -601,7 +607,7 @@ public class SearchQueryFilterMapper {
     if (filter.equals(SearchQueryRequestMapper.EMPTY_DECISION_INSTANCE_FILTER)) {
       return Either.left(List.of(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted("filter criteria")));
     }
-    return Either.right(toDecisionInstanceFilter(filter));
+    return toDecisionInstanceFilter(filter);
   }
 
   public static Either<List<String>, ProcessInstanceFilter> toProcessInstanceFilter(
@@ -637,41 +643,42 @@ public class SearchQueryFilterMapper {
     final List<String> validationErrors = new ArrayList<>();
     if (filter != null) {
       ofNullable(filter.getProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeyOperations);
       ofNullable(filter.getProcessDefinitionId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionIdOperations);
       ofNullable(filter.getProcessDefinitionName())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionNameOperations);
       ofNullable(filter.getProcessDefinitionVersion())
-          .map(mapToOperations(Integer.class))
+          .map(mapToIntegerOperations())
           .ifPresent(builder::processDefinitionVersionOperations);
       ofNullable(filter.getProcessDefinitionVersionTag())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionVersionTagOperations);
       ofNullable(filter.getProcessDefinitionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeyOperations);
       ofNullable(filter.getParentProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("parentProcessInstanceKey", validationErrors))
           .ifPresent(builder::parentProcessInstanceKeyOperations);
       ofNullable(filter.getParentElementInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("parentElementInstanceKey", validationErrors))
           .ifPresent(builder::parentFlowNodeInstanceKeyOperations);
       ofNullable(filter.getStartDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("startDate", validationErrors))
           .ifPresent(builder::startDateOperations);
       ofNullable(filter.getEndDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("endDate", validationErrors))
           .ifPresent(builder::endDateOperations);
       ofNullable(filter.getState())
-          .map(mapToOperations(String.class, new ProcessInstanceStateConverter()))
+          .map(
+              mapToStringOperations("state", validationErrors, new ProcessInstanceStateConverter()))
           .ifPresent(builder::stateOperations);
       ofNullable(filter.getHasIncident()).ifPresent(builder::hasIncident);
       ofNullable(filter.getTenantId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);
       if (filter.getBatchOperationId() != null && filter.getBatchOperationKey() != null) {
         validationErrors.add(
@@ -683,23 +690,23 @@ public class SearchQueryFilterMapper {
                 ? filter.getBatchOperationKey()
                 : filter.getBatchOperationId();
         ofNullable(batchOperationFilter)
-            .map(mapToOperations(String.class))
+            .map(mapToStringOperations())
             .ifPresent(builder::batchOperationIdOperations);
       }
       ofNullable(filter.getErrorMessage())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::errorMessageOperations);
       ofNullable(filter.getHasRetriesLeft()).ifPresent(builder::hasRetriesLeft);
       ofNullable(filter.getElementId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::flowNodeIdOperations);
       ofNullable(filter.getHasElementInstanceIncident())
           .ifPresent(builder::hasFlowNodeInstanceIncident);
       ofNullable(filter.getElementInstanceState())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::flowNodeInstanceStateOperations);
       ofNullable(filter.getIncidentErrorHashCode())
-          .map(mapToOperations(Integer.class))
+          .map(mapToIntegerOperations())
           .ifPresent(builder::incidentErrorHashCodeOperations);
 
       if (!CollectionUtils.isEmpty(filter.getTags())) {
@@ -712,7 +719,7 @@ public class SearchQueryFilterMapper {
       }
 
       ofNullable(filter.getBusinessId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::businessIdOperations);
 
       if (!CollectionUtils.isEmpty(filter.getVariables())) {
@@ -741,7 +748,7 @@ public class SearchQueryFilterMapper {
     final var builder = FilterBuilders.group();
     if (filter != null) {
       ofNullable(filter.getGroupId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::groupIdOperations);
       ofNullable(filter.getName()).ifPresent(builder::name);
     }
@@ -816,47 +823,46 @@ public class SearchQueryFilterMapper {
     return builder.build();
   }
 
-  static FlowNodeInstanceFilter toElementInstanceFilter(
+  static Either<List<String>, FlowNodeInstanceFilter> toElementInstanceFilter(
       final io.camunda.gateway.protocol.model.ElementInstanceFilter filter) {
     final var builder = FilterBuilders.flowNodeInstance();
-    Optional.ofNullable(filter)
-        .ifPresent(
-            f -> {
-              Optional.ofNullable(f.getElementInstanceKey())
-                  .map(KeyUtil::keyToLong)
-                  .ifPresent(builder::flowNodeInstanceKeys);
-              Optional.ofNullable(f.getProcessInstanceKey())
-                  .map(KeyUtil::keyToLong)
-                  .ifPresent(builder::processInstanceKeys);
-              Optional.ofNullable(f.getProcessDefinitionKey())
-                  .map(KeyUtil::keyToLong)
-                  .ifPresent(builder::processDefinitionKeys);
-              Optional.ofNullable(f.getProcessDefinitionId())
-                  .ifPresent(builder::processDefinitionIds);
-              Optional.ofNullable(f.getState())
-                  .map(mapToOperations(String.class))
-                  .ifPresent(builder::stateOperations);
-              Optional.ofNullable(f.getType())
-                  .ifPresent(
-                      t -> builder.types(FlowNodeType.fromZeebeBpmnElementType(t.getValue())));
-              Optional.ofNullable(f.getElementId()).ifPresent(builder::flowNodeIds);
-              Optional.ofNullable(f.getElementName()).ifPresent(builder::flowNodeNames);
-              Optional.ofNullable(f.getHasIncident()).ifPresent(builder::hasIncident);
-              Optional.ofNullable(f.getIncidentKey())
-                  .map(KeyUtil::keyToLong)
-                  .ifPresent(builder::incidentKeys);
-              Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
-              Optional.ofNullable(f.getStartDate())
-                  .map(mapToOperations(OffsetDateTime.class))
-                  .ifPresent(builder::startDateOperations);
-              Optional.ofNullable(f.getEndDate())
-                  .map(mapToOperations(OffsetDateTime.class))
-                  .ifPresent(builder::endDateOperations);
-              Optional.ofNullable(f.getElementInstanceScopeKey())
-                  .map(KeyUtil::keyToLong)
-                  .ifPresent(builder::elementInstanceScopeKeys);
-            });
-    return builder.build();
+    final List<String> validationErrors = new ArrayList<>();
+    if (filter != null) {
+      Optional.ofNullable(filter.getElementInstanceKey())
+          .map(KeyUtil::keyToLong)
+          .ifPresent(builder::flowNodeInstanceKeys);
+      Optional.ofNullable(filter.getProcessInstanceKey())
+          .map(KeyUtil::keyToLong)
+          .ifPresent(builder::processInstanceKeys);
+      Optional.ofNullable(filter.getProcessDefinitionKey())
+          .map(KeyUtil::keyToLong)
+          .ifPresent(builder::processDefinitionKeys);
+      Optional.ofNullable(filter.getProcessDefinitionId()).ifPresent(builder::processDefinitionIds);
+      Optional.ofNullable(filter.getState())
+          .map(mapToStringOperations())
+          .ifPresent(builder::stateOperations);
+      Optional.ofNullable(filter.getType())
+          .ifPresent(t -> builder.types(FlowNodeType.fromZeebeBpmnElementType(t.getValue())));
+      Optional.ofNullable(filter.getElementId()).ifPresent(builder::flowNodeIds);
+      Optional.ofNullable(filter.getElementName()).ifPresent(builder::flowNodeNames);
+      Optional.ofNullable(filter.getHasIncident()).ifPresent(builder::hasIncident);
+      Optional.ofNullable(filter.getIncidentKey())
+          .map(KeyUtil::keyToLong)
+          .ifPresent(builder::incidentKeys);
+      Optional.ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
+      Optional.ofNullable(filter.getStartDate())
+          .map(mapToOffsetDateTimeOperations("startDate", validationErrors))
+          .ifPresent(builder::startDateOperations);
+      Optional.ofNullable(filter.getEndDate())
+          .map(mapToOffsetDateTimeOperations("endDate", validationErrors))
+          .ifPresent(builder::endDateOperations);
+      Optional.ofNullable(filter.getElementInstanceScopeKey())
+          .map(KeyUtil::keyToLong)
+          .ifPresent(builder::elementInstanceScopeKeys);
+    }
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
   static Either<List<String>, UserTaskFilter> toUserTaskFilter(
@@ -868,24 +874,24 @@ public class SearchQueryFilterMapper {
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::userTaskKeys);
       Optional.ofNullable(filter.getState())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::stateOperations);
       Optional.ofNullable(filter.getProcessDefinitionId()).ifPresent(builder::bpmnProcessIds);
       Optional.ofNullable(filter.getElementId()).ifPresent(builder::elementIds);
       Optional.ofNullable(filter.getName())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::nameOperations);
       Optional.ofNullable(filter.getAssignee())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::assigneeOperations);
       Optional.ofNullable(filter.getPriority())
-          .map(mapToOperations(Integer.class))
+          .map(mapToIntegerOperations())
           .ifPresent(builder::priorityOperations);
       Optional.ofNullable(filter.getCandidateGroup())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::candidateGroupOperations);
       Optional.ofNullable(filter.getCandidateUser())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::candidateUserOperations);
       Optional.ofNullable(filter.getProcessDefinitionKey())
           .map(KeyUtil::keyToLong)
@@ -894,7 +900,7 @@ public class SearchQueryFilterMapper {
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::processInstanceKeys);
       Optional.ofNullable(filter.getTenantId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);
       Optional.ofNullable(filter.getElementInstanceKey())
           .map(KeyUtil::keyToLong)
@@ -918,16 +924,16 @@ public class SearchQueryFilterMapper {
         }
       }
       Optional.ofNullable(filter.getCreationDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("creationDate", validationErrors))
           .ifPresent(builder::creationDateOperations);
       Optional.ofNullable(filter.getCompletionDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("completionDate", validationErrors))
           .ifPresent(builder::completionDateOperations);
       Optional.ofNullable(filter.getDueDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("dueDate", validationErrors))
           .ifPresent(builder::dueDateOperations);
       Optional.ofNullable(filter.getFollowUpDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("followUpDate", validationErrors))
           .ifPresent(builder::followUpDateOperations);
 
       if (!CollectionUtils.isEmpty(filter.getTags())) {
@@ -950,245 +956,266 @@ public class SearchQueryFilterMapper {
     final var builder = FilterBuilders.user();
     if (filter != null) {
       Optional.ofNullable(filter.getUsername())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::usernameOperations);
       Optional.ofNullable(filter.getName())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::nameOperations);
       Optional.ofNullable(filter.getEmail())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::emailOperations);
     }
     return builder.build();
   }
 
-  static IncidentFilter toIncidentFilter(
+  static Either<List<String>, IncidentFilter> toIncidentFilter(
       final io.camunda.gateway.protocol.model.IncidentFilter filter) {
     final var builder = FilterBuilders.incident();
+    final List<String> validationErrors = new ArrayList<>();
 
     if (filter != null) {
       ofNullable(filter.getIncidentKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("incidentKey", validationErrors))
           .ifPresent(builder::incidentKeyOperations);
       ofNullable(filter.getProcessDefinitionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeyOperations);
       ofNullable(filter.getProcessDefinitionId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionIdOperations);
       ofNullable(filter.getProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeyOperations);
       ofNullable(filter.getErrorType())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::errorTypeOperations);
       ofNullable(filter.getErrorMessage())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::errorMessageOperations);
       ofNullable(filter.getElementId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::flowNodeIdOperations);
       ofNullable(filter.getElementInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("elementInstanceKey", validationErrors))
           .ifPresent(builder::flowNodeInstanceKeyOperations);
       ofNullable(filter.getCreationTime())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("creationTime", validationErrors))
           .ifPresent(builder::creationTimeOperations);
       ofNullable(filter.getState())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::stateOperations);
       ofNullable(filter.getJobKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("jobKey", validationErrors))
           .ifPresent(builder::jobKeyOperations);
       ofNullable(filter.getTenantId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);
     }
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
-  static MessageSubscriptionFilter toMessageSubscriptionFilter(
+  static Either<List<String>, MessageSubscriptionFilter> toMessageSubscriptionFilter(
       final io.camunda.gateway.protocol.model.MessageSubscriptionFilter filter) {
     final var builder = FilterBuilders.messageSubscription();
+    final List<String> validationErrors = new ArrayList<>();
 
     if (filter != null) {
       ofNullable(filter.getProcessDefinitionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeyOperations);
       ofNullable(filter.getMessageSubscriptionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("messageSubscriptionKey", validationErrors))
           .ifPresent(builder::messageSubscriptionKeyOperations);
       ofNullable(filter.getProcessDefinitionId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionIdOperations);
       ofNullable(filter.getProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeyOperations);
       ofNullable(filter.getElementId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::flowNodeIdOperations);
       ofNullable(filter.getElementInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("elementInstanceKey", validationErrors))
           .ifPresent(builder::flowNodeInstanceKeyOperations);
       ofNullable(filter.getMessageSubscriptionState())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::messageSubscriptionStateOperations);
       ofNullable(filter.getLastUpdatedDate())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("lastUpdatedDate", validationErrors))
           .ifPresent(builder::dateTimeOperations);
       ofNullable(filter.getMessageName())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::messageNameOperations);
       ofNullable(filter.getCorrelationKey())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::correlationKeyOperations);
       ofNullable(filter.getTenantId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);
     }
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
-  static CorrelatedMessageSubscriptionFilter toCorrelatedMessageSubscriptionFilter(
-      final io.camunda.gateway.protocol.model.CorrelatedMessageSubscriptionFilter filter) {
+  static Either<List<String>, CorrelatedMessageSubscriptionFilter>
+      toCorrelatedMessageSubscriptionFilter(
+          final io.camunda.gateway.protocol.model.CorrelatedMessageSubscriptionFilter filter) {
     final var builder = FilterBuilders.correlatedMessageSubscription();
+    final List<String> validationErrors = new ArrayList<>();
 
     if (filter != null) {
       ofNullable(filter.getCorrelationKey())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::correlationKeyOperations);
       ofNullable(filter.getCorrelationTime())
-          .map(mapToOperations(OffsetDateTime.class))
+          .map(mapToOffsetDateTimeOperations("correlationTime", validationErrors))
           .ifPresent(builder::correlationTimeOperations);
       ofNullable(filter.getElementId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::flowNodeIdOperations);
       ofNullable(filter.getElementInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("elementInstanceKey", validationErrors))
           .ifPresent(builder::flowNodeInstanceKeyOperations);
       ofNullable(filter.getMessageKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("messageKey", validationErrors))
           .ifPresent(builder::messageKeyOperations);
       ofNullable(filter.getMessageName())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::messageNameOperations);
       ofNullable(filter.getPartitionId())
-          .map(mapToOperations(Integer.class))
+          .map(mapToIntegerOperations())
           .ifPresent(builder::partitionIdOperations);
       ofNullable(filter.getProcessDefinitionId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionIdOperations);
       ofNullable(filter.getProcessDefinitionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeyOperations);
       ofNullable(filter.getProcessInstanceKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeyOperations);
       ofNullable(filter.getSubscriptionKey())
-          .map(mapToOperations(Long.class))
+          .map(mapToKeyOperations("subscriptionKey", validationErrors))
           .ifPresent(builder::subscriptionKeyOperations);
       ofNullable(filter.getTenantId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);
     }
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
-  static io.camunda.search.filter.AuditLogFilter toAuditLogFilter(
+  static Either<List<String>, io.camunda.search.filter.AuditLogFilter> toAuditLogFilter(
       final io.camunda.gateway.protocol.model.AuditLogFilter filter) {
     if (filter == null) {
-      return FilterBuilders.auditLog().build();
+      return Either.right(FilterBuilders.auditLog().build());
     }
 
     final var builder = FilterBuilders.auditLog();
+    final List<String> validationErrors = new ArrayList<>();
     ofNullable(filter.getAuditLogKey())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::auditLogKeyOperations);
     ofNullable(filter.getProcessDefinitionKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("processDefinitionKey", validationErrors))
         .ifPresent(builder::processDefinitionKeyOperations);
     ofNullable(filter.getProcessInstanceKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("processInstanceKey", validationErrors))
         .ifPresent(builder::processInstanceKeyOperations);
     ofNullable(filter.getElementInstanceKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("elementInstanceKey", validationErrors))
         .ifPresent(builder::elementInstanceKeyOperations);
     ofNullable(filter.getOperationType())
-        .map(mapToOperations(String.class, new AuditLogOperationTypeConverter()))
+        .map(
+            mapToStringOperations(
+                "operationType", validationErrors, new AuditLogOperationTypeConverter()))
         .ifPresent(builder::operationTypeOperations);
     ofNullable(filter.getResult())
-        .map(mapToOperations(String.class, new AuditLogResultConverter()))
+        .map(mapToStringOperations("result", validationErrors, new AuditLogResultConverter()))
         .ifPresent(builder::resultOperations);
     ofNullable(filter.getTimestamp())
-        .map(mapToOperations(OffsetDateTime.class))
+        .map(mapToOffsetDateTimeOperations("timestamp", validationErrors))
         .ifPresent(builder::timestampOperations);
     ofNullable(filter.getActorId())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::actorIdOperations);
     ofNullable(filter.getActorType())
-        .map(mapToOperations(String.class, new AuditLogActorTypeConverter()))
+        .map(mapToStringOperations("actorType", validationErrors, new AuditLogActorTypeConverter()))
         .ifPresent(builder::actorTypeOperations);
     ofNullable(filter.getAgentElementId())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::agentElementIdOperations);
     ofNullable(filter.getEntityType())
-        .map(mapToOperations(String.class, new AuditLogEntityTypeConverter()))
+        .map(
+            mapToStringOperations(
+                "entityType", validationErrors, new AuditLogEntityTypeConverter()))
         .ifPresent(builder::entityTypeOperations);
     ofNullable(filter.getEntityKey())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::entityKeyOperations);
     ofNullable(filter.getTenantId())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::tenantIdOperations);
     ofNullable(filter.getCategory())
-        .map(mapToOperations(String.class, new AuditLogCategoryConverter()))
+        .map(mapToStringOperations("category", validationErrors, new AuditLogCategoryConverter()))
         .ifPresent(builder::categoryOperations);
     ofNullable(filter.getDeploymentKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("deploymentKey", validationErrors))
         .ifPresent(builder::deploymentKeyOperations);
     ofNullable(filter.getFormKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("formKey", validationErrors))
         .ifPresent(builder::formKeyOperations);
     ofNullable(filter.getResourceKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("resourceKey", validationErrors))
         .ifPresent(builder::resourceKeyOperations);
     ofNullable(filter.getBatchOperationType())
-        .map(mapToOperations(String.class, new BatchOperationTypeConverter()))
+        .map(
+            mapToStringOperations(
+                "batchOperationType", validationErrors, new BatchOperationTypeConverter()))
         .ifPresent(builder::batchOperationTypeOperations);
     ofNullable(filter.getProcessDefinitionId())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::processDefinitionIdOperations);
     ofNullable(filter.getJobKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("jobKey", validationErrors))
         .ifPresent(builder::jobKeyOperations);
     ofNullable(filter.getUserTaskKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("userTaskKey", validationErrors))
         .ifPresent(builder::userTaskKeyOperations);
     ofNullable(filter.getDecisionRequirementsId())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::decisionRequirementsIdOperations);
     ofNullable(filter.getDecisionRequirementsKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("decisionRequirementsKey", validationErrors))
         .ifPresent(builder::decisionRequirementsKeyOperations);
     ofNullable(filter.getDecisionDefinitionId())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::decisionDefinitionIdOperations);
     ofNullable(filter.getDecisionDefinitionKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("decisionDefinitionKey", validationErrors))
         .ifPresent(builder::decisionDefinitionKeyOperations);
     ofNullable(filter.getDecisionEvaluationKey())
-        .map(mapToOperations(Long.class))
+        .map(mapToKeyOperations("decisionEvaluationKey", validationErrors))
         .ifPresent(builder::decisionEvaluationKeyOperations);
     ofNullable(filter.getRelatedEntityKey())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::relatedEntityKeyOperations);
     ofNullable(filter.getRelatedEntityType())
-        .map(mapToOperations(String.class, new AuditLogEntityTypeConverter()))
+        .map(
+            mapToStringOperations(
+                "relatedEntityType", validationErrors, new AuditLogEntityTypeConverter()))
         .ifPresent(builder::relatedEntityTypeOperations);
     ofNullable(filter.getEntityDescription())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::entityDescriptionOperations);
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
   static Either<List<String>, ProcessDefinitionInstanceVersionStatisticsFilter>
@@ -1246,7 +1273,7 @@ public class SearchQueryFilterMapper {
 
   private static List<VariableValueFilter> toVariableValueFilters(
       final String name, final StringFilterProperty value) {
-    final List<Operation<String>> operations = mapToOperations(String.class).apply(value);
+    final List<Operation<String>> operations = mapToStringOperations().apply(value);
     return new VariableValueFilter.Builder()
         .name(name)
         .valueTypedOperations(operations)
@@ -1269,28 +1296,34 @@ public class SearchQueryFilterMapper {
         .orElse(null);
   }
 
-  static AuditLogFilter toUserTaskAuditLogFilter(final UserTaskAuditLogFilter filter) {
+  static Either<List<String>, AuditLogFilter> toUserTaskAuditLogFilter(
+      final UserTaskAuditLogFilter filter) {
     if (filter == null) {
-      return FilterBuilders.auditLog().build();
+      return Either.right(FilterBuilders.auditLog().build());
     }
 
     final var builder = FilterBuilders.auditLog();
+    final List<String> validationErrors = new ArrayList<>();
     ofNullable(filter.getOperationType())
-        .map(mapToOperations(String.class, new AuditLogOperationTypeConverter()))
+        .map(
+            mapToStringOperations(
+                "operationType", validationErrors, new AuditLogOperationTypeConverter()))
         .ifPresent(builder::operationTypeOperations);
     ofNullable(filter.getResult())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::resultOperations);
     ofNullable(filter.getTimestamp())
-        .map(mapToOperations(OffsetDateTime.class))
+        .map(mapToOffsetDateTimeOperations("timestamp", validationErrors))
         .ifPresent(builder::timestampOperations);
     ofNullable(filter.getActorId())
-        .map(mapToOperations(String.class))
+        .map(mapToStringOperations())
         .ifPresent(builder::actorIdOperations);
     ofNullable(filter.getActorType())
-        .map(mapToOperations(String.class, new AuditLogActorTypeConverter()))
+        .map(mapToStringOperations("actorType", validationErrors, new AuditLogActorTypeConverter()))
         .ifPresent(builder::actorTypeOperations);
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
   static VariableFilter toUserTaskVariableFilter(final UserTaskVariableFilter filter) {
@@ -1299,9 +1332,7 @@ public class SearchQueryFilterMapper {
     }
 
     final var builder = FilterBuilders.variable();
-    ofNullable(filter.getName())
-        .map(mapToOperations(String.class))
-        .ifPresent(builder::nameOperations);
+    ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
 
     return builder.build();
   }
@@ -1324,34 +1355,35 @@ public class SearchQueryFilterMapper {
             f -> f.state(IncidentState.ACTIVE.name()).errorHashCode(filter.getErrorHashCode())));
   }
 
-  static GlobalListenerFilter toGlobalTaskListenerFilter(
+  static Either<List<String>, GlobalListenerFilter> toGlobalTaskListenerFilter(
       final GlobalTaskListenerSearchQueryFilterRequest filter) {
 
     final var builder =
         FilterBuilders.globalListener().listenerTypes(GlobalListenerType.USER_TASK.name());
+    final List<String> validationErrors = new ArrayList<>();
 
     if (filter != null) {
       ofNullable(filter.getId())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::listenerIdOperations);
-      ofNullable(filter.getType())
-          .map(mapToOperations(String.class))
-          .ifPresent(builder::typeOperations);
+      ofNullable(filter.getType()).map(mapToStringOperations()).ifPresent(builder::typeOperations);
       ofNullable(filter.getRetries())
-          .map(mapToOperations(Integer.class))
+          .map(mapToIntegerOperations())
           .ifPresent(builder::retriesOperations);
       ofNullable(filter.getEventTypes())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::eventTypeOperations);
       ofNullable(filter.getAfterNonGlobal()).ifPresent(builder::afterNonGlobal);
       ofNullable(filter.getPriority())
-          .map(mapToOperations(Integer.class))
+          .map(mapToIntegerOperations())
           .ifPresent(builder::priorityOperations);
       ofNullable(filter.getSource())
-          .map(mapToOperations(String.class))
+          .map(mapToStringOperations())
           .ifPresent(builder::sourceOperations);
     }
 
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -11,6 +11,7 @@ import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapT
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToKeyOperations;
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToOffsetDateTimeOperations;
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToStringOperations;
+import static io.camunda.gateway.mapping.http.util.KeyUtil.mapKeyToLong;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_NULL_VARIABLE_NAME;
@@ -28,7 +29,6 @@ import io.camunda.gateway.mapping.http.converters.AuditLogResultConverter;
 import io.camunda.gateway.mapping.http.converters.BatchOperationTypeConverter;
 import io.camunda.gateway.mapping.http.converters.DecisionInstanceStateConverter;
 import io.camunda.gateway.mapping.http.converters.ProcessInstanceStateConverter;
-import io.camunda.gateway.mapping.http.util.KeyUtil;
 import io.camunda.gateway.mapping.http.validator.TagsValidator;
 import io.camunda.gateway.protocol.model.BaseProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.ClusterVariableSearchQueryFilterRequest;
@@ -265,7 +265,7 @@ public class SearchQueryFilterMapper {
 
     if (filter != null) {
       ofNullable(filter.getDecisionEvaluationKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("decisionEvaluationKey", validationErrors))
           .ifPresent(builder::decisionInstanceKeys);
       ofNullable(filter.getDecisionEvaluationInstanceKey())
           .map(mapToStringOperations())
@@ -280,10 +280,10 @@ public class SearchQueryFilterMapper {
           .map(mapToOffsetDateTimeOperations("evaluationDate", validationErrors))
           .ifPresent(builder::evaluationDateOperations);
       ofNullable(filter.getProcessDefinitionKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeys);
       ofNullable(filter.getProcessInstanceKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeys);
       ofNullable(filter.getElementInstanceKey())
           .map(mapToKeyOperations("elementInstanceKey", validationErrors))
@@ -559,29 +559,28 @@ public class SearchQueryFilterMapper {
         : Either.left(validationErrors);
   }
 
-  static ProcessDefinitionFilter toProcessDefinitionFilter(
+  static Either<List<String>, ProcessDefinitionFilter> toProcessDefinitionFilter(
       final io.camunda.gateway.protocol.model.ProcessDefinitionFilter filter) {
     final var builder = FilterBuilders.processDefinition();
-    Optional.ofNullable(filter)
-        .ifPresent(
-            f -> {
-              Optional.ofNullable(f.getIsLatestVersion()).ifPresent(builder::isLatestVersion);
-              Optional.ofNullable(f.getProcessDefinitionKey())
-                  .map(KeyUtil::keyToLong)
-                  .ifPresent(builder::processDefinitionKeys);
-              Optional.ofNullable(f.getName())
-                  .map(mapToStringOperations())
-                  .ifPresent(builder::nameOperations);
-              Optional.ofNullable(f.getResourceName()).ifPresent(builder::resourceNames);
-              Optional.ofNullable(f.getVersion()).ifPresent(builder::versions);
-              Optional.ofNullable(f.getVersionTag()).ifPresent(builder::versionTags);
-              Optional.ofNullable(f.getProcessDefinitionId())
-                  .map(mapToStringOperations())
-                  .ifPresent(builder::processDefinitionIdOperations);
-              Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
-              Optional.ofNullable(f.getHasStartForm()).ifPresent(builder::hasStartForm);
-            });
-    return builder.build();
+    final List<String> validationErrors = new ArrayList<>();
+    if (filter != null) {
+      ofNullable(filter.getIsLatestVersion()).ifPresent(builder::isLatestVersion);
+      ofNullable(filter.getProcessDefinitionKey())
+          .map(mapKeyToLong("processDefinitionKey", validationErrors))
+          .ifPresent(builder::processDefinitionKeys);
+      ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
+      ofNullable(filter.getResourceName()).ifPresent(builder::resourceNames);
+      ofNullable(filter.getVersion()).ifPresent(builder::versions);
+      ofNullable(filter.getVersionTag()).ifPresent(builder::versionTags);
+      ofNullable(filter.getProcessDefinitionId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::processDefinitionIdOperations);
+      ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
+      ofNullable(filter.getHasStartForm()).ifPresent(builder::hasStartForm);
+    }
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
   static OffsetDateTime toOffsetDateTime(final String text) {
@@ -776,13 +775,14 @@ public class SearchQueryFilterMapper {
     return builder.build();
   }
 
-  static DecisionDefinitionFilter toDecisionDefinitionFilter(
+  static Either<List<String>, DecisionDefinitionFilter> toDecisionDefinitionFilter(
       final io.camunda.gateway.protocol.model.DecisionDefinitionFilter filter) {
     final var builder = FilterBuilders.decisionDefinition();
+    final List<String> validationErrors = new ArrayList<>();
 
     if (filter != null) {
       ofNullable(filter.getDecisionDefinitionKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("decisionDefinitionKey", validationErrors))
           .ifPresent(builder::decisionDefinitionKeys);
       ofNullable(filter.getDecisionDefinitionId()).ifPresent(builder::decisionDefinitionIds);
       ofNullable(filter.getName()).ifPresent(builder::names);
@@ -790,7 +790,7 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getVersion()).ifPresent(builder::versions);
       ofNullable(filter.getDecisionRequirementsId()).ifPresent(builder::decisionRequirementsIds);
       ofNullable(filter.getDecisionRequirementsKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("decisionRequirementsKey", validationErrors))
           .ifPresent(builder::decisionRequirementsKeys);
       ofNullable(filter.getDecisionRequirementsName())
           .ifPresent(builder::decisionRequirementsNames);
@@ -799,28 +799,30 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
     }
 
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
-  static DecisionRequirementsFilter toDecisionRequirementsFilter(
+  static Either<List<String>, DecisionRequirementsFilter> toDecisionRequirementsFilter(
       final io.camunda.gateway.protocol.model.DecisionRequirementsFilter filter) {
     final var builder = FilterBuilders.decisionRequirements();
+    final List<String> validationErrors = new ArrayList<>();
 
-    Optional.ofNullable(filter)
-        .ifPresent(
-            f -> {
-              Optional.ofNullable(f.getDecisionRequirementsKey())
-                  .map(KeyUtil::keyToLong)
-                  .ifPresent(builder::decisionRequirementsKeys);
-              Optional.ofNullable(f.getDecisionRequirementsName()).ifPresent(builder::names);
-              Optional.ofNullable(f.getVersion()).ifPresent(builder::versions);
-              Optional.ofNullable(f.getDecisionRequirementsId())
-                  .ifPresent(builder::decisionRequirementsIds);
-              Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
-              Optional.ofNullable(f.getResourceName()).ifPresent(builder::resourceNames);
-            });
+    if (filter != null) {
+      ofNullable(filter.getDecisionRequirementsKey())
+          .map(mapKeyToLong("decisionRequirementsKey", validationErrors))
+          .ifPresent(builder::decisionRequirementsKeys);
+      ofNullable(filter.getDecisionRequirementsName()).ifPresent(builder::names);
+      ofNullable(filter.getVersion()).ifPresent(builder::versions);
+      ofNullable(filter.getDecisionRequirementsId()).ifPresent(builder::decisionRequirementsIds);
+      ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
+      ofNullable(filter.getResourceName()).ifPresent(builder::resourceNames);
+    }
 
-    return builder.build();
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
   }
 
   static Either<List<String>, FlowNodeInstanceFilter> toElementInstanceFilter(
@@ -829,13 +831,13 @@ public class SearchQueryFilterMapper {
     final List<String> validationErrors = new ArrayList<>();
     if (filter != null) {
       Optional.ofNullable(filter.getElementInstanceKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("elementInstanceKey", validationErrors))
           .ifPresent(builder::flowNodeInstanceKeys);
       Optional.ofNullable(filter.getProcessInstanceKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeys);
       Optional.ofNullable(filter.getProcessDefinitionKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeys);
       Optional.ofNullable(filter.getProcessDefinitionId()).ifPresent(builder::processDefinitionIds);
       Optional.ofNullable(filter.getState())
@@ -847,7 +849,7 @@ public class SearchQueryFilterMapper {
       Optional.ofNullable(filter.getElementName()).ifPresent(builder::flowNodeNames);
       Optional.ofNullable(filter.getHasIncident()).ifPresent(builder::hasIncident);
       Optional.ofNullable(filter.getIncidentKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("incidentKey", validationErrors))
           .ifPresent(builder::incidentKeys);
       Optional.ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
       Optional.ofNullable(filter.getStartDate())
@@ -857,7 +859,7 @@ public class SearchQueryFilterMapper {
           .map(mapToOffsetDateTimeOperations("endDate", validationErrors))
           .ifPresent(builder::endDateOperations);
       Optional.ofNullable(filter.getElementInstanceScopeKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("elementInstanceScopeKey", validationErrors))
           .ifPresent(builder::elementInstanceScopeKeys);
     }
     return validationErrors.isEmpty()
@@ -871,7 +873,7 @@ public class SearchQueryFilterMapper {
     final List<String> validationErrors = new ArrayList<>();
     if (filter != null) {
       Optional.ofNullable(filter.getUserTaskKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("userTaskKey", validationErrors))
           .ifPresent(builder::userTaskKeys);
       Optional.ofNullable(filter.getState())
           .map(mapToStringOperations())
@@ -894,16 +896,16 @@ public class SearchQueryFilterMapper {
           .map(mapToStringOperations())
           .ifPresent(builder::candidateUserOperations);
       Optional.ofNullable(filter.getProcessDefinitionKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeys);
       Optional.ofNullable(filter.getProcessInstanceKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeys);
       Optional.ofNullable(filter.getTenantId())
           .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);
       Optional.ofNullable(filter.getElementInstanceKey())
-          .map(KeyUtil::keyToLong)
+          .map(mapKeyToLong("elementInstanceKey", validationErrors))
           .ifPresent(builder::elementInstanceKeys);
       if (!CollectionUtils.isEmpty(filter.getProcessInstanceVariables())) {
         final Either<List<String>, List<VariableValueFilter>> either =

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -106,7 +106,7 @@ public class SearchQueryFilterMapper {
           final var orBuilder = toBaseProcessInstanceFilterFields(processDefinitionKey, or);
           if (orBuilder.isLeft()) {
             validationErrors.addAll(orBuilder.getLeft());
-          } else {
+          } else if (builder.isRight()) {
             builder.get().addOrOperation(orBuilder.get().build());
           }
         }
@@ -624,7 +624,7 @@ public class SearchQueryFilterMapper {
           final var orBuilder = toProcessInstanceFilterFields(or);
           if (orBuilder.isLeft()) {
             validationErrors.addAll(orBuilder.getLeft());
-          } else {
+          } else if (builder.isRight()) {
             builder.get().addOrOperation(orBuilder.get().build());
           }
         }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -173,7 +173,7 @@ public class SearchQueryFilterMapper {
           .map(mapToStringOperations())
           .ifPresent(builder::flowNodeInstanceStateOperations);
       ofNullable(filter.getIncidentErrorHashCode())
-          .map(mapToIntegerOperations())
+          .map(mapToIntegerOperations("incidentErrorHashCode", validationErrors))
           .ifPresent(builder::incidentErrorHashCodeOperations);
       if (!CollectionUtils.isEmpty(filter.getVariables())) {
         final Either<List<String>, List<VariableValueFilter>> either =
@@ -243,7 +243,7 @@ public class SearchQueryFilterMapper {
           .ifPresent(builder::errorMessageOperations);
       ofNullable(filter.getHasFailedWithRetriesLeft()).ifPresent(builder::hasFailedWithRetriesLeft);
       ofNullable(filter.getRetries())
-          .map(mapToIntegerOperations())
+          .map(mapToIntegerOperations("retries", validationErrors))
           .ifPresent(builder::retriesOperations);
       ofNullable(filter.getCreationTime())
           .map(mapToOffsetDateTimeOperations("creationTime", validationErrors))
@@ -651,7 +651,7 @@ public class SearchQueryFilterMapper {
           .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionNameOperations);
       ofNullable(filter.getProcessDefinitionVersion())
-          .map(mapToIntegerOperations())
+          .map(mapToIntegerOperations("processDefinitionVersion", validationErrors))
           .ifPresent(builder::processDefinitionVersionOperations);
       ofNullable(filter.getProcessDefinitionVersionTag())
           .map(mapToStringOperations())
@@ -705,7 +705,7 @@ public class SearchQueryFilterMapper {
           .map(mapToStringOperations())
           .ifPresent(builder::flowNodeInstanceStateOperations);
       ofNullable(filter.getIncidentErrorHashCode())
-          .map(mapToIntegerOperations())
+          .map(mapToIntegerOperations("incidentErrorHashCode", validationErrors))
           .ifPresent(builder::incidentErrorHashCodeOperations);
 
       if (!CollectionUtils.isEmpty(filter.getTags())) {
@@ -887,7 +887,7 @@ public class SearchQueryFilterMapper {
           .map(mapToStringOperations())
           .ifPresent(builder::assigneeOperations);
       Optional.ofNullable(filter.getPriority())
-          .map(mapToIntegerOperations())
+          .map(mapToIntegerOperations("priority", validationErrors))
           .ifPresent(builder::priorityOperations);
       Optional.ofNullable(filter.getCandidateGroup())
           .map(mapToStringOperations())
@@ -1089,7 +1089,7 @@ public class SearchQueryFilterMapper {
           .map(mapToStringOperations())
           .ifPresent(builder::messageNameOperations);
       ofNullable(filter.getPartitionId())
-          .map(mapToIntegerOperations())
+          .map(mapToIntegerOperations("partitionId", validationErrors))
           .ifPresent(builder::partitionIdOperations);
       ofNullable(filter.getProcessDefinitionId())
           .map(mapToStringOperations())
@@ -1370,14 +1370,14 @@ public class SearchQueryFilterMapper {
           .ifPresent(builder::listenerIdOperations);
       ofNullable(filter.getType()).map(mapToStringOperations()).ifPresent(builder::typeOperations);
       ofNullable(filter.getRetries())
-          .map(mapToIntegerOperations())
+          .map(mapToIntegerOperations("retries", validationErrors))
           .ifPresent(builder::retriesOperations);
       ofNullable(filter.getEventTypes())
           .map(mapToStringOperations())
           .ifPresent(builder::eventTypeOperations);
       ofNullable(filter.getAfterNonGlobal()).ifPresent(builder::afterNonGlobal);
       ofNullable(filter.getPriority())
-          .map(mapToIntegerOperations())
+          .map(mapToIntegerOperations("priority", validationErrors))
           .ifPresent(builder::priorityOperations);
       ofNullable(filter.getSource())
           .map(mapToStringOperations())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -21,10 +21,8 @@ import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.filter.FilterBuilders;
-import io.camunda.search.filter.GlobalListenerFilter;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.UsageMetricsFilter;
-import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
@@ -586,7 +584,7 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper.fromVariableSearchQuerySortRequest(request.getSort()),
             SortOptionBuilders::variable,
             SearchQuerySortRequestMapper::applyVariableSortField);
-    final VariableFilter filter = SearchQueryFilterMapper.toVariableFilter(request.getFilter());
+    final var filter = SearchQueryFilterMapper.toVariableFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::variableSearchQuery);
   }
 
@@ -891,7 +889,7 @@ public final class SearchQueryRequestMapper {
                 actualRequest.getSort()),
             SortOptionBuilders::globalListener,
             SearchQuerySortRequestMapper::applyGlobalTaskListenerSortField);
-    final GlobalListenerFilter filter =
+    final var filter =
         SearchQueryFilterMapper.toGlobalTaskListenerFilter(actualRequest.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::globalListenerSearchQuery);
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
@@ -65,8 +65,7 @@ public class AdvancedSearchFilterUtil {
   }
 
   public static Function<Object, List<Operation<String>>> mapToStringOperations() {
-    return (final Object filter) ->
-        mapToTypedOperations(filter, value -> value == null ? null : value.toString());
+    return (final Object filter) -> mapToTypedOperations(filter, Object::toString);
   }
 
   public static Function<Object, List<Operation<String>>> mapToStringOperations(
@@ -87,7 +86,7 @@ public class AdvancedSearchFilterUtil {
                   return null;
                 }
               }
-              return value == null ? null : value.toString();
+              return value.toString();
             });
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.gateway.mapping.http.util;
 
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_DATE_PARSING;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_KEY_FORMAT;
+
 import io.camunda.gateway.mapping.http.converters.CustomConverter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.Operator;
@@ -25,51 +28,82 @@ public class AdvancedSearchFilterUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(AdvancedSearchFilterUtil.class);
 
-  public static <T> Function<Object, List<Operation<T>>> mapToOperations(final Class<T> tClass) {
-    return (final Object filter) -> mapToOperations(filter, tClass);
+  public static Function<Object, List<Operation<Long>>> mapToKeyOperations(
+      final String fieldName, final List<String> validationErrors) {
+    return (final Object filter) ->
+        mapToTypedOperations(
+            filter,
+            value -> {
+              if (value instanceof final Long l) {
+                return l;
+              } else if (value instanceof final String s) {
+                try {
+                  return Long.valueOf(s);
+                } catch (final NumberFormatException e) {
+                  validationErrors.add(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted(fieldName, s));
+                  return null;
+                }
+              }
+              validationErrors.add(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted(fieldName, value));
+              return null;
+            });
   }
 
-  public static <T> Function<Object, List<Operation<T>>> mapToOperations(
-      final Class<T> tClass, final CustomConverter<T> customConverter) {
-    return (final Object filter) -> mapToOperations(filter, tClass, customConverter);
+  public static Function<Object, List<Operation<Integer>>> mapToIntegerOperations() {
+    return (final Object filter) ->
+        mapToTypedOperations(filter, value -> value instanceof final Integer i ? i : null);
   }
 
-  protected static <T> T convertValue(final Class<T> tClass, final Object value) {
-    return convertValue(tClass, value, null);
+  public static Function<Object, List<Operation<String>>> mapToStringOperations() {
+    return (final Object filter) ->
+        mapToTypedOperations(filter, value -> value == null ? null : value.toString());
   }
 
-  protected static <T> T convertValue(
-      final Class<T> tClass, final Object value, final CustomConverter<T> customConverter) {
-    if (customConverter != null && customConverter.canConvert(value)) {
-      return customConverter.convertValue(value);
-    }
-    if (value == null) {
-      return null;
-    } else if (tClass.isInstance(value)) {
-      return tClass.cast(value);
-    } else if (tClass == String.class) {
-      return (T) value.toString();
-    } else if (tClass == OffsetDateTime.class && value instanceof String) {
-      try {
-        return (T) OffsetDateTime.parse((String) value);
-      } catch (final DateTimeParseException e) {
-        throw new IllegalArgumentException("Failed to parse date-time: [%s]".formatted(value), e);
-      }
-    } else if (tClass == Long.class && value instanceof String) {
-      return (T) Long.valueOf((String) value);
-    }
-
-    throw new IllegalArgumentException(
-        "Could not convert request value [%s] to [%s]".formatted(value, tClass.getName()));
+  public static Function<Object, List<Operation<String>>> mapToStringOperations(
+      final String fieldName,
+      final List<String> validationErrors,
+      final CustomConverter<String> converter) {
+    return (final Object filter) ->
+        mapToTypedOperations(
+            filter,
+            value -> {
+              if (converter.canConvert(value)) {
+                try {
+                  return converter.convertValue(value);
+                } catch (final Exception e) {
+                  validationErrors.add(
+                      "The provided %s '%s' is not valid: %s"
+                          .formatted(fieldName, value, e.getMessage()));
+                  return null;
+                }
+              }
+              return value == null ? null : value.toString();
+            });
   }
 
-  protected static <T> List<Operation<T>> mapToOperations(
-      final Object filter, final Class<T> tClass) {
-    return mapToOperations(filter, tClass, null);
+  public static Function<Object, List<Operation<OffsetDateTime>>> mapToOffsetDateTimeOperations(
+      final String fieldName, final List<String> validationErrors) {
+    return (final Object filter) ->
+        mapToTypedOperations(
+            filter,
+            value -> {
+              if (value instanceof final OffsetDateTime odt) {
+                return odt;
+              } else if (value instanceof final String s) {
+                try {
+                  return OffsetDateTime.parse(s);
+                } catch (final DateTimeParseException e) {
+                  validationErrors.add(ERROR_MESSAGE_DATE_PARSING.formatted(fieldName, s));
+                  return null;
+                }
+              }
+              validationErrors.add(ERROR_MESSAGE_DATE_PARSING.formatted(fieldName, value));
+              return null;
+            });
   }
 
-  protected static <T> List<Operation<T>> mapToOperations(
-      final Object filter, final Class<T> tClass, final CustomConverter<T> customConverter) {
+  private static <T> List<Operation<T>> mapToTypedOperations(
+      final Object filter, final Function<Object, T> converter) {
     final var fClass = filter.getClass();
     final var operations = new ArrayList<Operation<T>>();
     for (final Operator operator : Operator.values()) {
@@ -84,23 +118,54 @@ public class AdvancedSearchFilterUtil {
       method.setAccessible(true);
       try {
         final var value = method.invoke(filter);
-        if (value != null) {
-          if (value instanceof final Boolean booleanValue) {
-            operations.add(Operation.exists(booleanValue));
-          } else if (value instanceof final List<?> values) {
-            if (!values.isEmpty()) {
-              final var tValues =
-                  values.stream().map(v -> convertValue(tClass, v, customConverter)).toList();
-              operations.add(new Operation<>(operator, tValues));
-            }
-          } else {
-            operations.add(new Operation<>(operator, convertValue(tClass, value, customConverter)));
-          }
+        if (value == null) {
+          continue;
         }
+        addTypedOperation(operations, operator, value, converter);
       } catch (final InvocationTargetException | IllegalAccessException e) {
         LOG.error(e.getMessage(), e);
       }
     }
     return operations;
+  }
+
+  private static <T> void addTypedOperation(
+      final List<Operation<T>> operations,
+      final Operator operator,
+      final Object value,
+      final Function<Object, T> converter) {
+    if (value instanceof final Boolean booleanValue) {
+      operations.add(Operation.exists(booleanValue));
+    } else if (value instanceof final List<?> values) {
+      convertListOperation(operations, operator, values, converter);
+    } else {
+      final T converted = converter.apply(value);
+      if (converted != null) {
+        operations.add(new Operation<>(operator, converted));
+      }
+    }
+  }
+
+  private static <T> void convertListOperation(
+      final List<Operation<T>> operations,
+      final Operator operator,
+      final List<?> values,
+      final Function<Object, T> converter) {
+    if (values.isEmpty()) {
+      return;
+    }
+    final var tValues = new ArrayList<T>();
+    boolean hasNull = false;
+    for (final Object v : values) {
+      final T converted = converter.apply(v);
+      if (converted == null) {
+        hasNull = true;
+      } else {
+        tValues.add(converted);
+      }
+    }
+    if (!hasNull && !tValues.isEmpty()) {
+      operations.add(new Operation<>(operator, tValues));
+    }
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
@@ -49,9 +49,19 @@ public class AdvancedSearchFilterUtil {
             });
   }
 
-  public static Function<Object, List<Operation<Integer>>> mapToIntegerOperations() {
+  public static Function<Object, List<Operation<Integer>>> mapToIntegerOperations(
+      final String fieldName, final List<String> validationErrors) {
     return (final Object filter) ->
-        mapToTypedOperations(filter, value -> value instanceof final Integer i ? i : null);
+        mapToTypedOperations(
+            filter,
+            value -> {
+              if (value instanceof final Integer i) {
+                return i;
+              }
+              validationErrors.add(
+                  "The provided %s '%s' is not a valid integer value.".formatted(fieldName, value));
+              return null;
+            });
   }
 
   public static Function<Object, List<Operation<String>>> mapToStringOperations() {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/KeyUtil.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/KeyUtil.java
@@ -7,12 +7,31 @@
  */
 package io.camunda.gateway.mapping.http.util;
 
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_KEY_FORMAT;
+
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 public class KeyUtil {
 
   public static Long keyToLong(final String key) {
     return key != null ? Long.parseLong(key) : null;
+  }
+
+  public static Function<String, Long> mapKeyToLong(
+      final String fieldName, final List<String> validationErrors) {
+    return key -> {
+      if (key == null) {
+        return null;
+      }
+      try {
+        return Long.parseLong(key);
+      } catch (final NumberFormatException e) {
+        validationErrors.add(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted(fieldName, key));
+        return null;
+      }
+    };
   }
 
   public static String keyToString(final Long value) {

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
@@ -11,6 +11,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_KEY_FORMAT;
 import static org.assertj.core.api.Assertions.*;
 
+import io.camunda.gateway.mapping.http.converters.CustomConverter;
 import io.camunda.gateway.mapping.http.converters.ProcessInstanceStateConverter;
 import io.camunda.gateway.protocol.model.AdvancedDateTimeFilter;
 import io.camunda.gateway.protocol.model.AdvancedIntegerFilter;
@@ -333,6 +334,53 @@ class AdvancedSearchFilterUtilTest {
     // then
     assertThat(errors).isEmpty();
     assertThat(actual).containsExactly(Operation.exists(true));
+  }
+
+  @Test
+  void shouldCollectErrorForNonIntegerValue() {
+    // given — BasicStringFilter has String fields, simulating a type mismatch
+    final var filter = new BasicStringFilter();
+    filter.set$Eq("notAnInteger");
+    final var errors = new ArrayList<String>();
+
+    // when
+    final var actual =
+        AdvancedSearchFilterUtil.mapToIntegerOperations("retries", errors).apply(filter);
+
+    // then
+    assertThat(errors)
+        .containsExactly("The provided retries 'notAnInteger' is not a valid integer value.");
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void shouldCollectErrorWhenConverterThrows() {
+    // given
+    final var filter = new BasicStringFilter();
+    filter.set$Eq("badValue");
+    final var errors = new ArrayList<String>();
+    final CustomConverter<String> failingConverter =
+        new CustomConverter<>() {
+          @Override
+          public boolean canConvert(final Object value) {
+            return true;
+          }
+
+          @Override
+          public String convertValue(final Object value) {
+            throw new IllegalArgumentException("conversion failed");
+          }
+        };
+
+    // when
+    final var actual =
+        AdvancedSearchFilterUtil.mapToStringOperations("state", errors, failingConverter)
+            .apply(filter);
+
+    // then
+    assertThat(errors)
+        .containsExactly("The provided state 'badValue' is not valid: conversion failed");
+    assertThat(actual).isEmpty();
   }
 
   @Test

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
@@ -189,11 +189,14 @@ class AdvancedSearchFilterUtilTest {
       throws Exception {
     // given
     final var filter = constructFilter(AdvancedIntegerFilter.class, Integer.class, operations);
+    final var errors = new ArrayList<String>();
 
     // when
-    final var actual = AdvancedSearchFilterUtil.mapToIntegerOperations().apply(filter);
+    final var actual =
+        AdvancedSearchFilterUtil.mapToIntegerOperations("retries", errors).apply(filter);
 
     // then
+    assertThat(errors).isEmpty();
     assertThat(actual).hasSize(operations.size());
     assertThat(actual).containsExactlyInAnyOrderElementsOf(operations);
   }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.gateway.mapping.http.util;
 
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_DATE_PARSING;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_KEY_FORMAT;
 import static org.assertj.core.api.Assertions.*;
 
+import io.camunda.gateway.mapping.http.converters.ProcessInstanceStateConverter;
 import io.camunda.gateway.protocol.model.AdvancedDateTimeFilter;
 import io.camunda.gateway.protocol.model.AdvancedIntegerFilter;
 import io.camunda.gateway.protocol.model.AdvancedStringFilter;
@@ -17,6 +20,7 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.Operator;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
@@ -27,14 +31,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class AdvancedSearchFilterUtilTest {
 
-  private static final List<List<Operation<Long>>> LONG_OPERATIONS =
-      List.of(
-          List.of(Operation.gt(5L)),
-          List.of(Operation.gte(5L)),
-          List.of(Operation.lt(5L)),
-          List.of(Operation.lte(5L)),
-          List.of(Operation.gt(5L), Operation.lt(10L)),
-          List.of(Operation.gte(5L), Operation.lte(10L)));
   private static final List<List<Operation<Long>>> BASIC_LONG_OPERATIONS =
       List.of(
           List.of(Operation.eq(10L)),
@@ -42,6 +38,7 @@ class AdvancedSearchFilterUtilTest {
           List.of(Operation.exists(true)),
           List.of(Operation.exists(false)),
           List.of(Operation.in(5L, 10L)));
+
   private static final List<List<Operation<String>>> BASIC_STRING_OPERATIONS =
       List.of(
           List.of(Operation.eq("this")),
@@ -49,10 +46,12 @@ class AdvancedSearchFilterUtilTest {
           List.of(Operation.exists(true)),
           List.of(Operation.exists(false)),
           List.of(Operation.in("this", "that")));
+
   private static final List<List<Operation<String>>> STRING_OPERATIONS =
       List.of(
           List.of(Operation.like("th%")),
           List.of(Operation.in("this", "that"), Operation.like("th%")));
+
   private static final List<List<Operation<OffsetDateTime>>> DATE_TIME_OPERATIONS =
       List.of(
           List.of(Operation.eq(OffsetDateTime.now())),
@@ -70,6 +69,23 @@ class AdvancedSearchFilterUtilTest {
               Operation.lte(OffsetDateTime.now())),
           List.of(Operation.in(OffsetDateTime.now(), OffsetDateTime.now().minusDays(1))));
 
+  private static final List<List<Operation<Integer>>> BASIC_INTEGER_OPERATIONS =
+      List.of(
+          List.of(Operation.eq(10)),
+          List.of(Operation.neq(1)),
+          List.of(Operation.exists(true)),
+          List.of(Operation.exists(false)),
+          List.of(Operation.in(5, 10)));
+
+  private static final List<List<Operation<Integer>>> INTEGER_OPERATIONS =
+      List.of(
+          List.of(Operation.gt(5)),
+          List.of(Operation.gte(5)),
+          List.of(Operation.lt(5)),
+          List.of(Operation.lte(5)),
+          List.of(Operation.gt(5), Operation.lt(10)),
+          List.of(Operation.gte(5), Operation.lte(10)));
+
   private <F, T> F constructFilter(
       final Class<F> fClass, final Class<T> pClass, final List<Operation<T>> operations)
       throws Exception {
@@ -86,122 +102,248 @@ class AdvancedSearchFilterUtilTest {
           };
       method.setAccessible(true);
       switch (operator) {
-        case IN ->
-            method.invoke(
-                filter,
-                op.values().stream()
-                    .map(v -> AdvancedSearchFilterUtil.convertValue(pClass, v))
-                    .toList());
+        case IN -> method.invoke(filter, op.values());
         case EXISTS, NOT_EXISTS -> method.invoke(filter, operator.equals(Operator.EXISTS));
-        default -> method.invoke(filter, AdvancedSearchFilterUtil.convertValue(pClass, op.value()));
+        default -> method.invoke(filter, op.value());
       }
     }
     return filter;
   }
 
-  private static Stream<Arguments> provideAdvancedFilterParameters() {
+  /**
+   * Constructs a BasicStringFilter from Long operations by converting values to String (simulating
+   * how JSON key fields like processInstanceKey arrive as strings).
+   */
+  private BasicStringFilter constructStringFilterFromLongOps(final List<Operation<Long>> operations)
+      throws Exception {
+    final List<Operation<String>> stringOps =
+        operations.stream()
+            .map(
+                op ->
+                    new Operation<>(
+                        op.operator(),
+                        op.values() != null
+                            ? op.values().stream().map(String::valueOf).toList()
+                            : null))
+            .toList();
+    return constructFilter(BasicStringFilter.class, String.class, stringOps);
+  }
+
+  private static Stream<List<Operation<Long>>> provideKeyOperationsParameters() {
+    return BASIC_LONG_OPERATIONS.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideKeyOperationsParameters")
+  void shouldMapKeyOperationsCorrectly(final List<Operation<Long>> operations) throws Exception {
+    // given
+    final var filter = constructStringFilterFromLongOps(operations);
+    final var errors = new ArrayList<String>();
+
+    // when
+    final var actual = AdvancedSearchFilterUtil.mapToKeyOperations("key", errors).apply(filter);
+
+    // then
+    assertThat(errors).isEmpty();
+    assertThat(actual).hasSize(operations.size());
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(operations);
+  }
+
+  private static Stream<Arguments> provideStringOperationsParameters() {
     final var streamBuilder = Stream.<Arguments>builder();
-    // AdvancedIntegerFilter
-    BASIC_LONG_OPERATIONS.stream()
-        .map(ops -> ops.stream().map(AdvancedSearchFilterUtilTest::toIntOperation).toList())
-        .map(ops -> Arguments.of(AdvancedIntegerFilter.class, Integer.class, Integer.class, ops))
-        .forEach(streamBuilder::add);
-    LONG_OPERATIONS.stream()
-        .map(ops -> ops.stream().map(AdvancedSearchFilterUtilTest::toIntOperation).toList())
-        .map(ops -> Arguments.of(AdvancedIntegerFilter.class, Integer.class, Integer.class, ops))
-        .forEach(streamBuilder::add);
-    // BasicStringFilter
     BASIC_STRING_OPERATIONS.stream()
-        .map(ops -> Arguments.of(BasicStringFilter.class, String.class, String.class, ops))
-        .forEach(streamBuilder::add);
-    // BasicStringFilter - String keys to long
-    BASIC_LONG_OPERATIONS.stream()
-        .map(ops -> Arguments.of(BasicStringFilter.class, String.class, Long.class, ops))
-        .forEach(streamBuilder::add);
-    // AdvancedStringFilter
-    BASIC_STRING_OPERATIONS.stream()
-        .map(ops -> Arguments.of(AdvancedStringFilter.class, String.class, String.class, ops))
+        .flatMap(
+            ops ->
+                Stream.of(
+                    Arguments.of(BasicStringFilter.class, ops),
+                    Arguments.of(AdvancedStringFilter.class, ops)))
         .forEach(streamBuilder::add);
     STRING_OPERATIONS.stream()
-        .map(ops -> Arguments.of(AdvancedStringFilter.class, String.class, String.class, ops))
-        .forEach(streamBuilder::add);
-    // AdvancedDateTimeFilter
-    DATE_TIME_OPERATIONS.stream()
-        .map(
-            ops ->
-                Arguments.of(AdvancedDateTimeFilter.class, String.class, OffsetDateTime.class, ops))
+        .map(ops -> Arguments.of(AdvancedStringFilter.class, ops))
         .forEach(streamBuilder::add);
     return streamBuilder.build();
   }
 
-  private static Operation<Integer> toIntOperation(final Operation<Long> op) {
-    return new Operation<>(
-        op.operator(),
-        op.values() != null ? op.values().stream().map(Long::intValue).toList() : null);
-  }
-
   @ParameterizedTest
-  @MethodSource("provideAdvancedFilterParameters")
-  public <T> void shouldMapAdvancedFilterCorrectly(
-      final Class<?> filterClass,
-      final Class<T> filterValueClass,
-      final Class<T> mappedClass,
-      final List<Operation<T>> operations)
-      throws Exception {
+  @MethodSource("provideStringOperationsParameters")
+  void shouldMapStringOperationsCorrectly(
+      final Class<?> filterClass, final List<Operation<String>> operations) throws Exception {
     // given
-    final var filter = constructFilter(filterClass, filterValueClass, operations);
+    final var filter = constructFilter(filterClass, String.class, operations);
+
     // when
-    final var actual = AdvancedSearchFilterUtil.mapToOperations(filter, mappedClass);
+    final var actual = AdvancedSearchFilterUtil.mapToStringOperations().apply(filter);
+
     // then
     assertThat(actual).hasSize(operations.size());
     assertThat(actual).containsExactlyInAnyOrderElementsOf(operations);
   }
 
+  private static Stream<List<Operation<Integer>>> provideIntegerOperationsParameters() {
+    return Stream.concat(BASIC_INTEGER_OPERATIONS.stream(), INTEGER_OPERATIONS.stream());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideIntegerOperationsParameters")
+  void shouldMapIntegerOperationsCorrectly(final List<Operation<Integer>> operations)
+      throws Exception {
+    // given
+    final var filter = constructFilter(AdvancedIntegerFilter.class, Integer.class, operations);
+
+    // when
+    final var actual = AdvancedSearchFilterUtil.mapToIntegerOperations().apply(filter);
+
+    // then
+    assertThat(actual).hasSize(operations.size());
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(operations);
+  }
+
+  private static Stream<List<Operation<OffsetDateTime>>> provideDateTimeOperationsParameters() {
+    return DATE_TIME_OPERATIONS.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideDateTimeOperationsParameters")
+  void shouldMapDateTimeOperationsCorrectly(final List<Operation<OffsetDateTime>> operations)
+      throws Exception {
+    // given — AdvancedDateTimeFilter has String fields, so convert OffsetDateTime to String
+    final List<Operation<String>> stringOps =
+        operations.stream()
+            .map(
+                op ->
+                    new Operation<>(
+                        op.operator(),
+                        op.values() != null
+                            ? op.values().stream().map(OffsetDateTime::toString).toList()
+                            : null))
+            .toList();
+    final var filter = constructFilter(AdvancedDateTimeFilter.class, String.class, stringOps);
+    final var errors = new ArrayList<String>();
+
+    // when
+    final var actual =
+        AdvancedSearchFilterUtil.mapToOffsetDateTimeOperations("date", errors).apply(filter);
+
+    // then
+    assertThat(errors).isEmpty();
+    assertThat(actual).hasSize(operations.size());
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(operations);
+  }
+
   @Test
-  public void shouldMapToStringOperations() {
+  void shouldMapToStringOperationsFromInteger() {
     // given
     final var filter = new AdvancedIntegerFilter();
     filter.set$Eq(10);
+
     // when
-    final var actual = AdvancedSearchFilterUtil.mapToOperations(filter, String.class);
+    final var actual = AdvancedSearchFilterUtil.mapToStringOperations().apply(filter);
+
     // then
     assertThat(actual).hasSize(1);
     assertThat(actual.getFirst()).isEqualTo(Operation.eq("10"));
   }
 
   @Test
-  public void shouldMapToLongOperations() {
+  void shouldMapToStringOperationsWithConverter() {
     // given
     final var filter = new BasicStringFilter();
-    filter.set$Eq("10");
+    filter.set$Eq("ACTIVE");
+    final var errors = new ArrayList<String>();
+
     // when
-    final var actual = AdvancedSearchFilterUtil.mapToOperations(filter, Long.class);
+    final var actual =
+        AdvancedSearchFilterUtil.mapToStringOperations(
+                "state", errors, new ProcessInstanceStateConverter())
+            .apply(filter);
+
     // then
+    assertThat(errors).isEmpty();
     assertThat(actual).hasSize(1);
-    assertThat(actual.getFirst()).isEqualTo(Operation.eq(10L));
   }
 
   @Test
-  void shouldThrowExceptionWhenCannotConvert() {
+  void shouldCollectErrorForInvalidKeyValue() {
     // given
-    final var filter = new AdvancedIntegerFilter();
-    filter.set$Eq(10);
+    final var filter = new BasicStringFilter();
+    filter.set$Eq("abc");
+    final var errors = new ArrayList<String>();
 
-    // when/then
-    assertThatThrownBy(() -> AdvancedSearchFilterUtil.mapToOperations(filter, Boolean.class))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Could not convert request value [10] to [java.lang.Boolean]");
+    // when
+    final var actual =
+        AdvancedSearchFilterUtil.mapToKeyOperations("processInstanceKey", errors).apply(filter);
+
+    // then
+    assertThat(errors)
+        .containsExactly(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted("processInstanceKey", "abc"));
+    assertThat(actual).isEmpty();
   }
 
   @Test
-  void shouldThrowExceptionWhenDateInvalid() {
+  void shouldCollectErrorForInvalidDateValue() {
     // given
     final var filter = new AdvancedDateTimeFilter();
-    filter.set$Eq("2023-11-11T10:10:10.1010+0100");
+    filter.set$Eq("not-a-date");
+    final var errors = new ArrayList<String>();
 
-    // when/then
-    assertThatThrownBy(() -> AdvancedSearchFilterUtil.mapToOperations(filter, OffsetDateTime.class))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Failed to parse date-time: [2023-11-11T10:10:10.1010+0100]");
+    // when
+    final var actual =
+        AdvancedSearchFilterUtil.mapToOffsetDateTimeOperations("startDate", errors).apply(filter);
+
+    // then
+    assertThat(errors)
+        .containsExactly(ERROR_MESSAGE_DATE_PARSING.formatted("startDate", "not-a-date"));
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void shouldCollectMultipleErrors() {
+    // given
+    final var filter1 = new BasicStringFilter();
+    filter1.set$Eq("abc");
+    final var filter2 = new AdvancedDateTimeFilter();
+    filter2.set$Eq("not-a-date");
+    final var errors = new ArrayList<String>();
+
+    // when
+    AdvancedSearchFilterUtil.mapToKeyOperations("processInstanceKey", errors).apply(filter1);
+    AdvancedSearchFilterUtil.mapToOffsetDateTimeOperations("startDate", errors).apply(filter2);
+
+    // then
+    assertThat(errors).hasSize(2);
+    assertThat(errors.get(0))
+        .isEqualTo(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted("processInstanceKey", "abc"));
+    assertThat(errors.get(1))
+        .isEqualTo(ERROR_MESSAGE_DATE_PARSING.formatted("startDate", "not-a-date"));
+  }
+
+  @Test
+  void shouldHandleExistsOperationInTypedMethods() {
+    // given
+    final var filter = new BasicStringFilter();
+    filter.set$Exists(true);
+    final var errors = new ArrayList<String>();
+
+    // when
+    final var actual = AdvancedSearchFilterUtil.mapToKeyOperations("key", errors).apply(filter);
+
+    // then
+    assertThat(errors).isEmpty();
+    assertThat(actual).containsExactly(Operation.exists(true));
+  }
+
+  @Test
+  void shouldSkipInvalidValuesInListForKeyOperations() {
+    // given
+    final var filter = new BasicStringFilter();
+    filter.set$In(List.of("abc", "def"));
+    final var errors = new ArrayList<String>();
+
+    // when
+    final var actual = AdvancedSearchFilterUtil.mapToKeyOperations("key", errors).apply(filter);
+
+    // then
+    assertThat(errors).hasSize(2);
+    assertThat(actual).isEmpty();
   }
 }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -356,6 +356,52 @@ class IncidentToolsTest extends ToolsTest {
 
       assertTextContentFallback(result);
     }
+
+    @Test
+    void shouldRejectNonNumericProcessInstanceKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchIncidents")
+                  .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail()).contains("processInstanceKey").contains("abc");
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldRejectInvalidCreationTime() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchIncidents")
+                  .arguments(Map.of("filter", Map.of("creationTime", Map.of("from", "not-a-date"))))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail()).contains("creationTime").contains("not-a-date");
+
+      assertTextContentFallback(result);
+    }
   }
 
   @Nested

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -375,7 +375,8 @@ class IncidentToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-      assertThat(problemDetail.getDetail()).contains("processInstanceKey").contains("abc");
+      assertThat(problemDetail.getDetail())
+          .startsWith("The provided processInstanceKey 'abc' is not a valid key.");
 
       assertTextContentFallback(result);
     }
@@ -398,7 +399,8 @@ class IncidentToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-      assertThat(problemDetail.getDetail()).contains("creationTime").contains("not-a-date");
+      assertThat(problemDetail.getDetail())
+          .startsWith("The provided creationTime 'not-a-date' cannot be parsed as a date");
 
       assertTextContentFallback(result);
     }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -380,6 +380,82 @@ class ProcessInstanceToolsTest extends ToolsTest {
 
       assertTextContentFallback(result);
     }
+
+    @Test
+    void shouldRejectNonNumericProcessInstanceKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchProcessInstances")
+                  .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail()).contains("processInstanceKey").contains("abc");
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldRejectInvalidStartDate() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchProcessInstances")
+                  .arguments(Map.of("filter", Map.of("startDate", Map.of("from", "not-a-date"))))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail()).contains("startDate").contains("not-a-date");
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldCollectMultipleFilterValidationErrors() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchProcessInstances")
+                  .arguments(
+                      Map.of(
+                          "filter",
+                          Map.of(
+                              "processInstanceKey",
+                              "abc",
+                              "startDate",
+                              Map.of("from", "not-a-date"))))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail()).contains("processInstanceKey").contains("startDate");
+
+      assertTextContentFallback(result);
+    }
   }
 
   @Nested

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -399,7 +399,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-      assertThat(problemDetail.getDetail()).contains("processInstanceKey").contains("abc");
+      assertThat(problemDetail.getDetail())
+          .startsWith("The provided processInstanceKey 'abc' is not a valid key.");
 
       assertTextContentFallback(result);
     }
@@ -422,7 +423,8 @@ class ProcessInstanceToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-      assertThat(problemDetail.getDetail()).contains("startDate").contains("not-a-date");
+      assertThat(problemDetail.getDetail())
+          .startsWith("The provided startDate 'not-a-date' cannot be parsed as a date");
 
       assertTextContentFallback(result);
     }
@@ -452,7 +454,9 @@ class ProcessInstanceToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-      assertThat(problemDetail.getDetail()).contains("processInstanceKey").contains("startDate");
+      assertThat(problemDetail.getDetail())
+          .contains("The provided processInstanceKey 'abc' is not a valid key.")
+          .contains("The provided startDate 'not-a-date' cannot be parsed as a date");
 
       assertTextContentFallback(result);
     }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -568,6 +568,29 @@ class UserTaskToolsTest extends ToolsTest {
 
       assertTextContentFallback(result);
     }
+
+    @Test
+    void shouldRejectInvalidCreationDate() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchUserTasks")
+                  .arguments(Map.of("filter", Map.of("creationDate", Map.of("from", "not-a-date"))))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail()).contains("creationDate").contains("not-a-date");
+
+      assertTextContentFallback(result);
+    }
   }
 
   @Nested

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -570,6 +570,30 @@ class UserTaskToolsTest extends ToolsTest {
     }
 
     @Test
+    void shouldRejectNonNumericProcessInstanceKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchUserTasks")
+                  .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail())
+          .startsWith("The provided processInstanceKey 'abc' is not a valid key.");
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
     void shouldRejectInvalidCreationDate() {
       // when
       final CallToolResult result =
@@ -587,7 +611,8 @@ class UserTaskToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-      assertThat(problemDetail.getDetail()).contains("creationDate").contains("not-a-date");
+      assertThat(problemDetail.getDetail())
+          .startsWith("The provided creationDate 'not-a-date' cannot be parsed as a date");
 
       assertTextContentFallback(result);
     }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -364,5 +364,49 @@ class VariableToolsTest extends ToolsTest {
 
       assertTextContentFallback(result);
     }
+
+    @Test
+    void shouldRejectNonNumericProcessInstanceKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchVariables")
+                  .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail()).contains("processInstanceKey").contains("abc");
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldRejectNonNumericVariableKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchVariables")
+                  .arguments(Map.of("filter", Map.of("variableKey", "abc")))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail()).contains("variableKey").contains("abc");
+
+      assertTextContentFallback(result);
+    }
   }
 }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -382,7 +382,8 @@ class VariableToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-      assertThat(problemDetail.getDetail()).contains("processInstanceKey").contains("abc");
+      assertThat(problemDetail.getDetail())
+          .startsWith("The provided processInstanceKey 'abc' is not a valid key.");
 
       assertTextContentFallback(result);
     }
@@ -404,7 +405,8 @@ class VariableToolsTest extends ToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
-      assertThat(problemDetail.getDetail()).contains("variableKey").contains("abc");
+      assertThat(problemDetail.getDetail())
+          .startsWith("The provided variableKey 'abc' is not a valid key.");
 
       assertTextContentFallback(result);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -530,9 +530,9 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         """
             {
               "type": "about:blank",
-              "title": "Bad Request",
+              "title": "INVALID_ARGUMENT",
               "status": 400,
-              "detail": "Failed to parse date-time: [invalid]",
+              "detail": "The provided evaluationDate 'invalid' cannot be parsed as a date according to RFC 3339, section 5.6.",
               "instance": "/v2/decision-instances/search"
             }""";
     webClient

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -391,6 +391,47 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  public void shouldRejectElementStatisticsWithInvalidRootFilterAndValidOrClause() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "processInstanceKey": "abc",
+                "$or": [
+                  { "elementId": "elementId" }
+                ]
+              }
+            }""";
+    final var expectedResponse =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided processInstanceKey 'abc' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.",
+              "instance": "/v2/process-definitions/1/statistics/element-instances"
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_URL + "1/statistics/element-instances")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processDefinitionServices, never()).elementStatistics(any(), any());
+  }
+
+  @Test
   public void shouldGetProcessDefinitionXml() {
     // given
     when(processDefinitionServices.getProcessDefinitionXml(eq(23L), any()))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -1045,6 +1045,49 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldReturnBadRequestForInvalidRootFilterWithValidOrClause() {
+    // given
+    final var request =
+        """
+        {
+          "filter": {
+            "processInstanceKey": "abc",
+            "$or": [
+              { "processDefinitionId": "process_v1" }
+            ]
+          }
+        }""";
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "The provided processInstanceKey 'abc' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.",
+                  "instance": "%s"
+                }""",
+            PROCESS_INSTANCES_SEARCH_URL);
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+  }
+
+  @Test
   public void shouldReturnCallHierarchyForGivenKey() {
     // given
     final var processInstanceKey = 123L;


### PR DESCRIPTION
## Description

Instead of throwing exception on conversion errors (from String to Long or to OffsetDateTime), add to the list of validation errors and return a collection of validation errors (see [comment](https://github.com/camunda/camunda/issues/48578#issuecomment-4066021617) on the original issue).

This fixes multiple issues from #48578, but also makes the REST API validation more usable as it collects errors:

- Key conversion errors in MCP tool filters lead to `400 Bad Request` responses with a proper validation message. Same for OffsetDateTime conversions.
- No leaked Java class names in validation error messages.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48578
