### PR TITLE
fix: optimize, accept allowed roles only for specific organization

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
@@ -249,7 +249,8 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
   @SuppressWarnings("unchecked")
   private OAuth2TokenValidator<Jwt> createIdTokenValidators() {
     // Only include role validation for ID tokens
-    final OAuth2TokenValidator<Jwt> roleValidator = new RoleValidator(ALLOWED_ORG_ROLES);
+    final OAuth2TokenValidator<Jwt> roleValidator =
+        new RoleValidator(ALLOWED_ORG_ROLES, getAuth0Configuration().getOrganizationId());
 
     // The role validation uses organization claims which are present in ID tokens
     return JwtValidators.createDefaultWithValidators(roleValidator);
@@ -269,7 +270,8 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
                 .getUserAccessTokenAudience()
                 .orElse(""));
     final OAuth2TokenValidator<Jwt> profileValidator = new ScopeValidator("profile");
-    final OAuth2TokenValidator<Jwt> roleValidator = new RoleValidator(ALLOWED_ORG_ROLES);
+    final OAuth2TokenValidator<Jwt> roleValidator =
+        new RoleValidator(ALLOWED_ORG_ROLES, getAuth0Configuration().getOrganizationId());
     // The default validator already contains validation for timestamp and X509 thumbprint
     final OAuth2TokenValidator<Jwt> combinedValidatorWithDefaults =
         JwtValidators.createDefaultWithValidators(

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/oauth/RoleValidator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/oauth/RoleValidator.java
@@ -25,9 +25,11 @@ public class RoleValidator implements OAuth2TokenValidator<Jwt> {
   private static final Logger LOG = LoggerFactory.getLogger(RoleValidator.class);
 
   private final List<String> allowedRoles;
+  private final String organizationId;
 
-  public RoleValidator(final List<String> allowedRoles) {
+  public RoleValidator(final List<String> allowedRoles, final String organizationId) {
     this.allowedRoles = Objects.requireNonNull(allowedRoles, "allowedRoles must not be null");
+    this.organizationId = Objects.requireNonNull(organizationId, "organizationId must not be null");
   }
 
   @Override
@@ -60,14 +62,21 @@ public class RoleValidator implements OAuth2TokenValidator<Jwt> {
 
   private boolean hasAllowedRole(final Collection<?> claimedOrgs) {
     for (final Object claimedOrg : claimedOrgs) {
-      if (claimedOrg instanceof final Map<?, ?> orgDetails) {
-        final Object rolesObj = orgDetails.get("roles");
-        if (rolesObj instanceof final Collection<?> userRoles) {
-          for (final Object userRole : userRoles) {
-            if (userRole instanceof String && allowedRoles.contains(userRole)) {
-              LOG.debug("User has allowed role '{}' for Optimize access", userRole);
-              return true;
-            }
+      if (!(claimedOrg instanceof final Map<?, ?> orgDetails)) {
+        continue;
+      }
+
+      // https://github.com/camunda/camunda/issues/39350 allowed roles per organization
+      if (!organizationId.equals(orgDetails.get("id"))) {
+        continue;
+      }
+
+      final Object rolesObj = orgDetails.get("roles");
+      if (rolesObj instanceof final Collection<?> userRoles) {
+        for (final Object userRole : userRoles) {
+          if (userRole instanceof String role && allowedRoles.contains(role)) {
+            LOG.debug("User has allowed role '{}' for Optimize access", role);
+            return true;
           }
         }
       }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/oauth/RoleValidator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/oauth/RoleValidator.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -35,8 +36,10 @@ public class RoleValidator implements OAuth2TokenValidator<Jwt> {
   @Override
   public OAuth2TokenValidatorResult validate(final Jwt token) {
     final var claimValue = token.getClaims().get(ORGANIZATION_CLAIM_KEY);
-    if (claimValue == null) {
-      LOG.debug("Rejected token: missing organization claim '{}'", ORGANIZATION_CLAIM_KEY);
+
+    if (!(claimValue instanceof Collection<?> claimedOrgs)) {
+      LOG.debug(
+          "Rejected token: missing or invalid organization claim '{}'", ORGANIZATION_CLAIM_KEY);
       return OAuth2TokenValidatorResult.failure(
           new OAuth2Error(
               OAuth2ErrorCodes.INVALID_TOKEN,
@@ -44,43 +47,48 @@ public class RoleValidator implements OAuth2TokenValidator<Jwt> {
               null));
     }
 
-    if (claimValue instanceof final Collection<?> claimedOrgs) {
-      if (hasAllowedRole(claimedOrgs)) {
-        return OAuth2TokenValidatorResult.success();
-      }
-    }
-
-    LOG.debug(
-        "Rejected token with organizations '{}', required roles: {}", claimValue, allowedRoles);
-    return OAuth2TokenValidatorResult.failure(
-        new OAuth2Error(
-            OAuth2ErrorCodes.INVALID_TOKEN,
-            "Token does not contain required organization role for Optimize access. Required roles: %s"
-                .formatted(allowedRoles),
-            null));
+    return getClaimedOrgById(claimedOrgs)
+        .filter(this::hasAllowedRole)
+        .map(org -> OAuth2TokenValidatorResult.success())
+        .orElseGet(
+            () -> {
+              LOG.debug(
+                  "Rejected token with organizations '{}', required roles: {}",
+                  claimValue,
+                  allowedRoles);
+              return OAuth2TokenValidatorResult.failure(
+                  new OAuth2Error(
+                      OAuth2ErrorCodes.INVALID_TOKEN,
+                      "Token does not contain required organization role for Optimize access. Required roles: %s"
+                          .formatted(allowedRoles),
+                      null));
+            });
   }
 
-  private boolean hasAllowedRole(final Collection<?> claimedOrgs) {
-    for (final Object claimedOrg : claimedOrgs) {
-      if (!(claimedOrg instanceof final Map<?, ?> orgDetails)) {
-        continue;
-      }
+  private Optional<? extends Map<?, ?>> getClaimedOrgById(final Collection<?> claimedOrgs) {
+    LOG.debug("Getting claimed organization with id: {}", organizationId);
+    return claimedOrgs.stream()
+        .filter(org -> org instanceof Map<?, ?>)
+        .map(org -> (Map<?, ?>) org)
+        .filter(org -> organizationId.equals(org.get("id")))
+        .findFirst();
+  }
 
-      // https://github.com/camunda/camunda/issues/39350 allowed roles per organization
-      if (!organizationId.equals(orgDetails.get("id"))) {
-        continue;
-      }
-
-      final Object rolesObj = orgDetails.get("roles");
-      if (rolesObj instanceof final Collection<?> userRoles) {
-        for (final Object userRole : userRoles) {
-          if (userRole instanceof String role && allowedRoles.contains(role)) {
-            LOG.debug("User has allowed role '{}' for Optimize access", role);
-            return true;
-          }
-        }
-      }
+  private boolean hasAllowedRole(final Map<?, ?> claimedOrg) {
+    final Object rolesObj = claimedOrg.get("roles");
+    if (!(rolesObj instanceof Collection<?> userRoles)) {
+      return false;
     }
-    return false;
+    return userRoles.stream()
+        .filter(String.class::isInstance)
+        .map(String.class::cast)
+        .anyMatch(
+            role -> {
+              if (allowedRoles.contains(role)) {
+                LOG.debug("User has allowed role '{}' for Optimize access", role);
+                return true;
+              }
+              return false;
+            });
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.rest.security.oauth;
 
+import static io.camunda.optimize.rest.security.oauth.RoleValidator.ORGANIZATION_CLAIM_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -22,9 +23,10 @@ import org.springframework.security.oauth2.jwt.Jwt;
 
 class RoleValidatorTest {
 
-  private static final String ORGANIZATION_ID = "org1";
+  private static final String ORGANIZATION_ID_1 = "org1";
+  private static final String ORGANIZATION_ID_2 = "org2";
   private final List<String> allowedRoles = Arrays.asList("admin", "analyst", "owner");
-  private final RoleValidator validator = new RoleValidator(allowedRoles, ORGANIZATION_ID);
+  private final RoleValidator validator = new RoleValidator(allowedRoles, ORGANIZATION_ID_1);
 
   @Test
   void shouldFailWhenTokenHasNoOrganizationClaim() {
@@ -46,9 +48,9 @@ class RoleValidatorTest {
     final Jwt token = mock(Jwt.class);
     final Map<String, Object> claims = new HashMap<>();
     final Map<String, Object> org = new HashMap<>();
-    org.put("id", "org1");
+    org.put("id", ORGANIZATION_ID_1);
     org.put("roles", Arrays.asList("admin", "developer"));
-    claims.put("https://camunda.com/orgs", List.of(org));
+    claims.put(ORGANIZATION_CLAIM_KEY, List.of(org));
     when(token.getClaims()).thenReturn(claims);
 
     // when
@@ -64,12 +66,12 @@ class RoleValidatorTest {
     final Jwt token = mock(Jwt.class);
     final Map<String, Object> claims = new HashMap<>();
     final Map<String, Object> org1 = new HashMap<>();
-    org1.put("id", "org1");
+    org1.put("id", ORGANIZATION_ID_1);
     org1.put("roles", List.of("analyst"));
     final Map<String, Object> org2 = new HashMap<>();
-    org2.put("id", "org2");
+    org2.put("id", ORGANIZATION_ID_2);
     org2.put("roles", List.of("developer"));
-    claims.put("https://camunda.com/orgs", Arrays.asList(org1, org2));
+    claims.put(ORGANIZATION_CLAIM_KEY, Arrays.asList(org1, org2));
     when(token.getClaims()).thenReturn(claims);
 
     // when
@@ -85,12 +87,12 @@ class RoleValidatorTest {
     final Jwt token = mock(Jwt.class);
     final Map<String, Object> claims = new HashMap<>();
     final Map<String, Object> org1 = new HashMap<>();
-    org1.put("id", "org1");
+    org1.put("id", ORGANIZATION_ID_1);
     org1.put("roles", List.of("developer"));
     final Map<String, Object> org2 = new HashMap<>();
-    org2.put("id", "org2");
+    org2.put("id", ORGANIZATION_ID_2);
     org2.put("roles", List.of("analyst"));
-    claims.put("https://camunda.com/orgs", Arrays.asList(org1, org2));
+    claims.put(ORGANIZATION_CLAIM_KEY, Arrays.asList(org1, org2));
     when(token.getClaims()).thenReturn(claims);
 
     // when
@@ -107,9 +109,9 @@ class RoleValidatorTest {
     final Jwt token = mock(Jwt.class);
     final Map<String, Object> claims = new HashMap<>();
     final Map<String, Object> org = new HashMap<>();
-    org.put("id", "org1");
+    org.put("id", ORGANIZATION_ID_1);
     org.put("roles", Arrays.asList("developer", "viewer"));
-    claims.put("https://camunda.com/orgs", List.of(org));
+    claims.put(ORGANIZATION_CLAIM_KEY, List.of(org));
     when(token.getClaims()).thenReturn(claims);
 
     // when
@@ -126,9 +128,9 @@ class RoleValidatorTest {
     final Jwt token = mock(Jwt.class);
     final Map<String, Object> claims = new HashMap<>();
     final Map<String, Object> org = new HashMap<>();
-    org.put("id", "org1");
+    org.put("id", ORGANIZATION_ID_1);
     org.put("roles", Collections.emptyList());
-    claims.put("https://camunda.com/orgs", List.of(org));
+    claims.put(ORGANIZATION_CLAIM_KEY, List.of(org));
     when(token.getClaims()).thenReturn(claims);
 
     // when
@@ -143,7 +145,7 @@ class RoleValidatorTest {
     // given
     final Jwt token = mock(Jwt.class);
     final Map<String, Object> claims = new HashMap<>();
-    claims.put("https://camunda.com/orgs", Collections.emptyList());
+    claims.put(ORGANIZATION_CLAIM_KEY, Collections.emptyList());
     when(token.getClaims()).thenReturn(claims);
 
     // when
@@ -158,7 +160,7 @@ class RoleValidatorTest {
     // given
     final Jwt token = mock(Jwt.class);
     final Map<String, Object> claims = new HashMap<>();
-    claims.put("https://camunda.com/orgs", "invalid-structure");
+    claims.put(ORGANIZATION_CLAIM_KEY, "invalid-structure");
     when(token.getClaims()).thenReturn(claims);
 
     // when

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
@@ -22,8 +22,9 @@ import org.springframework.security.oauth2.jwt.Jwt;
 
 class RoleValidatorTest {
 
+  private static final String ORGANIZATION_ID = "org1";
   private final List<String> allowedRoles = Arrays.asList("admin", "analyst", "owner");
-  private final RoleValidator validator = new RoleValidator(allowedRoles);
+  private final RoleValidator validator = new RoleValidator(allowedRoles, ORGANIZATION_ID);
 
   @Test
   void shouldFailWhenTokenHasNoOrganizationClaim() {
@@ -58,8 +59,29 @@ class RoleValidatorTest {
   }
 
   @Test
-  void shouldSucceedWhenUserHasAllowedRoleInAnyOrg() {
-    // given
+  void shouldSucceedWhenUserHasAllowedRoleInCorrectOrg() {
+    // given - user has "analyst" in org1 (the configured org) and only disallowed roles in org2
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org1 = new HashMap<>();
+    org1.put("id", "org1");
+    org1.put("roles", List.of("analyst"));
+    final Map<String, Object> org2 = new HashMap<>();
+    org2.put("id", "org2");
+    org2.put("roles", List.of("developer"));
+    claims.put("https://camunda.com/orgs", Arrays.asList(org1, org2));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldFailWhenUserHasAllowedRoleInDifferentOrgOnly() {
+    // given - user2 has "analyst" in org2 but the cluster belongs to org1 (the bug scenario)
     final Jwt token = mock(Jwt.class);
     final Map<String, Object> claims = new HashMap<>();
     final Map<String, Object> org1 = new HashMap<>();
@@ -75,7 +97,8 @@ class RoleValidatorTest {
     final OAuth2TokenValidatorResult result = validator.validate(token);
 
     // then
-    assertThat(result.hasErrors()).isFalse();
+    assertThat(result.hasErrors()).isTrue();
+    assertThat(result.getErrors().iterator().next().getErrorCode()).isEqualTo("invalid_token");
   }
 
   @Test


### PR DESCRIPTION
## Description

- `RoleValidator` is instantiated only from `CCSaaSSecurityConfigurerAdapter`
- Camunda SaaS infrastructure/platform provisioning layer, should always provide `organizationId`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #39350 -- will close once backported successfully
