### PR TITLE
[Backport stable/8.9] fix: correctly tag and override docker image from docker compose

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -97,7 +97,7 @@ services:
 
   camunda:
     container_name: camunda
-    image: camunda/camunda:8.9-SNAPSHOT
+    image: ${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:8.9-SNAPSHOT}
     environment:
       - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g'
       - ZEEBE_BROKER_NETWORK_HOST=camunda


### PR DESCRIPTION
# Description
Backport of #48926 to `stable/8.9`.

relates to 