### PR TITLE
[Backport stable/8.9] fix: align broker write limit to 10000 with ES load test

### DIFF
--- a/load-tests/camunda-platform-values-rdbms.yaml
+++ b/load-tests/camunda-platform-values-rdbms.yaml
@@ -42,19 +42,20 @@ orchestration:
   extraConfiguration:
     - file: application.yml
       content: |
-        zeebe.gateway.monitoring.enabled: "true"
-        zeebe.gateway.threads.managementThreads: "1"
-        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
-        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
         zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
         zeebe.broker.data.disk.freeSpace.processing: "3GB"
         zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.
         zeebe.broker.flowControl.write.enabled: "true"
-        zeebe.broker.flowControl.write.limit: 4000
+        zeebe.broker.flowControl.write.limit: 10000
         zeebe.broker.flowControl.write.throttling.enabled: "true"
-        #Metrics:
-        camunda.flags.jfr.metrics: "true"
         # RocksDB memory limit setting, limits the overall RocksDB memory usage
         # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
         zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"


### PR DESCRIPTION
# Description
Backport of #48978 to `stable/8.9`.

relates to 