### PR TITLE
fix: Fix incomplete scope cleanup when deleting one of multiple coexisting property-based authorizations

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -189,8 +189,12 @@ public class DbAuthorizationState implements MutableAuthorizationState {
       final PersistedAuthorization candidateAuthorization,
       final PersistedAuthorization storedAuthorization) {
     return candidateAuthorization.getResourceType() == storedAuthorization.getResourceType()
+        && candidateAuthorization.getResourceMatcher() == storedAuthorization.getResourceMatcher()
         && Objects.equals(
-            candidateAuthorization.getResourceId(), storedAuthorization.getResourceId());
+            candidateAuthorization.getResourceId(), storedAuthorization.getResourceId())
+        && Objects.equals(
+            candidateAuthorization.getResourcePropertyName(),
+            storedAuthorization.getResourcePropertyName());
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
@@ -288,6 +288,78 @@ public class CreateAuthorizationTest {
         .hasPermissionTypes(Set.of(PermissionType.UPDATE));
   }
 
+  // regression test for "https://github.com/camunda/camunda/issues/48847" bug
+  @Test
+  public void shouldRecreatePropertyBasedAuthorizationAfterCoexistingAuthorizationIsDeleted() {
+    // Regression test: when 2 PROPERTY-based authorizations for the same owner coexist,
+    // deleting both and then re-creating authorization A must succeed without a
+    // false ALREADY_EXISTS rejection.
+
+    final var groupId = "groupId";
+    final var ownerType = AuthorizationOwnerType.GROUP;
+    final var resourceType = AuthorizationResourceType.USER_TASK;
+
+    // given - create group for the test
+    engine.group().newGroup(groupId).create();
+
+    // create BOTH auths while they coexist
+    final var assigneeKey =
+        engine
+            .authorization()
+            .newAuthorization()
+            .withOwnerId(groupId)
+            .withOwnerType(ownerType)
+            .withResourceMatcher(AuthorizationResourceMatcher.PROPERTY)
+            .withResourcePropertyName(UserTaskAuthorizationProperties.PROP_ASSIGNEE)
+            .withResourceType(resourceType)
+            .withPermissions(PermissionType.READ, PermissionType.UPDATE)
+            .create()
+            .getValue()
+            .getAuthorizationKey();
+
+    final var candidateGroupsKey =
+        engine
+            .authorization()
+            .newAuthorization()
+            .withOwnerId(groupId)
+            .withOwnerType(ownerType)
+            .withResourceMatcher(AuthorizationResourceMatcher.PROPERTY)
+            .withResourcePropertyName(UserTaskAuthorizationProperties.PROP_CANDIDATE_GROUPS)
+            .withResourceType(resourceType)
+            .withPermissions(PermissionType.READ, PermissionType.UPDATE)
+            .create()
+            .getValue()
+            .getAuthorizationKey();
+
+    // when - delete auth A while auth B still exists (this is the critical ordering)
+    engine.authorization().deleteAuthorization(assigneeKey).delete();
+
+    // then - delete auth B
+    engine.authorization().deleteAuthorization(candidateGroupsKey).delete();
+
+    // when - re-create auth for "assignee"
+    final var response =
+        engine
+            .authorization()
+            .newAuthorization()
+            .withOwnerId(groupId)
+            .withOwnerType(ownerType)
+            .withResourceMatcher(AuthorizationResourceMatcher.PROPERTY)
+            .withResourcePropertyName(UserTaskAuthorizationProperties.PROP_ASSIGNEE)
+            .withResourceType(resourceType)
+            .withPermissions(PermissionType.READ, PermissionType.UPDATE)
+            .create()
+            .getValue();
+
+    // then - must succeed without rejection
+    Assertions.assertThat(response)
+        .hasOwnerId(groupId)
+        .hasOwnerType(ownerType)
+        .hasResourceMatcher(AuthorizationResourceMatcher.PROPERTY)
+        .hasResourcePropertyName(UserTaskAuthorizationProperties.PROP_ASSIGNEE)
+        .hasResourceType(resourceType);
+  }
+
   @Test
   public void shouldRejectCreateWithIdMatcherWhenResourceIdIsMissing() {
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.authorization;
 
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_ASSIGNEE;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_CANDIDATE_GROUPS;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD_CHAR;
@@ -21,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -737,6 +740,72 @@ public class AuthorizationStateTest {
     assertThat(keys1).isEmpty();
     final var keys2 = authorizationState.getAuthorizationKeysForOwner(ownerType2, ownerId2);
     assertThat(keys2).containsExactly(authorizationKey2);
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/48847")
+  void shouldNotLeaveStalePropertyScopesWhenDeletingCoexistingPropertyBasedAuthorizations() {
+    // Regression test: when two PROPERTY-based authorizations for the same owner/resourceType but
+    // different resourcePropertyNames coexist, deleting one while the other still exists must not
+    // leave stale scopes in the PERMISSIONS column family.
+
+    final var ownerId = "demo";
+    final var ownerType = AuthorizationOwnerType.GROUP;
+    final var resourceType = AuthorizationResourceType.USER_TASK;
+    final var permissions =
+        Set.of(PermissionType.READ, PermissionType.CLAIM, PermissionType.COMPLETE);
+
+    // given - create BOTH auths so they coexist (this is the critical precondition)
+    final var authKeyA = 1L;
+    authorizationState.create(
+        authKeyA,
+        new AuthorizationRecord()
+            .setAuthorizationKey(authKeyA)
+            .setOwnerId(ownerId)
+            .setOwnerType(ownerType)
+            .setResourceMatcher(AuthorizationResourceMatcher.PROPERTY)
+            .setResourcePropertyName(PROP_ASSIGNEE)
+            .setResourceType(resourceType)
+            .setPermissionTypes(permissions));
+
+    final var authKeyB = 2L;
+    authorizationState.create(
+        authKeyB,
+        new AuthorizationRecord()
+            .setAuthorizationKey(authKeyB)
+            .setOwnerId(ownerId)
+            .setOwnerType(ownerType)
+            .setResourceMatcher(AuthorizationResourceMatcher.PROPERTY)
+            .setResourcePropertyName(PROP_CANDIDATE_GROUPS)
+            .setResourceType(resourceType)
+            .setPermissionTypes(permissions));
+
+    // when - delete auth A while auth B still exists
+    authorizationState.delete(authKeyA);
+
+    // then - auth A's scopes must be gone; auth B's scopes must still be present
+    permissions.forEach(
+        pt -> {
+          final var scopes =
+              authorizationState.getAuthorizationScopes(ownerType, ownerId, resourceType, pt);
+          assertThat(scopes)
+              .as(
+                  "after deleting assignee auth, only candidateGroups scope should remain for %s[%s]",
+                  resourceType, pt)
+              .containsExactly(AuthorizationScope.property(PROP_CANDIDATE_GROUPS));
+        });
+
+    // when - delete auth B
+    authorizationState.delete(authKeyB);
+
+    // then - all scopes must be gone; no stale assignee scope must remain
+    permissions.forEach(
+        pt ->
+            assertThat(
+                    authorizationState.getAuthorizationScopes(ownerType, ownerId, resourceType, pt))
+                .as(
+                    "all scopes must be empty after deleting both auths — no stale assignee scope expected for %s[%s]",
+                    resourceType, pt)
+                .isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes a bug in `DbAuthorizationState.delete()` where deleting one of multiple coexisting property-based authorizations (e.g. `assignee` and `candidateGroups` for the same owner) left stale permission scopes in the `permissions` column family. This caused a false `ALREADY_EXISTS` error when attempting to recreate the deleted authorization.

### Root Cause

When an authorization is deleted, the engine must avoid removing permission scopes from the shared `permissions` CF entry if another authorization for the same owner still needs them. To do this, it identifies **sibling authorizations** — other auths that share the same scope — and skips removing any permission type a sibling still holds.

The sibling check was performed by `filterMatchingAuthorization`, which only compared
`resourceType` and `resourceId`:

```java
// BUGGY version
private boolean filterMatchingAuthorization(...) {
  return candidateAuthorization.getResourceType() == storedAuthorization.getResourceType()
      && Objects.equals(
          candidateAuthorization.getResourceId(), storedAuthorization.getResourceId());
}
```

`resourcePropertyName` and `resourceMatcher` were **not compared**, so two property-based authorizations scoped to different properties (e.g. `assignee` vs. `candidateGroups`) were incorrectly treated as siblings of each other.

### Consequence

Given two property-based authorizations for the same `(ownerType, ownerId, resourceType)`:

1. **Create** `assignee` auth → `permissions` CF: `READ → {PROPERTY,"","assignee"}, ...`
2. **Create** `candidateGroups` auth → `permissions` CF: `READ → {PROPERTY,"","assignee"}, {PROPERTY,"","candidateGroups"}, ...`
3. **Delete** `assignee` auth:
   - The engine finds `candidateGroups` as a sibling (due to the buggy check).
   - Since `candidateGroups` holds the same permission types (`READ`, `UPDATE`, ...), all of them are added to `sharedPermissionTypes`.
   - `removePermission` is **skipped for all permission types**.
   - The `{PROPERTY,"","assignee"}` scopes are **never removed** from the `permissions` CF.
4. **Delete** `candidateGroups` auth → its scopes are cleaned up correctly (no siblings left).
5. **Recreate** `assignee` auth:
   - `permissionsAlreadyExist` finds the stale `{PROPERTY,"","assignee"}` scopes.
   - Returns **`ALREADY_EXISTS`** ❌

### Fix

Add `resourceMatcher` and `resourcePropertyName` in the sibling comparison, so that only authorizations pointing to the **exact same scope** are treated as siblings:

```java
// FIXED version
private boolean filterMatchingAuthorization(...) {
  return candidateAuthorization.getResourceType() == storedAuthorization.getResourceType()
      && candidateAuthorization.getResourceMatcher() == storedAuthorization.getResourceMatcher()
      && Objects.equals(
          candidateAuthorization.getResourceId(), storedAuthorization.getResourceId())
      && Objects.equals(
          candidateAuthorization.getResourcePropertyName(),
          storedAuthorization.getResourcePropertyName());
}
```

With this fix, when deleting `assignee` while `candidateGroups` exists:
- `resourcePropertyName`: `"assignee" != "candidateGroups"` → **not a sibling** ✅
- `removePermission` is called correctly → `{PROPERTY,"","assignee"}` scopes are removed ✅
- Recreating `assignee` finds no stale data → **succeeds** ✅

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48847 
