### PR TITLE
fix: wrap unknown exceptions in the search layer

### DIFF
--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -575,13 +575,27 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final SearchEntityReader<T, Q> reader,
       final Q query,
       final Function<ResourceAccessChecks, ResourceAccessChecks> overwriteResourceAccessChecks) {
-    return withResultTypeCheck(reader, query, overwriteResourceAccessChecks);
+    try {
+      return withResultTypeCheck(reader, query, overwriteResourceAccessChecks);
+    } catch (final CamundaSearchException e) {
+      throw e; // rethrow known exceptions
+    } catch (final Exception e) {
+      LOG.warn("Unexpected error while trying to get search result", e);
+      throw new CamundaSearchException(e, Reason.SEARCH_SERVER_FAILED);
+    }
   }
 
   protected <T, A extends TypedSearchAggregationQuery<?, ?, ?>>
       SearchQueryResult<T> doSearchWithReader(
           final SearchQueryStatisticsReader<T, A> reader, final A query) {
-    return withResultTypeCheck(reader, query);
+    try {
+      return withResultTypeCheck(reader, query);
+    } catch (final CamundaSearchException e) {
+      throw e; // rethrow known exceptions
+    } catch (final Exception e) {
+      LOG.warn("Unexpected error while trying to get search result", e);
+      throw new CamundaSearchException(e, Reason.SEARCH_SERVER_FAILED);
+    }
   }
 
   protected <T, A extends TypedSearchAggregationQuery<?, ?, ?>>
@@ -636,6 +650,11 @@ public class CamundaSearchClients implements SearchClientsProxy {
     } catch (final TenantAccessDeniedException e) {
       LOG.trace("Forbidden to access tenant, returning null", e);
       return Optional.empty();
+    } catch (final CamundaSearchException e) {
+      throw e; // rethrow known exceptions
+    } catch (final Exception e) {
+      LOG.warn("Unexpected error while trying to get search result", e);
+      throw new CamundaSearchException(e, Reason.SEARCH_SERVER_FAILED);
     }
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -579,8 +579,11 @@ public class CamundaSearchClients implements SearchClientsProxy {
       return withResultTypeCheck(reader, query, overwriteResourceAccessChecks);
     } catch (final CamundaSearchException e) {
       throw e; // rethrow known exceptions
-    } catch (final Exception e) {
-      LOG.warn("Unexpected error while trying to get search result", e);
+    } catch (final RuntimeException e) {
+      LOG.warn(
+          "Unexpected runtime error while trying to get search result for search query type {}",
+          query != null ? query.getClass().getSimpleName() : "null",
+          e);
       throw new CamundaSearchException(e, Reason.SEARCH_SERVER_FAILED);
     }
   }
@@ -592,8 +595,11 @@ public class CamundaSearchClients implements SearchClientsProxy {
       return withResultTypeCheck(reader, query);
     } catch (final CamundaSearchException e) {
       throw e; // rethrow known exceptions
-    } catch (final Exception e) {
-      LOG.warn("Unexpected error while trying to get search result", e);
+    } catch (final RuntimeException e) {
+      LOG.warn(
+          "Unexpected runtime error while trying to get search result for aggregation query type {}",
+          query != null ? query.getClass().getSimpleName() : "null",
+          e);
       throw new CamundaSearchException(e, Reason.SEARCH_SERVER_FAILED);
     }
   }
@@ -652,8 +658,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
       return Optional.empty();
     } catch (final CamundaSearchException e) {
       throw e; // rethrow known exceptions
-    } catch (final Exception e) {
-      LOG.warn("Unexpected error while trying to get search result", e);
+    } catch (final RuntimeException e) {
+      LOG.warn("Unexpected runtime error while performing doGet operation", e);
       throw new CamundaSearchException(e, Reason.SEARCH_SERVER_FAILED);
     }
   }

