### PR TITLE
feat: 48285 startup url to operate

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -12,7 +12,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -21,6 +20,7 @@ import (
 	"github.com/camunda/camunda/c8run/internal/processmanagement"
 	"github.com/camunda/camunda/c8run/internal/shutdown"
 	"github.com/camunda/camunda/c8run/internal/start"
+	"github.com/camunda/camunda/c8run/internal/startupurl"
 	"github.com/camunda/camunda/c8run/internal/types"
 	"github.com/camunda/camunda/c8run/internal/unix"
 	"github.com/camunda/camunda/c8run/internal/windows"
@@ -193,6 +193,11 @@ func handleDockerCommand(settings types.C8RunSettings, baseCommand string, compo
 			return err
 		}
 		err = health.PrintStatus(settings)
+		if err == nil {
+			if markerErr := startupurl.MarkSeen(settings.StartupMarkerPath); markerErr != nil {
+				log.Warn().Err(markerErr).Str("path", settings.StartupMarkerPath).Msg("Failed to persist quickstart marker")
+			}
+		}
 	case "stop":
 		err = runDockerCommand(composeExtractedFolder, "down")
 	default:
@@ -207,7 +212,7 @@ func handleDockerCommand(settings types.C8RunSettings, baseCommand string, compo
 	return nil // This line will never be reached, but it's required to satisfy the function signature
 }
 
-const docsStartupURL = "https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/c8run/#work-with-camunda-8-run"
+const docsStartupURL = startupurl.DocsURL
 
 func getBaseCommandSettings(baseCommand string) (types.C8RunSettings, bool, error) {
 	var (
@@ -267,46 +272,11 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 }
 
 func createOperateUrl(settings *types.C8RunSettings) string {
-	return fmt.Sprintf("%s://localhost:%s/operate", settings.GetProtocol(), strconv.Itoa(settings.Port))
+	return startupurl.OperateURL(*settings)
 }
 
 func createDefaultStartupUrl(settings *types.C8RunSettings, camundaVersion string) string {
-	if shouldUseDocsStartup(camundaVersion) {
-		return docsStartupURL
-	}
-	return createOperateUrl(settings)
-}
-
-func shouldUseDocsStartup(camundaVersion string) bool {
-	major, minor, ok := parseMajorMinor(camundaVersion)
-	if !ok {
-		return false
-	}
-	if major > 8 {
-		return true
-	}
-	return major == 8 && minor >= 9
-}
-
-func parseMajorMinor(version string) (int, int, bool) {
-	version = strings.TrimSpace(version)
-	if version == "" {
-		return 0, 0, false
-	}
-	base := strings.SplitN(version, "-", 2)[0]
-	parts := strings.Split(base, ".")
-	if len(parts) < 2 {
-		return 0, 0, false
-	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, 0, false
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, 0, false
-	}
-	return major, minor, true
+	return startupurl.Default(*settings, camundaVersion)
 }
 
 func createStopFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
@@ -338,6 +308,7 @@ func initialize(baseCommand string, baseDir string) *types.State {
 	}
 
 	applySecondaryStorageDefaults(baseDir, &settings)
+	settings.StartupMarkerPath = startupurl.MarkerPath(baseDir)
 
 	if strings.EqualFold(settings.SecondaryStorageType, "rdbms") && settings.ResolvedConfigPath != "" {
 		var vendor string

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -271,10 +271,6 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	return startFlagSet
 }
 
-func createOperateUrl(settings *types.C8RunSettings) string {
-	return startupurl.OperateURL(*settings)
-}
-
 func createDefaultStartupUrl(settings *types.C8RunSettings, camundaVersion string) string {
 	return startupurl.Default(*settings, camundaVersion)
 }

--- a/c8run/cmd/c8run/startupurl_test.go
+++ b/c8run/cmd/c8run/startupurl_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/camunda/camunda/c8run/internal/startupurl"
@@ -13,6 +14,7 @@ import (
 func TestShouldUseQuickstartUrlForFirstStartupOnEightNineAndLater(t *testing.T) {
 	// given
 	baseDir := t.TempDir()
+	setUserConfigEnv(t, t.TempDir())
 
 	// when
 	settings := buildSettingsWithVersion(t, []string{"c8run", "start"}, "8.9.0", baseDir)
@@ -26,6 +28,7 @@ func TestShouldUseQuickstartUrlForFirstStartupOnEightNineAndLater(t *testing.T) 
 func TestShouldUseOperateUrlAfterQuickstartWasSeen(t *testing.T) {
 	// given
 	baseDir := t.TempDir()
+	setUserConfigEnv(t, t.TempDir())
 	markerPath := startupurl.MarkerPath(baseDir)
 	if err := startupurl.MarkSeen(markerPath); err != nil {
 		t.Fatalf("failed to create quickstart marker: %v", err)
@@ -44,6 +47,7 @@ func TestShouldUseOperateUrlAfterQuickstartWasSeen(t *testing.T) {
 func TestShouldUseOperateUrlForOlderVersions(t *testing.T) {
 	// given
 	baseDir := t.TempDir()
+	setUserConfigEnv(t, t.TempDir())
 
 	// when
 	settings := buildSettingsWithVersion(t, []string{"c8run", "start", "--port", "9090"}, "8.8.0", baseDir)
@@ -58,6 +62,7 @@ func TestShouldUseOperateUrlForOlderVersions(t *testing.T) {
 func TestShouldKeepCustomStartupUrlWhenProvided(t *testing.T) {
 	// given
 	baseDir := t.TempDir()
+	setUserConfigEnv(t, t.TempDir())
 
 	// when
 	settings := buildSettingsWithVersion(t, []string{
@@ -86,4 +91,18 @@ func buildSettingsWithVersion(t *testing.T, args []string, camundaVersion string
 		settings.StartupUrl = createDefaultStartupUrl(&settings, camundaVersion)
 	}
 	return settings
+}
+
+func setUserConfigEnv(t *testing.T, dir string) {
+	t.Helper()
+
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("APPDATA", dir)
+	case "darwin":
+		t.Setenv("HOME", dir)
+	default:
+		t.Setenv("XDG_CONFIG_HOME", dir)
+		t.Setenv("HOME", dir)
+	}
 }

--- a/c8run/cmd/c8run/startupurl_test.go
+++ b/c8run/cmd/c8run/startupurl_test.go
@@ -4,39 +4,73 @@ import (
 	"os"
 	"testing"
 
+	"github.com/camunda/camunda/c8run/internal/startupurl"
 	"github.com/camunda/camunda/c8run/internal/types"
 )
 
 // We test getBaseCommandSettings indirectly by constructing args and invoking parsing logic.
 
-func TestDefaultStartupUrlUsesDocsForEightNineAndLater(t *testing.T) {
-	settings := buildSettingsWithVersion(t, []string{"c8run", "start"}, "8.9.0")
+func TestShouldUseQuickstartUrlForFirstStartupOnEightNineAndLater(t *testing.T) {
+	// given
+	baseDir := t.TempDir()
 
+	// when
+	settings := buildSettingsWithVersion(t, []string{"c8run", "start"}, "8.9.0", baseDir)
+
+	// then
 	if settings.StartupUrl != docsStartupURL {
 		t.Fatalf("expected StartupUrl to be docs URL, got %s", settings.StartupUrl)
 	}
 }
 
-func TestDefaultStartupUrlUsesOperateForOlderVersions(t *testing.T) {
-	settings := buildSettingsWithVersion(t, []string{"c8run", "start", "--port", "9090"}, "8.8.0")
+func TestShouldUseOperateUrlAfterQuickstartWasSeen(t *testing.T) {
+	// given
+	baseDir := t.TempDir()
+	markerPath := startupurl.MarkerPath(baseDir)
+	if err := startupurl.MarkSeen(markerPath); err != nil {
+		t.Fatalf("failed to create quickstart marker: %v", err)
+	}
 
+	// when
+	settings := buildSettingsWithVersion(t, []string{"c8run", "start"}, "8.9.0", baseDir)
+
+	// then
+	expected := "http://localhost:8080/operate"
+	if settings.StartupUrl != expected {
+		t.Fatalf("expected StartupUrl to be %s, got %s", expected, settings.StartupUrl)
+	}
+}
+
+func TestShouldUseOperateUrlForOlderVersions(t *testing.T) {
+	// given
+	baseDir := t.TempDir()
+
+	// when
+	settings := buildSettingsWithVersion(t, []string{"c8run", "start", "--port", "9090"}, "8.8.0", baseDir)
+
+	// then
 	expected := "http://localhost:9090/operate"
 	if settings.StartupUrl != expected {
 		t.Fatalf("expected StartupUrl to be %s, got %s", expected, settings.StartupUrl)
 	}
 }
 
-func TestStartupUrlNotRecomputedWhenProvided(t *testing.T) {
+func TestShouldKeepCustomStartupUrlWhenProvided(t *testing.T) {
+	// given
+	baseDir := t.TempDir()
+
+	// when
 	settings := buildSettingsWithVersion(t, []string{
 		"c8run", "start", "--port", "9090", "--startup-url", "http://example.test/custom",
-	}, "8.9.0")
+	}, "8.9.0", baseDir)
 
+	// then
 	if settings.StartupUrl != "http://example.test/custom" {
 		t.Fatalf("expected StartupUrl to remain custom value, got %s", settings.StartupUrl)
 	}
 }
 
-func buildSettingsWithVersion(t *testing.T, args []string, camundaVersion string) types.C8RunSettings {
+func buildSettingsWithVersion(t *testing.T, args []string, camundaVersion string, baseDir string) types.C8RunSettings {
 	t.Helper()
 
 	oldArgs := os.Args
@@ -47,6 +81,7 @@ func buildSettingsWithVersion(t *testing.T, args []string, camundaVersion string
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	settings.StartupMarkerPath = startupurl.MarkerPath(baseDir)
 	if !startupURLProvided {
 		settings.StartupUrl = createDefaultStartupUrl(&settings, camundaVersion)
 	}

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -17,6 +17,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/camunda/camunda/c8run/internal/startupurl"
 	"github.com/camunda/camunda/c8run/internal/types"
 	"github.com/rs/zerolog/log"
 )
@@ -51,16 +52,24 @@ type StartupSummary struct {
 	AgentGuideURL        string
 }
 
+var (
+	isRunningFunc   = isRunning
+	printStatusFunc = PrintStatus
+	markSeenStartup = startupurl.MarkSeen
+)
+
 func QueryCamunda(ctx context.Context, c8 opener, name string, settings types.C8RunSettings, retries int) error {
 	healthEndpoint := fmt.Sprintf("%s://localhost:9600/actuator/health", settings.GetProtocol())
-	if isRunning(ctx, name, healthEndpoint, retries, 14*time.Second) {
+	if isRunningFunc(ctx, name, healthEndpoint, retries, 14*time.Second) {
 		if err := c8.OpenBrowser(ctx, settings.StartupUrl); err != nil {
 			log.Err(err).Msg("Failed to open browser")
-			return nil
 		}
-		if err := PrintStatus(settings); err != nil {
+		if err := printStatusFunc(settings); err != nil {
 			log.Err(err).Msg("Failed to print status")
 			return err
+		}
+		if err := markSeenStartup(settings.StartupMarkerPath); err != nil {
+			log.Warn().Err(err).Str("path", settings.StartupMarkerPath).Msg("Failed to persist quickstart marker")
 		}
 		return nil
 	}

--- a/c8run/internal/health/camunda_test.go
+++ b/c8run/internal/health/camunda_test.go
@@ -1,107 +1,177 @@
 package health
 
 import (
-    "bytes"
-    "io"
-    "os"
-    "path/filepath"
-    "strings"
-    "testing"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
 
-    "github.com/camunda/camunda/c8run/internal/types"
+	"github.com/camunda/camunda/c8run/internal/types"
 )
 
 // captureOutput executes f while capturing stdout output and returns it as string.
 func captureOutput(t *testing.T, f func()) string {
-    t.Helper()
-    old := os.Stdout
-    r, w, err := os.Pipe()
-    if err != nil {
-        t.Fatalf("failed to create pipe: %v", err)
-    }
-    os.Stdout = w
-    defer func() { os.Stdout = old }()
+	t.Helper()
 
-    done := make(chan struct{})
-    var buf bytes.Buffer
-    go func() {
-        _, _ = io.Copy(&buf, r)
-        close(done)
-    }()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
 
-    f()
-    _ = w.Close()
-    <-done
-    return buf.String()
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	f()
+	_ = w.Close()
+	<-done
+	return buf.String()
 }
 
 // assertEndpointForLabel finds the output line containing "label:" and asserts it also contains endpoint.
 func assertEndpointForLabel(t *testing.T, out, label, endpoint string) {
-    t.Helper()
-    prefix := label + ":"
-    for _, line := range strings.Split(out, "\n") {
-        if strings.Contains(line, prefix) {
-            if !strings.Contains(line, endpoint) {
-                t.Fatalf("line for %q does not contain expected endpoint %s: %s", label, endpoint, line)
-            }
-            return
-        }
-    }
-    t.Fatalf("no line found containing label %q; output: %s", label, out)
+	t.Helper()
+
+	prefix := label + ":"
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, prefix) {
+			if !strings.Contains(line, endpoint) {
+				t.Fatalf("line for %q does not contain expected endpoint %s: %s", label, endpoint, line)
+			}
+			return
+		}
+	}
+	t.Fatalf("no line found containing label %q; output: %s", label, out)
 }
 
-func TestPrintStatus_NonDockerUsesPortFlag(t *testing.T) {
-    // Ensure working directory contains endpoints.txt
-    cwd, err := os.Getwd()
-    if err != nil { t.Fatalf("failed to get wd: %v", err) }
-    root := filepath.Clean(filepath.Join(cwd, "../..")) // c8run module root
-    if err := os.Chdir(root); err != nil { t.Fatalf("failed to chdir to module root: %v", err) }
-    t.Cleanup(func(){ _ = os.Chdir(cwd) })
-
-    settings := types.C8RunSettings{Port: 9090, Docker: false}
-    out := captureOutput(t, func() {
-        if err := PrintStatus(settings); err != nil { t.Fatalf("PrintStatus failed: %v", err) }
-    })
-
-    // Verify specific endpoint paths are rendered with the correct port
-    expectedEndpoints := map[string]string{
-        "Operate":                   "http://localhost:9090/operate",
-        "Tasklist":                  "http://localhost:9090/tasklist",
-        "Admin":                     "http://localhost:9090/admin",
-        "Orchestration Cluster API": "http://localhost:9090/v2/",
-        "Orchestration Cluster":     "http://localhost:9090/mcp/cluster",
-    }
-    for label, endpoint := range expectedEndpoints {
-        assertEndpointForLabel(t, out, label, endpoint)
-    }
+type stubOpener struct {
+	url string
 }
 
-func TestPrintStatus_DockerModeIgnoresPortFlag(t *testing.T) {
-    // Ensure working directory contains endpoints.txt
-    cwd, err := os.Getwd()
-    if err != nil { t.Fatalf("failed to get wd: %v", err) }
-    root := filepath.Clean(filepath.Join(cwd, "../.."))
-    if err := os.Chdir(root); err != nil { t.Fatalf("failed to chdir to module root: %v", err) }
-    t.Cleanup(func(){ _ = os.Chdir(cwd) })
+func (s *stubOpener) OpenBrowser(_ context.Context, url string) error {
+	s.url = url
+	return nil
+}
 
-    settings := types.C8RunSettings{Port: 9090, Docker: true}
-    out := captureOutput(t, func() {
-        if err := PrintStatus(settings); err != nil { t.Fatalf("PrintStatus failed: %v", err) }
-    })
+func TestShouldUsePortFlagForStatusOutputOutsideDocker(t *testing.T) {
+	// given
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get wd: %v", err)
+	}
+	root := filepath.Clean(filepath.Join(cwd, "../.."))
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to module root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
 
-    // Verify fixed docker ports are present - all components use port 8080 in Docker mode
-    expectedEndpoints := map[string]string{
-        "Operate":                   "http://localhost:8080/operate",
-        "Tasklist":                  "http://localhost:8080/tasklist",
-        "Admin":                     "http://localhost:8080/admin",
-        "Orchestration Cluster API": "http://localhost:8080/v2/",
-        "Orchestration Cluster":     "http://localhost:8080/mcp/cluster",
-    }
-    for label, endpoint := range expectedEndpoints {
-        assertEndpointForLabel(t, out, label, endpoint)
-    }
-    // Ensure the provided (ignored) port is not shown for those endpoints
-    if strings.Contains(out, "http://localhost:9090/operate") || strings.Contains(out, "http://localhost:9090/tasklist") || strings.Contains(out, "http://localhost:9090/admin") || strings.Contains(out, "http://localhost:9090/v2/") || strings.Contains(out, "http://localhost:9090/mcp/cluster") {
-        t.Fatalf("docker mode should ignore custom port 9090; output: %s", out)
-    }
+	settings := types.C8RunSettings{Port: 9090, Docker: false}
+
+	// when
+	out := captureOutput(t, func() {
+		if err := PrintStatus(settings); err != nil {
+			t.Fatalf("PrintStatus failed: %v", err)
+		}
+	})
+
+	// then
+	expectedEndpoints := map[string]string{
+		"Operate":                   "http://localhost:9090/operate",
+		"Tasklist":                  "http://localhost:9090/tasklist",
+		"Admin":                     "http://localhost:9090/admin",
+		"Orchestration Cluster API": "http://localhost:9090/v2/",
+		"Orchestration Cluster":     "http://localhost:9090/mcp/cluster",
+	}
+	for label, endpoint := range expectedEndpoints {
+		assertEndpointForLabel(t, out, label, endpoint)
+	}
+}
+
+func TestShouldIgnorePortFlagForStatusOutputInDockerMode(t *testing.T) {
+	// given
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get wd: %v", err)
+	}
+	root := filepath.Clean(filepath.Join(cwd, "../.."))
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to module root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	settings := types.C8RunSettings{Port: 9090, Docker: true}
+
+	// when
+	out := captureOutput(t, func() {
+		if err := PrintStatus(settings); err != nil {
+			t.Fatalf("PrintStatus failed: %v", err)
+		}
+	})
+
+	// then
+	expectedEndpoints := map[string]string{
+		"Operate":                   "http://localhost:8080/operate",
+		"Tasklist":                  "http://localhost:8080/tasklist",
+		"Admin":                     "http://localhost:8080/admin",
+		"Orchestration Cluster API": "http://localhost:8080/v2/",
+		"Orchestration Cluster":     "http://localhost:8080/mcp/cluster",
+	}
+	for label, endpoint := range expectedEndpoints {
+		assertEndpointForLabel(t, out, label, endpoint)
+	}
+	if strings.Contains(out, "http://localhost:9090/operate") ||
+		strings.Contains(out, "http://localhost:9090/tasklist") ||
+		strings.Contains(out, "http://localhost:9090/admin") ||
+		strings.Contains(out, "http://localhost:9090/v2/") ||
+		strings.Contains(out, "http://localhost:9090/mcp/cluster") {
+		t.Fatalf("docker mode should ignore custom port 9090; output: %s", out)
+	}
+}
+
+func TestShouldMarkQuickstartAsSeenAfterSuccessfulStartup(t *testing.T) {
+	// given
+	markerPath := filepath.Join(t.TempDir(), ".c8run-quickstart-seen")
+	settings := types.C8RunSettings{
+		StartupUrl:        "http://localhost:8080/operate",
+		StartupMarkerPath: markerPath,
+	}
+	opener := &stubOpener{}
+
+	originalIsRunningFunc := isRunningFunc
+	originalPrintStatusFunc := printStatusFunc
+	t.Cleanup(func() {
+		isRunningFunc = originalIsRunningFunc
+		printStatusFunc = originalPrintStatusFunc
+	})
+
+	isRunningFunc = func(_ context.Context, _ string, _ string, _ int, _ time.Duration) bool {
+		return true
+	}
+	printStatusFunc = func(types.C8RunSettings) error {
+		return nil
+	}
+
+	// when
+	err := QueryCamunda(context.Background(), opener, "Camunda", settings, 0)
+	if err != nil {
+		t.Fatalf("QueryCamunda failed: %v", err)
+	}
+
+	// then
+	if opener.url != settings.StartupUrl {
+		t.Fatalf("expected browser to open %s, got %s", settings.StartupUrl, opener.url)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected marker file to be created: %v", err)
+	}
 }

--- a/c8run/internal/startupurl/startupurl.go
+++ b/c8run/internal/startupurl/startupurl.go
@@ -16,7 +16,20 @@ const (
 	markerFileValue = "seen\n"
 )
 
+var (
+	userConfigDir = os.UserConfigDir
+	userHomeDir   = os.UserHomeDir
+)
+
 func MarkerPath(baseDir string) string {
+	if configDir, err := userConfigDir(); err == nil && strings.TrimSpace(configDir) != "" {
+		return filepath.Join(configDir, "camunda", "c8run", markerFileName)
+	}
+
+	if homeDir, err := userHomeDir(); err == nil && strings.TrimSpace(homeDir) != "" {
+		return filepath.Join(homeDir, ".config", "camunda", "c8run", markerFileName)
+	}
+
 	return filepath.Join(baseDir, markerFileName)
 }
 

--- a/c8run/internal/startupurl/startupurl.go
+++ b/c8run/internal/startupurl/startupurl.go
@@ -1,0 +1,98 @@
+package startupurl
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/camunda/camunda/c8run/internal/types"
+)
+
+const (
+	DocsURL         = "https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/c8run/#work-with-camunda-8-run"
+	markerFileName  = ".c8run-quickstart-seen"
+	markerFileValue = "seen\n"
+)
+
+func MarkerPath(baseDir string) string {
+	return filepath.Join(baseDir, markerFileName)
+}
+
+func OperateURL(settings types.C8RunSettings) string {
+	return fmt.Sprintf("%s://localhost:%s/operate", settings.GetProtocol(), strconv.Itoa(settings.Port))
+}
+
+func Default(settings types.C8RunSettings, camundaVersion string) string {
+	if shouldUseDocsStartup(camundaVersion, settings.StartupMarkerPath) {
+		return DocsURL
+	}
+	return OperateURL(settings)
+}
+
+func MarkSeen(markerPath string) error {
+	markerPath = strings.TrimSpace(markerPath)
+	if markerPath == "" || hasSeen(markerPath) {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create quickstart marker directory: %w", err)
+	}
+
+	if err := os.WriteFile(markerPath, []byte(markerFileValue), 0o644); err != nil {
+		return fmt.Errorf("failed to write quickstart marker: %w", err)
+	}
+
+	return nil
+}
+
+func shouldUseDocsStartup(camundaVersion string, markerPath string) bool {
+	major, minor, ok := parseMajorMinor(camundaVersion)
+	if !ok {
+		return false
+	}
+	if hasSeen(markerPath) {
+		return false
+	}
+	if major > 8 {
+		return true
+	}
+	return major == 8 && minor >= 9
+}
+
+func hasSeen(markerPath string) bool {
+	markerPath = strings.TrimSpace(markerPath)
+	if markerPath == "" {
+		return false
+	}
+
+	_, err := os.Stat(markerPath)
+	return err == nil
+}
+
+func parseMajorMinor(version string) (int, int, bool) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return 0, 0, false
+	}
+
+	base := strings.SplitN(version, "-", 2)[0]
+	parts := strings.Split(base, ".")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return major, minor, true
+}

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -28,6 +28,7 @@ type C8RunSettings struct {
 	Password             string
 	Docker               bool
 	StartupUrl           string
+	StartupMarkerPath    string
 	ExtraDrivers         []string
 }
 


### PR DESCRIPTION
## Description

This changes the default C8Run startup URL to be quickstart first, then Operate on later startups.

  On the first successful startup, C8Run still opens the quickstart docs page to preserve the onboarding flow. After that, it persists a local marker and opens Operate on subsequent startups, which matches
  the common developer workflow. Explicit `--startup-url` values are unchanged.

  The marker follows the existing C8Run local state model and is stored alongside the process state files in the C8Run working directory.

closes #48285
