### PR TITLE
[Backport stable/8.9] fix: follow-up fix to conversion validation errors to avoid NPEs when converting lists of operations

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
@@ -166,6 +166,10 @@ public class AdvancedSearchFilterUtil {
     final var tValues = new ArrayList<T>();
     boolean hasNull = false;
     for (final Object v : values) {
+      if (v == null) {
+        hasNull = true;
+        continue;
+      }
       final T converted = converter.apply(v);
       if (converted == null) {
         hasNull = true;

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
@@ -397,4 +397,54 @@ class AdvancedSearchFilterUtilTest {
     assertThat(errors).hasSize(2);
     assertThat(actual).isEmpty();
   }
+
+  @Test
+  void shouldHandleNullElementInListForStringOperations() {
+    // given
+    final var filter = new BasicStringFilter();
+    filter.set$In(nullableList("a", null, "b"));
+
+    // when
+    final var actual = AdvancedSearchFilterUtil.mapToStringOperations().apply(filter);
+
+    // then — null element causes the whole operation to be dropped
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void shouldHandleNullElementInListForKeyOperations() {
+    // given
+    final var filter = new BasicStringFilter();
+    filter.set$In(nullableList("123", null));
+    final var errors = new ArrayList<String>();
+
+    // when
+    final var actual = AdvancedSearchFilterUtil.mapToKeyOperations("key", errors).apply(filter);
+
+    // then — null element causes the whole operation to be dropped
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void shouldHandleNullElementInListForIntegerOperations() {
+    // given
+    final var filter = new AdvancedIntegerFilter();
+    filter.set$In(nullableList(1, null, 2));
+    final var errors = new ArrayList<String>();
+
+    // when
+    final var actual =
+        AdvancedSearchFilterUtil.mapToIntegerOperations("retries", errors).apply(filter);
+
+    // then — null element causes the whole operation to be dropped
+    assertThat(actual).isEmpty();
+  }
+
+  /** Creates an ArrayList that allows null elements (unlike List.of). */
+  @SafeVarargs
+  private static <T> List<T> nullableList(final T... elements) {
+    final var list = new ArrayList<T>(elements.length);
+    java.util.Collections.addAll(list, elements);
+    return list;
+  }
 }


### PR DESCRIPTION
# Description
Backport of #48830 to `stable/8.9`.

relates to #48578