### PR TITLE
fix: use more robust getLong method

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/StandaloneDecisionInstanceDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/StandaloneDecisionInstanceDaoIT.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.api.v1.dao;
+
+import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.connect.OperateDateTimeFormatter;
+import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
+import io.camunda.operate.webapp.api.v1.entities.DecisionInstance;
+import io.camunda.operate.webapp.api.v1.entities.DecisionInstanceState;
+import io.camunda.operate.webapp.api.v1.entities.Query;
+import io.camunda.operate.webapp.api.v1.entities.Query.Sort;
+import io.camunda.operate.webapp.api.v1.entities.Query.Sort.Order;
+import io.camunda.operate.webapp.api.v1.entities.Results;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
+import io.camunda.webapps.schema.entities.dmn.DecisionType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Integration test for standalone decision instances (evaluated without a process context). These
+ * instances have processDefinitionKey=0 and processInstanceKey=0, which can trigger
+ * ClassCastException if Jackson deserializes them as Integer instead of Long.
+ */
+public class StandaloneDecisionInstanceDaoIT extends OperateSearchAbstractIT {
+  private static final String DECISION_RESULT = "\"standalone result\"";
+  private final String evaluationDate = "2024-02-15T22:40:10.834+0000";
+
+  @Autowired private DecisionInstanceDao dao;
+
+  @Autowired private DecisionInstanceTemplate decisionInstanceIndex;
+  @Autowired private OperateDateTimeFormatter dateTimeFormatter;
+
+  @Override
+  protected void runAdditionalBeforeAllSetup() throws Exception {
+    final String indexName = decisionInstanceIndex.getFullQualifiedName();
+
+    // Create a standalone decision instance with processDefinitionKey=0 and processInstanceKey=0
+    // This simulates decisions evaluated via the standalone Evaluate Decision API
+    testSearchRepository.createOrUpdateDocumentFromObject(
+        indexName,
+        new DecisionInstanceEntity()
+            .setId("9999999999999999-1")
+            .setKey(9999999999999999L)
+            .setState(io.camunda.webapps.schema.entities.dmn.DecisionInstanceState.EVALUATED)
+            .setEvaluationDate(dateTimeFormatter.parseGeneralDateTime(evaluationDate))
+            .setProcessDefinitionKey(-1) // -1 for standalone decisions
+            .setProcessInstanceKey(-1) // -1 for standalone decisions
+            .setDecisionId("standaloneDecision")
+            .setDecisionDefinitionId("9999999999999998")
+            .setDecisionName("Standalone Decision")
+            .setDecisionVersion(1)
+            .setDecisionType(DecisionType.DECISION_TABLE)
+            .setResult(DECISION_RESULT)
+            .setTenantId(DEFAULT_TENANT_ID));
+
+    // Create another standalone decision instance with explicit zero values
+    testSearchRepository.createOrUpdateDocumentFromObject(
+        indexName,
+        new DecisionInstanceEntity()
+            .setId("9999999999999997-1")
+            .setKey(9999999999999997L)
+            .setState(io.camunda.webapps.schema.entities.dmn.DecisionInstanceState.EVALUATED)
+            .setEvaluationDate(dateTimeFormatter.parseGeneralDateTime(evaluationDate))
+            .setProcessDefinitionKey(-1L)
+            .setProcessInstanceKey(-1L)
+            .setDecisionId("anotherStandaloneDecision")
+            .setDecisionDefinitionId("9999999999999996")
+            .setDecisionName("Another Standalone Decision")
+            .setDecisionVersion(2)
+            .setDecisionType(DecisionType.DECISION_TABLE)
+            .setResult(DECISION_RESULT)
+            .setTenantId(DEFAULT_TENANT_ID));
+
+    searchContainerManager.refreshIndices("*operate-decision*");
+  }
+
+  @Test
+  public void shouldSearchStandaloneDecisionInstances() {
+    // When searching for all decision instances
+    final Results<DecisionInstance> results = dao.search(new Query<>());
+
+    // Then standalone decisions should be returned without ClassCastException
+    assertThat(results.getTotal()).isGreaterThanOrEqualTo(2);
+    assertThat(results.getItems()).isNotEmpty();
+
+    // Find our standalone decision instances
+    final var standaloneDecisions =
+        results.getItems().stream()
+            .filter(
+                di ->
+                    "standaloneDecision".equals(di.getDecisionId())
+                        || "anotherStandaloneDecision".equals(di.getDecisionId()))
+            .toList();
+
+    assertThat(standaloneDecisions).hasSize(2);
+
+    // Verify that zero values are correctly deserialized as Long, not Integer
+    for (final DecisionInstance decision : standaloneDecisions) {
+      assertThat(decision.getProcessDefinitionKey())
+          .isNotNull()
+          .isEqualTo(-1L)
+          .isInstanceOf(Long.class);
+      assertThat(decision.getProcessInstanceKey())
+          .isNotNull()
+          .isEqualTo(-1L)
+          .isInstanceOf(Long.class);
+      assertThat(decision.getState()).isEqualTo(DecisionInstanceState.EVALUATED);
+    }
+  }
+
+  @Test
+  public void shouldFindStandaloneDecisionInstanceById() {
+    // When fetching a standalone decision instance by ID
+    final DecisionInstance decision = dao.byId("9999999999999999-1");
+
+    // Then it should be retrieved successfully without ClassCastException
+    assertThat(decision).isNotNull();
+    assertThat(decision.getDecisionId()).isEqualTo("standaloneDecision");
+    assertThat(decision.getDecisionName()).isEqualTo("Standalone Decision");
+
+    // Verify zero values are correctly deserialized
+    assertThat(decision.getProcessDefinitionKey())
+        .isNotNull()
+        .isEqualTo(-1L)
+        .isInstanceOf(Long.class);
+    assertThat(decision.getProcessInstanceKey())
+        .isNotNull()
+        .isEqualTo(-1L)
+        .isInstanceOf(Long.class);
+  }
+
+  @Test
+  public void shouldFilterStandaloneDecisionsByProcessDefinitionKey() {
+    // When filtering by processDefinitionKey=0
+    final Results<DecisionInstance> results =
+        dao.search(
+            new Query<DecisionInstance>()
+                .setFilter(new DecisionInstance().setProcessDefinitionKey(-1L)));
+
+    // Then standalone decisions should be found
+    assertThat(results.getTotal()).isGreaterThanOrEqualTo(2);
+
+    final var decisions = results.getItems();
+    assertThat(decisions).isNotEmpty();
+
+    // All returned decisions should have processDefinitionKey=0
+    assertThat(decisions)
+        .allMatch(d -> d.getProcessDefinitionKey() != null && d.getProcessDefinitionKey() == -1L);
+  }
+
+  @Test
+  public void shouldSortStandaloneDecisionInstances() {
+    // When sorting standalone decisions
+    final Results<DecisionInstance> results =
+        dao.search(
+            new Query<DecisionInstance>()
+                .setFilter(new DecisionInstance().setProcessDefinitionKey(-1L))
+                .setSort(Sort.listOf(DecisionInstance.DECISION_VERSION, Order.ASC)));
+
+    // Then sorting should work correctly
+    assertThat(results.getItems()).isNotEmpty();
+
+    final var versions =
+        results.getItems().stream()
+            .filter(d -> d.getProcessDefinitionKey() == 0L)
+            .map(DecisionInstance::getDecisionVersion)
+            .toList();
+
+    assertThat(versions).isSorted();
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDao.java
@@ -142,9 +142,12 @@ public abstract class ElasticsearchDao<T> {
   }
 
   protected Long getLong(final Object value) {
+    if (value == null) {
+      return null;
+    }
     if (value instanceof Number) {
       return ((Number) value).longValue();
     }
-    return Long.parseLong(value.toString());
+    throw new NumberFormatException(String.format("Value %s cannot be converted to Long", value));
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDao.java
@@ -140,4 +140,11 @@ public abstract class ElasticsearchDao<T> {
     }
     return null;
   }
+
+  protected Long getLong(final Object value) {
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    }
+    return Long.parseLong(value.toString());
+  }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDecisionInstanceDao.java
@@ -176,14 +176,15 @@ public class ElasticsearchDecisionInstanceDao extends ElasticsearchDao<DecisionI
     final DecisionInstance decisionInstance =
         new DecisionInstance()
             .setId((String) searchHitAsMap.get(DecisionInstance.ID))
-            .setKey((Long) searchHitAsMap.get(DecisionInstance.KEY))
+            .setKey(getLong(searchHitAsMap.get(DecisionInstance.KEY)))
             .setState(
                 DecisionInstanceState.fromString(
                     (String) searchHitAsMap.get(DecisionInstance.STATE)))
             .setEvaluationDate((String) searchHitAsMap.get(DecisionInstance.EVALUATION_DATE))
             .setProcessDefinitionKey(
-                (Long) searchHitAsMap.get(DecisionInstance.PROCESS_DEFINITION_KEY))
-            .setProcessInstanceKey((Long) searchHitAsMap.get(DecisionInstance.PROCESS_INSTANCE_KEY))
+                getLong(searchHitAsMap.get(DecisionInstance.PROCESS_DEFINITION_KEY)))
+            .setProcessInstanceKey(
+                getLong(searchHitAsMap.get(DecisionInstance.PROCESS_INSTANCE_KEY)))
             .setDecisionId((String) searchHitAsMap.get(DecisionInstance.DECISION_ID))
             .setTenantId((String) searchHitAsMap.get(DecisionInstance.TENANT_ID))
             .setDecisionDefinitionId(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchFlowNodeInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchFlowNodeInstanceDao.java
@@ -123,10 +123,11 @@ public class ElasticsearchFlowNodeInstanceDao extends ElasticsearchDao<FlowNodeI
     final Map<String, Object> searchHitAsMap = searchHit.getSourceAsMap();
     final FlowNodeInstance flowNodeInstance =
         new FlowNodeInstance()
-            .setKey((Long) searchHitAsMap.get(FlowNodeInstance.KEY))
-            .setProcessInstanceKey((Long) searchHitAsMap.get(FlowNodeInstance.PROCESS_INSTANCE_KEY))
+            .setKey(getLong(searchHitAsMap.get(FlowNodeInstance.KEY)))
+            .setProcessInstanceKey(
+                getLong(searchHitAsMap.get(FlowNodeInstance.PROCESS_INSTANCE_KEY)))
             .setProcessDefinitionKey(
-                (Long) searchHitAsMap.get(FlowNodeInstance.PROCESS_DEFINITION_KEY))
+                getLong(searchHitAsMap.get(FlowNodeInstance.PROCESS_DEFINITION_KEY)))
             .setStartDate(
                 dateTimeFormatter.convertGeneralToApiDateTime(
                     (String) searchHitAsMap.get(FlowNodeInstance.START_DATE)))
