### PR TITLE
test/docs: clarify businessId uniqueness conflict contract

### DIFF
--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/GatewayErrorMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/GatewayErrorMapperTest.java
@@ -225,6 +225,22 @@ public class GatewayErrorMapperTest {
     assertThat(problemDetail.getTitle()).isEqualTo(INVALID_ARGUMENT.name());
   }
 
+  @Test
+  void shouldMapAlreadyExistsServiceExceptionToConflictProblemDetail() {
+    // given
+    final var reason =
+        "Expected to create instance of process with business id 'order-12345', but an instance with this business id already exists for process definition 'bpmnProcessId'";
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(new ServiceException(reason, ALREADY_EXISTS));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+    assertThat(problemDetail.getTitle()).isEqualTo(ALREADY_EXISTS.name());
+    assertThat(problemDetail.getDetail()).isEqualTo(reason);
+  }
+
   // Sample custom ServiceException for testing
   public static class TestServiceException extends ServiceException {
     public TestServiceException(final String message, final Status status) {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
@@ -8,15 +8,21 @@
 package io.camunda.zeebe.gateway.api.process;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import org.junit.Test;
 
 public final class CreateProcessInstanceTest extends GatewayTest {
@@ -80,5 +86,41 @@ public final class CreateProcessInstanceTest extends GatewayTest {
     final ProcessInstanceCreationRecord brokerRequestValue = brokerRequest.getRequestWriter();
     assertThat(brokerRequestValue.hasBusinessId()).isTrue();
     assertThat(brokerRequestValue.getBusinessId()).isEqualTo(businessId);
+  }
+
+  @Test
+  public void shouldMapDuplicateBusinessIdRejectionToAlreadyExists() {
+    // given
+    final var businessId = "order-12345";
+    final var processDefinitionId = "bpmnProcessId";
+    final var rejectionReason =
+        "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'"
+            .formatted(businessId, processDefinitionId);
+    final CreateProcessInstanceStub stub = new CreateProcessInstanceStub();
+    stub.respondWith(
+            new BrokerRejectionResponse<>(
+                new BrokerRejection(
+                    ProcessInstanceCreationIntent.CREATE,
+                    1L,
+                    RejectionType.ALREADY_EXISTS,
+                    rejectionReason)))
+        .registerWith(brokerClient);
+
+    final CreateProcessInstanceRequest request =
+        CreateProcessInstanceRequest.newBuilder()
+            .setProcessDefinitionKey(stub.getProcessDefinitionKey())
+            .setBusinessId(businessId)
+            .build();
+
+    // when / then
+    assertThatThrownBy(() -> client.createProcessInstance(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.THROWABLE)
+        .extracting(
+            t -> ((StatusRuntimeException) t).getStatus().getCode(),
+            t -> ((StatusRuntimeException) t).getStatus().getDescription())
+        .containsExactly(
+            Status.Code.ALREADY_EXISTS,
+            "Command 'CREATE' rejected with code 'ALREADY_EXISTS': " + rejectionReason);
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultTest.java
@@ -9,16 +9,22 @@ package io.camunda.zeebe.gateway.api.process;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import java.util.HashSet;
 import java.util.List;
 import org.junit.Ignore;
@@ -116,6 +122,45 @@ public final class CreateProcessInstanceWithResultTest extends GatewayTest {
             .<BrokerCreateProcessInstanceWithResultRequest>getSingleBrokerRequest()
             .getRequestWriter();
     assertThat(brokerRequestValue.getBusinessId()).isEqualTo(businessId);
+  }
+
+  @Test
+  public void shouldMapDuplicateBusinessIdRejectionToAlreadyExists() {
+    // given
+    final var businessId = "order-12345";
+    final var processDefinitionId = "bpmnProcessId";
+    final var rejectionReason =
+        "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'"
+            .formatted(businessId, processDefinitionId);
+    brokerClient.registerHandler(
+        BrokerCreateProcessInstanceWithResultRequest.class,
+        request ->
+            new BrokerRejectionResponse<>(
+                new BrokerRejection(
+                    ProcessInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT,
+                    1L,
+                    RejectionType.ALREADY_EXISTS,
+                    rejectionReason)));
+
+    final CreateProcessInstanceWithResultRequest request =
+        CreateProcessInstanceWithResultRequest.newBuilder()
+            .setRequest(
+                CreateProcessInstanceRequest.newBuilder()
+                    .setProcessDefinitionKey(CreateProcessInstanceWithResultStub.PROCESS_KEY)
+                    .setBusinessId(businessId))
+            .build();
+
+    // when / then
+    assertThatThrownBy(() -> client.createProcessInstanceWithResult(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.THROWABLE)
+        .extracting(
+            t -> ((StatusRuntimeException) t).getStatus().getCode(),
+            t -> ((StatusRuntimeException) t).getStatus().getDescription())
+        .containsExactly(
+            Status.Code.ALREADY_EXISTS,
+            "Command 'CREATE_WITH_AWAITING_RESULT' rejected with code 'ALREADY_EXISTS': "
+                + rejectionReason);
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -15,10 +15,14 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Status;
 import io.atomix.cluster.messaging.MessagingException.ConnectionClosed;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.test.util.logging.RecordingAppender;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -215,5 +219,24 @@ final class GrpcErrorMapperTest {
     assertThat(recorder.getAppendedEvents()).hasSize(1);
     final LogEvent event = recorder.getAppendedEvents().getFirst();
     assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+  }
+
+  @Test
+  void shouldMapAlreadyExistsRejectionToAlreadyExistsStatus() {
+    // given
+    final var reason =
+        "Expected to create instance of process with business id 'order-12345', but an instance with this business id already exists for process definition 'bpmnProcessId'";
+    final var rejection =
+        new BrokerRejection(
+            ProcessInstanceCreationIntent.CREATE, 1L, RejectionType.ALREADY_EXISTS, reason);
+    final var exception = new BrokerRejectionException(rejection);
+
+    // when
+    final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.ALREADY_EXISTS);
+    assertThat(statusException.getStatus().getDescription())
+        .isEqualTo("Command 'CREATE' rejected with code 'ALREADY_EXISTS': " + reason);
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -1040,8 +1040,8 @@ service Gateway {
           JSON document where the root node is an object.
 
       ALREADY_EXISTS:
-        - the request contains a businessId, Business ID Uniqueness Control is enabled,
-          and an active root process instance with the same businessId already exists
+        - Business ID Uniqueness Control is enabled, and an active root process instance
+          with the provided businessId already exists
           for the same process definition and tenant.
    */
   rpc CreateProcessInstance (CreateProcessInstanceRequest) returns (CreateProcessInstanceResponse) {
@@ -1052,8 +1052,8 @@ service Gateway {
 
     Errors:
       ALREADY_EXISTS:
-        - the request contains a businessId, Business ID Uniqueness Control is enabled,
-          and an active root process instance with the same businessId already exists
+        - Business ID Uniqueness Control is enabled, and an active root process instance
+          with the provided businessId already exists
           for the same process definition and tenant.
   */
   rpc CreateProcessInstanceWithResult (CreateProcessInstanceWithResultRequest) returns (CreateProcessInstanceWithResultResponse) {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -1040,8 +1040,9 @@ service Gateway {
           JSON document where the root node is an object.
 
       ALREADY_EXISTS:
-        - the request contains a businessId and an active root process instance with the same businessId
-          already exists for the same process definition and tenant.
+        - the request contains a businessId, Business ID Uniqueness Control is enabled,
+          and an active root process instance with the same businessId already exists
+          for the same process definition and tenant.
    */
   rpc CreateProcessInstance (CreateProcessInstanceRequest) returns (CreateProcessInstanceResponse) {
   }
@@ -1051,8 +1052,9 @@ service Gateway {
 
     Errors:
       ALREADY_EXISTS:
-        - the request contains a businessId and an active root process instance with the same businessId
-          already exists for the same process definition and tenant.
+        - the request contains a businessId, Business ID Uniqueness Control is enabled,
+          and an active root process instance with the same businessId already exists
+          for the same process definition and tenant.
   */
   rpc CreateProcessInstanceWithResult (CreateProcessInstanceWithResultRequest) returns (CreateProcessInstanceWithResultResponse) {
   }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -1038,12 +1038,21 @@ service Gateway {
       INVALID_ARGUMENT:
         - the given variables argument is not a valid JSON document; it is expected to be a valid
           JSON document where the root node is an object.
+
+      ALREADY_EXISTS:
+        - the request contains a businessId and an active root process instance with the same businessId
+          already exists for the same process definition and tenant.
    */
   rpc CreateProcessInstance (CreateProcessInstanceRequest) returns (CreateProcessInstanceResponse) {
   }
 
   /*
     Behaves similarly to `rpc CreateProcessInstance`, except that a successful response is received when the process completes successfully.
+
+    Errors:
+      ALREADY_EXISTS:
+        - the request contains a businessId and an active root process instance with the same businessId
+          already exists for the same process definition and tenant.
   */
   rpc CreateProcessInstanceWithResult (CreateProcessInstanceWithResultRequest) returns (CreateProcessInstanceWithResultResponse) {
   }

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -42,6 +42,15 @@ paths:
                 $ref: '#/components/schemas/CreateProcessInstanceResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "409":
+          description: |
+            The process instance creation was rejected due to a business ID uniqueness conflict.
+            This can happen when `businessId` is provided and an active root process instance
+            with the same business ID already exists for the same process definition and tenant.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -45,9 +45,9 @@ paths:
         "409":
           description: |
             The process instance creation was rejected due to a business ID uniqueness conflict.
-            This can happen only when Business ID Uniqueness Control is enabled,
-            `businessId` is provided, and an active root process instance with the same
-            business ID already exists for the same process definition and tenant.
+            This can happen only when Business ID Uniqueness Control is enabled and an
+            active root process instance with the provided business ID already exists
+            for the same process definition and tenant.
           content:
             application/problem+json:
               schema:

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -45,8 +45,9 @@ paths:
         "409":
           description: |
             The process instance creation was rejected due to a business ID uniqueness conflict.
-            This can happen when `businessId` is provided and an active root process instance
-            with the same business ID already exists for the same process definition and tenant.
+            This can happen only when Business ID Uniqueness Control is enabled,
+            `businessId` is provided, and an active root process instance with the same
+            business ID already exists for the same process definition and tenant.
           content:
             application/problem+json:
               schema:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -374,20 +374,18 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             CompletableFuture.failedFuture(
                 new ServiceException(rejectionReason, ServiceException.Status.ALREADY_EXISTS)));
 
-    final var request =
-        """
-            {
-                "processDefinitionId": "bpmnProcessId",
-                "businessId": "order-12345"
-            }""";
-
     // when / then
     webClient
         .post()
         .uri(PROCESS_INSTANCES_START_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
+        .bodyValue(
+            """
+            {
+                "processDefinitionId": "bpmnProcessId",
+                "businessId": "order-12345"
+            }""")
         .exchange()
         .expectStatus()
         .isEqualTo(HttpStatus.CONFLICT)
@@ -775,41 +773,38 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             any(ProcessInstanceCreateRequest.class), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
-    final var request =
-        """
-            {
-                "processDefinitionKey": "123",
-                "awaitCompletion": true,
-                "businessId": "order-12345"
-            }""";
-
-    final var expectedResponse =
-        """
-            {
-              "processDefinitionKey":"123",
-              "processDefinitionId":"bpmnProcessId",
-              "processDefinitionVersion":-1,
-              "processInstanceKey":"456",
-              "tenantId":"<default>",
-              "variables":{},
-              "tags":[],
-              "businessId":"order-12345"
-            }""";
-
     // when / then
     webClient
         .post()
         .uri(PROCESS_INSTANCES_START_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
+        .bodyValue(
+            """
+            {
+                "processDefinitionKey": "123",
+                "awaitCompletion": true,
+                "businessId": "order-12345"
+            }""")
         .exchange()
         .expectStatus()
         .isOk()
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedResponse, JsonCompareMode.STRICT);
+        .json(
+            """
+            {
+                "processDefinitionKey":"123",
+                "processDefinitionId":"bpmnProcessId",
+                "processDefinitionVersion":-1,
+                "processInstanceKey":"456",
+                "tenantId":"<default>",
+                "variables":{},
+                "tags":[],
+                "businessId":"order-12345"
+            }""",
+            JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
         .createProcessInstanceWithResult(createRequestCaptor.capture(), any());
@@ -833,21 +828,19 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             CompletableFuture.failedFuture(
                 new ServiceException(rejectionReason, ServiceException.Status.ALREADY_EXISTS)));
 
-    final var request =
-        """
-            {
-                "processDefinitionId": "bpmnProcessId",
-                "awaitCompletion": true,
-                "businessId": "order-12345"
-            }""";
-
     // when / then
     webClient
         .post()
         .uri(PROCESS_INSTANCES_START_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
+        .bodyValue(
+            """
+            {
+              "processDefinitionId": "bpmnProcessId",
+              "awaitCompletion": true,
+              "businessId": "order-12345"
+            }""")
         .exchange()
         .expectStatus()
         .isEqualTo(HttpStatus.CONFLICT)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -32,6 +32,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.exception.ServiceException;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
@@ -357,6 +358,54 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.businessId()).isEqualTo(businessId);
+  }
+
+  @Test
+  void shouldRejectCreateProcessInstanceWhenBusinessIdAlreadyExists() {
+    // given
+    final var businessId = "order-12345";
+    final var processDefinitionId = "bpmnProcessId";
+    final var rejectionReason =
+        "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'"
+            .formatted(businessId, processDefinitionId);
+    when(processInstanceServices.createProcessInstance(
+            any(ProcessInstanceCreateRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(rejectionReason, ServiceException.Status.ALREADY_EXISTS)));
+
+    final var request =
+        """
+            {
+                "processDefinitionId": "bpmnProcessId",
+                "businessId": "order-12345"
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("ALREADY_EXISTS")
+        .jsonPath("$.status")
+        .isEqualTo(409)
+        .jsonPath("$.detail")
+        .value(
+            detail -> {
+              assertThat((String) detail)
+                  .startsWith("Expected to create instance of process with business id")
+                  .contains("business id '" + businessId + "'")
+                  .contains("process definition '" + processDefinitionId + "'");
+            });
   }
 
   @Test
@@ -768,6 +817,55 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.awaitCompletion()).isTrue();
     assertThat(capturedRequest.businessId()).isEqualTo(businessId);
+  }
+
+  @Test
+  void shouldRejectCreateProcessInstanceWithResultWhenBusinessIdAlreadyExists() {
+    // given
+    final var businessId = "order-12345";
+    final var processDefinitionId = "bpmnProcessId";
+    final var rejectionReason =
+        "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'"
+            .formatted(businessId, processDefinitionId);
+    when(processInstanceServices.createProcessInstanceWithResult(
+            any(ProcessInstanceCreateRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(rejectionReason, ServiceException.Status.ALREADY_EXISTS)));
+
+    final var request =
+        """
+            {
+                "processDefinitionId": "bpmnProcessId",
+                "awaitCompletion": true,
+                "businessId": "order-12345"
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("ALREADY_EXISTS")
+        .jsonPath("$.status")
+        .isEqualTo(409)
+        .jsonPath("$.detail")
+        .value(
+            detail -> {
+              assertThat((String) detail)
+                  .startsWith("Expected to create instance of process with business id")
+                  .contains("business id '" + businessId + "'")
+                  .contains("process definition '" + processDefinitionId + "'");
+            });
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -394,18 +394,18 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .jsonPath("$.title")
-        .isEqualTo("ALREADY_EXISTS")
-        .jsonPath("$.status")
-        .isEqualTo(409)
-        .jsonPath("$.detail")
-        .value(
-            detail -> {
-              assertThat((String) detail)
-                  .startsWith("Expected to create instance of process with business id")
-                  .contains("business id '" + businessId + "'")
-                  .contains("process definition '" + processDefinitionId + "'");
-            });
+        .json(
+            """
+            {
+                "type":"about:blank",
+                "title":"ALREADY_EXISTS",
+                "status":409,
+                "detail":"Expected to create instance of process with business id '%s', \
+            but an instance with this business id already exists for process definition '%s'",
+                "instance":"/v2/process-instances"
+            }"""
+                .formatted(businessId, processDefinitionId),
+            JsonCompareMode.STRICT);
   }
 
   @Test
@@ -854,18 +854,18 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
-        .jsonPath("$.title")
-        .isEqualTo("ALREADY_EXISTS")
-        .jsonPath("$.status")
-        .isEqualTo(409)
-        .jsonPath("$.detail")
-        .value(
-            detail -> {
-              assertThat((String) detail)
-                  .startsWith("Expected to create instance of process with business id")
-                  .contains("business id '" + businessId + "'")
-                  .contains("process definition '" + processDefinitionId + "'");
-            });
+        .json(
+            """
+            {
+                "type":"about:blank",
+                "title":"ALREADY_EXISTS",
+                "status":409,
+                "detail":"Expected to create instance of process with business id '%s', \
+            but an instance with this business id already exists for process definition '%s'",
+                "instance":"/v2/process-instances"
+            }"""
+                .formatted(businessId, processDefinitionId),
+            JsonCompareMode.STRICT);
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
@@ -8,11 +8,14 @@
 package io.camunda.zeebe.it.engine.client.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -25,11 +28,14 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.grpc.Status.Code;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -39,7 +45,11 @@ public final class CreateProcessInstanceTest {
 
   @TestZeebe
   private static final TestStandaloneBroker ZEEBE =
-      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withUnauthenticatedAccess()
+          .withUnifiedConfig(
+              c -> c.getProcessInstanceCreation().setBusinessIdUniquenessEnabled(true));
 
   @AutoClose CamundaClient client;
   ZeebeResourcesHelper resourcesHelper;
@@ -175,6 +185,87 @@ public final class CreateProcessInstanceTest {
 
     // then
     assertThat(processInstance.getBusinessId()).isEqualTo("bizniz");
+  }
+
+  @Test
+  public void shouldRejectCreateWithDuplicateBusinessIdOverRest(final TestInfo testInfo) {
+    // given
+    final var useRest = true;
+    final var testName = testInfo.getTestMethod().orElseThrow().getName();
+    final var processId = "proces_" + testName;
+    final var businessId = "business_" + testName;
+    resourcesHelper.deployProcess(
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("job_" + testName))
+            .done(),
+        useRest);
+
+    getCommand(client, useRest)
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .businessId(businessId)
+        .send()
+        .join();
+
+    // when / then
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () ->
+                getCommand(client, useRest)
+                    .bpmnProcessId(processId)
+                    .latestVersion()
+                    .businessId(businessId)
+                    .send()
+                    .join())
+        .satisfies(
+            ex -> {
+              assertThat(ex.details().getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+              assertThat(ex.details().getTitle()).isEqualTo("ALREADY_EXISTS");
+              assertThat(ex.details().getDetail())
+                  .contains("business id '" + businessId + "'")
+                  .contains("process definition '" + processId + "'");
+            });
+  }
+
+  @Test
+  public void shouldRejectCreateWithDuplicateBusinessIdOverGrpc(final TestInfo testInfo) {
+    // given
+    final var useRest = false;
+    final var testName = testInfo.getTestMethod().orElseThrow().getName();
+    final var processId = "proces_" + testName;
+    final var businessId = "business_" + testName;
+    resourcesHelper.deployProcess(
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("job_" + testName))
+            .done(),
+        useRest);
+
+    getCommand(client, useRest)
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .businessId(businessId)
+        .send()
+        .join();
+
+    // when / then
+    assertThatExceptionOfType(ClientStatusException.class)
+        .isThrownBy(
+            () ->
+                getCommand(client, useRest)
+                    .bpmnProcessId(processId)
+                    .latestVersion()
+                    .businessId(businessId)
+                    .send()
+                    .join())
+        .satisfies(
+            ex -> {
+              assertThat(ex.getStatusCode()).isEqualTo(Code.ALREADY_EXISTS);
+              assertThat(ex.getMessage())
+                  .contains("business id '" + businessId + "'")
+                  .contains("process definition '" + processId + "'");
+            });
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Clarify and verify the `businessId` uniqueness conflict contract for process instance creation across REST and gRPC, by adding tests and aligning protocol documentation with the existing enforced behavior.

This PR adds:
- REST contract tests for both create paths (`awaitCompletion` false/true) asserting `409` + `ALREADY_EXISTS`
- gRPC contract tests for `CreateProcessInstance` and `CreateProcessInstanceWithResult` asserting `Status.Code.ALREADY_EXISTS`
- mapper parity tests to ensure consistent conflict mapping across gRPC and HTTP
- docs updates in `gateway.proto` and `process-instances.yaml` documenting `ALREADY_EXISTS` / `409` for `businessId` uniqueness conflicts

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48260