### PR TITLE
Test backup store connection when required

### DIFF
--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -12,6 +12,7 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.azure.AzureBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.azure.AzureBackupStoreException.ContainerDoesNotExist;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
@@ -34,6 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +63,7 @@ public final class AzureBackupStore implements BackupStore {
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
   private final BlobContainerClient blobContainerClient;
+  private final AzureBackupConfig config;
   private volatile boolean containerCreated;
 
   AzureBackupStore(final AzureBackupConfig config) {
@@ -67,6 +71,7 @@ public final class AzureBackupStore implements BackupStore {
   }
 
   AzureBackupStore(final AzureBackupConfig config, final BlobServiceClient client) {
+    this.config = config;
     executor = Executors.newVirtualThreadPerTaskExecutor();
     blobContainerClient = getContainerClient(client, config);
     final boolean createContainer = isCreateContainer(config);
@@ -319,6 +324,37 @@ public final class AzureBackupStore implements BackupStore {
             throw new RuntimeException(e);
           }
         });
+  }
+
+  @Override
+  public CompletableFuture<Void> verifyConnection() {
+    return CompletableFuture.runAsync(
+            () -> {
+              try {
+                blobContainerClient
+                    .listBlobs(new ListBlobsOptions().setMaxResultsPerPage(1), null)
+                    .stream()
+                    .findFirst();
+              } catch (final Exception e) {
+                throw new ConfigurationException(
+                    "Failed to connect to Azure Blob Storage with the provided configuration '%s'"
+                        .formatted(config),
+                    e);
+              }
+            },
+            executor)
+        .orTimeout(10, TimeUnit.SECONDS)
+        .exceptionally(
+            error -> {
+              if (error instanceof TimeoutException) {
+                throw new ConfigurationException(
+                    "Failed to connect to Azure Blob Storage: connection timed out after 10 seconds");
+              }
+              throw new ConfigurationException(
+                  "Failed to connect to Azure Blob Storage with the provided configuration '%s'"
+                      .formatted(config),
+                  error);
+            });
   }
 
   private String backupMetadataPath(final int partitionId) {

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -337,9 +337,7 @@ public final class AzureBackupStore implements BackupStore {
                     .findFirst();
               } catch (final Exception e) {
                 throw new ConfigurationException(
-                    "Failed to connect to Azure Blob Storage with the provided configuration '%s'"
-                        .formatted(config),
-                    e);
+                    "Failed to connect to Azure Blob Storage with the provided configuration", e);
               }
             },
             executor)
@@ -348,12 +346,11 @@ public final class AzureBackupStore implements BackupStore {
             error -> {
               if (error instanceof TimeoutException) {
                 throw new ConfigurationException(
-                    "Failed to connect to Azure Blob Storage: connection timed out after 10 seconds");
+                    "Failed to connect to Azure Blob Storage: connection timed out after 10 seconds",
+                    error);
               }
               throw new ConfigurationException(
-                  "Failed to connect to Azure Blob Storage with the provided configuration '%s'"
-                      .formatted(config),
-                  error);
+                  "Failed to connect to Azure Blob Storage with the provided configuration", error);
             });
   }
 

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -346,8 +346,7 @@ public final class AzureBackupStore implements BackupStore {
             error -> {
               if (error instanceof TimeoutException) {
                 throw new ConfigurationException(
-                    "Failed to connect to Azure Blob Storage: connection timed out after 10 seconds",
-                    error);
+                    "Failed to connect to Azure Blob Storage: connection timed out after 10 seconds");
               }
               throw new ConfigurationException(
                   "Failed to connect to Azure Blob Storage with the provided configuration", error);

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStoreException.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStoreException.java
@@ -28,4 +28,14 @@ public abstract class AzureBackupStoreException extends RuntimeException {
       super(message);
     }
   }
