### PR TITLE
Fix termination of children when modifying an ad-hoc sub-process

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -1467,6 +1467,8 @@ public final class ProcessInstanceModificationModifyProcessor
     // terminate all child instances if the element is an event subprocess
     if (elementType == BpmnElementType.EVENT_SUB_PROCESS
         || elementType == BpmnElementType.SUB_PROCESS
+        || elementType == BpmnElementType.AD_HOC_SUB_PROCESS
+        || elementType == BpmnElementType.AD_HOC_SUB_PROCESS_INNER_INSTANCE
         || elementType == BpmnElementType.PROCESS
         || elementType == BpmnElementType.MULTI_INSTANCE_BODY) {
       elementInstanceState.getChildren(elementInstanceKey).stream()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -1465,12 +1465,7 @@ public final class ProcessInstanceModificationModifyProcessor
       final ElementInstance currentElement) {
     final var childInstances = new ArrayList<ElementInstance>();
     // terminate all child instances if the element is an event subprocess
-    if (elementType == BpmnElementType.EVENT_SUB_PROCESS
-        || elementType == BpmnElementType.SUB_PROCESS
-        || elementType == BpmnElementType.AD_HOC_SUB_PROCESS
-        || elementType == BpmnElementType.AD_HOC_SUB_PROCESS_INNER_INSTANCE
-        || elementType == BpmnElementType.PROCESS
-        || elementType == BpmnElementType.MULTI_INSTANCE_BODY) {
+    if (elementType.isContainerElement()) {
       elementInstanceState.getChildren(elementInstanceKey).stream()
           .filter(ElementInstance::canTerminate)
           .forEach(childInstances::add);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -1464,7 +1464,6 @@ public final class ProcessInstanceModificationModifyProcessor
       final long elementInstanceKey,
       final ElementInstance currentElement) {
     final var childInstances = new ArrayList<ElementInstance>();
-    // terminate all child instances if the element is an event subprocess
     if (elementType.isContainerElement()) {
       elementInstanceState.getChildren(elementInstanceKey).stream()
           .filter(ElementInstance::canTerminate)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -32,6 +32,8 @@ import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -3394,16 +3396,28 @@ public class ModifyProcessInstanceTest {
 
   private void assertThatElementIsTerminated(
       final long processInstanceKey, final String elementId) {
+    assertThatElementIsTerminated(processInstanceKey, elementId, 1);
+  }
+
+  private void assertThatElementIsTerminated(
+      final long processInstanceKey, final String elementId, final int count) {
+    final var expectedIntents = new ArrayList<ProcessInstanceIntent>();
+    expectedIntents.addAll(Collections.nCopies(count, ProcessInstanceIntent.ELEMENT_TERMINATING));
+    expectedIntents.addAll(Collections.nCopies(count, ProcessInstanceIntent.ELEMENT_TERMINATED));
+
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .onlyEvents()
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementId(elementId)
-                .limit(elementId, ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .limitByCount(
+                    r ->
+                        r.getValue().getElementId().equals(elementId)
+                            && r.getIntent().equals(ProcessInstanceIntent.ELEMENT_TERMINATED),
+                    count)
                 .toList())
         .extracting(Record::getIntent)
-        .containsSequence(
-            ProcessInstanceIntent.ELEMENT_TERMINATING, ProcessInstanceIntent.ELEMENT_TERMINATED);
+        .containsSequence(expectedIntents);
   }
 
   @Test
@@ -3544,6 +3558,43 @@ public class ModifyProcessInstanceTest {
                 .exists())
         .describedAs("Expect the conditional event subscription to have been created")
         .isTrue();
+  }
+
+  @Test
+  public void shouldTerminateElementsInsideAdHocSubProcess() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .adHocSubProcess(
+                    "AHSP",
+                    ahsp -> {
+                      ahsp.userTask("A").zeebeUserTask();
+                      ahsp.userTask("B").zeebeUserTask();
+                      ahsp.zeebeActiveElementsCollectionExpression("=[\"A\", \"B\"]");
+                    })
+                .userTask("C")
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElements("AHSP", "C")
+        .modify();
+
+    // then
+    assertThatElementIsTerminated(processInstanceKey, "AHSP");
+    assertThatElementIsTerminated(processInstanceKey, "AHSP#innerInstance", 2);
+    assertThatElementIsTerminated(processInstanceKey, "A");
+    assertThatElementIsTerminated(processInstanceKey, "B");
+    verifyThatRootElementIsActivated(processInstanceKey, "C", BpmnElementType.USER_TASK);
   }
 
   private void verifyThatElementTreePathIsUpdated(

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
@@ -21,48 +21,50 @@ import java.util.Optional;
 public enum BpmnElementType {
 
   // Default
-  UNSPECIFIED(null),
+  UNSPECIFIED(null, false),
 
   // Containers
-  PROCESS("process"),
-  SUB_PROCESS("subProcess"),
-  EVENT_SUB_PROCESS(null),
-  AD_HOC_SUB_PROCESS("adHocSubProcess"),
-  AD_HOC_SUB_PROCESS_INNER_INSTANCE(null),
+  PROCESS("process", true),
+  SUB_PROCESS("subProcess", true),
+  EVENT_SUB_PROCESS(null, true),
+  AD_HOC_SUB_PROCESS("adHocSubProcess", true),
+  AD_HOC_SUB_PROCESS_INNER_INSTANCE(null, true),
 
   // Events
-  START_EVENT("startEvent"),
-  INTERMEDIATE_CATCH_EVENT("intermediateCatchEvent"),
-  INTERMEDIATE_THROW_EVENT("intermediateThrowEvent"),
-  BOUNDARY_EVENT("boundaryEvent"),
-  END_EVENT("endEvent"),
+  START_EVENT("startEvent", false),
+  INTERMEDIATE_CATCH_EVENT("intermediateCatchEvent", false),
+  INTERMEDIATE_THROW_EVENT("intermediateThrowEvent", false),
+  BOUNDARY_EVENT("boundaryEvent", false),
+  END_EVENT("endEvent", false),
 
   // Tasks
-  SERVICE_TASK("serviceTask"),
-  RECEIVE_TASK("receiveTask"),
-  USER_TASK("userTask"),
-  MANUAL_TASK("manualTask"),
-  TASK("task"),
+  SERVICE_TASK("serviceTask", false),
+  RECEIVE_TASK("receiveTask", false),
+  USER_TASK("userTask", false),
+  MANUAL_TASK("manualTask", false),
+  TASK("task", false),
 
   // Gateways
-  EXCLUSIVE_GATEWAY("exclusiveGateway"),
-  PARALLEL_GATEWAY("parallelGateway"),
-  EVENT_BASED_GATEWAY("eventBasedGateway"),
-  INCLUSIVE_GATEWAY("inclusiveGateway"),
+  EXCLUSIVE_GATEWAY("exclusiveGateway", false),
+  PARALLEL_GATEWAY("parallelGateway", false),
+  EVENT_BASED_GATEWAY("eventBasedGateway", false),
+  INCLUSIVE_GATEWAY("inclusiveGateway", false),
 
   // Other
-  SEQUENCE_FLOW("sequenceFlow"),
-  MULTI_INSTANCE_BODY(null),
-  CALL_ACTIVITY("callActivity"),
+  SEQUENCE_FLOW("sequenceFlow", false),
+  MULTI_INSTANCE_BODY(null, true),
+  CALL_ACTIVITY("callActivity", false),
 
-  BUSINESS_RULE_TASK("businessRuleTask"),
-  SCRIPT_TASK("scriptTask"),
-  SEND_TASK("sendTask");
+  BUSINESS_RULE_TASK("businessRuleTask", false),
+  SCRIPT_TASK("scriptTask", false),
+  SEND_TASK("sendTask", false);
 
   private final String elementTypeName;
+  private final boolean isContainerElement;
 
-  BpmnElementType(final String elementTypeName) {
+  BpmnElementType(final String elementTypeName, final boolean isContainerElement) {
     this.elementTypeName = elementTypeName;
+    this.isContainerElement = isContainerElement;
   }
 
   public Optional<String> getElementTypeName() {
@@ -78,5 +80,9 @@ public enum BpmnElementType {
         .findFirst()
         .orElseThrow(
             () -> new RuntimeException("Unsupported BPMN element of type " + elementTypeName));
+  }
+
+  public boolean isContainerElement() {
+    return isContainerElement;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
@@ -53,6 +53,8 @@ public enum BpmnElementType {
   // Other
   SEQUENCE_FLOW("sequenceFlow", false),
   MULTI_INSTANCE_BODY(null, true),
+  // Note that a call activity is not considered to be a container element. Whilst it creates a
+  // child process instance, it does not contain direct child elements itself.
   CALL_ACTIVITY("callActivity", false),
 
   BUSINESS_RULE_TASK("businessRuleTask", false),
@@ -60,6 +62,11 @@ public enum BpmnElementType {
   SEND_TASK("sendTask", false);
 
   private final String elementTypeName;
+
+  /**
+   * A container element is defined as an element that contains child elements within, such as a
+   * sub-process.
+   */
   private final boolean isContainerElement;
 
   BpmnElementType(final String elementTypeName, final boolean isContainerElement) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Children of the ad-hoc sub-process were never terminated. The element type was not added to the if-statement that would fetch the children. As a result, the ad-hoc sub-process itself would get terminated, the process instance would get terminated, but the children inside of the ad-hoc sub-process would remain indefinitely.

I added a small refactoring to make it harder to forget this in the future if more container elements are added.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48530 
