### PR TITLE
[Backport stable/8.9] fix: use decisionEvaluationKey instead of decisionInstanceKey in delete endpoint

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1304,14 +1304,14 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *  .newDeleteDecisionInstanceCommand(decisionInstanceKey)
+   *  .newDeleteDecisionInstanceCommand(decisionEvaluationKey)
    *  .send();
    * </pre>
    *
-   * @param decisionInstanceKey the key which identifies the corresponding decision instance
+   * @param decisionEvaluationKey the key which identifies the corresponding decision evaluation
    * @return a builder for the command
    */
-  DeleteDecisionInstanceCommandStep1 newDeleteDecisionInstanceCommand(long decisionInstanceKey);
+  DeleteDecisionInstanceCommandStep1 newDeleteDecisionInstanceCommand(long decisionEvaluationKey);
 
   /**
    * Executes a search request to query incidents.

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteDecisionInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteDecisionInstanceCommandImpl.java
@@ -31,18 +31,18 @@ import org.apache.hc.client5.http.config.RequestConfig;
 
 public class DeleteDecisionInstanceCommandImpl implements DeleteDecisionInstanceCommandStep1 {
 
-  private final long decisionInstanceKey;
+  private final long decisionEvaluationKey;
   private final DeleteDecisionInstanceRequest httpRequestObject;
   private final HttpClient httpClient;
   private final JsonMapper jsonMapper;
   private final RequestConfig.Builder httpRequestConfig;
 
   public DeleteDecisionInstanceCommandImpl(
-      final long decisionInstanceKey,
+      final long decisionEvaluationKey,
       final CamundaClientConfiguration config,
       final HttpClient httpClient,
       final JsonMapper jsonMapper) {
-    this.decisionInstanceKey = decisionInstanceKey;
+    this.decisionEvaluationKey = decisionEvaluationKey;
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
     httpRequestConfig = httpClient.newRequestConfig();
@@ -68,7 +68,7 @@ public class DeleteDecisionInstanceCommandImpl implements DeleteDecisionInstance
   public CamundaFuture<DeleteDecisionInstanceResponse> send() {
     final HttpCamundaFuture<DeleteDecisionInstanceResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
-        "/decision-instances/" + decisionInstanceKey + "/deletion",
+        "/decision-instances/" + decisionEvaluationKey + "/deletion",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
         DeleteDecisionInstanceResponseImpl::new,

--- a/clients/java/src/test/java/io/camunda/client/process/rest/DeleteDecisionInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/DeleteDecisionInstanceRestTest.java
@@ -27,12 +27,12 @@ import org.junit.jupiter.api.Test;
 
 public class DeleteDecisionInstanceRestTest extends ClientRestTest {
 
-  private static final long DECISION_INSTANCE_KEY = 123L;
+  private static final long DECISION_EVALUATION_KEY = 123L;
 
   @Test
   public void shouldSendDeleteCommand() {
     // when
-    client.newDeleteDecisionInstanceCommand(DECISION_INSTANCE_KEY).send().join();
+    client.newDeleteDecisionInstanceCommand(DECISION_EVALUATION_KEY).send().join();
 
     // then
     final DeleteDecisionInstanceRequest request =
@@ -44,11 +44,11 @@ public class DeleteDecisionInstanceRestTest extends ClientRestTest {
   public void shouldRaiseExceptionOnError() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getDeleteDecisionInstanceUrl(DECISION_INSTANCE_KEY),
+        RestGatewayPaths.getDeleteDecisionInstanceUrl(DECISION_EVALUATION_KEY),
         () -> new ProblemDetail().title("Invalid request").status(400));
 
     assertThatThrownBy(
-            () -> client.newDeleteDecisionInstanceCommand(DECISION_INSTANCE_KEY).send().join())
+            () -> client.newDeleteDecisionInstanceCommand(DECISION_EVALUATION_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }
@@ -60,7 +60,7 @@ public class DeleteDecisionInstanceRestTest extends ClientRestTest {
 
     // when
     client
-        .newDeleteDecisionInstanceCommand(DECISION_INSTANCE_KEY)
+        .newDeleteDecisionInstanceCommand(DECISION_EVALUATION_KEY)
         .operationReference(operationReference)
         .execute();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryAuthorizationIT.java
@@ -116,13 +116,13 @@ public class DeleteDecisionInstanceHistoryAuthorizationIT {
       @Authenticated(UNAUTHORIZED_USER) final CamundaClient camundaClient,
       @Authenticated final CamundaClient adminClient) {
     // given
-    final var decisionInstanceKey =
+    final var decisionEvaluationKey =
         evaluateDecision(adminClient, decisionKey, "{}").getDecisionEvaluationKey();
-    waitForDecisionInstanceCount(adminClient, f -> f.decisionInstanceKey(decisionInstanceKey), 1);
+    waitForDecisionInstanceCount(adminClient, f -> f.decisionInstanceKey(decisionEvaluationKey), 1);
 
     // when
     final ThrowingCallable executeDelete =
-        () -> camundaClient.newDeleteDecisionInstanceCommand(decisionInstanceKey).send().join();
+        () -> camundaClient.newDeleteDecisionInstanceCommand(decisionEvaluationKey).send().join();
 
     // then
     final var problemException =

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -93,13 +93,13 @@ public final class DecisionInstanceServices
   /**
    * Deletes a decision instance and all associated decision evaluations.
    *
-   * @param decisionInstanceKey the key of the decision instance to delete
+   * @param decisionEvaluationKey the key of the decision evaluation to delete
    * @param operationReference optional operation reference for tracking
    * @return a CompletableFuture containing the batch operation creation record
    * @throws CamundaSearchException if no decision instance with the given key exists
    */
   public CompletableFuture<HistoryDeletionRecord> deleteDecisionInstance(
-      final long decisionInstanceKey,
+      final long decisionEvaluationKey,
       final Long operationReference,
       final CamundaAuthentication authentication) {
 
@@ -107,13 +107,13 @@ public final class DecisionInstanceServices
     final var searchResult =
         search(
             decisionInstanceSearchQuery(
-                q -> q.filter(f -> f.decisionInstanceKeys(decisionInstanceKey))),
+                q -> q.filter(f -> f.decisionInstanceKeys(decisionEvaluationKey))),
             authentication);
 
     if (searchResult.items().isEmpty()) {
       throw ErrorMapper.mapSearchError(
           new CamundaSearchException(
-              ERROR_ENTITY_BY_KEY_NOT_FOUND.formatted("Decision Instance", decisionInstanceKey),
+              ERROR_ENTITY_BY_KEY_NOT_FOUND.formatted("Decision Instance", decisionEvaluationKey),
               CamundaSearchException.Reason.NOT_FOUND));
     }
 
