### PR TITLE
perf: don't delay first migration snapshot attempt

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
@@ -186,15 +186,14 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
 
   private static final class RetryState {
     private int retryCount = 0;
-    private final ExponentialBackoff backoff = new ExponentialBackoff(5000, 500);
-    private long lastDelay = 500;
-
-    public void retry() {
-      retryCount++;
-    }
+    private final ExponentialBackoff backoff = new ExponentialBackoff(5000, 100);
+    private long lastDelay = 0;
 
     public Duration nextDelay() {
-      retry();
+      if (retryCount++ == 0) {
+        return Duration.ZERO;
+      }
+
       lastDelay = backoff.supplyRetryDelay(lastDelay);
       return Duration.ofMillis(lastDelay);
     }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoff.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoff.java
@@ -86,7 +86,7 @@ public final class ExponentialBackoff implements LongUnaryOperator {
   }
 
   public long supplyRetryDelay(final long currentRetryDelay) {
-    final var delay = Math.max(Math.min(maxDelay, currentRetryDelay * backoffFactor), minDelay);
+    final var delay = Math.clamp(currentRetryDelay * backoffFactor, minDelay, maxDelay);
     final var jitter = computeJitter(delay);
     return Math.round(delay + jitter);
   }


### PR DESCRIPTION
The first attempt to take a snapshot was already delayed by 500ms even though we could immediately take it. This change should reduce time-to-ready by ~500ms. The minimum delay for subsequent attempts is also reduced from 500ms to 100ms.