### PR TITLE
fix: use separate DTO for inserting tags #48502

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
@@ -16,6 +16,7 @@ import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
@@ -103,4 +104,6 @@ public interface ProcessInstanceMapper {
 
   record SelectExpiredRootProcessInstancesDto(
       int partitionId, OffsetDateTime cleanupDate, DbQueryPage page) {}
+
+  record ProcessInstanceTagsDto(long processInstanceKey, Collection<String> tags) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write.service;
 
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.EndProcessInstanceDto;
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper.ProcessInstanceTagsDto;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.UpdateHistoryCleanupDateDto;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
@@ -49,7 +50,8 @@ public class ProcessInstanceWriter implements RdbmsWriter {
               WriteStatementType.INSERT,
               processInstance.processInstanceKey(),
               "io.camunda.db.rdbms.sql.ProcessInstanceMapper.insertTags",
-              processInstance));
+              new ProcessInstanceTagsDto(
+                  processInstance.processInstanceKey(), processInstance.tags())));
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Set;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -109,6 +110,29 @@ public class ProcessInstanceIT {
 
     assertThat(resolvedInstance).isNotNull();
     assertThat(resolvedInstance.hasIncident()).isFalse();
+  }
+
+  @TestTemplate
+  public void shouldSaveTagsAndCompleteInSameFlush(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
+
+    final ProcessInstanceDbModel instance =
+        ProcessInstanceFixtures.createRandomized(b -> b.tags(Set.of("foo", "bar")));
+    rdbmsWriters.getProcessInstanceWriter().create(instance);
+    rdbmsWriters
+        .getProcessInstanceWriter()
+        .finish(instance.processInstanceKey(), ProcessInstanceState.COMPLETED, NOW);
+    rdbmsWriters.flush();
+
+    final var readInstance =
+        processInstanceReader.findOne(instance.processInstanceKey()).orElse(null);
+
+    assertThat(readInstance).isNotNull();
+    assertThat(readInstance.state()).isEqualTo(ProcessInstanceState.COMPLETED);
+    assertThat(readInstance.tags()).containsExactlyInAnyOrder("foo", "bar");
   }
 
   @TestTemplate


### PR DESCRIPTION
## Description

This PR introduces a new DTO for inserting tags.

Previously the merger accidentally merged a `finish` command with an `insertTags` command instead of the last `insert` command

## Related issues

closes #48502
