### PR TITLE
fix: correctly tag and override docker image from docker compose

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -138,6 +138,7 @@ jobs:
         run: |
           echo "===== Forward Compatibility Test Configuration ====="
           echo "Server branch: ${{ matrix.server_branch }}"
+          echo "Server image:  ${{ matrix.server_image }}"
           echo "Test branch:   ${{ matrix.test_branch }}"
           echo "===================================================="
 
@@ -151,10 +152,9 @@ jobs:
         run: |
           echo "Pulling image: ${{ matrix.server_image }}"
           docker pull ${{ matrix.server_image }}
-          docker tag ${{ matrix.server_image }} camunda/camunda:SNAPSHOT
 
       - name: Start Camunda
-        run: DATABASE=elasticsearch docker compose up -d camunda
+        run: CAMUNDA_DOCKER_IMAGE=${{ matrix.server_image }} DATABASE=elasticsearch docker compose up -d camunda
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -97,7 +97,7 @@ services:
 
   camunda:
     container_name: camunda
-    image: camunda/camunda:SNAPSHOT
+    image: ${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:SNAPSHOT}
     environment:
       - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g'
       - ZEEBE_BROKER_NETWORK_HOST=camunda


### PR DESCRIPTION
## Description

### Problem
The workflow was not actually testing forward compatibility. The workflow pulls a server Docker image from one branch but runs it using a docker-compose config checked out from the test branch. Each branch's docker-compose hardcodes its own version-specific image tag (e.g., camunda/camunda:8.8-SNAPSHOT), which caused docker compose up to pull the test branch's own image from Docker Hub — completely ignoring the intended server image.

For example, in the "Server: stable/8.9 / Tests: stable/8.8" job:

The workflow pulls camunda/camunda:8.9-SNAPSHOT and re-tags it as camunda/camunda:SNAPSHOT
But docker-compose (from stable/8.8) specifies image: camunda/camunda:8.8-SNAPSHOT
Docker Compose ignores the re-tagged image and pulls 8.8-SNAPSHOT from Docker Hub
The test ends up running 8.8 server against 8.8 tests — not forward compatibility at all
This means the workflow has never caught a real forward compatibility issue between stable branches, and the recent failure in "Server: main / Tests: stable/8.9" was a false positive (testing 8.9 server vs 8.9 tests, not main vs 8.9).

### Solution
Pass the server image as an environment variable (CAMUNDA_DOCKER_IMAGE) to docker compose up
Parameterize the docker-compose image: field to accept this variable, falling back to the branch default when not set
Remove the unnecessary docker tag re-tagging step