--- a/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
+import io.camunda.search.clients.reader.ProcessInstanceReader;
+import io.camunda.search.clients.reader.SearchClientReaders;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
+import io.camunda.search.exception.TenantAccessDeniedException;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.ResourceAccessController;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CamundaSearchClientsTest {
+
+  private final SearchClientReaders readers = mock(SearchClientReaders.class);
+  private final ResourceAccessController resourceAccessController =
+      mock(ResourceAccessController.class);
+  private final ProcessInstanceReader processInstanceReader = mock(ProcessInstanceReader.class);
+  private final ProcessDefinitionInstanceStatisticsReader
+      processDefinitionInstanceStatisticsReader =
+          mock(ProcessDefinitionInstanceStatisticsReader.class);
+
+  private CamundaSearchClients camundaSearchClients;
+
+  @BeforeEach
+  void setUp() {
+    camundaSearchClients =
+        new CamundaSearchClients(readers, resourceAccessController, SecurityContext.of(b -> b));
+
+    // Make the resource access controller simply invoke the applier with a no-op check
+    when(resourceAccessController.doSearch(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              final Function<ResourceAccessChecks, Object> applier = invocation.getArgument(1);
+              return applier.apply(ResourceAccessChecks.disabled());
+            });
+  }
+
+  @Nested
+  class DoSearchWithEntityReaderExceptional {
+
+    @Test
+    void shouldRethrowCamundaSearchException() {
+      // given
+      final var originalException = new CamundaSearchException("already wrapped", Reason.NOT_FOUND);
+      when(readers.processInstanceReader()).thenReturn(processInstanceReader);
+      when(processInstanceReader.search(any(), any())).thenThrow(originalException);
+
+      // when / then
+      assertThatThrownBy(
+              () -> camundaSearchClients.searchProcessInstances(ProcessInstanceQuery.of(b -> b)))
+          .isSameAs(originalException);
+    }
+
+    @Test
+    void shouldWrapUnexpectedExceptionIntoCamundaSearchException() {
+      // given
+      final var cause = new RuntimeException("something went wrong in the search layer");
+      when(readers.processInstanceReader()).thenReturn(processInstanceReader);
+      when(processInstanceReader.search(any(), any())).thenThrow(cause);
+
+      // when / then
+      assertThatThrownBy(
+              () -> camundaSearchClients.searchProcessInstances(ProcessInstanceQuery.of(b -> b)))
+          .isInstanceOf(CamundaSearchException.class)
+          .hasCause(cause)
+          .extracting(t -> ((CamundaSearchException) t).getReason())
+          .isEqualTo(Reason.SEARCH_SERVER_FAILED);
+    }
+  }
+
+  @Nested
+  class DoSearchWithStatisticsReaderExceptional {
+
+    @Test
+    void shouldRethrowCamundaSearchException() {
+      // given
+      final var originalException = new CamundaSearchException("already wrapped", Reason.NOT_FOUND);
+      when(readers.processDefinitionInstanceStatisticsReader())
+          .thenReturn(processDefinitionInstanceStatisticsReader);
+      when(processDefinitionInstanceStatisticsReader.aggregate(any(), any()))
+          .thenThrow(originalException);
+
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  camundaSearchClients.processDefinitionInstanceStatistics(
+                      ProcessDefinitionInstanceStatisticsQuery.of(b -> b)))
+          .isSameAs(originalException);
+    }
+
+    @Test
+    void shouldWrapUnexpectedExceptionIntoCamundaSearchException() {
+      // given
+      final var cause = new RuntimeException("something went wrong in the statistics layer");
+      when(readers.processDefinitionInstanceStatisticsReader())
+          .thenReturn(processDefinitionInstanceStatisticsReader);
+      when(processDefinitionInstanceStatisticsReader.aggregate(any(), any())).thenThrow(cause);
+
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  camundaSearchClients.processDefinitionInstanceStatistics(
+                      ProcessDefinitionInstanceStatisticsQuery.of(b -> b)))
+          .isInstanceOf(CamundaSearchException.class)
+          .hasCause(cause)
+          .extracting(t -> ((CamundaSearchException) t).getReason())
+          .isEqualTo(Reason.SEARCH_SERVER_FAILED);
+    }
+  }
+
+  @Nested
+  class DoGetExceptional {
+
+    @Test
+    void shouldReturnEmptyWhenTenantAccessIsDenied() {
+      // given
+      when(readers.processInstanceReader()).thenReturn(processInstanceReader);
+      when(resourceAccessController.doGet(any(), any()))
+          .thenThrow(new TenantAccessDeniedException("tenant access denied"));
+
+      // when / then — getProcessInstance wraps the Optional and re-throws NOT_FOUND when empty
+      assertThatThrownBy(() -> camundaSearchClients.getProcessInstance(1L))
+          .isInstanceOf(CamundaSearchException.class)
+          .extracting(t -> ((CamundaSearchException) t).getReason())
+          .isEqualTo(Reason.NOT_FOUND);
+    }
+
+    @Test
+    void shouldRethrowCamundaSearchException() {
+      // given
+      final var originalException = new CamundaSearchException("already wrapped", Reason.NOT_FOUND);
+      when(readers.processInstanceReader()).thenReturn(processInstanceReader);
+      when(resourceAccessController.doGet(any(), any()))
+          .thenAnswer(
+              invocation -> {
+                final Function<ResourceAccessChecks, Object> applier = invocation.getArgument(1);
+                return applier.apply(ResourceAccessChecks.disabled());
+              });
+      when(processInstanceReader.getByKey(any(long.class), any())).thenThrow(originalException);
+
+      // when / then
+      assertThatThrownBy(() -> camundaSearchClients.getProcessInstance(1L))
+          .isSameAs(originalException);
+    }
+
+    @Test
+    void shouldWrapUnexpectedExceptionIntoCamundaSearchException() {
+      // given
+      final var cause = new RuntimeException("something went wrong in the search layer");
+      when(readers.processInstanceReader()).thenReturn(processInstanceReader);
+      when(resourceAccessController.doGet(any(), any()))
+          .thenAnswer(
+              invocation -> {
+                final Function<ResourceAccessChecks, Object> applier = invocation.getArgument(1);
+                return applier.apply(ResourceAccessChecks.disabled());
+              });
+      when(processInstanceReader.getByKey(any(long.class), any())).thenThrow(cause);
+
+      // when / then
+      assertThatThrownBy(() -> camundaSearchClients.getProcessInstance(1L))
+          .isInstanceOf(CamundaSearchException.class)
+          .hasCause(cause)
+          .extracting(t -> ((CamundaSearchException) t).getReason())
+          .isEqualTo(Reason.SEARCH_SERVER_FAILED);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR wraps any unknown and unchecked exception in a `CamundaSearchException` of type `SEARCH_SERVER_FAILED`
- any already thrown `CamundaSearchException` is rethrown as it is
- logs a `WARN` message with the error

## Related issues

closes #46793 
