### PR TITLE
fix: use oneOf for ScopeKey

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -315,6 +315,7 @@
             <!-- map complex String schemas to String -->
             <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
             <typeMapping>ResourceKey=String</typeMapping>
+            <typeMapping>ScopeKey=String</typeMapping>
             <!-- map specific filter properties to basic filter types -->
             <typeMapping>AuditLogEntityKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>AuditLogKeyFilterProperty=BasicStringFilterProperty</typeMapping>

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -90,6 +90,7 @@
                 <!-- map complex String schemas to String -->
                 <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
                 <typeMapping>ResourceKey=String</typeMapping>
+                <typeMapping>ScopeKey=String</typeMapping>
                 <typeMapping>ElementInstanceKey=String</typeMapping>
                 <!-- map specific filter properties to basic filter types -->
                 <typeMapping>AuditLogEntityKeyFilterProperty=BasicStringFilterProperty</typeMapping>
@@ -145,6 +146,7 @@
                 <!-- map complex String schemas to String -->
                 <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
                 <typeMapping>ResourceKey=String</typeMapping>
+                <typeMapping>ScopeKey=String</typeMapping>
                 <typeMapping>ElementInstanceKey=String</typeMapping>
                 <!-- map specific filter properties to String for equality behavior -->
                 <typeMapping>AuditLogEntityKeyFilterProperty=String</typeMapping>

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -66,6 +66,8 @@ components:
       description: |
         System-generated key for a scope. A scope can hold variables and represents either an
         element instance in a BPMN process or the process instance itself.
+      type: string
+      format: ScopeKey
       x-semantic-type: ScopeKey
       example: "2251799813683890"
       oneOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -66,10 +66,8 @@ components:
       description: |
         System-generated key for a scope. A scope can hold variables and represents either an
         element instance in a BPMN process or the process instance itself.
-      format: ScopeKey
       x-semantic-type: ScopeKey
       example: "2251799813683890"
-      type: string
       oneOf:
         - $ref: '#/components/schemas/ProcessInstanceKey'
         - $ref: '#/components/schemas/ElementInstanceKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -70,8 +70,9 @@ components:
       x-semantic-type: ScopeKey
       example: "2251799813683890"
       type: string
-      allOf:
-        - $ref: '#/components/schemas/LongKey'
+      oneOf:
+        - $ref: '#/components/schemas/ProcessInstanceKey'
+        - $ref: '#/components/schemas/ElementInstanceKey'
 
     IncidentKey:
       description: System-generated key for a incident.


### PR DESCRIPTION
## Description

Change `ScopeKey` from a standalone branded key type to a `oneOf` union of `ElementInstanceKey | ProcessInstanceKey`.

### Problem

A `scopeKey` can be either a process instance key (for process-level variables) or an element instance key (for local variables). However, the current schema defines `ScopeKey` as its own independent type extending `LongKey`:

```yaml
ScopeKey:
  type: string
  allOf:
    - $ref: "#/components/schemas/LongKey"
```

In typed SDK clients (e.g. TypeScript), this produces a nominally distinct branded type that is incompatible with `ElementInstanceKey` and `ProcessInstanceKey`. Users cannot compare a `scopeKey` to an `elementInstanceKey` without an explicit cast:

```ts
// TS2367: This comparison appears to be unintentional because the types
// 'ElementInstanceKey' and 'ScopeKey' have no overlap.
if (elementInstance.elementInstanceKey === variable.scopeKey) { ... }
```

### Fix

Replace the `allOf: [LongKey]` definition with `oneOf: [ElementInstanceKey, ProcessInstanceKey]`, matching the existing pattern already used by `elementInstanceScopeKey` in the element instances spec:

```yaml
ScopeKey:
  type: string
  oneOf:
    - $ref: "#/components/schemas/ElementInstanceKey"
    - $ref: "#/components/schemas/ProcessInstanceKey"
```

This produces a union type in generated SDKs (`ScopeKey = ElementInstanceKey | ProcessInstanceKey`), allowing direct comparisons without casts. The same `oneOf` pattern is already used successfully by `ResourceKey` and `elementInstanceScopeKey` in this spec.

### Impact

- `Variable.scopeKey` and `VariableSearchQueryFilter.scopeKey` now carry the union type
- `ScopeKeyFilterProperty` / `AdvancedScopeKeyFilter` continue to reference `ScopeKey` and work unchanged
- No wire format change — the JSON representation is still a string

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&amp;-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/orchestration-cluster-api-js/issues/54