### PR TITLE
fix: allow fullscreen api in permissions-policy header

### DIFF
--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -70,7 +70,9 @@ const useFullscreen = (
       return;
     }
 
-    el.requestFullscreen();
+    el.requestFullscreen().catch(() => {
+      // Fullscreen blocked by Permissions Policy — silently ignore
+    });
   }, [diagramRef]);
 
   useEffect(() => {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/headers/PermissionsPolicyConfig.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/headers/PermissionsPolicyConfig.java
@@ -46,7 +46,7 @@ public class PermissionsPolicyConfig {
           + "deferred-fetch-minimal=(), "
           + "display-capture=(), "
           + "encrypted-media=(), "
-          + "fullscreen=(), "
+          + "fullscreen=(self), "
           + "gamepad=(), "
           + "geolocation=(), "
           + "gyroscope=(), "
@@ -80,7 +80,7 @@ public class PermissionsPolicyConfig {
    * <p>Default: accelerometer=(), ambient-light-sensor=(), attribution-reporting=(), autoplay=(),
    * bluetooth=(), browsing-topics=(), camera=(), compute-pressure=(), cross-origin-isolated=(),
    * deferred-fetch=(), deferred-fetch-minimal=(), display-capture=(), encrypted-media=(),
-   * fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(),
+   * fullscreen=(self), gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(),
    * idle-detection=(), language-detector=(), local-fonts=(), magnetometer=(), microphone=(),
    * midi=(), otp-credentials=(), payment=(), picture-in-picture=(),
    * publickey-credentials-create=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(),

--- a/security/security-core/src/main/java/io/camunda/security/configuration/headers/PermissionsPolicyConfig.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/headers/PermissionsPolicyConfig.java
@@ -80,9 +80,9 @@ public class PermissionsPolicyConfig {
    * <p>Default: accelerometer=(), ambient-light-sensor=(), attribution-reporting=(), autoplay=(),
    * bluetooth=(), browsing-topics=(), camera=(), compute-pressure=(), cross-origin-isolated=(),
    * deferred-fetch=(), deferred-fetch-minimal=(), display-capture=(), encrypted-media=(),
-   * fullscreen=(self), gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(),
-   * idle-detection=(), language-detector=(), local-fonts=(), magnetometer=(), microphone=(),
-   * midi=(), otp-credentials=(), payment=(), picture-in-picture=(),
+   * fullscreen=(self), gamepad=(), geolocation=(), gyroscope=(), hid=(),
+   * identity-credentials-get=(), idle-detection=(), language-detector=(), local-fonts=(),
+   * magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(),
    * publickey-credentials-create=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(),
    * speaker-selection=(), storage-access=(), summarizer=(), translator=(), usb=(), web-share=(),
    * window-management=(), xr-spatial-tracking=() which disables all features by default.


### PR DESCRIPTION
## Description

  - Change `fullscreen=()` to `fullscreen=(self)` in the default `Permissions-Policy` HTTP header to allow the Fullscreen API for same-origin documents
  - Add `.catch()` to `requestFullscreen()` in the diagram component to handle policy rejections
  
 Root cause analysis: 
In deployed environments, clickig the diagram fullscreen button logs `[Violation] Permissions policy violation: fullscreen is not allowed in this document` and does nothing. This works locally because the dev server doesn't set the `Permissions-Policy` header.
The root cause is the server-side `Permissions-Policy` header includes `fullscreen=()`, which completely disables the Fullscreen API for the document. The Diagram component `el.requestFullscreen()` call then fail because browser enforces this policy.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48823 
