### PR TITLE
[Backport stable/8.8] Document timeout responses

### DIFF
--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CancelProcessInstanceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CancelProcessInstanceTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.api.process;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
@@ -15,6 +16,9 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstance
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceResponse;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
 public final class CancelProcessInstanceTest extends GatewayTest {
@@ -38,5 +42,28 @@ public final class CancelProcessInstanceTest extends GatewayTest {
     assertThat(brokerRequest.getKey()).isEqualTo(123);
     assertThat(brokerRequest.getIntent()).isEqualTo(ProcessInstanceIntent.CANCEL);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.PROCESS_INSTANCE);
+  }
+
+  @Test
+  public void shouldMapTimeoutToDeadlineExceeded() {
+    // given
+    brokerClient.registerHandler(
+        BrokerCancelProcessInstanceRequest.class,
+        request -> {
+          throw new TimeoutException("request timeout");
+        });
+
+    final CancelProcessInstanceRequest request =
+        CancelProcessInstanceRequest.newBuilder().setProcessInstanceKey(123).build();
+
+    // when / then
+    assertThatThrownBy(() -> client.cancelProcessInstance(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.THROWABLE)
+        .extracting(
+            t -> ((StatusRuntimeException) t).getStatus().getCode(),
+            t -> ((StatusRuntimeException) t).getStatus().getDescription())
+        .containsExactly(
+            Status.Code.DEADLINE_EXCEEDED, "Time out between gateway and broker: request timeout");
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/SetVariablesTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/SetVariablesTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.api.process;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
@@ -19,7 +20,10 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.test.util.JsonUtil;
 import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import java.util.Collections;
+import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
 public final class SetVariablesTest extends GatewayTest {
@@ -56,5 +60,31 @@ public final class SetVariablesTest extends GatewayTest {
     final VariableDocumentRecord brokerRequestValue = brokerRequest.getRequestWriter();
     MsgPackUtil.assertEqualityExcluding(brokerRequestValue.getVariablesBuffer(), variables);
     assertThat(brokerRequestValue.getScopeKey()).isEqualTo(elementInstanceKey);
+  }
+
+  @Test
+  public void shouldMapTimeoutToDeadlineExceeded() {
+    // given
+    brokerClient.registerHandler(
+        BrokerSetVariablesRequest.class,
+        request -> {
+          throw new TimeoutException("request timeout");
+        });
+
+    final SetVariablesRequest request =
+        SetVariablesRequest.newBuilder()
+            .setElementInstanceKey(Protocol.encodePartitionId(1, 1))
+            .setVariables("{\"key\":\"value\"}")
+            .build();
+
+    // when / then
+    assertThatThrownBy(() -> client.setVariables(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.THROWABLE)
+        .extracting(
+            t -> ((StatusRuntimeException) t).getStatus().getCode(),
+            t -> ((StatusRuntimeException) t).getStatus().getDescription())
+        .containsExactly(
+            Status.Code.DEADLINE_EXCEEDED, "Time out between gateway and broker: request timeout");
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -1048,6 +1048,14 @@ service Gateway {
       INVALID_ARGUMENT:
         - the given variables document is not a valid JSON document; valid documents are expected to
           be JSON documents where the root node is an object.
+      DEADLINE_EXCEEDED:
+        - the request timed out between the gateway and the broker. This can happen for general
+          timeout reasons (for example transient communication delays). On user-task-listener-
+          related operations, this can additionally happen when the corresponding listener job is
+          not completed within the request timeout.
+
+    If this happens repeatedly, retry with backoff and check listener worker availability and
+    health.
    */
   rpc SetVariables (SetVariablesRequest) returns (SetVariablesResponse) {
   }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1129,7 +1129,8 @@ paths:
       description: >
         Completes a user task with the given key. Completion waits for blocking task listeners on
         this lifecycle transition. If listener processing is delayed beyond the request timeout,
-        this endpoint can return 504.
+        this endpoint can return 504. Other gateway timeout causes are also possible. Retry with
+        backoff and inspect listener worker availability and logs when this repeats.
       parameters:
         - name: userTaskKey
           in: path
@@ -1178,7 +1179,9 @@ paths:
       description: >
         Assigns a user task with the given key to the given assignee. Assignment waits for
         blocking task listeners on this lifecycle transition. If listener processing is delayed
-        beyond the request timeout, this endpoint can return 504.
+        beyond the request timeout, this endpoint can return 504. Other gateway timeout causes are
+        also possible. Retry with backoff and inspect listener worker availability and logs when
+        this repeats.
       parameters:
         - name: userTaskKey
           in: path
@@ -1354,7 +1357,9 @@ paths:
       description: >
         Removes the assignee of a task with the given key. Unassignment waits for blocking task
         listeners on this lifecycle transition. If listener processing is delayed beyond the
-        request timeout, this endpoint can return 504.
+        request timeout, this endpoint can return 504. Other gateway timeout causes are also
+        possible. Retry with backoff and inspect listener worker availability and logs when this
+        repeats.
       parameters:
         - name: userTaskKey
           in: path
@@ -2015,7 +2020,8 @@ paths:
         Cancels a running process instance. As a cancellation includes more than just the removal
         of the process instance resource, the cancellation resource must be posted. Cancellation
         can wait on listener-related processing; when that processing does not complete in time,
-        this endpoint can return 504.
+        this endpoint can return 504. Other gateway timeout causes are also possible. Retry with
+        backoff and inspect listener worker availability and logs when this repeats.
       parameters:
         - name: processInstanceKey
           in: path
@@ -5276,7 +5282,9 @@ paths:
         Updates all the variables of a particular scope (for example, process instance, element instance) with the given variable data.
         Specify the element instance in the `elementInstanceKey` parameter.
         Variable updates can be delayed by listener-related processing; if processing exceeds the
-        request timeout, this endpoint can return 504.
+        request timeout, this endpoint can return 504. Other gateway timeout causes are also
+        possible. Retry with backoff and inspect listener worker availability and logs when this
+        repeats.
       parameters:
         - name: elementInstanceKey
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5275,6 +5275,8 @@ paths:
       description: |
         Updates all the variables of a particular scope (for example, process instance, element instance) with the given variable data.
         Specify the element instance in the `elementInstanceKey` parameter.
+        Variable updates can be delayed by listener-related processing; if processing exceeds the
+        request timeout, this endpoint can return 504.
       parameters:
         - name: elementInstanceKey
           in: path
@@ -5300,6 +5302,8 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: '#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-eventually-consistent: false
   /element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation:
     post:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -12394,6 +12394,33 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetail"
+    GatewayTimeoutTaskListenerBlocking:
+      description: >
+        The request timed out between the gateway and the broker. For these endpoints, this often
+        happens when user task listeners are configured and the corresponding listener job is not
+        completed within the request timeout. Common causes include no available job workers for
+        the listener type, busy or crashed job workers, or delayed job completion. As with any
+        gateway timeout, general timeout causes (for example transient network issues) can also
+        result in a 504 response.
+
+        Troubleshooting:
+        - verify that job workers for the listener type are running and healthy
+        - check worker logs for crashes, retries, and completion failures
+        - check network connectivity between workers, gateway, and broker
+        - retry with backoff after transient failures
+        - fail without retries if a problem persists
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+          examples:
+            taskListenerTimeout:
+              value:
+                type: about:blank
+                title: DEADLINE_EXCEEDED
+                status: 504
+                detail: Expected to handle request, but request timed out between gateway and broker
+                instance: /v2/user-tasks/123/completion
   securitySchemes:
     BearerAuth:
       type: http

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2011,7 +2011,11 @@ paths:
         - Process instance
       operationId: cancelProcessInstance
       summary: Cancel process instance
-      description: Cancels a running process instance. As a cancelation includes more than just the removal of the process instance resource, the cancelation resource must be posted.
+      description: >
+        Cancels a running process instance. As a cancellation includes more than just the removal
+        of the process instance resource, the cancellation resource must be posted. Cancellation
+        can wait on listener-related processing; when that processing does not complete in time,
+        this endpoint can return 504.
       parameters:
         - name: processInstanceKey
           in: path
@@ -2040,6 +2044,8 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: '#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-eventually-consistent: false
   /process-instances/cancellation:
     post:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1126,7 +1126,10 @@ paths:
         - User task
       operationId: completeUserTask
       summary: Complete user task
-      description: Completes a user task with the given key.
+      description: >
+        Completes a user task with the given key. Completion waits for blocking task listeners on
+        this lifecycle transition. If listener processing is delayed beyond the request timeout,
+        this endpoint can return 504.
       parameters:
         - name: userTaskKey
           in: path
@@ -1163,6 +1166,8 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: '#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-eventually-consistent: false
   /user-tasks/{userTaskKey}/assignment:
     post:
@@ -1170,7 +1175,10 @@ paths:
         - User task
       operationId: assignUserTask
       summary: Assign user task
-      description: Assigns a user task with the given key to the given assignee.
+      description: >
+        Assigns a user task with the given key to the given assignee. Assignment waits for
+        blocking task listeners on this lifecycle transition. If listener processing is delayed
+        beyond the request timeout, this endpoint can return 504.
       parameters:
         - name: userTaskKey
           in: path
@@ -1207,6 +1215,8 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: '#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-eventually-consistent: false
   /user-tasks/{userTaskKey}:
     get:
@@ -1251,7 +1261,10 @@ paths:
         - User task
       operationId: updateUserTask
       summary: Update user task
-      description: Update a user task with the given key.
+      description: >
+        Update a user task with the given key. Updates wait for blocking task listeners on this
+        lifecycle transition. If listener processing is delayed beyond the request timeout, this
+        endpoint can return 504.Update a user task with the given key.
       parameters:
         - name: userTaskKey
           in: path
@@ -1288,6 +1301,8 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: '#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-eventually-consistent: false
   /user-tasks/{userTaskKey}/form:
     get:
@@ -1336,7 +1351,10 @@ paths:
         - User task
       operationId: unassignUserTask
       summary: Unassign user task
-      description: Removes the assignee of a task with the given key.
+      description: >
+        Removes the assignee of a task with the given key. Unassignment waits for blocking task
+        listeners on this lifecycle transition. If listener processing is delayed beyond the
+        request timeout, this endpoint can return 504.
       parameters:
         - name: userTaskKey
           in: path
@@ -1367,6 +1385,8 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: '#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-eventually-consistent: false
   /user-tasks/search:
     post:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
@@ -15,16 +15,19 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -187,5 +190,42 @@ public class ElementInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnGatewayTimeoutWhenSetVariablesTimesOut() {
+    // given
+    when(elementInstanceServices.setVariables(any(SetVariablesRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked set variables"))));
+
+    final var request =
+        """
+            {
+              "variables": {
+                "key": "value"
+              }
+            }""";
+
+    // when / then
+    webClient
+        .put()
+        .uri(ELEMENTS_BASE_URL + "/123/variables")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -30,6 +30,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOpe
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
@@ -42,12 +43,14 @@ import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -845,6 +848,33 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnGatewayTimeoutWhenCancelProcessInstanceTimesOut() {
+    // given
+    when(processInstanceServices.cancelProcessInstance(any(ProcessInstanceCancelRequest.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked cancellation"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri(CANCEL_PROCESS_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
@@ -825,6 +826,34 @@ public class UserTaskControllerTest extends RestControllerTest {
 
   @ParameterizedTest
   @MethodSource("urls")
+  void shouldReturnGatewayTimeoutWhenCompleteTaskTimesOut(final String baseUrl) {
+    // given
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked completion"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl + "/1/completion")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
   void shouldYieldConflictWhenInvalidState(final String baseUrl) {
     // given
     Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString()))
@@ -1169,6 +1198,80 @@ public class UserTaskControllerTest extends RestControllerTest {
 
   @ParameterizedTest
   @MethodSource("urls")
+  void shouldReturnGatewayTimeoutWhenAssignTaskTimesOut(final String baseUrl) {
+    // given
+    Mockito.when(userTaskServices.assignUserTask(anyLong(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked assignment"))));
+
+    final var request =
+        """
+            {
+              "assignee": "Test Assignee"
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl + "/1/assignment")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
+  void shouldReturnGatewayTimeoutWhenUpdateTaskTimesOut(final String baseUrl) {
+    // given
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked update"))));
+
+    final var request =
+        """
+            {
+              "changeset": {
+                "priority": 50
+              }
+            }""";
+
+    // when / then
+    webClient
+        .patch()
+        .uri(baseUrl + "/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
   void shouldUnassignTask(final String baseUrl) {
     // given
     Mockito.when(userTaskServices.unassignUserTask(anyLong(), anyString()))
@@ -1184,5 +1287,33 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices).unassignUserTask(2251799813685732L, "unassign");
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
+  void shouldReturnGatewayTimeoutWhenUnassignTaskTimesOut(final String baseUrl) {
+    // given
+    Mockito.when(userTaskServices.unassignUserTask(anyLong(), anyString()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapError(new TimeoutException("Task listener blocked unassignment"))));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(baseUrl + "/1/assignee")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("DEADLINE_EXCEEDED")
+        .jsonPath("$.detail")
+        .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
+        .jsonPath("$.status")
+        .isEqualTo(504);
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public final class StubbedBrokerClient implements BrokerClient {
@@ -110,6 +111,9 @@ public final class StubbedBrokerClient implements BrokerClient {
       } catch (final RuntimeException e) {
         throwableConsumer.accept(new BrokerResponseException(e));
       }
+    } catch (final TimeoutException e) {
+      // Preserve timeout semantics so endpoint tests can assert gateway timeout mappings.
+      throwableConsumer.accept(e);
     } catch (final Exception e) {
       throwableConsumer.accept(new BrokerResponseException(e));
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UserTaskListenersTest.java
@@ -61,7 +61,10 @@ public class UserTaskListenersTest {
 
   @TestZeebe
   private static final TestStandaloneBroker ZEEBE =
-      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withUnauthenticatedAccess()
+          .withProperty("zeebe.broker.gateway.cluster.requestTimeout", "1s");
 
   @AutoClose private CamundaClient client;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UserTaskListenersTest.java
@@ -1049,6 +1049,51 @@ public class UserTaskListenersTest {
                 .isEqualTo(createdUserTask));
   }
 
+  @Test
+  void shouldReturnGatewayTimeoutWhenUpdatingTaskListenerBlocksVariableUpdate() {
+    // given
+    final var listenerType = "blocking_updating_listener";
+    final var userTaskKey =
+        resourcesHelper.createSingleUserTask(
+            t -> t.zeebeTaskListener(l -> l.updating().type(listenerType)));
+    final var createdUserTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withRecordKey(userTaskKey)
+            .getFirst()
+            .getValue();
+
+    try (final var restClient =
+        ZEEBE
+            .newClientBuilder()
+            .preferRestOverGrpc(false)
+            .defaultRequestTimeout(Duration.ofSeconds(60))
+            .build()) {
+      final var updateTaskVariablesFuture =
+          restClient
+              .newSetVariablesCommand(createdUserTask.getElementInstanceKey())
+              .useRest()
+              .variables(Map.of("approvalStatus", "APPROVED"))
+              .local(true)
+              .send();
+
+      // when: the listener job is created but not completed by any worker
+      await().untilAsserted(() -> ZeebeAssertHelper.assertJobCreated(listenerType));
+
+      // then
+      assertThatExceptionOfType(ProblemException.class)
+          .isThrownBy(updateTaskVariablesFuture::join)
+          .extracting(ProblemException::details)
+          .satisfies(
+              details -> {
+                assertThat(details.getStatus()).isEqualTo(HttpStatus.SC_GATEWAY_TIMEOUT);
+                assertThat(details.getTitle()).isEqualTo("DEADLINE_EXCEEDED");
+                assertThat(details.getDetail())
+                    .isEqualTo(
+                        "Expected to handle request, but request timed out between gateway and broker");
+              });
+    }
+  }
+
   private void waitForJobRetriesToBeExhausted(final RecordingJobHandler recordingHandler) {
     await("until all retries are exhausted")
         .untilAsserted(


### PR DESCRIPTION
# Description
Backport of #48577 to `stable/8.8`.

relates to #44179

There were conflicts because the `rest-api.yaml` file was split into smaller files in 8.9, and this refactoring was not ported back to 8.8.