### PR TITLE
feat: allow to get variable value as type

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Variable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Variable.java
@@ -47,4 +47,6 @@ public interface Variable {
 
   /* Check if the variable is truncated */
   Boolean isTruncated();
+
+  <T> T getValueAsType(Class<T> type);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Variable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Variable.java
@@ -48,5 +48,13 @@ public interface Variable {
   /* Check if the variable is truncated */
   Boolean isTruncated();
 
+  /**
+   * Deserializes the variable's JSON value into the given type.
+   *
+   * @param type the class to deserialize the value into
+   * @param <T> the target type
+   * @return the deserialized value
+   * @throws IllegalStateException if the variable value is truncated
+   */
   <T> T getValueAsType(Class<T> type);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1270,7 +1270,7 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public VariableGetRequest newVariableGetRequest(final long variableKey) {
-    return new VariableGetRequestImpl(httpClient, variableKey);
+    return new VariableGetRequestImpl(httpClient, variableKey, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/VariableGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/VariableGetRequestImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.fetch;
 
 import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -31,11 +32,14 @@ public class VariableGetRequestImpl implements VariableGetRequest {
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
   private final long variableKey;
+  private final JsonMapper jsonMapper;
 
-  public VariableGetRequestImpl(final HttpClient httpClient, final long variableKey) {
+  public VariableGetRequestImpl(
+      final HttpClient httpClient, final long variableKey, final JsonMapper jsonMapper) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     this.variableKey = variableKey;
+    this.jsonMapper = jsonMapper;
   }
 
   @Override
@@ -51,7 +55,7 @@ public class VariableGetRequestImpl implements VariableGetRequest {
         String.format("/variables/%d", variableKey),
         httpRequestConfig.build(),
         VariableResult.class,
-        VariableImpl::new,
+        v -> new VariableImpl(v, jsonMapper),
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UserTaskEffectiveVariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UserTaskEffectiveVariableSearchRequestImpl.java
@@ -80,7 +80,7 @@ public class UserTaskEffectiveVariableSearchRequestImpl
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         VariableSearchQueryResult.class,
-        SearchResponseMapper::toVariableSearchResponse,
+        r -> SearchResponseMapper.toVariableSearchResponse(r, jsonMapper),
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UserTaskVariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UserTaskVariableSearchRequestImpl.java
@@ -80,7 +80,7 @@ public class UserTaskVariableSearchRequestImpl
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         VariableSearchQueryResult.class,
-        SearchResponseMapper::toVariableSearchResponse,
+        r -> SearchResponseMapper.toVariableSearchResponse(r, jsonMapper),
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/VariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/VariableSearchRequestImpl.java
@@ -76,7 +76,7 @@ public class VariableSearchRequestImpl
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         VariableSearchQueryResult.class,
-        SearchResponseMapper::toVariableSearchResponse,
+        r -> SearchResponseMapper.toVariableSearchResponse(r, jsonMapper),
         result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -125,10 +125,10 @@ public final class SearchResponseMapper {
   }
 
   public static SearchResponse<Variable> toVariableSearchResponse(
-      final VariableSearchQueryResult response) {
+      final VariableSearchQueryResult response, final JsonMapper jsonMapper) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<Variable> instances =
-        toSearchResponseInstances(response.getItems(), VariableImpl::new);
+        toSearchResponseInstances(response.getItems(), v -> new VariableImpl(v, jsonMapper));
     return new SearchResponseImpl<>(instances, page);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.impl.search.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.util.ParseUtil;
@@ -31,7 +32,7 @@ public class VariableImpl implements Variable {
   private final Long rootProcessInstanceKey;
   private final String tenantId;
   private final Boolean isTruncated;
-  private final JsonMapper jsonMapper;
+  @JsonIgnore private final JsonMapper jsonMapper;
 
   public VariableImpl(final VariableSearchResult item, final JsonMapper jsonMapper) {
     variableKey = ParseUtil.parseLongOrNull(item.getVariableKey());
@@ -99,7 +100,7 @@ public class VariableImpl implements Variable {
 
   @Override
   public <T> T getValueAsType(final Class<T> type) {
-    if (isTruncated()) {
+    if (Boolean.TRUE.equals(isTruncated())) {
       throw new IllegalStateException("Cannot return truncated value as type " + type);
     }
     return jsonMapper.fromJson(value, type);

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.impl.search.response;
 
+import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.VariableResult;
@@ -30,8 +31,9 @@ public class VariableImpl implements Variable {
   private final Long rootProcessInstanceKey;
   private final String tenantId;
   private final Boolean isTruncated;
+  private final JsonMapper jsonMapper;
 
-  public VariableImpl(final VariableSearchResult item) {
+  public VariableImpl(final VariableSearchResult item, final JsonMapper jsonMapper) {
     variableKey = ParseUtil.parseLongOrNull(item.getVariableKey());
     name = item.getName();
     value = item.getValue();
@@ -40,9 +42,10 @@ public class VariableImpl implements Variable {
     rootProcessInstanceKey = ParseUtil.parseLongOrNull(item.getRootProcessInstanceKey());
     tenantId = item.getTenantId();
     isTruncated = item.getIsTruncated();
+    this.jsonMapper = jsonMapper;
   }
 
-  public VariableImpl(final VariableResult item) {
+  public VariableImpl(final VariableResult item, final JsonMapper jsonMapper) {
     variableKey = ParseUtil.parseLongOrNull(item.getVariableKey());
     name = item.getName();
     value = item.getValue();
@@ -51,6 +54,7 @@ public class VariableImpl implements Variable {
     rootProcessInstanceKey = ParseUtil.parseLongOrNull(item.getRootProcessInstanceKey());
     tenantId = item.getTenantId();
     isTruncated = false;
+    this.jsonMapper = jsonMapper;
   }
 
   @Override
@@ -91,5 +95,13 @@ public class VariableImpl implements Variable {
   @Override
   public Boolean isTruncated() {
     return isTruncated;
+  }
+
+  @Override
+  public <T> T getValueAsType(final Class<T> type) {
+    if (isTruncated()) {
+      throw new IllegalStateException("Cannot return truncated value as type " + type);
+    }
+    return jsonMapper.fromJson(value, type);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/variable/VariableValueAsTypeTest.java
+++ b/clients/java/src/test/java/io/camunda/client/variable/VariableValueAsTypeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.variable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.impl.search.response.VariableImpl;
+import io.camunda.client.protocol.rest.VariableSearchResult;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class VariableValueAsTypeTest {
+
+  private final JsonMapper jsonMapper = new CamundaObjectMapper();
+
+  @Test
+  void shouldDeserializeValueAsType() {
+    // given
+    final VariableSearchResult searchResult =
+        new VariableSearchResult()
+            .name("myVar")
+            .value("{\"key\":\"value\"}")
+            .isTruncated(false)
+            .variableKey("1")
+            .scopeKey("2")
+            .processInstanceKey("3")
+            .tenantId("default");
+    final VariableImpl variable = new VariableImpl(searchResult, jsonMapper);
+
+    // when
+    @SuppressWarnings("unchecked")
+    final Map<String, String> result = variable.getValueAsType(Map.class);
+
+    // then
+    assertThat(result).containsEntry("key", "value");
+  }
+
+  @Test
+  void shouldThrowExceptionForTruncatedValue() {
+    // given
+    final VariableSearchResult searchResult =
+        new VariableSearchResult()
+            .name("myVar")
+            .value("{\"key\":\"val...")
+            .isTruncated(true)
+            .variableKey("1")
+            .scopeKey("2")
+            .processInstanceKey("3")
+            .tenantId("default");
+    final VariableImpl variable = new VariableImpl(searchResult, jsonMapper);
+
+    // when / then
+    assertThatThrownBy(() -> variable.getValueAsType(Map.class))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("truncated");
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/VariableBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/VariableBuilder.java
@@ -72,6 +72,9 @@ public class VariableBuilder implements Variable {
 
   @Override
   public <T> T getValueAsType(final Class<T> type) {
+    if (Boolean.TRUE.equals(isTruncated)) {
+      throw new IllegalStateException("Cannot return truncated value as type " + type);
+    }
     if (jsonMapper == null) {
       throw new IllegalStateException(
           "jsonMapper not set on VariableBuilder. Please set it using setJsonMapper() before calling getValueAsType().");

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/VariableBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/VariableBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.utils;
 
+import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.search.response.Variable;
 
 public class VariableBuilder implements Variable {
@@ -27,6 +28,7 @@ public class VariableBuilder implements Variable {
   private Long rootProcessInstanceKey;
   private String tenantId;
   private Boolean isTruncated;
+  private JsonMapper jsonMapper;
 
   @Override
   public Long getVariableKey() {
@@ -68,6 +70,15 @@ public class VariableBuilder implements Variable {
     return isTruncated;
   }
 
+  @Override
+  public <T> T getValueAsType(final Class<T> type) {
+    if (jsonMapper == null) {
+      throw new IllegalStateException(
+          "jsonMapper not set on VariableBuilder. Please set it using setJsonMapper() before calling getValueAsType().");
+    }
+    return jsonMapper.fromJson(value, type);
+  }
+
   public VariableBuilder setTenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
@@ -105,6 +116,11 @@ public class VariableBuilder implements Variable {
 
   public VariableBuilder setTruncated(final Boolean truncated) {
     isTruncated = truncated;
+    return this;
+  }
+
+  public VariableBuilder setJsonMapper(final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
     return this;
   }
 


### PR DESCRIPTION
## Description

Adds `Variable#getValueAsType(Class<T>)` to the Java client, allowing users to deserialize a variable's JSON value directly into a requested Java type. The `JsonMapper` is threaded through variable response construction so the feature works for both get and search endpoints.

### Changes
- Add `getValueAsType(Class<T>)` to the public `Variable` interface with Javadoc
- Implement in `VariableImpl`, with `@JsonIgnore` on the `JsonMapper` field and null-safe `isTruncated` handling
- Thread `JsonMapper` through variable search response mapping and variable get request
- Mirror truncated-value guard in test `VariableBuilder`
- Add unit tests for happy path deserialization and the truncated-value error path

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #