### PR TITLE
fix: remove leftover service worker

### DIFF
--- a/identity/client/src/App.tsx
+++ b/identity/client/src/App.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, StrictMode } from "react";
+import { FC, StrictMode, useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { getBaseUrl } from "./configuration";
 import AppRoot from "./components/global/AppRoot";
@@ -16,28 +16,35 @@ import Forbidden from "src/pages/forbidden/index.tsx";
 import { NotificationProvider } from "src/components/notifications";
 import { Paths } from "src/components/global/routePaths";
 import { SetupPage } from "src/pages/setup/SetupPage";
+import { cleanServiceWorkers } from "src/utility/cleanServiceWorkers.ts";
 
-const App: FC = () => (
-  <BrowserRouter basename={getBaseUrl()}>
-    <StrictMode>
-      <NotificationProvider>
-        <Routes>
-          <Route key="setup" path={Paths.setup()} Component={SetupPage} />
-          <Route key="login" path={Paths.login()} Component={LoginPage} />
-          <Route path={Paths.forbidden()} element={<Forbidden />} />
-          <Route
-            key="identity-ui"
-            path="*"
-            element={
-              <AppRoot>
-                <GlobalRoutes />
-              </AppRoot>
-            }
-          />
-        </Routes>
-      </NotificationProvider>
-    </StrictMode>
-  </BrowserRouter>
-);
+const App: FC = () => {
+  useEffect(() => {
+    void cleanServiceWorkers();
+  });
+
+  return (
+    <BrowserRouter basename={getBaseUrl()}>
+      <StrictMode>
+        <NotificationProvider>
+          <Routes>
+            <Route key="setup" path={Paths.setup()} Component={SetupPage} />
+            <Route key="login" path={Paths.login()} Component={LoginPage} />
+            <Route path={Paths.forbidden()} element={<Forbidden />} />
+            <Route
+              key="identity-ui"
+              path="*"
+              element={
+                <AppRoot>
+                  <GlobalRoutes />
+                </AppRoot>
+              }
+            />
+          </Routes>
+        </NotificationProvider>
+      </StrictMode>
+    </BrowserRouter>
+  );
+};
 
 export default App;

--- a/identity/client/src/utility/cleanServiceWorkers.ts
+++ b/identity/client/src/utility/cleanServiceWorkers.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export const cleanServiceWorkers = async () => {
+  try {
+    if ("serviceWorker" in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+
+      for (let registration of registrations) {
+        console.log(
+          "Found service worker with scriptUrl:",
+          registration.active?.scriptURL,
+          "Assuming this is leftover from a previous Management Identity deployment and removing it...",
+        );
+        await registration.unregister();
+      }
+    }
+  } catch (e) {
+    console.error("Error occurred during cleanup of service workers", e);
+  }
+};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Unregister leftover service worker from management identity

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44867 
