### PR TITLE
[Backport stable/8.8] fix: clean up runtime instructions on process instance removal to prevent NPE

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -505,10 +505,9 @@ public final class BpmnStateTransitionBehavior {
     }
 
     final var processInstance = stateBehavior.getElementInstance(context.getProcessInstanceKey());
-    if (processInstance == null || processInstance.isTerminating()) {
-      // if the process instance is null (already removed from state) or already terminating, we
-      // don't need to interrupt and terminate it again — the instruction is stale or already
-      // processed.
+    if (processInstance.isTerminating()) {
+      // if the process instance is already terminating, we don't need to interrupt and terminate it
+      // again, the instruction has already been processed.
       return Either.right(context);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -505,9 +505,10 @@ public final class BpmnStateTransitionBehavior {
     }
 
     final var processInstance = stateBehavior.getElementInstance(context.getProcessInstanceKey());
-    if (processInstance.isTerminating()) {
-      // if the process instance is already terminating, we don't need to interrupt and terminate it
-      // again, the instruction has already been processed.
+    if (processInstance == null || processInstance.isTerminating()) {
+      // if the process instance is null (already removed from state) or already terminating, we
+      // don't need to interrupt and terminate it again — the instruction is stale or already
+      // processed.
       return Either.right(context);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
@@ -64,6 +64,10 @@ final class ProcessInstanceElementCompletedApplier
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
 
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.removeRuntimeInstructions(key);
+    }
+
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
 
     if (flowScopeInstance == null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedApplier.java
@@ -48,6 +48,10 @@ final class ProcessInstanceElementTerminatedApplier
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
 
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.removeRuntimeInstructions(key);
+    }
+
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
 
     if (flowScopeInstance == null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -337,6 +337,12 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
+  public void removeRuntimeInstructions(final long processInstanceKey) {
+    elementInstanceKey.wrapLong(processInstanceKey);
+    runtimeInstructionsByProcessInstanceKey.deleteIfExists(elementInstanceKey);
+  }
+
+  @Override
   public ElementInstance getInstance(final long key) {
     elementInstanceKey.wrapLong(key);
     return elementInstanceColumnFamily.get(elementInstanceKey, ElementInstance::new);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -111,4 +111,15 @@ public interface MutableElementInstanceState extends ElementInstanceState {
   void addRuntimeInstructions(
       long processInstanceKey,
       List<ProcessInstanceCreationRuntimeInstructionValue> runtimeInstructions);
+
+  /**
+   * Removes all runtime instructions associated with the given process instance key.
+   *
+   * <p>This should be called when the process instance is removed from state to prevent stale
+   * runtime instructions from being evaluated after the instance no longer exists.
+   *
+   * @param processInstanceKey the key of the process instance whose runtime instructions should be
+   *     removed
+   */
+  void removeRuntimeInstructions(long processInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithTerminationInstructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithTerminationInstructionTest.java
@@ -327,4 +327,38 @@ public class CreateProcessInstanceWithTerminationInstructionTest {
             Tuple.tuple(ProcessInstanceIntent.ELEMENT_TERMINATING, BpmnElementType.PROCESS),
             Tuple.tuple(ProcessInstanceIntent.ELEMENT_TERMINATED, BpmnElementType.PROCESS));
   }
+
+  @Test
+  public void shouldNotThrowNPEWhenCancellingInstanceWithRuntimeInstruction() {
+    // given
+    final String processId = "process";
+    final String serviceTaskId = "serviceTask";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(serviceTaskId, t -> t.zeebeJobType("jobType"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withRuntimeTerminateInstruction(serviceTaskId)
+            .create();
+
+    // when - cancel the process instance while the service task is active
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - process should be terminated without NPE
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(processId)
+                .exists())
+        .isTrue();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -867,6 +867,36 @@ public final class ProcessExecutionCleanStateTest {
     assertThatStateIsEmpty();
   }
 
+  @Test
+  public void testProcessWithRuntimeTerminateInstruction() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .manualTask("task")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var processInstanceKey =
+        engineRule
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withRuntimeTerminateInstruction("task")
+            .create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
   private void assertThatStateIsEmpty() {
     // sometimes the state takes few moments until is empty
     Awaitility.await()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -15,9 +15,11 @@ import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
@@ -566,5 +568,36 @@ public final class ElementInstanceStateTest {
     assertThat(record.getVersion()).isEqualTo(1);
     assertThat(record.getProcessDefinitionKey()).isEqualTo(2);
     assertThat(record.getBpmnElementType()).isEqualTo(BpmnElementType.START_EVENT);
+  }
+
+  @Test
+  public void shouldRemoveRuntimeInstructionsForProcessInstance() {
+    // given
+    final long processInstanceKey = 100L;
+    final var instruction =
+        new ProcessInstanceCreationRuntimeInstruction()
+            .setType(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE)
+            .setAfterElementId("taskA");
+    elementInstanceState.addRuntimeInstructions(processInstanceKey, List.of(instruction));
+
+    // verify instructions exist
+    assertThat(elementInstanceState.getRuntimeInstructionsForElementId(processInstanceKey, "taskA"))
+        .isNotEmpty();
+
+    // when
+    elementInstanceState.removeRuntimeInstructions(processInstanceKey);
+
+    // then
+    assertThat(elementInstanceState.getRuntimeInstructionsForElementId(processInstanceKey, "taskA"))
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldNotFailWhenRemovingNonExistentRuntimeInstructions() {
+    // given - no runtime instructions exist for this key
+    final long processInstanceKey = 999L;
+
+    // when/then - should not throw
+    elementInstanceState.removeRuntimeInstructions(processInstanceKey);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_COMPLETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_COMPLETED_v1.golden
@@ -64,6 +64,10 @@ final class ProcessInstanceElementCompletedApplier
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
 
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.removeRuntimeInstructions(key);
+    }
+
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
 
     if (flowScopeInstance == null) {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_TERMINATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_TERMINATED_v1.golden
@@ -48,6 +48,10 @@ final class ProcessInstanceElementTerminatedApplier
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
 
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.removeRuntimeInstructions(key);
+    }
+
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
 
     if (flowScopeInstance == null) {


### PR DESCRIPTION
# Description
Backport of #47841 to `stable/8.8`.

relates to #38481 camunda/camunda#38481