### PR TITLE
Refactor starter for better reliability and observability

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Clock.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Clock.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+@FunctionalInterface
+/** Clock interface to abstract away System.nanoTime() usage, and improve testability. */
+public interface Clock {
+
+  /** Returns the current time in nanoseconds. */
+  long getNanos();
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ProcessInstanceStartMeter implements AutoCloseable {
-
+  public static final long MAX_DURATION = Duration.ofSeconds(90).toNanos();
   private static final Logger LOG = LoggerFactory.getLogger(ProcessInstanceStartMeter.class);
   private final ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
   private final Map<Long, PiCreationResult> startedInstances;
@@ -87,22 +87,48 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
                 return;
               }
 
-              LOG.debug("Available process instances items: {}, instances: {}", availableInstances.size(), availableInstances);
-              availableInstances.stream()
-                  .map(startedInstances::get)
-                  .filter(Objects::nonNull)
-                  .forEach(this::recordInstanceAvailable);
+              LOG.debug("Available process instances items: {}", availableInstances.size());
+              processAvailableInstances(availableInstances);
+              cleanUpStaleInstances();
             },
             piCheckExecutorService);
   }
 
-  private void recordInstanceAvailable(final PiCreationResult awaitingPI) {
-    final long durationNanos = System.nanoTime() - awaitingPI.startTimeNanos;
-    LOG.debug(
-        "Process instance {} retrieved in {} ms",
-        awaitingPI.processInstanceKey,
-        TimeUnit.NANOSECONDS.toMillis(durationNanos));
+  private void cleanUpStaleInstances() {
+    // clean up stale instances which exceeded the max duration - to safe memory
+    final long nanoTime = System.nanoTime();
+    final var instancesWhereTimeExceededDeadline =
+        startedInstances.values().stream()
+            .filter(piCreationResult -> nanoTime - piCreationResult.startTimeNanos > MAX_DURATION)
+            .toList();
+    instancesWhereTimeExceededDeadline.forEach(
+        piResults -> {
+          final long durationNanos = System.nanoTime() - piResults.startTimeNanos;
+          LOG.debug(
+              "Process instance {} was not retrieved after {} ms, removing it from the awaiting list.",
+              piResults.processInstanceKey,
+              TimeUnit.NANOSECONDS.toMillis(durationNanos));
+          recordInstanceAvailable(piResults, durationNanos);
+        });
+  }
 
+  private void processAvailableInstances(final List<Long> availableInstances) {
+    availableInstances.stream()
+        .map(startedInstances::get)
+        .filter(Objects::nonNull)
+        .forEach(
+            piResults -> {
+              final long durationNanos = System.nanoTime() - piResults.startTimeNanos;
+              LOG.debug(
+                  "Process instance {} retrieved in {} ms",
+                  piResults.processInstanceKey,
+                  TimeUnit.NANOSECONDS.toMillis(durationNanos));
+              recordInstanceAvailable(piResults, durationNanos);
+            });
+  }
+
+  private void recordInstanceAvailable(
+      final PiCreationResult awaitingPI, final long durationNanos) {
     final int partitionId = Protocol.decodePartitionId(awaitingPI.processInstanceKey);
     partitionToTimerMap
         .computeIfAbsent(

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ProcessInstanceStartMeter implements AutoCloseable {
-  public static final long MAX_DURATION = Duration.ofSeconds(90).toNanos();
+  private static final long MAX_DURATION = Duration.ofSeconds(90).toNanos();
   private static final Logger LOG = LoggerFactory.getLogger(ProcessInstanceStartMeter.class);
   private final ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
   private final Map<Long, PiCreationResult> startedInstances;

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -33,6 +33,7 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
   private final MeterRegistry registry;
   private final Duration availabilityCheckInterval;
   private final Clock clock;
+  private final Timer dataAvailabilityQueryDurationTimer;
 
   public ProcessInstanceStartMeter(
       final Clock clock,
@@ -45,6 +46,9 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
     partitionToTimerMap = new ConcurrentHashMap<>();
     startedInstances = new ConcurrentHashMap<>();
     piCheckExecutorService = scheduledExecutorService;
+    dataAvailabilityQueryDurationTimer =
+        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_QUERY_DURATION)
+            .register(registry);
     this.availabilityCheckInterval = availabilityCheckInterval;
     this.availabilityChecker = availabilityChecker;
   }
@@ -81,12 +85,18 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
     }
 
     LOG.debug("Current instances awaiting {}", startedInstances.size());
+    final var startQueryTime = clock.getNanos();
     availabilityChecker
         .findAvailableInstances(List.copyOf(startedInstances.keySet()))
         .whenCompleteAsync(
             (availableInstances, error) -> {
+              final var endQueryTime = clock.getNanos();
+              dataAvailabilityQueryDurationTimer.record(
+                  endQueryTime - startQueryTime, TimeUnit.NANOSECONDS);
+
               if (error != null) {
                 LOG.error("Error while checking for available process instances", error);
+
                 return;
               }
 

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -108,7 +108,7 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
   }
 
   private void cleanUpStaleInstances() {
-    // clean up stale instances which exceeded the max duration - to safe memory
+    // clean up stale instances which exceeded the max duration - to save memory
     final long nanoTime = clock.getNanos();
     final var instancesWhereTimeExceededDeadline =
         startedInstances.values().stream()

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -32,12 +32,15 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
   private final AvailabilityChecker availabilityChecker;
   private final MeterRegistry registry;
   private final Duration availabilityCheckInterval;
+  private final Clock clock;
 
   public ProcessInstanceStartMeter(
+      final Clock clock,
       final MeterRegistry meterRegistry,
       final ScheduledExecutorService scheduledExecutorService,
       final Duration availabilityCheckInterval,
       final AvailabilityChecker availabilityChecker) {
+    this.clock = clock;
     registry = meterRegistry;
     partitionToTimerMap = new ConcurrentHashMap<>();
     startedInstances = new ConcurrentHashMap<>();
@@ -96,14 +99,14 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
 
   private void cleanUpStaleInstances() {
     // clean up stale instances which exceeded the max duration - to safe memory
-    final long nanoTime = System.nanoTime();
+    final long nanoTime = clock.getNanos();
     final var instancesWhereTimeExceededDeadline =
         startedInstances.values().stream()
             .filter(piCreationResult -> nanoTime - piCreationResult.startTimeNanos > MAX_DURATION)
             .toList();
     instancesWhereTimeExceededDeadline.forEach(
         piResults -> {
-          final long durationNanos = System.nanoTime() - piResults.startTimeNanos;
+          final long durationNanos = clock.getNanos() - piResults.startTimeNanos;
           LOG.debug(
               "Process instance {} was not retrieved after {} ms, removing it from the awaiting list.",
               piResults.processInstanceKey,
@@ -118,7 +121,7 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
         .filter(Objects::nonNull)
         .forEach(
             piResults -> {
-              final long durationNanos = System.nanoTime() - piResults.startTimeNanos;
+              final long durationNanos = clock.getNanos() - piResults.startTimeNanos;
               LOG.debug(
                   "Process instance {} retrieved in {} ms",
                   piResults.processInstanceKey,

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -87,7 +87,7 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
                 return;
               }
 
-              LOG.debug("Available process instances items: {} ", availableInstances.size());
+              LOG.debug("Available process instances items: {}, instances: {}", availableInstances.size(), availableInstances);
               availableInstances.stream()
                   .map(startedInstances::get)
                   .filter(Objects::nonNull)

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -96,7 +96,7 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
 
               if (error != null) {
                 LOG.error("Error while checking for available process instances", error);
-
+                cleanUpStaleInstances();
                 return;
               }
 

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -156,6 +156,7 @@ public class Starter extends App {
                       .newProcessInstanceSearchRequest()
                       .filter((f) -> f.processInstanceKey(key -> key.in(listOfStartedInstances)))
                       .sort(ProcessInstanceSort::startDate)
+                      .page(p -> p.limit(100))
                       .send();
 
               return send.thenApply(

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -147,6 +147,7 @@ public class Starter extends App {
     LOG.info("Monitor data availability of started process instances");
     processInstanceStartMeter =
         new ProcessInstanceStartMeter(
+            System::nanoTime,
             registry,
             Executors.newScheduledThreadPool(1),
             config.getMonitorDataAvailabilityInterval(),

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
@@ -60,6 +60,46 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
   },
 
   /**
+   * The data availability query duration. It measures the individual time for each search query
+   * which we use to track the data availability of a process instance creation.
+   */
+  DATA_AVAILABILITY_QUERY_DURATION {
+
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45),
+      Duration.ofSeconds(60),
+      Duration.ofSeconds(90),
+    };
+
+    @Override
+    public String getDescription() {
+      return "The data availability query duration. It measures the individual time for each search query, which we use to track the data availability of a process instance creation.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.data.availability.query.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /**
    * The response latency when starting process instances. It measures the time from sending the
    * request to receiving the response.
    */

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
@@ -20,6 +20,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ public class ProcessInstanceStartMeterTest {
     availabilityChecker = CompletableFuture::completedFuture;
     processInstanceStartMeter =
         new ProcessInstanceStartMeter(
+            System::nanoTime,
             meterRegistry,
             Executors.newScheduledThreadPool(1),
             Duration.ofMillis(1),
@@ -132,6 +135,7 @@ public class ProcessInstanceStartMeterTest {
     // given
     processInstanceStartMeter =
         new ProcessInstanceStartMeter(
+            System::nanoTime,
             meterRegistry,
             Executors.newScheduledThreadPool(1),
             Duration.ZERO,
@@ -148,6 +152,42 @@ public class ProcessInstanceStartMeterTest {
                     .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
                     .timer())
         .hasMessageContaining("No meter with name 'starter.data.availability.latency' was found.");
+  }
+
+  @Test
+  public void shouldRecordMetricAfterMaxDuration() {
+    // given
+    final AtomicLong time = new AtomicLong();
+    processInstanceStartMeter =
+        new ProcessInstanceStartMeter(
+            time::get,
+            meterRegistry,
+            Executors.newScheduledThreadPool(1),
+            Duration.ofMillis(1),
+            CompletableFuture::completedFuture);
+    processInstanceStartMeter.start();
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 1), System.nanoTime());
+
+    // when
+    time.set(System.nanoTime() + Duration.ofSeconds(90).toNanos());
+
+    // then
+    Awaitility.await()
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                meterRegistry
+                    .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                    .timer()
+                    .count(),
+            (count) -> assertThat(count).isOne());
+    assertThat(
+            meterRegistry
+                .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                .timer()
+                .totalTime(TimeUnit.MILLISECONDS))
+        .isGreaterThan(Duration.ofSeconds(90).toMillis());
   }
 
   @Test

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
@@ -76,7 +76,35 @@ public class ProcessInstanceStartMeterTest {
                 .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
                 .timer()
                 .totalTime(TimeUnit.MILLISECONDS))
-        .isGreaterThan(1);
+        .isNotZero();
+  }
+
+  @Test
+  public void shouldRecordQueryDurationForAvailabilityMeasurement() {
+    // given
+
+    // when
+    processInstanceStartMeter.start();
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 1), System.nanoTime());
+
+    // then
+    await()
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                meterRegistry
+                    .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_QUERY_DURATION.getName())
+                    .timer()
+                    .count(),
+            (count) -> assertThat(count).isGreaterThanOrEqualTo(1));
+
+    assertThat(
+            meterRegistry
+                .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_QUERY_DURATION.getName())
+                .timer()
+                .totalTime(TimeUnit.MILLISECONDS))
+        .isNotZero();
   }
 
   @Test
@@ -93,7 +121,7 @@ public class ProcessInstanceStartMeterTest {
     processInstanceStartMeter.start();
 
     // then
-    countDownLatch.await(1, TimeUnit.SECONDS);
+    countDownLatch.await(250, TimeUnit.MILLISECONDS);
 
     assertThatThrownBy(
             () ->
@@ -101,6 +129,29 @@ public class ProcessInstanceStartMeterTest {
                     .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
                     .timer())
         .hasMessageContaining("No meter with name 'starter.data.availability.latency' was found.");
+  }
+
+  @Test
+  public void shouldNotRecordQueryDurationWhenNoInstancesStarted() throws InterruptedException {
+    // given
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    availabilityChecker =
+        (list) -> {
+          countDownLatch.countDown();
+          return CompletableFuture.completedFuture(list);
+        };
+
+    // when
+    processInstanceStartMeter.start();
+
+    // then
+    countDownLatch.await(250, TimeUnit.MILLISECONDS);
+    assertThat(
+            meterRegistry
+                .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_QUERY_DURATION.getName())
+                .timer()
+                .count())
+        .isZero();
   }
 
   @Test
@@ -131,6 +182,43 @@ public class ProcessInstanceStartMeterTest {
   }
 
   @Test
+  public void shouldRecordQueryDurationEvenWhenPIsNotAvailable() throws InterruptedException {
+    // given
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    availabilityChecker =
+        (list) -> {
+          countDownLatch.countDown();
+          // return empty list to simulate no available instances
+          return CompletableFuture.completedFuture(List.of());
+        };
+
+    // when
+    processInstanceStartMeter.start();
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 1), System.nanoTime());
+
+    // then
+    countDownLatch.await(1, TimeUnit.SECONDS);
+
+    await()
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                meterRegistry
+                    .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_QUERY_DURATION.getName())
+                    .timer()
+                    .count(),
+            (count) -> assertThat(count).isGreaterThan(1));
+
+    assertThat(
+            meterRegistry
+                .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_QUERY_DURATION.getName())
+                .timer()
+                .totalTime(TimeUnit.MILLISECONDS))
+        .isGreaterThan(1);
+  }
+
+  @Test
   public void shouldNotRecordInstanceAvailabilityWhenNotStarted() {
     // given
     processInstanceStartMeter =
@@ -152,6 +240,30 @@ public class ProcessInstanceStartMeterTest {
                     .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
                     .timer())
         .hasMessageContaining("No meter with name 'starter.data.availability.latency' was found.");
+  }
+
+  @Test
+  public void shouldNotRecordQueryDurationWhenNotStarted() {
+    // given
+    processInstanceStartMeter =
+        new ProcessInstanceStartMeter(
+            System::nanoTime,
+            meterRegistry,
+            Executors.newScheduledThreadPool(1),
+            Duration.ZERO,
+            CompletableFuture::completedFuture);
+
+    // when
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 1), System.nanoTime());
+
+    // then
+    assertThat(
+            meterRegistry
+                .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_QUERY_DURATION.getName())
+                .timer()
+                .count())
+        .isZero();
   }
 
   @Test


