### PR TITLE
[Backport stable/8.9] fix: remove stale Liquibase lock after container crash

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -41,7 +41,7 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   /**
    * The maximum duration a Liquibase lock can be held before it is considered stale and forcibly
    * released. This allows recovery from container crashes that left the schema locked. Set to null
-   * to disable stale lock detection. Default is 10 minutes.
+   * to disable stale lock detection. Default is 15 minutes.
    */
   private Duration ddlLockWaitTimeout = Duration.ofMinutes(15);
 

--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -38,6 +38,13 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
    */
   private Integer maxVarcharFieldLength = RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH;
 
+  /**
+   * The maximum duration a Liquibase lock can be held before it is considered stale and forcibly
+   * released. This allows recovery from container crashes that left the schema locked. Set to null
+   * to disable stale lock detection. Default is 10 minutes.
+   */
+  private Duration ddlLockWaitTimeout = Duration.ofMinutes(10);
+
   /** Process definition cache configuration. Defines the size of the process definition cache. */
   private RdbmsCache processCache = new RdbmsCache();
 
@@ -189,5 +196,13 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
 
   public void setMaxVarcharFieldLength(final Integer maxVarcharFieldLength) {
     this.maxVarcharFieldLength = maxVarcharFieldLength;
+  }
+
+  public Duration getDdlLockWaitTimeout() {
+    return ddlLockWaitTimeout;
+  }
+
+  public void setDdlLockWaitTimeout(final Duration ddlLockWaitTimeout) {
+    this.ddlLockWaitTimeout = ddlLockWaitTimeout;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -43,7 +43,7 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
    * released. This allows recovery from container crashes that left the schema locked. Set to null
    * to disable stale lock detection. Default is 10 minutes.
    */
-  private Duration ddlLockWaitTimeout = Duration.ofMinutes(10);
+  private Duration ddlLockWaitTimeout = Duration.ofMinutes(15);
 
   /** Process definition cache configuration. Defines the size of the process definition cache. */
   private RdbmsCache processCache = new RdbmsCache();

--- a/db/rdbms/pom.xml
+++ b/db/rdbms/pom.xml
@@ -135,6 +135,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
@@ -7,7 +7,16 @@
  */
 package io.camunda.db.rdbms;
 
+import java.sql.Connection;
+import java.time.Duration;
+import java.time.Instant;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.DatabaseException;
 import liquibase.integration.spring.MultiTenantSpringLiquibase;
+import liquibase.lockservice.LockService;
+import liquibase.lockservice.LockServiceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,9 +34,11 @@ public class LiquibaseSchemaManager extends MultiTenantSpringLiquibase
   private static final Logger LOG = LoggerFactory.getLogger(LiquibaseSchemaManager.class);
 
   private volatile boolean initialized = false;
+  private Duration ddlLockWaitTimeout;
 
   @Override
   public void afterPropertiesSet() throws Exception {
+    releaseStaleLockIfPresent();
     super.afterPropertiesSet();
     initialized = true;
     LOG.debug("Liquibase migrations completed.");
@@ -36,5 +47,75 @@ public class LiquibaseSchemaManager extends MultiTenantSpringLiquibase
   @Override
   public boolean isInitialized() {
     return initialized;
+  }
+
+  public Duration getDdlLockWaitTimeout() {
+    return ddlLockWaitTimeout;
+  }
+
+  public void setDdlLockWaitTimeout(final Duration ddlLockWaitTimeout) {
+    this.ddlLockWaitTimeout = ddlLockWaitTimeout;
+  }
+
+  /**
+   * Checks for stale Liquibase locks and forcibly releases them if they are older than the
+   * configured {@link #ddlLockWaitTimeout}. This allows recovery from container crashes that left
+   * the schema locked without being properly cleaned up.
+   *
+   * <p>If {@link #ddlLockWaitTimeout} is {@code null}, or the lock table does not exist yet (first
+   * run), this method does nothing.
+   */
+  protected void releaseStaleLockIfPresent() {
+    if (ddlLockWaitTimeout == null || getDataSource() == null) {
+      return;
+    }
+    try (final var connection = getDataSource().getConnection()) {
+      final var database = openDatabase(connection);
+      try {
+        final var lockService = getLockService(database);
+        final var threshold = Instant.now().minus(ddlLockWaitTimeout);
+        for (final var lock : lockService.listLocks()) {
+          if (lock.getLockGranted() != null
+              && lock.getLockGranted().toInstant().isBefore(threshold)) {
+            LOG.warn(
+                "Detected stale Liquibase lock acquired at {} by '{}' (older than configured"
+                    + " ddl-lock-wait-timeout of {}). Releasing lock to allow migrations to"
+                    + " proceed.",
+                lock.getLockGranted(),
+                lock.getLockedBy(),
+                ddlLockWaitTimeout);
+            lockService.forceReleaseLock();
+            LOG.info("Stale Liquibase lock released successfully.");
+            break;
+          }
+        }
+      } finally {
+        database.close();
+      }
+    } catch (final Exception e) {
+      LOG.warn("Failed to check or release stale Liquibase lock. Proceeding with migration.", e);
+    }
+  }
+
+  /**
+   * Creates a Liquibase {@link Database} from the given JDBC connection. Protected to allow
+   * overriding in tests.
+   */
+  protected Database openDatabase(final Connection connection) throws DatabaseException {
+    final var database =
+        DatabaseFactory.getInstance()
+            .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+    final var lockTableName = getDatabaseChangeLogLockTable();
+    if (lockTableName != null) {
+      database.setDatabaseChangeLogLockTableName(lockTableName);
+    }
+    return database;
+  }
+
+  /**
+   * Returns the {@link LockService} for the given database. Protected to allow overriding in tests.
+   */
+  protected LockService getLockService(final Database database) {
+    return LockServiceFactory.getInstance().getLockService(database);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerStaleLockH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerStaleLockH2Test.java
@@ -60,7 +60,7 @@ class LiquibaseSchemaManagerStaleLockH2Test {
   }
 
   @Test
-  void shouldNotReleaseRecentLockAndFailGracefully() throws Exception {
+  void shouldNotReleaseRecentLockWhenTimeoutNotExceeded() throws Exception {
     // given - insert a recent lock (just acquired)
     insertLock(Instant.now(), "another-running-pod");
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerStaleLockH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerStaleLockH2Test.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * H2-based test that verifies stale Liquibase lock detection and release against a real in-memory
+ * database.
+ */
+class LiquibaseSchemaManagerStaleLockH2Test {
+
+  private static final String DB_URL = "jdbc:h2:mem:liquibase-lock-test;DB_CLOSE_DELAY=-1";
+  private static final String LOCK_TABLE = "DATABASECHANGELOGLOCK";
+
+  private JdbcDataSource dataSource;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    dataSource = new JdbcDataSource();
+    dataSource.setURL(DB_URL + ";MODE=LEGACY");
+    dataSource.setUser("sa");
+    dataSource.setPassword("");
+
+    // Clean up any prior state from a previous test run
+    try (final var conn = dataSource.getConnection();
+        final var stmt = conn.createStatement()) {
+      stmt.execute("DROP TABLE IF EXISTS " + LOCK_TABLE);
+    }
+    createLockTable();
+  }
+
+  @Test
+  void shouldReleaseStaleLockAndRunMigrations() throws Exception {
+    // given - insert a stale lock (granted 1 hour ago)
+    insertLock(Instant.now().minus(Duration.ofHours(1)), "crashed-pod-192.168.1.1");
+
+    // when - run LiquibaseSchemaManager with a 10-minute timeout (so the 1-hour-old lock is stale)
+    final var schemaManager = buildSchemaManager(Duration.ofMinutes(10));
+    schemaManager.afterPropertiesSet();
+
+    // then - migration completed successfully and the stale lock was released
+    assertThat(schemaManager.isInitialized()).isTrue();
+    assertThat(isLockHeld()).isFalse();
+  }
+
+  @Test
+  void shouldNotReleaseRecentLockAndFailGracefully() throws Exception {
+    // given - insert a recent lock (just acquired)
+    insertLock(Instant.now(), "another-running-pod");
+
+    // when - configure the schema manager with a 10-minute timeout
+    // Since the lock is brand-new, it should NOT be force-released
+    final var schemaManager = buildSchemaManager(Duration.ofMinutes(10));
+
+    // then - the stale-lock check should not release the recent lock
+    schemaManager.releaseStaleLockIfPresent();
+
+    // the recent lock remains held
+    assertThat(isLockHeld()).isTrue();
+  }
+
+  @Test
+  void shouldSkipLockCheckWhenTimeoutIsNull() throws Exception {
+    // given - insert a stale lock
+    insertLock(Instant.now().minus(Duration.ofHours(1)), "crashed-pod");
+
+    // when - timeout is null (feature disabled)
+    final var schemaManager = buildSchemaManager(null);
+    schemaManager.releaseStaleLockIfPresent();
+
+    // then - the stale lock should still be held (not released because timeout is disabled)
+    assertThat(isLockHeld()).isTrue();
+  }
+
+  // --- helpers ---
+
+  private LiquibaseSchemaManager buildSchemaManager(final Duration ddlLockWaitTimeout) {
+    final var manager = new LiquibaseSchemaManager();
+    manager.setDataSource(dataSource);
+    manager.setDatabaseChangeLogLockTable(LOCK_TABLE);
+    manager.setChangeLog("db/changelog/rdbms-exporter/changelog-master.xml");
+    manager.setParameters(
+        Map.of(
+            "prefix", "",
+            "userCharColumnSize", "256",
+            "errorMessageSize", "4000",
+            "treePathSize", "8191"));
+    manager.setDdlLockWaitTimeout(ddlLockWaitTimeout);
+    return manager;
+  }
+
+  /**
+   * Creates a minimal DATABASECHANGELOGLOCK table matching the schema expected by Liquibase. This
+   * simulates the state of a database where Liquibase has run previously.
+   */
+  private void createLockTable() throws Exception {
+    try (final var conn = dataSource.getConnection();
+        final var stmt = conn.createStatement()) {
+      stmt.execute(
+          "CREATE TABLE "
+              + LOCK_TABLE
+              + " ("
+              + "ID INT NOT NULL, "
+              + "LOCKED BOOL NOT NULL, "
+              + "LOCKGRANTED TIMESTAMP, "
+              + "LOCKEDBY VARCHAR(255), "
+              + "CONSTRAINT PK_DATABASECHANGELOGLOCK PRIMARY KEY (ID)"
+              + ")");
+      // Liquibase expects a row with ID=1 to exist (it inserts it on first run)
+      stmt.execute("INSERT INTO " + LOCK_TABLE + " (ID, LOCKED) VALUES (1, FALSE)");
+    }
+  }
+
+  /** Inserts (or updates) the lock row to simulate a lock held since the given time. */
+  private void insertLock(final Instant lockedSince, final String lockedBy) throws Exception {
+    try (final var conn = dataSource.getConnection();
+        final PreparedStatement ps =
+            conn.prepareStatement(
+                "UPDATE "
+                    + LOCK_TABLE
+                    + " SET LOCKED = TRUE, LOCKGRANTED = ?, LOCKEDBY = ? WHERE ID = 1")) {
+      ps.setTimestamp(1, Timestamp.from(lockedSince));
+      ps.setString(2, lockedBy);
+      ps.executeUpdate();
+    }
+  }
+
+  /** Returns true if the lock table has an active lock. */
+  private boolean isLockHeld() throws Exception {
+    try (final Connection conn = dataSource.getConnection();
+        final var ps =
+            conn.prepareStatement("SELECT LOCKED FROM " + LOCK_TABLE + " WHERE ID = 1")) {
+      final var rs = ps.executeQuery();
+      return rs.next() && rs.getBoolean("LOCKED");
+    }
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
@@ -10,8 +10,20 @@ package io.camunda.db.rdbms;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
+import java.time.Duration;
+import java.util.Date;
+import javax.sql.DataSource;
+import liquibase.database.Database;
+import liquibase.exception.DatabaseException;
+import liquibase.lockservice.DatabaseChangeLogLock;
+import liquibase.lockservice.LockService;
 import org.junit.jupiter.api.Test;
 
 class LiquibaseSchemaManagerTest {
@@ -51,15 +63,106 @@ class LiquibaseSchemaManagerTest {
     assertThat(schemaManager.isInitialized()).isFalse();
   }
 
+  @Test
+  void shouldSkipStaleLockCheckWhenDdlLockWaitTimeoutIsNull() throws Exception {
+    // given
+    final var schemaManager = new TestLiquibaseSchemaManager();
+    schemaManager.setDdlLockWaitTimeout(null);
+    final var mockDataSource = mock(DataSource.class);
+    schemaManager.setDataSource(mockDataSource);
+
+    // when
+    schemaManager.releaseStaleLockIfPresent();
+
+    // then - no interaction with datasource because timeout is null
+    verify(mockDataSource, never()).getConnection();
+  }
+
+  @Test
+  void shouldSkipStaleLockCheckWhenDataSourceIsNull() throws Exception {
+    // given
+    final var schemaManager = new TestLiquibaseSchemaManager();
+    schemaManager.setDdlLockWaitTimeout(Duration.ofMinutes(10));
+    // No datasource set
+
+    // when / then - should not throw any exception
+    schemaManager.releaseStaleLockIfPresent();
+  }
+
+  @Test
+  void shouldNotReleaseLockWhenNoLocksPresent() throws Exception {
+    // given
+    final var mockLockService = mock(LockService.class);
+    when(mockLockService.listLocks()).thenReturn(new DatabaseChangeLogLock[0]);
+
+    final var schemaManager = new TestableSchemaManager(mockLockService);
+    schemaManager.setDdlLockWaitTimeout(Duration.ofMinutes(10));
+
+    // when
+    schemaManager.releaseStaleLockIfPresent();
+
+    // then
+    verify(mockLockService, never()).forceReleaseLock();
+  }
+
+  @Test
+  void shouldNotReleaseLockWhenLockIsRecent() throws Exception {
+    // given
+    final var recentLock = new DatabaseChangeLogLock(1, new Date(), "some-host");
+    final var mockLockService = mock(LockService.class);
+    when(mockLockService.listLocks()).thenReturn(new DatabaseChangeLogLock[] {recentLock});
+
+    final var schemaManager = new TestableSchemaManager(mockLockService);
+    schemaManager.setDdlLockWaitTimeout(Duration.ofMinutes(10));
+
+    // when
+    schemaManager.releaseStaleLockIfPresent();
+
+    // then - lock is recent (just now), so it should not be released
+    verify(mockLockService, never()).forceReleaseLock();
+  }
+
+  @Test
+  void shouldReleaseLockWhenLockIsStale() throws Exception {
+    // given
+    final var staleLockTime = new Date(System.currentTimeMillis() - Duration.ofHours(1).toMillis());
+    final var staleLock = new DatabaseChangeLogLock(1, staleLockTime, "crashed-pod");
+    final var mockLockService = mock(LockService.class);
+    when(mockLockService.listLocks()).thenReturn(new DatabaseChangeLogLock[] {staleLock});
+
+    final var schemaManager = new TestableSchemaManager(mockLockService);
+    schemaManager.setDdlLockWaitTimeout(Duration.ofMinutes(10));
+
+    // when
+    schemaManager.releaseStaleLockIfPresent();
+
+    // then - stale lock (1 hour old, timeout 10 min) should be released
+    verify(mockLockService).forceReleaseLock();
+  }
+
+  @Test
+  void shouldContinueMigrationWhenStaleLockCheckThrowsException() throws Exception {
+    // given
+    final var schemaManager = new TestLiquibaseSchemaManager();
+    schemaManager.setDdlLockWaitTimeout(Duration.ofMinutes(10));
+    final var mockDataSource = mock(DataSource.class);
+    when(mockDataSource.getConnection()).thenThrow(new RuntimeException("DB connection failed"));
+    schemaManager.setDataSource(mockDataSource);
+
+    // when / then - exception should be swallowed, method should return normally
+    schemaManager.releaseStaleLockIfPresent();
+  }
+
   /**
    * Test implementation that overrides the parent's afterPropertiesSet to avoid actual Liquibase
-   * initialization.
+   * initialization. Designed for extension by test subclasses (e.g. {@code TestableSchemaManager}).
    */
-  private static final class TestLiquibaseSchemaManager extends LiquibaseSchemaManager {
+  private static class TestLiquibaseSchemaManager extends LiquibaseSchemaManager {
     @Override
     public void afterPropertiesSet() throws Exception {
       // Skip the actual Liquibase initialization (super.afterPropertiesSet())
       // and just perform our state update
+      releaseStaleLockIfPresent();
       performMigration();
       setInitialized();
     }
@@ -77,6 +180,36 @@ class LiquibaseSchemaManagerTest {
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
+    }
+  }
+
+  /**
+   * Test implementation that injects a mock {@link LockService} and a mock {@link DataSource} to
+   * allow testing of stale lock detection without a real database.
+   */
+  private static final class TestableSchemaManager extends TestLiquibaseSchemaManager {
+    private final LockService mockLockService;
+
+    TestableSchemaManager(final LockService mockLockService) {
+      this.mockLockService = mockLockService;
+      final var mockDataSource = mock(DataSource.class);
+      final var mockConnection = mock(Connection.class);
+      try {
+        when(mockDataSource.getConnection()).thenReturn(mockConnection);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+      setDataSource(mockDataSource);
+    }
+
+    @Override
+    protected Database openDatabase(final Connection connection) throws DatabaseException {
+      return mock(Database.class);
+    }
+
+    @Override
+    protected LockService getLockService(final Database database) {
+      return mockLockService;
     }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.rdbms;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.db.rdbms.LiquibaseSchemaManager;
 import io.camunda.db.rdbms.NoopSchemaManager;
 import io.camunda.db.rdbms.RdbmsSchemaManager;
@@ -79,8 +80,9 @@ public class MyBatisConfiguration {
   public RdbmsSchemaManager rdbmsExporterLiquibase(
       final DataSource dataSource,
       final VendorDatabaseProperties vendorDatabaseProperties,
-      @Value("${camunda.data.secondary-storage.rdbms.prefix:}") final String prefix) {
-    final String trimmedPrefix = StringUtils.trimToEmpty(prefix);
+      final Camunda configuration) {
+    final var rdbmsConfig = configuration.getData().getSecondaryStorage().getRdbms();
+    final String trimmedPrefix = StringUtils.trimToEmpty(rdbmsConfig.getPrefix());
     LOGGER.info(
         "Initializing Liquibase for RDBMS with global table trimmedPrefix '{}'.", trimmedPrefix);
 
@@ -100,6 +102,7 @@ public class MyBatisConfiguration {
             Integer.toString(vendorDatabaseProperties.treePathSize())));
     // changelog file located in src/main/resources directly in the module
     moduleConfig.setChangeLog("db/changelog/rdbms-exporter/changelog-master.xml");
+    moduleConfig.setDdlLockWaitTimeout(rdbmsConfig.getDdlLockWaitTimeout());
 
     return moduleConfig;
   }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.application.commons.rdbms;
 
-import io.camunda.configuration.Camunda;
 import io.camunda.db.rdbms.LiquibaseSchemaManager;
 import io.camunda.db.rdbms.NoopSchemaManager;
 import io.camunda.db.rdbms.RdbmsSchemaManager;
@@ -46,6 +45,7 @@ import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 import javax.sql.DataSource;
@@ -80,9 +80,10 @@ public class MyBatisConfiguration {
   public RdbmsSchemaManager rdbmsExporterLiquibase(
       final DataSource dataSource,
       final VendorDatabaseProperties vendorDatabaseProperties,
-      final Camunda configuration) {
-    final var rdbmsConfig = configuration.getData().getSecondaryStorage().getRdbms();
-    final String trimmedPrefix = StringUtils.trimToEmpty(rdbmsConfig.getPrefix());
+      @Value("${camunda.data.secondary-storage.rdbms.prefix:}") final String prefix,
+      @Value("${camunda.data.secondary-storage.rdbms.ddl-lock-wait-timeout:PT15M}")
+          final Duration lockWaitTimeout) {
+    final String trimmedPrefix = StringUtils.trimToEmpty(prefix);
     LOGGER.info(
         "Initializing Liquibase for RDBMS with global table trimmedPrefix '{}'.", trimmedPrefix);
 
@@ -102,7 +103,7 @@ public class MyBatisConfiguration {
             Integer.toString(vendorDatabaseProperties.treePathSize())));
     // changelog file located in src/main/resources directly in the module
     moduleConfig.setChangeLog("db/changelog/rdbms-exporter/changelog-master.xml");
-    moduleConfig.setDdlLockWaitTimeout(rdbmsConfig.getDdlLockWaitTimeout());
+    moduleConfig.setDdlLockWaitTimeout(lockWaitTimeout);
 
     return moduleConfig;
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/LiquibaseStaleLockIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/LiquibaseStaleLockIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test that verifies the full application can recover from a stale Liquibase lock left
+ * by a crashed container. The test pre-seeds a DATABASECHANGELOGLOCK table with a stale lock, then
+ * starts the whole Camunda application and asserts that it starts successfully (i.e., the stale
+ * lock was automatically detected and released before Liquibase migrations ran).
+ */
+@Tag("rdbms")
+class LiquibaseStaleLockIT {
+
+  /**
+   * Unique H2 in-memory database name for this test. A dedicated database is used to avoid
+   * interfering with the shared "testdb" used by other RDBMS tests.
+   */
+  private static final String DB_NAME = "stale-lock-it";
+
+  private static final String H2_URL =
+      "jdbc:h2:mem:" + DB_NAME + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
+  private static final String LOCK_TABLE = "DATABASECHANGELOGLOCK";
+  private static final String SIMULATED_CRASHED_POD = "crashed-pod-10.52.55.196";
+
+  private CamundaRdbmsTestApplication app;
+
+  @AfterEach
+  void tearDown() {
+    if (app != null) {
+      app.close();
+    }
+  }
+
+  @Test
+  void shouldStartApplicationWhenStaleLockIsPresent() throws Exception {
+    // given - pre-seed the H2 in-memory database with a stale lock acquired 1 hour ago
+    // (exceeds the default 10-minute ddl-lock-wait-timeout threshold)
+    insertStaleLock(Instant.now().minus(Duration.ofHours(1)), SIMULATED_CRASHED_POD);
+
+    // when - start the whole application; LiquibaseSchemaManager should detect and release the
+    // stale lock (older than the configured ddl-lock-wait-timeout of 10 min) before running
+    // migrations
+    app =
+        new CamundaRdbmsTestApplication(RdbmsTestConfiguration.class)
+            .withH2()
+            // override URL so that the app connects to the same pre-seeded H2 database
+            .withUnifiedConfig(c -> c.getData().getSecondaryStorage().getRdbms().setUrl(H2_URL))
+            // explicitly configure Spring's datasource to match the unified config URL
+            .withProperty("spring.datasource.url", H2_URL)
+            .withProperty("spring.datasource.username", "sa")
+            .withProperty("spring.datasource.password", "");
+    app.start();
+
+    // then - the application started successfully, meaning migrations ran without deadlock
+    assertThat(app.isStarted()).isTrue();
+  }
+
+  // --- helpers ---
+
+  /**
+   * Connects to the H2 in-memory database, creates the DATABASECHANGELOGLOCK table (simulating a
+   * previous Liquibase run), and inserts a lock row that appears stale.
+   */
+  private void insertStaleLock(final Instant lockedSince, final String lockedBy) throws Exception {
+    final var dataSource = new JdbcDataSource();
+    dataSource.setURL(H2_URL);
+    dataSource.setUser("sa");
+    dataSource.setPassword("");
+
+    try (final var conn = dataSource.getConnection();
+        final var stmt = conn.createStatement()) {
+
+      stmt.execute(
+          "CREATE TABLE IF NOT EXISTS "
+              + LOCK_TABLE
+              + " ("
+              + "ID INT NOT NULL, "
+              + "LOCKED BOOL NOT NULL, "
+              + "LOCKGRANTED TIMESTAMP, "
+              + "LOCKEDBY VARCHAR(255), "
+              + "CONSTRAINT PK_DATABASECHANGELOGLOCK PRIMARY KEY (ID)"
+              + ")");
+
+      // Row ID=1 is the standard Liquibase lock row
+      stmt.execute("DELETE FROM " + LOCK_TABLE + " WHERE ID = 1");
+
+      try (final PreparedStatement ps =
+          conn.prepareStatement(
+              "INSERT INTO "
+                  + LOCK_TABLE
+                  + " (ID, LOCKED, LOCKGRANTED, LOCKEDBY) VALUES (1, TRUE, ?, ?)")) {
+        ps.setTimestamp(1, Timestamp.from(lockedSince));
+        ps.setString(2, lockedBy);
+        ps.executeUpdate();
+      }
+    }
+    // DB_CLOSE_DELAY=-1 keeps the database alive without an active connection
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/LiquibaseStaleLockIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/LiquibaseStaleLockIT.java
@@ -52,11 +52,11 @@ class LiquibaseStaleLockIT {
   @Test
   void shouldStartApplicationWhenStaleLockIsPresent() throws Exception {
     // given - pre-seed the H2 in-memory database with a stale lock acquired 1 hour ago
-    // (exceeds the default 10-minute ddl-lock-wait-timeout threshold)
+    // (exceeds the default 15-minute ddl-lock-wait-timeout threshold)
     insertStaleLock(Instant.now().minus(Duration.ofHours(1)), SIMULATED_CRASHED_POD);
 
     // when - start the whole application; LiquibaseSchemaManager should detect and release the
-    // stale lock (older than the configured ddl-lock-wait-timeout of 10 min) before running
+    // stale lock (older than the configured ddl-lock-wait-timeout of 15 min) before running
     // migrations
     app =
         new CamundaRdbmsTestApplication(RdbmsTestConfiguration.class)


### PR DESCRIPTION
# Description
Backport of #48679 to `stable/8.9`.

relates to camunda/camunda#48332 camunda/camunda#48343