### PR TITLE
RocksDB: make PARTITION strategy use partition count per broker.

### DIFF
--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/SnapshotUtil.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/SnapshotUtil.java
@@ -39,7 +39,7 @@ public class SnapshotUtil {
             new ConsistencyChecksSettings(true, true),
             new AccessMetricsConfiguration(Kind.NONE, 1),
             SimpleMeterRegistry::new,
-            SharedRocksDbResources.allocate(DEFAULT_MEMORY_LIMIT),
+            new SharedRocksDbResources(DEFAULT_MEMORY_LIMIT),
             3);
   }
 

--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/StateCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/StateCommand.java
@@ -34,7 +34,7 @@ public class StateCommand {
             new ConsistencyChecksSettings(true, true),
             new AccessMetricsConfiguration(Kind.NONE, 1),
             SimpleMeterRegistry::new,
-            SharedRocksDbResources.allocate(DEFAULT_MEMORY_LIMIT),
+            new SharedRocksDbResources(DEFAULT_MEMORY_LIMIT),
             3);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -119,7 +119,7 @@ public final class PartitionManagerImpl
 
     final List<PartitionListener> listeners = new ArrayList<>(partitionListeners);
     listeners.add(topologyManager);
-    sharedRocksDbResources = SharedRocksDbResources.uninitialized();
+    sharedRocksDbResources = new SharedRocksDbResources();
 
     zeebePartitionFactory =
         new ZeebePartitionFactory(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
-import static io.camunda.zeebe.broker.partitioning.RocksDbSharedCache.allocateSharedCache;
-
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
@@ -121,7 +119,7 @@ public final class PartitionManagerImpl
 
     final List<PartitionListener> listeners = new ArrayList<>(partitionListeners);
     listeners.add(topologyManager);
-    sharedRocksDbResources = allocateSharedCache(brokerCfg, meterRegistry);
+    sharedRocksDbResources = SharedRocksDbResources.uninitialized();
 
     zeebePartitionFactory =
         new ZeebePartitionFactory(
@@ -143,7 +141,8 @@ public final class PartitionManagerImpl
             searchClientsProxy,
             brokerRequestAuthorizationConverter,
             sharedRocksDbResources,
-            clusterConfigurationService);
+            clusterConfigurationService,
+            meterRegistry);
     managementService =
         new DefaultPartitionManagementService(
             clusterServices.getMembershipService(), clusterServices.getCommunicationService());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -152,10 +152,7 @@ public final class PartitionManagerImpl
   public void start() {
     actorSchedulingService.submitActor(topologyManager);
     final var localMemberId = managementService.getMembershipService().getLocalMember().id();
-    final var memberPartitions =
-        clusterConfigurationService.getPartitionDistribution().partitions().stream()
-            .filter(p -> p.members().contains(localMemberId))
-            .toList();
+    final var memberPartitions = clusterConfigurationService.getMemberPartitions(localMemberId);
 
     healthCheckService.registerBootstrapPartitions(memberPartitions);
     for (final var partitionMetadata : memberPartitions) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -31,20 +31,21 @@ public class RocksDbSharedCache {
         ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
 
     RocksDbSharedCacheMetrics.registerAllocationStrategy(meterRegistry, memoryAllocationStrategy);
-    final SharedRocksDbResources rocksDbResources = new SharedRocksDbResources(rocksDbMemoryLimit);
+    try (final SharedRocksDbResources rocksDbResources =
+        new SharedRocksDbResources(rocksDbMemoryLimit)) {
+      LOGGER.info(
+          "Allocating {} bytes ({} MB) for RocksDB memory Limit (with {} MB cache size), with memory allocation strategy: {}. "
+              + "Total system memory: {} bytes ({} MB). Partitions per broker: {}",
+          rocksDbResources.getMemoryLimit(),
+          rocksDbResources.getMemoryLimit() / (1024 * 1024),
+          rocksDbResources.getBlockCacheSize() / (1024 * 1024),
+          memoryAllocationStrategy,
+          totalMemorySize,
+          totalMemorySize / (1024 * 1024),
+          partitionsPerBroker);
 
-    LOGGER.info(
-        "Allocating {} bytes ({} MB) for RocksDB memory Limit (with {} MB cache size), with memory allocation strategy: {}. "
-            + "Total system memory: {} bytes ({} MB). Partitions per broker: {}",
-        rocksDbResources.getMemoryLimit(),
-        rocksDbResources.getMemoryLimit() / (1024 * 1024),
-        rocksDbResources.getBlockCacheSize() / (1024 * 1024),
-        memoryAllocationStrategy,
-        totalMemorySize,
-        totalMemorySize / (1024 * 1024),
-        partitionsPerBroker);
-
-    return rocksDbResources.getBlockCacheSize();
+      return rocksDbResources.getBlockCacheSize();
+    }
   }
 
   public static long getMemoryLimitBytes(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -22,13 +22,8 @@ public class RocksDbSharedCache {
   public static final double ADVICE_MAX_MEMORY_FRACTION = 0.5;
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
 
-  static SharedRocksDbResources allocateSharedCache(
-      final BrokerCfg brokerCfg, final MeterRegistry meterRegistry) {
-    final int partitionsCount = brokerCfg.getCluster().getPartitionsCount();
-    final int brokerCount = brokerCfg.getCluster().getClusterSize();
-    final int replicationFactor = brokerCfg.getCluster().getReplicationFactor();
-    final int partitionsPerBroker = partitionsCount * replicationFactor / brokerCount;
-
+  public static SharedRocksDbResources allocateSharedCache(
+      final BrokerCfg brokerCfg, final MeterRegistry meterRegistry, final int partitionsPerBroker) {
     final var rocksdbCfg = brokerCfg.getExperimental().getRocksdb();
     final long rocksDbMemoryLimit = getMemoryLimitBytes(rocksdbCfg, partitionsPerBroker);
     final var memoryAllocationStrategy = rocksdbCfg.getMemoryAllocationStrategy();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -31,24 +31,20 @@ public class RocksDbSharedCache {
         ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
 
     RocksDbSharedCacheMetrics.registerAllocationStrategy(meterRegistry, memoryAllocationStrategy);
-
-    final SharedRocksDbResources rocksDbResources =
-        SharedRocksDbResources.allocate(rocksDbMemoryLimit);
+    final SharedRocksDbResources rocksDbResources = new SharedRocksDbResources(rocksDbMemoryLimit);
 
     LOGGER.info(
         "Allocating {} bytes ({} MB) for RocksDB memory Limit (with {} MB cache size), with memory allocation strategy: {}. "
             + "Total system memory: {} bytes ({} MB). Partitions per broker: {}",
-        rocksDbResources.memoryLimit(),
-        rocksDbResources.memoryLimit() / (1024 * 1024),
-        rocksDbResources.blockCacheSize() / (1024 * 1024),
+        rocksDbResources.getMemoryLimit(),
+        rocksDbResources.getMemoryLimit() / (1024 * 1024),
+        rocksDbResources.getBlockCacheSize() / (1024 * 1024),
         memoryAllocationStrategy,
         totalMemorySize,
         totalMemorySize / (1024 * 1024),
         partitionsPerBroker);
 
-    RocksDbSharedCacheMetrics.registerAllocationStrategy(meterRegistry, memoryAllocationStrategy);
-
-    return rocksDbResources;
+    return rocksDbResources.getBlockCacheSize();
   }
 
   public static long getMemoryLimitBytes(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -25,9 +25,12 @@ public class RocksDbSharedCache {
   static SharedRocksDbResources allocateSharedCache(
       final BrokerCfg brokerCfg, final MeterRegistry meterRegistry) {
     final int partitionsCount = brokerCfg.getCluster().getPartitionsCount();
+    final int brokerCount = brokerCfg.getCluster().getClusterSize();
+    final int replicationFactor = brokerCfg.getCluster().getReplicationFactor();
+    final int partitionsPerBroker = partitionsCount * replicationFactor / brokerCount;
 
     final var rocksdbCfg = brokerCfg.getExperimental().getRocksdb();
-    final long rocksDbMemoryLimit = getMemoryLimitBytes(rocksdbCfg, partitionsCount);
+    final long rocksDbMemoryLimit = getMemoryLimitBytes(rocksdbCfg, partitionsPerBroker);
     final var memoryAllocationStrategy = rocksdbCfg.getMemoryAllocationStrategy();
     final long totalMemorySize =
         ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
@@ -39,25 +42,26 @@ public class RocksDbSharedCache {
 
     LOGGER.info(
         "Allocating {} bytes ({} MB) for RocksDB memory Limit (with {} MB cache size), with memory allocation strategy: {}. "
-            + "Total system memory: {} bytes ({} MB). Partitions count: {}",
+            + "Total system memory: {} bytes ({} MB). Partitions per broker: {}",
         rocksDbResources.memoryLimit(),
         rocksDbResources.memoryLimit() / (1024 * 1024),
         rocksDbResources.blockCacheSize() / (1024 * 1024),
         memoryAllocationStrategy,
         totalMemorySize,
         totalMemorySize / (1024 * 1024),
-        partitionsCount);
+        partitionsPerBroker);
 
     return rocksDbResources;
   }
 
-  public static long getMemoryLimitBytes(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
+  public static long getMemoryLimitBytes(
+      final RocksdbCfg rocksdbCfg, final int partitionsPerBrokerCount) {
 
     return switch (rocksdbCfg.getMemoryAllocationStrategy()) {
       case BROKER -> rocksdbCfg.getMemoryLimit().toBytes();
       case FRACTION -> getFixedMemoryPercentage(rocksdbCfg.getMemoryFraction());
       // in case of PARTITION or null, we allocate per partition
-      default -> rocksdbCfg.getMemoryLimit().toBytes() * partitionsCount;
+      default -> rocksdbCfg.getMemoryLimit().toBytes() * partitionsPerBrokerCount;
     };
   }
 
@@ -68,8 +72,9 @@ public class RocksDbSharedCache {
     return Math.round(totalMemorySize * memoryFraction);
   }
 
-  public static void validateRocksDbMemory(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
-    final long blockCacheBytes = getMemoryLimitBytes(rocksdbCfg, partitionsCount);
+  public static void validateRocksDbMemory(
+      final RocksdbCfg rocksdbCfg, final int partitionsPerBrokerCount) {
+    final long blockCacheBytes = getMemoryLimitBytes(rocksdbCfg, partitionsPerBrokerCount);
 
     final long totalMemorySize =
         ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
@@ -83,15 +88,15 @@ public class RocksDbSharedCache {
       validateMaxMemoryFraction(rocksdbCfg, totalMemorySize, blockCacheBytes);
       // validate that the allocated memory does not exceed total system memory.
       validateMemoryDoesNotExceedSystemMemory(
-          rocksdbCfg, totalMemorySize, blockCacheBytes, partitionsCount);
+          rocksdbCfg, totalMemorySize, blockCacheBytes, partitionsPerBrokerCount);
     }
 
     // validate that each partition has at least the minimum required memory
-    if (blockCacheBytes / partitionsCount < MINIMUM_PARTITION_MEMORY_LIMIT) {
+    if (blockCacheBytes / partitionsPerBrokerCount < MINIMUM_PARTITION_MEMORY_LIMIT) {
       throw new IllegalArgumentException(
           String.format(
               "Expected the allocated memory for RocksDB per partition to be at least %s bytes, but was %s bytes.",
-              MINIMUM_PARTITION_MEMORY_LIMIT, blockCacheBytes / partitionsCount));
+              MINIMUM_PARTITION_MEMORY_LIMIT, blockCacheBytes / partitionsPerBrokerCount));
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -22,7 +22,7 @@ public class RocksDbSharedCache {
   public static final double ADVICE_MAX_MEMORY_FRACTION = 0.5;
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
 
-  public static SharedRocksDbResources allocateSharedCache(
+  public static long getSharedCacheSize(
       final BrokerCfg brokerCfg, final MeterRegistry meterRegistry, final int partitionsPerBroker) {
     final var rocksdbCfg = brokerCfg.getExperimental().getRocksdb();
     final long rocksDbMemoryLimit = getMemoryLimitBytes(rocksdbCfg, partitionsPerBroker);
@@ -45,6 +45,8 @@ public class RocksDbSharedCache {
         totalMemorySize,
         totalMemorySize / (1024 * 1024),
         partitionsPerBroker);
+
+    RocksDbSharedCacheMetrics.registerAllocationStrategy(meterRegistry, memoryAllocationStrategy);
 
     return rocksDbResources;
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.partitioning.startup;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -16,6 +17,7 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.logstreams.state.DbPositionSupplier;
+import io.camunda.zeebe.broker.partitioning.RocksDbSharedCache;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -102,8 +104,9 @@ public final class ZeebePartitionFactory {
   private final SecurityConfiguration securityConfig;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
-  private final SharedRocksDbResources sharedRocksDbResources;
+  private SharedRocksDbResources sharedRocksDbResources;
   private final ClusterConfigurationService clusterConfigurationService;
+  private final MeterRegistry brokerMeterRegistry;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -124,7 +127,8 @@ public final class ZeebePartitionFactory {
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final SharedRocksDbResources sharedRocksDbResources,
-      final ClusterConfigurationService clusterConfigurationService) {
+      final ClusterConfigurationService clusterConfigurationService,
+      final MeterRegistry brokerMeterRegistry) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -144,6 +148,7 @@ public final class ZeebePartitionFactory {
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
     this.sharedRocksDbResources = sharedRocksDbResources;
     this.clusterConfigurationService = clusterConfigurationService;
+    this.brokerMeterRegistry = brokerMeterRegistry;
   }
 
   public ZeebePartition constructPartition(
@@ -152,6 +157,8 @@ public final class ZeebePartitionFactory {
       final DynamicPartitionConfig initialPartitionConfig,
       final BrokerHealthCheckService brokerHealthCheckService,
       final MeterRegistry partitionMeterRegistry) {
+    initializeSharedRocksDbResources();
+
     final var communicationService = clusterServices.getCommunicationService();
     final var membershipService = clusterServices.getMembershipService();
     final var typedRecordProcessorsFactory = createFactory(localBroker, featureFlags);
@@ -204,6 +211,55 @@ public final class ZeebePartitionFactory {
         new PartitionTransitionImpl(generateTransitionSteps());
 
     return new ZeebePartition(context, newTransitionBehavior, STARTUP_STEPS);
+  }
+
+  /**
+   * Lazily initializes the shared RocksDB resources on the first partition construction. This
+   * ensures the cluster configuration service is initialized and partition distribution is
+   * available.
+   */
+  private synchronized void initializeSharedRocksDbResources() {
+    if (sharedRocksDbResources.isInitialized()) {
+      return;
+    }
+
+    final var localMemberId = clusterServices.getMembershipService().getLocalMember().id();
+    final int partitionsPerBroker =
+        getPartitionsPerBroker(clusterConfigurationService, localMemberId, brokerCfg);
+    sharedRocksDbResources =
+        RocksDbSharedCache.allocateSharedCache(brokerCfg, brokerMeterRegistry, partitionsPerBroker);
+  }
+
+  /**
+   * Determines the number of partitions this broker is responsible for. First attempts to get the
+   * actual partition count from the cluster configuration. If no partitions are assigned yet (e.g.,
+   * during initial cluster bootstrap), falls back to a static calculation based on cluster
+   * configuration.
+   */
+  private static int getPartitionsPerBroker(
+      final ClusterConfigurationService clusterConfigurationService,
+      final MemberId localMemberId,
+      final BrokerCfg brokerCfg) {
+    final var partitionDistribution = clusterConfigurationService.getPartitionDistribution();
+
+    if (partitionDistribution != null) {
+      final long partitionCount =
+          partitionDistribution.partitions().stream()
+              .filter(p -> p.members().contains(localMemberId))
+              .count();
+      if (partitionCount > 0) {
+        return (int) partitionCount;
+      }
+    }
+
+    // Fallback to static calculation if partition distribution not yet available
+    final int partitionsCount = brokerCfg.getCluster().getPartitionsCount();
+    final int brokerCount = brokerCfg.getCluster().getClusterSize();
+    final int replicationFactor = brokerCfg.getCluster().getReplicationFactor();
+    final double estimatedPartitionsPerBroker =
+        (double) partitionsCount * replicationFactor / brokerCount;
+    // Round up to ensure enough resources are allocated, even if the division is not even
+    return (int) Math.ceil(estimatedPartitionsPerBroker);
   }
 
   private List<PartitionTransitionStep> generateTransitionSteps() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -104,7 +104,7 @@ public final class ZeebePartitionFactory {
   private final SecurityConfiguration securityConfig;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
-  private volatile SharedRocksDbResources sharedRocksDbResources;
+  private final SharedRocksDbResources sharedRocksDbResources;
   private final ClusterConfigurationService clusterConfigurationService;
   private final MeterRegistry brokerMeterRegistry;
 
@@ -174,7 +174,7 @@ public final class ZeebePartitionFactory {
             () -> MicrometerUtil.wrap(partitionMeterRegistry, PartitionKeyNames.tags(partitionId)),
             sharedRocksDbResources,
             getPartitionsPerBroker(
-                clusterConfigurationService, membershipService.getLocalMember().id(), brokerCfg));
+                clusterConfigurationService, membershipService.getLocalMember().id()));
     final StateController stateController =
         createStateController(raftPartition, zeebeFactory, snapshotStore, snapshotStore);
 
@@ -226,21 +226,17 @@ public final class ZeebePartitionFactory {
 
     final var localMemberId = clusterServices.getMembershipService().getLocalMember().id();
     final int partitionsPerBroker =
-        getPartitionsPerBroker(clusterConfigurationService, localMemberId, brokerCfg);
-    sharedRocksDbResources =
-        RocksDbSharedCache.allocateSharedCache(brokerCfg, brokerMeterRegistry, partitionsPerBroker);
+        getPartitionsPerBroker(clusterConfigurationService, localMemberId);
+    sharedRocksDbResources.allocate(
+        RocksDbSharedCache.getSharedCacheSize(brokerCfg, brokerMeterRegistry, partitionsPerBroker));
   }
 
   /**
-   * Determines the number of partitions this broker is responsible for. First attempts to get the
-   * actual partition count from the cluster topology. If no partitions are assigned yet (e.g.,
-   * during initial cluster bootstrap), falls back to a static calculation based on cluster
-   * configuration.
+   * Determines the number of partitions this broker is responsible for. Attempts to get the actual
+   * partition count from the cluster topology.
    */
   private static int getPartitionsPerBroker(
-      final ClusterConfigurationService clusterConfigurationService,
-      final MemberId localMemberId,
-      final BrokerCfg brokerCfg) {
+      final ClusterConfigurationService clusterConfigurationService, final MemberId localMemberId) {
     final var partitionDistribution = clusterConfigurationService.getPartitionDistribution();
 
     if (partitionDistribution != null) {
@@ -250,17 +246,14 @@ public final class ZeebePartitionFactory {
               .count();
       if (partitionCount > 0) {
         return (int) partitionCount;
+      } else {
+        throw new IllegalStateException(
+            "Local broker with member id %s is not assigned to any partition in the topology."
+                .formatted(localMemberId));
       }
     }
-
-    // Fallback to static calculation if partition distribution not yet available
-    final int partitionsCount = brokerCfg.getCluster().getPartitionsCount();
-    final int brokerCount = brokerCfg.getCluster().getClusterSize();
-    final int replicationFactor = brokerCfg.getCluster().getReplicationFactor();
-    final double estimatedPartitionsPerBroker =
-        (double) partitionsCount * replicationFactor / brokerCount;
-    // Round up to ensure enough resources are allocated, even if the division is not even
-    return (int) Math.ceil(estimatedPartitionsPerBroker);
+    throw new IllegalStateException(
+        "Partition distribution is not available during partition construction.");
   }
 
   private List<PartitionTransitionStep> generateTransitionSteps() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -241,9 +241,7 @@ public final class ZeebePartitionFactory {
 
     if (partitionDistribution != null) {
       final long partitionCount =
-          partitionDistribution.partitions().stream()
-              .filter(p -> p.members().contains(localMemberId))
-              .count();
+          clusterConfigurationService.getMemberPartitions(localMemberId).size();
       if (partitionCount > 0) {
         return (int) partitionCount;
       } else {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -235,17 +235,26 @@ public final class ZeebePartitionFactory {
    * Determines the number of partitions this broker is responsible for. Attempts to get the actual
    * partition count from the cluster topology.
    */
-  private static int getPartitionsPerBroker(
+  static int getPartitionsPerBroker(
       final ClusterConfigurationService clusterConfigurationService, final MemberId localMemberId) {
     final long partitionCount =
         clusterConfigurationService.getMemberPartitions(localMemberId).size();
     if (partitionCount > 0) {
       return (int) partitionCount;
-    } else {
-      throw new IllegalStateException(
-          "Local broker with member id %s is not assigned to any partition in the topology."
-              .formatted(localMemberId));
     }
+
+    // Fall back to counting JOINING partitions — this happens during scale-up when a broker is
+    // being asked to join a partition for the first time, and the partition distribution does not
+    // include the partitions that are  in JOINING.
+    final int joiningPartitionCount =
+        clusterConfigurationService.getJoiningMemberPartitionCount(localMemberId);
+    if (joiningPartitionCount > 0) {
+      return joiningPartitionCount;
+    }
+
+    throw new IllegalStateException(
+        "Local broker with member id %s is not assigned to any partition in the topology."
+            .formatted(localMemberId));
   }
 
   private List<PartitionTransitionStep> generateTransitionSteps() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -82,10 +82,13 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ZeebePartitionFactory {
 
   public static final String DEFAULT_RUNTIME_DIRECTORY = "runtime";
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeebePartitionFactory.class);
   private static final List<StartupStep<PartitionStartupContext>> STARTUP_STEPS = List.of();
   private final ActorSchedulingService actorSchedulingService;
   private final BrokerCfg brokerCfg;
@@ -174,7 +177,7 @@ public final class ZeebePartitionFactory {
             () -> MicrometerUtil.wrap(partitionMeterRegistry, PartitionKeyNames.tags(partitionId)),
             sharedRocksDbResources,
             getPartitionsPerBroker(
-                clusterConfigurationService, membershipService.getLocalMember().id()));
+                clusterConfigurationService, membershipService.getLocalMember().id(), brokerCfg));
     final StateController stateController =
         createStateController(raftPartition, zeebeFactory, snapshotStore, snapshotStore);
 
@@ -226,17 +229,19 @@ public final class ZeebePartitionFactory {
 
     final var localMemberId = clusterServices.getMembershipService().getLocalMember().id();
     final int partitionsPerBroker =
-        getPartitionsPerBroker(clusterConfigurationService, localMemberId);
+        getPartitionsPerBroker(clusterConfigurationService, localMemberId, brokerCfg);
     sharedRocksDbResources.allocate(
         RocksDbSharedCache.getSharedCacheSize(brokerCfg, brokerMeterRegistry, partitionsPerBroker));
   }
 
   /**
    * Determines the number of partitions this broker is responsible for. Attempts to get the actual
-   * partition count from the cluster topology.
+   * partition count from the cluster topology, with a static-config estimate as last resort.
    */
   static int getPartitionsPerBroker(
-      final ClusterConfigurationService clusterConfigurationService, final MemberId localMemberId) {
+      final ClusterConfigurationService clusterConfigurationService,
+      final MemberId localMemberId,
+      final BrokerCfg brokerCfg) {
     final long partitionCount =
         clusterConfigurationService.getMemberPartitions(localMemberId).size();
     if (partitionCount > 0) {
@@ -245,16 +250,30 @@ public final class ZeebePartitionFactory {
 
     // Fall back to counting JOINING partitions — this happens during scale-up when a broker is
     // being asked to join a partition for the first time, and the partition distribution does not
-    // include the partitions that are  in JOINING.
+    // include the partitions that are in JOINING state yet.
     final int joiningPartitionCount =
         clusterConfigurationService.getJoiningMemberPartitionCount(localMemberId);
     if (joiningPartitionCount > 0) {
       return joiningPartitionCount;
     }
 
-    throw new IllegalStateException(
-        "Local broker with member id %s is not assigned to any partition in the topology."
-            .formatted(localMemberId));
+    // Last-resort fallback: the cluster configuration hasn't been updated yet (e.g. join called
+    // before the dynamic config reflects the JOINING state). Estimate the per-broker partition count
+    // from the static cluster config so the RocksDB cache is sized appropriately.
+    final var clusterCfg = brokerCfg.getCluster();
+    final int estimate =
+        (int)
+            Math.ceil(
+                (double) clusterCfg.getPartitionsCount()
+                    * clusterCfg.getReplicationFactor()
+                    / clusterCfg.getClusterSize());
+    LOGGER.warn(
+        "Could not determine partition count for broker {} from topology; "
+            + "falling back to static config estimate of {} partition(s) for RocksDB cache sizing. "
+            + "This is expected when joining a partition before the cluster configuration is updated.",
+        localMemberId,
+        estimate);
+    return estimate;
   }
 
   private List<PartitionTransitionStep> generateTransitionSteps() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -104,7 +104,7 @@ public final class ZeebePartitionFactory {
   private final SecurityConfiguration securityConfig;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
-  private SharedRocksDbResources sharedRocksDbResources;
+  private volatile SharedRocksDbResources sharedRocksDbResources;
   private final ClusterConfigurationService clusterConfigurationService;
   private final MeterRegistry brokerMeterRegistry;
 
@@ -232,7 +232,7 @@ public final class ZeebePartitionFactory {
 
   /**
    * Determines the number of partitions this broker is responsible for. First attempts to get the
-   * actual partition count from the cluster configuration. If no partitions are assigned yet (e.g.,
+   * actual partition count from the cluster topology. If no partitions are assigned yet (e.g.,
    * during initial cluster bootstrap), falls back to a static calculation based on cluster
    * configuration.
    */

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -258,7 +258,8 @@ public final class ZeebePartitionFactory {
     }
 
     // Last-resort fallback: the cluster configuration hasn't been updated yet (e.g. join called
-    // before the dynamic config reflects the JOINING state). Estimate the per-broker partition count
+    // before the dynamic config reflects the JOINING state). Estimate the per-broker partition
+    // count
     // from the static cluster config so the RocksDB cache is sized appropriately.
     final var clusterCfg = brokerCfg.getCluster();
     final int estimate =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -173,7 +173,8 @@ public final class ZeebePartitionFactory {
             new AccessMetricsConfiguration(databaseCfg.getAccessMetrics(), partitionId),
             () -> MicrometerUtil.wrap(partitionMeterRegistry, PartitionKeyNames.tags(partitionId)),
             sharedRocksDbResources,
-            brokerCfg.getCluster().getPartitionsCount());
+            getPartitionsPerBroker(
+                clusterConfigurationService, membershipService.getLocalMember().id(), brokerCfg));
     final StateController stateController =
         createStateController(raftPartition, zeebeFactory, snapshotStore, snapshotStore);
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -237,21 +237,15 @@ public final class ZeebePartitionFactory {
    */
   private static int getPartitionsPerBroker(
       final ClusterConfigurationService clusterConfigurationService, final MemberId localMemberId) {
-    final var partitionDistribution = clusterConfigurationService.getPartitionDistribution();
-
-    if (partitionDistribution != null) {
-      final long partitionCount =
-          clusterConfigurationService.getMemberPartitions(localMemberId).size();
-      if (partitionCount > 0) {
-        return (int) partitionCount;
-      } else {
-        throw new IllegalStateException(
-            "Local broker with member id %s is not assigned to any partition in the topology."
-                .formatted(localMemberId));
-      }
+    final long partitionCount =
+        clusterConfigurationService.getMemberPartitions(localMemberId).size();
+    if (partitionCount > 0) {
+      return (int) partitionCount;
+    } else {
+      throw new IllegalStateException(
+          "Local broker with member id %s is not assigned to any partition in the topology."
+              .formatted(localMemberId));
     }
-    throw new IllegalStateException(
-        "Partition distribution is not available during partition construction.");
   }
 
   private List<PartitionTransitionStep> generateTransitionSteps() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/ZeebePartitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/ZeebePartitionStep.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning.startup.steps;
 
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 
@@ -28,15 +29,21 @@ public final class ZeebePartitionStep implements StartupStep<PartitionStartupCon
   public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
     final var result = context.concurrencyControl().<PartitionStartupContext>createFuture();
 
-    final var zeebePartition =
-        context
-            .zeebePartitionFactory()
-            .constructPartition(
-                context.raftPartition(),
-                context.snapshotStore(),
-                context.initialPartitionConfig(),
-                context.brokerHealthCheckService(),
-                context.partitionMeterRegistry());
+    final ZeebePartition zeebePartition;
+    try {
+      zeebePartition =
+          context
+              .zeebePartitionFactory()
+              .constructPartition(
+                  context.raftPartition(),
+                  context.snapshotStore(),
+                  context.initialPartitionConfig(),
+                  context.brokerHealthCheckService(),
+                  context.partitionMeterRegistry());
+    } catch (final Exception e) {
+      result.completeExceptionally(e);
+      return result;
+    }
     final var submit = context.schedulingService().submitActor(zeebePartition);
     context
         .concurrencyControl()

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.List;
@@ -48,6 +49,28 @@ public interface ClusterConfigurationService extends AsyncClosable {
   }
 
   ClusterConfiguration getInitialClusterConfiguration();
+
+  /**
+   * Returns the current cluster configuration, including in-progress topology changes. Unlike
+   * {@link #getInitialClusterConfiguration()}, this reflects updates that occurred after startup
+   * (e.g., partitions in {@code JOINING} state during scale-up).
+   */
+  ClusterConfiguration getCurrentClusterConfiguration();
+
+  /**
+   * Returns the number of partitions assigned to the given member that are currently in the {@code
+   * JOINING} state.
+   */
+  default int getJoiningMemberPartitionCount(final MemberId memberId) {
+    final var config = getCurrentClusterConfiguration();
+    if (config == null || !config.hasMember(memberId)) {
+      return 0;
+    }
+    return (int)
+        config.getMember(memberId).partitions().values().stream()
+            .filter(p -> p.state() == State.JOINING)
+            .count();
+  }
 
   ClusterChangeExecutor getClusterChangeExecutor();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
@@ -15,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.List;
 
 public interface ClusterConfigurationService extends AsyncClosable {
   PartitionDistribution getPartitionDistribution();
@@ -30,6 +33,8 @@ public interface ClusterConfigurationService extends AsyncClosable {
   void registerInconsistentConfigurationListener(InconsistentConfigurationListener listener);
 
   void removeInconsistentConfigurationListener();
+
+  List<PartitionMetadata> getMemberPartitions(final MemberId memberId);
 
   ClusterConfiguration getInitialClusterConfiguration();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
@@ -34,7 +34,18 @@ public interface ClusterConfigurationService extends AsyncClosable {
 
   void removeInconsistentConfigurationListener();
 
-  List<PartitionMetadata> getMemberPartitions(final MemberId memberId);
+  default List<PartitionMetadata> getMemberPartitions(final MemberId memberId) {
+    final var partitionDistribution = getPartitionDistribution();
+
+    if (partitionDistribution != null) {
+      return partitionDistribution.partitions().stream()
+          .filter(partition -> partition.members().contains(memberId))
+          .toList();
+    }
+
+    throw new IllegalStateException(
+        "Cannot get member partitions before the topology manager is started");
+  }
 
   ClusterConfiguration getInitialClusterConfiguration();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
-import io.atomix.cluster.MemberId;
-import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -22,7 +20,6 @@ import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
-import java.util.List;
 
 public class DynamicClusterConfigurationService implements ClusterConfigurationService {
 
@@ -117,18 +114,6 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   public void removeInconsistentConfigurationListener() {
     if (clusterConfigurationManagerService != null) {
       clusterConfigurationManagerService.removeTopologyChangedListener();
-    }
-  }
-
-  @Override
-  public List<PartitionMetadata> getMemberPartitions(final MemberId memberId) {
-    if (partitionDistribution != null) {
-      return partitionDistribution.partitions().stream()
-          .filter(p -> p.members().contains(memberId))
-          .toList();
-    } else {
-      throw new IllegalStateException(
-          "Cannot get member partitions before the topology manager is started");
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -20,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
+import java.util.List;
 
 public class DynamicClusterConfigurationService implements ClusterConfigurationService {
 
@@ -114,6 +117,18 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   public void removeInconsistentConfigurationListener() {
     if (clusterConfigurationManagerService != null) {
       clusterConfigurationManagerService.removeTopologyChangedListener();
+    }
+  }
+
+  @Override
+  public List<PartitionMetadata> getMemberPartitions(final MemberId memberId) {
+    if (partitionDistribution != null) {
+      return partitionDistribution.partitions().stream()
+          .filter(p -> p.members().contains(memberId))
+          .toList();
+    } else {
+      throw new IllegalStateException(
+          "Cannot get member partitions before the topology manager is started");
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -26,6 +26,7 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   private PartitionDistribution partitionDistribution;
 
   private volatile ClusterConfiguration initialClusterConfiguration;
+  private volatile ClusterConfiguration currentClusterConfiguration;
 
   private ClusterConfigurationManagerService clusterConfigurationManagerService;
   private final ClusterChangeExecutor clusterChangeExecutor;
@@ -75,6 +76,8 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
           } else {
             clusterConfigurationManagerService.addUpdateListener(
                 brokerStartupContext.getBrokerClient().getTopologyManager());
+            clusterConfigurationManagerService.addUpdateListener(
+                config -> currentClusterConfiguration = config);
             clusterConfigurationManagerService
                 .getClusterTopology()
                 .onComplete(
@@ -88,6 +91,9 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
                                   ConfigurationUtil.getPartitionDistributionFrom(
                                       configuration, PartitionManagerImpl.GROUP_NAME));
                           initialClusterConfiguration = configuration;
+                          if (currentClusterConfiguration == null) {
+                            currentClusterConfiguration = configuration;
+                          }
                           started.complete(null);
                         } catch (final Exception topologyConversionFailed) {
                           started.completeExceptionally(topologyConversionFailed);
@@ -123,6 +129,11 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   }
 
   @Override
+  public ClusterConfiguration getCurrentClusterConfiguration() {
+    return currentClusterConfiguration;
+  }
+
+  @Override
   public ClusterChangeExecutor getClusterChangeExecutor() {
     return clusterChangeExecutor;
   }
@@ -142,6 +153,7 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   @Override
   public ActorFuture<Void> closeAsync() {
     partitionDistribution = null;
+    currentClusterConfiguration = null;
     if (clusterConfigurationManagerService != null) {
       return clusterConfigurationManagerService.closeAsync();
     } else {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -30,8 +30,10 @@ import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
+@Timeout(120)
 final class PartitionJoinTest {
   private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -32,8 +32,10 @@ import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
+@Timeout(120)
 final class PartitionLeaveTest {
   private static final MeterRegistry METER_REGISTRY = new SimpleMeterRegistry();
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -12,8 +12,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.management.ManagementFactory;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,13 +26,11 @@ import org.springframework.util.unit.DataSize;
 class RocksDbSharedCacheTest {
   private static final int DEFAULT_PARTITION_COUNT = 1;
   private BrokerCfg brokerCfg;
-  private MeterRegistry meterRegistry;
 
   @BeforeEach
   void setUp() {
     brokerCfg = new BrokerCfg();
     brokerCfg.getExperimental().getRocksdb().setMemoryLimit(DataSize.ofBytes(512 * 1024 * 1024L));
-    meterRegistry = new SimpleMeterRegistry();
   }
 
   /**
@@ -258,36 +254,6 @@ class RocksDbSharedCacheTest {
                     brokerCfg.getExperimental().getRocksdb(), morePartitionsCount);
               })
           .doesNotThrowAnyException();
-    }
-  }
-
-  @Test
-  void shouldAccountForReplicationFactorWhenAllocatingMemoryPerPartition() {
-    // given
-    // 8 partitions, 3 replicas, 4 brokers =>
-    // partitionsPerBroker = 8 * 3 / 4 = 6 partitions per broker
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
-    brokerCfg.getCluster().setPartitionsCount(8);
-    brokerCfg.getCluster().setReplicationFactor(3);
-    brokerCfg.getCluster().setClusterSize(4);
-    brokerCfg
-        .getExperimental()
-        .getRocksdb()
-        .setMemoryLimit(DataSize.ofBytes(64L * 1024 * 1024)); // 64MB per partition
-
-    // when
-    // Total allocation = 64MB * 6 partitions per broker = 384MB
-    try (final var ignored = mockMemoryEnvironment(512L * 1024 * 1024)) { // 512MB
-      try (final var sharedResources =
-          RocksDbSharedCache.allocateSharedCache(brokerCfg, meterRegistry)) {
-        // then
-        // Expected: 64MB * (8 partitions * 3 replicas / 4 brokers) = 64MB * 6 = 384MB
-        final long expectedAllocation = 64L * 1024 * 1024 * 6;
-        assertThat(sharedResources.reservedMemory()).isEqualTo(expectedAllocation);
-      }
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.*;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.management.ManagementFactory;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,11 +28,13 @@ import org.springframework.util.unit.DataSize;
 class RocksDbSharedCacheTest {
   private static final int DEFAULT_PARTITION_COUNT = 1;
   private BrokerCfg brokerCfg;
+  private MeterRegistry meterRegistry;
 
   @BeforeEach
   void setUp() {
     brokerCfg = new BrokerCfg();
     brokerCfg.getExperimental().getRocksdb().setMemoryLimit(DataSize.ofBytes(512 * 1024 * 1024L));
+    meterRegistry = new SimpleMeterRegistry();
   }
 
   /**
@@ -254,6 +258,36 @@ class RocksDbSharedCacheTest {
                     brokerCfg.getExperimental().getRocksdb(), morePartitionsCount);
               })
           .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  void shouldAccountForReplicationFactorWhenAllocatingMemoryPerPartition() {
+    // given
+    // 8 partitions, 3 replicas, 4 brokers =>
+    // partitionsPerBroker = 8 * 3 / 4 = 6 partitions per broker
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
+    brokerCfg.getCluster().setPartitionsCount(8);
+    brokerCfg.getCluster().setReplicationFactor(3);
+    brokerCfg.getCluster().setClusterSize(4);
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryLimit(DataSize.ofBytes(64L * 1024 * 1024)); // 64MB per partition
+
+    // when
+    // Total allocation = 64MB * 6 partitions per broker = 384MB
+    try (final var ignored = mockMemoryEnvironment(512L * 1024 * 1024)) { // 512MB
+      try (final var sharedResources =
+          RocksDbSharedCache.allocateSharedCache(brokerCfg, meterRegistry)) {
+        // then
+        // Expected: 64MB * (8 partitions * 3 replicas / 4 brokers) = 64MB * 6 = 384MB
+        final long expectedAllocation = 64L * 1024 * 1024 * 6;
+        assertThat(sharedResources.reservedMemory()).isEqualTo(expectedAllocation);
+      }
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/PartitionsPerBrokerResolutionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/PartitionsPerBrokerResolutionTest.java
@@ -8,13 +8,13 @@
 package io.camunda.zeebe.broker.partitioning.startup;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
@@ -45,7 +45,8 @@ class PartitionsPerBrokerResolutionTest {
       when(configService.getMemberPartitions(MEMBER_ID)).thenReturn(List.of(partition1, partition2));
 
       // when
-      final int result = ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID);
+      final int result =
+          ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID, null);
 
       // then
       assertThat(result).isEqualTo(2);
@@ -60,23 +61,33 @@ class PartitionsPerBrokerResolutionTest {
       when(configService.getJoiningMemberPartitionCount(MEMBER_ID)).thenReturn(1);
 
       // when
-      final int result = ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID);
+      final int result =
+          ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID, null);
 
       // then
       assertThat(result).isEqualTo(1);
     }
 
     @Test
-    void shouldThrowWhenBrokerHasNeitherActiveNorJoiningPartitions() {
-      // given
+    void shouldEstimateFromConfigWhenBrokerHasNeitherActiveNorJoiningPartitions() {
+      // given — broker is joining its first partition but the cluster config hasn't been updated
+      // yet (e.g. join called before the dynamic config reflects the JOINING state).
+      // 3 partitions × RF 2 across 3 brokers → ceil(6/3) = 2 partitions per broker.
       final var configService = mock(ClusterConfigurationService.class);
       when(configService.getMemberPartitions(MEMBER_ID)).thenReturn(List.of());
       when(configService.getJoiningMemberPartitionCount(MEMBER_ID)).thenReturn(0);
 
-      // when / then
-      assertThatThrownBy(() -> ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID))
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining(MEMBER_ID.id());
+      final var brokerCfg = new BrokerCfg();
+      brokerCfg.getCluster().setPartitionsCount(3);
+      brokerCfg.getCluster().setReplicationFactor(2);
+      brokerCfg.getCluster().setClusterSize(3);
+
+      // when
+      final int result =
+          ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID, brokerCfg);
+
+      // then — ceil(3 * 2 / 3) = 2
+      assertThat(result).isEqualTo(2);
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/PartitionsPerBrokerResolutionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/PartitionsPerBrokerResolutionTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class PartitionsPerBrokerResolutionTest {
+
+  private static final MemberId MEMBER_ID = MemberId.from("1");
+
+  /**
+   * Tests for {@link ZeebePartitionFactory#getPartitionsPerBroker}, which determines how many
+   * partitions this broker owns — used to size the shared RocksDB cache.
+   */
+  @Nested
+  class GetPartitionsPerBroker {
+
+    @Test
+    void shouldReturnActivePartitionCountWhenBrokerHasActivePartitions() {
+      // given
+      final var configService = mock(ClusterConfigurationService.class);
+      final var partition1 = mock(PartitionMetadata.class);
+      final var partition2 = mock(PartitionMetadata.class);
+      when(configService.getMemberPartitions(MEMBER_ID)).thenReturn(List.of(partition1, partition2));
+
+      // when
+      final int result = ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID);
+
+      // then
+      assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    void shouldFallBackToJoiningCountWhenBrokerIsJoiningPartitions() {
+      // given — broker not yet in the partition distribution (partition in JOINING state),
+      // so getMemberPartitions returns empty; only getJoiningMemberPartitionCount has the answer
+      final var configService = mock(ClusterConfigurationService.class);
+      when(configService.getMemberPartitions(MEMBER_ID)).thenReturn(List.of());
+      when(configService.getJoiningMemberPartitionCount(MEMBER_ID)).thenReturn(1);
+
+      // when
+      final int result = ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID);
+
+      // then
+      assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    void shouldThrowWhenBrokerHasNeitherActiveNorJoiningPartitions() {
+      // given
+      final var configService = mock(ClusterConfigurationService.class);
+      when(configService.getMemberPartitions(MEMBER_ID)).thenReturn(List.of());
+      when(configService.getJoiningMemberPartitionCount(MEMBER_ID)).thenReturn(0);
+
+      // when / then
+      assertThatThrownBy(() -> ZeebePartitionFactory.getPartitionsPerBroker(configService, MEMBER_ID))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining(MEMBER_ID.id());
+    }
+  }
+
+  /**
+   * Tests for the {@link ClusterConfigurationService#getJoiningMemberPartitionCount} default
+   * method, which counts partitions in JOINING state from the live cluster configuration.
+   */
+  @Nested
+  class GetJoiningMemberPartitionCount {
+
+    private ClusterConfigurationService serviceWithConfig(final ClusterConfiguration config) {
+      final var service = mock(ClusterConfigurationService.class, Mockito.CALLS_REAL_METHODS);
+      when(service.getCurrentClusterConfiguration()).thenReturn(config);
+      return service;
+    }
+
+    @Test
+    void shouldCountJoiningPartitions() {
+      // given
+      final var config =
+          ClusterConfiguration.init()
+              .addMember(
+                  MEMBER_ID,
+                  MemberState.initializeAsActive(
+                      Map.of(
+                          1, PartitionState.joining(1, DynamicPartitionConfig.init()),
+                          2, PartitionState.joining(1, DynamicPartitionConfig.init()))));
+      final var service = serviceWithConfig(config);
+
+      // when
+      final int result = service.getJoiningMemberPartitionCount(MEMBER_ID);
+
+      // then
+      assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    void shouldIgnoreNonJoiningPartitions() {
+      // given — member has one ACTIVE and one LEAVING partition; none are JOINING
+      final var config =
+          ClusterConfiguration.init()
+              .addMember(
+                  MEMBER_ID,
+                  MemberState.initializeAsActive(
+                      Map.of(
+                          1, PartitionState.active(1, DynamicPartitionConfig.init()),
+                          2,
+                              PartitionState.active(1, DynamicPartitionConfig.init())
+                                  .toLeaving())));
+      final var service = serviceWithConfig(config);
+
+      // when
+      final int result = service.getJoiningMemberPartitionCount(MEMBER_ID);
+
+      // then
+      assertThat(result).isEqualTo(0);
+    }
+
+    @Test
+    void shouldReturnZeroWhenMemberNotInConfiguration() {
+      // given
+      final var config = ClusterConfiguration.init();
+      final var service = serviceWithConfig(config);
+
+      // when
+      final int result = service.getJoiningMemberPartitionCount(MEMBER_ID);
+
+      // then
+      assertThat(result).isEqualTo(0);
+    }
+
+    @Test
+    void shouldReturnZeroWhenConfigurationIsNull() {
+      // given
+      final var service = serviceWithConfig(null);
+
+      // when
+      final int result = service.getJoiningMemberPartitionCount(MEMBER_ID);
+
+      // then
+      assertThat(result).isEqualTo(0);
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/PartitionsPerBrokerResolutionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/PartitionsPerBrokerResolutionTest.java
@@ -42,7 +42,8 @@ class PartitionsPerBrokerResolutionTest {
       final var configService = mock(ClusterConfigurationService.class);
       final var partition1 = mock(PartitionMetadata.class);
       final var partition2 = mock(PartitionMetadata.class);
-      when(configService.getMemberPartitions(MEMBER_ID)).thenReturn(List.of(partition1, partition2));
+      when(configService.getMemberPartitions(MEMBER_ID))
+          .thenReturn(List.of(partition1, partition2));
 
       // when
       final int result =
@@ -134,9 +135,7 @@ class PartitionsPerBrokerResolutionTest {
                   MemberState.initializeAsActive(
                       Map.of(
                           1, PartitionState.active(1, DynamicPartitionConfig.init()),
-                          2,
-                              PartitionState.active(1, DynamicPartitionConfig.init())
-                                  .toLeaving())));
+                          2, PartitionState.active(1, DynamicPartitionConfig.init()).toLeaving())));
       final var service = serviceWithConfig(config);
 
       // when

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -429,8 +429,7 @@ public final class ZeebeRocksDbFactory<
     @Override
     public void close() {
       if (isInitialized()) {
-        sharedWbm.close();
-        sharedCache.close();
+        CloseHelper.closeAll(sharedCache, sharedWbm);
         sharedCache = null;
         sharedWbm = null;
       }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -428,8 +428,12 @@ public final class ZeebeRocksDbFactory<
 
     @Override
     public void close() {
-      sharedWbm.close();
-      sharedCache.close();
+      if (isInitialized()) {
+        sharedWbm.close();
+        sharedCache.close();
+        sharedCache = null;
+        sharedWbm = null;
+      }
     }
   }
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -59,12 +59,13 @@ public final class ZeebeRocksDbFactory<
       final ConsistencyChecksSettings consistencyChecksSettings,
       final AccessMetricsConfiguration metricsConfiguration,
       final Supplier<MeterRegistry> meterRegistryFactory) {
+
     this(
         rocksDbConfiguration,
         consistencyChecksSettings,
         metricsConfiguration,
         meterRegistryFactory,
-        SharedRocksDbResources.allocate(rocksDbConfiguration.getMemoryLimit()),
+        new SharedRocksDbResources(rocksDbConfiguration.getMemoryLimit()),
         3);
   }
 
@@ -169,7 +170,7 @@ public final class ZeebeRocksDbFactory<
             // a good balance between useful for performance and small for replication
             .setLogFileTimeToRoll(Duration.ofMinutes(30).toSeconds())
             .setKeepLogFileNum(2)
-            .setWriteBufferManager(sharedRocksDbResources.sharedWbm);
+            .setWriteBufferManager(sharedRocksDbResources.getSharedWbm());
 
     // limit I/O writes
     if (rocksDbConfiguration.getIoRateBytesPerSecond() > 0) {
@@ -230,11 +231,11 @@ public final class ZeebeRocksDbFactory<
    * centralizes memory calculations to avoid duplication.
    */
   MemoryConfiguration calculateMemoryConfiguration() {
-    final var totalMemoryBudgetPerPartition = sharedRocksDbResources.memoryLimit / partitionCount;
+    final var totalMemoryBudgetPerPartition = sharedRocksDbResources.getMemoryLimit() / partitionCount;
 
     // recommended by RocksDB, but we could tweak it; keep in mind we're also caching the indexes
     // and filters into the block cache, so we don't need to account for more memory there
-    final var blockCacheMemoryPerPartition = sharedRocksDbResources.blockCacheSize / partitionCount;
+    final var blockCacheMemoryPerPartition = sharedRocksDbResources.getBlockCacheSize() / partitionCount;
     // flushing the memtables is done asynchronously, so there may be multiple memtables in memory,
     // although only a single one is writable. once we have too many memtables, writes will stop.
     // since prefix iteration is our bread n butter, we will build an additional filter for each
@@ -338,7 +339,7 @@ public final class ZeebeRocksDbFactory<
     closeables.add(filter);
 
     return new BlockBasedTableConfig()
-        .setBlockCache(sharedRocksDbResources.sharedCache)
+        .setBlockCache(sharedRocksDbResources.getSharedCache())
         // increasing block size means reducing memory usage, but increasing read iops
         .setBlockSize(32 * 1024L)
         // full and partitioned filters use a more efficient bloom filter implementation when
@@ -365,9 +366,7 @@ public final class ZeebeRocksDbFactory<
         .setWholeKeyFiltering(true);
   }
 
-  public record SharedRocksDbResources(
-      LRUCache sharedCache, WriteBufferManager sharedWbm, long memoryLimit, long blockCacheSize)
-      implements AutoCloseable {
+  public static final class SharedRocksDbResources implements AutoCloseable {
 
     // memoryLimit represents the total memory budget we expect RocksDB to use on this node.
     // We follow the recommended heuristic where roughly 1/3 of that total budget is assigned to
@@ -382,22 +381,49 @@ public final class ZeebeRocksDbFactory<
       RocksDB.loadLibrary();
     }
 
-    public static SharedRocksDbResources allocate(final long memoryLimit) {
+    private LRUCache sharedCache;
+    private WriteBufferManager sharedWbm;
+    private long memoryLimit;
+    private long blockCacheSize;
+
+    public SharedRocksDbResources() {}
+
+    public SharedRocksDbResources(final long cacheSize) {
+      allocate(cacheSize);
+    }
+
+    public void allocate(final long memoryLimit) {
+      if (isInitialized()) {
+        close();
+      }
       // (#DBs) × write_buffer_size × max_write_buffer_number should be comfortably ≤ your WBM
       // limit, with headroom for memtable bloom/filter overhead. write_buffer_size is calculated in
       // zeebeRocksDBFactory.
       final long blockCacheSize = memoryLimit / CACHE_RATIO_OF_MEMORY_LIMIT;
-      final LRUCache sharedCache = new LRUCache(blockCacheSize, 8, false, 0.15);
-      final WriteBufferManager sharedWbm = new WriteBufferManager(blockCacheSize / 4, sharedCache);
-      return new SharedRocksDbResources(sharedCache, sharedWbm, memoryLimit, blockCacheSize);
-    }
-
-    public static SharedRocksDbResources uninitialized() {
-      return new SharedRocksDbResources(null, null, 0);
+      sharedCache = new LRUCache(blockCacheSize, 8, false, 0.15);
+      sharedWbm = new WriteBufferManager(blockCacheSize / 4, sharedCache);
+      this.memoryLimit = memoryLimit;
+      this.blockCacheSize = blockCacheSize;
     }
 
     public boolean isInitialized() {
       return sharedCache != null && sharedWbm != null;
+    }
+
+    public LRUCache getSharedCache() {
+      return sharedCache;
+    }
+
+    public WriteBufferManager getSharedWbm() {
+      return sharedWbm;
+    }
+
+    public long getMemoryLimit() {
+      return memoryLimit;
+    }
+
+    public long getBlockCacheSize() {
+      return blockCacheSize;
     }
 
     @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -392,6 +392,14 @@ public final class ZeebeRocksDbFactory<
       return new SharedRocksDbResources(sharedCache, sharedWbm, memoryLimit, blockCacheSize);
     }
 
+    public static SharedRocksDbResources uninitialized() {
+      return new SharedRocksDbResources(null, null, 0);
+    }
+
+    public boolean isInitialized() {
+      return sharedCache != null && sharedWbm != null;
+    }
+
     @Override
     public void close() {
       sharedWbm.close();

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -231,11 +231,13 @@ public final class ZeebeRocksDbFactory<
    * centralizes memory calculations to avoid duplication.
    */
   MemoryConfiguration calculateMemoryConfiguration() {
-    final var totalMemoryBudgetPerPartition = sharedRocksDbResources.getMemoryLimit() / partitionCount;
+    final var totalMemoryBudgetPerPartition =
+        sharedRocksDbResources.getMemoryLimit() / partitionCount;
 
     // recommended by RocksDB, but we could tweak it; keep in mind we're also caching the indexes
     // and filters into the block cache, so we don't need to account for more memory there
-    final var blockCacheMemoryPerPartition = sharedRocksDbResources.getBlockCacheSize() / partitionCount;
+    final var blockCacheMemoryPerPartition =
+        sharedRocksDbResources.getBlockCacheSize() / partitionCount;
     // flushing the memtables is done asynchronously, so there may be multiple memtables in memory,
     // although only a single one is writable. once we have too many memtables, writes will stop.
     // since prefix iteration is our bread n butter, we will build an additional filter for each

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -250,6 +250,7 @@ final class ZeebeRocksDbFactoryTest {
 
     // when - then
     assertThatCode(sharedResources::close).doesNotThrowAnyException();
+    assertThat(sharedResources.isInitialized()).isFalse();
   }
 
   private static void validateDefaultExpectedOptions(

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DefaultColumnFamily;
 import io.camunda.zeebe.db.impl.DefaultZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.SharedRocksDbResources;
 import io.camunda.zeebe.util.ByteValue;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
@@ -240,6 +241,15 @@ final class ZeebeRocksDbFactoryTest {
     try (final var db = factory.openSnapshotOnlyDb(dbPath)) {
       assertThatCode(() -> assertions.accept(db)).isInstanceOf(UnsupportedOperationException.class);
     }
+  }
+
+  @Test
+  void shouldNotThrowWhenClosingUninitializedSharedResources() {
+    // given
+    final var sharedResources = new SharedRocksDbResources();
+
+    // when - then
+    assertThatCode(sharedResources::close).doesNotThrowAnyException();
   }
 
   private static void validateDefaultExpectedOptions(


### PR DESCRIPTION
## Description

This PR makes the memory allocation strategy `PARTITION` to use the partition count per broker, instead of the partition count configured. These two are usually the same but can differ if broker count and replication count are not the same.

This change is only being made to maintain the legacy behaviour of 8.7 and before as close as possible since the introduction of the shared cache in the broker for RocksDB. The reason that we have to consider the partition count per broker instead is that in 8.7 every partition (even followers) opened a DB instance. 

We now also lazily initialize the shared RocksDB resources on the first partition construction. This ensures the cluster configuration service is initialized and the partition distribution is available so that we can use the number of partitions from the topology, instead of having to guess how many partitions in the brokers through the configuration.

This should be backported to 8.8 and 8.9.

After this is merged, the camunda docs will be updated to reflect these changes, https://github.com/camunda/camunda/issues/48792

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to: https://github.com/camunda/camunda/issues/48791
