### PR TITLE
fix: use elementInstancesTreeStore inside useEffect

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -809,9 +809,14 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
       processInstance.state === 'ACTIVE' &&
       !modificationsStore.isModificationModeEnabled;
 
-    elementInstancesTreeStore.setRootNode(processInstance.processInstanceKey, {
-      enablePolling,
-    });
+    useEffect(() => {
+      elementInstancesTreeStore.setRootNode(
+        processInstance.processInstanceKey,
+        {
+          enablePolling,
+        },
+      );
+    }, [processInstance.processInstanceKey, enablePolling]);
 
     useEffect(() => {
       return elementInstancesTreeStore.reset;


### PR DESCRIPTION
## Description

Move `elementInstancesTreeStore.setRootNode` usage to `useEffect`.
 
Issue root cause: `setRootNode` is an async method that  immediately fires `fetchFirstPage`, aborts old controllers, and starts polling. Calling it during render causes side effects to fire on every re-render during the navigation transition.                                                                                                                                                                     
On 8.8, the equivalent store (`flowNodeInstanceStore`) was explicitly reset in a `useEffect` cleanup on `processInstanceId` change, preventing cascading requests.   

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #48198 
related to #48807
