### PR TITLE
fix: fix swagger CSRF request matcher short-circuit condition

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
+++ b/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
@@ -31,27 +31,27 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
   private final Pattern allowedPathsPattern;
 
   public CsrfProtectionRequestMatcher() {
-    final Set<String> allowedPaths = new HashSet<>();
-    allowedPaths.addAll(WebSecurityConfig.UNPROTECTED_PATHS);
-    allowedPaths.addAll(WebSecurityConfig.UNPROTECTED_API_PATHS);
-    allowedPaths.add(WebSecurityConfig.LOGIN_URL);
-    allowedPaths.add(WebSecurityConfig.LOGOUT_URL);
-    allowedPathsPattern = allowedPathsToPattern(allowedPaths);
-    LOG.debug("CSRF protection configuration - allowed paths pattern: {}", allowedPathsPattern);
+    allowedPathsPattern = getAllowedPathsPattern();
   }
 
   @Override
   public boolean matches(final HttpServletRequest request) {
-    // These methods are CSRF-safe
-    if (ALLOWED_METHODS.matcher(request.getMethod()).matches()) {
+    // short-circuit check for the following conditions
+    if (matchesPattern(ALLOWED_METHODS, request.getMethod())
+        || matchesPattern(allowedPathsPattern, request.getServletPath())
+        || isSwaggerReferer(request)) {
       return false;
     }
 
-    if (allowedPathsPattern.matcher(request.getServletPath()).matches()) {
-      return false;
-    }
+    // check if API call is coming from the browser
+    return request.getSession(false) != null;
+  }
 
-    // If request coming from Swagger UI
+  private boolean matchesPattern(final Pattern pattern, final String str) {
+    return pattern.matcher(str).matches();
+  }
+
+  private boolean isSwaggerReferer(final HttpServletRequest request) {
     final String referer = request.getHeader(HttpHeaders.REFERER);
     final String baseRequestUrl;
     try {
@@ -64,23 +64,20 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
     } catch (final MalformedURLException e) {
       throw new RuntimeException(e);
     }
-
-    if (referer != null && referer.matches(baseRequestUrl + "/swagger-ui.*")) {
-      return false;
-    }
-
-    return apiCallComingFromBrowser(request);
+    return referer != null && referer.matches(baseRequestUrl + ".*/swagger-ui.*");
   }
 
-  private boolean apiCallComingFromBrowser(final HttpServletRequest request) {
-    return request.getSession(false) != null;
-  }
-
-  private Pattern allowedPathsToPattern(final Set<String> paths) {
+  private Pattern getAllowedPathsPattern() {
+    final Set<String> paths = new HashSet<>();
+    paths.addAll(WebSecurityConfig.UNPROTECTED_PATHS);
+    paths.addAll(WebSecurityConfig.UNPROTECTED_API_PATHS);
+    paths.add(WebSecurityConfig.LOGIN_URL);
+    paths.add(WebSecurityConfig.LOGOUT_URL);
     final String patternAsString =
         paths.stream()
             .map(path -> path.replace("**", ".*")) // Replace wildcard with regex equivalent
             .collect(Collectors.joining("|", "^(", ")$")); // Combine paths into regex
+    LOG.debug("CSRF protection configuration - allowed paths pattern: {}", allowedPathsPattern);
     return Pattern.compile(patternAsString);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
+++ b/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
@@ -56,7 +56,6 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
     final String baseRequestUrl;
     try {
       final URL requestUrl = URI.create(request.getRequestURL().toString()).toURL();
-      final URI uri = URI.create(request.getRequestURI());
       baseRequestUrl =
           requestUrl.getProtocol()
               + "://"

--- a/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
+++ b/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
@@ -56,6 +56,7 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
     final String baseRequestUrl;
     try {
       final URL requestUrl = URI.create(request.getRequestURL().toString()).toURL();
+      final URI uri = URI.create(request.getRequestURI());
       baseRequestUrl =
           requestUrl.getProtocol()
               + "://"
@@ -64,7 +65,7 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
     } catch (final MalformedURLException e) {
       throw new RuntimeException(e);
     }
-    return referer != null && referer.matches(baseRequestUrl + ".*/swagger-ui.*");
+    return referer != null && referer.matches(Pattern.quote(baseRequestUrl) + ".*/swagger-ui.*");
   }
 
   private Pattern getAllowedPathsPattern() {
@@ -77,7 +78,8 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
         paths.stream()
             .map(path -> path.replace("**", ".*")) // Replace wildcard with regex equivalent
             .collect(Collectors.joining("|", "^(", ")$")); // Combine paths into regex
-    LOG.debug("CSRF protection configuration - allowed paths pattern: {}", allowedPathsPattern);
-    return Pattern.compile(patternAsString);
+    final Pattern compiledPattern = Pattern.compile(patternAsString);
+    LOG.debug("CSRF protection configuration - allowed paths pattern: {}", compiledPattern);
+    return compiledPattern;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
@@ -101,6 +101,32 @@ class CsrfProtectionRequestMatcherTest {
   }
 
   @Test
+  void swaggerReferrerWithExtraPathDoesNotMatchForCsrf() {
+    final var request = prepareMockRequest();
+    request.setServerName("hel-1.operate.ultrawombat.com");
+    request.setScheme("https");
+    request.setServerPort(443);
+    request.addHeader(
+        REFERER,
+        "https://hel-1.operate.ultrawombat.com/00000000-0000-0000-0000-000000000000/swagger-ui/index.html");
+    request.getSession(true);
+    assertThat(matcher.matches(request)).isFalse();
+  }
+
+  @Test
+  void swaggerReferrerWithExtraPathAndPortDoesNotMatchForCsrf() {
+    final var request = prepareMockRequest();
+    request.setServerName("hel-1.operate.ultrawombat.com");
+    request.setScheme("https");
+    request.setServerPort(12345);
+    request.addHeader(
+        REFERER,
+        "https://hel-1.operate.ultrawombat.com:12345/00000000-0000-0000-0000-000000000000/swagger-ui/index.html");
+    request.getSession(true);
+    assertThat(matcher.matches(request)).isFalse();
+  }
+
+  @Test
   void arbitraryReferrerMatchesForCsrf() {
     final var request = prepareMockRequest();
     request.addHeader(REFERER, "http://localhost/fake-swagger/index.html");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix the Swagger UI matching in the `CsrfProtectionRequestMatcher` class. Also did a little bit of refactoring to make that class easier to read.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48902
