### PR TITLE
[Backport stable/8.8] Rename Observer, Scheduler, Checker, Redistributor, Initializer classes according to naming convention

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1499,11 +1499,11 @@
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:
-        # Changes the DueDateTimerChecker to give yield to other processing steps in situations where
-        # it has many (i.e. millions of) timers to process. If set to false (default) the DueDateTimerChecker will activate all
+        # Changes the DueDateTimerCheckScheduler to give yield to other processing steps in situations where
+        # it has many (i.e. millions of) timers to process. If set to false (default) the DueDateTimerCheckScheduler will activate all
         # due timers. In the worst case, this can lead to the node being blocked for indefinite amount of time,
         # being subsequently flagged as unhealthy. Currently, there is no known way to recover from this situation
-        # If set to true, the DueDateTimerChecker will give yield to other processing steps. This avoids the worst case
+        # If set to true, the DueDateTimerCheckScheduler will give yield to other processing steps. This avoids the worst case
         # described above. However, under consistent high load it may happen that the activated timers will fall behind real time,
         # if more timers become due than can be activated during a certain time period.
         #

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1424,11 +1424,11 @@
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:
-        # Changes the DueDateTimerChecker to give yield to other processing steps in situations where
-        # it has many (i.e. millions of) timers to process. If set to false (default) the DueDateTimerChecker will activate all
+        # Changes the DueDateTimerCheckScheduler to give yield to other processing steps in situations where
+        # it has many (i.e. millions of) timers to process. If set to false (default) the DueDateTimerCheckScheduler will activate all
         # due timers. In the worst case, this can lead to the node being blocked for indefinite amount of time,
         # being subsequently flagged as unhealthy. Currently, there is no known way to recover from this situation
-        # If set to true, the DueDateTimerChecker will give yield to other processing steps. This avoids the worst case
+        # If set to true, the DueDateTimerCheckScheduler will give yield to other processing steps. This avoids the worst case
         # described above. However, under consistent high load it may happen that the activated timers will fall behind real time,
         # if more timers become due than can be activated during a certain time period.
         #

--- a/docs/zeebe/developer_handbook.md
+++ b/docs/zeebe/developer_handbook.md
@@ -188,7 +188,7 @@ In some cases, a partition needs to communicate with other partitions:
 
 The engine can send a command to another partition using `InterPartitionCommandSender`. Note that this may fail because network communication is not reliable. So for all inter-partition communication, you must use some retry mechanism.
 
-For example, the `DeploymentRedistributor` resends deployment distribution commands to other partitions.
+For example, the `DeploymentRedistributionScheduler` resends deployment distribution commands to other partitions.
 
 > **Note**
 > There is no response for inter-partition communication. It is a case of "fire and forget".

--- a/docs/zeebe/generalized_distribution.md
+++ b/docs/zeebe/generalized_distribution.md
@@ -124,7 +124,7 @@ Using different queue ids per partition or conversely maintaining order across p
 
 A command distribution means we have network traffic between partition. Where there's network
 traffic there's a chance of failure. If this happens we need a way to redistribute the command. For
-this we have the `CommandRedistributor`.
+this we have the `CommandRedistributionScheduler`.
 
 As shown in the diagram we store multiple things in the state. First there's the record metadata and
 the raw record value. Next there's a pending command distribution. Both of these are used during
