### PR TITLE
fix: rewrite localhost Elasticsearch URL for c8run Docker config

### DIFF
--- a/c8run/README.md
+++ b/c8run/README.md
@@ -27,6 +27,8 @@ Elasticsearch remains available, but it is no longer started automatically. The 
    ```bash
    ./c8run start --disable-elasticsearch=false
    ```
+   When you use `--docker`, c8run automatically rewrites loopback Elasticsearch URLs such as
+   `http://localhost:9200` to the bundled Docker Compose service hostname.
 3. When stopping a stack that was started with Elasticsearch, pass the same flag to ensure the Elasticsearch processes are terminated:
 
    ```bash

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -27,8 +27,6 @@ Elasticsearch remains available, but it is no longer started automatically. The 
    ```bash
    ./c8run start --disable-elasticsearch=false
    ```
-   When you use `--docker`, c8run automatically rewrites loopback Elasticsearch URLs such as
-   `http://localhost:9200` to the bundled Docker Compose service hostname.
 3. When stopping a stack that was started with Elasticsearch, pass the same flag to ensure the Elasticsearch processes are terminated:
 
    ```bash

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -470,6 +472,16 @@ func prepareDockerComposeConfig(baseDir, composeFolder, resolvedConfigPath strin
 		return "", fmt.Errorf("failed to ensure docker-compose configuration directory: %w", err)
 	}
 
+	content, err := os.ReadFile(resolvedConfigPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read configuration for docker-compose: %w", err)
+	}
+
+	dockerContent, rewritten, err := rewriteDockerComposeConfig(content)
+	if err != nil {
+		return "", fmt.Errorf("failed to adapt configuration for docker-compose: %w", err)
+	}
+
 	fileName := filepath.Base(resolvedConfigPath)
 	destPath := filepath.Join(configDir, fileName)
 
@@ -478,17 +490,77 @@ func prepareDockerComposeConfig(baseDir, composeFolder, resolvedConfigPath strin
 		return "", err
 	}
 
-	if !sameFile {
-		if err := copyFileEnsureDir(resolvedConfigPath, destPath); err != nil {
-			return "", fmt.Errorf("failed to copy configuration for docker-compose: %w", err)
+	if !sameFile || rewritten {
+		contentToWrite := content
+		if rewritten {
+			contentToWrite = dockerContent
 		}
-		log.Info().
+		if err := os.WriteFile(destPath, contentToWrite, 0o644); err != nil {
+			return "", fmt.Errorf("failed to write configuration for docker-compose: %w", err)
+		}
+
+		event := log.Info().
 			Str("source", resolvedConfigPath).
-			Str("destination", destPath).
-			Msg("Copied configuration for docker-compose")
+			Str("destination", destPath)
+		if rewritten {
+			event = event.Str("rewrite", "elasticsearch-loopback-url")
+		}
+		event.Msg("Prepared configuration for docker-compose")
 	}
 
 	return fileName, nil
+}
+
+func rewriteDockerComposeConfig(content []byte) ([]byte, bool, error) {
+	if len(bytes.TrimSpace(content)) == 0 {
+		return content, false, nil
+	}
+
+	var root map[string]any
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		return nil, false, err
+	}
+
+	rewritten, err := rewriteDockerComposeElasticsearchURL(root)
+	if err != nil {
+		return nil, false, err
+	}
+	if !rewritten {
+		return content, false, nil
+	}
+
+	updatedContent, err := yaml.Marshal(root)
+	if err != nil {
+		return nil, false, err
+	}
+	return updatedContent, true, nil
+}
+
+func rewriteDockerComposeElasticsearchURL(root map[string]any) (bool, error) {
+	if !strings.EqualFold(extractSecondaryStorageTypeFromMap(root), "elasticsearch") {
+		return false, nil
+	}
+
+	elasticsearchConfig, ok := extractElasticsearchConfigFromMap(root)
+	if !ok {
+		return false, nil
+	}
+
+	rawURL, ok := elasticsearchConfig["url"].(string)
+	if !ok {
+		return false, nil
+	}
+
+	rewrittenURL, changed, err := rewriteLoopbackURLForDocker(rawURL, "elasticsearch")
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+
+	elasticsearchConfig["url"] = rewrittenURL
+	return true, nil
 }
 
 func filesAreSame(a, b string) (bool, error) {
@@ -575,6 +647,64 @@ func extractSecondaryStorageTypeFromMap(root map[string]any) string {
 		return typ
 	}
 	return ""
+}
+
+func extractElasticsearchConfigFromMap(root map[string]any) (map[string]any, bool) {
+	camunda, ok := root["camunda"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	data, ok := camunda["data"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	secondary, ok := data["secondary-storage"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	elasticsearch, ok := secondary["elasticsearch"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	return elasticsearch, true
+}
+
+func rewriteLoopbackURLForDocker(rawURL string, dockerHost string) (string, bool, error) {
+	trimmedURL := strings.TrimSpace(rawURL)
+	if trimmedURL == "" {
+		return rawURL, false, nil
+	}
+
+	parseTarget := trimmedURL
+	if !strings.Contains(parseTarget, "://") {
+		parseTarget = "http://" + parseTarget
+	}
+
+	parsedURL, err := neturl.Parse(parseTarget)
+	if err != nil {
+		return "", false, err
+	}
+
+	if !isLoopbackHost(parsedURL.Hostname()) {
+		return rawURL, false, nil
+	}
+
+	if port := parsedURL.Port(); port != "" {
+		parsedURL.Host = net.JoinHostPort(dockerHost, port)
+	} else {
+		parsedURL.Host = dockerHost
+	}
+
+	return parsedURL.String(), true, nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func detectRdbmsURLFromConfig(path string) (string, error) {

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -841,13 +841,6 @@ func copyFile(src, dst string) error {
 	return nil
 }
 
-func copyFileEnsureDir(src, dst string) error {
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
-	}
-	return copyFile(src, dst)
-}
-
 func main() {
 	consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
 	logger := zerolog.New(consoleWriter).With().Timestamp().Logger()

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -216,3 +216,59 @@ func TestDockerCommandEnvNoOverrideWithoutDockerVersion(t *testing.T) {
 
 	assert.Equal(t, base, result)
 }
+
+func TestPrepareDockerComposeConfigRewritesLoopbackElasticsearchURL(t *testing.T) {
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "configuration")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+
+	config := `
+camunda:
+  data:
+    secondary-storage:
+      type: elasticsearch
+      elasticsearch:
+        url: http://localhost:9200
+`
+	configPath := filepath.Join(configDir, "application.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o644))
+
+	fileName, err := prepareDockerComposeConfig(tempDir, "docker-compose-8.9", configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "application.yaml", fileName)
+
+	preparedConfigPath := filepath.Join(tempDir, "docker-compose-8.9", "configuration", fileName)
+	preparedConfig, err := os.ReadFile(preparedConfigPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(preparedConfig), "url: http://elasticsearch:9200")
+	assert.NotContains(t, string(preparedConfig), "url: http://localhost:9200")
+}
+
+func TestPrepareDockerComposeConfigKeepsExternalElasticsearchURL(t *testing.T) {
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "configuration")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+
+	config := `
+camunda:
+  data:
+    secondary-storage:
+      type: elasticsearch
+      elasticsearch:
+        url: https://es.example.com:9243
+`
+	configPath := filepath.Join(configDir, "application.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o644))
+
+	fileName, err := prepareDockerComposeConfig(tempDir, "docker-compose-8.9", configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "application.yaml", fileName)
+
+	preparedConfigPath := filepath.Join(tempDir, "docker-compose-8.9", "configuration", fileName)
+	preparedConfig, err := os.ReadFile(preparedConfigPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(preparedConfig), "url: https://es.example.com:9243")
+	assert.NotContains(t, string(preparedConfig), "elasticsearch:9243")
+}


### PR DESCRIPTION
## Description

 When `c8run --docker` is started with an Elasticsearch config that uses `http://localhost:9200`, the config was copied into the Docker Compose bundle unchanged. Inside the `orchestration` container,
  `localhost` points to the container itself, so Operate and the exporter could not reach Elasticsearch and the container stayed unhealthy.

  This change rewrites loopback Elasticsearch URLs to the Docker Compose service hostname during Docker config preparation, while leaving non-loopback URLs unchanged.

  ## Verification

  - Ran `go test ./...` in `c8run`
  - Verified the Docker flow with:
    - `CAMUNDA_VERSION=8.10.0-SNAPSHOT`
    - `CAMUNDA_DOCKER_VERSION=8.10-SNAPSHOT`
    - `--docker --disable-elasticsearch=false`
  - Confirmed the generated config uses `http://elasticsearch:9200`
  - Confirmed `orchestration` becomes healthy and the exporter opens
  - Reproduced the original failure in a pre-fix copy, where `http://localhost:9200` caused repeated `Connection refused` errors

closes #48873
