### PR TITLE
fix: include default sort field in AuthorizationQuery

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
@@ -63,12 +63,7 @@ public class AuthorizationDbReader extends AbstractEntityReader<AuthorizationEnt
   @Override
   public SearchQueryResult<AuthorizationEntity> search(
       final AuthorizationQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    final var dbSort =
-        convertSort(
-            query.sort(),
-            AuthorizationSearchColumn.OWNER_ID,
-            AuthorizationSearchColumn.OWNER_TYPE,
-            AuthorizationSearchColumn.RESOURCE_TYPE);
+    final var dbSort = convertSort(query.sort(), AuthorizationSearchColumn.AUTHORIZATION_KEY);
 
     if (shouldReturnEmptyResult(resourceAccessChecks)) {
       return buildSearchQueryResult(0, List.of(), dbSort);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuthorizationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuthorizationSearchColumn.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.sql.columns;
 import io.camunda.search.entities.AuthorizationEntity;
 
 public enum AuthorizationSearchColumn implements SearchColumn<AuthorizationEntity> {
+  AUTHORIZATION_KEY("authorizationKey"),
   OWNER_ID("ownerId"),
   OWNER_TYPE("ownerType"),
   RESOURCE_TYPE("resourceType"),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIT.java
@@ -546,6 +546,67 @@ public class AuthorizationIT {
   }
 
   @Test
+  void searchShouldUsAuthorizationKeyAsDiscriminatorForTiedRecordsAndYieldCursors() {
+    // given — two authorizations that are identical on the explicit sort field (ownerType)
+    final var resourceIdPrefix = Strings.newRandomValidIdentityId();
+    camundaClient
+        .newCreateAuthorizationCommand()
+        .ownerId(USER_ID_1)
+        .ownerType(OwnerType.USER)
+        .resourceId(resourceIdPrefix + "-a")
+        .resourceType(ResourceType.RESOURCE)
+        .permissionTypes(CREATE)
+        .send()
+        .join();
+
+    camundaClient
+        .newCreateAuthorizationCommand()
+        .ownerId(USER_ID_1)
+        .ownerType(OwnerType.USER)
+        .resourceId(resourceIdPrefix + "-b")
+        .resourceType(ResourceType.RESOURCE)
+        .permissionTypes(CREATE)
+        .send()
+        .join();
+
+    // when / then — sort by ownerType (tied), paginate with limit 1
+    // the authorization key should break the tie and cursors should work
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var firstPage =
+                  camundaClient
+                      .newAuthorizationSearchRequest()
+                      .filter(
+                          f ->
+                              f.ownerId(USER_ID_1)
+                                  .resourceIds(resourceIdPrefix + "-a", resourceIdPrefix + "-b"))
+                      .sort(s -> s.ownerType().asc())
+                      .page(p -> p.limit(1))
+                      .send()
+                      .join();
+              assertThat(firstPage.items()).hasSize(1);
+              assertThat(firstPage.page().endCursor()).isNotNull();
+
+              final var secondPage =
+                  camundaClient
+                      .newAuthorizationSearchRequest()
+                      .filter(
+                          f ->
+                              f.ownerId(USER_ID_1)
+                                  .resourceIds(resourceIdPrefix + "-a", resourceIdPrefix + "-b"))
+                      .sort(s -> s.ownerType().asc())
+                      .page(p -> p.limit(1).after(firstPage.page().endCursor()))
+                      .send()
+                      .join();
+              assertThat(secondPage.items()).hasSize(1);
+              assertThat(secondPage.items().getFirst().getAuthorizationKey())
+                  .isNotEqualTo(firstPage.items().getFirst().getAuthorizationKey());
+            });
+  }
+
+  @Test
   void searchShouldReturnCursorsWithDefaultSort() {
     // given
     final var resourceIdPrefix = Strings.newRandomValidIdentityId();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIT.java
@@ -546,6 +546,108 @@ public class AuthorizationIT {
   }
 
   @Test
+  void searchShouldReturnCursorsWithDefaultSort() {
+    // given
+    final var resourceIdPrefix = Strings.newRandomValidIdentityId();
+    camundaClient
+        .newCreateAuthorizationCommand()
+        .ownerId(USER_ID_1)
+        .ownerType(OwnerType.USER)
+        .resourceId(resourceIdPrefix + "-1")
+        .resourceType(ResourceType.RESOURCE)
+        .permissionTypes(CREATE)
+        .send()
+        .join();
+
+    camundaClient
+        .newCreateAuthorizationCommand()
+        .ownerId(USER_ID_1)
+        .ownerType(OwnerType.USER)
+        .resourceId(resourceIdPrefix + "-2")
+        .resourceType(ResourceType.RESOURCE)
+        .permissionTypes(CREATE)
+        .send()
+        .join();
+
+    // when / then — a search with no explicit sort should still return cursors
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newAuthorizationSearchRequest()
+                      .filter(
+                          f ->
+                              f.ownerId(USER_ID_1)
+                                  .resourceIds(resourceIdPrefix + "-1", resourceIdPrefix + "-2"))
+                      .send()
+                      .join();
+              assertThat(result.items()).hasSize(2);
+              assertThat(result.page().startCursor()).isNotNull();
+              assertThat(result.page().endCursor()).isNotNull();
+            });
+  }
+
+  @Test
+  void searchShouldSupportCursorBasedPagination() {
+    // given
+    final var resourceIdPrefix = Strings.newRandomValidIdentityId();
+    camundaClient
+        .newCreateAuthorizationCommand()
+        .ownerId(USER_ID_1)
+        .ownerType(OwnerType.USER)
+        .resourceId(resourceIdPrefix + "-a")
+        .resourceType(ResourceType.RESOURCE)
+        .permissionTypes(CREATE)
+        .send()
+        .join();
+
+    camundaClient
+        .newCreateAuthorizationCommand()
+        .ownerId(USER_ID_1)
+        .ownerType(OwnerType.USER)
+        .resourceId(resourceIdPrefix + "-b")
+        .resourceType(ResourceType.RESOURCE)
+        .permissionTypes(CREATE)
+        .send()
+        .join();
+
+    // when / then — paginate with limit 1 and use cursors to navigate
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var firstPage =
+                  camundaClient
+                      .newAuthorizationSearchRequest()
+                      .filter(
+                          f ->
+                              f.ownerId(USER_ID_1)
+                                  .resourceIds(resourceIdPrefix + "-a", resourceIdPrefix + "-b"))
+                      .page(p -> p.limit(1))
+                      .send()
+                      .join();
+              assertThat(firstPage.items()).hasSize(1);
+              assertThat(firstPage.page().endCursor()).isNotNull();
+
+              final var secondPage =
+                  camundaClient
+                      .newAuthorizationSearchRequest()
+                      .filter(
+                          f ->
+                              f.ownerId(USER_ID_1)
+                                  .resourceIds(resourceIdPrefix + "-a", resourceIdPrefix + "-b"))
+                      .page(p -> p.limit(1).after(firstPage.page().endCursor()))
+                      .send()
+                      .join();
+              assertThat(secondPage.items()).hasSize(1);
+              assertThat(secondPage.items().getFirst().getAuthorizationKey())
+                  .isNotEqualTo(firstPage.items().getFirst().getAuthorizationKey());
+            });
+  }
+
+  @Test
   void searchShouldReturnEmptyListWhenSearchingForNonExistingAuthorizations() {
     final var searchResponse =
         camundaClient

--- a/search/search-domain/src/main/java/io/camunda/search/query/AuthorizationQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AuthorizationQuery.java
@@ -29,7 +29,7 @@ public record AuthorizationQuery(
   @Override
   public List<SearchSortOptions> retainValidSortings(final List<SearchSortOptions> sorting) {
     final var fieldNames =
-        List.of("ownerId", "ownerType", "resourceId", "resourcePropertyName", "resourceType");
+        List.of("id", "ownerId", "ownerType", "resourceId", "resourcePropertyName", "resourceType");
     return sorting.stream().filter(s -> fieldNames.contains(s.field().field())).toList();
   }
 


### PR DESCRIPTION
## Description

For ES/OS:
The default sort field "id" was filtered out by retainValidSortings(), causing no sort to be sent to ES/OS for authorization searches without explicit sort. Without sort values on hits, cursors were always null.

For RDBMS:
The previous discriminator columns (ownerId, ownerType, resourceType)
were not unique, causing keyset pagination to skip rows with identical
values. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48857
