### PR TITLE
[Backport stable/8.9] fix: use elementInstancesTreeStore inside useEffect

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -809,9 +809,14 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
       processInstance.state === 'ACTIVE' &&
       !modificationsStore.isModificationModeEnabled;
 
-    elementInstancesTreeStore.setRootNode(processInstance.processInstanceKey, {
-      enablePolling,
-    });
+    useEffect(() => {
+      elementInstancesTreeStore.setRootNode(
+        processInstance.processInstanceKey,
+        {
+          enablePolling,
+        },
+      );
+    }, [processInstance.processInstanceKey, enablePolling]);
 
     useEffect(() => {
       return elementInstancesTreeStore.reset;


### PR DESCRIPTION
# Description
Backport of #48789 to `stable/8.9`.

relates to #48198 #48807