### PR TITLE
[Backport stable/8.6] fix: enhance namespace handling and add usage instructions in newCloudBenchmark.sh (stable/8.7)

### DIFF
--- a/zeebe/benchmarks/setup/newCloudBenchmark.sh
+++ b/zeebe/benchmarks/setup/newCloudBenchmark.sh
@@ -4,9 +4,30 @@ set -exo pipefail
 # Contains OS specific sed function
 . utils.sh
 
-if [ -z $1 ]
-then
-  echo "Please provide an namespace name!"
+usage() {
+  cat <<'EOF'
+Usage: newCloudBenchmark.sh <namespace>
+
+Arguments:
+  namespace          Base namespace name. Will be prefixed with "c8-" if missing.
+
+Options:
+  -h, --help         Show this help message.
+
+Examples:
+  ./newCloudBenchmark.sh demo
+  ./newCloudBenchmark.sh c8-demo
+EOF
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ -z "$1" ]; then
+  echo "Error: Missing namespace name."
+  usage
   exit 1
 fi
 
@@ -16,6 +37,12 @@ fi
 
 
 namespace=$1
+
+# Add c8- prefix if not present
+if [[ ! "$namespace" =~ ^c8- ]]; then
+  namespace="c8-$namespace"
+  echo "Namespace prefix added: $namespace"
+fi
 
 kubectl create namespace $namespace
 cp -rv cloud-default/ $namespace


### PR DESCRIPTION
# Description
Backport of #48880 to `stable/8.6`.

relates to #48812 #48812