### PR TITLE
test: fix visual regression tests

### DIFF
--- a/operate/client/e2e-playwright/visual/processes.spec.ts
+++ b/operate/client/e2e-playwright/visual/processes.spec.ts
@@ -218,6 +218,7 @@ test.describe('processes page', () => {
     });
 
     await expect(processesPage.processInstancesTable).toBeVisible();
+    await expect(page.getByTestId(/^state-overlay/).first()).toBeVisible();
 
     await expect(page).toHaveScreenshot();
   });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The tests were failing because the tokens weren't loaded on the diagram yet

This fixes that
