### PR TITLE
ci: switch check-licenses runner to non-preemptible longrunning

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -29,7 +29,7 @@ jobs:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
-    runs-on: gcp-core-16-default
+    runs-on: gcp-core-16-longrunning
     # Skip analysis on fork PRs as they cannot access FOSSA due to lack of credentials
     if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.


### PR DESCRIPTION
## Description

Switch `check-licenses.yml` workflow runner from `gcp-core-16-default` (preemptible) to `gcp-core-16-longrunning` (non-preemptible) to improve reliability. 

Related Slack thread: https://camunda.slack.com/archives/C07STDFAX09/p1742289534988629.

