### PR TITLE
[Backport stable/8.9] fix: add missing junit-vintage-engine to gateway and msgpack-value

### DIFF
--- a/.ci/scripts/ci/check-junit-vintage-engine.sh
+++ b/.ci/scripts/ci/check-junit-vintage-engine.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Checks that every Maven module with both junit:junit and junit-jupiter-engine
+# also has junit-vintage-engine. Without it, JUnit 4 tests are silently skipped
+# because the JUnit Platform provider doesn't discover them.
+set -euo pipefail
+
+ROOT_DIR="${1:-.}"
+FAILED=0
+
+while IFS= read -r -d '' pom; do
+  has_junit4=$(grep -c '<artifactId>junit</artifactId>' "$pom" || true)
+  has_jupiter_engine=$(grep -c '<artifactId>junit-jupiter-engine</artifactId>' "$pom" || true)
+  has_vintage_engine=$(grep -c '<artifactId>junit-vintage-engine</artifactId>' "$pom" || true)
+
+  if [[ "$has_junit4" -gt 0 && "$has_jupiter_engine" -gt 0 && "$has_vintage_engine" -eq 0 ]]; then
+    echo "ERROR: $pom has junit:junit and junit-jupiter-engine but is missing junit-vintage-engine." >&2
+    echo "  JUnit 4 tests will be silently skipped. Add junit-vintage-engine as a test dependency." >&2
+    FAILED=1
+  fi
+done < <(find "$ROOT_DIR" -name pom.xml -not -path '*/target/*' -print0)
+
+if [[ "$FAILED" -eq 1 ]]; then
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,27 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  junit-vintage-check:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    name: "Lint / JUnit Vintage Engine"
+    needs: [ detect-changes ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for missing junit-vintage-engine
+        run: .ci/scripts/ci/check-junit-vintage-engine.sh .
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   java-checks:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "Java Checks"
@@ -1394,6 +1415,7 @@ jobs:
       - identity-tests
       - integration-tests
       - java-checks
+      - junit-vintage-check
       - maven-spotless-linter
       - openapi-lint
       - operate-ci

--- a/zeebe/gateway/pom.xml
+++ b/zeebe/gateway/pom.xml
@@ -135,6 +135,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- required to run both junit4 and junit 5 as test engines side by side -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -48,7 +48,7 @@ public final class GatewayCfgTest {
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(5), Duration.ofSeconds(30), 6, Duration.ofSeconds(1))));
+                    Duration.ofSeconds(5), Duration.ofSeconds(30), 6, Duration.ofSeconds(5))));
     CUSTOM_CFG
         .getSecurity()
         .setEnabled(true)
@@ -174,8 +174,8 @@ public final class GatewayCfgTest {
     setEnv("zeebe.gateway.filters.0.id", "overwrittenFilter");
     setEnv("zeebe.gateway.filters.0.className", "OverwrittenFilter");
     setEnv("zeebe.gateway.filters.0.jarPath", "./overwrittenFilter.jar");
-    setEnv("zeebe.gateway.network.socketSendBuffer", "3MB");
-    setEnv("zeebe.gateway.network.socketReceiveBuffer", "3MB");
+    setEnv("zeebe.gateway.cluster.socketSendBuffer", "3MB");
+    setEnv("zeebe.gateway.cluster.socketReceiveBuffer", "3MB");
 
     final GatewayCfg expected = new GatewayCfg();
     expected
@@ -198,7 +198,7 @@ public final class GatewayCfgTest {
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(5), Duration.ofSeconds(5), 4, Duration.ofSeconds(1))));
+                    Duration.ofSeconds(5), Duration.ofSeconds(5), 4, Duration.ofSeconds(5))));
     expected.getThreads().setManagementThreads(32);
     expected
         .getSecurity()

--- a/zeebe/msgpack-value/pom.xml
+++ b/zeebe/msgpack-value/pom.xml
@@ -43,6 +43,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- required to run both junit4 and junit 5 as test engines side by side -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>


### PR DESCRIPTION
# Description
Backport of #48980 to `stable/8.9`.

relates to 