### PR TITLE
fix: tenant custom filters on Tasklist

### DIFF
--- a/tasklist/client/src/common/i18n/locales/de.json
+++ b/tasklist/client/src/common/i18n/locales/de.json
@@ -251,6 +251,7 @@
     "customFiltersModalConfirmDeletion": "Löschen bestätigen",
     "customFiltersModalApplyFilters": "Filter anwenden",
     "customFiltersModalAllProcesses": "Alle Prozesse",
+    "customFiltersModalAllTenants": "Alle Mandanten",
     "taskFilterPanelControlsAria": "Filtersteuerungen",
     "taskFilterPanelExpandButton": "Erweitern, um Filter anzuzeigen",
     "taskFilterPanelFilterButton": "Aufgaben filtern",

--- a/tasklist/client/src/common/i18n/locales/en.json
+++ b/tasklist/client/src/common/i18n/locales/en.json
@@ -255,6 +255,7 @@
     "customFiltersModalConfirmDeletion": "Confirm deletion",
     "customFiltersModalApplyFilters": "Apply filters",
     "customFiltersModalAllProcesses": "All processes",
+    "customFiltersModalAllTenants": "All tenants",
     "taskFilterPanelControlsAria": "Filter controls",
     "taskFilterPanelExpandButton": "Expand to show filters",
     "taskFilterPanelFilterButton": "Filter tasks",

--- a/tasklist/client/src/common/i18n/locales/es.json
+++ b/tasklist/client/src/common/i18n/locales/es.json
@@ -251,6 +251,7 @@
     "customFiltersModalConfirmDeletion": "Confirmar eliminación",
     "customFiltersModalApplyFilters": "Aplicar filtros",
     "customFiltersModalAllProcesses": "Todos los procesos",
+    "customFiltersModalAllTenants": "Todos los arrendatarios",
     "taskFilterPanelCompleted": "Completada",
     "taskFilterPanelControlsAria": "Controles de filtro",
     "taskFilterPanelExpandButton": "Expandir para mostrar filtros",

--- a/tasklist/client/src/common/i18n/locales/fr.json
+++ b/tasklist/client/src/common/i18n/locales/fr.json
@@ -252,6 +252,7 @@
     "customFiltersModalConfirmDeletion": "Confirmer la suppression",
     "customFiltersModalApplyFilters": "Appliquer les filtres",
     "customFiltersModalAllProcesses": "Tous les processus",
+    "customFiltersModalAllTenants": "Tous les clients",
     "taskFilterPanelControlsAria": "Contrôles de filtre",
     "taskFilterPanelExpandButton": "Ouvrir pour afficher les filtres",
     "taskFilterPanelFilterButton": "Filtrer les tâches",

--- a/tasklist/client/src/common/multitenancy/MultitenancySelect.tsx
+++ b/tasklist/client/src/common/multitenancy/MultitenancySelect.tsx
@@ -8,15 +8,18 @@
 
 import {Select, SelectItem} from '@carbon/react';
 import {useCurrentUser} from 'common/api/useCurrentUser.query';
+import {useTranslation} from 'react-i18next';
 
 type Props = React.ComponentProps<typeof Select>;
 
 const MultitenancySelect: React.FC<Props> = (props) => {
   const {data: currentUser} = useCurrentUser();
+  const {t} = useTranslation();
   const tenants = currentUser?.tenants ?? [];
 
   return (
     <Select {...props} disabled={props.disabled || currentUser === undefined}>
+      <SelectItem value="" text={t('customFiltersModalAllTenants')} />
       {tenants.map(({tenantId, name}) => (
         <SelectItem key={tenantId} value={tenantId} text={name} />
       ))}

--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.tsx
@@ -63,6 +63,7 @@ function getNavLinkSearchParam(options: {
     'processDefinitionKey',
     'processInstanceKey',
     'tenantIds',
+    'tenantId',
     'taskVariables',
   ] as const;
   const {filter, username, currentParams} = options;

--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.v2.test.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.v2.test.tsx
@@ -191,6 +191,75 @@ describe('<CollapsiblePanel />', () => {
     );
   });
 
+  it('should include tenantId in custom filter link when tenant is set', async () => {
+    const {user} = render(<CollapsiblePanel />, {
+      wrapper: createWrapper(),
+    });
+
+    storeStateLocally('customFilters', {
+      custom: {
+        status: 'all',
+        assignee: 'all',
+        tenant: '<default>',
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: 'Expand to show filters'}),
+    );
+
+    expect(screen.getByRole('link', {name: 'Custom'})).toHaveAttribute(
+      'href',
+      '/?tenantId=%3Cdefault%3E&filter=custom',
+    );
+  });
+
+  it('should not include tenantId in custom filter link when tenant is empty string', async () => {
+    const {user} = render(<CollapsiblePanel />, {
+      wrapper: createWrapper(),
+    });
+
+    storeStateLocally('customFilters', {
+      custom: {
+        status: 'all',
+        assignee: 'all',
+        tenant: '',
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: 'Expand to show filters'}),
+    );
+
+    expect(screen.getByRole('link', {name: 'Custom'})).toHaveAttribute(
+      'href',
+      '/?filter=custom',
+    );
+  });
+
+  it('should clean up tenantId when switching from custom filter with tenant to built-in filter', async () => {
+    const {user} = render(<CollapsiblePanel />, {
+      wrapper: createWrapper(['/?filter=custom&tenantId=%3Cdefault%3E']),
+    });
+
+    storeStateLocally('customFilters', {
+      custom: {
+        status: 'all',
+        assignee: 'all',
+        tenant: '<default>',
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: 'Expand to show filters'}),
+    );
+
+    expect(screen.getByRole('link', {name: 'All open tasks'})).toHaveAttribute(
+      'href',
+      '/?filter=all-open',
+    );
+  });
+
   it('should not erase existing search params', async () => {
     const {user} = render(<CollapsiblePanel />, {
       wrapper: createWrapper(['/tasks?filter=completed&foo=bar']),

--- a/tasklist/client/src/common/tasks/filters/prepareCustomFiltersParams.ts
+++ b/tasklist/client/src/common/tasks/filters/prepareCustomFiltersParams.ts
@@ -63,7 +63,7 @@ function prepareCustomFiltersParams(
     params.processDefinitionKey = bpmnProcess!;
   }
 
-  if (tenant !== undefined) {
+  if (tenant !== undefined && tenant !== '') {
     if (clientMode === 'v1') {
       params.tenantIds = JSON.stringify([tenant]);
     } else {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On this PR:
- Fix custom filter cleanup when switching filters
- Fixes default tenant selection
- Add extra check for empty strings on tenant field

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #37296
