### PR TITLE
fix: assigning roles to groups in initialization

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeEntityRelationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeEntityRelationsIT.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.identity;
+
+import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.ResourceType.GROUP;
+import static io.camunda.client.api.search.enums.ResourceType.ROLE;
+import static io.camunda.client.api.search.enums.ResourceType.TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.configuration.ConfiguredGroup;
+import io.camunda.security.configuration.ConfiguredRole;
+import io.camunda.security.configuration.ConfiguredTenant;
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class InitializeEntityRelationsIT {
+
+  public static final String DEFAULT_ROLE_CONNECTORS = "connectors";
+  private static final String TEST_ROLE_ID = "role1";
+  private static final String TEST_TENANT_ID = "tenant1";
+  private static final String USERNAME_ADMIN = "admin";
+  private static final String DEFAULT_ROLE_ADMIN = "admin";
+  private static final String DEFAULT_PASSWORD = "password";
+  private static final String TEST_USERNAME = "test-user";
+  private static final String TEST_GROUP_ID = "group1";
+  private static final String TEST_CLIENT_ID = "test-client";
+  private static final ConfiguredGroup CONFIGURED_GROUP_1 =
+      new ConfiguredGroup(
+          TEST_GROUP_ID,
+          "Group 1",
+          "something to test",
+          List.of(),
+          List.of(DEFAULT_ROLE_ADMIN, DEFAULT_ROLE_CONNECTORS),
+          List.of(),
+          List.of());
+  private static final ConfiguredRole CONFIGURED_ROLE_1 =
+      new ConfiguredRole(
+          TEST_ROLE_ID,
+          "Role 1",
+          "something to test",
+          List.of(),
+          List.of(),
+          List.of(),
+          List.of(TEST_GROUP_ID));
+  private static final ConfiguredTenant CONFIGURED_TENANT_1 =
+      new ConfiguredTenant(
+          TEST_TENANT_ID,
+          "Tenant 1",
+          "something to test",
+          List.of(),
+          List.of(),
+          List.of(TEST_ROLE_ID),
+          List.of(TEST_GROUP_ID),
+          List.of());
+
+  private static final ConfiguredUser CONFIGURED_USER =
+      new ConfiguredUser("test-user", DEFAULT_PASSWORD, "test-user", "");
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withSecurityConfig(
+              conf -> {
+                conf.getInitialization().setGroups(List.of(CONFIGURED_GROUP_1));
+                conf.getInitialization().getUsers().add(CONFIGURED_USER);
+                conf.getInitialization().getRoles().add(CONFIGURED_ROLE_1);
+                conf.getInitialization().getTenants().add(CONFIGURED_TENANT_1);
+              });
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER =
+      new TestUser(
+          USERNAME_ADMIN,
+          DEFAULT_PASSWORD,
+          List.of(
+              new Permissions(GROUP, READ, List.of("*")),
+              new Permissions(ROLE, READ, List.of("*")),
+              new Permissions(TENANT, READ, List.of("*"))));
+
+  @Test
+  void shouldMakeRoleGroupRelations(
+      @Authenticated(USERNAME_ADMIN) final CamundaClient adminClient) {
+    // when:
+    final var response = adminClient.newRolesByGroupSearchRequest(TEST_GROUP_ID).send().join();
+
+    // then:
+    assertThat(response.items()).hasSize(3);
+    assertThat(response.items()).anyMatch(actual -> actual.getRoleId().equals(DEFAULT_ROLE_ADMIN));
+    assertThat(response.items())
+        .anyMatch(actual -> actual.getRoleId().equals(DEFAULT_ROLE_CONNECTORS));
+    assertThat(response.items()).anyMatch(actual -> actual.getRoleId().equals(TEST_ROLE_ID));
+  }
+
+  @Test
+  void shouldMakeTenantRoleRelations(
+      @Authenticated(USERNAME_ADMIN) final CamundaClient adminClient) {
+    // when:
+    final var response = adminClient.newRolesByTenantSearchRequest(TEST_TENANT_ID).send().join();
+
+    // then:
+    assertThat(response.items()).hasSize(1);
+    assertThat(response.items()).anyMatch(actual -> actual.getRoleId().equals(TEST_ROLE_ID));
+  }
+
+  @Test
+  void shouldMakeTenantGroupRelations(
+      @Authenticated(USERNAME_ADMIN) final CamundaClient adminClient) {
+    // when:
+    final var response = adminClient.newGroupsByTenantSearchRequest(TEST_TENANT_ID).send().join();
+
+    // then:
+    assertThat(response.items()).hasSize(1);
+    assertThat(response.items()).anyMatch(actual -> actual.getGroupId().equals(TEST_GROUP_ID));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeEntityRelationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeEntityRelationsIT.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class InitializeEntityRelationsIT {
 
-  public static final String DEFAULT_ROLE_CONNECTORS = "connectors";
+  private static final String DEFAULT_ROLE_CONNECTORS = "connectors";
   private static final String TEST_ROLE_ID = "role1";
   private static final String TEST_TENANT_ID = "tenant1";
   private static final String USERNAME_ADMIN = "admin";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/GroupConfigurer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/GroupConfigurer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.identity.initialize;
 
 import io.camunda.security.configuration.ConfiguredGroup;
 import io.camunda.security.validation.GroupValidator;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.util.Either;
@@ -43,11 +44,30 @@ public class GroupConfigurer
     final String groupId = group.groupId();
     return Stream.of(
             mapToGroupMembers(groupId, group.users(), EntityType.USER),
-            mapToGroupMembers(groupId, group.roles(), EntityType.ROLE),
             mapToGroupMembers(groupId, group.mappingRules(), EntityType.MAPPING_RULE),
             mapToGroupMembers(groupId, group.clients(), EntityType.CLIENT))
         .flatMap(s -> s)
         .toList();
+  }
+
+  // Adding a role to a group is a special case as the relation can only be created one way round.
+  public List<RoleRecord> configureRoleMembers(final ConfiguredGroup group) {
+    final String groupId = group.groupId();
+    return mapToRoleMembers(groupId, group.roles()).toList();
+  }
+
+  private static Stream<RoleRecord> mapToRoleMembers(
+      final String groupId, final List<String> memberIds) {
+    if (memberIds == null) {
+      return Stream.empty();
+    }
+    return memberIds.stream()
+        .map(
+            id ->
+                new RoleRecord()
+                    .setRoleId(id)
+                    .setEntityId(groupId)
+                    .setEntityType(EntityType.GROUP));
   }
 
   private static Stream<GroupRecord> mapToGroupMembers(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.identity.initialize;
 
-import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.validation.IdentityInitializationException;
 import io.camunda.zeebe.engine.Loggers;
@@ -20,11 +19,12 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.util.Either;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -156,9 +156,8 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             group ->
                 groupConfigurer.configureRoleMembers(group).forEach(setupRecord::addRoleMember));
 
-    initialization
-        .getRoles()
-        .forEach(role -> roleConfigurer.configureMembers(role).forEach(setupRecord::addRoleMember));
+    final List<RoleRecord> customRoleMembers =
+        initialization.getRoles().stream().flatMap(roleConfigurer::configureMembers).toList();
 
     initialization
         .getUsers()
@@ -182,34 +181,16 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
                         .setClaimValue(mappingRule.getClaimValue())
                         .setName(mappingRule.getMappingRuleId())));
 
