### PR TITLE
[Backport stable/8.9] test: fix visual regression tests

### DIFF
--- a/operate/client/e2e-playwright/visual/processes.spec.ts
+++ b/operate/client/e2e-playwright/visual/processes.spec.ts
@@ -218,6 +218,7 @@ test.describe('processes page', () => {
     });
 
     await expect(processesPage.processInstancesTable).toBeVisible();
+    await expect(page.getByTestId(/^state-overlay/).first()).toBeVisible();
 
     await expect(page).toHaveScreenshot();
   });


### PR DESCRIPTION
# Description
Backport of #48967 to `stable/8.9`.

relates to 