+
+  public static final class ConfigurationException extends AzureBackupStoreException {
+    public ConfigurationException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+
+    public ConfigurationException(final String message) {
+      super(message);
+    }
+  }
 }

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
@@ -30,8 +30,10 @@ import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -129,6 +131,36 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
                 Expected to restore from completed backup with id \
                 'BackupId{node=1, partition=2, checkpoint=3}', \
                 but was in state 'IN_PROGRESS'""");
+  }
+
+  @Test
+  void shouldSuccessfullyVerifyConnectionWithValidConnectionString() {
+    // given
+    final AzureBackupConfig azureBackupConfig =
+        new AzureBackupConfig.Builder()
+            .withConnectionString(AZURITE_CONTAINER.getConnectString())
+            .withContainerName(AZURITE_CONTAINER.getContainerName())
+            .build();
+    final var store = new AzureBackupStore(azureBackupConfig);
+
+    // when - then
+    Assertions.assertThat(store.verifyConnection()).succeedsWithin(Duration.ofSeconds(10));
+  }
+
+  @Test
+  void shouldFailVerifyConnectionWhenContainerDoesNotExist() {
+    // given
+    final AzureBackupConfig azureBackupConfig =
+        new AzureBackupConfig.Builder()
+            .withConnectionString(AZURITE_CONTAINER.getConnectString())
+            .withContainerName(UUID.randomUUID().toString())
+            .build();
+    final var store = new AzureBackupStore(azureBackupConfig);
+
+    // when - then
+    Assertions.assertThat(store.verifyConnection())
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(ExecutionException.class);
   }
 
   void uploadInProgressManifest(final Backup backup) {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -58,6 +58,7 @@ public final class FilesystemBackupStore implements BackupStore {
   private final ExecutorService executor;
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
+  private final FilesystemBackupConfig config;
   private final Path rangesDir;
   private final Path metadataBaseDir;
 
@@ -67,7 +68,7 @@ public final class FilesystemBackupStore implements BackupStore {
 
   FilesystemBackupStore(final FilesystemBackupConfig config, final ExecutorService executor) {
     validateConfig(config);
-
+    this.config = config;
     this.executor = executor;
 
     final var contentsDir = Path.of(config.basePath()).resolve(CONTENTS_PATH);
@@ -258,6 +259,29 @@ public final class FilesystemBackupStore implements BackupStore {
                 e);
           }
         });
+  }
+
+  /**
+   * Validates that the filesystem backup store is usable by verifying that the base path directory
+   * can be created and is writable. This goes beyond {@link
+   * #validateConfig(FilesystemBackupConfig)} by performing filesystem operations.
+   */
+  @Override
+  public CompletableFuture<Void> verifyConnection() {
+    return CompletableFuture.runAsync(
+        () -> {
+          final var basePath = Path.of(config.basePath());
+          final var file = basePath.toFile();
+          if (!file.exists() || !file.isDirectory()) {
+            throw new IllegalArgumentException(
+                "Backup base directory '%s' does not exist".formatted(config.basePath()));
+          }
+          if (!Files.isWritable(basePath)) {
+            throw new IllegalArgumentException(
+                "Backup base directory '%s' is not writable".formatted(config.basePath()));
+          }
+        },
+        executor);
   }
 
   public static void validateConfig(final FilesystemBackupConfig config) {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -261,11 +261,6 @@ public final class FilesystemBackupStore implements BackupStore {
         });
   }
 
-  /**
-   * Validates that the filesystem backup store is usable by verifying that the base path directory
-   * can be created and is writable. This goes beyond {@link
-   * #validateConfig(FilesystemBackupConfig)} by performing filesystem operations.
-   */
   @Override
   public CompletableFuture<Void> verifyConnection() {
     return CompletableFuture.runAsync(

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -21,12 +21,14 @@ import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestSta
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.testkit.BackupStoreTestKit;
 import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
+import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
@@ -166,6 +168,55 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
         backupDir.resolve("manifests").resolve(String.valueOf(node2Backup.id().partitionId()));
     assertThat(partitionContentsDir).isNotEmptyDirectory();
     assertThat(partitionManifestsDir).isNotEmptyDirectory();
+  }
+
+  @Test
+  void shouldSuccessfullyVerifyConnectionWhenDirectoryIsWritable() {
+    // given - backupStore is already set up with writable TempDir in @BeforeEach
+
+    // when/then
+    assertThat(backupStore.verifyConnection()).succeedsWithin(Duration.ofSeconds(10));
+  }
+
+  @Test
+  void shouldFailVerifyConnectionWhenDirectoryIsNotWritable(@TempDir final Path readOnlyDir)
+      throws IOException {
+    // given
+    final var readOnlyConfig =
+        new FilesystemBackupConfig.Builder().withBasePath(readOnlyDir.toString()).build();
+    final var readOnlyStore =
+        new FilesystemBackupStore(readOnlyConfig, Executors.newVirtualThreadPerTaskExecutor());
+
+    // when dir is readonly
+    final var permissions = PosixFilePermissions.fromString("r-xr-xr-x");
+    Files.setPosixFilePermissions(readOnlyDir, permissions);
+
+    // then
+    assertThat(readOnlyStore.verifyConnection())
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(Throwable.class)
+        .withMessageContaining("is not writable");
+  }
+
+  @Test
+  void shouldFailVerifyConnectionWhenDirectoryDoesNotExist(@TempDir final Path tempDir)
+      throws IOException {
+    // given
+    final var nonExistentDir = tempDir.resolve("new-backup-dir");
+    final var config =
+        new FilesystemBackupConfig.Builder().withBasePath(nonExistentDir.toString()).build();
+    final var store =
+        new FilesystemBackupStore(config, Executors.newVirtualThreadPerTaskExecutor());
+
+    // when delete directory
+    FileUtil.deleteFolder(nonExistentDir);
+    assertThat(nonExistentDir).doesNotExist();
+
+    // then
+    assertThat(store.verifyConnection())
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(Throwable.class)
+        .withMessageContaining("does not exist");
   }
 
   void uploadInProgressManifest(final Backup backup) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -271,11 +271,13 @@ public final class GcsBackupStore implements BackupStore {
     return CompletableFuture.runAsync(
             () -> {
               try {
-                client
-                    .list(config.bucketName(), BlobListOption.pageSize(1))
-                    .iterateAll()
-                    .iterator()
-                    .hasNext();
+                // Trigger a list operation to verify connection
+                final var ignored =
+                    client
+                        .list(config.bucketName(), BlobListOption.pageSize(1))
+                        .iterateAll()
+                        .iterator()
+                        .hasNext();
               } catch (final Exception e) {
                 throw new ConfigurationException(
                     "Unable to connect to GCS bucket '%s': %s"

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,12 +51,14 @@ public final class GcsBackupStore implements BackupStore {
   private final Storage client;
   private final BucketInfo bucketInfo;
   private final String basePath;
+  private final GcsBackupConfig config;
 
   GcsBackupStore(final GcsBackupConfig config) {
     this(config, buildClient(config));
   }
 
   GcsBackupStore(final GcsBackupConfig config, final Storage client) {
+    this.config = config;
     bucketInfo = BucketInfo.of(config.bucketName());
     basePath = Optional.ofNullable(config.basePath()).map(s -> s + "/").orElse("");
     this.client = client;
@@ -263,6 +266,37 @@ public final class GcsBackupStore implements BackupStore {
         });
   }
 
+  @Override
+  public CompletableFuture<Void> verifyConnection() {
+    return CompletableFuture.runAsync(
+            () -> {
+              try {
+                client
+                    .list(config.bucketName(), BlobListOption.pageSize(1))
+                    .iterateAll()
+                    .iterator()
+                    .hasNext();
+              } catch (final Exception e) {
+                throw new ConfigurationException(
+                    "Unable to connect to GCS bucket '%s': %s"
+                        .formatted(config.bucketName(), e.getMessage()),
+                    e);
+              }
+            },
+            executor)
+        .orTimeout(10, TimeUnit.SECONDS)
+        .exceptionally(
+            error -> {
+              if (error instanceof TimeoutException) {
+                throw new ConfigurationException(
+                    "Failed to connect to GCS: connection timed out after 10 seconds");
+              }
+              throw new ConfigurationException(
+                  "Failed to connect to GCS with the provided configuration '%s'".formatted(config),
+                  error);
+            });
+  }
+
   private BlobInfo backupMetadataBlobInfo(final int partitionId) {
     return BlobInfo.newBuilder(
             bucketInfo, "%smetadata/%d/%s".formatted(basePath, partitionId, METADATA_OBJECT_NAME))
@@ -284,17 +318,39 @@ public final class GcsBackupStore implements BackupStore {
   }
 
   public static void validateConfig(final GcsBackupConfig config) {
-    try (final var storage = buildClient(config)) {
-      try {
-        storage.list(config.bucketName(), BlobListOption.pageSize(1));
-      } catch (final Exception e) {
-        LOG.warn(
-            "Unable to verify that the bucket {} exists, initialization will continue as it can be a transient network issue",
-            config.bucketName(),
-            e);
+    if (config == null) {
+      throw new IllegalArgumentException(ERROR_VALIDATION_FAILED.formatted("config is null"));
+    }
+
+    if (config.bucketName() == null || config.bucketName().isBlank()) {
+      throw new IllegalArgumentException(
+          ERROR_VALIDATION_FAILED.formatted("bucketName must not be null or empty"));
+    }
+
+    if (config.connection() == null) {
+      throw new IllegalArgumentException(
+          ERROR_VALIDATION_FAILED.formatted("connection configuration must not be null"));
+    }
+
+    if (config.connection().auth() == null) {
+      throw new IllegalArgumentException(
+          ERROR_VALIDATION_FAILED.formatted("authentication configuration must not be null"));
+    }
+
+    // Validate None authentication has projectId
+    if (config.connection().auth() instanceof None(final var projectId)) {
+      if (projectId == null || projectId.isBlank()) {
+        throw new IllegalArgumentException(
+            ERROR_VALIDATION_FAILED.formatted(
+                "projectId must be provided when using no authentication"));
       }
-    } catch (final Exception e) {
-      throw new ConfigurationException(ERROR_VALIDATION_FAILED.formatted(config), e);
+    }
+
+    // Max concurrent transfers validation
+    if (config.maxConcurrentTransfers() <= 0) {
+      throw new IllegalArgumentException(
+          ERROR_VALIDATION_FAILED.formatted(
+              "maxConcurrentTransfers must be positive, got " + config.maxConcurrentTransfers()));
     }
   }
 }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
@@ -21,7 +21,7 @@ public abstract class GcsBackupStoreException extends RuntimeException {
       super(message);
     }
 
-    public ConfigurationException(final String message, final Exception cause) {
+    public ConfigurationException(final String message, final Throwable cause) {
       super(message, cause);
     }
   }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.backup.gcs;
 
 import com.google.cloud.storage.BucketInfo;
 import io.camunda.zeebe.backup.gcs.util.GcsContainer;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,5 +57,45 @@ public class ConfigIT {
     // then
     Assertions.assertThatCode(() -> GcsBackupStore.validateConfig(config))
         .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldSuccessfullyVerifyConnectionWhenBucketExists() throws Exception {
+    // given
+    final var bucketName = RandomStringUtils.insecure().nextAlphanumeric(12).toLowerCase();
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withHost(GCS.externalEndpoint())
+            .withBucketName(bucketName)
+            .withoutAuthentication()
+            .build();
+
+    try (final var client = GcsBackupStore.buildClient(config)) {
+      client.create(BucketInfo.of(bucketName));
+    }
+
+    final var store = new GcsBackupStore(config);
+
+    // when - then
+    Assertions.assertThat(store.verifyConnection()).succeedsWithin(Duration.ofSeconds(10));
+  }
+
+  @Test
+  void shouldFailVerifyConnectionWhenHostNotReachable() {
+    // given
+    final var bucketName = RandomStringUtils.insecure().nextAlphanumeric(12).toLowerCase();
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withHost("http://localhost:1")
+            .withBucketName(bucketName)
+            .withoutAuthentication()
+            .build();
+
+    final var store = new GcsBackupStore(config);
+
+    // when - then
+    Assertions.assertThat(store.verifyConnection())
+        .failsWithin(Duration.ofSeconds(11))
+        .withThrowableOfType(ExecutionException.class);
   }
 }

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -357,8 +357,7 @@ public final class S3BackupStore implements BackupStore {
         .whenCompleteAsync(
             (ignore, err) -> {
               if (err != null) {
-                throw new ConfigurationException(
-                    "Failed to connect to S3 bucket '%s'".formatted(config), err);
+                throw new ConfigurationException("Failed to connect to S3", err);
               }
             })
         .thenApply(ignore -> null);

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupDeletionIncomplete;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupInInvalidStateException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupReadException;
+import io.camunda.zeebe.backup.s3.S3BackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.ManifestParseException;
 import io.camunda.zeebe.backup.s3.manifest.FileSet;
 import io.camunda.zeebe.backup.s3.manifest.Manifest;
@@ -57,6 +58,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -346,6 +348,20 @@ public final class S3BackupStore implements BackupStore {
   public CompletableFuture<Void> closeAsync() {
     client.close();
     return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> verifyConnection() {
+    return client
+        .headBucket(HeadBucketRequest.builder().bucket(config.bucketName()).build())
+        .whenCompleteAsync(
+            (ignore, err) -> {
+              if (err != null) {
+                throw new ConfigurationException(
+                    "Failed to connect to S3 bucket '%s'".formatted(config), err);
+              }
+            })
+        .thenApply(ignore -> null);
   }
 
   private String backupMetadataKey(final int partitionId) {

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStoreException.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStoreException.java
@@ -75,4 +75,11 @@ public abstract sealed class S3BackupStoreException extends RuntimeException {
       super(message, cause);
     }
   }
+
+  public static final class ConfigurationException extends S3BackupStoreException {
+
+    public ConfigurationException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
 }

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
@@ -72,4 +72,18 @@ final class ConnectionErrorTest {
         .failsWithin(Duration.ofSeconds(10))
         .withThrowableOfType(ExecutionException.class);
   }
+
+  @Test
+  void shouldFailVerifyConnectionWhenStoreIsNotReachable() {
+    // given
+    // s3 container is not running
+
+    // when
+    final var res = store.verifyConnection();
+
+    // then
+    assertThat(res)
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(ExecutionException.class);
+  }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -61,4 +61,6 @@ public interface BackupStore {
   CompletableFuture<Optional<byte[]>> loadBackupMetadata(int partitionId);
 
   CompletableFuture<Void> closeAsync();
+
+  CompletableFuture<Void> verifyConnection();
 }

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -245,6 +245,11 @@
       <artifactId>camunda-search-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/InvalidConfigurationException.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/InvalidConfigurationException.java
@@ -8,7 +8,11 @@
 package io.camunda.zeebe.broker.system;
 
 public class InvalidConfigurationException extends RuntimeException {
-  public InvalidConfigurationException(final String message, final Exception cause) {
+  public InvalidConfigurationException(final String message, final Throwable cause) {
     super(message, cause);
+  }
+
+  public InvalidConfigurationException(final String message) {
+    super(message);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -415,6 +415,13 @@ public final class SystemContext {
   }
 
   private void validateBackupCfg(final BackupCfg backup) {
+    if (backup.isRequired() && backup.getStore() == BackupCfg.BackupStoreType.NONE) {
+      throw new InvalidConfigurationException(
+          "Backup is required but no backup store is configured. "
+              + "Set zeebe.broker.data.backup.store to one of: S3, GCS, AZURE, FILESYSTEM",
+          null);
+    }
+
     try {
       switch (backup.getStore()) {
         case NONE -> LOG.warn("No backup store is configured. Backups will not be taken");

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.util.health.ComponentTreeListener;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public interface PartitionTransitionContext extends PartitionContext {
 
@@ -131,9 +132,9 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   void setCheckpointProcessor(CheckpointRecordsProcessor checkpointRecordsProcessor);
 
-  BackupStore getBackupStore();
+  @Nullable BackupStore getBackupStore();
 
-  void setBackupStore(BackupStore backupStore);
+  void setBackupStore(@Nullable BackupStore backupStore);
 
   /**
    * Returns a meter registry which already has some common tags for the partition (so you can omit

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.backup.azure.AzureBackupStore;
 import io.camunda.zeebe.backup.filesystem.FilesystemBackupStore;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.broker.system.InvalidConfigurationException;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
@@ -54,20 +55,44 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
     if (shouldInstallOnTransition(context.getCurrentRole(), targetRole)
         || (context.getBackupStore() == null && targetRole != Role.INACTIVE)) {
       final var backupCfg = context.getBrokerCfg().getData().getBackup();
-      switch (backupCfg.getStore()) {
-        case NONE -> {
-          // No backup store is installed. BackupManager can handle this case
-          context.setBackupStore(null);
-          installed.complete(null);
+      final BackupStore store;
+      try {
+        store =
+            switch (backupCfg.getStore()) {
+              case NONE -> null; // No backup store is installed. BackupManager can handle this case
+              case S3 -> createS3Store(backupCfg);
+              case GCS -> createGcsStore(backupCfg);
+              case AZURE -> createAzureStore(backupCfg);
+              case FILESYSTEM -> createFilesystemStore(backupCfg);
+            };
+      } catch (final Exception e) {
+        installed.completeExceptionally("Failed to create backup store.", e);
+        return installed;
+      }
+
+      if (backupCfg.isRequired()) {
+        if (store == null) {
+          installed.completeExceptionally(
+              new InvalidConfigurationException(
+                  "Backup store is required but no backup store type is configured."));
+          return installed;
         }
-        case S3 -> installS3Store(context, backupCfg, installed);
-        case GCS -> installGcsStore(context, backupCfg, installed);
-        case AZURE -> installAzureStore(context, backupCfg, installed);
-        case FILESYSTEM -> installFilesystemStore(context, backupCfg, installed);
-        default ->
-            installed.completeExceptionally(
-                new IllegalArgumentException(
-                    "Unknown backup store type %s".formatted(backupCfg.getStore())));
+
+        store
+            .verifyConnection()
+            .whenComplete(
+                (ignore, err) -> {
+                  if (err != null) {
+                    context.setBackupStore(null);
+                    installed.completeExceptionally(err);
+                  } else {
+                    context.setBackupStore(store);
+                    installed.complete(null);
+                  }
+                });
+      } else {
+        context.setBackupStore(store);
+        installed.complete(null);
       }
     } else {
       installed.complete(null);
@@ -80,64 +105,28 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
     return "BackupStore";
   }
 
-  private static void installS3Store(
-      final PartitionTransitionContext context,
-      final BackupCfg backupCfg,
-      final ActorFuture<Void> installed) {
-    try {
-      final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupCfg.getS3());
-      final var backupStore = S3BackupStore.of(storeConfig);
-      context.setBackupStore(backupStore);
-      installed.complete(null);
-    } catch (final Exception error) {
-      installed.completeExceptionally("Failed to create backup store", error);
-    }
+  private static BackupStore createS3Store(final BackupCfg backupCfg) {
+    final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupCfg.getS3());
+    return S3BackupStore.of(storeConfig);
   }
 
-  private static void installGcsStore(
-      final PartitionTransitionContext context,
-      final BackupCfg backupCfg,
-      final ActorFuture<Void> installed) {
-    try {
-      final var brokerGcsConfig = backupCfg.getGcs();
-      final var storeGcsConfig = GcsBackupStoreConfig.toStoreConfig(brokerGcsConfig);
-      final var gcsStore = GcsBackupStore.of(storeGcsConfig);
-      context.setBackupStore(gcsStore);
-      installed.complete(null);
-    } catch (final Exception error) {
-      installed.completeExceptionally("Failed to create backup store", error);
-    }
+  private static BackupStore createGcsStore(final BackupCfg backupCfg) {
+    final var brokerGcsConfig = backupCfg.getGcs();
+    final var storeGcsConfig = GcsBackupStoreConfig.toStoreConfig(brokerGcsConfig);
+    return GcsBackupStore.of(storeGcsConfig);
   }
 
-  private static void installAzureStore(
-      final PartitionTransitionContext context,
-      final BackupCfg backupCfg,
-      final ActorFuture<Void> installed) {
-    try {
-      final var brokerAzureConfig = backupCfg.getAzure();
-      final var storeAzureConfig = AzureBackupStoreConfig.toStoreConfig(brokerAzureConfig);
-      final var azureStore = AzureBackupStore.of(storeAzureConfig);
-      context.setBackupStore(azureStore);
-      installed.complete(null);
-    } catch (final Exception error) {
-      installed.completeExceptionally("Failed to create backup store", error);
-    }
+  private static BackupStore createAzureStore(final BackupCfg backupCfg) {
+    final var brokerAzureConfig = backupCfg.getAzure();
+    final var storeAzureConfig = AzureBackupStoreConfig.toStoreConfig(brokerAzureConfig);
+    return AzureBackupStore.of(storeAzureConfig);
   }
 
-  private static void installFilesystemStore(
-      final PartitionTransitionContext context,
-      final BackupCfg backupCfg,
-      final ActorFuture<Void> installed) {
-    try {
-      final var brokerFilesystemConfig = backupCfg.getFilesystem();
-      final var storeFilesystemConfig =
-          FilesystemBackupStoreConfig.toStoreConfig(brokerFilesystemConfig);
-      final var filesystemStore = FilesystemBackupStore.of(storeFilesystemConfig);
-      context.setBackupStore(filesystemStore);
-      installed.complete(null);
-    } catch (final Exception error) {
-      installed.completeExceptionally("Failed to create backup store", error);
-    }
+  private static BackupStore createFilesystemStore(final BackupCfg backupCfg) {
+    final var brokerFilesystemConfig = backupCfg.getFilesystem();
+    final var storeFilesystemConfig =
+        FilesystemBackupStoreConfig.toStoreConfig(brokerFilesystemConfig);
+    return FilesystemBackupStore.of(storeFilesystemConfig);
   }
 
   private boolean shouldInstallOnTransition(final Role currentRole, final Role targetRole) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -91,7 +91,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
                     installed.complete(null);
                   }
                 },
-                context.getConcurrencyControl()::run);
+                context.getConcurrencyControl());
       } else {
         context.setBackupStore(store);
         installed.complete(null);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -80,16 +80,18 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
 
         store
             .verifyConnection()
-            .whenComplete(
+            .whenCompleteAsync(
                 (ignore, err) -> {
                   if (err != null) {
                     context.setBackupStore(null);
+                    store.closeAsync();
                     installed.completeExceptionally(err);
                   } else {
                     context.setBackupStore(store);
                     installed.complete(null);
                   }
-                });
+                },
+                context.getConcurrencyControl()::run);
       } else {
         context.setBackupStore(store);
         installed.complete(null);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/InMemoryMockBackupStore.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/InMemoryMockBackupStore.java
@@ -96,6 +96,11 @@ public class InMemoryMockBackupStore implements BackupStore, AutoCloseable {
     return CompletableFuture.completedFuture(null);
   }
 
+  @Override
+  public CompletableFuture<Void> verifyConnection() {
+    return CompletableFuture.completedFuture(null);
+  }
+
   public void completeSaveFutures() {
     for (final var entry : saveFutures.entrySet()) {
       final var future = entry.getValue();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -802,6 +802,8 @@ final class SystemContextTest {
     final var backupCfg = brokerCfg.getData().getBackup();
     backupCfg.setContinuous(true);
     backupCfg.setRequired(true);
+    backupCfg.setStore(BackupStoreType.FILESYSTEM);
+    backupCfg.getFilesystem().setBasePath("/tmp");
     backupCfg.setSchedule("invalid-schedule");
 
     // when/then
@@ -818,6 +820,8 @@ final class SystemContextTest {
     final var backupCfg = brokerCfg.getData().getBackup();
     backupCfg.setContinuous(true);
     backupCfg.setRequired(true);
+    backupCfg.setStore(BackupStoreType.FILESYSTEM);
+    backupCfg.getFilesystem().setBasePath("/tmp");
     backupCfg.setSchedule("PT10M");
     backupCfg.getRetention().setCleanupSchedule("invalid-schedule");
 
@@ -837,6 +841,32 @@ final class SystemContextTest {
     backupCfg.setRequired(false);
 
     // when/then
+    assertThatNoException().isThrownBy(() -> initSystemContext(brokerCfg));
+  }
+
+  @Test
+  void shouldThrowWhenBackupIsRequiredButStoreIsNone() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    final var backupCfg = brokerCfg.getData().getBackup();
+    backupCfg.setRequired(true);
+    backupCfg.setStore(BackupStoreType.NONE);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining("Backup is required but no backup store is configured");
+  }
+
+  @Test
+  void shouldNotThrowWhenBackupIsNotRequiredAndStoreIsNone() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    final var backupCfg = brokerCfg.getData().getBackup();
+    backupCfg.setRequired(false);
+    backupCfg.setStore(BackupStoreType.NONE);
+
+    // when - then
     assertThatNoException().isThrownBy(() -> initSystemContext(brokerCfg));
   }
 
@@ -861,6 +891,8 @@ final class SystemContextTest {
     final var backupCfg = brokerCfg.getData().getBackup();
     backupCfg.setContinuous(false);
     backupCfg.setRequired(true);
+    backupCfg.setStore(BackupStoreType.FILESYSTEM);
+    backupCfg.getFilesystem().setBasePath("/tmp");
     backupCfg.setSchedule("PT10M");
     backupCfg.getRetention().setCleanupSchedule("invalid-schedule");
 
@@ -888,6 +920,8 @@ final class SystemContextTest {
     final var backupCfg = brokerCfg.getData().getBackup();
     backupCfg.setContinuous(true);
     backupCfg.setRequired(true);
+    backupCfg.setStore(BackupStoreType.FILESYSTEM);
+    backupCfg.getFilesystem().setBasePath("/tmp");
     backupCfg.setSchedule(null);
 
     // when/then
@@ -903,6 +937,8 @@ final class SystemContextTest {
     final var backupCfg = brokerCfg.getData().getBackup();
     backupCfg.setContinuous(true);
     backupCfg.setRequired(true);
+    backupCfg.setStore(BackupStoreType.FILESYSTEM);
+    backupCfg.getFilesystem().setBasePath("/tmp");
     backupCfg.setSchedule("PT10M");
     backupCfg.getRetention().setCleanupSchedule(null);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
@@ -14,10 +14,16 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.azure.AzureBackupStoreException;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldCloseService;
@@ -112,6 +118,108 @@ class BackupStoreTransitionStepTest {
         .withThrowableOfType(ExecutionException.class);
   }
 
+  @Test
+  void shouldFailConnectionCheckWhenRequiredAndS3NotReachable() {
+    // given
+    setUpCurrentRole(null);
+    configureStore(BackupStoreType.S3);
+    final var s3Config = new S3BackupStoreConfig();
+    s3Config.setBucketName("non-existent-bucket");
+    s3Config.setRegion("us-east-1");
+    s3Config.setEndpoint("http://localhost:1");
+    s3Config.setAccessKey("key");
+    s3Config.setSecretKey("secret");
+    configureRequiredStore(BackupStoreType.S3, s3Config);
+    final var targetRole = Role.LEADER;
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+    final var transitionFuture = step.transitionTo(transitionContext, 1, targetRole);
+
+    // then
+    assertThat(transitionFuture)
+        .describedAs(
+            "Expected to fail installation when backup is required and S3 is not reachable.")
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class);
+    assertThat(transitionContext.getBackupStore()).isNull();
+  }
+
+  @Test
+  void shouldFailConnectionCheckWhenRequiredAndFilesystemBasePathNotWritable() {
+    // given
+    setUpCurrentRole(null);
+    final var filesystemConfig =
+        new io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig();
+    filesystemConfig.setBasePath("/proc/non-existent-path-that-cannot-be-created");
+    configureRequiredStore(filesystemConfig);
+    final var targetRole = Role.LEADER;
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+    final var transitionFuture = step.transitionTo(transitionContext, 1, targetRole);
+
+    // then
+    assertThat(transitionFuture)
+        .describedAs(
+            "Expected to fail installation when backup is required and filesystem path is not writable.")
+        .failsWithin(Duration.ofMillis(500))
+        .withThrowableOfType(ExecutionException.class);
+    assertThat(transitionContext.getBackupStore()).isNull();
+  }
+
+  @Test
+  void shouldFailConnectionCheckWhenRequiredAndAzureNotReachable() {
+    // given
+    setUpCurrentRole(null);
+    final var azureConfig = new AzureBackupStoreConfig();
+    azureConfig.setEndpoint("http://localhost:1");
+    azureConfig.setAccountName("devstoreaccount1");
+    azureConfig.setAccountKey(
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==");
+    azureConfig.setBasePath("non-existent-container");
+    configureRequiredStore(BackupStoreType.AZURE, azureConfig);
+    final var targetRole = Role.LEADER;
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+    final var transitionFuture = step.transitionTo(transitionContext, 1, targetRole);
+
+    // then
+    assertThat(transitionFuture)
+        .describedAs(
+            "Expected to fail installation when backup is required and Azure is not reachable.")
+        .failsWithin(Duration.ofSeconds(11))
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(AzureBackupStoreException.ConfigurationException.class);
+    assertThat(transitionContext.getBackupStore()).isNull();
+  }
+
+  @Test
+  void shouldFailConnectionCheckWhenRequiredAndGcsNotReachable() {
+    // given
+    setUpCurrentRole(null);
+    final var gcsConfig = new GcsBackupStoreConfig();
+    gcsConfig.setBucketName("non-existent-bucket");
+    gcsConfig.setHost("http://localhost:1");
+    gcsConfig.setAuth(GcsBackupStoreAuth.NONE);
+    configureRequiredStore(BackupStoreType.GCS, gcsConfig);
+    final var targetRole = Role.LEADER;
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+    final var transitionFuture = step.transitionTo(transitionContext, 1, targetRole);
+
+    // then
+    assertThat(transitionFuture)
+        .describedAs(
+            "Expected to fail installation when backup is required and GCS is not reachable.")
+        .failsWithin(Duration.ofSeconds(11))
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(ConfigurationException.class);
+    assertThat(transitionContext.getBackupStore()).isNull();
+  }
+
   @ParameterizedTest
   @ArgumentsSource(TransitionsThatShouldInstallService.class)
   void shouldNotInstallServiceWhenStoreTypeIsNone(final Role currentRole, final Role targetRole) {
@@ -156,6 +264,45 @@ class BackupStoreTransitionStepTest {
     final var backupCfg = new BackupCfg();
     backupCfg.setStore(type);
     backupCfg.setS3(s3Config);
+    when(brokerCfg.getData()).thenReturn(dataCfg);
+    when(dataCfg.getBackup()).thenReturn(backupCfg);
+  }
+
+  private void configureRequiredStore(
+      final BackupStoreType type, final S3BackupStoreConfig s3Config) {
+    final var backupCfg = new BackupCfg();
+    backupCfg.setStore(type);
+    backupCfg.setRequired(true);
+    backupCfg.setS3(s3Config);
+    when(brokerCfg.getData()).thenReturn(dataCfg);
+    when(dataCfg.getBackup()).thenReturn(backupCfg);
+  }
+
+  private void configureRequiredStore(
+      final BackupStoreType type, final AzureBackupStoreConfig azureConfig) {
+    final var backupCfg = new BackupCfg();
+    backupCfg.setStore(type);
+    backupCfg.setRequired(true);
+    backupCfg.setAzure(azureConfig);
+    when(brokerCfg.getData()).thenReturn(dataCfg);
+    when(dataCfg.getBackup()).thenReturn(backupCfg);
+  }
+
+  private void configureRequiredStore(
+      final BackupStoreType type, final GcsBackupStoreConfig gcsConfig) {
+    final var backupCfg = new BackupCfg();
+    backupCfg.setStore(type);
+    backupCfg.setRequired(true);
+    backupCfg.setGcs(gcsConfig);
+    when(brokerCfg.getData()).thenReturn(dataCfg);
+    when(dataCfg.getBackup()).thenReturn(backupCfg);
+  }
+
+  private void configureRequiredStore(final FilesystemBackupStoreConfig filesystemConfig) {
+    final var backupCfg = new BackupCfg();
+    backupCfg.setStore(BackupStoreType.FILESYSTEM);
+    backupCfg.setRequired(true);
+    backupCfg.setFilesystem(filesystemConfig);
     when(brokerCfg.getData()).thenReturn(dataCfg);
     when(dataCfg.getBackup()).thenReturn(backupCfg);
   }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
@@ -146,6 +146,11 @@ final class TestRestorableBackupStore implements BackupStore {
     return CompletableFuture.completedFuture(null);
   }
 
+  @Override
+  public CompletableFuture<Void> verifyConnection() {
+    return CompletableFuture.completedFuture(null);
+  }
+
   private NamedFileSet copyNamedFileSet(
       final Path targetFolder, final Map<String, Path> snapshotFiles) {
     return new NamedFileSetImpl(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When the backup config contains the `required` flag we make sure that partitions fail to start if the backup configuration is invalid. To do this we perform one request to the backup store that will guarantee the connection and the validity of the config. 

The `BackupStoreTransitionStep` has also been refactored to pull the store verification up in the method chain in the BackupStore interface.

Sidenote:
- GCS and Azure _list_ bucket iterators are busy that's why we wrap them in a _orTimeout_ of a default 10sec
- GCS configuration validation used to actually perform that _list_ call, now it only verifies the presence of the configuration values

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #40691
