### PR TITLE
test: 8.9 changed skip location

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
@@ -16,8 +16,10 @@ import {
 import {deploy} from '../../../../utils/zeebeClient';
 import {createProcessInstanceAndRetrieveTimeStamp} from '@requestHelpers';
 
-test.describe('Pin Clock API Tests', () => {
+//Skipped due to bug 48562: https://github.com/camunda/camunda/issues/48562
+test.describe.skip('Pin Clock API Tests', () => {
   let processDefinitionId: string;
+
   test.beforeAll(async ({request}) => {
     await test.step('Deploy process definition', async () => {
       const deployment = await deploy([
@@ -43,8 +45,7 @@ test.describe('Pin Clock API Tests', () => {
     await assertStatusCode(res, 204);
   });
 
-  //Skipped due to bug 48562: https://github.com/camunda/camunda/issues/48562
-  test.skip('Pin clock to a fixed instant', async ({request}) => {
+  test('Pin clock to a fixed instant', async ({request}) => {
     const timestamp = Date.parse('2025-01-01T00:00:00Z');
 
     await test.step('Pin clock to fixed instant and verify', async () => {
@@ -73,8 +74,7 @@ test.describe('Pin Clock API Tests', () => {
     });
   });
 
-  //Skipped due to bug 48562: https://github.com/camunda/camunda/issues/48562
-  test.skip('Pin clock - bad request', async ({request}) => {
+  test('Pin clock - bad request', async ({request}) => {
     const someInvalidData = 'meow';
     const pin = await request.put(buildUrl('/clock'), {
       data: {timestamp: someInvalidData},


### PR DESCRIPTION
## Description

After all section of the test might affect other tests due to clock bug. So moved the bug skip to the top.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
