### PR TITLE
refactor: copy variables panel tests to new variables-tab

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/NewVariableModifications.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {
   render,
   screen,
@@ -225,10 +225,7 @@ describe('New Variable Modifications', () => {
     modificationsStore.enableModificationMode();
     modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
     });
@@ -262,10 +259,7 @@ describe('New Variable Modifications', () => {
     modificationsStore.enableModificationMode();
     modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
     });
@@ -326,10 +320,7 @@ describe('New Variable Modifications', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
     });
@@ -432,10 +423,7 @@ describe('New Variable Modifications', () => {
     modificationsStore.enableModificationMode();
     modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
     });
@@ -478,7 +466,7 @@ describe('New Variable Modifications', () => {
 
     const {user} = render(
       <>
-        <VariablePanel setListenerTabVisibility={vi.fn()} />
+        <VariablesTab />
         <LastModification />
       </>,
       {wrapper: getWrapper()},
@@ -671,10 +659,7 @@ describe('New Variable Modifications', () => {
     modificationsStore.enableModificationMode();
     modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
 
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
@@ -765,10 +750,7 @@ describe('New Variable Modifications', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
     });
@@ -933,14 +915,11 @@ describe('New Variable Modifications', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {
-        wrapper: getWrapper([
-          `${Paths.processInstance('instance_id')}?elementId=element-that-has-not-run-yet`,
-        ]),
-      },
-    );
+    const {user} = render(<VariablesTab />, {
+      wrapper: getWrapper([
+        `${Paths.processInstance('instance_id')}?elementId=element-that-has-not-run-yet`,
+      ]),
+    });
     expect(
       await screen.findByText('The element has no variables'),
     ).toBeInTheDocument();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/NewVariableModifications.test.tsx
@@ -1,0 +1,1007 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {
+  render,
+  screen,
+  fireEvent,
+  type UserEvent,
+  waitFor,
+} from 'modules/testing-library';
+
+import {LastModification} from 'App/ProcessInstance/LastModification';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {createVariable} from 'modules/testUtils';
+import {
+  modificationsStore,
+  type ElementModification,
+} from 'modules/stores/modifications';
+import {useEffect} from 'react';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.9';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+
+/**
+ * Variables can only be added and modified in the root if a pending add/move token modification exists.
+ * Tests need to queue this modification first, before they can make changes to the root variables.
+ */
+const INITIAL_ADD_MODIFICATION: ElementModification = {
+  type: 'token',
+  payload: {
+    affectedTokenCount: 1,
+    element: {
+      id: 'element_0',
+      name: 'element 0',
+    },
+    operation: 'ADD_TOKEN',
+    parentScopeIds: {},
+    scopeId: 'random-scope-id-0',
+    visibleAffectedTokenCount: 1,
+  },
+};
+
+const editLastNewVariableName = async (
+  user: UserEvent,
+  value: string,
+  index: number = 0,
+) => {
+  const nameField = screen.getAllByTestId('new-variable-name').at(-1);
+
+  if (!nameField) {
+    throw new Error(`No name field found at index ${index}`);
+  }
+
+  await user.click(nameField);
+  fireEvent.focus(nameField);
+  await user.type(nameField, value);
+  await user.tab();
+};
+
+const editLastNewVariableValue = async (
+  user: UserEvent,
+  value: string,
+  index: number = 0,
+) => {
+  const valueField = screen.getAllByTestId('new-variable-value').at(-1);
+
+  if (!valueField) {
+    throw new Error(`No value field found at index ${index}`);
+  }
+
+  await user.click(valueField);
+  await user.type(valueField, value);
+  await user.tab();
+};
+
+const TestSelectionControls: React.FC = () => {
+  const {selectElementInstance, selectElement, clearSelection} =
+    useProcessInstanceElementSelection();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'TEST_ELEMENT',
+            elementInstanceKey: 'instance_id',
+          })
+        }
+      >
+        select element instance
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElement({
+            elementId: 'element-that-has-not-run-yet',
+          })
+        }
+      >
+        select element from diagram
+      </button>
+      <button type="button" onClick={() => clearSelection()}>
+        clear selection
+      </button>
+    </>
+  );
+};
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('instance_id')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+              <Route
+                path={Paths.processInstance()}
+                element={
+                  <>
+                    <TestSelectionControls />
+                    {children}
+                  </>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('New Variable Modifications', () => {
+  const mockProcessInstance: ProcessInstance = {
+    processInstanceKey: 'instance_id',
+    state: 'ACTIVE',
+    startDate: '2018-06-21',
+    endDate: null,
+    processDefinitionKey: '2',
+    processDefinitionVersion: 1,
+    processDefinitionVersionTag: null,
+    processDefinitionId: 'someKey',
+    tenantId: '<default>',
+    processDefinitionName: 'someProcessName',
+    hasIncident: false,
+    parentProcessInstanceKey: null,
+    parentElementInstanceKey: null,
+    rootProcessInstanceKey: null,
+    tags: [],
+  };
+
+  beforeEach(async () => {
+    const statisticsData = [
+      {
+        elementId: 'TEST_ELEMENT',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 1,
+        completed: 0,
+      },
+    ];
+
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statisticsData,
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess('');
+  });
+
+  it('should not create add variable modification if fields are empty', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    vi.runOnlyPendingTimers();
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+    await user.click(screen.getByTestId('new-variable-name'));
+    await user.tab();
+    await user.click(screen.getByTestId('new-variable-value'));
+    await user.tab();
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeDisabled();
+    expect(modificationsStore.state.modifications.length).toBe(1);
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not create add variable modification if name field is empty', async () => {
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+    await user.click(screen.getByTestId('new-variable-name'));
+    await user.tab();
+    await editLastNewVariableValue(user, '123');
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeDisabled();
+    expect(
+      await screen.findByText(/Name has to be filled/i),
+    ).toBeInTheDocument();
+    expect(modificationsStore.state.modifications.length).toBe(1);
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not create add variable modification if name field is duplicate', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+    await editLastNewVariableName(user, 'testVariableName');
+    await editLastNewVariableValue(user, '123');
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {name: /add variable/i}),
+      ).toBeDisabled(),
+    );
+    expect(
+      await screen.findByText(/Name should be unique/i),
+    ).toBeInTheDocument();
+
+    await user.clear(screen.getByTestId('new-variable-name'));
+    await editLastNewVariableName(user, 'test2');
+
+    expect(modificationsStore.state.modifications).toEqual([
+      INITIAL_ADD_MODIFICATION,
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2',
+          newValue: '123',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+    ]);
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    await editLastNewVariableName(user, 'test2');
+    await editLastNewVariableValue(user, '1234');
+    expect(
+      await screen.findByText(/Name should be unique/i),
+    ).toBeInTheDocument();
+    expect(modificationsStore.state.modifications).toEqual([
+      INITIAL_ADD_MODIFICATION,
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2',
+          newValue: '123',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+    ]);
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not create add variable modification if value field is empty or invalid', async () => {
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+
+    await editLastNewVariableName(user, 'test2');
+    await user.click(screen.getByTestId('new-variable-value'));
+    await user.tab();
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeDisabled();
+    expect(
+      await screen.findByText(/Value has to be filled/i),
+    ).toBeInTheDocument();
+    expect(modificationsStore.state.modifications.length).toBe(1);
+    await editLastNewVariableValue(user, 'invalid value');
+    expect(
+      await screen.findByText(/Value has to be JSON/i),
+    ).toBeInTheDocument();
+    expect(modificationsStore.state.modifications.length).toBe(1);
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should create add variable modification on blur and update same modification if name or value is changed', async () => {
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+    const {user} = render(
+      <>
+        <VariablePanel setListenerTabVisibility={vi.fn()} />
+        <LastModification />
+      </>,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+
+    await editLastNewVariableName(user, 'test2');
+    await editLastNewVariableValue(user, '12345');
+
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    expect(modificationsStore.state.modifications).toEqual([
+      INITIAL_ADD_MODIFICATION,
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+    ]);
+
+    await user.click(screen.getByTestId('new-variable-name'));
+    await user.tab();
+    await user.click(screen.getByTestId('new-variable-value'));
+    await user.tab();
+
+    expect(modificationsStore.state.modifications).toEqual([
+      INITIAL_ADD_MODIFICATION,
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+    ]);
+
+    await editLastNewVariableName(user, '-updated');
+
+    expect(modificationsStore.state.modifications).toEqual([
+      INITIAL_ADD_MODIFICATION,
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2-updated',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+    ]);
+
+    expect(
+      modificationsStore.getAddVariableModifications('instance_id'),
+    ).toEqual([
+      {
+        id: expect.any(String),
+        name: 'test2-updated',
+        value: '12345',
+      },
+    ]);
+
+    await editLastNewVariableValue(user, '678');
+    expect(modificationsStore.state.modifications).toEqual([
+      INITIAL_ADD_MODIFICATION,
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2-updated',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2-updated',
+          newValue: '12345678',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+    ]);
+
+    expect(
+      modificationsStore.getAddVariableModifications('instance_id'),
+    ).toEqual([
+      {
+        id: expect.any(String),
+        name: 'test2-updated',
+        value: '12345678',
+      },
+    ]);
+
+    await user.click(screen.getByRole('button', {name: 'Undo'}));
+
+    expect(modificationsStore.state.modifications).toEqual([
+      INITIAL_ADD_MODIFICATION,
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2-updated',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+    ]);
+
+    expect(
+      modificationsStore.getAddVariableModifications('instance_id'),
+    ).toEqual([
+      {
+        id: expect.any(String),
+        name: 'test2-updated',
+        value: '12345',
+      },
+    ]);
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not apply modification if value is the same as the last modification', async () => {
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('new-variable-name'));
+    await user.tab();
+
+    await user.click(screen.getByTestId('new-variable-value'));
+    await user.tab();
+
+    await user.clear(screen.getByTestId('new-variable-name'));
+    await editLastNewVariableName(user, 'test2');
+    await user.clear(screen.getByTestId('new-variable-value'));
+    await editLastNewVariableValue(user, '12345');
+
+    expect(modificationsStore.state.modifications).toEqual([
+      INITIAL_ADD_MODIFICATION,
+      {
+        payload: {
+          elementName: 'someProcessName',
+          id: expect.any(String),
+          name: 'test2',
+          newValue: '12345',
+          operation: 'ADD_VARIABLE',
+          scopeId: 'instance_id',
+        },
+        type: 'variable',
+      },
+    ]);
+
+    expect(
+      modificationsStore.getAddVariableModifications('instance_id'),
+    ).toEqual([
+      {
+        id: expect.any(String),
+        name: 'test2',
+        value: '12345',
+      },
+    ]);
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should be able to remove the first added variable modification after switching between element instances', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    // add first variable
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+
+    await editLastNewVariableName(user, 'test1');
+    await editLastNewVariableValue(user, '123');
+
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+
+    // add second variable
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findAllByTestId('new-variable-name')).toHaveLength(2);
+
+    await editLastNewVariableName(user, 'test2', 1);
+    await editLastNewVariableValue(user, '456', 1);
+
+    mockFetchElementInstance('instance_id').withSuccess({
+      elementInstanceKey: 'instance_id',
+      elementId: 'TEST_ELEMENT',
+      elementName: 'Test Element',
+      type: 'SERVICE_TASK',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      endDate: null,
+      processInstanceKey: 'instance_id',
+      processDefinitionKey: '2',
+      processDefinitionId: 'someKey',
+      tenantId: '<default>',
+      hasIncident: false,
+      rootProcessInstanceKey: null,
+      incidentKey: null,
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: /select element instance/i}),
+    );
+
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(screen.getByRole('button', {name: /clear selection/i}));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    const [deleteFirstAddedVariable] = screen.getAllByRole('button', {
+      name: /delete variable/i,
+    });
+    await user.click(deleteFirstAddedVariable!);
+
+    expect(screen.queryByDisplayValue('test1')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('123')).not.toBeInTheDocument();
+
+    expect(screen.getByDisplayValue('test2')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('456')).toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should be able to add variable when a element that has no tokens on it is selected from the diagram', async () => {
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification({
+      type: 'token',
+      payload: {
+        operation: 'ADD_TOKEN',
+        element: {
+          id: 'element-that-has-not-run-yet',
+          name: 'some-element',
+        },
+        scopeId: 'some-scope-id',
+        affectedTokenCount: 1,
+        visibleAffectedTokenCount: 1,
+        parentScopeIds: {},
+      },
+    });
+
+    mockSearchElementInstances().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {
+        wrapper: getWrapper([
+          `${Paths.processInstance('instance_id')}?elementId=element-that-has-not-run-yet`,
+        ]),
+      },
+    );
+    expect(
+      await screen.findByText('The element has no variables'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+
+    await editLastNewVariableName(user, 'test1');
+    await editLastNewVariableValue(user, '123');
+
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchElementInstances().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: /select element from diagram/i}),
+    );
+
+    expect(await screen.findByDisplayValue('test1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
@@ -13,7 +13,7 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockVariables} from './index.setup';
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 
 describe('Add variable', () => {
   beforeEach(() => {
@@ -37,12 +37,9 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
+    const {user} = render(<VariablesTab />, {
+      wrapper: getWrapper(),
+    });
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -97,10 +94,7 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -152,10 +146,7 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
 
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
@@ -260,10 +251,7 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -355,10 +343,7 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -430,10 +415,7 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -459,10 +441,7 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -512,10 +491,7 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -539,10 +515,7 @@ describe('Add variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
@@ -1,0 +1,566 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, within, waitFor} from 'modules/testing-library';
+import {getWrapper, mockProcessInstance} from './mocks';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockVariables} from './index.setup';
+import {VariablePanel} from '../index';
+
+describe('Add variable', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+  });
+
+  it('should show/hide add variable inputs', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('textbox', {
+        name: /name/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', {
+        name: /value/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+
+    // clicks are not doing anything because we mock context value... we need to either move the test elsewhere or mock the context properly
+    expect(
+      await screen.findByRole('textbox', {name: /name/i}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
+
+    expect(
+      screen.queryByRole('textbox', {
+        name: /name/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', {
+        name: /value/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not allow empty value', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {name: /save variable/i}),
+      ).toBeDisabled(),
+    );
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'test',
+    );
+    expect(screen.getByRole('button', {name: /save variable/i})).toBeDisabled();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '    ',
+    );
+
+    expect(screen.getByRole('button', {name: /save variable/i})).toBeDisabled();
+    expect(screen.queryByTitle('Value has to be JSON')).not.toBeInTheDocument();
+
+    vi.runOnlyPendingTimers();
+
+    expect(await screen.findByText('Value has to be JSON')).toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not allow empty characters in variable name', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+
+    expect(
+      await screen.findByRole('button', {
+        name: /save variable/i,
+      }),
+    ).toBeDisabled();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '123',
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    ).toBeDisabled();
+    vi.runOnlyPendingTimers();
+    expect(
+      await screen.findByText('Name has to be filled'),
+    ).toBeInTheDocument();
+
+    await user.dblClick(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      'test',
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    ).toBeDisabled();
+
+    expect(screen.getByText('Name has to be filled')).toBeInTheDocument();
+    expect(screen.queryByText('Value has to be JSON')).not.toBeInTheDocument();
+    vi.runOnlyPendingTimers();
+    expect(await screen.findByText('Value has to be JSON')).toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      '   ',
+    );
+
+    expect(screen.getByText('Value has to be JSON')).toBeInTheDocument();
+    vi.runOnlyPendingTimers();
+    expect(await screen.findByText('Name is invalid')).toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      ' test',
+    );
+
+    expect(screen.getByText('Value has to be JSON')).toBeInTheDocument();
+    expect(screen.getByText('Name is invalid')).toBeInTheDocument();
+
+    await user.dblClick(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '"valid value"',
+    );
+
+    expect(screen.queryByText('Value has to be JSON')).not.toBeInTheDocument();
+    expect(screen.getByText('Name is invalid')).toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not allow to add duplicate variables', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+
+    expect(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    ).toBeDisabled();
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      mockVariables.items[0]!.name,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    ).toBeDisabled();
+    expect(screen.queryByText('Name should be unique')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Value has to be filled'),
+    ).not.toBeInTheDocument();
+    vi.runOnlyPendingTimers();
+    expect(
+      await screen.findByText('Name should be unique'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Value has to be filled')).toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '123',
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.queryByText('Value has to be filled'),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByText('Name should be unique')).toBeInTheDocument();
+
+    await user.dblClick(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'someOtherName',
+    );
+
+    vi.runOnlyPendingTimers();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /save variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    expect(screen.queryByText('Name should be unique')).not.toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not allow to add variable with invalid name', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+
+    expect(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    ).toBeDisabled();
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      '"invalid"',
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '123',
+    );
+
+    vi.runOnlyPendingTimers();
+
+    expect(await screen.findByText('Name is invalid')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    ).toBeDisabled();
+
+    await user.clear(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'someOtherName',
+    );
+
+    vi.runOnlyPendingTimers();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /save variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    expect(screen.queryByText('Name is invalid')).not.toBeInTheDocument();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('clicking edit variables while add mode is open, should not display a validation error', async () => {
+    mockSearchVariables().withSuccess(mockVariables);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variable-clientNo')).toBeInTheDocument();
+    });
+    const withinVariable = within(screen.getByTestId('variable-clientNo'));
+    await user.click(
+      withinVariable.getByRole('button', {name: /edit variable/i}),
+    );
+    expect(
+      screen.queryByTitle('Name should be unique'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not exit add variable state when user presses Enter', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('textbox', {
+        name: /name/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', {
+        name: /value/i,
+      }),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+
+    expect(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+    ).toBeInTheDocument();
+
+    await user.keyboard('{Enter}');
+
+    expect(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should exit Add Variable mode when process is canceled', async () => {
+    mockFetchProcessInstance().withSuccess({
+      ...mockProcessInstance,
+      state: 'TERMINATED',
+    });
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(
+      screen.queryByRole('textbox', {
+        name: /name/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', {
+        name: /value/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should have JSON editor when adding a new Variable', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(
+      await screen.findByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    await user.click(screen.getByRole('button', {name: /open json editor/i}));
+
+    expect(
+      within(screen.getByRole('dialog')).getByRole('button', {name: /cancel/i}),
+    ).toBeEnabled();
+    expect(
+      within(screen.getByRole('dialog')).getByRole('button', {name: /apply/i}),
+    ).toBeEnabled();
+    expect(
+      await within(screen.getByRole('dialog')).findByTestId('monaco-editor'),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
@@ -1,0 +1,798 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  render,
+  screen,
+  within,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
+import {getWrapper, mockProcessInstance} from './mocks';
+import {createVariable} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {notificationsStore} from 'modules/stores/notifications';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockVariables} from './index.setup';
+import {mockGetVariable} from 'modules/mocks/api/v2/variables/getVariable';
+import {VariablePanel} from '../index';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockUpdateElementInstanceVariables} from 'modules/mocks/api/v2/elementInstances/updateElementInstanceVariables';
+import {act} from 'react';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+describe('Edit variable', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+  });
+
+  it('should disable edit buttons while a variable update is being submitted', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    const mockVariables = {
+      items: [
+        createVariable({
+          name: 'firstVariable',
+          value: '"initial-value"',
+          isTruncated: false,
+        }),
+        createVariable({
+          name: 'secondVariable',
+          value: '"another-value"',
+          isTruncated: false,
+        }),
+      ],
+      page: {
+        totalItems: 2,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    };
+
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    const firstVariableContainer = screen.getByTestId('variable-firstVariable');
+    const secondVariableContainer = screen.getByTestId(
+      'variable-secondVariable',
+    );
+
+    const firstEditButton = within(firstVariableContainer).getByRole('button', {
+      name: /edit variable/i,
+    });
+    const secondEditButton = within(secondVariableContainer).getByRole(
+      'button',
+      {name: /edit variable/i},
+    );
+
+    expect(firstEditButton).toBeEnabled();
+    expect(secondEditButton).toBeEnabled();
+
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(firstEditButton);
+
+    const editInput = await within(firstVariableContainer).findByTestId(
+      'edit-variable-value',
+    );
+    await user.clear(editInput);
+    await user.type(editInput, '"updated-value"');
+
+    vi.runOnlyPendingTimers();
+
+    const saveButton = within(firstVariableContainer).getByRole('button', {
+      name: /save variable/i,
+    });
+    await waitFor(() => {
+      expect(saveButton).toBeEnabled();
+    });
+
+    mockUpdateElementInstanceVariables('1').withDelay(null);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(saveButton);
+
+    expect(
+      within(firstVariableContainer).getByTestId('full-variable-loader'),
+    ).toBeInTheDocument();
+    expect(secondEditButton).toBeDisabled();
+
+    await waitForElementToBeRemoved(
+      within(firstVariableContainer).queryByTestId('full-variable-loader'),
+    );
+
+    expect(secondEditButton).toBeEnabled();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should show/hide edit variable inputs', async () => {
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockGetVariable().withSuccess(mockVariables.items[0]!);
+    mockGetVariable().withSuccess(mockVariables.items[0]!);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('add-variable-value')).not.toBeInTheDocument();
+
+    expect(await screen.findByTestId(`variable-clientNo`)).toBeInTheDocument();
+    const withinFirstVariable = within(screen.getByTestId(`variable-clientNo`));
+    expect(
+      withinFirstVariable.queryByTestId('edit-variable-value'),
+    ).not.toBeInTheDocument();
+    expect(
+      withinFirstVariable.queryByRole('button', {name: /exit edit mode/i}),
+    ).not.toBeInTheDocument();
+    expect(
+      withinFirstVariable.queryByRole('button', {name: /save variable/i}),
+    ).not.toBeInTheDocument();
+
+    expect(
+      await withinFirstVariable.findByRole('button', {name: /edit variable/i}),
+    ).toBeInTheDocument();
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(
+      withinFirstVariable.getByRole('button', {name: /edit variable/i}),
+    );
+
+    expect(
+      await withinFirstVariable.findByTestId('edit-variable-value'),
+    ).toBeInTheDocument();
+    expect(
+      withinFirstVariable.getByRole('button', {name: /exit edit mode/i}),
+    ).toBeInTheDocument();
+    expect(
+      withinFirstVariable.getByRole('button', {name: /save variable/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should disable save button when nothing is changed', async () => {
+    mockGetVariable().withSuccess(mockVariables.items[0]!);
+    mockGetVariable().withSuccess(mockVariables.items[0]!);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('add-variable-value')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`variable-clientNo`)).toBeInTheDocument();
+    });
+    const withinFirstVariable = within(screen.getByTestId(`variable-clientNo`));
+
+    expect(
+      await withinFirstVariable.findByRole('button', {name: /edit variable/i}),
+    ).toBeInTheDocument();
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(
+      withinFirstVariable.getByRole('button', {name: /edit variable/i}),
+    );
+
+    expect(
+      withinFirstVariable.getByRole('button', {name: /save variable/i}),
+    ).toBeDisabled();
+  });
+
+  it('should validate when editing variables', async () => {
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockGetVariable().withSuccess(mockVariables.items[0]!);
+    mockGetVariable().withSuccess(mockVariables.items[0]!);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`variable-clientNo`)).toBeInTheDocument();
+    });
+    const withinFirstVariable = within(screen.getByTestId(`variable-clientNo`));
+
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(
+      withinFirstVariable.getByRole('button', {name: /edit variable/i}),
+    );
+
+    expect(
+      await screen.findByTestId('edit-variable-value'),
+    ).toBeInTheDocument();
+    await user.type(
+      screen.getByTestId('edit-variable-value'),
+      "{{invalidKey: 'value'}}",
+    );
+
+    expect(screen.getByRole('button', {name: /save variable/i})).toBeDisabled();
+    expect(screen.queryByText('Value has to be JSON')).not.toBeInTheDocument();
+    vi.runOnlyPendingTimers();
+    expect(await screen.findByText('Value has to be JSON')).toBeInTheDocument();
+
+    await user.clear(screen.getByTestId('edit-variable-value'));
+    await user.type(screen.getByTestId('edit-variable-value'), '123');
+
+    vi.runOnlyPendingTimers();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {name: /save variable/i}),
+      ).toBeEnabled(),
+    );
+
+    expect(screen.queryByText('Value has to be JSON')).not.toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should get variable details on edit button click if the variables value was a preview', async () => {
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          name: 'clientNo',
+          value: '"value-preview"',
+          isTruncated: true,
+        }),
+        createVariable({
+          name: 'mwst',
+          value: '"124.26"',
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          name: 'clientNo',
+          value: '"value-preview"',
+          isTruncated: true,
+        }),
+        createVariable({
+          name: 'mwst',
+          value: '"124.26"',
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('"value-preview"')).toBeInTheDocument();
+    });
+
+    mockGetVariable().withSuccess(
+      createVariable({
+        name: 'clientNo',
+        value: '"full-value"',
+        isTruncated: false,
+      }),
+    );
+
+    expect(await screen.findByTestId('variable-clientNo')).toBeInTheDocument();
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(
+      within(screen.getByTestId('variable-clientNo')).getByRole('button', {
+        name: /edit variable/i,
+      }),
+    );
+
+    expect(screen.queryByText('"value-preview"')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-variable-value')).toHaveValue(
+        '"full-value"',
+      );
+    });
+    expect(
+      within(screen.getByTestId('variable-mwst')).getByRole('button', {
+        name: /edit variable/i,
+      }),
+    ).toBeEnabled();
+
+    expect(notificationsStore.displayNotification).not.toHaveBeenCalled();
+  });
+
+  it('should display notification if error occurs when getting single variable details', async () => {
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          value: '"value-preview"',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          value: '"value-preview"',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('"value-preview"')).toBeInTheDocument();
+    });
+
+    mockGetVariable().withServerError();
+
+    expect(
+      await screen.findByTestId('variable-testVariableName'),
+    ).toBeInTheDocument();
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(
+      within(screen.getByTestId('variable-testVariableName')).getByRole(
+        'button',
+        {
+          name: /edit variable/i,
+        },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        isDismissable: true,
+        kind: 'error',
+        title: 'Variable could not be fetched',
+      });
+    });
+  });
+
+  it('should not get variable details on edit button click if the variables value was not a preview', async () => {
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          value: '"full-value"',
+          isTruncated: false,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          value: '"full-value"',
+          isTruncated: false,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('"full-value"')).toBeInTheDocument();
+    });
+
+    expect(
+      await screen.findByTestId('variable-testVariableName'),
+    ).toBeInTheDocument();
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(
+      within(screen.getByTestId('variable-testVariableName')).getByRole(
+        'button',
+        {
+          name: /edit variable/i,
+        },
+      ),
+    );
+
+    expect(
+      screen.queryByTestId('full-variable-loader'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should load full value on focus during modification mode if it was truncated', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess('');
+
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          value: '123',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          value: '123',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockGetVariable().withSuccess(
+      createVariable({
+        value: '123456',
+        isTruncated: false,
+      }),
+    );
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    act(() => {
+      modificationsStore.enableModificationMode();
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          element: {id: 'element_0', name: 'element 0'},
+          scopeId: 'random-scope-id-0',
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          parentScopeIds: {},
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-variable-value')).toHaveValue('123');
+    });
+
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(screen.getByTestId('edit-variable-value'));
+
+    expect(screen.getByTestId('edit-variable-value')).toHaveValue('123456');
+  });
+
+  it('should load full value on json viewer click during modification mode if it was truncated', async () => {
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          value: '123',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          value: '123',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockGetVariable().withSuccess(
+      createVariable({
+        value: '123456',
+        isTruncated: false,
+      }),
+    );
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    act(() => {
+      modificationsStore.enableModificationMode();
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          element: {id: 'element_0', name: 'element 0'},
+          scopeId: 'random-scope-id-0',
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          parentScopeIds: {},
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-variable-value')).toHaveValue('123');
+    });
+
+    mockGetVariable().withSuccess(
+      createVariable({
+        value: '123456',
+        isTruncated: false,
+      }),
+    );
+
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(screen.getByRole('button', {name: /open json editor/i}));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('monaco-editor')).toHaveValue('123456'),
+    );
+  });
+
+  it('should have JSON editor when editing a Variable', async () => {
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(
+      await screen.findByRole('button', {name: /edit variable/i}),
+    ).toBeInTheDocument();
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(screen.getByRole('button', {name: /edit variable/i}));
+    await user.click(screen.getByRole('button', {name: /open json editor/i}));
+
+    expect(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: /cancel/i,
+      }),
+    ).toBeEnabled();
+    expect(
+      within(screen.getByRole('dialog')).getByRole('button', {name: /apply/i}),
+    ).toBeEnabled();
+    expect(
+      within(screen.getByRole('dialog')).getByTestId('monaco-editor'),
+    ).toBeInTheDocument();
+  });
+
+  it('should allow editing a variable with dots in modification mode', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess('');
+
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({name: 'a.b', value: '"old"', isTruncated: false}),
+        createVariable({name: 'a.b.c', value: '"old"', isTruncated: false}),
+      ],
+      page: {
+        totalItems: 2,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({name: 'a.b', value: '"old"', isTruncated: false}),
+        createVariable({name: 'a.b.c', value: '"old"', isTruncated: false}),
+      ],
+      page: {
+        totalItems: 2,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    act(() => {
+      modificationsStore.enableModificationMode();
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          element: {id: 'element_0', name: 'element 0'},
+          scopeId: 'random-scope-id-0',
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    const variableRow = await screen.findByTestId('variable-a.b');
+    const input = within(variableRow).getByTestId('edit-variable-value');
+    expect(input).toHaveValue('"old"');
+
+    await user.clear(input);
+    await user.type(input, '"new"');
+
+    await waitFor(() => {
+      expect(input).toHaveValue('"new"');
+    });
+  });
+
+  it('should display view full value button and not display edit button if instance is completed or canceled', async () => {
+    mockFetchProcessInstance().withSuccess({
+      ...mockProcessInstance,
+      state: 'TERMINATED',
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('button', {name: /edit variable/i}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /view full value of testVariableName/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
@@ -22,7 +22,7 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockVariables} from './index.setup';
 import {mockGetVariable} from 'modules/mocks/api/v2/variables/getVariable';
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockUpdateElementInstanceVariables} from 'modules/mocks/api/v2/elementInstances/updateElementInstanceVariables';
 import {act} from 'react';
@@ -78,10 +78,7 @@ describe('Edit variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
 
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
@@ -157,10 +154,7 @@ describe('Edit variable', () => {
     mockGetVariable().withSuccess(mockVariables.items[0]!);
     mockGetVariable().withSuccess(mockVariables.items[0]!);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -204,10 +198,7 @@ describe('Edit variable', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -242,10 +233,7 @@ describe('Edit variable', () => {
 
     vi.useFakeTimers({shouldAdvanceTime: true});
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -332,10 +320,7 @@ describe('Edit variable', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -405,10 +390,7 @@ describe('Edit variable', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -471,10 +453,7 @@ describe('Edit variable', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -539,12 +518,9 @@ describe('Edit variable', () => {
       }),
     );
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
+    const {user} = render(<VariablesTab />, {
+      wrapper: getWrapper(),
+    });
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -609,12 +585,9 @@ describe('Edit variable', () => {
       }),
     );
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
+    const {user} = render(<VariablesTab />, {
+      wrapper: getWrapper(),
+    });
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -671,10 +644,7 @@ describe('Edit variable', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -728,10 +698,7 @@ describe('Edit variable', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -778,7 +745,7 @@ describe('Edit variable', () => {
       },
     });
 
-    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+    render(<VariablesTab />, {
       wrapper: getWrapper(),
     });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/elementStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/elementStates.test.tsx
@@ -1,0 +1,602 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
+import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {cancelAllTokens} from 'modules/utils/modifications';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {act} from 'react';
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.9';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const defaultStatistics = [
+  {
+    elementId: 'TEST_ELEMENT',
+    active: 0,
+    canceled: 0,
+    incidents: 0,
+    completed: 1,
+  },
+  {
+    elementId: 'Activity_0qtp1k6',
+    active: 0,
+    canceled: 0,
+    incidents: 1,
+    completed: 0,
+  },
+];
+
+const finishedTokenStatistics = [
+  {
+    elementId: 'StartEvent_1',
+    active: 1,
+    canceled: 0,
+    incidents: 0,
+    completed: 0,
+  },
+  {
+    elementId: 'Activity_0qtp1k6',
+    active: 0,
+    canceled: 0,
+    incidents: 0,
+    completed: 1,
+  },
+];
+
+const activityElementInstance: ElementInstance = {
+  elementInstanceKey: '2251799813695856',
+  elementId: 'Activity_0qtp1k6',
+  elementName: 'Activity',
+  type: 'SERVICE_TASK',
+  state: 'ACTIVE',
+  startDate: '2018-06-21',
+  endDate: null,
+  processDefinitionId: 'someKey',
+  processInstanceKey: '1',
+  processDefinitionKey: '2',
+  rootProcessInstanceKey: null,
+  hasIncident: false,
+  incidentKey: null,
+  tenantId: '<default>',
+};
+
+const emptyVariablesResponse = {
+  items: [],
+  page: {
+    totalItems: 0,
+    startCursor: null,
+    endCursor: null,
+    hasMoreTotalItems: false,
+  },
+};
+
+const emptyJobsResponse = {
+  items: [],
+  page: {
+    totalItems: 0,
+    startCursor: null,
+    endCursor: null,
+    hasMoreTotalItems: false,
+  },
+};
+
+const setupElementStateMocks = (statistics = defaultStatistics) => {
+  mockFetchProcessInstance().withSuccess(mockProcessInstance);
+  mockFetchProcessDefinitionXml().withSuccess(
+    mockProcessWithInputOutputMappingsXML,
+  );
+  mockFetchElementInstancesStatistics().withSuccess({
+    items: statistics,
+  });
+  mockSearchJobs().withSuccess(emptyJobsResponse);
+  mockSearchJobs().withSuccess(emptyJobsResponse);
+};
+
+const TestSelectionControls: React.FC = () => {
+  const {selectElement, selectElementInstance} =
+    useProcessInstanceElementSelection();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          selectElement({
+            elementId: 'Activity_0qtp1k6',
+          })
+        }
+      >
+        select activity element
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'Activity_0qtp1k6',
+            elementInstanceKey: '2251799813695856',
+          })
+        }
+      >
+        select existing activity scope
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'Activity_0qtp1k6',
+            elementInstanceKey: 'some-new-scope-id',
+            isPlaceholder: true,
+          })
+        }
+      >
+        select new activity scope
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElement({
+            elementId: 'element-without-running-tokens',
+          })
+        }
+      >
+        select no-token element
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'element-without-running-tokens',
+            elementInstanceKey: 'some-new-scope-id-1',
+            isPlaceholder: true,
+          })
+        }
+      >
+        select no-token new scope
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'another-element-without-any-tokens',
+            elementInstanceKey: 'some-new-parent-scope-id',
+            isPlaceholder: true,
+          })
+        }
+      >
+        select no-token parent scope
+      </button>
+    </>
+  );
+};
+
+const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
+  const BaseWrapper = getBaseWrapper(...args);
+
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <BaseWrapper>
+      <>
+        <TestSelectionControls />
+        {children}
+      </>
+    </BaseWrapper>
+  );
+
+  return Wrapper;
+};
+
+describe('VariablePanel element states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should display correct state for element that has only one running token on it', async () => {
+    setupElementStateMocks();
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    modificationsStore.enableModificationMode();
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    mockSearchElementInstances().withSuccess({
+      items: [activityElementInstance],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchJobs().withSuccess(emptyJobsResponse);
+
+    await user.click(
+      screen.getByRole('button', {name: /^select activity element$/i}),
+    );
+
+    act(() => {
+      cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('testVariableName')).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          element: {
+            id: 'Activity_0qtp1k6',
+            name: 'Element with running tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id',
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        'To view the variables, select a single element instance in the instance history.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      modificationsStore.removeElementModification({
+        operation: 'CANCEL_TOKEN',
+        element: {
+          id: 'Activity_0qtp1k6',
+          name: 'Element with running tokens',
+        },
+        affectedTokenCount: 1,
+        visibleAffectedTokenCount: 1,
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        'To view the variables, select a single element instance in the instance history.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    mockFetchElementInstance('2251799813695856').withSuccess(
+      activityElementInstance,
+    );
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchJobs().withSuccess(emptyJobsResponse);
+
+    await user.click(
+      screen.getByRole('button', {name: /^select existing activity scope$/i}),
+    );
+
+    expect(
+      screen.queryByText(
+        'To view the variables, select a single element instance in the instance history.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByText('The element has no variables'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {name: /^select new activity scope$/i}),
+    );
+
+    expect(
+      screen.queryByText(
+        'To view the variables, select a single element instance in the instance history.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByText('The element has no variables'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should display correct state for element that has no running or finished tokens on it', async () => {
+    setupElementStateMocks();
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    modificationsStore.enableModificationMode();
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    mockSearchElementInstances().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchJobs().withSuccess(emptyJobsResponse);
+
+    await user.click(
+      screen.getByRole('button', {name: /^select no-token element$/i}),
+    );
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('testVariableName')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('The element has no variables'),
+    ).toBeInTheDocument();
+
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          element: {
+            id: 'element-without-running-tokens',
+            name: 'Element without running tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id',
+          parentScopeIds: {
+            'another-element-without-any-tokens': 'some-new-parent-scope-id',
+          },
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText('The element has no variables'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
+    expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    expect(
+      await screen.findByText('The element has no variables'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
+
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          element: {
+            id: 'element-without-running-tokens',
+            name: 'Element without running tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id-2',
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        'To view the variables, select a single element instance in the instance history.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchJobs().withSuccess(emptyJobsResponse);
+
+    await user.click(
+      screen.getByRole('button', {name: /^select no-token new scope$/i}),
+    );
+
+    expect(
+      await screen.findByText('The element has no variables'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchJobs().withSuccess(emptyJobsResponse);
+
+    await user.click(
+      screen.getByRole('button', {name: /^select no-token parent scope$/i}),
+    );
+
+    expect(
+      await screen.findByText('The element has no variables'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should display correct state for element that has only one finished token on it', async () => {
+    setupElementStateMocks(finishedTokenStatistics);
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    modificationsStore.enableModificationMode();
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    mockSearchElementInstances().withSuccess({
+      items: [
+        {
+          ...activityElementInstance,
+          state: 'COMPLETED',
+        },
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchJobs().withSuccess(emptyJobsResponse);
+
+    await user.click(
+      screen.getByRole('button', {name: /^select activity element$/i}),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
+    );
+    expect(
+      await screen.findByText(/the element has no variables/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          element: {
+            id: 'Activity_0qtp1k6',
+            name: 'Element with finished tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id',
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        /to view the variables, select a single element instance in the instance history/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    await waitFor(() =>
+      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
+    );
+    expect(
+      await screen.findByText(
+        /to view the variables, select a single element instance in the instance history/i,
+      ),
+    ).toBeInTheDocument();
+
+    mockSearchVariables().withSuccess(emptyVariablesResponse);
+    mockSearchJobs().withSuccess(emptyJobsResponse);
+
+    await user.click(
+      screen.getByRole('button', {name: /^select new activity scope$/i}),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
+    );
+    expect(
+      await screen.findByText(/the element has no variables/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/elementStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/elementStates.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {
   createVariable,
@@ -207,7 +207,7 @@ const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
   return Wrapper;
 };
 
-describe('VariablePanel element states', () => {
+describe('VariablesTab element states', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -226,12 +226,9 @@ describe('VariablePanel element states', () => {
 
     modificationsStore.enableModificationMode();
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
+    const {user} = render(<VariablesTab />, {
+      wrapper: getWrapper(),
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
@@ -367,10 +364,7 @@ describe('VariablePanel element states', () => {
 
     modificationsStore.enableModificationMode();
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -425,15 +419,6 @@ describe('VariablePanel element states', () => {
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
-
-    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
-    expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
-
-    await user.click(screen.getByRole('tab', {name: 'Variables'}));
-    expect(
-      await screen.findByText('The element has no variables'),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
 
     act(() => {
       modificationsStore.addModification({
@@ -505,10 +490,9 @@ describe('VariablePanel element states', () => {
 
     modificationsStore.enableModificationMode();
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {
+      wrapper: getWrapper(),
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
@@ -536,12 +520,11 @@ describe('VariablePanel element states', () => {
       screen.getByRole('button', {name: /^select activity element$/i}),
     );
 
-    await waitFor(() =>
-      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
-    );
-    expect(
-      await screen.findByText(/the element has no variables/i),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/the element has no variables/i),
+      ).toBeInTheDocument();
+    });
     expect(
       screen.queryByRole('button', {name: /add variable/i}),
     ).not.toBeInTheDocument();
@@ -572,16 +555,6 @@ describe('VariablePanel element states', () => {
       screen.queryByRole('button', {name: /add variable/i}),
     ).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('tab', {name: 'Variables'}));
-    await waitFor(() =>
-      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
-    );
-    expect(
-      await screen.findByText(
-        /to view the variables, select a single element instance in the instance history/i,
-      ),
-    ).toBeInTheDocument();
-
     mockSearchVariables().withSuccess(emptyVariablesResponse);
     mockSearchJobs().withSuccess(emptyJobsResponse);
 
@@ -589,12 +562,12 @@ describe('VariablePanel element states', () => {
       screen.getByRole('button', {name: /^select new activity scope$/i}),
     );
 
-    await waitFor(() =>
-      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
-    );
-    expect(
-      await screen.findByText(/the element has no variables/i),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/the element has no variables/i),
+      ).toBeInTheDocument();
+    });
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/footer.test.tsx
@@ -14,7 +14,7 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockVariables} from './index.setup';
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
@@ -117,10 +117,7 @@ describe('Footer', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -190,14 +187,11 @@ describe('Footer', () => {
       tenantId: '<default>',
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {
-        wrapper: getWrapper([
-          `${Paths.processInstance('1')}?elementId=start&elementInstanceKey=2`,
-        ]),
-      },
-    );
+    const {user} = render(<VariablesTab />, {
+      wrapper: getWrapper([
+        `${Paths.processInstance('1')}?elementId=start&elementInstanceKey=2`,
+      ]),
+    });
 
     await waitFor(() =>
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled(),
@@ -246,7 +240,7 @@ describe('Footer', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+    render(<VariablesTab />, {
       wrapper: getWrapper(),
     });
 
@@ -263,7 +257,7 @@ describe('Footer', () => {
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchVariables().withSuccess(mockVariables);
 
-    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+    render(<VariablesTab />, {
       wrapper: getWrapper(),
     });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/footer.test.tsx
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, waitFor} from 'modules/testing-library';
+import {mockProcessInstance} from './mocks';
+import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockVariables} from './index.setup';
+import {VariablePanel} from '../index';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {useEffect} from 'react';
+import {modificationsStore} from 'modules/stores/modifications';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+
+const TestSelectionControls: React.FC = () => {
+  const {selectElementInstance} = useProcessInstanceElementSelection();
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        selectElementInstance({
+          elementId: 'neverFails',
+          elementInstanceKey: '3',
+        })
+      }
+    >
+      select completed element
+    </button>
+  );
+};
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('1')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+              <Route
+                path={Paths.processInstance()}
+                element={
+                  <>
+                    <TestSelectionControls />
+                    {children}
+                  </>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('Footer', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: 'start',
+          active: 0,
+          canceled: 0,
+          incidents: 0,
+          completed: 1,
+        },
+        {
+          elementId: 'neverFails',
+          active: 0,
+          canceled: 0,
+          incidents: 0,
+          completed: 1,
+        },
+      ],
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+  });
+
+  it('should hide/disable add variable button if add/edit variable button is clicked', async () => {
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+
+    const [firstEditVariableButton] = screen.getAllByRole('button', {
+      name: /edit variable/i,
+    });
+    expect(firstEditVariableButton).toBeInTheDocument();
+    await user.click(firstEditVariableButton!);
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeDisabled();
+
+    await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+  });
+
+  it('should disable add variable button when selected element is not running', async () => {
+    const mockSearchVariablesPayload = {
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    };
+    mockSearchVariables().withSuccess(mockSearchVariablesPayload);
+    mockSearchVariables().withSuccess(mockSearchVariablesPayload);
+    mockSearchVariables().withSuccess(mockSearchVariablesPayload);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockFetchElementInstance('2').withSuccess({
+      elementInstanceKey: '2',
+      elementId: 'start',
+      elementName: 'Start',
+      type: 'START_EVENT',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      endDate: null,
+      processDefinitionId: 'someKey',
+      processInstanceKey: '1',
+      processDefinitionKey: '2',
+      rootProcessInstanceKey: null,
+      hasIncident: false,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {
+        wrapper: getWrapper([
+          `${Paths.processInstance('1')}?elementId=start&elementInstanceKey=2`,
+        ]),
+      },
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled(),
+    );
+
+    mockSearchVariables().withSuccess(mockSearchVariablesPayload);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockFetchElementInstance('3').withSuccess({
+      elementInstanceKey: '3',
+      elementId: 'neverFails',
+      elementName: 'Never Fails',
+      type: 'SERVICE_TASK',
+      state: 'COMPLETED',
+      startDate: '2018-06-21',
+      endDate: '2018-06-21',
+      processDefinitionId: 'someKey',
+      processInstanceKey: '1',
+      processDefinitionKey: '2',
+      rootProcessInstanceKey: null,
+      hasIncident: false,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: /select completed element/i}),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {name: /add variable/i}),
+      ).toBeDisabled(),
+    );
+  });
+
+  it('should disable add variable button when loading', async () => {
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled(),
+    );
+  });
+
+  it('should disable add variable button if instance state is cancelled', async () => {
+    mockFetchProcessInstance().withSuccess({
+      ...mockProcessInstance,
+      state: 'TERMINATED',
+    });
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {name: /add variable/i}),
+      ).toBeDisabled(),
+    );
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.setup.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.setup.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {QueryVariablesResponseBody} from '@camunda/camunda-api-zod-schemas/8.9';
+
+const mockVariables: QueryVariablesResponseBody = {
+  items: [
+    {
+      value: '"CNT-1211132-0223222"',
+      isTruncated: false,
+      name: 'clientNo',
+      tenantId: '<default>',
+      variableKey: '2251799813686037-clientNo',
+      scopeKey: '2251799813696123',
+      processInstanceKey: '2251799813696123',
+      rootProcessInstanceKey: null,
+    },
+    {
+      value: '124.26',
+      isTruncated: false,
+      name: 'mwst',
+      tenantId: '<default>',
+      variableKey: '2251799813686037-mwst',
+      scopeKey: '2251799813696123',
+      processInstanceKey: '2251799813696123',
+      rootProcessInstanceKey: null,
+    },
+    {
+      value: '1',
+      isTruncated: false,
+      name: 'active-operation-variable',
+      tenantId: '<default>',
+      variableKey: '2251799813686037-mwst',
+      scopeKey: '2251799813696123',
+      processInstanceKey: '2251799813696123',
+      rootProcessInstanceKey: null,
+    },
+  ],
+  page: {
+    totalItems: 3,
+    startCursor: null,
+    endCursor: null,
+    hasMoreTotalItems: false,
+  },
+};
+
+export {mockVariables};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {
   render,
   screen,
@@ -14,10 +14,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'modules/testing-library';
-import {
-  createVariable,
-  mockProcessWithInputOutputMappingsXML,
-} from 'modules/testUtils';
+import {createVariable} from 'modules/testUtils';
 import {act} from 'react';
 import {notificationsStore} from 'modules/stores/notifications';
 import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
@@ -27,7 +24,7 @@ import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariable
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockUpdateElementInstanceVariables} from 'modules/mocks/api/v2/elementInstances/updateElementInstanceVariables';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
-import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
 
@@ -38,8 +35,7 @@ vi.mock('modules/stores/notifications', () => ({
 }));
 
 const TestSelectionControls: React.FC = () => {
-  const {selectElementInstance, selectElement, clearSelection} =
-    useProcessInstanceElementSelection();
+  const {selectElementInstance} = useProcessInstanceElementSelection();
   return (
     <>
       <button
@@ -52,40 +48,6 @@ const TestSelectionControls: React.FC = () => {
         }
       >
         select test element
-      </button>
-      <button
-        type="button"
-        onClick={() =>
-          selectElementInstance({
-            elementId: 'Activity_0qtp1k6',
-            elementInstanceKey: '2',
-          })
-        }
-      >
-        select activity
-      </button>
-      <button
-        type="button"
-        onClick={() =>
-          selectElement({
-            elementId: 'Event_0bonl61',
-          })
-        }
-      >
-        select end event
-      </button>
-      <button
-        type="button"
-        onClick={() =>
-          selectElement({
-            elementId: 'StartEvent_1',
-          })
-        }
-      >
-        select start event
-      </button>
-      <button type="button" onClick={() => clearSelection()}>
-        clear selection
       </button>
     </>
   );
@@ -106,7 +68,7 @@ const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
   return Wrapper;
 };
 
-describe('VariablePanel', () => {
+describe('VariablesTab', () => {
   const statistics = [
     {
       elementId: 'TEST_ELEMENT',
@@ -148,9 +110,7 @@ describe('VariablePanel', () => {
         hasMoreTotalItems: false,
       },
     });
-    mockFetchProcessDefinitionXml().withSuccess(
-      mockProcessWithInputOutputMappingsXML,
-    );
+    mockFetchProcessDefinitionXml().withSuccess('');
     mockSearchJobs().withSuccess({
       items: [],
       page: {
@@ -177,7 +137,7 @@ describe('VariablePanel', () => {
       },
     });
 
-    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+    render(<VariablesTab />, {
       wrapper: getWrapper(),
     });
 
@@ -193,10 +153,7 @@ describe('VariablePanel', () => {
       `:${mockProcessInstance.processInstanceKey}`,
     ).withDelay(null);
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
@@ -316,10 +273,7 @@ describe('VariablePanel', () => {
   it('should remove pending variable if scope changes', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
@@ -456,10 +410,7 @@ describe('VariablePanel', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
@@ -521,234 +472,5 @@ describe('VariablePanel', () => {
         title: 'Variable could not be saved',
       }),
     );
-  });
-
-  it('should select correct tab when navigating between elements', async () => {
-    mockFetchProcessInstance().withSuccess(mockProcessInstance);
-    mockSearchVariables().withSuccess({
-      items: [createVariable()],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
-
-    mockSearchVariables().withSuccess({
-      items: [createVariable({name: 'test2'})],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockFetchProcessDefinitionXml().withSuccess(
-      mockProcessWithInputOutputMappingsXML,
-    );
-
-    mockFetchElementInstance('2').withSuccess({
-      elementInstanceKey: '2',
-      elementId: 'Activity_0qtp1k6',
-      elementName: 'Activity',
-      type: 'SERVICE_TASK',
-      state: 'ACTIVE',
-      startDate: '2018-06-21',
-      endDate: null,
-      processDefinitionId: 'someKey',
-      processInstanceKey: mockProcessInstance.processInstanceKey,
-      processDefinitionKey: '2',
-      rootProcessInstanceKey: null,
-      hasIncident: true,
-      incidentKey: null,
-      tenantId: '<default>',
-    });
-
-    await user.click(screen.getByRole('button', {name: /select activity/i}));
-
-    expect(await screen.findByText('test2')).toBeInTheDocument();
-
-    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
-
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockSearchVariables().withSuccess({
-      items: [createVariable({name: 'test2'})],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockFetchProcessDefinitionXml().withSuccess(
-      mockProcessWithInputOutputMappingsXML,
-    );
-
-    mockSearchElementInstances().withSuccess({
-      items: [
-        {
-          elementInstanceKey: '10',
-          elementId: 'Event_0bonl61',
-          elementName: 'End Event',
-          type: 'END_EVENT',
-          state: 'COMPLETED',
-          startDate: '2018-06-21',
-          endDate: null,
-          processDefinitionId: 'someKey',
-          processInstanceKey: mockProcessInstance.processInstanceKey,
-          processDefinitionKey: '2',
-          rootProcessInstanceKey: null,
-          hasIncident: false,
-          incidentKey: null,
-          tenantId: '<default>',
-        },
-      ],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-
-    await user.click(screen.getByRole('button', {name: /select end event/i}));
-
-    expect(
-      await screen.findByText('No Input Mappings defined'),
-    ).toBeInTheDocument();
-
-    mockSearchVariables().withSuccess({
-      items: [createVariable({name: 'test2'})],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-
-    await user.click(screen.getByRole('button', {name: /clear selection/i}));
-
-    await waitFor(() =>
-      expect(
-        screen.queryByText('No Input Mappings defined'),
-      ).not.toBeInTheDocument(),
-    );
-    expect(screen.getByRole('tab', {name: 'Variables'})).toBeInTheDocument();
-    expect(
-      screen.queryByRole('tab', {name: 'Input Mappings'}),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('tab', {name: 'Output Mappings'}),
-    ).not.toBeInTheDocument();
-
-    mockSearchVariables().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-
-    mockSearchElementInstances().withSuccess({
-      items: [
-        {
-          elementInstanceKey: '20',
-          elementId: 'StartEvent_1',
-          elementName: 'Start Event',
-          type: 'START_EVENT',
-          state: 'COMPLETED',
-          startDate: '2018-06-21',
-          endDate: null,
-          processDefinitionId: 'someKey',
-          processInstanceKey: mockProcessInstance.processInstanceKey,
-          processDefinitionKey: '2',
-          rootProcessInstanceKey: null,
-          hasIncident: false,
-          incidentKey: null,
-          tenantId: '<default>',
-        },
-      ],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-
-    await user.click(screen.getByRole('button', {name: /select start event/i}));
-
-    expect(
-      await screen.findByText('No Input Mappings defined'),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.queryByRole('heading', {name: 'Variables'}),
-    ).not.toBeInTheDocument();
-
-    expect(screen.getByRole('tab', {name: 'Variables'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('tab', {name: 'Input Mappings'}),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('tab', {name: 'Output Mappings'}),
-    ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.test.tsx
@@ -1,0 +1,754 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from 'modules/testing-library';
+import {
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {act} from 'react';
+import {notificationsStore} from 'modules/stores/notifications';
+import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockUpdateElementInstanceVariables} from 'modules/mocks/api/v2/elementInstances/updateElementInstanceVariables';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const TestSelectionControls: React.FC = () => {
+  const {selectElementInstance, selectElement, clearSelection} =
+    useProcessInstanceElementSelection();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'TEST_ELEMENT',
+            elementInstanceKey: '2',
+          })
+        }
+      >
+        select test element
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'Activity_0qtp1k6',
+            elementInstanceKey: '2',
+          })
+        }
+      >
+        select activity
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElement({
+            elementId: 'Event_0bonl61',
+          })
+        }
+      >
+        select end event
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElement({
+            elementId: 'StartEvent_1',
+          })
+        }
+      >
+        select start event
+      </button>
+      <button type="button" onClick={() => clearSelection()}>
+        clear selection
+      </button>
+    </>
+  );
+};
+
+const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
+  const BaseWrapper = getBaseWrapper(...args);
+
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <BaseWrapper>
+      <>
+        <TestSelectionControls />
+        {children}
+      </>
+    </BaseWrapper>
+  );
+
+  return Wrapper;
+};
+
+describe('VariablePanel', () => {
+  const statistics = [
+    {
+      elementId: 'TEST_ELEMENT',
+      active: 0,
+      canceled: 0,
+      incidents: 0,
+      completed: 1,
+    },
+    {
+      elementId: 'Activity_0qtp1k6',
+      active: 0,
+      canceled: 0,
+      incidents: 1,
+      completed: 0,
+    },
+  ];
+
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it('should render variables', async () => {
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+  });
+
+  it('should add new variable', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockUpdateElementInstanceVariables(
+      `:${mockProcessInstance.processInstanceKey}`,
+    ).withDelay(null);
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /add variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    );
+
+    expect(
+      screen.queryByRole('button', {
+        name: /add variable/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'foo',
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '"bar"',
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /save variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable(),
+        createVariable({
+          variableKey: '2251799813725337-foo',
+          name: 'foo',
+          value: '"bar"',
+        }),
+      ],
+      page: {
+        totalItems: 2,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable(),
+        createVariable({
+          variableKey: '2251799813725337-foo',
+          name: 'foo',
+          value: '"bar"',
+        }),
+      ],
+      page: {
+        totalItems: 2,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: /add variable/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('full-variable-loader')).toBeInTheDocument();
+
+    const withinVariablesList = within(screen.getByTestId('variables-list'));
+    expect(
+      withinVariablesList.queryByTestId('variable-foo'),
+    ).not.toBeInTheDocument();
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('full-variable-loader'),
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    ).toBeInTheDocument();
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      isDismissable: true,
+      kind: 'success',
+      title: 'Variable added',
+    });
+
+    expect(
+      await withinVariablesList.findByTestId('variable-foo'),
+    ).toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should remove pending variable if scope changes', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /add variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: /add variable/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'foo',
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '"bar"',
+    );
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockUpdateElementInstanceVariables(
+      `:${mockProcessInstance.processInstanceKey}`,
+    ).withSuccess(null);
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /save variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: /add variable/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockFetchElementInstance('2').withSuccess({
+      elementInstanceKey: '2',
+      elementId: 'TEST_ELEMENT',
+      elementName: 'Test Element',
+      type: 'SERVICE_TASK',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      endDate: null,
+      processDefinitionId: 'someKey',
+      processInstanceKey: mockProcessInstance.processInstanceKey,
+      processDefinitionKey: '2',
+      rootProcessInstanceKey: null,
+      hasIncident: false,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: /select test element/i}),
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('foo')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('"bar"')).not.toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should display validation error if backend validation fails while adding variable', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /add variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: /add variable/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'foo',
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '"bar"',
+    );
+
+    mockUpdateElementInstanceVariables(
+      `:${mockProcessInstance.processInstanceKey}`,
+    ).withServerError(400);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /save variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('full-variable-loader'),
+      ).not.toBeInTheDocument(),
+    );
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'error',
+        title: 'Variable could not be saved',
+      }),
+    );
+  });
+
+  it('should select correct tab when navigating between elements', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    mockSearchVariables().withSuccess({
+      items: [createVariable({name: 'test2'})],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+
+    mockFetchElementInstance('2').withSuccess({
+      elementInstanceKey: '2',
+      elementId: 'Activity_0qtp1k6',
+      elementName: 'Activity',
+      type: 'SERVICE_TASK',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      endDate: null,
+      processDefinitionId: 'someKey',
+      processInstanceKey: mockProcessInstance.processInstanceKey,
+      processDefinitionKey: '2',
+      rootProcessInstanceKey: null,
+      hasIncident: true,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+
+    await user.click(screen.getByRole('button', {name: /select activity/i}));
+
+    expect(await screen.findByText('test2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
+
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable({name: 'test2'})],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+
+    mockSearchElementInstances().withSuccess({
+      items: [
+        {
+          elementInstanceKey: '10',
+          elementId: 'Event_0bonl61',
+          elementName: 'End Event',
+          type: 'END_EVENT',
+          state: 'COMPLETED',
+          startDate: '2018-06-21',
+          endDate: null,
+          processDefinitionId: 'someKey',
+          processInstanceKey: mockProcessInstance.processInstanceKey,
+          processDefinitionKey: '2',
+          rootProcessInstanceKey: null,
+          hasIncident: false,
+          incidentKey: null,
+          tenantId: '<default>',
+        },
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(screen.getByRole('button', {name: /select end event/i}));
+
+    expect(
+      await screen.findByText('No Input Mappings defined'),
+    ).toBeInTheDocument();
+
+    mockSearchVariables().withSuccess({
+      items: [createVariable({name: 'test2'})],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(screen.getByRole('button', {name: /clear selection/i}));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText('No Input Mappings defined'),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole('tab', {name: 'Variables'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('tab', {name: 'Input Mappings'}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('tab', {name: 'Output Mappings'}),
+    ).not.toBeInTheDocument();
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockSearchElementInstances().withSuccess({
+      items: [
+        {
+          elementInstanceKey: '20',
+          elementId: 'StartEvent_1',
+          elementName: 'Start Event',
+          type: 'START_EVENT',
+          state: 'COMPLETED',
+          startDate: '2018-06-21',
+          endDate: null,
+          processDefinitionId: 'someKey',
+          processInstanceKey: mockProcessInstance.processInstanceKey,
+          processDefinitionKey: '2',
+          rootProcessInstanceKey: null,
+          hasIncident: false,
+          incidentKey: null,
+          tenantId: '<default>',
+        },
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(screen.getByRole('button', {name: /select start event/i}));
+
+    expect(
+      await screen.findByText('No Input Mappings defined'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('heading', {name: 'Variables'}),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByRole('tab', {name: 'Variables'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', {name: 'Input Mappings'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', {name: 'Output Mappings'}),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/mocks.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {useEffect} from 'react';
+import {modificationsStore} from 'modules/stores/modifications';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.9';
+
+const mockProcessInstance: ProcessInstance = {
+  processInstanceKey: '1',
+  state: 'ACTIVE',
+  startDate: '2018-06-21',
+  endDate: null,
+  processDefinitionKey: '2',
+  processDefinitionVersion: 1,
+  processDefinitionVersionTag: null,
+  processDefinitionId: 'someKey',
+  tenantId: '<default>',
+  processDefinitionName: 'someProcessName',
+  hasIncident: false,
+  parentProcessInstanceKey: null,
+  parentElementInstanceKey: null,
+  rootProcessInstanceKey: null,
+  tags: [],
+};
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('1')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
+};
+
+export {getWrapper, mockProcessInstance};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/notification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/notification.test.tsx
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {mockVariables} from './index.setup';
+import {getWrapper, mockProcessInstance} from './mocks';
+import {notificationsStore} from 'modules/stores/notifications';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockUpdateElementInstanceVariables} from 'modules/mocks/api/v2/elementInstances/updateElementInstanceVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+describe('VariablePanel notifications', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+  });
+
+  it('should display error notification if add variable operation could not be created', async () => {
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /add variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: /add variable/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'foo',
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '"bar"',
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /save variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    mockUpdateElementInstanceVariables(':1').withDelayedServerError();
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        isDismissable: true,
+        kind: 'error',
+        subtitle: 'Internal Server Error',
+        title: 'Variable could not be saved',
+      }),
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should display warning notification if add variable operation could not be created because of authorization error', async () => {
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /add variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: /add variable/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'foo',
+    );
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /value/i,
+      }),
+      '"bar"',
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /save variable/i,
+        }),
+      ).toBeEnabled(),
+    );
+
+    mockUpdateElementInstanceVariables(':1').withDelayedServerError(403);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /save variable/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        isDismissable: true,
+        kind: 'warning',
+        title: "You don't have permission to perform this operation",
+        subtitle: 'Please contact the administrator if you need access.',
+      }),
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /add variable/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/notification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/notification.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {mockVariables} from './index.setup';
 import {getWrapper, mockProcessInstance} from './mocks';
@@ -23,7 +23,7 @@ vi.mock('modules/stores/notifications', () => ({
   },
 }));
 
-describe('VariablePanel notifications', () => {
+describe('VariablesTab notifications', () => {
   beforeEach(() => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
@@ -43,10 +43,7 @@ describe('VariablePanel notifications', () => {
   });
 
   it('should display error notification if add variable operation could not be created', async () => {
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
@@ -122,10 +119,7 @@ describe('VariablePanel notifications', () => {
   });
 
   it('should display warning notification if add variable operation could not be created because of authorization error', async () => {
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() =>
       expect(
         screen.getByRole('button', {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/placeholder.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {render, screen} from 'modules/testing-library';
 import {
   createVariable,
@@ -86,7 +86,7 @@ const selectedElementInstance = {
   tenantId: '<default>',
 };
 
-describe('VariablePanel placeholders', () => {
+describe('VariablesTab placeholders', () => {
   beforeEach(() => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
@@ -182,12 +182,9 @@ describe('VariablePanel placeholders', () => {
         },
       });
 
-      const {user} = render(
-        <VariablePanel setListenerTabVisibility={vi.fn()} />,
-        {
-          wrapper: getWrapper(),
-        },
-      );
+      const {user} = render(<VariablesTab />, {
+        wrapper: getWrapper(),
+      });
 
       expect(await screen.findByTestId('variables-list')).toBeInTheDocument();
 
@@ -221,12 +218,9 @@ describe('VariablePanel placeholders', () => {
         },
       });
 
-      const {user} = render(
-        <VariablePanel setListenerTabVisibility={vi.fn()} />,
-        {
-          wrapper: getWrapper(),
-        },
-      );
+      const {user} = render(<VariablesTab />, {
+        wrapper: getWrapper(),
+      });
 
       expect(await screen.findByTestId('variables-list')).toBeInTheDocument();
 
@@ -263,12 +257,9 @@ describe('VariablePanel placeholders', () => {
         },
       });
 
-      const {user} = render(
-        <VariablePanel setListenerTabVisibility={vi.fn()} />,
-        {
-          wrapper: getWrapper(),
-        },
-      );
+      const {user} = render(<VariablesTab />, {
+        wrapper: getWrapper(),
+      });
 
       expect(await screen.findByTestId('variables-list')).toBeInTheDocument();
 
@@ -305,12 +296,9 @@ describe('VariablePanel placeholders', () => {
         },
       });
 
-      const {user} = render(
-        <VariablePanel setListenerTabVisibility={vi.fn()} />,
-        {
-          wrapper: getWrapper(),
-        },
-      );
+      const {user} = render(<VariablesTab />, {
+        wrapper: getWrapper(),
+      });
 
       expect(await screen.findByTestId('variables-list')).toBeInTheDocument();
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/placeholder.test.tsx
@@ -1,0 +1,340 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen} from 'modules/testing-library';
+import {
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
+import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+
+const TestSelectionControls: React.FC = () => {
+  const {selectElement, selectElementInstance} =
+    useProcessInstanceElementSelection();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          selectElement({
+            elementId: 'TEST_ELEMENT',
+          })
+        }
+      >
+        select element
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'TEST_ELEMENT',
+            elementInstanceKey: '2',
+          })
+        }
+      >
+        select element instance
+      </button>
+    </>
+  );
+};
+
+const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
+  const BaseWrapper = getBaseWrapper(...args);
+
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <BaseWrapper>
+      <>
+        <TestSelectionControls />
+        {children}
+      </>
+    </BaseWrapper>
+  );
+
+  return Wrapper;
+};
+
+const selectedElementInstance = {
+  elementInstanceKey: '2',
+  elementId: 'TEST_ELEMENT',
+  elementName: 'Test Element',
+  type: 'SERVICE_TASK' as const,
+  state: 'ACTIVE' as const,
+  startDate: '2018-06-21',
+  endDate: null,
+  processDefinitionId: 'someKey',
+  processInstanceKey: '1',
+  processDefinitionKey: '2',
+  rootProcessInstanceKey: null,
+  hasIncident: false,
+  incidentKey: null,
+  tenantId: '<default>',
+};
+
+describe('VariablePanel placeholders', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    const statistics = [
+      {
+        elementId: 'TEST_ELEMENT',
+        active: 1,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 1,
+        completed: 0,
+      },
+    ];
+
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+  });
+
+  it.each([true, false])(
+    'should show multiple scope placeholder when multiple nodes are selected - modification mode: %p',
+    async (enableModificationMode) => {
+      if (enableModificationMode) {
+        modificationsStore.enableModificationMode();
+      }
+
+      mockSearchElementInstances().withSuccess({
+        items: [
+          selectedElementInstance,
+          {
+            ...selectedElementInstance,
+            elementInstanceKey: '3',
+          },
+        ],
+        page: {
+          totalItems: 2,
+          startCursor: null,
+          endCursor: null,
+          hasMoreTotalItems: false,
+        },
+      });
+      mockSearchVariables().withSuccess({
+        items: [createVariable()],
+        page: {
+          totalItems: 1,
+          startCursor: null,
+          endCursor: null,
+          hasMoreTotalItems: false,
+        },
+      });
+      mockSearchVariables().withSuccess({
+        items: [createVariable()],
+        page: {
+          totalItems: 1,
+          startCursor: null,
+          endCursor: null,
+          hasMoreTotalItems: false,
+        },
+      });
+
+      const {user} = render(
+        <VariablePanel setListenerTabVisibility={vi.fn()} />,
+        {
+          wrapper: getWrapper(),
+        },
+      );
+
+      expect(await screen.findByTestId('variables-list')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', {name: /^select element$/i}));
+
+      expect(
+        await screen.findByText(
+          'To view the variables, select a single element instance in the instance history.',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it.each([true, false])(
+    'should show failed placeholder if server error occurs while fetching variables - modification mode: %p',
+    async (enableModificationMode) => {
+      if (enableModificationMode) {
+        modificationsStore.enableModificationMode();
+      }
+
+      mockSearchVariables().withSuccess({
+        items: [createVariable()],
+        page: {
+          totalItems: 1,
+          startCursor: null,
+          endCursor: null,
+          hasMoreTotalItems: false,
+        },
+      });
+
+      const {user} = render(
+        <VariablePanel setListenerTabVisibility={vi.fn()} />,
+        {
+          wrapper: getWrapper(),
+        },
+      );
+
+      expect(await screen.findByTestId('variables-list')).toBeInTheDocument();
+
+      mockFetchElementInstance('2').withSuccess(selectedElementInstance);
+      mockSearchVariables().withServerError();
+
+      await user.click(
+        screen.getByRole('button', {name: /^select element instance$/i}),
+      );
+
+      expect(
+        await screen.findByText('Variables could not be fetched'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it.each([true, false])(
+    'should show failed placeholder if network error occurs while fetching variables - modification mode: %p',
+    async (enableModificationMode) => {
+      if (enableModificationMode) {
+        modificationsStore.enableModificationMode();
+      }
+
+      mockSearchVariables().withSuccess({
+        items: [createVariable()],
+        page: {
+          totalItems: 1,
+          startCursor: null,
+          endCursor: null,
+          hasMoreTotalItems: false,
+        },
+      });
+
+      const {user} = render(
+        <VariablePanel setListenerTabVisibility={vi.fn()} />,
+        {
+          wrapper: getWrapper(),
+        },
+      );
+
+      expect(await screen.findByTestId('variables-list')).toBeInTheDocument();
+
+      mockFetchElementInstance('2').withSuccess(selectedElementInstance);
+      mockSearchVariables().withNetworkError();
+
+      await user.click(
+        screen.getByRole('button', {name: /^select element instance$/i}),
+      );
+
+      expect(
+        await screen.findByText('Variables could not be fetched'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it.each([true, false])(
+    'should show failed placeholder if network error occurs while fetching selected element instance metadata - modification mode: %p',
+    async (enableModificationMode) => {
+      if (enableModificationMode) {
+        modificationsStore.enableModificationMode();
+      }
+
+      mockSearchVariables().withSuccess({
+        items: [createVariable()],
+        page: {
+          totalItems: 1,
+          startCursor: null,
+          endCursor: null,
+          hasMoreTotalItems: false,
+        },
+      });
+
+      const {user} = render(
+        <VariablePanel setListenerTabVisibility={vi.fn()} />,
+        {
+          wrapper: getWrapper(),
+        },
+      );
+
+      expect(await screen.findByTestId('variables-list')).toBeInTheDocument();
+
+      mockFetchElementInstance('2').withNetworkError();
+      mockSearchVariables().withSuccess({
+        items: [createVariable()],
+        page: {
+          totalItems: 1,
+          startCursor: null,
+          endCursor: null,
+          hasMoreTotalItems: false,
+        },
+      });
+
+      await user.click(
+        screen.getByRole('button', {name: /^select element instance$/i}),
+      );
+
+      expect(
+        await screen.findByText('Variables could not be fetched'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    },
+  );
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/readonly.test.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
+import {getWrapper, mockProcessInstance} from './mocks';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {Paths} from 'modules/Routes';
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.9';
+
+const selectedElementInstance: ElementInstance = {
+  elementInstanceKey: '2',
+  elementId: 'Activity_0qtp1k6',
+  elementName: 'Activity',
+  type: 'SERVICE_TASK',
+  state: 'ACTIVE',
+  startDate: '2018-06-21',
+  endDate: null,
+  processDefinitionId: 'someKey',
+  processInstanceKey: '1',
+  processDefinitionKey: '2',
+  rootProcessInstanceKey: null,
+  hasIncident: false,
+  incidentKey: null,
+  tenantId: '<default>',
+};
+
+describe('VariablePanel readonly', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+
+    const statistics = [
+      {
+        elementId: 'TEST_ELEMENT',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 1,
+        canceled: 0,
+        incidents: 0,
+        completed: 0,
+      },
+    ];
+
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+  });
+
+  it('should be readonly if root node is selected and no add/move modification is created yet', async () => {
+    modificationsStore.enableModificationMode();
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /edit variable testVariableName/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should be readonly if root node is selected and only cancel modifications exist', async () => {
+    modificationsStore.enableModificationMode();
+    modificationsStore.cancelToken('some-element-id', 'some-instance-key', {});
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /edit variable testVariableName/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should be readonly for existing nodes without add/move modifications', async () => {
+    modificationsStore.enableModificationMode();
+    mockFetchElementInstance('2').withSuccess(selectedElementInstance);
+    mockSearchVariables().withSuccess({
+      items: [createVariable({scopeKey: '2'})],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+      wrapper: getWrapper([
+        `${Paths.processInstance('1')}?elementId=Activity_0qtp1k6&elementInstanceKey=2`,
+      ]),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /edit variable testVariableName/i}),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/readonly.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {
   createVariable,
@@ -40,7 +40,7 @@ const selectedElementInstance: ElementInstance = {
   tenantId: '<default>',
 };
 
-describe('VariablePanel readonly', () => {
+describe('VariablesTab readonly', () => {
   beforeEach(() => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
@@ -97,7 +97,7 @@ describe('VariablePanel readonly', () => {
       },
     });
 
-    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+    render(<VariablesTab />, {
       wrapper: getWrapper(),
     });
 
@@ -128,7 +128,7 @@ describe('VariablePanel readonly', () => {
       },
     });
 
-    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+    render(<VariablesTab />, {
       wrapper: getWrapper(),
     });
 
@@ -168,7 +168,7 @@ describe('VariablePanel readonly', () => {
       },
     });
 
-    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+    render(<VariablesTab />, {
       wrapper: getWrapper([
         `${Paths.processInstance('1')}?elementId=Activity_0qtp1k6&elementInstanceKey=2`,
       ]),

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/skeleton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/skeleton.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {getWrapper, mockProcessInstance} from './mocks';
+import {VariablePanel} from '../index';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockProcessXml} from 'modules/mocks/mockProcessXml';
+import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+
+const EMPTY_PLACEHOLDER = 'The element has no variables';
+
+describe('Skeleton', () => {
+  it('should display empty content if there are no variables', async () => {
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockFetchProcessDefinitionXml({processDefinitionKey: '123'}).withSuccess(
+      mockProcessXml,
+    );
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: 'StartEvent_1',
+          active: 0,
+          canceled: 0,
+          incidents: 0,
+          completed: 1,
+        },
+      ],
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+      wrapper: getWrapper(),
+    });
+    expect(await screen.findByText(EMPTY_PLACEHOLDER)).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/skeleton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/skeleton.test.tsx
@@ -8,7 +8,7 @@
 
 import {render, screen} from 'modules/testing-library';
 import {getWrapper, mockProcessInstance} from './mocks';
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
@@ -54,7 +54,7 @@ describe('Skeleton', () => {
       },
     });
 
-    render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+    render(<VariablesTab />, {
       wrapper: getWrapper(),
     });
     expect(await screen.findByText(EMPTY_PLACEHOLDER)).toBeInTheDocument();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/spinner.test.tsx
@@ -1,0 +1,309 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
+import {
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
+import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.9';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const TestSelectionControls: React.FC = () => {
+  const {selectElementInstance} = useProcessInstanceElementSelection();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'TEST_ELEMENT',
+            elementInstanceKey: '2',
+          })
+        }
+      >
+        select element instance
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'non-existing',
+            elementInstanceKey: 'non-existing-placeholder',
+            isPlaceholder: true,
+          })
+        }
+      >
+        select placeholder scope
+      </button>
+    </>
+  );
+};
+
+const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
+  const BaseWrapper = getBaseWrapper(...args);
+
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <BaseWrapper>
+      <>
+        <TestSelectionControls />
+        {children}
+      </>
+    </BaseWrapper>
+  );
+
+  return Wrapper;
+};
+
+const selectedElementInstance: ElementInstance = {
+  elementInstanceKey: '2',
+  elementId: 'TEST_ELEMENT',
+  elementName: 'Test Element',
+  type: 'SERVICE_TASK',
+  state: 'ACTIVE',
+  startDate: '2018-06-21',
+  endDate: null,
+  processDefinitionId: 'someKey',
+  processInstanceKey: '1',
+  processDefinitionKey: '2',
+  rootProcessInstanceKey: null,
+  hasIncident: false,
+  incidentKey: null,
+  tenantId: '<default>',
+};
+
+describe('VariablePanel spinner', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    const statistics = [
+      {
+        elementId: 'TEST_ELEMENT',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 1,
+        completed: 0,
+      },
+    ];
+
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+  });
+
+  it('should display spinner for variables tab when switching between tabs', async () => {
+    mockSearchVariables().withDelay({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    mockFetchElementInstance('2').withSuccess(selectedElementInstance);
+    mockSearchVariables().withDelay({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: /select element instance/i}),
+    );
+
+    expect(await screen.findByTestId('variables-spinner')).toBeInTheDocument();
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-spinner'),
+    );
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
+
+    await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
+  });
+
+  it('should display spinner on second variable fetch', async () => {
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withDelay({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withDelay({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    mockFetchElementInstance('2').withSuccess(selectedElementInstance);
+    await user.click(
+      screen.getByRole('button', {name: /select element instance/i}),
+    );
+
+    expect(screen.getByTestId('variables-spinner')).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-spinner'),
+    );
+  });
+
+  it('should not display spinner for variables tab when switching between tabs if scope does not exist', async () => {
+    modificationsStore.enableModificationMode();
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [createVariable()],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    await user.click(
+      screen.getByRole('button', {name: /select placeholder scope/i}),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('testVariableName')).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
+    expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/spinner.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {
   render,
   screen,
@@ -17,7 +17,6 @@ import {
   createVariable,
   mockProcessWithInputOutputMappingsXML,
 } from 'modules/testUtils';
-import {modificationsStore} from 'modules/stores/modifications';
 import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
 import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
@@ -49,18 +48,6 @@ const TestSelectionControls: React.FC = () => {
         }
       >
         select element instance
-      </button>
-      <button
-        type="button"
-        onClick={() =>
-          selectElementInstance({
-            elementId: 'non-existing',
-            elementInstanceKey: 'non-existing-placeholder',
-            isPlaceholder: true,
-          })
-        }
-      >
-        select placeholder scope
       </button>
     </>
   );
@@ -98,7 +85,7 @@ const selectedElementInstance: ElementInstance = {
   tenantId: '<default>',
 };
 
-describe('VariablePanel spinner', () => {
+describe('VariablesTab spinner', () => {
   beforeEach(() => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 
@@ -137,62 +124,6 @@ describe('VariablePanel spinner', () => {
     });
   });
 
-  it('should display spinner for variables tab when switching between tabs', async () => {
-    mockSearchVariables().withDelay({
-      items: [createVariable()],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
-
-    mockFetchElementInstance('2').withSuccess(selectedElementInstance);
-    mockSearchVariables().withDelay({
-      items: [createVariable()],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-
-    await user.click(
-      screen.getByRole('button', {name: /select element instance/i}),
-    );
-
-    expect(await screen.findByTestId('variables-spinner')).toBeInTheDocument();
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-spinner'),
-    );
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
-
-    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
-
-    await user.click(screen.getByRole('tab', {name: 'Variables'}));
-    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
-  });
-
   it('should display spinner on second variable fetch', async () => {
     mockSearchJobs().withSuccess({
       items: [],
@@ -222,12 +153,9 @@ describe('VariablePanel spinner', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
+    const {user} = render(<VariablesTab />, {
+      wrapper: getWrapper(),
+    });
     await waitFor(() => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
@@ -242,68 +170,5 @@ describe('VariablePanel spinner', () => {
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId('variables-spinner'),
     );
-  });
-
-  it('should not display spinner for variables tab when switching between tabs if scope does not exist', async () => {
-    modificationsStore.enableModificationMode();
-    mockSearchVariables().withSuccess({
-      items: [createVariable()],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockSearchVariables().withSuccess({
-      items: [createVariable()],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
-
-    mockSearchVariables().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
-    await user.click(
-      screen.getByRole('button', {name: /select placeholder scope/i}),
-    );
-
-    await waitFor(() => {
-      expect(screen.queryByText('testVariableName')).not.toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
-    expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
-
-    await user.click(screen.getByRole('tab', {name: 'Variables'}));
-    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/undoFromDifferentScope.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/undoFromDifferentScope.test.tsx
@@ -1,0 +1,367 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen, waitFor, type UserEvent} from 'modules/testing-library';
+import {createVariable} from 'modules/testUtils';
+import {
+  modificationsStore,
+  type ElementModification,
+} from 'modules/stores/modifications';
+import {act} from 'react';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
+
+const INITIAL_ADD_MODIFICATION: ElementModification = {
+  type: 'token',
+  payload: {
+    affectedTokenCount: 1,
+    element: {
+      id: 'element_0',
+      name: 'element 0',
+    },
+    operation: 'ADD_TOKEN',
+    parentScopeIds: {},
+    scopeId: 'random-scope-id-0',
+    visibleAffectedTokenCount: 1,
+  },
+};
+
+const editExistingVariableValue = async (
+  user: UserEvent,
+  variableName: string,
+  newValue: string,
+) => {
+  const variableRow = screen.getByTestId(`variable-${variableName}`);
+  const valueField = variableRow.querySelector('input');
+
+  if (!valueField) {
+    throw new Error(`No value field found for variable ${variableName}`);
+  }
+
+  await user.click(valueField);
+  await user.keyboard('{Control>}a{/Control}');
+  await user.keyboard('{Backspace}');
+  await user.type(valueField, newValue);
+  await user.tab();
+};
+
+const editLastNewVariableName = async (user: UserEvent, value: string) => {
+  const nameField = screen.getAllByTestId('new-variable-name').at(-1);
+
+  if (!nameField) {
+    throw new Error('No name field found');
+  }
+
+  await user.click(nameField);
+  await user.type(nameField, value);
+  await user.tab();
+};
+
+const editLastNewVariableValue = async (user: UserEvent, value: string) => {
+  const valueField = screen.getAllByTestId('new-variable-value').at(-1);
+
+  if (!valueField) {
+    throw new Error('No value field found');
+  }
+
+  await user.click(valueField);
+  await user.type(valueField, value);
+  await user.tab();
+};
+
+const TestSelectionControls: React.FC = () => {
+  const {selectElementInstance, clearSelection} =
+    useProcessInstanceElementSelection();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          selectElementInstance({
+            elementId: 'different_element',
+            elementInstanceKey: 'different_instance_id',
+          })
+        }
+      >
+        select different scope
+      </button>
+      <button type="button" onClick={() => clearSelection()}>
+        clear selection
+      </button>
+    </>
+  );
+};
+
+const getWrapper = (...args: Parameters<typeof getBaseWrapper>) => {
+  const BaseWrapper = getBaseWrapper(...args);
+
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <BaseWrapper>
+      <>
+        <TestSelectionControls />
+        {children}
+      </>
+    </BaseWrapper>
+  );
+
+  return Wrapper;
+};
+
+describe('Undo variable modifications from different scope', () => {
+  beforeEach(async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess('');
+  });
+
+  it('should preserve earlier edit modifications after undoing from a different scope', async () => {
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({name: 'foo', value: '"bar"', isTruncated: false}),
+        createVariable({name: 'test', value: '123', isTruncated: false}),
+      ],
+      page: {
+        totalItems: 2,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+
+    expect(await screen.findByDisplayValue('"bar"')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+
+    await editExistingVariableValue(user, 'foo', '1');
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+    });
+
+    await editExistingVariableValue(user, 'test', '2');
+    expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+
+    await editExistingVariableValue(user, 'foo', '3');
+    expect(screen.getByDisplayValue('3')).toBeInTheDocument();
+
+    act(() => {
+      modificationsStore.removeLastModification();
+    });
+    expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockFetchElementInstance('different_instance_id').withSuccess({
+      elementInstanceKey: 'different_instance_id',
+      elementId: 'different_element',
+      elementName: 'Different Element',
+      type: 'SERVICE_TASK',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      endDate: null,
+      processDefinitionId: 'someKey',
+      processInstanceKey: mockProcessInstance.processInstanceKey,
+      processDefinitionKey: '2',
+      rootProcessInstanceKey: null,
+      hasIncident: false,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: /select different scope/i}),
+    );
+
+    act(() => {
+      modificationsStore.removeLastModification();
+    });
+
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({name: 'foo', value: '"bar"', isTruncated: false}),
+        createVariable({name: 'test', value: '123', isTruncated: false}),
+      ],
+      page: {
+        totalItems: 2,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(screen.getByRole('button', {name: /clear selection/i}));
+
+    expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+  });
+
+  it('should preserve earlier added variable modifications after undoing from a different scope', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    modificationsStore.enableModificationMode();
+    modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    expect(await screen.findByTestId('new-variable-name')).toBeInTheDocument();
+    await editLastNewVariableName(user, 'test2');
+    await editLastNewVariableValue(user, '1');
+
+    expect(screen.getByDisplayValue('test2')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    await waitFor(() => {
+      expect(screen.getAllByTestId('new-variable-name')).toHaveLength(2);
+    });
+    await editLastNewVariableName(user, 'test3');
+    await editLastNewVariableValue(user, '2');
+
+    expect(screen.getByDisplayValue('test3')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    mockFetchElementInstance('different_instance_id').withSuccess({
+      elementInstanceKey: 'different_instance_id',
+      elementId: 'different_element',
+      elementName: 'Different Element',
+      type: 'SERVICE_TASK',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      endDate: null,
+      processDefinitionId: 'someKey',
+      processInstanceKey: mockProcessInstance.processInstanceKey,
+      processDefinitionKey: '2',
+      rootProcessInstanceKey: null,
+      hasIncident: false,
+      incidentKey: null,
+      tenantId: '<default>',
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: /select different scope/i}),
+    );
+
+    act(() => {
+      modificationsStore.removeLastModification();
+    });
+
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(screen.getByRole('button', {name: /clear selection/i}));
+
+    expect(screen.getByDisplayValue('test2')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+
+    expect(screen.queryByDisplayValue('test3')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('2')).not.toBeInTheDocument();
+
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/undoFromDifferentScope.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/undoFromDifferentScope.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {VariablePanel} from '../index';
+import {VariablesTab} from '../index';
 import {render, screen, waitFor, type UserEvent} from 'modules/testing-library';
 import {createVariable} from 'modules/testUtils';
 import {
@@ -160,10 +160,7 @@ describe('Undo variable modifications from different scope', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
 
     expect(await screen.findByDisplayValue('"bar"')).toBeInTheDocument();
     expect(screen.getByDisplayValue('123')).toBeInTheDocument();
@@ -281,10 +278,7 @@ describe('Undo variable modifications from different scope', () => {
       },
     });
 
-    const {user} = render(
-      <VariablePanel setListenerTabVisibility={vi.fn()} />,
-      {wrapper: getWrapper()},
-    );
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
 
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();


### PR DESCRIPTION
## Description

Copies the variables test suites from the bottom panel into the new bottom panel tabs. First commit is a pure copy, the second one adjust the tests to work with the updated `VariablesTab`.

## Related issues

relates #47046
