### PR TITLE
fix: fix client mapping in transformer config

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -177,7 +177,7 @@ public class AuditLogTransformerConfigs {
   private static final Map<EntityType, AuditLogEntityType> ENTITY_TYPE_AUDIT_LOG_ENTITY_TYPE_MAP =
       Map.ofEntries(
           Map.entry(EntityType.USER, AuditLogEntityType.USER),
-          Map.entry(EntityType.CLIENT, AuditLogEntityType.USER),
+          Map.entry(EntityType.CLIENT, AuditLogEntityType.CLIENT),
           Map.entry(EntityType.GROUP, AuditLogEntityType.GROUP),
           Map.entry(EntityType.ROLE, AuditLogEntityType.ROLE),
           Map.entry(EntityType.MAPPING_RULE, AuditLogEntityType.MAPPING_RULE));

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogTransformerConfigsTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogTransformerConfigsTest.java
@@ -174,6 +174,7 @@ class AuditLogTransformerConfigsTest {
   private static Stream<Arguments> entityTypeToRelatedEntityTypeProvider() {
     return Stream.of(
         Arguments.of(EntityType.USER, AuditLogEntityType.USER),
+        Arguments.of(EntityType.CLIENT, AuditLogEntityType.CLIENT),
         Arguments.of(EntityType.GROUP, AuditLogEntityType.GROUP),
         Arguments.of(EntityType.ROLE, AuditLogEntityType.ROLE),
         Arguments.of(EntityType.MAPPING_RULE, AuditLogEntityType.MAPPING_RULE),


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes the mistake I made – CLIENT entity type should map to CLIENT audit log entity type. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48256 
