### PR TITLE
[Backport main] fix: use valid `combine.children` attribute in testing POMs

### DIFF
--- a/testing/camunda-process-test-langchain4j/pom.xml
+++ b/testing/camunda-process-test-langchain4j/pom.xml
@@ -104,7 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <configuration combine.self="append">
+        <configuration combine.children="append">
           <ignoredUsedUndeclaredDependencies>
             <dep>software.amazon.awssdk:aws-core</dep>
             <dep>software.amazon.awssdk:auth</dep>

--- a/testing/camunda-process-test-spring-boot-3/pom.xml
+++ b/testing/camunda-process-test-spring-boot-3/pom.xml
@@ -251,19 +251,24 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- Ignore any non-test scoped deps, we only have test source here -->
-          <ignoredNonTestScopedDependencies>
-            <dependency>*</dependency>
-          </ignoredNonTestScopedDependencies>
-          <!-- Ignore all unused/undeclared, we duplicate all from the base module -->
-          <ignoredUsedUndeclaredDependencies>
-            <dependency>*</dependency>
-          </ignoredUsedUndeclaredDependencies>
-          <ignoredUnusedDeclaredDependencies>
-            <dependency>*</dependency>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
+        <executions>
+          <execution>
+            <id>analyze-dependencies</id>
+            <configuration>
+              <!-- Ignore any non-test scoped deps, we only have test source here -->
+              <ignoredNonTestScopedDependencies combine.self="override">
+                <dep>*</dep>
+              </ignoredNonTestScopedDependencies>
+              <!-- Ignore all unused/undeclared, we duplicate all from the base module -->
+              <ignoredUsedUndeclaredDependencies combine.self="override">
+                <dep>*</dep>
+              </ignoredUsedUndeclaredDependencies>
+              <ignoredUnusedDeclaredDependencies combine.self="override">
+                <dep>*</dep>
+              </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- Add test re-/sources from the base module -->

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -205,22 +205,26 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <ignoredNonTestScopedDependencies>
-            <dependency>org.springframework:spring-beans</dependency>
-            <dependency>org.awaitility:awaitility</dependency>
-            <dependency>org.apache.httpcomponents.client5:httpclient5</dependency>
-            <dependency>org.apache.httpcomponents.core5:httpcore5</dependency>
-            <dependency>io.camunda:camunda-process-test-json-test-cases</dependency>
-            <dependency>io.camunda:camunda-process-test-langchain4j</dependency>
-          </ignoredNonTestScopedDependencies>
-          <ignoredUnusedDeclaredDependencies>
-            <dep>dev.langchain4j:langchain4j-open-ai</dep>
-            <dep>dev.langchain4j:langchain4j-anthropic</dep>
-            <dep>dev.langchain4j:langchain4j-bedrock</dep>
-            <dep>io.camunda:camunda-process-test-langchain4j</dep>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
+        <executions>
+          <execution>
+            <id>analyze-dependencies</id>
+            <configuration>
+              <ignoredNonTestScopedDependencies combine.children="append">
+                <dep>org.awaitility:awaitility</dep>
+                <dep>org.apache.httpcomponents.client5:httpclient5</dep>
+                <dep>org.apache.httpcomponents.core5:httpcore5</dep>
+                <dep>io.camunda:camunda-process-test-json-test-cases</dep>
+                <dep>io.camunda:camunda-process-test-langchain4j</dep>
+              </ignoredNonTestScopedDependencies>
+              <ignoredUnusedDeclaredDependencies combine.children="append">
+                <dep>dev.langchain4j:langchain4j-open-ai</dep>
+                <dep>dev.langchain4j:langchain4j-anthropic</dep>
+                <dep>dev.langchain4j:langchain4j-bedrock</dep>
+                <dep>io.camunda:camunda-process-test-langchain4j</dep>
+              </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <configuration combine.self="append">
+        <configuration combine.children="append">
           <ignoredUnusedDeclaredDependencies>
             <dep>org.apache.logging.log4j:log4j-slf4j2-impl</dep>
             <dep>org.apache.logging.log4j:log4j-core</dep>


### PR DESCRIPTION
# Description
Backport of #48982 to `main`.

relates to #48979