### PR TITLE
fix: optimize use optimize distball

### DIFF
--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -78,9 +78,12 @@ jobs:
         run: |
           ./mvnw -B -T1C -DskipTests -DskipChecks -Dflatten.skip=true -Dskip.fe.build=false package
           ARTIFACT=$(./mvnw -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
-          export ARTIFACT
-          echo "distball=dist/target/${ARTIFACT}.tar.gz" >> "$GITHUB_OUTPUT"
-          echo "distzip=dist/target/${ARTIFACT}.zip" >> "$GITHUB_OUTPUT"
+          OPTIMIZE_ARTIFACT=$(./mvnw -pl optimize-distro/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+          {
+            echo "distball=dist/target/${ARTIFACT}.tar.gz"
+            echo "distzip=dist/target/${ARTIFACT}.zip"
+            echo "optimize_distball=optimize-distro/target/${OPTIMIZE_ARTIFACT}-production.tar.gz"
+          } >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/build-platform-docker
         id: build-push-camunda-docker
         name: Build & Push zeebe-io/camunda
@@ -131,7 +134,7 @@ jobs:
         with:
           repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/optimize
           version: ${{ steps.image-tag.outputs.image-tag }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
+          distball: ${{ steps.build-camunda.outputs.optimize_distball }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: optimize.Dockerfile
           push: true


### PR DESCRIPTION
## Description

This pull request updates the workflow for building and deploying Docker images in the `.github/workflows/camunda-platform-docker-deploy-saas-image.yml` file. The main focus is to ensure that the correct optimized artifact is built and used for the Optimize Docker image, improving the build process for the SaaS deployment.

Build artifact output changes:

* The workflow now evaluates and outputs both the main distribution artifact and a new optimized artifact (`optimize-distball`), saving the optimized tarball path to the GitHub Actions output.

Optimize Docker image deployment:

* The Docker build step for the Optimize image now uses the new optimized artifact (`optimize-distball`) as its input, ensuring the correct artifact is deployed.

Based on this issue reported: https://camunda.slack.com/archives/C071KP5BTHB/p1773777444285759?thread_ts=1773762340.917849&cid=C071KP5BTHB

Workflow run: https://github.com/camunda/camunda/actions/runs/23214387266

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
