### PR TITLE
[Backport stable/8.9] fix: liveness probe should not depend on Elasticsearch availability

### DIFF
--- a/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -46,9 +45,6 @@ public class HealthConfigurationInitializer
   private static final String HEALTH_GROUP_LIVENESS_PROPERTY =
       "management.endpoint.health.group.liveness.include";
 
-  @Value("camunda.mode")
-  private String camundaMode;
-
   @Override
   public void initialize(final ConfigurableApplicationContext context) {
     final var environment = context.getEnvironment();
@@ -56,20 +52,24 @@ public class HealthConfigurationInitializer
     final var activeProfiles =
         Stream.of(environment.getActiveProfiles()).map(String::toLowerCase).toList();
 
-    final var healthIndicators = collectHealthIndicators(activeProfiles, environment);
-    final var enableReadinessState = shouldReadinessState(activeProfiles);
-    final var enableProbes = shouldEnableProbes(activeProfiles);
-
     final var propertyMap = new HashMap<String, Object>();
 
-    // Enables readinessState
-    propertyMap.put(SPRING_READINESS_PROPERTY, enableReadinessState);
+    // Enables Kubernetes health group endpoints (/actuator/health/{liveness,readiness,startup}).
+    // Always enabled so that liveness and readiness endpoints are available for all profiles
+    propertyMap.put("management.endpoint.health.probes.enabled", true);
 
-    // Enables Kubernetes health groups
-    propertyMap.put(SPRING_PROBES_PROPERTY, enableProbes);
+    final var readinessGroupHealthIndicators =
+        collectReadinessGroupHealthIndicators(activeProfiles, environment);
+    if (!readinessGroupHealthIndicators.isEmpty()) {
+      propertyMap.put(
+          "management.endpoint.health.group.readiness.include", readinessGroupHealthIndicators);
+    }
 
-    if (!healthIndicators.isEmpty()) {
-      propertyMap.put(SPRING_READINESS_GROUP_PROPERTY, healthIndicators);
+    final var livenessGroupHealthIndicators = collectLivenessGroupHealthIndicators(activeProfiles);
+    if (!livenessGroupHealthIndicators.isEmpty()) {
+      propertyMap.put(
+          "management.endpoint.health.group.liveness.include", livenessGroupHealthIndicators);
+      propertyMap.put("management.endpoint.health.group.liveness.show-details", "always");
     }
 
     final Set<String> startupGroup = new HashSet<>();
@@ -80,14 +80,6 @@ public class HealthConfigurationInitializer
       propertyMap.put("management.health.defaults.enabled", true);
       startupGroup.add(INDICATOR_GATEWAY_STARTED);
       propertyMap.put("management.endpoint.health.group.startup.show-details", "never");
-
-      final Set<String> livenessGroup = new HashSet<>();
-      livenessGroup.add("livenessGatewayClusterAwareness");
-      livenessGroup.add("livenessGatewayPartitionLeaderAwareness");
-      livenessGroup.add("livenessMemory");
-      propertyMap.put(HEALTH_GROUP_LIVENESS_PROPERTY, livenessGroup);
-      propertyMap.put("management.endpoint.health.group.liveness.show-details", "always");
-
       propertyMap.put(
           "management.endpoint.health.status.order", "down,out-of-service,unknown,degraded,up");
 
@@ -124,31 +116,37 @@ public class HealthConfigurationInitializer
     DefaultPropertiesPropertySource.addOrMerge(propertyMap, propertySources);
   }
 
-  protected boolean shouldEnableProbes(final List<String> activeProfiles) {
-    return activeProfiles.stream()
-        .anyMatch(
-            Set.of(
-                    Profile.OPERATE.getId(),
-                    Profile.TASKLIST.getId(),
-                    Profile.IDENTITY.getId(),
-                    Profile.ADMIN.getId())
-                ::contains);
-  }
+  /**
+   * Returns health indicators for the liveness group. Liveness must never depend on external
+   * systems (like Elasticsearch/OpenSearch) to avoid cascading pod restarts when the search engine
+   * is temporarily unavailable.
+   *
+   * <p>For the broker profile, {@code brokerReady} and {@code nodeIdProviderReady} are included so
+   * that a broker stuck in an unready state (e.g., partitions never forming) is eventually
+   * restarted by Kubernetes.
+   *
+   * <p>For the gateway profile, delayed liveness indicators with built-in grace periods are used to
+   * avoid restarting on transient issues.
+   */
+  List<String> collectLivenessGroupHealthIndicators(final List<String> activeProfiles) {
+    final var healthIndicators = new ArrayList<String>();
 
-  protected boolean shouldReadinessState(final List<String> activeProfiles) {
-    return activeProfiles.stream()
-        .anyMatch(
-            Set.of(
-                    Profile.OPERATE.getId(),
-                    Profile.TASKLIST.getId(),
-                    Profile.BROKER,
-                    Profile.IDENTITY.getId(),
-                    Profile.ADMIN.getId())
-                ::contains);
+    if (activeProfiles.contains(Profile.BROKER.getId())) {
+      healthIndicators.add("brokerReady");
+      healthIndicators.add("nodeIdProviderReady");
+    }
+
+    if (activeProfiles.contains(Profile.GATEWAY.getId())) {
+      healthIndicators.add("livenessGatewayClusterAwareness");
+      healthIndicators.add("livenessGatewayPartitionLeaderAwareness");
+      healthIndicators.add("livenessMemory");
+    }
+
+    return healthIndicators;
   }
 
   /** Returns a list of health indicators which will be member of the readiness group */
-  protected List<String> collectHealthIndicators(
+  protected List<String> collectReadinessGroupHealthIndicators(
       final List<String> activeProfiles, final Environment env) {
     final var healthIndicators = new ArrayList<String>();
     final boolean secondaryStorageEnabled = DatabaseTypeUtils.isSecondaryStorageEnabled(env);
@@ -162,23 +160,20 @@ public class HealthConfigurationInitializer
       healthIndicators.add(INDICATOR_GATEWAY_STARTED);
     }
 
-    if (secondaryStorageEnabled && activeProfiles.contains(Profile.OPERATE.getId())) {
-      healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
-      if (DatabaseTypeUtils.isRdbmsDisabled(env)) {
-        healthIndicators.add(INDICATOR_OPERATE_INDICES_CHECK);
+    if (secondaryStorageEnabled) {
+      if (Profile.getWebappProfiles().stream()
+          .map(Profile::getId)
+          .anyMatch(activeProfiles::contains)) {
+        healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
       }
-    }
-
-    if (secondaryStorageEnabled
-        && activeProfiles.contains(Profile.TASKLIST.getId())
-        && DatabaseTypeUtils.isRdbmsDisabled(env)) {
-      healthIndicators.add(INDICATOR_TASKLIST_SEARCH_ENGINE_CHECK);
-    }
-
-    if (secondaryStorageEnabled
-        && (activeProfiles.contains(Profile.IDENTITY.getId())
-            || activeProfiles.contains(Profile.ADMIN.getId()))) {
-      healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
+      if (DatabaseTypeUtils.isRdbmsDisabled(env)) {
+        if (activeProfiles.contains(Profile.OPERATE.getId())) {
+          healthIndicators.add("indicesCheck");
+        }
+        if (activeProfiles.contains(Profile.TASKLIST.getId())) {
+          healthIndicators.add("searchEngineCheck");
+        }
+      }
     }
 
     return healthIndicators;

--- a/dist/src/test/java/io/camunda/application/StartCamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/StartCamundaDockerIT.java
@@ -10,11 +10,13 @@ package io.camunda.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.testcontainers.containers.GenericContainer;
@@ -23,6 +25,8 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 @EnabledIfSystemProperty(named = "camunda.docker.test.enabled", matches = "true")
 public class StartCamundaDockerIT extends AbstractCamundaDockerIT {
   protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @AutoClose private CloseableHttpClient httpClient = HttpClients.createDefault();
 
   @Test
   public void testStartCamundaDocker() throws Exception {
@@ -36,44 +40,81 @@ public class StartCamundaDockerIT extends AbstractCamundaDockerIT {
 
     // when
     startContainer(camundaContainer);
-    // and when performing health check
-    try (final CloseableHttpClient httpClient = HttpClients.createDefault();
-        final CloseableHttpResponse healthCheckResponse =
-            httpClient.execute(
-                new HttpGet(
-                    String.format(
-                        "http://%s:%d%s",
-                        camundaContainer.getHost(),
-                        camundaContainer.getMappedPort(MANAGEMENT_PORT),
-                        "/actuator/health")))) {
+    // then - verify overall health endpoint
+    assertHealthEndpoint(
+        camundaContainer,
+        "/actuator/health",
+        """
+            {
+              "status": "UP",
+              "components": {
+                "brokerReady": {"status": "UP"},
+                "brokerStartup": {"status": "UP"},
+                "brokerStatus": {"status": "UP"},
+                "indicesCheck": {"status": "UP"},
+                "livenessState": {"status": "UP"},
+                "nodeIdProvider":{"status":"UP"},
+                "nodeIdProviderReady":{"status":"UP"},
+                "readinessState": {"status": "UP"},
+                "searchEngineCheck": {"status": "UP"}
+              },
+              "groups": ["liveness", "readiness", "startup", "status"]
+            }
+            """);
 
-      // then - convert the response and expected response to intermediate JSON representation
-      // this will allow us to compare without worrying about the ordering of the values, and just
-      // checking that they are logically equivalent
-      assertThat(healthCheckResponse.getCode()).isEqualTo(200);
-      final String expectedHealthCheckResponse =
-          """
-              {
-                "status": "UP",
-                "components": {
-                  "brokerReady": {"status": "UP"},
-                  "brokerStartup": {"status": "UP"},
-                  "brokerStatus": {"status": "UP"},
-                  "indicesCheck": {"status": "UP"},
-                  "livenessState": {"status": "UP"},
-                  "nodeIdProvider":{"status":"UP"},
-                  "nodeIdProviderReady":{"status":"UP"},
-                  "readinessState": {"status": "UP"},
-                  "searchEngineCheck": {"status": "UP"}
-                },
-                "groups": ["liveness", "readiness", "startup", "status"]
+    // verify readiness probe
+    assertHealthEndpoint(
+        camundaContainer,
+        "/actuator/health/readiness",
+        """
+            {
+              "status": "UP",
+              "components": {
+                "brokerReady": {"status": "UP"},
+                "indicesCheck": {"status": "UP"},
+                "nodeIdProviderReady": {"status": "UP"},
+                "readinessState": {"status": "UP"},
+                "searchEngineCheck": {"status": "UP"}
               }
-              """;
-      final var expectedJson = OBJECT_MAPPER.readTree(expectedHealthCheckResponse);
-      final var actualJson =
-          OBJECT_MAPPER.readTree(EntityUtils.toString(healthCheckResponse.getEntity()));
+            }
+            """);
 
-      assertThat(actualJson).isEqualTo(expectedJson);
+    // verify liveness probe
+    assertHealthEndpoint(
+        camundaContainer,
+        "/actuator/health/liveness",
+        """
+            {
+              "status": "UP",
+              "components": {
+                "brokerReady": {"status": "UP"},
+                "nodeIdProviderReady": {"status": "UP"}
+              }
+            }
+            """);
+
+    // verify startup probe
+    assertHealthEndpoint(
+        camundaContainer,
+        "/actuator/health/startup",
+        """
+            {"status": "UP"}
+            """);
+  }
+
+  private static String healthUrl(final GenericContainer<?> container, final String path) {
+    return String.format(
+        "http://%s:%d%s", container.getHost(), container.getMappedPort(MANAGEMENT_PORT), path);
+  }
+
+  private void assertHealthEndpoint(
+      final GenericContainer<?> container, final String path, final String expectedJson)
+      throws IOException, ParseException {
+    try (final var response = httpClient.execute(new HttpGet(healthUrl(container, path)))) {
+      assertThat(response.getCode()).isEqualTo(200);
+      final var actual = OBJECT_MAPPER.readTree(EntityUtils.toString(response.getEntity()));
+      final var expected = OBJECT_MAPPER.readTree(expectedJson);
+      assertThat(actual).isEqualTo(expected);
     }
   }
 }

--- a/dist/src/test/java/io/camunda/application/initializers/HealthConfigurationInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/initializers/HealthConfigurationInitializerTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.initializers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.application.Profile;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.core.env.Environment;
+
+class HealthConfigurationInitializerTest {
+
+  private HealthConfigurationInitializer initializer;
+  private Environment environment;
+
+  @BeforeEach
+  void setUp() {
+    initializer = new HealthConfigurationInitializer();
+    environment = mock(Environment.class);
+  }
+
+  private void withElasticsearchSecondaryStorage() {
+    when(environment.getProperty("camunda.data.secondary-storage.type"))
+        .thenReturn("elasticsearch");
+  }
+
+  private void withRdbmsSecondaryStorage() {
+    when(environment.getProperty("camunda.data.secondary-storage.type")).thenReturn("rdbms");
+  }
+
+  private void withNoSecondaryStorage() {
+    when(environment.getProperty("camunda.data.secondary-storage.type")).thenReturn("none");
+  }
+
+  @Nested
+  class LivenessGroup {
+
+    @Test
+    void shouldReturnBrokerIndicatorsForBrokerProfile() {
+      // given
+      final var profiles = List.of(Profile.BROKER.getId());
+
+      // when
+      final var indicators = initializer.collectLivenessGroupHealthIndicators(profiles);
+
+      // then
+      assertThat(indicators).containsExactly("brokerReady", "nodeIdProviderReady");
+    }
+
+    @Test
+    void shouldReturnGatewayLivenessIndicatorsForGatewayProfile() {
+      // given
+      final var profiles = List.of(Profile.GATEWAY.getId());
+
+      // when
+      final var indicators = initializer.collectLivenessGroupHealthIndicators(profiles);
+
+      // then
+      assertThat(indicators)
+          .containsExactly(
+              "livenessGatewayClusterAwareness",
+              "livenessGatewayPartitionLeaderAwareness",
+              "livenessMemory");
+    }
+
+    @Test
+    void shouldReturnBrokerIndicatorsForAllInOneMode() {
+      // given — all-in-one mode: broker + webapps, no GATEWAY profile
+      final var profiles =
+          List.of(Profile.BROKER.getId(), Profile.OPERATE.getId(), Profile.TASKLIST.getId());
+
+      // when
+      final var indicators = initializer.collectLivenessGroupHealthIndicators(profiles);
+
+      // then — only broker indicators, no ES-dependent indicators from webapp profiles
+      assertThat(indicators)
+          .containsExactly("brokerReady", "nodeIdProviderReady")
+          .doesNotContain("indicesCheck", "searchEngineCheck");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"operate", "tasklist", "identity", "admin"})
+    void shouldReturnEmptyForWebappOnlyProfiles(final String profile) {
+      // given
+      final var profiles = List.of(profile);
+
+      // when
+      final var indicators = initializer.collectLivenessGroupHealthIndicators(profiles);
+
+      // then
+      assertThat(indicators).isEmpty();
+    }
+
+    @Test
+    void shouldNeverContainEsDependentIndicators() {
+      // given — full deployment with all profiles
+      final var profiles = Stream.of(Profile.values()).map(Profile::getId).toList();
+
+      // when
+      final var indicators = initializer.collectLivenessGroupHealthIndicators(profiles);
+
+      // then — must not contain any ES-dependent indicators
+      assertThat(indicators).doesNotContain("indicesCheck", "searchEngineCheck");
+    }
+  }
+
+  @Nested
+  class ReadinessGroup {
+
+    @Test
+    void shouldIncludeBrokerIndicators() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.of(Profile.BROKER.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).containsExactly("brokerReady", "nodeIdProviderReady");
+    }
+
+    @Test
+    void shouldIncludeGatewayStartedIndicator() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.of(Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).containsExactly("gatewayStarted");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"operate", "tasklist", "identity", "admin"})
+    void shouldIncludeReadinessStateForAnyWebappProfile(final String profile) {
+      // given — Identity is a webapp profile, should get readinessState
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(profile);
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains("readinessState");
+    }
+
+    @Test
+    void shouldNotDuplicateReadinessStateForMultipleWebappProfiles() {
+      // given
+      withElasticsearchSecondaryStorage();
+      final var profiles = Profile.getWebappProfiles().stream().map(Profile::getId).toList();
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then — readinessState should appear exactly once
+      assertThat(indicators.stream().filter("readinessState"::equals)).hasSize(1);
+    }
+
+    @Test
+    void shouldIncludeIndicesCheckForOperateWithES() {
+      // given
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.OPERATE.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains("readinessState", "indicesCheck");
+    }
+
+    @Test
+    void shouldIncludeSearchEngineCheckForTasklistWithES() {
+      // given
+      withElasticsearchSecondaryStorage();
+      final var profiles = List.of(Profile.TASKLIST.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains("readinessState", "searchEngineCheck");
+    }
+
+    @Test
+    void shouldNotIncludeEsIndicatorsWithRdbms() {
+      // given
+      withRdbmsSecondaryStorage();
+      final var profiles = List.of(Profile.OPERATE.getId(), Profile.TASKLIST.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains("readinessState")
+          .doesNotContain("indicesCheck", "searchEngineCheck");
+    }
+
+    @Test
+    void shouldNotIncludeSecondaryStorageIndicatorsWhenDisabled() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.of(Profile.OPERATE.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #48759 to `stable/8.9`.

relates to #48718