### PR TITLE
fix: add refetch interval to audit log search in tasklist

### DIFF
--- a/tasklist/client/src/v2/TaskDetailsHistoryView/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/index.test.tsx
@@ -20,6 +20,7 @@ import {getMockQueryClient} from 'common/testing/getMockQueryClient';
 import {LocationLog} from 'common/testing/LocationLog';
 import * as auditLogMocks from 'v2/mocks/auditLogs';
 import {endpoints} from '@camunda/camunda-api-zod-schemas/8.9';
+import {vi} from 'vitest';
 
 function getRouter(initialEntry: string = '/0/history') {
   const routes = [
@@ -575,5 +576,35 @@ describe('<TaskDetailsHistoryView />', () => {
     expect(screen.getByTestId('search')).toHaveTextContent(
       'sort=operationType+asc',
     );
+  });
+
+  it('should poll audit logs again after the refetch interval', async () => {
+    const auditLogsResolver = vi.fn(() =>
+      HttpResponse.json(auditLogMocks.getQueryUserTaskAuditLogsResponseMock()),
+    );
+
+    nodeMockServer.use(
+      http.post(
+        endpoints.queryUserTaskAuditLogs.getUrl({
+          userTaskKey: ':userTaskKey',
+        }),
+        auditLogsResolver,
+      ),
+    );
+
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    render(<RouterProvider router={getRouter()} />, {wrapper: getWrapper()});
+
+    await screen.findByTestId('task-details-history-view');
+
+    // Expect 2 initial calls: 1 from the route loader (ensureInfiniteQueryData) + 1 from useSuspenseInfiniteQuery (refetchOnMount)
+    expect(auditLogsResolver).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(5000);
+
+    await waitFor(() => expect(auditLogsResolver).toHaveBeenCalledTimes(3));
+
+    vi.useRealTimers();
   });
 });

--- a/tasklist/client/src/v2/api/useUserTaskAuditLogs.query.ts
+++ b/tasklist/client/src/v2/api/useUserTaskAuditLogs.query.ts
@@ -74,6 +74,7 @@ function getUserTaskAuditLogsQueryOptions(
 
       return previousPage;
     },
+    refetchInterval: 5000,
   });
 }
 


### PR DESCRIPTION
## Description

Add `refetchInterval` to Tasklist Audit Log query to show fresh data after interactions are performed within the history tab

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48240