-    setupRoleMembership(initialization, setupRecord);
+    final List<RoleRecord> defaultRoleMemberships =
+        PlatformDefaultEntities.setupRoleMemberships(initialization.getDefaultRoles());
+    deduplicate(defaultRoleMemberships, customRoleMembers).forEach(setupRecord::addRoleMember);
     return setupRecord;
   }
 
-  private static void setupRoleMembership(
-      final InitializationConfiguration initialization, final IdentitySetupRecord setupRecord) {
-    for (final var assignmentsForRole : initialization.getDefaultRoles().entrySet()) {
-      final var roleId = assignmentsForRole.getKey();
-      for (final var assignmentsForEntityType : assignmentsForRole.getValue().entrySet()) {
-        final var entityType =
-            switch (assignmentsForEntityType.getKey().toLowerCase()) {
-              case "users" -> EntityType.USER;
-              case "clients" -> EntityType.CLIENT;
-              // when using config via env variables,
-              // spring will convert MAPPING_RULES to mapping.rules
-              case "mappingrules", "mapping-rules", "mapping.rules" -> EntityType.MAPPING_RULE;
-              case "groups" -> EntityType.GROUP;
-              case "roles" -> EntityType.ROLE;
-              default ->
-                  throw new IllegalStateException(
-                      "Unexpected entity type for role membership: %s"
-                          .formatted(assignmentsForEntityType.getKey()));
-            };
-        for (final var entityId : assignmentsForEntityType.getValue()) {
-          setupRecord.addRoleMember(
-              new RoleRecord().setRoleId(roleId).setEntityType(entityType).setEntityId(entityId));
-        }
-      }
-    }
+  private static Stream<RoleRecord> deduplicate(
+      final List<RoleRecord> defaultRoleMemberships, final List<RoleRecord> customRoleMembers) {
+    return Stream.of(defaultRoleMemberships, customRoleMembers)
+        .flatMap(Collection::stream)
+        .distinct();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
@@ -150,6 +150,11 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
         .getGroups()
         .forEach(
             group -> groupConfigurer.configureMembers(group).forEach(setupRecord::addGroupMember));
+    initialization
+        .getGroups()
+        .forEach(
+            group ->
+                groupConfigurer.configureRoleMembers(group).forEach(setupRecord::addRoleMember));
 
     initialization
         .getRoles()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/PlatformDefaultEntities.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/PlatformDefaultEntities.java
@@ -23,6 +23,10 @@ import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -44,6 +48,28 @@ public class PlatformDefaultEntities {
     setupConnectorsRole(setupRecord);
     setupAppIntegrationsRole(setupRecord);
     setupTaskWorkerRole(setupRecord);
+  }
+
+  static List<RoleRecord> setupRoleMemberships(
+      final Map<String, Map<String, Collection<String>>> defaultRoles) {
+
+    final List<RoleRecord> roleRecords = new ArrayList<>();
+    // this is not using an immutable stream/map/toList approach by trail and choice,
+    // as iterating maps through streams required using EntrySets and is much less readable.
+    defaultRoles.forEach(
+        (defaultRole, groupedMembers) ->
+            groupedMembers.forEach(
+                (memberType, members) ->
+                    members.stream()
+                        .map(
+                            entityId ->
+                                new RoleRecord()
+                                    .setRoleId(defaultRole)
+                                    .setEntityType(getEntityType(memberType))
+                                    .setEntityId(entityId))
+                        .forEach(roleRecords::add)));
+
+    return roleRecords;
   }
 
   private static void setupReadOnlyAdminRole(final IdentitySetupRecord setupRecord) {
@@ -238,5 +264,20 @@ public class PlatformDefaultEntities {
             .setTenantId(DEFAULT_TENANT_ID)
             .setEntityType(EntityType.ROLE)
             .setEntityId(taskWorkerRoleId));
+  }
+
+  private static EntityType getEntityType(final String key) {
+    return switch (key.toLowerCase()) {
+      case "users" -> EntityType.USER;
+      case "clients" -> EntityType.CLIENT;
+      // when using config via env variables,
+      // spring will convert MAPPING_RULES to mapping.rules
+      case "mappingrules", "mapping-rules", "mapping.rules" -> EntityType.MAPPING_RULE;
+      case "groups" -> EntityType.GROUP;
+      case "roles" -> EntityType.ROLE;
+      default ->
+          throw new IllegalStateException(
+              "Unexpected entity type for role membership: %s".formatted(key));
+    };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/RoleConfigurer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/RoleConfigurer.java
@@ -39,15 +39,14 @@ public class RoleConfigurer implements EntityInitializationConfigurer<Configured
     return Either.right(mapToRecord(role));
   }
 
-  public List<RoleRecord> configureMembers(final ConfiguredRole role) {
+  public Stream<RoleRecord> configureMembers(final ConfiguredRole role) {
     final String roleId = role.roleId();
     return Stream.of(
             mapToTenantMembers(roleId, role.users(), EntityType.USER),
             mapToTenantMembers(roleId, role.groups(), EntityType.GROUP),
             mapToTenantMembers(roleId, role.mappingRules(), EntityType.MAPPING_RULE),
             mapToTenantMembers(roleId, role.clients(), EntityType.CLIENT))
-        .flatMap(s -> s)
-        .toList();
+        .flatMap(s -> s);
   }
 
   private static Stream<RoleRecord> mapToTenantMembers(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/GroupConfigurerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/GroupConfigurerTest.java
@@ -12,7 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.security.configuration.ConfiguredGroup;
 import io.camunda.security.validation.GroupValidator;
 import io.camunda.security.validation.IdentifierValidator;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.util.Either;
 import java.util.Collections;
 import java.util.List;
@@ -20,6 +22,12 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 class GroupConfigurerTest {
+
+  public static final String TEST_GROUP_ID = "foo";
+  public static final String TEST_USERNAME = "user-a";
+  public static final String TEST_ROLE_ID = "test-role";
+  public static final String TEST_MAPPING_RULE_ID = "mapping-rule-a";
+  public static final String TEST_CLIENT_ID = "client-a";
 
   private static final ConfiguredGroup MISSING_GROUP_ID =
       new ConfiguredGroup(
@@ -30,15 +38,16 @@ class GroupConfigurerTest {
           Collections.emptyList(),
           Collections.emptyList(),
           Collections.emptyList());
+
   private static final ConfiguredGroup VALID_GROUP =
       new ConfiguredGroup(
-          "foo",
+          TEST_GROUP_ID,
           "Foo",
           "",
-          Collections.emptyList(),
-          Collections.emptyList(),
-          Collections.emptyList(),
-          Collections.emptyList());
+          List.of(TEST_USERNAME),
+          List.of(TEST_ROLE_ID),
+          List.of(TEST_MAPPING_RULE_ID),
+          List.of(TEST_CLIENT_ID));
 
   private static final GroupValidator VALIDATOR =
       new GroupValidator(new IdentifierValidator(Pattern.compile(".*"), Pattern.compile(".*")));
@@ -61,6 +70,37 @@ class GroupConfigurerTest {
 
     // then:
     assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldCorrectlyMapMemberships() {
+    // when:
+    final List<GroupRecord> members = CONFIGURER.configureMembers(VALID_GROUP);
+    final List<RoleRecord> roleMembers = CONFIGURER.configureRoleMembers(VALID_GROUP);
+
+    // then:
+    assertThat(members).hasSize(3);
+    assertThat(members)
+        .containsExactlyInAnyOrder(
+            new GroupRecord()
+                .setGroupId(TEST_GROUP_ID)
+                .setEntityId(TEST_USERNAME)
+                .setEntityType(EntityType.USER),
+            new GroupRecord()
+                .setGroupId(TEST_GROUP_ID)
+                .setEntityId(TEST_MAPPING_RULE_ID)
+                .setEntityType(EntityType.MAPPING_RULE),
+            new GroupRecord()
+                .setGroupId(TEST_GROUP_ID)
+                .setEntityId(TEST_CLIENT_ID)
+                .setEntityType(EntityType.CLIENT));
+    assertThat(roleMembers).hasSize(1);
+    assertThat(roleMembers)
+        .containsExactlyInAnyOrder(
+            new RoleRecord()
+                .setRoleId(TEST_ROLE_ID)
+                .setEntityId(TEST_GROUP_ID)
+                .setEntityType(EntityType.GROUP));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/GroupConfigurerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/GroupConfigurerTest.java
@@ -23,11 +23,11 @@ import org.junit.jupiter.api.Test;
 
 class GroupConfigurerTest {
 
-  public static final String TEST_GROUP_ID = "foo";
-  public static final String TEST_USERNAME = "user-a";
-  public static final String TEST_ROLE_ID = "test-role";
-  public static final String TEST_MAPPING_RULE_ID = "mapping-rule-a";
-  public static final String TEST_CLIENT_ID = "client-a";
+  private static final String TEST_GROUP_ID = "foo";
+  private static final String TEST_USERNAME = "user-a";
+  private static final String TEST_ROLE_ID = "test-role";
+  private static final String TEST_MAPPING_RULE_ID = "mapping-rule-a";
+  private static final String TEST_CLIENT_ID = "client-a";
 
   private static final ConfiguredGroup MISSING_GROUP_ID =
       new ConfiguredGroup(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
fix assigning roles to groups in initialization

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48856
