### PR TITLE
[Backport stable/8.6] fix: don't abort pending snapshot replication on heartbeat appends

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
@@ -44,6 +44,11 @@ public abstract class ActiveRole extends PassiveRole {
     // If the request indicates a term that is greater than the current term then
     // assign that term and leader to the current context and transition to follower.
     final boolean transition = updateTermAndLeader(request.term(), request.leader());
+    if (transition) {
+      // A new leader was elected; the previous leader will no longer complete any in-progress
+      // snapshot replication, so we must abort it to avoid waiting forever.
+      abortPendingSnapshots();
+    }
 
     // Handle the append request.
     final CompletableFuture<AppendResponse> future = handleAppend(request);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -392,7 +392,12 @@ public class PassiveRole extends InactiveRole {
   public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
     raft.checkThread();
     logRequest(request);
-    updateTermAndLeader(request.term(), request.leader());
+    final boolean leaderChanged = updateTermAndLeader(request.term(), request.leader());
+    if (leaderChanged) {
+      // A new leader was elected; the previous leader will no longer complete any in-progress
+      // snapshot replication, so we must abort it to avoid waiting forever.
+      abortPendingSnapshots();
+    }
     return handleAppend(request);
   }
 
@@ -544,7 +549,7 @@ public class PassiveRole extends InactiveRole {
     nextPendingSnapshotChunkId = nextChunkId;
   }
 
-  private void abortPendingSnapshots() {
+  protected void abortPendingSnapshots() {
     if (pendingSnapshot != null) {
       setNextExpected(null);
       previouslyReceivedSnapshotChunkId = null;
@@ -584,9 +589,13 @@ public class PassiveRole extends InactiveRole {
     // Append the entries to the log.
     appendEntries(request, future);
 
-    // If a snapshot replication was ongoing, reset it. Otherwise SnapshotReplicationListeners will
-    // wait for ever for the snapshot to be received.
-    abortPendingSnapshots();
+    // If the request contains entries, abort any in-progress snapshot replication. The follower
+    // is now receiving log entries and must not continue waiting for snapshot chunks. We skip this
+    // for empty appends (heartbeats) because the leader may send heartbeats concurrently with
+    // snapshot chunks when there have been prior communication failures.
+    if (!request.entries().isEmpty()) {
+      abortPendingSnapshots();
+    }
     return future;
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
@@ -112,6 +112,35 @@ public class RaftSnapshotReplicationFailureHandlingTest {
         .isEqualTo(2);
   }
 
+  /**
+   * Regression test for <a href="https://github.com/camunda/camunda/issues/46345">#46345</a>.
+   *
+   * <p>When install responses time out repeatedly, the leader accumulates failures and switches to
+   * sending heartbeats (empty appends). Before the fix, these heartbeats would abort the pending
+   * snapshot on the follower, forcing a full restart of the snapshot replication. With the fix,
+   * heartbeats from the same leader no longer abort in-progress snapshots.
+   */
+  @Test
+  public void shouldCompleteSnapshotReplicationDespiteHeartbeats() throws Throwable {
+    // given
+    final int numberOfChunks = 10;
+    disconnectFollowerAndTakeSnapshot(numberOfChunks);
+
+    // Let the first 5 install responses succeed, then time out the next 5 responses.
+    // After 5 timeouts, the leader will start sending heartbeats.
+    leaderProtocol.interceptResponse(
+        InstallResponse.class, new SucceedThenTimeoutInterceptor(5, 5));
+
+    // when - resume snapshot replication
+    reconnectFollowerAndAwaitSnapshot();
+
+    // then - snapshot should complete without a full restart. Only the 5 timed out chunks are
+    // retried.
+    assertThat(totalInstallRequest.get())
+        .describedAs("Should complete snapshot without restarting due to heartbeats")
+        .isEqualTo(numberOfChunks + 5);
+  }
+
   private void reconnectFollowerAndAwaitSnapshot() throws InterruptedException {
     final var snapshotReceived = new CountDownLatch(1);
     raftRule
@@ -177,6 +206,28 @@ public class RaftSnapshotReplicationFailureHandlingTest {
         return CompletableFuture.failedFuture(new TimeoutException());
       } else {
         return CompletableFuture.completedFuture(null);
+      }
+    }
+  }
+
+  private static class SucceedThenTimeoutInterceptor
+      implements ResponseInterceptor<InstallResponse> {
+    private int count = 0;
+    private final int succeedCount;
+    private final int timeoutCount;
+
+    public SucceedThenTimeoutInterceptor(final int succeedCount, final int timeoutCount) {
+      this.succeedCount = succeedCount;
+      this.timeoutCount = timeoutCount;
+    }
+
+    @Override
+    public CompletableFuture<InstallResponse> apply(final InstallResponse installResponse) {
+      count++;
+      if (count > succeedCount && count <= succeedCount + timeoutCount) {
+        return CompletableFuture.failedFuture(new TimeoutException());
+      } else {
+        return CompletableFuture.completedFuture(installResponse);
       }
     }
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -43,7 +43,6 @@ import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -245,7 +245,6 @@ public class PassiveRoleTest {
     assertThat(response.succeeded()).isTrue();
   }
 
-
   @Test
   public void shouldNotAbortPendingSnapshotOnEmptyAppend() throws Exception {
     // given - a pending snapshot is in progress

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -39,9 +39,11 @@ import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -242,5 +244,72 @@ public class PassiveRoleTest {
 
     // then
     assertThat(response.succeeded()).isTrue();
+  }
+
+
+  @Test
+  public void shouldNotAbortPendingSnapshotOnEmptyAppend() throws Exception {
+    // given - a pending snapshot is in progress
+    final ReceivedSnapshot receivedSnapshot = mock(ReceivedSnapshot.class);
+    setPendingSnapshot(receivedSnapshot);
+
+    // an empty append request (heartbeat)
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(List.of())
+            .withCommitIndex(0)
+            .build();
+
+    // when
+    role.handleAppend(ProtocolVersionHandler.transform(request)).join();
+
+    // then - the pending snapshot should not be aborted
+    verify(receivedSnapshot, never()).abort();
+    assertThat(getPendingSnapshot()).as("pending snapshot should still be present").isNotNull();
+  }
+
+  @Test
+  public void shouldAbortPendingSnapshotOnNonEmptyAppend() throws Exception {
+    // given - a pending snapshot is in progress
+    final ReceivedSnapshot receivedSnapshot = mock(ReceivedSnapshot.class);
+    setPendingSnapshot(receivedSnapshot);
+
+    // an append request with entries
+    final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(1)
+            .build();
+
+    when(log.append(any(ReplicatableJournalRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class));
+
+    // when
+    role.handleAppend(ProtocolVersionHandler.transform(request)).join();
+
+    // then - the pending snapshot should be aborted
+    verify(receivedSnapshot).abort();
+    assertThat(getPendingSnapshot()).as("pending snapshot should be cleared").isNull();
+  }
+
+  private void setPendingSnapshot(final ReceivedSnapshot snapshot) throws Exception {
+    final var field = PassiveRole.class.getDeclaredField("pendingSnapshot");
+    field.setAccessible(true);
+    field.set(role, snapshot);
+  }
+
+  private Object getPendingSnapshot() throws Exception {
+    final var field = PassiveRole.class.getDeclaredField("pendingSnapshot");
+    field.setAccessible(true);
+    return field.get(role);
   }
 }


### PR DESCRIPTION
# Description
Backport of #48714 to `stable/8.6`.

relates to #46345