### PR TITLE
test: fix flaky RingBufferTest

### DIFF
--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -497,7 +497,8 @@ final class RingBufferTest {
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   final var entry = new InFlightEntry(METRICS, null, null);
                   entry.highestPosition = pos;
-                  publishedIndex.set(buffer.put(entry));
+                  buffer.put(entry);
+                  publishedIndex.set(pos);
                 }
               });
 
@@ -510,7 +511,7 @@ final class RingBufferTest {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   if (pos > publishedIndex.get()) {
-                    Thread.yield();
+                    LockSupport.parkNanos(1);
                   }
                   final var entry = buffer.findAndRemove(pos);
                   if (entry != null) {

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -488,6 +488,7 @@ final class RingBufferTest {
       final var buffer = new RingBuffer(smallCapacity);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
+      final var publishedIndex = new AtomicLong(0);
 
       final var writer =
           new Thread(
@@ -496,7 +497,7 @@ final class RingBufferTest {
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   final var entry = new InFlightEntry(METRICS, null, null);
                   entry.highestPosition = pos;
-                  buffer.put(entry);
+                  publishedIndex.set(buffer.put(entry));
                 }
               });
 
@@ -508,6 +509,9 @@ final class RingBufferTest {
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  if (pos > publishedIndex.get()) {
+                    Thread.yield();
+                  }
                   final var entry = buffer.findAndRemove(pos);
                   if (entry != null) {
                     try {


### PR DESCRIPTION
## Description
`sequentialIndexingWorksUnderConcurrentWraparound` test was flaky because the reader thread could go ahead of the writer thread. This is not a problem in production, because the writer thread reads from the logstream, so it cannot go ahead of the producer thread.

Before the fix the test would fail after 20-30 iterations. 
<img width="1092" height="127" alt="image" src="https://github.com/user-attachments/assets/922a63ff-ee25-44b4-84a3-0988905c9893" />

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
