### PR TITLE
[Backport stable/8.9] fix: configure firstUser password for camunda-platform 14.x

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/secrets.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/secrets.yml
@@ -12,9 +12,9 @@ metadata:
     {{- include "commonAnnotations" $ | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.camundaPlatform.identity.firstUser.existingSecret }}
-  # Identity login.
-  {{ .Values.camundaPlatform.identity.firstUser.existingSecretKey }}: "{{ .Values.camundaPlatform.identity.firstUser.username | b64enc }}"
+  {{- if .Values.camundaPlatform.identity.firstUser.secret.existingSecret }}
+  # Identity first user password (demo user for smoke tests).
+  {{ .Values.camundaPlatform.identity.firstUser.secret.existingSecretKey }}: "{{ .Values.camundaPlatform.identity.firstUser.username | b64enc }}"
   {{- end }}
   {{- if .Values.camundaPlatform.identityKeycloak.auth.existingSecret }}
   # Identity Keycloak login.

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -259,6 +259,12 @@ camunda-platform:
     fullURL: https://{{ include "ingress.domain" . }}{{ .Values.identity.contextPath }}
     # image:
     #     repository: camunda/identity
+    firstUser:
+      enabled: true
+      username: demo
+      secret:
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-firstuser-password
     resources:
       limits:
         cpu: "1"


### PR DESCRIPTION
# Description
Backport of #48732 to `stable/8.9`.

relates to 