### PR TITLE
fix: enhance namespace handling and add usage instructions in newCloudLoadTest.sh

### DIFF
--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -4,9 +4,30 @@ set -exo pipefail
 # Contains OS specific sed function
 . utils.sh
 
-if [ -z $1 ]
-then
-  echo "Please provide an namespace name!"
+usage() {
+  cat <<'EOF'
+Usage: newCloudLoadTest.sh <namespace>
+
+Arguments:
+  namespace          Base namespace name. Will be prefixed with "c8-" if missing.
+
+Options:
+  -h, --help         Show this help message.
+
+Examples:
+  ./newCloudLoadTest.sh demo
+  ./newCloudLoadTest.sh c8-demo
+EOF
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ -z "$1" ]; then
+  echo "Error: Missing namespace name."
+  usage
   exit 1
 fi
 
@@ -16,6 +37,12 @@ fi
 
 
 namespace=$1
+
+# Add c8- prefix if not present
+if [[ ! "$namespace" =~ ^c8- ]]; then
+  namespace="c8-$namespace"
+  echo "Namespace prefix added: $namespace"
+fi
 
 kubectl create namespace $namespace
 cp -rv cloud-default/ $namespace


### PR DESCRIPTION
## Description

This pull request improves the usability and robustness of the `newCloudLoadTest.sh` script by adding a help message, better argument validation, and automatic namespace prefixing. The most important changes are grouped below:

**Usability Improvements:**

* Added a `usage` function that displays a help message with usage instructions, arguments, options, and examples when invoked with `-h` or `--help`.

**Argument Validation:**

* Improved argument validation by checking for a missing namespace name, displaying an error message and usage instructions if not provided.

**Namespace Handling:**

* Automatically adds the `c8-` prefix to the namespace if not already present, and prints a message indicating the prefix was added.
