### PR TITLE
fix: broken operate process instance page e2e file

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -1003,6 +1003,8 @@ class OperateProcessInstancePage {
 
   getIncidentErrorMessageByText(errorText: string): Locator {
     return this.metadataPopover.getByText(errorText);
+  }
+
   getOperationsLogTableRowCount(): Promise<number> {
     return this.operationsLogTableRow.count();
   }


### PR DESCRIPTION
## Description

Fixes an error in process instance page file in E2E tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