@@ -121,7 +121,7 @@ public final class DecisionInstanceServices
 
     final var brokerRequest =
         new BrokerDeleteHistoryRequest()
-            .setResourceKey(decisionInstanceKey)
+            .setResourceKey(decisionEvaluationKey)
             .setResourceType(HistoryDeletionType.DECISION_INSTANCE)
             .setDecisionDefinitionId(decisionInstance.decisionDefinitionId())
             .setTenantId(decisionInstance.tenantId());

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -70,7 +70,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 
-  /decision-instances/{decisionInstanceKey}/deletion:
+  /decision-instances/{decisionEvaluationKey}/deletion:
     post:
       x-eventually-consistent: false
       tags:
@@ -79,12 +79,12 @@ paths:
       summary: Delete decision instance
       description: Delete all associated decision evaluations based on provided key.
       parameters:
-        - name: decisionInstanceKey
+        - name: decisionEvaluationKey
           in: path
           required: true
-          description: The key of the decision instance to delete.
+          description: The key of the decision evaluation to delete.
           schema:
-            $ref: 'keys.yaml#/components/schemas/DecisionInstanceKey'
+            $ref: 'keys.yaml#/components/schemas/DecisionEvaluationKey'
       requestBody:
         required: false
         content:

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -135,8 +135,8 @@ paths:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1search'
   /decision-instances/{decisionEvaluationInstanceKey}:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionEvaluationInstanceKey}'
-  /decision-instances/{decisionInstanceKey}/deletion:
-    $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionInstanceKey}~1deletion'
+  /decision-instances/{decisionEvaluationKey}/deletion:
+    $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionEvaluationKey}~1deletion'
   /decision-instances/deletion:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1deletion'
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
@@ -68,14 +68,14 @@ public class DecisionInstanceController {
   }
 
   @RequiresSecondaryStorage
-  @CamundaPostMapping(path = "/{decisionInstanceKey}/deletion")
+  @CamundaPostMapping(path = "/{decisionEvaluationKey}/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteDecisionInstance(
-      @PathVariable final long decisionInstanceKey,
+      @PathVariable final long decisionEvaluationKey,
       @RequestBody(required = false) final DeleteDecisionInstanceRequest request) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             decisionInstanceServices.deleteDecisionInstance(
-                decisionInstanceKey,
+                decisionEvaluationKey,
                 Objects.nonNull(request) ? request.getOperationReference() : null,
                 authenticationProvider.getCamundaAuthentication()));
   }


### PR DESCRIPTION
# Description
Backport of #48870 to `stable/8.9`.

relates to camunda/camunda#48867