### PR TITLE
feat: Address sonatype timeout issue, increase timeout to 60 minutes

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -208,6 +208,13 @@ jobs:
         env:
           SKIP_CENTRAL_RELEASE: ${{ inputs.dryRun }}
           SKIP_CAMUNDA_RELEASE: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
+          # Sonatype central-publishing-maven-plugin defaults to a 30-minute wait window.
+          # Use a longer wait to avoid polling timeouts on slower deployments.
+          # waitMaxTime (Default: 1800)
+          # User property: waitMaxTime
+          # Assign the amount of seconds that the plugin will wait for a deployment
+          # state. Can not be less than Constants.WAIT_MAX_TIME_DEFAULT_VALUE.
+          CENTRAL_WAIT_MAX_TIME: "3600"
         run: |
           # Perform a maven release
           # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
@@ -216,6 +223,8 @@ jobs:
           # -DskipQaBuild=true -P-autoFormat
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
+
+          
 
           # Conditionally set profile flags based on includeOptimize input
           if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
@@ -234,7 +243,7 @@ jobs:
             -DskipQaBuild=true \
             -P-autoFormat \
             ${PROFILE_FLAGS} \
-            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory


### PR DESCRIPTION
## Description

We faced an issue, when during the release of [8.8.17 ](https://github.com/camunda/camunda/actions/runs/23186749892/job/67372085358)we[ reached the default timeout of of the sonatype plugin](https://github.com/camunda/camunda/actions/runs/23186749892/job/67372085358#step:11:32929) (30min), which resulted in a failed release.

```
2026-03-17T09:46:19.8183888Z     [INFO] Uploaded bundle successfully, deployment name: io.camunda:camunda-8-root:8.8.17, deploymentId: 55972a8f-2512-4eec-92bf-f3742fceec6f. Deployment will require manual publishing
2026-03-17T09:46:19.8186473Z     [INFO] Waiting until Deployment 55972a8f-2512-4eec-92bf-f3742fceec6f is validated
2026-03-17T10:16:22.1392125Z ##[error]    [ERROR] Failed to execute goal org.sonatype.central:central-publishing-maven-plugin:0.8.0:publish (central-deploy) on project camunda-8-root: Execution central-deploy of goal org.sonatype.central:central-publishing-maven-plugin:0.8.0:publish failed: Polling for 55972a8f-2512-4eec-92bf-f3742fceec6f timed out before the deployment completed. -> [Help 1]

```

In order to avoid this in the future, the `waitMaxTime` is increased to 3600 (60 minutes)

```
  waitMaxTime (Default: 1800)
      User property: waitMaxTime
      Assign the amount of seconds that the plugin will wait for a deployment
      state. Can not be less than Constants.WAIT_MAX_TIME_DEFAULT_VALUE.
```
