### PR TITLE
[Backport stable/8.9] fix: revert MI token deduplication when moving outside MI scope

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -458,16 +458,19 @@ public final class ProcessInstanceModificationModifyProcessor
     // collect terminate-by-id instructions, add key instructions to final list
     final var terminateInstructionIds = new HashSet<String>();
     final var terminateInstanceKeys = new HashSet<Long>();
-    handleTerminateByKeyInstructions(
-        terminateInstructionsInput,
-        finalTerminateInstructions,
-        terminateInstanceKeys,
-        terminateInstructionIds);
+    terminateInstructionsInput.forEach(
+        instruction -> {
+          if (instruction.getElementInstanceKey() > 0) {
+            finalTerminateInstructions.add(instruction);
+            terminateInstanceKeys.add(instruction.getElementInstanceKey());
+          } else {
+            terminateInstructionIds.add(instruction.getElementId());
+          }
+        });
 
     // iterate over all active element instances, including child instances
     // use a queue to iterate over the descendants, recursion might lead to StackOverflow
     if (!moveInstructions.isEmpty() || !terminateInstructionIds.isEmpty()) {
-      final var activatedScopes = new HashSet<String>();
       final var elementInstances =
           new ArrayDeque<>(elementInstanceState.getChildren(processInstanceKey));
       while (!elementInstances.isEmpty()) {
@@ -479,12 +482,17 @@ public final class ProcessInstanceModificationModifyProcessor
           final var moveInstruction = moveInstructions.get(elementId);
           final var ancestorScopeKey =
               determineAncestorScopeKey(moveInstruction, elementInstance.getParentKey(), process);
-          final var shouldActivate =
-              shouldActivateElement(
-                  elementInstance, activatedScopes, ancestorScopeKey, moveInstruction);
-          if (shouldActivate) {
-            addActivateInstruction(finalActivateInstructions, moveInstruction, ancestorScopeKey);
-          }
+          final var activateInstruction =
+              new ProcessInstanceModificationActivateInstruction()
+                  .setElementId(moveInstruction.getTargetElementId())
+                  .setAncestorScopeKey(ancestorScopeKey);
+          moveInstruction
+              .getVariableInstructions()
+              .forEach(
+                  vi ->
+                      activateInstruction.addVariableInstruction(
+                          (ProcessInstanceModificationVariableInstruction) vi));
+          finalActivateInstructions.add(activateInstruction);
           // terminate source element instance
           finalTerminateInstructions.add(
               new ProcessInstanceModificationTerminateInstruction()
@@ -510,61 +518,6 @@ public final class ProcessInstanceModificationModifyProcessor
     }
   }
 
-  private static void addActivateInstruction(
-      final List<ProcessInstanceModificationActivateInstructionValue> finalActivateInstructions,
-      final ProcessInstanceModificationMoveInstructionValue moveInstruction,
-      final long ancestorScopeKey) {
-    final var activateInstruction =
-        new ProcessInstanceModificationActivateInstruction()
-            .setElementId(moveInstruction.getTargetElementId())
-            .setAncestorScopeKey(ancestorScopeKey);
-    moveInstruction
-        .getVariableInstructions()
-        .forEach(
-            vi ->
-                activateInstruction.addVariableInstruction(
-                    (ProcessInstanceModificationVariableInstruction) vi));
-    finalActivateInstructions.add(activateInstruction);
-  }
-
-  /**
-   * Check whether this element instance is inside a multi-instance body. If so, activate only when
-   * the resolved target ancestor scope and the move instruction's source haven't been used yet.
-   *
-   * <p>This avoids creating one activate per child when moving out of an MI sub-process while still
-   * allowing one activate per source scope when moving inside it.
-   */
-  private boolean shouldActivateElement(
-      final ElementInstance elementInstance,
-      final HashSet<String> activatedMiBodyAncestorAndScopeKeys,
-      final long ancestorScopeKey,
-      final ProcessInstanceModificationMoveInstructionValue moveInstruction) {
-    final var miBodyAncestorKey = findMiBodyAncestorKey(elementInstance.getParentKey());
-    return miBodyAncestorKey < 0
-        || activatedMiBodyAncestorAndScopeKeys.add(
-            miBodyAncestorKey
-                + ":"
-                + ancestorScopeKey
-                + ":"
-                + moveInstruction.getSourceElementId());
-  }
-
-  private static void handleTerminateByKeyInstructions(
-      final List<ProcessInstanceModificationTerminateInstructionValue> terminateInstructionsInput,
-      final List<ProcessInstanceModificationTerminateInstructionValue> finalTerminateInstructions,
-      final HashSet<Long> terminateInstanceKeys,
-      final HashSet<String> terminateInstructionIds) {
-    terminateInstructionsInput.forEach(
-        instruction -> {
-          if (instruction.getElementInstanceKey() > 0) {
-            finalTerminateInstructions.add(instruction);
-            terminateInstanceKeys.add(instruction.getElementInstanceKey());
-          } else {
-            terminateInstructionIds.add(instruction.getElementId());
-          }
-        });
-  }
-
   private void mapMoveInstructionsByInstanceKey(
       final List<ProcessInstanceModificationMoveInstructionValue> moveInstructions,
       final List<ProcessInstanceModificationActivateInstructionValue> finalActivateInstructions,
@@ -577,7 +530,17 @@ public final class ProcessInstanceModificationModifyProcessor
       final var ancestorScopeKey =
           determineAncestorScopeKey(moveInstruction, elementInstance.getParentKey(), process);
 
-      addActivateInstruction(finalActivateInstructions, moveInstruction, ancestorScopeKey);
+      final var activateInstruction =
+          new ProcessInstanceModificationActivateInstruction()
+              .setElementId(moveInstruction.getTargetElementId())
+              .setAncestorScopeKey(ancestorScopeKey);
+      moveInstruction
+          .getVariableInstructions()
+          .forEach(
+              vi ->
+                  activateInstruction.addVariableInstruction(
+                      (ProcessInstanceModificationVariableInstruction) vi));
+      finalActivateInstructions.add(activateInstruction);
       // terminate source element instance
       finalTerminateInstructions.add(
           new ProcessInstanceModificationTerminateInstruction()
@@ -684,29 +647,6 @@ public final class ProcessInstanceModificationModifyProcessor
     // No matching ancestor found - return -1 to let the activation logic handle it
     // (it will create new flow scope instances as needed)
     return ElementActivationBehavior.NO_ANCESTOR_SCOPE_KEY;
-  }
-
-  /**
-   * Walks up the ancestor chain from the given key and returns the key of the first ancestor whose
-   * element type is {@link BpmnElementType#MULTI_INSTANCE_BODY}, or {@code -1} if none is found.
-   *
-   * <p>This is used to deduplicate activate instructions when a source element lives inside a
-   * multi-instance sub-process: all sibling instances share the same MI body ancestor, so only one
-   * activate instruction should be produced for the whole group.
-   */
-  private long findMiBodyAncestorKey(final long startKey) {
-    var currentKey = startKey;
-    while (currentKey > 0) {
-      final var instance = elementInstanceState.getInstance(currentKey);
-      if (instance == null) {
-        break;
-      }
-      if (instance.getValue().getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY) {
-        return currentKey;
-      }
-      currentKey = instance.getParentKey();
-    }
-    return -1;
   }
 
   private Either<Rejection, ?> validateCommand(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -2238,6 +2238,254 @@ public class ModifyProcessInstanceTest {
   }
 
   @Test
+  public void shouldMoveAllMultiInstanceElementsOutOfSubprocessByIds() {
+    // given a multi-instance sub-process with a user task
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("subProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..5 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .userTask("A")
+                .zeebeUserTask()
+                .endEvent()
+                .subProcessDone()
+                .userTask("B")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElements("A", "B")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then the multi-instance sub-process is terminated and each MI child creates a token at B
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("subProcess", "A", "B"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            tuple(
+                BpmnElementType.MULTI_INSTANCE_BODY,
+                "subProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "subProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "subProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "subProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "subProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "subProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.MULTI_INSTANCE_BODY,
+                "subProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldMoveAllMultiInstanceElementsOutOfNestedSubprocessByIds() {
+    // given a parent sub-process containing a multi-instance inner sub-process with a user task
+    // "A", followed by user task "B" inside the parent, and user task "C" outside the parent.
+    // The move goes from "A" to "C", two nesting layers up.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("parentSubProcess")
+                .embeddedSubProcess()
+                .startEvent()
+                .subProcess("innerSubProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..5 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .userTask("A")
+                .zeebeUserTask()
+                .endEvent()
+                .subProcessDone()
+                .userTask("B")
+                .zeebeUserTask()
+                .endEvent()
+                .subProcessDone()
+                .userTask("C")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElements("A", "C")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then the multi-instance body and parent sub-process are terminated and each MI child
+    // creates a token at C
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("parentSubProcess", "innerSubProcess", "A", "C"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "parentSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.MULTI_INSTANCE_BODY,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.MULTI_INSTANCE_BODY,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "parentSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
   public void shouldMoveAllMultiInstanceParentElementsByIds() {
     // given a multi-instance with 5 elements
     ENGINE
@@ -2321,6 +2569,277 @@ public class ModifyProcessInstanceTest {
             tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldMoveAllOutsideOfMiSubprocessForDifferentTargets() {
+    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
+    // active simultaneously in each MI iteration
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("subProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .parallelGateway("fork")
+                .userTask("A")
+                .zeebeUserTask()
+                .endEvent("endA")
+                .moveToLastGateway()
+                .userTask("B")
+                .zeebeUserTask()
+                .endEvent("endB")
+                .subProcessDone()
+                .userTask("C")
+                .zeebeUserTask()
+                .userTask("D")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when - issue a single modification with two move instructions: A and B are different
+    // elements both inside the same MI body, moved to different target elements
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElements("A", "C")
+        .moveElements("B", "D")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - C and D are each activated for every MI child instance (3 times each)
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B", "C", "D"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            // A and B are each activated three times during initial MI sub-process start
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // all three MI instances of A and B are terminated by the modification
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            // C and D are each activated 3 times (once per MI child instance)
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // C and D are terminated by the cancel
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldMoveAllOutsideOfMiSubprocessForSameTargetMultipleTimes() {
+    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
+    // active simultaneously in each MI iteration
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("subProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .parallelGateway("fork")
+                .userTask("A")
+                .zeebeUserTask()
+                .endEvent("endA")
+                .moveToLastGateway()
+                .userTask("B")
+                .zeebeUserTask()
+                .endEvent("endB")
+                .subProcessDone()
+                .userTask("C")
+                .zeebeUserTask()
+                .userTask("D")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when - issue a single modification with two move instructions: A and B are different
+    // elements both inside the same MI body, moved to the same target element
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElements("A", "C")
+        .moveElements("B", "C")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - C is activated for every MI child instance of both A and B (6 times total)
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B", "C", "D"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            // A and B are each activated three times during initial MI sub-process start
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // all three MI instances of A and B are terminated by the modification
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            // C is activated 6 times (3 per move instruction × 2 instructions for A→C and B→C)
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // all C's are terminated by the cancel
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldMoveAllInsideMiSubprocessForDifferentTargets() {
+    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
+    // active simultaneously in each MI iteration
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("subProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .parallelGateway("fork")
+                .userTask("A")
+                .zeebeUserTask()
+                .userTask("C")
+                .zeebeUserTask()
+                .endEvent("endAC")
+                .moveToLastGateway()
+                .userTask("B")
+                .zeebeUserTask()
+                .userTask("D")
+                .zeebeUserTask()
+                .endEvent("endBD")
+                .subProcessDone()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when - issue a single modification with two move instructions: A and B are different
+    // elements both inside the same MI body, moved to different target elements within the same
+    // scope
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElementsWithSourceParentScope("A", "C")
+        .moveElementsWithSourceParentScope("B", "D")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - C and D are each activated for every MI child instance (3 times each)
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B", "C", "D"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            // A and B are each activated three times during initial MI sub-process start
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // all three MI instances of A and B are terminated by the modification
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            // C and D are each activated 3 times, once per MI child instance
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // C and D are terminated by the cancel
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -2189,7 +2189,7 @@ public class ModifyProcessInstanceTest {
                         mi.parallel()
                             .zeebeInputCollectionExpression("=for i in 1..5 return i")
                             .multiInstanceDone())
-                .userTask("B", u -> u.zeebeAssignee("foo"))
+                .userTask("B")
                 .zeebeUserTask()
                 .endEvent()
                 .done())
@@ -2203,7 +2203,6 @@ public class ModifyProcessInstanceTest {
         .modification()
         .moveElements("A", "B")
         .modify();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
 
     // then only the multi-instance parent creates a new token at the target
     assertThat(
@@ -2212,8 +2211,8 @@ public class ModifyProcessInstanceTest {
                     ProcessInstanceIntent.ELEMENT_TERMINATED,
                     ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceTerminated()
-                .withElementIdIn("A", "B"))
+                .withElementIdIn("A", "B")
+                .limit(13L))
         .extracting(
             r ->
                 tuple(
@@ -2233,240 +2232,7 @@ public class ModifyProcessInstanceTest {
             tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(
                 BpmnElementType.MULTI_INSTANCE_BODY, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED));
-  }
-
-  @Test
-  public void shouldMoveAllMultiInstanceElementsOutOfSubprocessByIds() {
-    // given a multi-instance sub-process with a user task
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .subProcess("subProcess")
-                .multiInstance(
-                    mi ->
-                        mi.parallel()
-                            .zeebeInputCollectionExpression("=for i in 1..5 return i")
-                            .multiInstanceDone())
-                .embeddedSubProcess()
-                .startEvent()
-                .userTask("A")
-                .zeebeUserTask()
-                .endEvent()
-                .subProcessDone()
-                .userTask("B")
-                .zeebeUserTask()
-                .endEvent()
-                .done())
-        .deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .moveElements("A", "B")
-        .modify();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
-
-    // then only the multi-instance parent creates a new token at the target
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withIntents(
-                    ProcessInstanceIntent.ELEMENT_TERMINATED,
-                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceTerminated()
-                .withElementIdIn("subProcess", "A", "B"))
-        .extracting(
-            r ->
-                tuple(
-                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
-        .containsExactly(
-            tuple(
-                BpmnElementType.MULTI_INSTANCE_BODY,
-                "subProcess",
-                ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS, "subProcess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "subProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "subProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "subProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "subProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "subProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.MULTI_INSTANCE_BODY,
-                "subProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED));
-  }
-
-  @Test
-  public void shouldMoveAllMultiInstanceElementsOutOfNestedSubprocessByIds() {
-    // given a parent sub-process containing a multi-instance inner sub-process with a user task
-    // "A", followed by user task "B" inside the parent, and user task "C" outside the parent.
-    // The move goes from "A" to "C", two nesting layers up.
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .subProcess("parentSubProcess")
-                .embeddedSubProcess()
-                .startEvent()
-                .subProcess("innerSubProcess")
-                .multiInstance(
-                    mi ->
-                        mi.parallel()
-                            .zeebeInputCollectionExpression("=for i in 1..5 return i")
-                            .multiInstanceDone())
-                .embeddedSubProcess()
-                .startEvent()
-                .userTask("A")
-                .zeebeUserTask()
-                .endEvent()
-                .subProcessDone()
-                .userTask("B")
-                .zeebeUserTask()
-                .endEvent()
-                .subProcessDone()
-                .userTask("C")
-                .zeebeUserTask()
-                .endEvent()
-                .done())
-        .deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .moveElements("A", "C")
-        .modify();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
-
-    // then the multi-instance body and parent sub-process are terminated and a single "C" is
-    // activated at the process level
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withIntents(
-                    ProcessInstanceIntent.ELEMENT_TERMINATED,
-                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceTerminated()
-                .withElementIdIn("parentSubProcess", "innerSubProcess", "A", "C"))
-        .extracting(
-            r ->
-                tuple(
-                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
-        .containsExactly(
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "parentSubProcess",
-                ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.MULTI_INSTANCE_BODY,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.MULTI_INSTANCE_BODY,
-                "innerSubProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(
-                BpmnElementType.SUB_PROCESS,
-                "parentSubProcess",
-                ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED));
   }
 
   @Test
@@ -2505,7 +2271,6 @@ public class ModifyProcessInstanceTest {
         .modification()
         .moveElements("A", "B")
         .modify();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
 
     // then both multi-instance parents create a new token at the target
     assertThat(
@@ -2514,8 +2279,8 @@ public class ModifyProcessInstanceTest {
                     ProcessInstanceIntent.ELEMENT_TERMINATED,
                     ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceTerminated()
-                .withElementIdIn("A", "B"))
+                .withElementIdIn("A", "B")
+                .limit(26L))
         .extracting(
             r ->
                 tuple(
@@ -2550,263 +2315,7 @@ public class ModifyProcessInstanceTest {
             tuple(
                 BpmnElementType.MULTI_INSTANCE_BODY, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED));
-  }
-
-  @Test
-  public void shouldMoveAllOutsideOfMiSubprocessForDifferentTargets() {
-    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
-    // active simultaneously in each MI iteration
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .subProcess("subProcess")
-                .multiInstance(
-                    mi ->
-                        mi.parallel()
-                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
-                            .multiInstanceDone())
-                .embeddedSubProcess()
-                .startEvent()
-                .parallelGateway("fork")
-                .userTask("A")
-                .zeebeUserTask()
-                .endEvent("endA")
-                .moveToLastGateway()
-                .userTask("B")
-                .zeebeUserTask()
-                .endEvent("endB")
-                .subProcessDone()
-                .userTask("C")
-                .zeebeUserTask()
-                .userTask("D")
-                .zeebeUserTask()
-                .endEvent()
-                .done())
-        .deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // when - issue a single modification with two move instructions: A and B are different
-    // elements both inside the same MI body, moved to different target elements
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .moveElements("A", "C")
-        .moveElements("B", "D")
-        .modify();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
-
-    // then - both C and D should each be activated exactly once
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withIntents(
-                    ProcessInstanceIntent.ELEMENT_TERMINATED,
-                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceTerminated()
-                .withElementIdIn("A", "B", "C", "D"))
-        .extracting(
-            r ->
-                tuple(
-                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
-        .containsExactly(
-            // A and B are each activated three times during initial MI sub-process start
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            // all three MI instances of A and B are terminated by the modification
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            // C and D are each activated exactly once despite 3 matching MI instances
-            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            // C and D are terminated by the cancel
-            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
-  }
-
-  @Test
-  public void shouldMoveAllOutsideOfMiSubprocessForSameTargetMultipleTimes() {
-    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
-    // active simultaneously in each MI iteration
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .subProcess("subProcess")
-                .multiInstance(
-                    mi ->
-                        mi.parallel()
-                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
-                            .multiInstanceDone())
-                .embeddedSubProcess()
-                .startEvent()
-                .parallelGateway("fork")
-                .userTask("A")
-                .zeebeUserTask()
-                .endEvent("endA")
-                .moveToLastGateway()
-                .userTask("B")
-                .zeebeUserTask()
-                .endEvent("endB")
-                .subProcessDone()
-                .userTask("C")
-                .zeebeUserTask()
-                .userTask("D")
-                .zeebeUserTask()
-                .endEvent()
-                .done())
-        .deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // when - issue a single modification with two move instructions: A and B are different
-    // elements both inside the same MI body, moved to different target elements
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .moveElements("A", "C")
-        .moveElements("B", "C")
-        .modify();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
-
-    // then - C should be activated twice (once for A and once for B), D should not be activated
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withIntents(
-                    ProcessInstanceIntent.ELEMENT_TERMINATED,
-                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceTerminated()
-                .withElementIdIn("A", "B", "C", "D"))
-        .extracting(
-            r ->
-                tuple(
-                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
-        .containsExactly(
-            // A and B are each activated three times during initial MI sub-process start
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            // all three MI instances of A and B are terminated by the modification
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            // C is activated twice despite 3 matching MI instances and two move instructions
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            // All C's are terminated by the cancel
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
-  }
-
-  @Test
-  public void shouldMoveAllInsideMiSubprocessForDifferentTargets() {
-    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
-    // active simultaneously in each MI iteration
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .subProcess("subProcess")
-                .multiInstance(
-                    mi ->
-                        mi.parallel()
-                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
-                            .multiInstanceDone())
-                .embeddedSubProcess()
-                .startEvent()
-                .parallelGateway("fork")
-                .userTask("A")
-                .zeebeUserTask()
-                .userTask("C")
-                .zeebeUserTask()
-                .endEvent("endAC")
-                .moveToLastGateway()
-                .userTask("B")
-                .zeebeUserTask()
-                .userTask("D")
-                .zeebeUserTask()
-                .endEvent("endBD")
-                .subProcessDone()
-                .endEvent()
-                .done())
-        .deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // when - issue a single modification with two move instructions: A and B are different
-    // elements both inside the same MI body, moved to different target elements
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .moveElementsWithSourceParentScope("A", "C")
-        .moveElementsWithSourceParentScope("B", "D")
-        .modify();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
-
-    // then - C should be activated twice (once for A and once for B), D should not be activated
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withIntents(
-                    ProcessInstanceIntent.ELEMENT_TERMINATED,
-                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceTerminated()
-                .withElementIdIn("A", "B", "C", "D"))
-        .extracting(
-            r ->
-                tuple(
-                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
-        .containsExactly(
-            // A and B are each activated three times during initial MI sub-process start
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            // all three MI instances of A and B are terminated by the modification
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            // C and D are each activated 3 times, matching sibling MI instances
-            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            // C and D are terminated by the cancel
-            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -2203,16 +2203,17 @@ public class ModifyProcessInstanceTest {
         .modification()
         .moveElements("A", "B")
         .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
 
-    // then only the multi-instance parent creates a new token at the target
+    // then the multi-instance body is terminated and a single token is created at B
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withIntents(
                     ProcessInstanceIntent.ELEMENT_TERMINATED,
                     ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementIdIn("A", "B")
-                .limit(13L))
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B"))
         .extracting(
             r ->
                 tuple(
@@ -2232,7 +2233,8 @@ public class ModifyProcessInstanceTest {
             tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(
                 BpmnElementType.MULTI_INSTANCE_BODY, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
 
   @Test
@@ -2271,16 +2273,17 @@ public class ModifyProcessInstanceTest {
         .modification()
         .moveElements("A", "B")
         .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
 
-    // then both multi-instance parents create a new token at the target
+    // then both multi-instance bodies are terminated and each creates a new token at B
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withIntents(
                     ProcessInstanceIntent.ELEMENT_TERMINATED,
                     ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementIdIn("A", "B")
-                .limit(26L))
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B"))
         .extracting(
             r ->
                 tuple(
@@ -2315,7 +2318,9 @@ public class ModifyProcessInstanceTest {
             tuple(
                 BpmnElementType.MULTI_INSTANCE_BODY, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #48813 to `stable/8.9`.

relates to #48527