@@ -137,7 +138,7 @@ public class ElasticsearchFlowNodeInstanceDao extends ElasticsearchDao<FlowNodeI
             .setState((String) searchHitAsMap.get(FlowNodeInstance.STATE))
             .setFlowNodeId((String) searchHitAsMap.get(FlowNodeInstance.FLOW_NODE_ID))
             .setIncident((Boolean) searchHitAsMap.get(FlowNodeInstance.INCIDENT))
-            .setIncidentKey((Long) searchHitAsMap.get(FlowNodeInstance.INCIDENT_KEY))
+            .setIncidentKey(getLong(searchHitAsMap.get(FlowNodeInstance.INCIDENT_KEY)))
             .setTenantId((String) searchHitAsMap.get(FlowNodeInstance.TENANT_ID));
 
     if (flowNodeInstance.getFlowNodeId() != null) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchIncidentDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchIncidentDao.java
@@ -123,16 +123,17 @@ public class ElasticsearchIncidentDao extends ElasticsearchDao<Incident> impleme
   protected Incident searchHitToIncident(final SearchHit searchHit) {
     final Map<String, Object> searchHitAsMap = searchHit.getSourceAsMap();
     return new Incident()
-        .setKey((Long) searchHitAsMap.get(IncidentTemplate.KEY))
-        .setProcessInstanceKey((Long) searchHitAsMap.get(IncidentTemplate.PROCESS_INSTANCE_KEY))
-        .setProcessDefinitionKey((Long) searchHitAsMap.get(IncidentTemplate.PROCESS_DEFINITION_KEY))
+        .setKey(getLong(searchHitAsMap.get(IncidentTemplate.KEY)))
+        .setProcessInstanceKey(getLong(searchHitAsMap.get(IncidentTemplate.PROCESS_INSTANCE_KEY)))
+        .setProcessDefinitionKey(
+            getLong(searchHitAsMap.get(IncidentTemplate.PROCESS_DEFINITION_KEY)))
         .setType((String) searchHitAsMap.get(IncidentTemplate.ERROR_TYPE))
         .setMessage((String) searchHitAsMap.get(IncidentTemplate.ERROR_MSG))
         .setCreationTime(
             dateTimeFormatter.convertGeneralToApiDateTime(
                 (String) searchHitAsMap.get(Incident.CREATION_TIME)))
         .setState((String) searchHitAsMap.get(Incident.STATE))
-        .setJobKey((Long) searchHitAsMap.get(Incident.JOB_KEY))
+        .setJobKey(getLong(searchHitAsMap.get(Incident.JOB_KEY)))
         .setTenantId((String) searchHitAsMap.get(Incident.TENANT_ID));
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchSequenceFlowDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchSequenceFlowDao.java
@@ -86,7 +86,8 @@ public class ElasticsearchSequenceFlowDao extends ElasticsearchDao<SequenceFlow>
     return new SequenceFlow()
         .setId((String) searchHitAsMap.get(SequenceFlowTemplate.ID))
         .setActivityId((String) searchHitAsMap.get(SequenceFlowTemplate.ACTIVITY_ID))
-        .setProcessInstanceKey((Long) searchHitAsMap.get(SequenceFlowTemplate.PROCESS_INSTANCE_KEY))
+        .setProcessInstanceKey(
+            getLong(searchHitAsMap.get(SequenceFlowTemplate.PROCESS_INSTANCE_KEY)))
         .setTenantId((String) searchHitAsMap.get(Incident.TENANT_ID));
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchVariableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchVariableDao.java
@@ -118,9 +118,9 @@ public class ElasticsearchVariableDao extends ElasticsearchDao<Variable> impleme
     final Map<String, Object> searchHitAsMap = searchHit.getSourceAsMap();
     final Variable variable =
         new Variable()
-            .setKey((Long) searchHitAsMap.get(Variable.KEY))
-            .setProcessInstanceKey((Long) searchHitAsMap.get(Variable.PROCESS_INSTANCE_KEY))
-            .setScopeKey((Long) searchHitAsMap.get(Variable.SCOPE_KEY))
+            .setKey(getLong(searchHitAsMap.get(Variable.KEY)))
+            .setProcessInstanceKey(getLong(searchHitAsMap.get(Variable.PROCESS_INSTANCE_KEY)))
+            .setScopeKey(getLong(searchHitAsMap.get(Variable.SCOPE_KEY)))
             .setTenantId((String) searchHitAsMap.get(Variable.TENANT_ID))
             .setName((String) searchHitAsMap.get(Variable.NAME))
             .setValue((String) searchHitAsMap.get(Variable.VALUE))

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDaoTest.java
@@ -1,0 +1,38 @@
+package io.camunda.operate.webapp.api.v1.dao.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.operate.webapp.api.v1.entities.Query;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchDaoTest {
+
+  ElasticsearchDao<Object> elasticsearchDao =
+      new ElasticsearchDao<Object>() {
+        @Override
+        protected void buildFiltering(
+            final Query<Object> query, final SearchSourceBuilder searchSourceBuilder) {}
+      };
+
+  @Test
+  void shouldGetLongFromInteger() {
+    assertThat(elasticsearchDao.getLong(1)).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldGetLongFromLong() {
+    assertThat(elasticsearchDao.getLong(1L)).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldGetNullFromNull() {
+    assertThat(elasticsearchDao.getLong(null)).isNull();
+  }
+
+  @Test
+  void shouldThrowExceptionForNonNumeric() {
+    assertThrows(IllegalArgumentException.class, () -> elasticsearchDao.getLong("not a number"));
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDaoTest.java
@@ -1,7 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
 package io.camunda.operate.webapp.api.v1.dao.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.operate.webapp.api.v1.entities.Query;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -33,6 +40,7 @@ class ElasticsearchDaoTest {
 
   @Test
   void shouldThrowExceptionForNonNumeric() {
-    assertThrows(IllegalArgumentException.class, () -> elasticsearchDao.getLong("not a number"));
+    assertThatThrownBy(() -> elasticsearchDao.getLong("not a number"))
+        .isInstanceOf(NumberFormatException.class);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes the long casting issue where `ElasticsearchDao` retrieves `-1` in Integer format for Long values. The tests will be coming from @eppdot's PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #44592
