### PR TITLE
[Backport stable/8.8] fix: change multi-instance input collection insert to upsert to avoid StreamProcessor crash on incident resolution

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MultiInstanceInputCollectionEvaluatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MultiInstanceInputCollectionEvaluatedApplier.java
@@ -24,7 +24,7 @@ public class MultiInstanceInputCollectionEvaluatedApplier
 
   @Override
   public void applyState(final long multiInstanceBodyKey, final MultiInstanceRecord value) {
-    multiInstanceState.insertInputCollection(
+    multiInstanceState.upsertInputCollection(
         multiInstanceBodyKey, value.getInputCollectionBuffers());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/multiinstance/DbMultiInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/multiinstance/DbMultiInstanceState.java
@@ -40,7 +40,7 @@ public class DbMultiInstanceState implements MutableMultiInstanceState {
       final long multiInstanceKey, final List<DirectBuffer> inputCollection) {
     this.multiInstanceKey.wrapLong(multiInstanceKey);
     this.inputCollection.setInputCollection(inputCollection);
-    inputCollectionColumnFamily.insert(this.multiInstanceKey, this.inputCollection);
+    inputCollectionColumnFamily.upsert(this.multiInstanceKey, this.inputCollection);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/multiinstance/DbMultiInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/multiinstance/DbMultiInstanceState.java
@@ -36,7 +36,7 @@ public class DbMultiInstanceState implements MutableMultiInstanceState {
   }
 
   @Override
-  public void insertInputCollection(
+  public void upsertInputCollection(
       final long multiInstanceKey, final List<DirectBuffer> inputCollection) {
     this.multiInstanceKey.wrapLong(multiInstanceKey);
     this.inputCollection.setInputCollection(inputCollection);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMultiInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMultiInstanceState.java
@@ -21,7 +21,7 @@ public interface MutableMultiInstanceState extends MultiInstanceState {
    * @param multiInstanceKey The key of the multi-instance element instance.
    * @param inputCollection The evaluated input collection as a list of buffers.
    */
-  void insertInputCollection(long multiInstanceKey, List<DirectBuffer> inputCollection);
+  void upsertInputCollection(long multiInstanceKey, List<DirectBuffer> inputCollection);
 
   /**
    * Deletes the input collection for a multi-instance body from the state.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMultiInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMultiInstanceState.java
@@ -14,7 +14,9 @@ import org.agrona.DirectBuffer;
 public interface MutableMultiInstanceState extends MultiInstanceState {
 
   /**
-   * Inserts the evaluated input collection for a multi-instance body into the state.
+   * Inserts or updates the evaluated input collection for a multi-instance body in the state. If an
+   * entry already exists for the given key (e.g. due to incident resolution re-activating the
+   * multi-instance body), the existing entry is overwritten with the new value.
    *
    * @param multiInstanceKey The key of the multi-instance element instance.
    * @param inputCollection The evaluated input collection as a list of buffers.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -559,17 +559,9 @@ public final class MultiInstanceIncidentTest {
         .isTrue();
   }
 
-  /**
-   * Regression test for the scenario where an incident is raised after the multi-instance input
-   * collection has already been evaluated and stored in state. On incident resolution, the
-   * multi-instance body is re-activated, which previously caused a {@code
-   * ZeebeDbInconsistentException} because the input collection was inserted again with {@code
-   * insert} (which rejects duplicates). The fix changes it to {@code upsert}.
-   */
   @Test
   public void shouldCompleteProcessAfterResolvingIncidentRaisedAfterInputCollectionEvaluated() {
-    // given - a multi-instance service task with a timer boundary event using an expression
-    // the timer boundary event is non-interrupting so it does not cancel the task instances
+    // given
     final var processId = "multi-instance-with-timer-boundary";
     ENGINE
         .deployment()
@@ -595,9 +587,8 @@ public final class MultiInstanceIncidentTest {
                 .done())
         .deploy();
 
-    // when - creating a process instance with items but without the timer duration variable
-    // the input collection is evaluated first (stored in state), then subscribeToEvents fails
-    // because timerDuration is not set, creating an incident on the multi-instance body
+    // when - create a process instance without the timerDuration variable to ensure an incident is
+    // created
     final long processInstanceKey =
         ENGINE
             .processInstance()
@@ -621,13 +612,11 @@ public final class MultiInstanceIncidentTest {
 
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
-    // then - the process continues and can complete after all jobs are done
-    // (without the fix, re-activation would throw ZeebeDbInconsistentException because
-    // the input collection INSERT would fail for the already-existing key)
     completeNthJob(processInstanceKey, 1);
     completeNthJob(processInstanceKey, 2);
     completeNthJob(processInstanceKey, 3);
 
+    // then
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
                 .withElementType(BpmnElementType.PROCESS)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -559,6 +559,85 @@ public final class MultiInstanceIncidentTest {
         .isTrue();
   }
 
+  /**
+   * Regression test for the scenario where an incident is raised after the multi-instance input
+   * collection has already been evaluated and stored in state. On incident resolution, the
+   * multi-instance body is re-activated, which previously caused a {@code
+   * ZeebeDbInconsistentException} because the input collection was inserted again with {@code
+   * insert} (which rejects duplicates). The fix changes it to {@code upsert}.
+   */
+  @Test
+  public void shouldCompleteProcessAfterResolvingIncidentRaisedAfterInputCollectionEvaluated() {
+    // given - a multi-instance service task with a timer boundary event using an expression
+    // the timer boundary event is non-interrupting so it does not cancel the task instances
+    final var processId = "multi-instance-with-timer-boundary";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    ELEMENT_ID,
+                    t ->
+                        t.zeebeJobType(jobType)
+                            .multiInstance(
+                                b ->
+                                    b.parallel()
+                                        .zeebeInputCollectionExpression(INPUT_COLLECTION)
+                                        .zeebeInputElement(INPUT_ELEMENT))
+                            .boundaryEvent(
+                                "timer-boundary",
+                                be ->
+                                    be.cancelActivity(false)
+                                        .timerWithDurationExpression("timerDuration")
+                                        .endEvent("timer-end")))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when - creating a process instance with items but without the timer duration variable
+    // the input collection is evaluated first (stored in state), then subscribeToEvents fails
+    // because timerDuration is not set, creating an incident on the multi-instance body
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable(INPUT_COLLECTION, List.of(1, 2, 3))
+            .create();
+
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.EXTRACT_VALUE_ERROR);
+
+    // when - resolving the incident by providing the missing timer duration variable
+    ENGINE
+        .variables()
+        .ofScope(incident.getValue().getVariableScopeKey())
+        .withDocument(Collections.singletonMap("timerDuration", "PT1H"))
+        .update();
+
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then - the process continues and can complete after all jobs are done
+    // (without the fix, re-activation would throw ZeebeDbInconsistentException because
+    // the input collection INSERT would fail for the already-existing key)
+    completeNthJob(processInstanceKey, 1);
+    completeNthJob(processInstanceKey, 2);
+    completeNthJob(processInstanceKey, 3);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withElementType(BpmnElementType.PROCESS)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .exists())
+        .describedAs("the process instance should have completed normally")
+        .isTrue();
+  }
+
   private BpmnModelInstance createProcessThatModifiesOutputCollection(
       final String processId,
       final String initialValueForCollection,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/multiinstance/MultiInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/multiinstance/MultiInstanceStateTest.java
@@ -31,14 +31,14 @@ public class MultiInstanceStateTest {
   }
 
   @Test
-  void shouldInsertAndGetInputCollection() {
+  void shouldUpsertAndGetInputCollection() {
     // given
     final long key = 123L;
     final List<DirectBuffer> inputCollection =
         List.of(new UnsafeBuffer("foo".getBytes()), new UnsafeBuffer("bar".getBytes()));
 
     // when
-    multiInstanceState.insertInputCollection(key, inputCollection);
+    multiInstanceState.upsertInputCollection(key, inputCollection);
 
     // then
     final Optional<List<DirectBuffer>> result = multiInstanceState.getInputCollection(key);
@@ -53,7 +53,7 @@ public class MultiInstanceStateTest {
     // given
     final long key = 456L;
     final List<DirectBuffer> input = List.of(new UnsafeBuffer("baz".getBytes()));
-    multiInstanceState.insertInputCollection(key, input);
+    multiInstanceState.upsertInputCollection(key, input);
 
     // when
     multiInstanceState.deleteInputCollection(key);
@@ -64,23 +64,22 @@ public class MultiInstanceStateTest {
   }
 
   @Test
-  void shouldUpdateExistingInputCollectionOnDuplicateInsert() {
+  void shouldUpdateExistingInputCollectionOnDuplicateUpsert() {
     // given
     final long key = 321L;
     final List<DirectBuffer> initialCollection =
         List.of(new UnsafeBuffer("foo".getBytes()), new UnsafeBuffer("bar".getBytes()));
-    multiInstanceState.insertInputCollection(key, initialCollection);
+    multiInstanceState.upsertInputCollection(key, initialCollection);
 
     // when - calling insert again with the same key (e.g. on incident resolution re-activation)
-    final List<DirectBuffer> updatedCollection =
-        List.of(new UnsafeBuffer("baz".getBytes()));
-    multiInstanceState.insertInputCollection(key, updatedCollection);
+    final List<DirectBuffer> updatedCollection = List.of(new UnsafeBuffer("baz".getBytes()));
+    multiInstanceState.upsertInputCollection(key, updatedCollection);
 
     // then - the value is overwritten without throwing an exception
     final Optional<List<DirectBuffer>> result = multiInstanceState.getInputCollection(key);
     assertThat(result).isPresent();
     assertThat(result.get()).hasSize(1);
-    assertThat(result.get().get(0)).isEqualTo(updatedCollection.get(0));
+    assertThat(result.get().getFirst()).isEqualTo(updatedCollection.getFirst());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/multiinstance/MultiInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/multiinstance/MultiInstanceStateTest.java
@@ -64,6 +64,26 @@ public class MultiInstanceStateTest {
   }
 
   @Test
+  void shouldUpdateExistingInputCollectionOnDuplicateInsert() {
+    // given
+    final long key = 321L;
+    final List<DirectBuffer> initialCollection =
+        List.of(new UnsafeBuffer("foo".getBytes()), new UnsafeBuffer("bar".getBytes()));
+    multiInstanceState.insertInputCollection(key, initialCollection);
+
+    // when - calling insert again with the same key (e.g. on incident resolution re-activation)
+    final List<DirectBuffer> updatedCollection =
+        List.of(new UnsafeBuffer("baz".getBytes()));
+    multiInstanceState.insertInputCollection(key, updatedCollection);
+
+    // then - the value is overwritten without throwing an exception
+    final Optional<List<DirectBuffer>> result = multiInstanceState.getInputCollection(key);
+    assertThat(result).isPresent();
+    assertThat(result.get()).hasSize(1);
+    assertThat(result.get().get(0)).isEqualTo(updatedCollection.get(0));
+  }
+
+  @Test
   void shouldReturnEmptyForMissingInputCollection() {
     // given
     final long key = 789L;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/multiinstance/MultiInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/multiinstance/MultiInstanceStateTest.java
@@ -71,7 +71,7 @@ public class MultiInstanceStateTest {
         List.of(new UnsafeBuffer("foo".getBytes()), new UnsafeBuffer("bar".getBytes()));
     multiInstanceState.upsertInputCollection(key, initialCollection);
 
-    // when - calling insert again with the same key (e.g. on incident resolution re-activation)
+    // when - calling upsert again with the same key (e.g. on incident resolution re-activation)
     final List<DirectBuffer> updatedCollection = List.of(new UnsafeBuffer("baz".getBytes()));
     multiInstanceState.upsertInputCollection(key, updatedCollection);
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MultiInstance_INPUT_COLLECTION_EVALUATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MultiInstance_INPUT_COLLECTION_EVALUATED_v1.golden
@@ -24,7 +24,7 @@ public class MultiInstanceInputCollectionEvaluatedApplier
 
   @Override
   public void applyState(final long multiInstanceBodyKey, final MultiInstanceRecord value) {
-    multiInstanceState.insertInputCollection(
+    multiInstanceState.upsertInputCollection(
         multiInstanceBodyKey, value.getInputCollectionBuffers());
   }
 }


### PR DESCRIPTION
# Description
Backport of #48796 to `stable/8.8`.

relates to 