### PR TITLE
refactor: update flowNode naming with element

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -94,7 +94,7 @@ const DiagramPanel: React.FC = observer(() => {
   } = useListViewXml({
     processDefinitionKey: selectedDefinitionKey,
   });
-  const selectableIds = processDefinitionXML?.selectableFlowNodes.map(
+  const selectableIds = processDefinitionXML?.selectableElements.map(
     (element) => element.id,
   );
 
@@ -118,8 +118,8 @@ const DiagramPanel: React.FC = observer(() => {
       },
     },
     {
-      sourceFlowNodeId: flowNodeId,
-      targetFlowNodeId: selectedTargetElementId ?? undefined,
+      sourceElementId: flowNodeId,
+      targetElementId: selectedTargetElementId ?? undefined,
     },
     selectedDefinitionKey,
     batchModificationStore.state.isEnabled,

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
@@ -66,8 +66,8 @@ const BottomPanel: React.FC = observer(() => {
   });
 
   const mappableElements = getMappableElements(
-    sourceData?.selectableFlowNodes,
-    targetData?.selectableFlowNodes,
+    sourceData?.selectableElements,
+    targetData?.selectableElements,
   );
 
   const mappableSequenceFlows =
@@ -98,12 +98,12 @@ const BottomPanel: React.FC = observer(() => {
     }
 
     return [
-      ...sourceData.selectableFlowNodes,
+      ...sourceData.selectableElements,
       ...sourceData.selectableSequenceFlows,
     ]
       .filter((sourceElement) => {
         const targetElement = [
-          ...targetData.selectableFlowNodes,
+          ...targetData.selectableElements,
           ...targetData.selectableSequenceFlows,
         ].find((element) => element.id === sourceElement.id);
 
@@ -129,8 +129,7 @@ const BottomPanel: React.FC = observer(() => {
   };
 
   const hasSelectableSourceElements =
-    sourceData?.selectableFlowNodes &&
-    sourceData.selectableFlowNodes.length > 0;
+    sourceData?.selectableElements && sourceData.selectableElements.length > 0;
 
   const hasSelectableSourceSequenceFlows =
     sourceData?.selectableSequenceFlows &&
@@ -143,10 +142,10 @@ const BottomPanel: React.FC = observer(() => {
     sourceElement: string,
     targetElement: string | undefined,
   ) => {
-    const sourceBusinessObject = sourceData?.selectableFlowNodes.find(
+    const sourceBusinessObject = sourceData?.selectableElements.find(
       (element) => element.id === sourceElement,
     );
-    const targetBusinessObject = targetData?.selectableFlowNodes.find(
+    const targetBusinessObject = targetData?.selectableElements.find(
       (element) => element.id === targetElement,
     );
     return (

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.tsx
@@ -80,7 +80,7 @@ const SourceDiagram: React.FC = observer(() => {
             xml={migrationSourceData.xml}
             processDefinitionKey={sourceProcessDefinition?.processDefinitionKey}
             selectableElements={[
-              ...migrationSourceData.selectableFlowNodes,
+              ...migrationSourceData.selectableElements,
               ...migrationSourceData.selectableSequenceFlows,
             ].map((element) => element.id)}
             selectedElementIds={selectedSourceElementIds}

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.tsx
@@ -111,7 +111,7 @@ const TargetDiagram: React.FC = observer(() => {
             xml={data.xml}
             processDefinitionKey={targetProcessDefinition?.processDefinitionKey}
             selectableElements={[
-              ...data.selectableFlowNodes,
+              ...data.selectableElements,
               ...data.selectableSequenceFlows,
             ].map((element) => element.id)}
             selectedElementIds={

--- a/operate/client/src/modules/queries/elementInstancesStatistics/useElementInstancesStatistics.test.tsx
+++ b/operate/client/src/modules/queries/elementInstancesStatistics/useElementInstancesStatistics.test.tsx
@@ -44,7 +44,7 @@ describe('useElementInstancesStatistics', () => {
     mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
-  it('should fetch flownode instances statistics successfully', async () => {
+  it('should fetch element instances statistics successfully', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
@@ -109,7 +109,7 @@ describe('useElementInstancesStatistics', () => {
     expect(result.current.data).toEqual(mockData.items.length);
   });
 
-  it('should handle server error while fetching flownode instances overlay statistics', async () => {
+  it('should handle server error while fetching element instances overlay statistics', async () => {
     mockFetchElementInstancesStatistics().withServerError();
 
     const {result} = renderHook(() => useElementInstancesStatistics(), {
@@ -123,7 +123,7 @@ describe('useElementInstancesStatistics', () => {
     expect(result.current.error?.response).toBeDefined();
   });
 
-  it('should handle network error while fetching flownode instances overlay statistics', async () => {
+  it('should handle network error while fetching element instances overlay statistics', async () => {
     mockFetchElementInstancesStatistics().withNetworkError();
 
     const {result} = renderHook(() => useElementInstancesStatistics(), {

--- a/operate/client/src/modules/queries/elementInstancesStatistics/useElementStatistics.test.tsx
+++ b/operate/client/src/modules/queries/elementInstancesStatistics/useElementStatistics.test.tsx
@@ -44,7 +44,7 @@ describe('useElementStatistics', () => {
     mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
-  it('should fetch parsed flownode statistics successfully', async () => {
+  it('should fetch parsed element statistics successfully', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
@@ -84,7 +84,7 @@ describe('useElementStatistics', () => {
     ]);
   });
 
-  it('should handle server error while fetching flownode statistics', async () => {
+  it('should handle server error while fetching element statistics', async () => {
     mockFetchElementInstancesStatistics().withServerError();
 
     const {result} = renderHook(() => useElementStatistics(), {
@@ -98,7 +98,7 @@ describe('useElementStatistics', () => {
     expect(result.current.error?.response).toBeDefined();
   });
 
-  it('should handle network error while fetching flownode statistics', async () => {
+  it('should handle network error while fetching element statistics', async () => {
     mockFetchElementInstancesStatistics().withNetworkError();
 
     const {result} = renderHook(() => useElementStatistics(), {

--- a/operate/client/src/modules/queries/elementInstancesStatistics/useExecutedElement.test.tsx
+++ b/operate/client/src/modules/queries/elementInstancesStatistics/useExecutedElement.test.tsx
@@ -44,7 +44,7 @@ describe('useExecutedElements', () => {
     mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
-  it('should fetch executed flow nodes successfully', async () => {
+  it('should fetch executed elements successfully', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
@@ -97,7 +97,7 @@ describe('useExecutedElements', () => {
     ]);
   });
 
-  it('should handle server error while fetching executed flow nodes', async () => {
+  it('should handle server error while fetching executed elements', async () => {
     mockFetchElementInstancesStatistics().withServerError();
 
     const {result} = renderHook(() => useExecutedElements(), {
@@ -111,7 +111,7 @@ describe('useExecutedElements', () => {
     expect(result.current.error?.response).toBeDefined();
   });
 
-  it('should handle network error while fetching executed flow nodes', async () => {
+  it('should handle network error while fetching executed elements', async () => {
     mockFetchElementInstancesStatistics().withNetworkError();
 
     const {result} = renderHook(() => useExecutedElements(), {

--- a/operate/client/src/modules/queries/elementInstancesStatistics/useSelectableElements.test.tsx
+++ b/operate/client/src/modules/queries/elementInstancesStatistics/useSelectableElements.test.tsx
@@ -44,7 +44,7 @@ describe('useSelectableElements', () => {
     mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
-  it('should fetch selectable flow nodes successfully', async () => {
+  it('should fetch selectable elements successfully', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
@@ -86,7 +86,7 @@ describe('useSelectableElements', () => {
     ]);
   });
 
-  it('should handle server error while fetching selectable flow nodes', async () => {
+  it('should handle server error while fetching selectable elements', async () => {
     mockFetchElementInstancesStatistics().withServerError();
 
     const {result} = renderHook(() => useSelectableElements(), {
@@ -100,7 +100,7 @@ describe('useSelectableElements', () => {
     expect(result.current.error?.response).toBeDefined();
   });
 
-  it('should handle network error while fetching selectable flow nodes', async () => {
+  it('should handle network error while fetching selectable elements', async () => {
     mockFetchElementInstancesStatistics().withNetworkError();
 
     const {result} = renderHook(() => useSelectableElements(), {

--- a/operate/client/src/modules/queries/elementInstancesStatistics/useTotalRunningInstancesForElement.test.tsx
+++ b/operate/client/src/modules/queries/elementInstancesStatistics/useTotalRunningInstancesForElement.test.tsx
@@ -49,7 +49,7 @@ describe('useTotalRunningInstancesForElement hooks', () => {
     mockFetchProcessInstance().withSuccess(createProcessInstance());
   });
 
-  it('should fetch total running instances for a single flow node', async () => {
+  it('should fetch total running instances for a single element', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
@@ -78,7 +78,7 @@ describe('useTotalRunningInstancesForElement hooks', () => {
     expect(result.current.data).toBe(7); // active + incidents
   });
 
-  it('should fetch total running instances for multiple flow nodes', async () => {
+  it('should fetch total running instances for multiple elements', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
@@ -117,7 +117,7 @@ describe('useTotalRunningInstancesForElement hooks', () => {
     }); // [active + incidents for node1, node2]
   });
 
-  it('should fetch total visible running instances for a single flow node', async () => {
+  it('should fetch total visible running instances for a single element', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
@@ -142,7 +142,7 @@ describe('useTotalRunningInstancesForElement hooks', () => {
     expect(result.current.data).toBe(7); // active + incidents
   });
 
-  it('should fetch total visible running instances for multiple flow nodes', async () => {
+  it('should fetch total visible running instances for multiple elements', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {

--- a/operate/client/src/modules/queries/elementInstancesStatistics/useTotalRunningInstancesForElement.ts
+++ b/operate/client/src/modules/queries/elementInstancesStatistics/useTotalRunningInstancesForElement.ts
@@ -13,26 +13,26 @@ import type {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {useBusinessObjects} from '../processDefinitions/useBusinessObjects';
 
 const totalRunningInstancesForElementParser =
-  (businessObjects?: BusinessObjects, flowNodeId?: string) =>
+  (businessObjects?: BusinessObjects, elementId?: string) =>
   (response: GetProcessInstanceStatisticsResponseBody) => {
-    if (!flowNodeId) {
+    if (!elementId) {
       return 0;
     }
     const statistics = getStatisticsByElement(response.items, businessObjects)[
-      flowNodeId
+      elementId
     ];
     return (statistics?.active ?? 0) + (statistics?.incidents ?? 0);
   };
 
 const totalRunningInstancesForElementsParser =
-  (flowNodeIds: string[], businessObjects?: BusinessObjects) =>
+  (elementIds: string[], businessObjects?: BusinessObjects) =>
   (response: GetProcessInstanceStatisticsResponseBody) => {
     const statistics = getStatisticsByElement(response.items, businessObjects);
 
-    return flowNodeIds.reduce<Record<string, number>>((acc, flowNodeId) => {
-      const active = statistics[flowNodeId]?.active ?? 0;
-      const incidents = statistics[flowNodeId]?.incidents ?? 0;
-      acc[flowNodeId] = active + incidents;
+    return elementIds.reduce<Record<string, number>>((acc, elementId) => {
+      const active = statistics[elementId]?.active ?? 0;
+      const incidents = statistics[elementId]?.incidents ?? 0;
+      acc[elementId] = active + incidents;
       return acc;
     }, {});
   };
@@ -45,10 +45,10 @@ const totalRunningInstancesByElementParser =
     const statistics = getStatisticsByElement(response.items, businessObjects);
 
     return Object.keys(statistics).reduce<Record<string, number>>(
-      (acc, flowNodeId) => {
-        const active = statistics[flowNodeId]?.active ?? 0;
-        const incidents = statistics[flowNodeId]?.incidents ?? 0;
-        acc[flowNodeId] = active + incidents;
+      (acc, elementId) => {
+        const active = statistics[elementId]?.active ?? 0;
+        const incidents = statistics[elementId]?.incidents ?? 0;
+        acc[elementId] = active + incidents;
         return acc;
       },
       {},
@@ -56,43 +56,43 @@ const totalRunningInstancesByElementParser =
   };
 
 const totalRunningInstancesVisibleForElementParser =
-  (businessObjects?: BusinessObjects, flowNodeId?: string) =>
+  (businessObjects?: BusinessObjects, elementId?: string) =>
   (response: GetProcessInstanceStatisticsResponseBody) => {
-    if (!flowNodeId) {
+    if (!elementId) {
       return 0;
     }
     const statistics = getStatisticsByElement(response.items, businessObjects)[
-      flowNodeId
+      elementId
     ];
     return (statistics?.active ?? 0) + (statistics?.incidents ?? 0);
   };
 
 const totalRunningInstancesVisibleForElementsParser =
-  (flowNodeIds: string[], businessObjects?: BusinessObjects) =>
+  (elementIds: string[], businessObjects?: BusinessObjects) =>
   (response: GetProcessInstanceStatisticsResponseBody) => {
     const statistics = getStatisticsByElement(response.items, businessObjects);
 
-    return flowNodeIds.reduce<Record<string, number>>((acc, flowNodeId) => {
-      const active = statistics[flowNodeId]?.active ?? 0;
-      const incidents = statistics[flowNodeId]?.incidents ?? 0;
-      acc[flowNodeId] = active + incidents;
+    return elementIds.reduce<Record<string, number>>((acc, elementId) => {
+      const active = statistics[elementId]?.active ?? 0;
+      const incidents = statistics[elementId]?.incidents ?? 0;
+      acc[elementId] = active + incidents;
       return acc;
     }, {});
   };
 
-const useTotalRunningInstancesForElement = (flowNodeId?: string) => {
+const useTotalRunningInstancesForElement = (elementId?: string) => {
   const {data: businessObjects} = useBusinessObjects();
 
   return useElementInstancesStatistics(
-    totalRunningInstancesForElementParser(businessObjects, flowNodeId),
+    totalRunningInstancesForElementParser(businessObjects, elementId),
   );
 };
 
-const useTotalRunningInstancesForElements = (flowNodeIds: string[]) => {
+const useTotalRunningInstancesForElements = (elementIds: string[]) => {
   const {data: businessObjects} = useBusinessObjects();
 
   return useElementInstancesStatistics(
-    totalRunningInstancesForElementsParser(flowNodeIds, businessObjects),
+    totalRunningInstancesForElementsParser(elementIds, businessObjects),
   );
 };
 
@@ -104,19 +104,19 @@ const useTotalRunningInstancesByElement = () => {
   );
 };
 
-const useTotalRunningInstancesVisibleForElement = (flowNodeId?: string) => {
+const useTotalRunningInstancesVisibleForElement = (elementId?: string) => {
   const {data: businessObjects} = useBusinessObjects();
 
   return useElementInstancesStatistics(
-    totalRunningInstancesVisibleForElementParser(businessObjects, flowNodeId),
+    totalRunningInstancesVisibleForElementParser(businessObjects, elementId),
   );
 };
 
-const useTotalRunningInstancesVisibleForElements = (flowNodeIds: string[]) => {
+const useTotalRunningInstancesVisibleForElements = (elementIds: string[]) => {
   const {data: businessObjects} = useBusinessObjects();
 
   return useElementInstancesStatistics(
-    totalRunningInstancesVisibleForElementsParser(flowNodeIds, businessObjects),
+    totalRunningInstancesVisibleForElementsParser(elementIds, businessObjects),
   );
 };
 

--- a/operate/client/src/modules/queries/processDefinitions/useListViewXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useListViewXml.ts
@@ -18,13 +18,13 @@ type ExtendedParsedXmlData = ParsedXmlData & {
 function listViewXmlXmlParser({
   xml,
   diagramModel,
-  selectableFlowNodes,
+  selectableElements,
 }: ParsedXmlData) {
   return {
     xml,
     diagramModel,
-    selectableFlowNodes: selectableFlowNodes,
-    flowNodeFilterOptions: selectableFlowNodes
+    selectableElements: selectableElements,
+    flowNodeFilterOptions: selectableElements
       .map(({id, name}) => ({
         id,
         label: name ?? id,

--- a/operate/client/src/modules/queries/processDefinitions/useMigrationSourceXml.test.tsx
+++ b/operate/client/src/modules/queries/processDefinitions/useMigrationSourceXml.test.tsx
@@ -22,7 +22,7 @@ describe('useMigrationSourceXml', () => {
     );
   };
 
-  it('should filter selectable flow nodes', async () => {
+  it('should filter selectable elements', async () => {
     mockFetchProcessDefinitionXml().withSuccess(open('instanceMigration.bpmn'));
 
     const {result} = renderHook(
@@ -39,7 +39,7 @@ describe('useMigrationSourceXml', () => {
     await waitFor(() => expect(result.current.data).toBeDefined());
 
     expect(
-      result.current.data?.selectableFlowNodes.map((flowNode) => flowNode.id),
+      result.current.data?.selectableElements.map((element) => element.id),
     ).toEqual([
       'checkPayment',
       'ExclusiveGateway',
@@ -84,7 +84,7 @@ describe('useMigrationSourceXml', () => {
     ]);
   });
 
-  it('should filter selectable flow nodes (ParticipantMigrationA)', async () => {
+  it('should filter selectable elements (ParticipantMigrationA)', async () => {
     mockFetchProcessDefinitionXml().withSuccess(
       open('ParticipantMigration_v1.bpmn'),
     );
@@ -103,11 +103,11 @@ describe('useMigrationSourceXml', () => {
     await waitFor(() => expect(result.current.data).toBeDefined());
 
     expect(
-      result.current.data?.selectableFlowNodes.map((flowNode) => flowNode.id),
+      result.current.data?.selectableElements.map((element) => element.id),
     ).toEqual(['TaskA']);
   });
 
-  it('should filter selectable flow nodes (ParticipantMigrationB)', async () => {
+  it('should filter selectable elements (ParticipantMigrationB)', async () => {
     mockFetchProcessDefinitionXml().withSuccess(
       open('ParticipantMigration_v1.bpmn'),
     );
@@ -126,7 +126,7 @@ describe('useMigrationSourceXml', () => {
     await waitFor(() => expect(result.current.data).toBeDefined());
 
     expect(
-      result.current.data?.selectableFlowNodes.map((flowNode) => flowNode.id),
+      result.current.data?.selectableElements.map((element) => element.id),
     ).toEqual(['TaskB']);
   });
 });

--- a/operate/client/src/modules/queries/processDefinitions/useMigrationSourceXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useMigrationSourceXml.ts
@@ -19,11 +19,11 @@ const getMigrationSourceXmlParser =
   ({
     xml,
     diagramModel,
-    selectableFlowNodes,
+    selectableElements,
   }: {
     xml: string;
     diagramModel: DiagramModel;
-    selectableFlowNodes: BusinessObject[];
+    selectableElements: BusinessObject[];
   }) => {
     const selectableSequenceFlows = getMappableSequenceFlows(
       diagramModel?.elementsById,
@@ -32,7 +32,7 @@ const getMigrationSourceXmlParser =
     return {
       xml,
       diagramModel,
-      selectableFlowNodes: selectableFlowNodes
+      selectableElements: selectableElements
         .filter(isMigratableElement)
         .filter((sourceElement) => {
           return (

--- a/operate/client/src/modules/queries/processDefinitions/useMigrationTargetXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useMigrationTargetXml.ts
@@ -19,16 +19,16 @@ const getMigrationTargetXmlParser =
   ({
     xml,
     diagramModel,
-    selectableFlowNodes,
+    selectableElements,
   }: {
     xml: string;
     diagramModel: DiagramModel;
-    selectableFlowNodes: BusinessObject[];
+    selectableElements: BusinessObject[];
   }) => {
     return {
       xml,
       diagramModel,
-      selectableFlowNodes: selectableFlowNodes
+      selectableElements: selectableElements
         .filter(isMigratableElement)
         .filter((targetElement) => {
           return (

--- a/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.test.tsx
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.test.tsx
@@ -86,7 +86,7 @@ describe('useProcessDefinitionXml', () => {
       id: 'TestTask',
       name: 'Test Task',
     });
-    expect(resolvedData?.selectableFlowNodes).toEqual([
+    expect(resolvedData?.selectableElements).toEqual([
       {
         $type: 'bpmn:StartEvent',
         id: 'StartEvent_1',

--- a/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.ts
@@ -20,14 +20,14 @@ import {queryKeys} from '../queryKeys';
 type ParsedXmlData = {
   xml: string;
   diagramModel: DiagramModel;
-  selectableFlowNodes: BusinessObject[];
+  selectableElements: BusinessObject[];
 };
 
 async function processDefinitionParser(data: string): Promise<ParsedXmlData> {
   const diagramModel = await parseDiagramXML(data);
-  const selectableFlowNodes = getFlowNodes(diagramModel?.elementsById);
+  const selectableElements = getFlowNodes(diagramModel?.elementsById);
 
-  return {xml: data, diagramModel, selectableFlowNodes};
+  return {xml: data, diagramModel, selectableElements};
 }
 
 const getUseProcessDefinitionXmlOptions = (

--- a/operate/client/src/modules/queries/processDefinitions/useProcessInstanceXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessInstanceXml.ts
@@ -20,7 +20,7 @@ type ExtendedParsedXmlData = ParsedXmlData & {
 function processInstanceXmlParser({
   xml,
   diagramModel,
-  selectableFlowNodes,
+  selectableElements,
 }: ParsedXmlData) {
   const businessObjects = businessObjectsParser({
     diagramModel,
@@ -29,7 +29,7 @@ function processInstanceXmlParser({
   return {
     xml,
     diagramModel,
-    selectableFlowNodes,
+    selectableElements,
     businessObjects,
   };
 }

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlay.test.tsx
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlay.test.tsx
@@ -54,8 +54,8 @@ describe('useBatchModificationOverlayData', () => {
         useBatchModificationOverlayData(
           {},
           {
-            sourceFlowNodeId: 'messageCatchEvent',
-            targetFlowNodeId: 'targetNode',
+            sourceElementId: 'messageCatchEvent',
+            targetElementId: 'targetNode',
           },
           'process1',
         ),
@@ -76,7 +76,7 @@ describe('useBatchModificationOverlayData', () => {
       () =>
         useBatchModificationOverlayData(
           {},
-          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          {sourceElementId: 'sourceNode', targetElementId: 'targetNode'},
           'process1',
         ),
       {
@@ -98,7 +98,7 @@ describe('useBatchModificationOverlayData', () => {
       () =>
         useBatchModificationOverlayData(
           {},
-          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          {sourceElementId: 'sourceNode', targetElementId: 'targetNode'},
           'process1',
         ),
       {
@@ -122,7 +122,7 @@ describe('useBatchModificationOverlayData', () => {
       () =>
         useBatchModificationOverlayData(
           {},
-          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          {sourceElementId: 'sourceNode', targetElementId: 'targetNode'},
           'process1',
         ),
       {
@@ -144,7 +144,7 @@ describe('useBatchModificationOverlayData', () => {
       () =>
         useBatchModificationOverlayData(
           {},
-          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          {sourceElementId: 'sourceNode', targetElementId: 'targetNode'},
           'process1',
         ),
       {

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
@@ -17,15 +17,15 @@ import type {
 } from '@camunda/camunda-api-zod-schemas/8.9';
 
 function batchModificationOverlayParser(params: {
-  sourceFlowNodeId?: string;
-  targetFlowNodeId?: string;
+  sourceElementId?: string;
+  targetElementId?: string;
 }): (data: GetProcessDefinitionStatisticsResponseBody) => OverlayData[] {
   return (data: GetProcessDefinitionStatisticsResponseBody): OverlayData[] => {
-    const {sourceFlowNodeId, targetFlowNodeId} = params;
+    const {sourceElementId, targetElementId} = params;
     if (
       data.items.length === 0 ||
-      targetFlowNodeId === undefined ||
-      sourceFlowNodeId === undefined
+      targetElementId === undefined ||
+      sourceElementId === undefined
     ) {
       return [];
     }
@@ -33,18 +33,18 @@ function batchModificationOverlayParser(params: {
     return [
       {
         payload: {
-          cancelledTokenCount: getInstancesCount(data.items, sourceFlowNodeId),
+          cancelledTokenCount: getInstancesCount(data.items, sourceElementId),
         },
         type: 'batchModificationsBadge',
-        elementId: sourceFlowNodeId,
+        elementId: sourceElementId,
         position: MODIFICATIONS,
       },
       {
         payload: {
-          newTokenCount: getInstancesCount(data.items, sourceFlowNodeId),
+          newTokenCount: getInstancesCount(data.items, sourceElementId),
         },
         type: 'batchModificationsBadge',
-        elementId: targetFlowNodeId,
+        elementId: targetElementId,
         position: MODIFICATIONS,
       },
     ];
@@ -53,7 +53,7 @@ function batchModificationOverlayParser(params: {
 
 function useBatchModificationOverlayData(
   payload: GetProcessDefinitionStatisticsRequestBody,
-  params: {sourceFlowNodeId?: string; targetFlowNodeId?: string},
+  params: {sourceElementId?: string; targetElementId?: string},
   processDefinitionKey?: string,
   enabled: boolean = true,
 ) {

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -27,7 +27,7 @@ const createRandomId = function* createRandomId(type: string) {
 
 const randomIdIterator = createRandomId('id');
 const randomJobIdIterator = createRandomId('jobId');
-const randomElementInstanceIdIterator = createRandomId('flowNodeInstance');
+const randomElementInstanceIdIterator = createRandomId('elementInstance');
 
 function searchResult<T>(items: T[], totalItems = items.length) {
   return {

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -27,7 +27,7 @@ const createRandomId = function* createRandomId(type: string) {
 
 const randomIdIterator = createRandomId('id');
 const randomJobIdIterator = createRandomId('jobId');
-const randomFlowNodeInstanceIdIterator = createRandomId('flowNodeInstance');
+const randomElementInstanceIdIterator = createRandomId('flowNodeInstance');
 
 function searchResult<T>(items: T[], totalItems = items.length) {
   return {
@@ -48,7 +48,7 @@ const createIncident = (options: Partial<Incident> = {}): Incident => {
     incidentKey: randomIdIterator.next().value,
     jobKey: randomJobIdIterator.next().value,
     elementId: 'flowNodeId_alwaysFailingTask',
-    elementInstanceKey: randomFlowNodeInstanceIdIterator.next().value,
+    elementInstanceKey: randomElementInstanceIdIterator.next().value,
     creationTime: '2019-03-01T14:26:19',
     processInstanceKey: '2251799813685294',
     processDefinitionId: 'someKey',

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.test.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.test.ts
@@ -17,82 +17,82 @@ import type {
 } from 'bpmn-js/lib/NavigatedViewer';
 
 describe('hasMultipleScopes', () => {
-  it('should return false if parentFlowNode is undefined', () => {
+  it('should return false if parent element is undefined', () => {
     const result = hasMultipleScopes(undefined, {});
     expect(result).toBe(false);
   });
 
-  it('should return false if totalRunningInstancesByFlowNode is undefined', () => {
-    const parentFlowNode: BusinessObject = {
+  it('should return false if total running instances by element is undefined', () => {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:SequenceFlow',
     };
-    const result = hasMultipleScopes(parentFlowNode, undefined);
+    const result = hasMultipleScopes(parentElement, undefined);
     expect(result).toBe(false);
   });
 
-  it('should return false if totalRunningInstancesByFlowNode does not contain the parentFlowNode id', () => {
-    const parentFlowNode: BusinessObject = {
+  it('should return false if total running instances by element does not contain the parent element id', () => {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:SequenceFlow',
     };
-    const result = hasMultipleScopes(parentFlowNode, {});
+    const result = hasMultipleScopes(parentElement, {});
     expect(result).toBe(false);
   });
 
   it('should return false if the scope count is 0 or undefined', () => {
-    const parentFlowNode: BusinessObject = {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:SequenceFlow',
     };
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       node1: 0,
     };
     const result = hasMultipleScopes(
-      parentFlowNode,
-      totalRunningInstancesByFlowNode,
+      parentElement,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(false);
   });
 
   it('should return true if the scope count is greater than 1', () => {
-    const parentFlowNode: BusinessObject = {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:SequenceFlow',
     };
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       node1: 2,
     };
     const result = hasMultipleScopes(
-      parentFlowNode,
-      totalRunningInstancesByFlowNode,
+      parentElement,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(true);
   });
 
-  it('should return false if the parentFlowNode has no parent and scope count is not greater than 1', () => {
-    const parentFlowNode: BusinessObject = {
+  it('should return false if the parent element has no parent and scope count is not greater than 1', () => {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:SequenceFlow',
       $parent: undefined,
     };
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       node1: 0,
     };
     const result = hasMultipleScopes(
-      parentFlowNode,
-      totalRunningInstancesByFlowNode,
+      parentElement,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(false);
   });
 
   it('should return true if a parent in the hierarchy has a scope count greater than 1', () => {
-    const parentFlowNode: BusinessObject = {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:Process',
@@ -109,21 +109,21 @@ describe('hasMultipleScopes', () => {
       },
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       node1: 0,
       node2: 0,
       node3: 2, // Parent node3 has a scope count greater than 1
     };
 
     const result = hasMultipleScopes(
-      parentFlowNode,
-      totalRunningInstancesByFlowNode,
+      parentElement,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(true);
   });
 
   it('should return false if no parent in the hierarchy has a scope count greater than 1', () => {
-    const parentFlowNode: BusinessObject = {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:Process',
@@ -140,21 +140,21 @@ describe('hasMultipleScopes', () => {
       },
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       node1: 0,
       node2: 0,
       node3: 0, // No parent has a scope count greater than 1
     };
 
     const result = hasMultipleScopes(
-      parentFlowNode,
-      totalRunningInstancesByFlowNode,
+      parentElement,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(false);
   });
 
   it('should stop checking parents if a non-SubProcess parent is encountered', () => {
-    const parentFlowNode: BusinessObject = {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:SequenceFlow',
@@ -171,21 +171,21 @@ describe('hasMultipleScopes', () => {
       },
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       node1: 0,
       node2: 2, // This node is not a SubProcess, so it should not be checked
       node3: 0,
     };
 
     const result = hasMultipleScopes(
-      parentFlowNode,
-      totalRunningInstancesByFlowNode,
+      parentElement,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(false);
   });
 
-  it('should return true if a parent AdHocSubProcess has a scope count greater than 1', () => {
-    const parentFlowNode: BusinessObject = {
+  it('should return true if a parent AdHocSubProcess element has a scope count greater than 1', () => {
+    const parentElement: BusinessObject = {
       id: 'node1',
       name: 'Node 1',
       $type: 'bpmn:Process',
@@ -202,22 +202,22 @@ describe('hasMultipleScopes', () => {
       },
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       node1: 0,
       node2: 2,
       node3: 0,
     };
 
     const result = hasMultipleScopes(
-      parentFlowNode,
-      totalRunningInstancesByFlowNode,
+      parentElement,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(true);
   });
 });
 
 describe('areInSameRunningScope', () => {
-  it('should return false if source flow node does not exist', () => {
+  it('should return false if source element does not exist', () => {
     const businessObjects: BusinessObjects = {
       node2: {
         id: 'node2',
@@ -230,7 +230,7 @@ describe('areInSameRunningScope', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false if target flow node does not exist', () => {
+  it('should return false if target element does not exist', () => {
     const businessObjects: BusinessObjects = {
       node1: {
         id: 'node1',
@@ -243,7 +243,7 @@ describe('areInSameRunningScope', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false if source flow node has no parent', () => {
+  it('should return false if source element has no parent', () => {
     const businessObjects: BusinessObjects = {
       node1: {
         id: 'node1',
@@ -267,7 +267,7 @@ describe('areInSameRunningScope', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false if target flow node has no parent', () => {
+  it('should return false if target element has no parent', () => {
     const businessObjects: BusinessObjects = {
       node1: {
         id: 'node1',
@@ -314,7 +314,7 @@ describe('areInSameRunningScope', () => {
       process: parentProcess,
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       process: 1,
     };
 
@@ -322,7 +322,7 @@ describe('areInSameRunningScope', () => {
       businessObjects,
       'node1',
       'node2',
-      totalRunningInstancesByFlowNode,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(true);
   });
@@ -350,7 +350,7 @@ describe('areInSameRunningScope', () => {
       process: parentProcess,
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       process: 0,
     };
 
@@ -358,7 +358,7 @@ describe('areInSameRunningScope', () => {
       businessObjects,
       'node1',
       'node2',
-      totalRunningInstancesByFlowNode,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(false);
   });
@@ -393,7 +393,7 @@ describe('areInSameRunningScope', () => {
       process2,
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       process1: 1,
       process2: 1,
     };
@@ -402,12 +402,12 @@ describe('areInSameRunningScope', () => {
       businessObjects,
       'node1',
       'node2',
-      totalRunningInstancesByFlowNode,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe(false);
   });
 
-  it('should return false when totalRunningInstancesByFlowNode is undefined', () => {
+  it('should return false when totalRunningInstancesByElement is undefined', () => {
     const parentProcess: BusinessObject = {
       id: 'process',
       name: 'Process',
@@ -448,7 +448,7 @@ describe('getAncestorScopeType', () => {
       $type: 'bpmn:Process',
     };
 
-    const targetFlowNode: BusinessObject = {
+    const targetElement: BusinessObject = {
       id: 'task-1',
       name: 'Task 1',
       $type: 'bpmn:ServiceTask',
@@ -456,7 +456,7 @@ describe('getAncestorScopeType', () => {
     };
 
     const businessObjects: BusinessObjects = {
-      'task-1': targetFlowNode,
+      'task-1': targetElement,
       'task-2': {
         id: 'task-2',
         name: 'Task 2',
@@ -466,7 +466,7 @@ describe('getAncestorScopeType', () => {
       process: parentProcess,
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       process: 1,
     };
 
@@ -474,7 +474,7 @@ describe('getAncestorScopeType', () => {
       businessObjects,
       'task-2',
       'task-1',
-      totalRunningInstancesByFlowNode,
+      totalRunningInstancesByElement,
     );
     expect(result).toBeUndefined();
   });
@@ -493,14 +493,14 @@ describe('getAncestorScopeType', () => {
       $parent: parentProcess,
     };
 
-    const targetFlowNode: BusinessObject = {
+    const targetElement: BusinessObject = {
       id: 'task-1',
       name: 'Task 1',
       $type: 'bpmn:ServiceTask',
       $parent: subprocess,
     };
 
-    const sourceFlowNode: BusinessObject = {
+    const sourceElement: BusinessObject = {
       id: 'task-2',
       name: 'Task 2',
       $type: 'bpmn:ServiceTask',
@@ -508,13 +508,13 @@ describe('getAncestorScopeType', () => {
     };
 
     const businessObjects: BusinessObjects = {
-      'task-1': targetFlowNode,
-      'task-2': sourceFlowNode,
+      'task-1': targetElement,
+      'task-2': sourceElement,
       subprocess,
       process: parentProcess,
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       subprocess: 2,
       process: 1,
     };
@@ -523,7 +523,7 @@ describe('getAncestorScopeType', () => {
       businessObjects,
       'task-2',
       'task-1',
-      totalRunningInstancesByFlowNode,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe('sourceParent');
   });
@@ -549,14 +549,14 @@ describe('getAncestorScopeType', () => {
       $parent: parentProcess,
     };
 
-    const targetFlowNode: BusinessObject = {
+    const targetElement: BusinessObject = {
       id: 'task-1',
       name: 'Task 1',
       $type: 'bpmn:ServiceTask',
       $parent: subprocess1,
     };
 
-    const sourceFlowNode: BusinessObject = {
+    const sourceElement: BusinessObject = {
       id: 'task-2',
       name: 'Task 2',
       $type: 'bpmn:ServiceTask',
@@ -564,14 +564,14 @@ describe('getAncestorScopeType', () => {
     };
 
     const businessObjects: BusinessObjects = {
-      'task-1': targetFlowNode,
-      'task-2': sourceFlowNode,
+      'task-1': targetElement,
+      'task-2': sourceElement,
       subprocess1,
       subprocess2,
       process: parentProcess,
     };
 
-    const totalRunningInstancesByFlowNode = {
+    const totalRunningInstancesByElement = {
       subprocess1: 2,
       subprocess2: 1,
       process: 1,
@@ -581,7 +581,7 @@ describe('getAncestorScopeType', () => {
       businessObjects,
       'task-2',
       'task-1',
-      totalRunningInstancesByFlowNode,
+      totalRunningInstancesByElement,
     );
     expect(result).toBe('inferred');
   });

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
@@ -15,51 +15,51 @@ import {isSubProcess} from 'modules/bpmn-js/utils/isSubProcess';
 import type {AncestorScopeType} from 'modules/stores/modifications';
 
 const checkScope = (
-  parentFlowNode: BusinessObject | undefined,
-  totalRunningInstancesByFlowNode: Record<string, number> | undefined,
+  parentElement: BusinessObject | undefined,
+  totalRunningInstancesByElement: Record<string, number> | undefined,
   predicate: (count: number) => boolean,
 ): boolean => {
-  if (!parentFlowNode) {
+  if (!parentElement) {
     return false;
   }
 
-  const count = totalRunningInstancesByFlowNode?.[parentFlowNode.id] ?? 0;
+  const count = totalRunningInstancesByElement?.[parentElement.id] ?? 0;
 
   if (predicate(count)) {
     return true;
   }
 
   if (
-    !isSubProcess(parentFlowNode.$parent) &&
-    !isAdHocSubProcess(parentFlowNode.$parent)
+    !isSubProcess(parentElement.$parent) &&
+    !isAdHocSubProcess(parentElement.$parent)
   ) {
     return false;
   }
 
   return checkScope(
-    parentFlowNode.$parent,
-    totalRunningInstancesByFlowNode,
+    parentElement.$parent,
+    totalRunningInstancesByElement,
     predicate,
   );
 };
 
 const hasMultipleScopes = (
-  parentFlowNode?: BusinessObject,
-  totalRunningInstancesByFlowNode?: Record<string, number>,
+  parentElement?: BusinessObject,
+  totalRunningInstancesByElement?: Record<string, number>,
 ): boolean =>
   checkScope(
-    parentFlowNode,
-    totalRunningInstancesByFlowNode,
+    parentElement,
+    totalRunningInstancesByElement,
     (count) => count > 1,
   );
 
 const hasSingleScope = (
-  parentFlowNode?: BusinessObject,
-  totalRunningInstancesByFlowNode?: Record<string, number>,
+  parentElement?: BusinessObject,
+  totalRunningInstancesByElement?: Record<string, number>,
 ): boolean =>
   checkScope(
-    parentFlowNode,
-    totalRunningInstancesByFlowNode,
+    parentElement,
+    totalRunningInstancesByElement,
     (count) => count === 1,
   );
 
@@ -103,7 +103,7 @@ const areInSameRunningScope = (
   businessObjects: BusinessObjects,
   sourceElementId: string,
   targetElementId: string,
-  totalRunningInstancesByFlowNode?: Record<string, number>,
+  totalRunningInstancesByElement?: Record<string, number>,
 ): boolean => {
   const sourceElement = businessObjects[sourceElementId];
   const targetElement = businessObjects[targetElementId];
@@ -120,8 +120,7 @@ const areInSameRunningScope = (
   }
 
   if (sourceParent.id === targetParent.id) {
-    const runningCount =
-      totalRunningInstancesByFlowNode?.[sourceParent.id] ?? 0;
+    const runningCount = totalRunningInstancesByElement?.[sourceParent.id] ?? 0;
     return runningCount > 0;
   }
 
@@ -130,21 +129,21 @@ const areInSameRunningScope = (
 
 const getAncestorScopeType = (
   businessObjects: BusinessObjects,
-  sourceFlowNodeId: string,
-  targetFlowNodeId: string,
-  totalRunningInstancesByFlowNode?: Record<string, number>,
+  sourceElementId: string,
+  targetElementId: string,
+  totalRunningInstancesByElement?: Record<string, number>,
 ): AncestorScopeType => {
-  const targetFlowNode = businessObjects[targetFlowNodeId];
+  const targetElement = businessObjects[targetElementId];
 
-  if (!hasMultipleScopes(targetFlowNode, totalRunningInstancesByFlowNode)) {
+  if (!hasMultipleScopes(targetElement, totalRunningInstancesByElement)) {
     return;
   }
 
   const inSameScope = areInSameRunningScope(
     businessObjects,
-    sourceFlowNodeId,
-    targetFlowNodeId,
-    totalRunningInstancesByFlowNode,
+    sourceElementId,
+    targetElementId,
+    totalRunningInstancesByElement,
   );
 
   return inSameScope ? 'sourceParent' : 'inferred';

--- a/operate/client/src/modules/utils/statistics/elementInstance.test.tsx
+++ b/operate/client/src/modules/utils/statistics/elementInstance.test.tsx
@@ -61,7 +61,7 @@ describe('getStatisticsByElement', () => {
     );
   };
 
-  it('should return statistics for valid flow nodes', () => {
+  it('should return statistics for valid elements', () => {
     const data = [
       {
         elementId: 'StartEvent_1',

--- a/operate/client/src/modules/utils/statistics/processInstances.test.ts
+++ b/operate/client/src/modules/utils/statistics/processInstances.test.ts
@@ -10,7 +10,7 @@ import type {ProcessDefinitionStatistic} from '@camunda/camunda-api-zod-schemas/
 import {getInstancesCount} from './processInstances';
 
 describe('getInstancesCount', () => {
-  it('should return the correct count of active and incident instances for a given flowNodeId', () => {
+  it('should return the correct count of active and incident instances for a given elementId', () => {
     const data: ProcessDefinitionStatistic[] = [
       {
         elementId: 'node1',
@@ -32,7 +32,7 @@ describe('getInstancesCount', () => {
     expect(getInstancesCount(data, 'node2')).toBe(4);
   });
 
-  it('should return 0 if the flowNodeId is not found in the data', () => {
+  it('should return 0 if the elementId is not found in the data', () => {
     const data: ProcessDefinitionStatistic[] = [
       {
         elementId: 'node1',

--- a/operate/client/src/modules/utils/statistics/processInstances.ts
+++ b/operate/client/src/modules/utils/statistics/processInstances.ts
@@ -12,15 +12,15 @@ function getInstancesCount(
   data: ProcessDefinitionStatistic[],
   elementId?: string,
 ) {
-  const flowNodeStatistics = data.find(
+  const elementStatistics = data.find(
     (statistics) => statistics.elementId === elementId,
   );
 
-  if (flowNodeStatistics === undefined) {
+  if (elementStatistics === undefined) {
     return 0;
   }
 
-  return flowNodeStatistics.active + flowNodeStatistics.incidents;
+  return elementStatistics.active + elementStatistics.incidents;
 }
 
 export {getInstancesCount};


### PR DESCRIPTION
## Description

Final cleanups for terminology update.

> [!NOTE]
> Areas that still use `flowNode` terminology:
> -  Filter/URL related names. Will be handled as part of https://github.com/camunda/camunda/issues/29418)
> - Tracking events. As renaming would improve consistency, but may break existing dashboards and historical tracking
> -  `isFlowNode`, `getFlowNodes` functions + their test files. These check `bpmn:FlowNode` - a BPMN spec type. The function semantics are tied to the diagram model not Operate's UI terminology. 
> -  `FlowNodeType`. Maps directly to BPMN spec `bpmn:FlowNode` subtypes

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46868 