@@ -151,7 +151,7 @@ is under heavy load, and we want to prevent it from receiving more commands.
 
 To pause command redistribution we can set the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_DISTRIBUTION_PAUSECOMMANDDISTRIBUTION`
 (i.e. `zeebe.broker.experimental.engine.distribution.pauseCommandDistribution`) flag to `true` and
-restart the brokers. This will prevent the `CommandRedistributor` from scheduling the retry cycle
+restart the brokers. This will prevent the `CommandRedistributionScheduler` from scheduling the retry cycle
 and allow an engineer to investigate any issues.
 
 #### Configuring retry intervals

--- a/zeebe/engine/spotbugs/spotbugs-exclude.xml
+++ b/zeebe/engine/spotbugs/spotbugs-exclude.xml
@@ -12,7 +12,7 @@
 <!--    <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>-->
 <!--  </Match>-->
   <Match>
-    <Class name="io.camunda.zeebe.engine.processing.scheduled.DueDateChecker"/>
+    <Class name="io.camunda.zeebe.engine.processing.scheduled.DueDateCheckScheduler"/>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
   </Match>
 </FindBugsFilter>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/DistributionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/DistributionMetrics.java
@@ -101,7 +101,7 @@ public final class DistributionMetrics {
   /**
    * This method is called when a current inflight distribution is being retried. This may happen if
    * the acknowledgement of the target partition is not received by the origin partition in-time.
-   * See {@link io.camunda.zeebe.engine.processing.distribution.CommandRedistributor}.
+   * See {@link io.camunda.zeebe.engine.processing.distribution.CommandRedistributionScheduler}.
    *
    * @param targetPartitionId the target partition id of the distribution
    */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.message.PendingProcessMessageSubscriptionChecker;
+import io.camunda.zeebe.engine.processing.message.PendingProcessMessageSubscriptionCheckScheduler;
 import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCorrelateProcessor;
 import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCreateProcessor;
 import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDeleteProcessor;
@@ -31,7 +31,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModific
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.processing.timer.TimerCancelProcessor;
 import io.camunda.zeebe.engine.processing.timer.TimerTriggerProcessor;
 import io.camunda.zeebe.engine.processing.variable.VariableDocumentUpdateProcessor;
@@ -67,7 +67,7 @@ public final class BpmnProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final SubscriptionCommandSender subscriptionCommandSender,
-      final DueDateTimerChecker timerChecker,
+      final DueDateTimerCheckScheduler timerChecker,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final int partitionId,
@@ -197,7 +197,7 @@ public final class BpmnProcessors {
             new ProcessMessageSubscriptionDeleteProcessor(
                 subscriptionState, writers, transientProcessMessageSubscriptionState))
         .withListener(
-            new PendingProcessMessageSubscriptionChecker(
+            new PendingProcessMessageSubscriptionCheckScheduler(
                 subscriptionCommandSender,
                 scheduledTaskState.get().getPendingProcessMessageSubscriptionState(),
                 clock));
@@ -205,7 +205,7 @@ public final class BpmnProcessors {
 
   private static void addTimerStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
-      final DueDateTimerChecker timerChecker,
+      final DueDateTimerCheckScheduler timerChecker,
       final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -27,12 +27,12 @@ import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCompleteProcessor;
-import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
+import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributionScheduler;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionAcknowledgeProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionContinueProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionFinishProcessor;
-import io.camunda.zeebe.engine.processing.distribution.CommandRedistributor;
+import io.camunda.zeebe.engine.processing.distribution.CommandRedistributionScheduler;
 import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluteProcessor;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationProcessors;
 import io.camunda.zeebe.engine.processing.identity.GroupProcessors;
@@ -55,7 +55,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorCo
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.tenant.TenantProcessors;
-import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.processing.user.UserProcessors;
 import io.camunda.zeebe.engine.processing.usertask.UserTaskProcessor;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -111,8 +111,8 @@ public final class EngineProcessors {
     final var config = typedRecordProcessorContext.getConfig();
     final var securityConfig = typedRecordProcessorContext.getSecurityConfig();
 
-    final DueDateTimerChecker timerChecker =
-        new DueDateTimerChecker(
+    final DueDateTimerCheckScheduler timerChecker =
+        new DueDateTimerCheckScheduler(
             scheduledTaskStateFactory.get().getTimerState(), featureFlags, clock);
 
     final var jobMetrics = new JobProcessingMetrics(typedRecordProcessorContext.getMeterRegistry());
@@ -370,7 +370,7 @@ public final class EngineProcessors {
       final Writers writers,
       final SubscriptionCommandSender subscriptionCommandSender,
       final RoutingInfo routingInfo,
-      final DueDateTimerChecker timerChecker,
+      final DueDateTimerCheckScheduler timerChecker,
       final JobStreamer jobStreamer,
       final JobProcessingMetrics jobMetrics,
       final DecisionBehavior decisionBehavior,
@@ -400,7 +400,7 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
-      final DueDateTimerChecker timerChecker,
+      final DueDateTimerCheckScheduler timerChecker,
       final CommandDistributionBehavior commandDistributionBehavior,
       final int partitionId,
       final RoutingInfo routingInfo,
@@ -462,7 +462,7 @@ public final class EngineProcessors {
 
     // periodically retries deployment distribution
     final var deploymentRedistributor =
-        new DeploymentRedistributor(
+        new DeploymentRedistributionScheduler(
             deploymentDistributionCommandSender,
             scheduledTaskStateSupplier.get().getDeploymentState(),
             routingInfo);
@@ -620,11 +620,12 @@ public final class EngineProcessors {
     {
       final var scheduledTaskState = scheduledTaskStateSupplier.get();
       // periodically retries command distribution
-      // Note that the CommandRedistributor runs in a separate actor, so it must not use the same
+      // Note that the CommandRedistributionScheduler runs in a separate actor, so it must not use
+      // the same
       // state as the StreamProcessors as it runs in another RocksDB transaction as well.
       // It can only use the state from scheduledTaskStateSupplier.
       typedRecordProcessors.withListener(
-          new CommandRedistributor(
+          new CommandRedistributionScheduler(
               commandDistributionBehavior.withScheduledState(
                   scheduledTaskState.getDistributionState()),
               RoutingInfo.dynamic(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.handlers.ResolveInciden
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationCommandAppender;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationExecutionScheduler;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializer;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -75,7 +75,7 @@ public final class BatchOperationSetupProcessors {
                 brokerRequestAuthorizationConverter));
 
     final var batchOperationInitializer =
-        new BatchOperationInitializer(
+        new BatchOperationInitializationHelper(
             new ItemProviderFactory(searchClientsProxy, batchOperationMetrics, partitionId),
             new BatchOperationPageProcessor(engineConfiguration.getBatchOperationChunkSize()),
             new BatchOperationCommandAppender(partitionId),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionScheduler.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * processing.
  *
  * @see StreamProcessorLifecycleAware
- * @see BatchOperationInitializer
+ * @see BatchOperationInitializationHelper
  * @see BatchOperationRetryHandler
  */
 public class BatchOperationExecutionScheduler implements StreamProcessorLifecycleAware {
@@ -56,7 +56,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
 
   private final Duration initialPollingInterval;
   private final BatchOperationState batchOperationState;
-  private final BatchOperationInitializer batchOperationInitializer;
+  private final BatchOperationInitializationHelper batchOperationInitializer;
   private final BatchOperationRetryHandler retryHandler;
   private final AtomicBoolean executing = new AtomicBoolean(false);
   private final AtomicReference<ExecutionLoopState> initializing = new AtomicReference<>();
@@ -65,7 +65,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
 
   public BatchOperationExecutionScheduler(
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
-      final BatchOperationInitializer batchOperationInitializer,
+      final BatchOperationInitializationHelper batchOperationInitializer,
       final BatchOperationRetryHandler retryHandler,
       final Duration batchOperationSchedulerInterval) {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationHelper.java
@@ -38,10 +38,11 @@ import org.slf4j.LoggerFactory;
  * @see ItemProviderFactory
  * @see PersistedBatchOperation
  */
-public class BatchOperationInitializer {
+public class BatchOperationInitializationHelper {
   public static final String ERROR_MSG_FAILED_FIRST_CHUNK_APPEND =
       "Unable to append first chunk of batch operation items. Number of items: %d";
-  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationInitializer.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BatchOperationInitializationHelper.class);
 
   private final ItemProviderFactory itemProviderFactory;
   private final BatchOperationMetrics metrics;
@@ -49,7 +50,7 @@ public class BatchOperationInitializer {
   private final BatchOperationPageProcessor pageProcessor;
   private final int queryPageSize;
 
-  public BatchOperationInitializer(
+  public BatchOperationInitializationHelper(
       final ItemProviderFactory itemProviderFactory,
       final BatchOperationPageProcessor pageProcessor,
       final BatchOperationCommandAppender commandAppender,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandler.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializer.BatchOperationInitializationException;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializer.BatchOperationInitializationResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationResult;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
 import java.time.Duration;
 import java.util.Set;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.processing.variable.VariableStateEvaluationContextLookup;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
@@ -63,7 +63,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final DecisionBehavior decisionBehavior,
       final SubscriptionCommandSender subscriptionCommandSender,
       final RoutingInfo routingInfo,
-      final DueDateTimerChecker timerChecker,
+      final DueDateTimerCheckScheduler timerChecker,
       final JobStreamer jobStreamer,
       final InstantSource clock,
       final AuthorizationCheckBehavior authCheckBehavior,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSig
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -63,7 +63,7 @@ public final class CatchEventBehavior {
   private final ProcessMessageSubscriptionRecord subscription =
       new ProcessMessageSubscriptionRecord();
   private final TimerRecord timerRecord = new TimerRecord();
-  private final DueDateTimerChecker timerChecker;
+  private final DueDateTimerCheckScheduler timerChecker;
   private final KeyGenerator keyGenerator;
   private final SignalSubscriptionRecord signalSubscription = new SignalSubscriptionRecord();
   private final InstantSource clock;
@@ -76,7 +76,7 @@ public final class CatchEventBehavior {
       final SubscriptionCommandSender subscriptionCommandSender,
       final StateWriter stateWriter,
       final SideEffectWriter sideEffectWriter,
-      final DueDateTimerChecker timerChecker,
+      final DueDateTimerCheckScheduler timerChecker,
       final RoutingInfo routingInfo,
       final InstantSource clock,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentRedistributionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentRedistributionScheduler.java
@@ -23,19 +23,20 @@ import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DeploymentRedistributor implements StreamProcessorLifecycleAware {
+public class DeploymentRedistributionScheduler implements StreamProcessorLifecycleAware {
 
   public static final Duration DEPLOYMENT_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
   private static final Duration RETRY_MAX_BACKOFF_DURATION = Duration.ofMinutes(5);
   private static final long MAX_RETRY_CYCLES =
       RETRY_MAX_BACKOFF_DURATION.dividedBy(DEPLOYMENT_REDISTRIBUTION_INTERVAL);
-  private static final Logger LOG = LoggerFactory.getLogger(DeploymentRedistributor.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DeploymentRedistributionScheduler.class);
   private final DeploymentDistributionCommandSender deploymentDistributionCommandSender;
   private final DeploymentState deploymentState;
   private final RoutingInfo routingInfo;
   private final Map<PendingDistribution, Long> retryCyclesPerDistribution = new HashMap<>();
 
-  public DeploymentRedistributor(
+  public DeploymentRedistributionScheduler(
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
       final DeploymentState deploymentState,
       final RoutingInfo routingInfo) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributionScheduler.java
@@ -31,9 +31,9 @@ import org.slf4j.LoggerFactory;
  * retry until it reaches the maximum backoff duration. This backoff is tracked for each retriable
  * distribution individually.
  */
-public final class CommandRedistributor implements StreamProcessorLifecycleAware {
+public final class CommandRedistributionScheduler implements StreamProcessorLifecycleAware {
 
-  private static final Logger LOG = LoggerFactory.getLogger(CommandRedistributor.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CommandRedistributionScheduler.class);
 
   /**
    * Specifies how often this redistributor runs, i.e. the fixed delay between runs. It is also used
@@ -59,7 +59,7 @@ public final class CommandRedistributor implements StreamProcessorLifecycleAware
    */
   private final Map<RetriableDistribution, Long> retryCyclesPerDistribution = new HashMap<>();
 
-  public CommandRedistributor(
+  public CommandRedistributionScheduler(
       final CommandDistributionBehavior distributionBehavior,
       final RoutingInfo routingInfo,
       final EngineConfiguration config) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -34,7 +34,7 @@ public class AuthorizationCreateProcessor
   private final SideEffectWriter sideEffectWriter;
   private final PermissionsBehavior permissionsBehavior;
   private final AuthorizationCheckBehavior authorizationCheckBehavior;
-  private final AuthorizationEntityChecker authorizationEntityChecker;
+  private final AuthorizationEntityValidator authorizationEntityChecker;
 
   public AuthorizationCreateProcessor(
       final Writers writers,
@@ -50,7 +50,7 @@ public class AuthorizationCreateProcessor
     sideEffectWriter = writers.sideEffect();
     authorizationCheckBehavior = authCheckBehavior;
     permissionsBehavior = new PermissionsBehavior(processingState, authCheckBehavior);
-    authorizationEntityChecker = new AuthorizationEntityChecker(processingState);
+    authorizationEntityChecker = new AuthorizationEntityValidator(processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidator.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 
-public class AuthorizationEntityChecker {
+public class AuthorizationEntityValidator {
   public static final String MAPPING_RULE_DOES_NOT_EXIST_ERROR_MESSAGE =
       "Expected to create or update authorization with ownerId or resourceId '%s', but a mapping rule with this ID does not exist.";
   public static final String ROLE_DOES_NOT_EXIST_ERROR_MESSAGE =
@@ -35,7 +35,7 @@ public class AuthorizationEntityChecker {
   private final GroupState groupState;
   private final RoleState roleState;
 
-  public AuthorizationEntityChecker(final ProcessingState processingState) {
+  public AuthorizationEntityValidator(final ProcessingState processingState) {
     userState = processingState.getUserState();
     mappingRuleState = processingState.getMappingRuleState();
     groupState = processingState.getGroupState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -35,7 +35,7 @@ public class AuthorizationUpdateProcessor
   private final SideEffectWriter sideEffectWriter;
   private final AuthorizationCheckBehavior authorizationCheckBehavior;
   private final PermissionsBehavior permissionsBehavior;
-  private final AuthorizationEntityChecker authorizationEntityChecker;
+  private final AuthorizationEntityValidator authorizationEntityChecker;
 
   public AuthorizationUpdateProcessor(
       final Writers writers,
@@ -51,7 +51,7 @@ public class AuthorizationUpdateProcessor
     sideEffectWriter = writers.sideEffect();
     authorizationCheckBehavior = authCheckBehavior;
     permissionsBehavior = new PermissionsBehavior(processingState, authCheckBehavior);
-    authorizationEntityChecker = new AuthorizationEntityChecker(processingState);
+    authorizationEntityChecker = new AuthorizationEntityValidator(processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffCheckScheduler.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
-import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker;
+import io.camunda.zeebe.engine.processing.scheduled.DueDateCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
@@ -15,15 +15,15 @@ import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.time.Duration;
 import java.time.InstantSource;
 
-public final class JobBackoffChecker implements StreamProcessorLifecycleAware {
+public final class JobBackoffCheckScheduler implements StreamProcessorLifecycleAware {
 
   static final long BACKOFF_RESOLUTION = Duration.ofMillis(100).toMillis();
 
-  private final DueDateChecker backOffDueDateChecker;
+  private final DueDateCheckScheduler backOffDueDateChecker;
 
-  public JobBackoffChecker(final InstantSource clock, final JobState jobState) {
+  public JobBackoffCheckScheduler(final InstantSource clock, final JobState jobState) {
     backOffDueDateChecker =
-        new DueDateChecker(
+        new DueDateCheckScheduler(
             BACKOFF_RESOLUTION,
             false,
             taskResultBuilder ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionValidator.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 
-public class JobCommandPreconditionChecker {
+public class JobCommandPreconditionValidator {
 
   public static final String NO_JOB_FOUND_MESSAGE =
       "Expected to %s job with key '%d', but no such job was found";
@@ -30,7 +30,7 @@ public class JobCommandPreconditionChecker {
   private final List<JobCommandCheck> customChecks;
   private final AuthorizationCheckBehavior authorizationCheckBehavior;
 
-  public JobCommandPreconditionChecker(
+  public JobCommandPreconditionValidator(
       final JobState jobState,
       final String intent,
       final List<State> validStates,
@@ -38,7 +38,7 @@ public class JobCommandPreconditionChecker {
     this(jobState, intent, validStates, List.of(), authorizationCheckBehavior);
   }
 
-  public JobCommandPreconditionChecker(
+  public JobCommandPreconditionValidator(
       final JobState jobState,
       final String intent,
       final List<State> validStates,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -118,7 +118,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
   private final UserTaskState userTaskState;
   private final JobState jobState;
   private final ElementInstanceState elementInstanceState;
-  private final JobCommandPreconditionChecker preconditionChecker;
+  private final JobCommandPreconditionValidator preconditionChecker;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final JobProcessingMetrics jobMetrics;
   private final EventHandle eventHandle;
@@ -146,7 +146,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     preconditionChecker =
-        new JobCommandPreconditionChecker(
+        new JobCommandPreconditionValidator(
             state.getJobState(),
             "complete",
             List.of(State.ACTIVATABLE, State.ACTIVATED),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -47,7 +47,7 @@ public final class JobEventProcessors {
             bpmnBehaviors.stateBehavior());
 
     final var jobBackoffChecker =
-        new JobBackoffChecker(clock, scheduledTaskStateFactory.get().getJobState());
+        new JobBackoffCheckScheduler(clock, scheduledTaskStateFactory.get().getJobState());
     typedRecordProcessors
         .onCommand(
             ValueType.JOB,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -56,12 +56,12 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
   private final TypedResponseWriter responseWriter;
   private final KeyGenerator keyGenerator;
   private final JobProcessingMetrics jobMetrics;
-  private final JobBackoffChecker jobBackoffChecker;
+  private final JobBackoffCheckScheduler jobBackoffChecker;
   private final VariableBehavior variableBehavior;
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final SideEffectWriter sideEffectWriter;
-  private final JobCommandPreconditionChecker preconditionChecker;
+  private final JobCommandPreconditionValidator preconditionChecker;
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
 
@@ -70,7 +70,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       final Writers writers,
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
-      final JobBackoffChecker jobBackoffChecker,
+      final JobBackoffCheckScheduler jobBackoffChecker,
       final BpmnBehaviors bpmnBehaviors,
       final AuthorizationCheckBehavior authCheckBehavior) {
     jobState = state.getJobState();
@@ -84,7 +84,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
     jobActivationBehavior = bpmnBehaviors.jobActivationBehavior();
     this.authCheckBehavior = authCheckBehavior;
     preconditionChecker =
-        new JobCommandPreconditionChecker(
+        new JobCommandPreconditionValidator(
             jobState, "fail", List.of(State.ACTIVATABLE, State.ACTIVATED), authCheckBehavior);
     this.keyGenerator = keyGenerator;
     this.jobBackoffChecker = jobBackoffChecker;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -69,7 +69,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
 
   private final JobState jobState;
   private final ElementInstanceState elementInstanceState;
-  private final JobCommandPreconditionChecker preconditionChecker;
+  private final JobCommandPreconditionValidator preconditionChecker;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final CatchEventAnalyzer stateAnalyzer;
   private final KeyGenerator keyGenerator;
@@ -96,7 +96,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
     this.authCheckBehavior = authCheckBehavior;
 
     preconditionChecker =
-        new JobCommandPreconditionChecker(
+        new JobCommandPreconditionValidator(
             jobState,
             "throw an error for",
             List.of(State.ACTIVATABLE, State.ACTIVATED),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckScheduler.java
@@ -20,8 +20,8 @@ import org.agrona.collections.MutableInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class JobTimeoutChecker implements Task {
-  private static final Logger LOG = LoggerFactory.getLogger(JobTimeoutChecker.class);
+final class JobTimeoutCheckScheduler implements Task {
+  private static final Logger LOG = LoggerFactory.getLogger(JobTimeoutCheckScheduler.class);
 
   private boolean shouldReschedule = false;
 
@@ -37,7 +37,7 @@ final class JobTimeoutChecker implements Task {
   private final int batchLimit;
   private final InstantSource clock;
 
-  public JobTimeoutChecker(
+  public JobTimeoutCheckScheduler(
       final JobState state,
       final Duration pollingInterval,
       final int batchLimit,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerScheduler.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 public final class JobTimeoutCheckerScheduler implements StreamProcessorLifecycleAware {
   private static final Logger LOG = LoggerFactory.getLogger(JobTimeoutCheckerScheduler.class);
   private final Duration pollingInterval;
-  private final JobTimeoutChecker jobTimeoutChecker;
+  private final JobTimeoutCheckScheduler jobTimeoutChecker;
 
   public JobTimeoutCheckerScheduler(
       final JobState state,
@@ -26,7 +26,7 @@ public final class JobTimeoutCheckerScheduler implements StreamProcessorLifecycl
       final int batchLimit,
       final InstantSource clock) {
     this.pollingInterval = pollingInterval;
-    jobTimeoutChecker = new JobTimeoutChecker(state, pollingInterval, batchLimit, clock);
+    jobTimeoutChecker = new JobTimeoutCheckScheduler(state, pollingInterval, batchLimit, clock);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
@@ -29,7 +29,7 @@ public final class JobYieldProcessor implements TypedRecordProcessor<JobRecord> 
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
-  private final JobCommandPreconditionChecker preconditionChecker;
+  private final JobCommandPreconditionValidator preconditionChecker;
   private final AuthorizationCheckBehavior authorizationCheckBehavior;
 
   public JobYieldProcessor(
@@ -43,7 +43,7 @@ public final class JobYieldProcessor implements TypedRecordProcessor<JobRecord> 
     rejectionWriter = writers.rejection();
     this.authorizationCheckBehavior = authorizationCheckBehavior;
     preconditionChecker =
-        new JobCommandPreconditionChecker(
+        new JobCommandPreconditionValidator(
             jobState, "yield", List.of(State.ACTIVATED), authorizationCheckBehavior);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -57,7 +57,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
     final var messageState = scheduledTaskStateFactory.get().getMessageState();
     final var timestamp = clock.millis() + messagesTtlCheckerInterval.toMillis();
     final var timeToLiveChecker =
-        new MessageTimeToLiveChecker(
+        new MessageTimeToLiveCheckScheduler(
             messagesTtlCheckerInterval,
             messagesTtlCheckerBatchLimit,
             enableMessageTtlCheckerAsync,
@@ -75,7 +75,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
       final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
     final var pendingSubscriptionChecker =
-        new PendingMessageSubscriptionChecker(
+        new PendingMessageSubscriptionCheckScheduler(
             subscriptionCommandSender,
             pendingState,
             SUBSCRIPTION_TIMEOUT.toMillis(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveCheckScheduler.java
@@ -31,7 +31,7 @@ import org.agrona.collections.MutableInteger;
  * it left off the last time. Otherwise, it starts with the first expired message deadline it can
  * find.
  */
-public final class MessageTimeToLiveChecker implements Task {
+public final class MessageTimeToLiveCheckScheduler implements Task {
 
   /** This determines the duration that the TTL checker is idle after it completes an execution. */
   private final Duration executionInterval;
@@ -53,7 +53,7 @@ public final class MessageTimeToLiveChecker implements Task {
 
   private final InstantSource clock;
 
-  public MessageTimeToLiveChecker(
+  public MessageTimeToLiveCheckScheduler(
       final Duration executionInterval,
       final int batchLimit,
       final boolean enableMessageTtlCheckerAsync,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionCheckScheduler.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.MessageSubscription;
 import java.time.InstantSource;
 
-public final class PendingMessageSubscriptionChecker implements Runnable {
+public final class PendingMessageSubscriptionCheckScheduler implements Runnable {
   private final SubscriptionCommandSender commandSender;
   private final PendingMessageSubscriptionState state;
 
@@ -25,7 +25,7 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
 
   private final InstantSource clock;
 
-  public PendingMessageSubscriptionChecker(
+  public PendingMessageSubscriptionCheckScheduler(
       final SubscriptionCommandSender commandSender,
       final PendingMessageSubscriptionState state,
       final long subscriptionTimeout,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionCheckScheduler.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import java.time.Duration;
 import java.time.InstantSource;
 
-public final class PendingProcessMessageSubscriptionChecker
+public final class PendingProcessMessageSubscriptionCheckScheduler
     implements StreamProcessorLifecycleAware {
 
   private static final Duration SUBSCRIPTION_TIMEOUT = Duration.ofSeconds(10);
@@ -30,7 +30,7 @@ public final class PendingProcessMessageSubscriptionChecker
   private boolean schouldRescheduleTimer = false;
   private final InstantSource clock;
 
-  public PendingProcessMessageSubscriptionChecker(
+  public PendingProcessMessageSubscriptionCheckScheduler(
       final SubscriptionCommandSender commandSender,
       final PendingProcessMessageSubscriptionState pendingState,
       final InstantSource clock) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckScheduler.java
@@ -23,9 +23,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UsageMetricsChecker implements Task {
+public class UsageMetricsCheckScheduler implements Task {
 
-  private static final Logger LOG = LoggerFactory.getLogger(UsageMetricsChecker.class);
+  private static final Logger LOG = LoggerFactory.getLogger(UsageMetricsCheckScheduler.class);
 
   private final Duration exportInterval;
   private final InstantSource clock;
@@ -33,7 +33,7 @@ public class UsageMetricsChecker implements Task {
   private volatile boolean shouldReschedule = false;
   private final AtomicReference<ScheduledTask> scheduledTask = new AtomicReference<>(null);
 
-  public UsageMetricsChecker(final Duration exportInterval, final InstantSource clock) {
+  public UsageMetricsCheckScheduler(final Duration exportInterval, final InstantSource clock) {
     this.exportInterval = exportInterval;
     this.clock = clock;
   }
@@ -47,7 +47,7 @@ public class UsageMetricsChecker implements Task {
           processingContext
               .getScheduleService()
               .runAt(clock.millis() + exportInterval.toMillis(), this);
-      LOG.trace("UsageMetricsChecker scheduled");
+      LOG.trace("UsageMetricsCheckScheduler scheduled");
     }
 
     ofNullable(scheduledTask.getAndSet(nextTask)).ifPresent(ScheduledTask::cancel);
@@ -55,7 +55,7 @@ public class UsageMetricsChecker implements Task {
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    LOG.trace("UsageMetricsChecker running...");
+    LOG.trace("UsageMetricsCheckScheduler running...");
 
     taskResultBuilder.appendCommandRecord(
         UsageMetricIntent.EXPORT, new UsageMetricRecord().setEventType(EventType.NONE));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckerScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckerScheduler.java
@@ -14,12 +14,12 @@ import java.time.InstantSource;
 
 public class UsageMetricsCheckerScheduler implements StreamProcessorLifecycleAware {
 
-  private final UsageMetricsChecker usageMetricsChecker;
+  private final UsageMetricsCheckScheduler usageMetricsChecker;
 
   public UsageMetricsCheckerScheduler(
       final EngineConfiguration engineConfiguration, final InstantSource clock) {
     final var exportInterval = engineConfiguration.getUsageMetricsExportInterval();
-    usageMetricsChecker = new UsageMetricsChecker(exportInterval, clock);
+    usageMetricsChecker = new UsageMetricsCheckScheduler(exportInterval, clock);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckScheduler.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.scheduled;
 
-import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker.NextExecution.None;
-import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker.NextExecution.Scheduled;
+import io.camunda.zeebe.engine.processing.scheduled.DueDateCheckScheduler.NextExecution.None;
+import io.camunda.zeebe.engine.processing.scheduled.DueDateCheckScheduler.NextExecution.Scheduled;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService.ScheduledTask;
@@ -30,7 +30,7 @@ import java.util.function.Function;
  * that multiple executions are scheduled. See the comment in {@link #execute(TaskResultBuilder)}
  * for details.
  */
-public final class DueDateChecker implements StreamProcessorLifecycleAware {
+public final class DueDateCheckScheduler implements StreamProcessorLifecycleAware {
   private final boolean scheduleAsync;
   private final long timerResolution;
   private final Function<TaskResultBuilder, Long> visitor;
@@ -56,7 +56,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
    * @param scheduleAsync Whether to schedule the execution happens asynchronously or not
    * @param visitor Function that runs the task and returns the next due date or -1 if there is none
    */
-  public DueDateChecker(
+  public DueDateCheckScheduler(
       final long timerResolution,
       final boolean scheduleAsync,
       final Function<TaskResultBuilder, Long> visitor,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckScheduler.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.timer;
 
-import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker;
+import io.camunda.zeebe.engine.processing.scheduled.DueDateCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState.TimerVisitor;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
@@ -21,18 +21,18 @@ import java.time.Duration;
 import java.time.InstantSource;
 import java.util.function.Function;
 
-public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
+public class DueDateTimerCheckScheduler implements StreamProcessorLifecycleAware {
 
   private static final long TIMER_RESOLUTION = Duration.ofMillis(100).toMillis();
   private static final double GIVE_YIELD_FACTOR = 0.5;
-  private final DueDateChecker dueDateChecker;
+  private final DueDateCheckScheduler dueDateChecker;
 
-  public DueDateTimerChecker(
+  public DueDateTimerCheckScheduler(
       final TimerInstanceState timerInstanceState,
       final FeatureFlags featureFlags,
       final InstantSource clock) {
     dueDateChecker =
-        new DueDateChecker(
+        new DueDateCheckScheduler(
             TIMER_RESOLUTION,
             featureFlags.enableTimerDueDateCheckerAsync(),
             new TriggerTimersSideEffect(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -32,7 +32,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
   private final TypedResponseWriter responseWriter;
   private final AsyncRequestState asyncRequestState;
   private final AsyncRequestBehavior asyncRequestBehavior;
-  private final UserTaskCommandPreconditionChecker preconditionChecker;
+  private final UserTaskCommandPreconditionValidator preconditionChecker;
 
   public UserTaskAssignProcessor(
       final ProcessingState state,
@@ -44,7 +44,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
     asyncRequestState = state.getAsyncRequestState();
     this.asyncRequestBehavior = asyncRequestBehavior;
     preconditionChecker =
-        new UserTaskCommandPreconditionChecker(
+        new UserTaskCommandPreconditionValidator(
             List.of(LifecycleState.CREATED), "assign", state.getUserTaskState(), authCheckBehavior);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -38,7 +38,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
   private final TypedResponseWriter responseWriter;
   private final AsyncRequestState asyncRequestState;
   private final AsyncRequestBehavior asyncRequestBehavior;
-  private final UserTaskCommandPreconditionChecker preconditionChecker;
+  private final UserTaskCommandPreconditionValidator preconditionChecker;
 
   public UserTaskClaimProcessor(
       final ProcessingState state,
@@ -50,7 +50,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
     asyncRequestState = state.getAsyncRequestState();
     this.asyncRequestBehavior = asyncRequestBehavior;
     preconditionChecker =
-        new UserTaskCommandPreconditionChecker(
+        new UserTaskCommandPreconditionValidator(
             List.of(LifecycleState.CREATED),
             "claim",
             UserTaskClaimProcessor::checkClaim,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionValidator.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-public class UserTaskCommandPreconditionChecker {
+public class UserTaskCommandPreconditionValidator {
 
   private static final String NO_USER_TASK_FOUND_MESSAGE =
       "Expected to %s user task with key '%d', but no such user task was found";
@@ -37,7 +37,7 @@ public class UserTaskCommandPreconditionChecker {
       additionalChecks;
   private final UserTaskState userTaskState;
 
-  public UserTaskCommandPreconditionChecker(
+  public UserTaskCommandPreconditionValidator(
       final List<LifecycleState> validLifecycleStates,
       final String intent,
       final UserTaskState userTaskState,
@@ -45,7 +45,7 @@ public class UserTaskCommandPreconditionChecker {
     this(validLifecycleStates, intent, null, userTaskState, authCheckBehavior);
   }
 
-  public UserTaskCommandPreconditionChecker(
+  public UserTaskCommandPreconditionValidator(
       final List<LifecycleState> validLifecycleStates,
       final String intent,
       final BiFunction<

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -39,7 +39,7 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
   private final TypedResponseWriter responseWriter;
-  private final UserTaskCommandPreconditionChecker preconditionChecker;
+  private final UserTaskCommandPreconditionValidator preconditionChecker;
   private final AsyncRequestBehavior asyncRequestBehavior;
 
   public UserTaskCompleteProcessor(
@@ -55,7 +55,7 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
     commandWriter = writers.command();
     responseWriter = writers.response();
     preconditionChecker =
-        new UserTaskCommandPreconditionChecker(
+        new UserTaskCommandPreconditionValidator(
             List.of(LifecycleState.CREATED),
             "complete",
             state.getUserTaskState(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -42,7 +42,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
   private final TypedResponseWriter responseWriter;
   private final VariableBehavior variableBehavior;
   private final AsyncRequestBehavior asyncRequestBehavior;
-  private final UserTaskCommandPreconditionChecker preconditionChecker;
+  private final UserTaskCommandPreconditionValidator preconditionChecker;
 
   public UserTaskUpdateProcessor(
       final ProcessingState state,
@@ -57,7 +57,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
     this.asyncRequestBehavior = asyncRequestBehavior;
     responseWriter = writers.response();
     preconditionChecker =
-        new UserTaskCommandPreconditionChecker(
+        new UserTaskCommandPreconditionValidator(
             List.of(LifecycleState.CREATED), "update", state.getUserTaskState(), authCheckBehavior);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobProcessingMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobProcessingMetricsTest.java
@@ -131,7 +131,7 @@ public class JobProcessingMetricsTest {
 
     // when
     // We need to add 1 ms as the deadline needs to be < the current time. Without the extra 1 ms
-    // it could be that the JobTimeoutChecker is triggered at the exact same time as the job
+    // it could be that the JobTimeoutCheckScheduler is triggered at the exact same time as the job
     // deadline resulting in the Job activation not being expired yet.
     engine
         .getClock()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.request.Authori
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandPreconditionChecker;
+import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandPreconditionValidator;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -95,10 +95,10 @@ public class AuthorizationArchTest {
                 ArchConditions.callMethod(
                     JobUpdateBehaviour.class, "isAuthorized", TypedRecord.class, JobRecord.class))
             // Or the processor should have delegated authorization to the
-            // UserTaskCommandPreconditionChecker
+            // UserTaskCommandPreconditionValidator
             .or(
                 ArchConditions.callMethod(
-                    UserTaskCommandPreconditionChecker.class, "check", TypedRecord.class))
+                    UserTaskCommandPreconditionValidator.class, "check", TypedRecord.class))
             // Or the processor should have delegate authorization to the PermissionsBehavior
             .or(
                 ArchConditions.callMethod(
@@ -125,7 +125,7 @@ public class AuthorizationArchTest {
       @Override
       public boolean test(final JavaClass javaClass) {
         return Predicates.assignableFrom(JobUpdateBehaviour.class)
-            .or(Predicates.assignableFrom(UserTaskCommandPreconditionChecker.class))
+            .or(Predicates.assignableFrom(UserTaskCommandPreconditionValidator.class))
             .or(Predicates.assignableFrom(PermissionsBehavior.class))
             .test(javaClass);
       }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationExecutionSchedulerTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 import static io.camunda.zeebe.protocol.record.value.BatchOperationType.CANCEL_PROCESS_INSTANCE;
 import static org.mockito.Mockito.*;
 
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializer.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
@@ -43,7 +43,7 @@ public class BatchOperationExecutionSchedulerTest {
   @Mock private ReadonlyStreamProcessorContext streamProcessorContext;
   @Mock private ProcessingScheduleService scheduleService;
   @Mock private BatchOperationState batchOperationState;
-  @Mock private BatchOperationInitializer batchOperationInitializer;
+  @Mock private BatchOperationInitializationHelper batchOperationInitializer;
   @Mock private BatchOperationRetryHandler retryHandler;
 
   @Captor private ArgumentCaptor<Task> taskCaptor;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationHelperTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationHelperTest.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvid
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProviderFactory;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializer.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationException;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationPageProcessor.PageProcessingResult;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationErrorType;
@@ -36,7 +36,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class BatchOperationInitializerTest {
+class BatchOperationInitializationHelperTest {
 
   private static final long BATCH_OPERATION_KEY = 12345L;
   private static final String SEARCH_CURSOR = "test-cursor";
@@ -52,12 +52,12 @@ class BatchOperationInitializerTest {
   private final TaskResultBuilder taskResultBuilder = mock(TaskResultBuilder.class);
   private PersistedBatchOperation batchOperation;
 
-  private BatchOperationInitializer initializer;
+  private BatchOperationInitializationHelper initializer;
 
   @BeforeEach
   void setUp() {
     initializer =
-        new BatchOperationInitializer(
+        new BatchOperationInitializationHelper(
             itemProviderFactory, pageProcessor, commandBuilder, PAGE_SIZE, metrics);
 
     // Default batch operation setup

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationRetryHandlerTest.java
@@ -13,8 +13,8 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializer.BatchOperationInitializationException;
-import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializer.BatchOperationInitializationResult;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationException;
+import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationInitializationHelper.BatchOperationInitializationResult;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryResult;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryHandler.RetryableOperation;
 import java.time.Duration;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributionSchedulerTest.java
@@ -42,7 +42,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({MockitoExtension.class, ProcessingStateExtension.class})
-public class CommandRedistributorTest {
+public class CommandRedistributionSchedulerTest {
 
   /** Injected by {@link ProcessingStateExtension} */
   private MutableProcessingState processingState;
@@ -52,7 +52,7 @@ public class CommandRedistributorTest {
   @Mock private InterPartitionCommandSender mockCommandSender;
   @Mock private ReadonlyStreamProcessorContext mockContext;
 
-  private CommandRedistributor commandRedistributor;
+  private CommandRedistributionScheduler commandRedistributor;
   private long distributionKey;
   private UserRecord recordValue;
   private MutableDistributionState distributionState;
@@ -121,7 +121,7 @@ public class CommandRedistributorTest {
             1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
   }
 
-  private CommandRedistributor getCommandRedistributor(
+  private CommandRedistributionScheduler getCommandRedistributor(
       final boolean commandDistributionPaused,
       final Duration redistributionInterval,
       final Duration maxBackoffDuration) {
@@ -149,7 +149,7 @@ public class CommandRedistributorTest {
             .setCommandRedistributionInterval(redistributionInterval)
             .setCommandRedistributionMaxBackoff(maxBackoffDuration);
 
-    return new CommandRedistributor(behavior, routingInfo, config);
+    return new CommandRedistributionScheduler(behavior, routingInfo, config);
   }
 
   @Nested

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidatorTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import static io.camunda.zeebe.engine.processing.identity.AuthorizationEntityChecker.*;
+import static io.camunda.zeebe.engine.processing.identity.AuthorizationEntityValidator.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -41,7 +41,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AuthorizationEntityCheckerTest {
+class AuthorizationEntityValidatorTest {
 
   @Mock private ProcessingState processingState;
   @Mock private UserState userState;
@@ -51,7 +51,7 @@ class AuthorizationEntityCheckerTest {
 
   @Mock private TypedRecord<AuthorizationRecord> command;
 
-  private AuthorizationEntityChecker checker;
+  private AuthorizationEntityValidator checker;
 
   @BeforeEach
   void setUp() {
@@ -60,7 +60,7 @@ class AuthorizationEntityCheckerTest {
     when(processingState.getGroupState()).thenReturn(groupState);
     when(processingState.getRoleState()).thenReturn(roleState);
 
-    checker = new AuthorizationEntityChecker(processingState);
+    checker = new AuthorizationEntityValidator(processingState);
     lenient().when(userState.getUser("user1")).thenReturn(Optional.of(mock(PersistedUser.class)));
     lenient().when(roleState.getRole("role1")).thenReturn(Optional.of(mock(PersistedRole.class)));
     lenient().when(groupState.get("group1")).thenReturn(Optional.of(mock(PersistedGroup.class)));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -227,7 +227,7 @@ public class ActivatableJobsPushTest {
     ENGINE.job().withKey(jobKey).withRetries(5).withBackOff(Duration.ofMillis(10L)).fail();
 
     // when job recurs
-    ENGINE.increaseTime(Duration.ofMillis(JobBackoffChecker.BACKOFF_RESOLUTION));
+    ENGINE.increaseTime(Duration.ofMillis(JobBackoffCheckScheduler.BACKOFF_RESOLUTION));
 
     // then
     jobRecords(JobIntent.RECURRED_AFTER_BACKOFF).withType(jobType).await();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -231,13 +231,14 @@ public final class FailJobTest {
     Assertions.assertThat(failRecord).hasRecordType(RecordType.EVENT).hasIntent(FAILED);
 
     // explicitly wait for polling
-    ENGINE.increaseTime(Duration.ofMillis(JobBackoffChecker.BACKOFF_RESOLUTION));
+    ENGINE.increaseTime(Duration.ofMillis(JobBackoffCheckScheduler.BACKOFF_RESOLUTION));
 
     // verify that our job didn't recur after backoff
     final var reactivatedJobs = ENGINE.jobs().withType(jobType).activate();
     assertThat(reactivatedJobs.getValue().getJobs()).isEmpty();
 
-    ENGINE.increaseTime(backOff.plus(Duration.ofMillis(JobBackoffChecker.BACKOFF_RESOLUTION)));
+    ENGINE.increaseTime(
+        backOff.plus(Duration.ofMillis(JobBackoffCheckScheduler.BACKOFF_RESOLUTION)));
 
     // verify that our job recurred after backoff
     assertThat(jobRecords(JobIntent.RECURRED_AFTER_BACKOFF).withType(jobType).getFirst().getKey())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckSchedulerTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
-public class JobTimeoutCheckerTest {
+public class JobTimeoutCheckSchedulerTest {
   public static final int NUMBER_OF_ACTIVE_JOBS = 10;
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
@@ -89,7 +89,7 @@ public class JobTimeoutCheckerTest {
     final int batchLimit = Integer.MAX_VALUE;
 
     final var task =
-        new JobTimeoutChecker(jobState, pollingInterval, batchLimit, InstantSource.system());
+        new JobTimeoutCheckScheduler(jobState, pollingInterval, batchLimit, InstantSource.system());
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 
@@ -120,7 +120,7 @@ public class JobTimeoutCheckerTest {
     final int batchLimit = 3;
 
     final var task =
-        new JobTimeoutChecker(jobState, pollingInterval, batchLimit, InstantSource.system());
+        new JobTimeoutCheckScheduler(jobState, pollingInterval, batchLimit, InstantSource.system());
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 
@@ -164,7 +164,7 @@ public class JobTimeoutCheckerTest {
     final int batchLimit = Integer.MAX_VALUE;
 
     final var task =
-        new JobTimeoutChecker(jobState, pollingInterval, batchLimit, InstantSource.system());
+        new JobTimeoutCheckScheduler(jobState, pollingInterval, batchLimit, InstantSource.system());
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckSchedulerTest.java
@@ -33,10 +33,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-public class UsageMetricsCheckerTest {
+public class UsageMetricsCheckSchedulerTest {
 
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
-  private UsageMetricsChecker checker;
+  private UsageMetricsCheckScheduler checker;
   private InstantSource mockClock;
   private TaskResultBuilder mockTaskResultBuilder;
   private ReadonlyStreamProcessorContext mockProcessingContext;
@@ -52,7 +52,7 @@ public class UsageMetricsCheckerTest {
     when(mockProcessingContext.getScheduleService()).thenReturn(mockProcessingScheduleService);
     recordCaptor = ArgumentCaptor.forClass(UnifiedRecordValue.class);
 
-    checker = new UsageMetricsChecker(Duration.ofMillis(1), mockClock);
+    checker = new UsageMetricsCheckScheduler(Duration.ofMillis(1), mockClock);
     checker.setProcessingContext(mockProcessingContext);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckSchedulerTest.java
@@ -24,14 +24,14 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class DueDateCheckerTest {
+public class DueDateCheckSchedulerTest {
 
   @Test
   public void shouldNotScheduleTwoTasks() {
     // given
     final var timerResolution = 100;
     final var dueDateChecker =
-        new DueDateChecker(timerResolution, false, (builder) -> 0L, InstantSource.system());
+        new DueDateCheckScheduler(timerResolution, false, (builder) -> 0L, InstantSource.system());
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
@@ -54,7 +54,7 @@ public class DueDateCheckerTest {
     // given
     final var timerResolution = 100;
     final var dueDateChecker =
-        new DueDateChecker(timerResolution, false, (builder) -> 0L, InstantSource.system());
+        new DueDateCheckScheduler(timerResolution, false, (builder) -> 0L, InstantSource.system());
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -84,7 +84,7 @@ public class DueDateCheckerTest {
 
     final var timerResolution = 100;
     final var dueDateChecker =
-        new DueDateChecker(timerResolution, false, visitor, InstantSource.system());
+        new DueDateCheckScheduler(timerResolution, false, visitor, InstantSource.system());
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -110,7 +110,7 @@ public class DueDateCheckerTest {
 
     final var timerResolution = 100;
     final var dueDateChecker =
-        new DueDateChecker(timerResolution, false, visitor, InstantSource.system());
+        new DueDateCheckScheduler(timerResolution, false, visitor, InstantSource.system());
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
@@ -17,8 +17,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker.TriggerTimersSideEffect;
-import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker.YieldingDecorator;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler.TriggerTimersSideEffect;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler.YieldingDecorator;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState.TimerVisitor;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-class DueDateTimerCheckerTest {
+class DueDateTimerCheckSchedulerTest {
 
   @Nested
   final class TriggerTimersSideEffectTest {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributionSchedulerTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
-import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
+import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributionScheduler;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
@@ -37,7 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({MockitoExtension.class, ProcessingStateExtension.class})
-public class DeploymentRedistributorTest {
+public class DeploymentRedistributionSchedulerTest {
 
   @Mock private DeploymentDistributionCommandSender deploymentDistributionCommandSender;
 
@@ -49,7 +49,7 @@ public class DeploymentRedistributorTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private StreamProcessorContext context;
 
-  private DeploymentRedistributor deploymentRedistributor;
+  private DeploymentRedistributionScheduler deploymentRedistributor;
   private ArgumentCaptor<Runnable> taskCaptor;
   private long recordKey;
   private DeploymentRecord deploymentRecord;
@@ -68,7 +68,7 @@ public class DeploymentRedistributorTest {
         RoutingInfo.dynamic(routingState, new StaticRoutingInfo(Set.of(1, 2), 2));
 
     deploymentRedistributor =
-        new DeploymentRedistributor(
+        new DeploymentRedistributionScheduler(
             deploymentDistributionCommandSender, deploymentState, routingInfo);
 
     final DeploymentResource deploymentResource =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/DeploymentClusteredTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/DeploymentClusteredTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.clustering;
 
-import static io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor.DEPLOYMENT_REDISTRIBUTION_INTERVAL;
+import static io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributionScheduler.DEPLOYMENT_REDISTRIBUTION_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.response.DeploymentEvent;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/TimerTriggerSchedulingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/TimerTriggerSchedulingTest.java
@@ -38,10 +38,11 @@ public class TimerTriggerSchedulingTest {
    * schedules a timer event every second, we should not produce many Timer TRIGGER commands for any
    * of these timers.
    *
-   * <p>This was a problem previously because every time the DueDateChecker ran, it would reschedule
-   * another execution for the next timer (the one further in the future). This would cause the
-   * DueDateChecker to run many times in a row for this same timer, and not benefit from the command
-   * cache because executions are scheduled beforehand and executed before the cache is persisted.
+   * <p>This was a problem previously because every time the DueDateCheckScheduler ran, it would
+   * reschedule another execution for the next timer (the one further in the future). This would
+   * cause the DueDateCheckScheduler to run many times in a row for this same timer, and not benefit
+   * from the command cache because executions are scheduled beforehand and executed before the
+   * cache is persisted.
    */
   @Test
   public void shouldTriggerTimerOnlyOnce() {


### PR DESCRIPTION
# Description
Backport of #41705 to `stable/8.8`.

relates to #41699