### PR TITLE
fix: disable Renovate updates for internal io.camunda deps on stable …

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -265,16 +265,11 @@
       "allowedVersions": "!/-SNAPSHOT$/"
     },
     {
-      "description": "Exclude internal Maven modules and Maven dependencies lacking metadata.",
+      "description": "Exclude Maven dependencies lacking metadata.",
       "matchManagers": [
         "maven"
       ],
       "matchPackageNames": [
-        "/io.camunda:operate-parent/",
-        "/io.camunda:operate-qa/",
-        "/io.camunda:operate-qa-migration-tests-parent/",
-        "/io.camunda:tasklist-qa/",
-        "/io.camunda:tasklist-qa-migration-tests-parent/",
         "/net.jcip:jcip-annotations/"
       ],
       "enabled": false
@@ -351,6 +346,19 @@
       ],
       "matchDepTypes": [
         "parent-root"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable internal io.camunda Maven updates on stable branches; versions are controlled by the release process.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchBaseBranches": [
+        "/^stable\\/8\\..*/"
+      ],
+      "matchPackageNames": [
+        "/^io\\.camunda:.+/"
       ],
       "enabled": false
     },


### PR DESCRIPTION
## Description

Prevents Renovate from updating internal `io.camunda:*` Maven dependencies on `stable/*` branches. These versions must stay aligned with the [BOM module](https://github.com/camunda/camunda/blob/main/bom/pom.xml) and are only updated as part of the release process.

During the window between a release branch cut and the merge-back to stable, the released version (e.g. `8.8.15`) is already published while stable still uses the SNAPSHOT (e.g. `8.8.15-SNAPSHOT`). Renovate detects this as an available update and bumps parent POM references and other internal dependencies, breaking version alignment across modules.

The existing `parent-root` exclusion (added in #30630) only covers the topmost parent in the hierarchy. Child module parent references (dep type `parent`) and regular internal dependencies were still being updated — see #47726 and #43453 for recent examples that caused release failures.

### Changes

1. **New rule**: Disables all `io.camunda:*` Maven updates on `stable/8.*` branches, covering parent, parent-root, and regular dependency types.
2. **Cleanup**: Removed obsolete `io.camunda:operate-parent`, `io.camunda:operate-qa*`, and `io.camunda:tasklist-qa*` entries from the individual exclusion list — they are now covered by the broader rule.

---

## Verification Against All Known Occurrences

Analyzed all 60+ Renovate PRs referenced in #20856 to confirm the new rule covers every case.

### Rule

```json
{
  "matchManagers": ["maven"],
  "matchBaseBranches": ["/^stable\\/8\\..*/"],
  "matchPackageNames": ["/^io\\.camunda:.+/"],
  "enabled": false
}
```

### All unique packages (11)

| Package | Dep Type | Example Files Changed |
|---|---|---|
| `io.camunda:zeebe-parent` | parent | `authentication/pom.xml`, `db/pom.xml`, `dist/pom.xml`, `identity/pom.xml`, 40+ more |
| `io.camunda:zeebe-bom` | parent | `build-tools/pom.xml`, `parent/pom.xml` |
| `io.camunda:zeebe-atomix-parent` | parent | `zeebe/atomix/cluster/pom.xml`, `zeebe/atomix/utils/pom.xml` |
| `io.camunda:zeebe-qa` | parent | `qa/integration-tests/pom.xml`, `qa/update-tests/pom.xml`, `qa/util/pom.xml` |
| `io.camunda:camunda-library-parent` | parent | `clients/java/pom.xml`, `testing/pom.xml`, `clients/camunda-spring-boot-4-starter/pom.xml` |
| `io.camunda:camunda-search` | parent | `search/search-client-connect/pom.xml`, `search/search-client/pom.xml`, 6+ more |
| `io.camunda:camunda-testing` | parent | `testing/camunda-process-test-java/pom.xml`, `testing/camunda-process-test-spring-4/pom.xml` |
| `io.camunda:tasklist-parent` | parent | `tasklist/archiver/pom.xml`, `tasklist/webapp/pom.xml`, 11+ more |
| `io.camunda:identity-parent` | parent | `identity/client/pom.xml`, `identity/migration/pom.xml` |
| `io.camunda:document-parent` | parent | `document/api/pom.xml`, `document/store/pom.xml` |
| `io.camunda:operate-parent` | parent | (from original issue examples) |

All packages use group ID `io.camunda` → matched by `/^io\.camunda:.+/`.

### All affected branches (5)

| Branch | Matches `/^stable\/8\..*/`? |
|---|---|
| `stable/8.4` | ✅ |
| `stable/8.5` | ✅ |
| `stable/8.6` | ✅ |
| `stable/8.7` | ✅ |
| `stable/8.8` | ✅ |

### Verified PRs

| PR | Branch | Package |
|---|---|---|
| #20842 | `stable/8.5` | `zeebe-parent` |
| #20829 | `stable/8.5` | `zeebe-qa` |
| #32480 | `stable/8.7` | `zeebe-atomix-parent` |
| #32481 | `stable/8.7` | `zeebe-bom` |
| #32482 | `stable/8.7` | `zeebe-parent` |
| #32478 | `stable/8.7` | `tasklist-parent` |
| #33070 | `stable/8.4` | `zeebe-atomix-parent` |
| #33071 | `stable/8.4` | `zeebe-bom` |
| #33072 | `stable/8.4` | `zeebe-parent` |
| #33073 | `stable/8.4` | `zeebe-qa` |
| #33074 | `stable/8.5` | `zeebe-atomix-parent` |
| #33075 | `stable/8.5` | `zeebe-bom` |
| #33076 | `stable/8.5` | `zeebe-parent` |
| #33094 | `stable/8.6` | `camunda-search` |
| #33095 | `stable/8.6` | `document-parent` |
| #33103 | `stable/8.6` | `identity-parent` |
| #33104 | `stable/8.6` | `tasklist-parent` |
| #33125 | `stable/8.6` | `zeebe-atomix-parent` |
| #33126 | `stable/8.6` | `zeebe-bom` |
| #33139 | `stable/8.6` | `zeebe-parent` |
| #33229 | `stable/8.6` | `camunda-search` |
| #33230 | `stable/8.6` | `document-parent` |
| #33231 | `stable/8.6` | `identity-parent` |
| #33232 | `stable/8.6` | `tasklist-parent` |
| #33233 | `stable/8.6` | `zeebe-atomix-parent` |
| #33234 | `stable/8.6` | `zeebe-bom` |
| #33240 | `stable/8.6` | `zeebe-parent` |
| #33243 | `stable/8.7` | `camunda-search` |
| #33244 | `stable/8.7` | `document-parent` |
| #33245 | `stable/8.7` | `identity-parent` |
| #33246 | `stable/8.7` | `tasklist-parent` |
| #33247 | `stable/8.7` | `zeebe-atomix-parent` |
| #33248 | `stable/8.7` | `zeebe-bom` |
| #33249 | `stable/8.7` | `zeebe-parent` |
| #43440 | `stable/8.6` | `camunda-library-parent` |
| #43441 | `stable/8.6` | `camunda-search` |
| #43442 | `stable/8.6` | `document-parent` |
| #43443 | `stable/8.6` | `identity-parent` |
| #43444 | `stable/8.6` | `tasklist-parent` |
| #43445 | `stable/8.6` | `zeebe-atomix-parent` |
| #43446 | `stable/8.6` | `zeebe-bom` |
| #43447 | `stable/8.6` | `zeebe-parent` |
| #43453 | `stable/8.7` | `camunda-library-parent` |
| #43461 | `stable/8.7` | `tasklist-parent` |
| #43463 | `stable/8.7` | `zeebe-atomix-parent` |
| #43464 | `stable/8.7` | `zeebe-bom` |
| #43465 | `stable/8.7` | `zeebe-parent` |
| #43534 | `stable/8.8` | `camunda-library-parent` |
| #43535 | `stable/8.8` | `camunda-search` |
| #47725 | `stable/8.8` | `camunda-library-parent` |
| #47726 | `stable/8.8` | `camunda-search` |
| #47728 | `stable/8.8` | `camunda-testing` |
| #47735 | `stable/8.8` | `zeebe-parent` |

All 53 unique PRs are covered by the new rule. No false negatives or edge cases found.

<img width="454" height="499" alt="image" src="https://github.com/user-attachments/assets/47ae6f67-032e-4503-bac1-b0b1033bacd3" />



## Related issues

Closes #20856