### PR TITLE
[Backport stable/8.9] ci: remove visual regression merge reporting

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -167,6 +167,7 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         job_id != "setup-tests"
         job_id != "utils-flaky-tests-summary"
         job_id != "fe-unit-tests-merge"
+        job_id != "operate-fe-visual-regression-merge"
         # temporary for docker-build-helm-integration.yml workflow from alwaysgreen
         job_id != "format-identifier"
         job_id != "should-run"

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -399,16 +399,6 @@ jobs:
           name: operate-visual-regression-report
           path: operate/client/playwright-report/
           retention-days: 30
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-update-screenshots:
     if: inputs.runFeTests


### PR DESCRIPTION
# Description
Backport of #48793 to `stable/8.9`.

relates to 