### PR TITLE
fix(cpt): Fix judge assertions re-asserting until timeout on failing condition

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -204,18 +205,8 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
 
     awaitBehavior.untilAsserted(
         () -> {
-          final List<Variable> variables = actualVariablesSupplier.get();
-
-          final Optional<Variable> matchingVariable =
-              variables.stream().filter(variableSelector::test).findFirst();
-
-          assertThat(matchingVariable)
-              .withFailMessage(
-                  "%s should have a variable '%s', but the variable doesn't exist.",
-                  actual, variableSelector.describe())
-              .isPresent();
-
-          rawRequirement.accept(matchingVariable.get().getValue());
+          final String rawValue = assertVariableExists(variableSelector, actualVariablesSupplier);
+          rawRequirement.accept(rawValue);
         });
   }
 
@@ -371,12 +362,12 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
     assertJudgeHasAllRequiredSettings();
     assertExpectationNotEmpty(expectation);
 
-    hasVariableSatisfies(
-        variableSelector,
-        rawValue ->
-            evaluateJudge(
-                variableSelector.describe(), expectation, judgeConfig.getThreshold(), rawValue),
-        () -> findGlobalVariablesBySelector(processInstanceKey, variableSelector));
+    final String rawValue =
+        waitForVariable(
+            variableSelector,
+            () -> findGlobalVariablesBySelector(processInstanceKey, variableSelector));
+
+    evaluateJudge(variableSelector.describe(), expectation, judgeConfig.getThreshold(), rawValue);
   }
 
   public void hasLocalVariableSatisfiesJudge(
@@ -388,21 +379,53 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
     assertJudgeHasAllRequiredSettings();
     assertExpectationNotEmpty(expectation);
 
+    final String rawValue =
+        waitForLocalVariable(processInstanceKey, elementSelector, variableSelector);
+
+    evaluateJudge(variableSelector.describe(), expectation, judgeConfig.getThreshold(), rawValue);
+  }
+
+  private String assertVariableExists(
+      final VariableSelector variableSelector,
+      final Supplier<List<Variable>> actualVariablesSupplier) {
+    final List<Variable> variables = actualVariablesSupplier.get();
+    final Optional<Variable> matchingVariable =
+        variables.stream().filter(variableSelector::test).findFirst();
+    assertThat(matchingVariable)
+        .withFailMessage(
+            "%s should have a variable '%s', but the variable doesn't exist.",
+            actual, variableSelector.describe())
+        .isPresent();
+    return matchingVariable.get().getValue();
+  }
+
+  private String waitForVariable(
+      final VariableSelector variableSelector,
+      final Supplier<List<Variable>> actualVariablesSupplier) {
+    final AtomicReference<String> result = new AtomicReference<>();
+    awaitBehavior.untilAsserted(
+        () -> result.set(assertVariableExists(variableSelector, actualVariablesSupplier)));
+    return result.get();
+  }
+
+  private String waitForLocalVariable(
+      final long processInstanceKey,
+      final ElementSelector elementSelector,
+      final VariableSelector variableSelector) {
+    final AtomicReference<String> result = new AtomicReference<>();
     withLocalVariableAssertion(
         processInstanceKey,
         elementSelector,
         instance ->
-            hasVariableSatisfies(
-                variableSelector,
-                rawValue ->
-                    evaluateJudge(
-                        variableSelector.describe(),
-                        expectation,
-                        judgeConfig.getThreshold(),
-                        rawValue),
-                () ->
-                    findLocalVariablesBySelector(
-                        processInstanceKey, instance.getElementInstanceKey(), variableSelector)));
+            result.set(
+                assertVariableExists(
+                    variableSelector,
+                    () ->
+                        findLocalVariablesBySelector(
+                            processInstanceKey,
+                            instance.getElementInstanceKey(),
+                            variableSelector))));
+    return result.get();
   }
 
   private void evaluateJudge(

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JudgeAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JudgeAssertTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -34,6 +35,7 @@ import io.camunda.process.test.utils.VariableBuilder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -103,11 +105,15 @@ public class JudgeAssertTest {
     }
 
     @Test
-    @CamundaAssertExpectFailure
     void shouldFailWhenJudgeScoreBelowThreshold() {
       // given
+      final AtomicInteger callCount = new AtomicInteger(0);
       final ChatModelAdapter mockModel =
-          prompt -> "{\"score\": 0.2, \"reasoning\": \"The value does not match.\"}";
+          prompt -> {
+            callCount.incrementAndGet();
+            return "{\"score\": 0.2, \"reasoning\": \"The value does not match.\"}";
+          };
+
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"random text\"");
@@ -124,6 +130,9 @@ public class JudgeAssertTest {
           .hasMessageContaining("did not satisfy judge expectation")
           .hasMessageContaining("Score: 0.20")
           .hasMessageContaining("The value does not match.");
+
+      // expect that the judge assertion is only being called once
+      assertThat(callCount).hasValue(1);
     }
 
     @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JudgeAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JudgeAssertTest.java
@@ -428,8 +428,12 @@ public class JudgeAssertTest {
     @CamundaAssertExpectFailure
     void shouldFailWhenLocalVariableScoreBelowThreshold() {
       // given
+      final AtomicInteger callCount = new AtomicInteger(0);
       final ChatModelAdapter mockModel =
-          prompt -> "{\"score\": 0.2, \"reasoning\": \"Poor match.\"}";
+          prompt -> {
+            callCount.incrementAndGet();
+            return "{\"score\": 0.2, \"reasoning\": \"Poor match.\"}";
+          };
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       when(camundaDataSource.findElementInstances(any()))
@@ -456,6 +460,9 @@ public class JudgeAssertTest {
           .isInstanceOf(AssertionError.class)
           .hasMessageContaining("did not satisfy judge expectation")
           .hasMessageContaining("Score: 0.20");
+
+      // expect that the judge assertion is only being called once
+      assertThat(callCount).hasValue(1);
     }
 
     @Test


### PR DESCRIPTION
## Description

`VariableAssertj.hasVariableSatisfiesJudge` and `VariableAssertj.hasLocalVariableSatisfiesJudge` are repeating their evaluation endlessly until the global assertion timeout is reached.

This is due to the evaluation running inside `awaitBehavior` scope leading to multiplied LLM provider calls, potentially increasing token costs unnecessarily. This PR fixes this by awaiting the existence of the required variable and then fires the evaluation once.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #47492 and #46128 
