### PR TITLE
ci: upload Maven SNAPSHOTs from stable/* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,7 +812,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions: {}  # GITHUB_TOKEN unused in this job
-    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-maven-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

- Enable Maven SNAPSHOT artifact deployment for `stable/*` branches by changing the `deploy-snapshots` job condition from `refs/heads/main` to `(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))`

## Context

This is needed for https://github.com/camunda/zeebe-process-test/issues/2021 — `zeebe-process-test` requires 8.6 SNAPSHOT artifacts to be available in artifacts.camunda.com.

## Test plan

- [ ] Verify the `deploy-snapshots` job triggers on `stable/8.6` CI runs
- [ ] Verify SNAPSHOT artifacts appear in artifacts.camunda.com for 8.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)