### PR TITLE
feat: require continuous backups when backup store is configured with RDBMS

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -791,6 +791,7 @@ public class BrokerBasedPropertiesOverride {
       final BrokerBasedProperties override, final PrimaryStorageBackup primaryStorageBackup) {
 
     validateSchedulerConfiguration(primaryStorageBackup);
+    validateContinuousBackupsForRdbms(primaryStorageBackup);
 
     final BackupCfg backupCfg = override.getData().getBackup();
     backupCfg.setRequired(primaryStorageBackup.isRequired());
@@ -812,6 +813,17 @@ public class BrokerBasedPropertiesOverride {
       throw new IllegalArgumentException(
           "Continuous backups are not compatible with secondary storage: `%s`. Please disable continuous backups."
               .formatted(dbType));
+    }
+  }
+
+  private void validateContinuousBackupsForRdbms(final PrimaryStorageBackup primaryStorageBackup) {
+    final var dbType = unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getType();
+    final var backupStoreConfigured =
+        primaryStorageBackup.getStore() != PrimaryStorageBackup.BackupStoreType.NONE;
+    if (dbType.isRdbms() && backupStoreConfigured && !primaryStorageBackup.isContinuous()) {
+      throw new IllegalArgumentException(
+          "Continuous backups must be enabled when a backup store is configured and RDBMS is used as secondary storage. "
+              + "Please set 'camunda.data.primary-storage.backup.continuous=true'.");
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
@@ -340,6 +340,82 @@ public class PrimaryStorageBackupPropertiesTest {
     }
 
     @Test
+    void shouldStartOnRdbmsWithBackupStoreAndContinuousEnabled() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.store",
+              "S3",
+              "camunda.data.primary-storage.backup.continuous",
+              "true",
+              "camunda.data.secondary-storage.type",
+              "rdbms");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should succeed
+      assertThatCode(app::run).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailOnRdbmsWithBackupStoreAndContinuousDisabled() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.store",
+              "S3",
+              "camunda.data.primary-storage.backup.continuous",
+              "false",
+              "camunda.data.secondary-storage.type",
+              "rdbms");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should fail
+      assertThatThrownBy(app::run)
+          .hasRootCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining(
+              "Continuous backups must be enabled when a backup store is configured and RDBMS is used as secondary storage");
+    }
+
+    @Test
+    void shouldStartOnRdbmsWithNoBackupStore() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.store",
+              "NONE",
+              "camunda.data.secondary-storage.type",
+              "rdbms");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should succeed
+      assertThatCode(app::run).doesNotThrowAnyException();
+    }
+
+    @Test
     void shouldStartOnNoDb() {
 
       // given


### PR DESCRIPTION
Adds startup validation that requires continuous backups to be enabled when a backup store is configured and RDBMS is used as secondary storage. Without continuous backups, restoring from a backup would leave the primary and secondary storage out of sync, since RDBMS does not support snapshot-based backups like Elasticsearch/Opensearch.

The validation is added as a dedicated `validateContinuousBackupsForRdbms` method in `BrokerBasedPropertiesOverride`, called from `populateBackupScheduler` alongside the existing `validateSchedulerConfiguration`. The application will now fail to start with a clear error message if `camunda.data.primary-storage.backup.store` is set to anything other than `NONE` and `camunda.data.secondary-storage.type` is `rdbms` but `camunda.data.primary-storage.backup.continuous` is not `true`.