### PR DESCRIPTION
## Summary

The load test starter's `ProcessInstanceStartMeter` was accumulating tracked process instances indefinitely, leading to OOM crashes when instances were slow to become available. This PR fixes the memory leak and adds observability improvements.

**Key changes:**

- **Fix OOM: clean up stale instances** — Process instances that exceed a 90-second max duration are now evicted from the tracking map, recording them with the max duration rather than holding them forever
- **Fix OOM: cleanup on error** — Stale instances are also cleaned up when the availability check errors, preventing unbounded accumulation during error scenarios
- **Make query limit explicit** — Set the search API page limit to 100 to avoid unbounded result sets
- **Add data availability query duration metric** — New `starter.data.availability.query.duration` timer to measure how long each availability check query takes, helping diagnose slow queries as a root cause
- **Improve testability** — Introduce a `Clock` interface to abstract `System.nanoTime()`, enabling deterministic tests for time-dependent behavior (e.g., max duration eviction)
- **Improve debug logging** — Better logging for awaiting instance count and stale instance eviction

## Test plan

- [x] New unit test: `shouldRecordMetricAfterMaxDuration` — verifies stale instances are evicted and recorded at max duration
- [x] New unit tests for query duration metric (recorded on success, on unavailable instances, not recorded when no instances tracked, not recorded when not started)
- [x] Existing tests updated to use `Clock` interface
- [x] Deploy to load test environment and verify no more OOM after extended runs
- [x] Verify new `starter.data.availability.query.duration` metric appears in Grafana