### PR TITLE
[Backport stable/8.9] feat(cpt): add VariableSelector for flexible variable identification in assertions

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -352,6 +352,19 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasVariable(String variableName, Object variableValue);
 
   /**
+   * Verifies that the process instance has the variable matching the selector with the given value.
+   * The verification fails if no variable matches or has a different value.
+   *
+   * <p>The assertion waits until a matching variable exists and has the given value.
+   *
+   * @param variableSelector the selector to identify the variable
+   * @param variableValue the variable value
+   * @return the assertion object
+   * @see VariableSelectors
+   */
+  ProcessInstanceAssert hasVariable(VariableSelector variableSelector, Object variableValue);
+
+  /**
    * Verifies that the given BPMN element has the local variable with the specified value. Local
    * variables are scoped to the element and do not appear in the parent scope. The verification
    * fails if the variable doesn't exist or has a different value.
@@ -383,6 +396,23 @@ public interface ProcessInstanceAssert {
       ElementSelector selector, String variableName, Object variableValue);
 
   /**
+   * Verifies that the given BPMN element has the local variable matching the variable selector with
+   * the specified value. Local variables are scoped to the element and do not appear in the parent
+   * scope. The verification fails if no variable matches or has a different value.
+   *
+   * <p>The assertion waits until a matching variable exists and has the given value.
+   *
+   * @param elementSelector the selector for the BPMN element
+   * @param variableSelector the selector to identify the variable
+   * @param variableValue the variable value
+   * @return the assertion object
+   * @see ElementSelectors
+   * @see VariableSelectors
+   */
+  ProcessInstanceAssert hasLocalVariable(
+      ElementSelector elementSelector, VariableSelector variableSelector, Object variableValue);
+
+  /**
    * Verifies that the process instance has a variable with a value that satisfies the given
    * requirements expressed as a {@link ThrowingConsumer}. It can be used to verify a complex object
    * partially with multiple grouped assertions. The verification fails if the variable doesn't
@@ -398,6 +428,26 @@ public interface ProcessInstanceAssert {
    */
   <T> ProcessInstanceAssert hasVariableSatisfies(
       String variableName, final Class<T> variableValueType, final ThrowingConsumer<T> requirement);
+
+  /**
+   * Verifies that the process instance has a variable matching the selector with a value that
+   * satisfies the given requirements expressed as a {@link ThrowingConsumer}. The verification
+   * fails if no variable matches or the value doesn't satisfy the requirements.
+   *
+   * <p>The assertion waits until a matching variable exists and the value satisfies the
+   * requirements.
+   *
+   * @param variableSelector the selector to identify the variable
+   * @param variableValueType the variable value's deserialization type, can be a JsonNode or Map
+   *     for a generic variable
+   * @param requirement the requirement that the variable must satisfy
+   * @return the assertion object
+   * @see VariableSelectors
+   */
+  <T> ProcessInstanceAssert hasVariableSatisfies(
+      VariableSelector variableSelector,
+      Class<T> variableValueType,
+      ThrowingConsumer<T> requirement);
 
   /**
    * Verifies that the process instance has a local variable with a value that satisfies the given
@@ -428,7 +478,8 @@ public interface ProcessInstanceAssert {
    *
    * <p>The assertion waits until the variable exists and the value satisfies the requirements.
    *
-   * @param selector the {@see ElementSelector} for the BPMN element the variable is associated with
+   * @param selector the {@link ElementSelector} for the BPMN element the variable is associated
+   *     with
    * @param variableName the variable name
    * @param variableValueType the variable value's deserialization type, can be a JsonNode or Map
    *     for a generic variable
@@ -438,6 +489,29 @@ public interface ProcessInstanceAssert {
   <T> ProcessInstanceAssert hasLocalVariableSatisfies(
       ElementSelector selector,
       String variableName,
+      Class<T> variableValueType,
+      ThrowingConsumer<T> requirement);
+
+  /**
+   * Verifies that the process instance has a local variable matching the variable selector with a
+   * value that satisfies the given requirements expressed as a {@link ThrowingConsumer}. The
+   * verification fails if no variable matches or the value doesn't satisfy the requirements.
+   *
+   * <p>The assertion waits until a matching variable exists and the value satisfies the
+   * requirements.
+   *
+   * @param elementSelector the {@link ElementSelector} for the BPMN element the variable is
+   *     associated with
+   * @param variableSelector the selector to identify the variable
+   * @param variableValueType the variable value's deserialization type, can be a JsonNode or Map
+   *     for a generic variable
+   * @param requirement the requirement that the variable must satisfy
+   * @return the assertion object
+   * @see VariableSelectors
+   */
+  <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      ElementSelector elementSelector,
+      VariableSelector variableSelector,
       Class<T> variableValueType,
       ThrowingConsumer<T> requirement);
 
@@ -596,6 +670,20 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasVariableSatisfiesJudge(String variableName, String expectation);
 
   /**
+   * Verifies that a process variable matching the selector satisfies a natural language expectation
+   * using an LLM judge. Uses the threshold from the configured {@link JudgeConfig}.
+   *
+   * <p>The assertion waits until a matching variable exists, then runs the judge evaluation once.
+   *
+   * @param variableSelector the selector to identify the variable
+   * @param expectation the natural language expectation
+   * @return the assertion object
+   * @see VariableSelectors
+   */
+  ProcessInstanceAssert hasVariableSatisfiesJudge(
+      VariableSelector variableSelector, String expectation);
+
+  /**
    * Verifies that a local variable's value satisfies a natural language expectation using an LLM
    * judge. Uses the threshold from the configured {@link JudgeConfig}.
    *
@@ -623,4 +711,20 @@ public interface ProcessInstanceAssert {
    */
   ProcessInstanceAssert hasLocalVariableSatisfiesJudge(
       ElementSelector selector, String variableName, String expectation);
+
+  /**
+   * Verifies that a local variable matching the variable selector satisfies a natural language
+   * expectation using an LLM judge. Uses the threshold from the configured {@link JudgeConfig}.
+   *
+   * <p>The assertion waits until a matching variable exists, then runs the judge evaluation once.
+   *
+   * @param elementSelector the selector for the BPMN element
+   * @param variableSelector the selector to identify the variable
+   * @param expectation the natural language expectation
+   * @return the assertion object
+   * @see ElementSelectors
+   * @see VariableSelectors
+   */
+  ProcessInstanceAssert hasLocalVariableSatisfiesJudge(
+      ElementSelector elementSelector, VariableSelector variableSelector, String expectation);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/VariableSelector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/VariableSelector.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.assertions;
+
+import io.camunda.client.api.search.filter.VariableFilter;
+import io.camunda.client.api.search.response.Variable;
+
+/** A selector for process variables. */
+@FunctionalInterface
+public interface VariableSelector {
+
+  /**
+   * Checks if the variable matches the selector.
+   *
+   * @param variable the process variable
+   * @return {@code true} if the variable matches, otherwise {@code false}
+   */
+  boolean test(Variable variable);
+
+  /**
+   * Returns a string representation of the selector. It is used to build the failure message of an
+   * assertion. Default: {@link Object#toString()}.
+   *
+   * @return the string representation
+   */
+  default String describe() {
+    return toString();
+  }
+
+  /**
+   * Applies the given filter to limit the search of variables that match the selector. Default: no
+   * filtering.
+   *
+   * @param filter the filter used to limit the variable search
+   */
+  default void applyFilter(final VariableFilter filter) {}
+
+  /**
+   * Combines two variable selectors together.
+   *
+   * @param other variable selector to be added.
+   * @return the combined variable selector
+   */
+  default VariableSelector and(final VariableSelector other) {
+    final VariableSelector self = this;
+
+    return new VariableSelector() {
+      @Override
+      public boolean test(final Variable variable) {
+        return self.test(variable) && other.test(variable);
+      }
+
+      @Override
+      public String describe() {
+        return String.format("%s, %s", self.describe(), other.describe());
+      }
+
+      @Override
+      public void applyFilter(final VariableFilter filter) {
+        self.applyFilter(filter);
+        other.applyFilter(filter);
+      }
+    };
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/VariableSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/VariableSelectors.java
@@ -43,8 +43,17 @@ public class VariableSelectors {
   }
 
   /**
-   * Select the variable by a substring of its value. Uses the {@code like} filter for server-side
-   * pre-filtering.
+   * Select the variable by its process instance key.
+   *
+   * @param processInstanceKey the process instance key of the variable.
+   * @return the selector
+   */
+  public static VariableSelector byProcessInstanceKey(final long processInstanceKey) {
+    return new VariableProcessInstanceKeySelector(processInstanceKey);
+  }
+
+  /**
+   * Select the variable by a substring of its value.
    *
    * @param substring the substring to search for in the variable value.
    * @return the selector
@@ -121,7 +130,31 @@ public class VariableSelectors {
 
     @Override
     public void applyFilter(final VariableFilter filter) {
-      filter.value(v -> v.like("%" + substring + "%"));
+      filter.value(v -> v.like("*" + substring + "*"));
+    }
+  }
+
+  private static final class VariableProcessInstanceKeySelector implements VariableSelector {
+
+    private final long processInstanceKey;
+
+    private VariableProcessInstanceKeySelector(final long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+    }
+
+    @Override
+    public boolean test(final Variable variable) {
+      return Objects.equals(variable.getProcessInstanceKey(), processInstanceKey);
+    }
+
+    @Override
+    public String describe() {
+      return String.format("processInstanceKey: %d", processInstanceKey);
+    }
+
+    @Override
+    public void applyFilter(final VariableFilter filter) {
+      filter.processInstanceKey(processInstanceKey);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/VariableSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/VariableSelectors.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.assertions;
+
+import io.camunda.client.api.search.filter.VariableFilter;
+import io.camunda.client.api.search.response.Variable;
+import java.util.Objects;
+
+/** A collection of predefined {@link VariableSelector}s. */
+public class VariableSelectors {
+
+  /**
+   * Select the variable by its name.
+   *
+   * @param name the name of the variable.
+   * @return the selector
+   */
+  public static VariableSelector byName(final String name) {
+    return new VariableNameSelector(name);
+  }
+
+  /**
+   * Select the variable by its scope key.
+   *
+   * @param scopeKey the scope key of the variable.
+   * @return the selector
+   */
+  public static VariableSelector byScopeKey(final long scopeKey) {
+    return new VariableScopeKeySelector(scopeKey);
+  }
+
+  /**
+   * Select the variable by a substring of its value. Uses the {@code like} filter for server-side
+   * pre-filtering.
+   *
+   * @param substring the substring to search for in the variable value.
+   * @return the selector
+   */
+  public static VariableSelector byValueContains(final String substring) {
+    return new VariableValueContainsSelector(substring);
+  }
+
+  private static final class VariableNameSelector implements VariableSelector {
+
+    private final String name;
+
+    private VariableNameSelector(final String name) {
+      this.name = name;
+    }
+
+    @Override
+    public boolean test(final Variable variable) {
+      return name.equals(variable.getName());
+    }
+
+    @Override
+    public String describe() {
+      return name;
+    }
+
+    @Override
+    public void applyFilter(final VariableFilter filter) {
+      filter.name(name);
+    }
+  }
+
+  private static final class VariableScopeKeySelector implements VariableSelector {
+
+    private final long scopeKey;
+
+    private VariableScopeKeySelector(final long scopeKey) {
+      this.scopeKey = scopeKey;
+    }
+
+    @Override
+    public boolean test(final Variable variable) {
+      return Objects.equals(variable.getScopeKey(), scopeKey);
+    }
+
+    @Override
+    public String describe() {
+      return String.format("scopeKey: %d", scopeKey);
+    }
+
+    @Override
+    public void applyFilter(final VariableFilter filter) {
+      filter.scopeKey(scopeKey);
+    }
+  }
+
+  private static final class VariableValueContainsSelector implements VariableSelector {
+
+    private final String substring;
+
+    private VariableValueContainsSelector(final String substring) {
+      this.substring = substring;
+    }
+
+    @Override
+    public boolean test(final Variable variable) {
+      return variable.getValue() != null && variable.getValue().contains(substring);
+    }
+
+    @Override
+    public String describe() {
+      return String.format("value contains: %s", substring);
+    }
+
+    @Override
+    public void applyFilter(final VariableFilter filter) {
+      filter.value(v -> v.like("%" + substring + "%"));
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -25,6 +25,7 @@ import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
 import io.camunda.process.test.api.assertions.VariableSelector;
+import io.camunda.process.test.api.assertions.VariableSelectors;
 import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.impl.assertions.util.CamundaAssertJsonMapper;
 import java.util.Arrays;
@@ -277,7 +278,8 @@ public class ProcessInstanceAssertj
 
   @Override
   public ProcessInstanceAssert hasVariable(final String variableName, final Object variableValue) {
-    variableAssertj.hasVariable(getProcessInstanceKey(), variableName, variableValue);
+    variableAssertj.hasVariable(
+        getProcessInstanceKey(), VariableSelectors.byName(variableName), variableValue);
     return this;
   }
 
@@ -292,7 +294,10 @@ public class ProcessInstanceAssertj
   public ProcessInstanceAssert hasLocalVariable(
       final String elementId, final String variableName, final Object variableValue) {
     variableAssertj.hasLocalVariable(
-        getProcessInstanceKey(), elementSelector.apply(elementId), variableName, variableValue);
+        getProcessInstanceKey(),
+        elementSelector.apply(elementId),
+        VariableSelectors.byName(variableName),
+        variableValue);
     return this;
   }
 
@@ -300,7 +305,7 @@ public class ProcessInstanceAssertj
   public ProcessInstanceAssert hasLocalVariable(
       final ElementSelector selector, final String variableName, final Object variableValue) {
     variableAssertj.hasLocalVariable(
-        getProcessInstanceKey(), selector, variableName, variableValue);
+        getProcessInstanceKey(), selector, VariableSelectors.byName(variableName), variableValue);
     return this;
   }
 
@@ -321,7 +326,10 @@ public class ProcessInstanceAssertj
       final ThrowingConsumer<T> requirement) {
 
     variableAssertj.hasVariableSatisfies(
-        getProcessInstanceKey(), variableName, variableValueType, requirement);
+        getProcessInstanceKey(),
+        VariableSelectors.byName(variableName),
+        variableValueType,
+        requirement);
     return this;
   }
 
@@ -344,7 +352,10 @@ public class ProcessInstanceAssertj
       final ThrowingConsumer<T> requirement) {
 
     return hasLocalVariableSatisfies(
-        elementSelector.apply(elementId), variableName, variableValueType, requirement);
+        elementSelector.apply(elementId),
+        VariableSelectors.byName(variableName),
+        variableValueType,
+        requirement);
   }
 
   @Override
@@ -355,7 +366,11 @@ public class ProcessInstanceAssertj
       final ThrowingConsumer<T> requirement) {
 
     variableAssertj.hasLocalVariableSatisfies(
-        getProcessInstanceKey(), selector, variableName, variableValueType, requirement);
+        getProcessInstanceKey(),
+        selector,
+        VariableSelectors.byName(variableName),
+        variableValueType,
+        requirement);
     return this;
   }
 
@@ -464,7 +479,8 @@ public class ProcessInstanceAssertj
   @Override
   public ProcessInstanceAssert hasVariableSatisfiesJudge(
       final String variableName, final String expectation) {
-    variableAssertj.hasVariableSatisfiesJudge(getProcessInstanceKey(), variableName, expectation);
+    variableAssertj.hasVariableSatisfiesJudge(
+        getProcessInstanceKey(), VariableSelectors.byName(variableName), expectation);
     return this;
   }
 
@@ -480,7 +496,10 @@ public class ProcessInstanceAssertj
   public ProcessInstanceAssert hasLocalVariableSatisfiesJudge(
       final String elementId, final String variableName, final String expectation) {
     variableAssertj.hasLocalVariableSatisfiesJudge(
-        getProcessInstanceKey(), elementSelector.apply(elementId), variableName, expectation);
+        getProcessInstanceKey(),
+        elementSelector.apply(elementId),
+        VariableSelectors.byName(variableName),
+        expectation);
     return this;
   }
 
@@ -488,7 +507,7 @@ public class ProcessInstanceAssertj
   public ProcessInstanceAssert hasLocalVariableSatisfiesJudge(
       final ElementSelector selector, final String variableName, final String expectation) {
     variableAssertj.hasLocalVariableSatisfiesJudge(
-        getProcessInstanceKey(), selector, variableName, expectation);
+        getProcessInstanceKey(), selector, VariableSelectors.byName(variableName), expectation);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -24,6 +24,7 @@ import io.camunda.process.test.api.assertions.ElementSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import io.camunda.process.test.api.assertions.VariableSelector;
 import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.impl.assertions.util.CamundaAssertJsonMapper;
 import java.util.Arrays;
@@ -281,6 +282,13 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasVariable(
+      final VariableSelector variableSelector, final Object variableValue) {
+    variableAssertj.hasVariable(getProcessInstanceKey(), variableSelector, variableValue);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasLocalVariable(
       final String elementId, final String variableName, final Object variableValue) {
     variableAssertj.hasLocalVariable(
@@ -297,6 +305,16 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasLocalVariable(
+      final ElementSelector elementSelector,
+      final VariableSelector variableSelector,
+      final Object variableValue) {
+    variableAssertj.hasLocalVariable(
+        getProcessInstanceKey(), elementSelector, variableSelector, variableValue);
+    return this;
+  }
+
+  @Override
   public <T> ProcessInstanceAssert hasVariableSatisfies(
       final String variableName,
       final Class<T> variableValueType,
@@ -304,6 +322,17 @@ public class ProcessInstanceAssertj
 
     variableAssertj.hasVariableSatisfies(
         getProcessInstanceKey(), variableName, variableValueType, requirement);
+    return this;
+  }
+
+  @Override
+  public <T> ProcessInstanceAssert hasVariableSatisfies(
+      final VariableSelector variableSelector,
+      final Class<T> variableValueType,
+      final ThrowingConsumer<T> requirement) {
+
+    variableAssertj.hasVariableSatisfies(
+        getProcessInstanceKey(), variableSelector, variableValueType, requirement);
     return this;
   }
 
@@ -327,6 +356,18 @@ public class ProcessInstanceAssertj
 
     variableAssertj.hasLocalVariableSatisfies(
         getProcessInstanceKey(), selector, variableName, variableValueType, requirement);
+    return this;
+  }
+
+  @Override
+  public <T> ProcessInstanceAssert hasLocalVariableSatisfies(
+      final ElementSelector elementSelector,
+      final VariableSelector variableSelector,
+      final Class<T> variableValueType,
+      final ThrowingConsumer<T> requirement) {
+
+    variableAssertj.hasLocalVariableSatisfies(
+        getProcessInstanceKey(), elementSelector, variableSelector, variableValueType, requirement);
     return this;
   }
 
@@ -428,6 +469,14 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasVariableSatisfiesJudge(
+      final VariableSelector variableSelector, final String expectation) {
+    variableAssertj.hasVariableSatisfiesJudge(
+        getProcessInstanceKey(), variableSelector, expectation);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasLocalVariableSatisfiesJudge(
       final String elementId, final String variableName, final String expectation) {
     variableAssertj.hasLocalVariableSatisfiesJudge(
@@ -440,6 +489,16 @@ public class ProcessInstanceAssertj
       final ElementSelector selector, final String variableName, final String expectation) {
     variableAssertj.hasLocalVariableSatisfiesJudge(
         getProcessInstanceKey(), selector, variableName, expectation);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasLocalVariableSatisfiesJudge(
+      final ElementSelector elementSelector,
+      final VariableSelector variableSelector,
+      final String expectation) {
+    variableAssertj.hasLocalVariableSatisfiesJudge(
+        getProcessInstanceKey(), elementSelector, variableSelector, expectation);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -24,6 +24,8 @@ import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import io.camunda.process.test.api.assertions.ElementSelector;
+import io.camunda.process.test.api.assertions.VariableSelector;
+import io.camunda.process.test.api.assertions.VariableSelectors;
 import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.impl.assertions.util.CamundaAssertJsonMapper;
 import io.camunda.process.test.impl.assertions.util.CamundaAssertJsonMapper.JsonMappingException;
@@ -108,72 +110,110 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
 
   public void hasLocalVariable(
       final long processInstanceKey,
-      final ElementSelector selector,
+      final ElementSelector elementSelector,
       final String variableName,
+      final Object variableValue) {
+
+    hasLocalVariable(
+        processInstanceKey, elementSelector, VariableSelectors.byName(variableName), variableValue);
+  }
+
+  public void hasLocalVariable(
+      final long processInstanceKey,
+      final ElementSelector elementSelector,
+      final VariableSelector variableSelector,
       final Object variableValue) {
 
     withLocalVariableAssertion(
         processInstanceKey,
-        selector,
+        elementSelector,
         instance ->
             hasVariable(
-                variableName,
+                variableSelector,
                 variableValue,
                 () ->
-                    getLocalProcessInstanceVariables(
-                        processInstanceKey, instance.getElementInstanceKey())));
+                    findVariablesBySelector(
+                        processInstanceKey, instance.getElementInstanceKey(), variableSelector)));
   }
 
   public void hasVariable(
       final long processInstanceKey, final String variableName, final Object variableValue) {
 
+    hasVariable(processInstanceKey, VariableSelectors.byName(variableName), variableValue);
+  }
+
+  public void hasVariable(
+      final long processInstanceKey,
+      final VariableSelector variableSelector,
+      final Object variableValue) {
+
     hasVariable(
-        variableName, variableValue, () -> getGlobalProcessInstanceVariables(processInstanceKey));
+        variableSelector,
+        variableValue,
+        () -> findVariablesBySelector(processInstanceKey, variableSelector));
   }
 
   private void hasVariable(
-      final String variableName,
+      final VariableSelector variableSelector,
       final Object variableValue,
-      final Supplier<Map<String, String>> actualVariablesSupplier) {
+      final Supplier<List<Variable>> actualVariablesSupplier) {
     final JsonNode expectedValue = jsonMapper.toJsonNode(variableValue);
 
     awaitBehavior.untilAsserted(
         () -> {
-          final Map<String, String> variables = actualVariablesSupplier.get();
+          final List<Variable> variables = actualVariablesSupplier.get();
 
-          assertThat(variables)
+          final Optional<Variable> matchingVariable =
+              variables.stream().filter(variableSelector::test).findFirst();
+
+          assertThat(matchingVariable)
               .withFailMessage(
                   "%s should have a variable '%s' with value '%s' but the variable doesn't exist.",
-                  actual, variableName, expectedValue)
-              .containsKey(variableName);
+                  actual, variableSelector.describe(), expectedValue)
+              .isPresent();
 
-          final JsonNode actualValue = jsonMapper.readJson(variables.get(variableName));
+          final JsonNode actualValue = jsonMapper.readJson(matchingVariable.get().getValue());
           assertThat(actualValue)
               .withFailMessage(
                   "%s should have a variable '%s' with value '%s' but was '%s'.",
-                  actual, variableName, expectedValue, actualValue)
+                  actual, variableSelector.describe(), expectedValue, actualValue)
               .isEqualTo(expectedValue);
         });
   }
 
   public <T> void hasLocalVariableSatisfies(
       final long processInstanceKey,
-      final ElementSelector selector,
+      final ElementSelector elementSelector,
       final String variableName,
+      final Class<T> variableValueType,
+      final ThrowingConsumer<T> requirement) {
+
+    hasLocalVariableSatisfies(
+        processInstanceKey,
+        elementSelector,
+        VariableSelectors.byName(variableName),
+        variableValueType,
+        requirement);
+  }
+
+  public <T> void hasLocalVariableSatisfies(
+      final long processInstanceKey,
+      final ElementSelector elementSelector,
+      final VariableSelector variableSelector,
       final Class<T> variableValueType,
       final ThrowingConsumer<T> requirement) {
 
     withLocalVariableAssertion(
         processInstanceKey,
-        selector,
+        elementSelector,
         instance ->
             hasVariableSatisfies(
-                variableName,
+                variableSelector,
                 variableValueType,
                 requirement,
                 () ->
-                    getLocalProcessInstanceVariables(
-                        processInstanceKey, instance.getElementInstanceKey())));
+                    findVariablesBySelector(
+                        processInstanceKey, instance.getElementInstanceKey(), variableSelector)));
   }
 
   public <T> void hasVariableSatisfies(
@@ -183,39 +223,52 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
       final ThrowingConsumer<T> requirement) {
 
     hasVariableSatisfies(
-        variableName,
+        processInstanceKey, VariableSelectors.byName(variableName), variableValueType, requirement);
+  }
+
+  public <T> void hasVariableSatisfies(
+      final long processInstanceKey,
+      final VariableSelector variableSelector,
+      final Class<T> variableValueType,
+      final ThrowingConsumer<T> requirement) {
+
+    hasVariableSatisfies(
+        variableSelector,
         variableValueType,
         requirement,
-        () -> getGlobalProcessInstanceVariables(processInstanceKey));
+        () -> findVariablesBySelector(processInstanceKey, variableSelector));
   }
 
   private void hasVariableSatisfies(
-      final String variableName,
+      final VariableSelector variableSelector,
       final ThrowingConsumer<String> rawRequirement,
-      final Supplier<Map<String, String>> actualVariablesSupplier) {
+      final Supplier<List<Variable>> actualVariablesSupplier) {
 
     awaitBehavior.untilAsserted(
         () -> {
-          final Map<String, String> variables = actualVariablesSupplier.get();
+          final List<Variable> variables = actualVariablesSupplier.get();
 
-          assertThat(variables)
+          final Optional<Variable> matchingVariable =
+              variables.stream().filter(variableSelector::test).findFirst();
+
+          assertThat(matchingVariable)
               .withFailMessage(
                   "%s should have a variable '%s', but the variable doesn't exist.",
-                  actual, variableName)
-              .containsKey(variableName);
+                  actual, variableSelector.describe())
+              .isPresent();
 
-          rawRequirement.accept(variables.get(variableName));
+          rawRequirement.accept(matchingVariable.get().getValue());
         });
   }
 
   private <T> void hasVariableSatisfies(
-      final String variableName,
+      final VariableSelector variableSelector,
       final Class<T> variableValueType,
       final ThrowingConsumer<T> requirement,
-      final Supplier<Map<String, String>> actualVariablesSupplier) {
+      final Supplier<List<Variable>> actualVariablesSupplier) {
 
     hasVariableSatisfies(
-        variableName,
+        variableSelector,
         rawValue -> {
           try {
             final T actualValue = jsonMapper.readJson(rawValue, variableValueType);
@@ -223,7 +276,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
           } catch (final AssertionError e) {
             fail(
                 "%s should have a variable '%s' but the following requirement was not satisfied: %s.",
-                actual, variableName, e.getMessage());
+                actual, variableSelector.describe(), e.getMessage());
           } catch (final JsonMappingException e) {
             final Throwable reason =
                 Optional.ofNullable(e.getCause())
@@ -235,7 +288,11 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                     "%s should have a variable '%s' of type '%s', but the JSON mapping failed:\n"
                         + "Error: %s\n"
                         + "Reason: %s",
-                    actual, variableName, variableValueType.getName(), e.getMessage(), reason);
+                    actual,
+                    variableSelector.describe(),
+                    variableValueType.getName(),
+                    e.getMessage(),
+                    reason);
 
             fail(failureMessage);
           }
@@ -351,19 +408,40 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   public void hasVariableSatisfiesJudge(
       final long processInstanceKey, final String variableName, final String expectation) {
 
+    hasVariableSatisfiesJudge(
+        processInstanceKey, VariableSelectors.byName(variableName), expectation);
+  }
+
+  public void hasVariableSatisfiesJudge(
+      final long processInstanceKey,
+      final VariableSelector variableSelector,
+      final String expectation) {
+
     assertJudgeHasAllRequiredSettings();
     assertExpectationNotEmpty(expectation);
 
     hasVariableSatisfies(
-        variableName,
-        rawValue -> evaluateJudge(variableName, expectation, judgeConfig.getThreshold(), rawValue),
-        () -> getGlobalProcessInstanceVariables(processInstanceKey));
+        variableSelector,
+        rawValue ->
+            evaluateJudge(
+                variableSelector.describe(), expectation, judgeConfig.getThreshold(), rawValue),
+        () -> findVariablesBySelector(processInstanceKey, variableSelector));
   }
 
   public void hasLocalVariableSatisfiesJudge(
       final long processInstanceKey,
-      final ElementSelector selector,
+      final ElementSelector elementSelector,
       final String variableName,
+      final String expectation) {
+
+    hasLocalVariableSatisfiesJudge(
+        processInstanceKey, elementSelector, VariableSelectors.byName(variableName), expectation);
+  }
+
+  public void hasLocalVariableSatisfiesJudge(
+      final long processInstanceKey,
+      final ElementSelector elementSelector,
+      final VariableSelector variableSelector,
       final String expectation) {
 
     assertJudgeHasAllRequiredSettings();
@@ -371,15 +449,19 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
 
     withLocalVariableAssertion(
         processInstanceKey,
-        selector,
+        elementSelector,
         instance ->
             hasVariableSatisfies(
-                variableName,
+                variableSelector,
                 rawValue ->
-                    evaluateJudge(variableName, expectation, judgeConfig.getThreshold(), rawValue),
+                    evaluateJudge(
+                        variableSelector.describe(),
+                        expectation,
+                        judgeConfig.getThreshold(),
+                        rawValue),
                 () ->
-                    getLocalProcessInstanceVariables(
-                        processInstanceKey, instance.getElementInstanceKey())));
+                    findVariablesBySelector(
+                        processInstanceKey, instance.getElementInstanceKey(), variableSelector)));
   }
 
   private void evaluateJudge(
@@ -451,6 +533,29 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
         dataSource.findVariables(
             filter -> filter.processInstanceKey(processInstanceKey).scopeKey(elementInstanceKey));
     return toMap(ensureVariablesAreNotTruncated(variables));
+  }
+
+  private List<Variable> findVariablesBySelector(
+      final long processInstanceKey, final VariableSelector selector) {
+    return ensureVariablesAreNotTruncated(
+        dataSource.findVariables(
+            filter -> {
+              filter.processInstanceKey(processInstanceKey);
+              selector.applyFilter(filter);
+            }));
+  }
+
+  private List<Variable> findVariablesBySelector(
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final VariableSelector selector) {
+    return ensureVariablesAreNotTruncated(
+        dataSource.findVariables(
+            filter -> {
+              filter.processInstanceKey(processInstanceKey);
+              filter.scopeKey(elementInstanceKey);
+              selector.applyFilter(filter);
+            }));
   }
 
   private List<Variable> ensureVariablesAreNotTruncated(final List<Variable> variablesToCheck) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -480,11 +480,9 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
       final long processInstanceKey, final VariableSelector selector) {
     return ensureVariablesAreNotTruncated(
         dataSource.findVariables(
-            filter -> {
-              filter.processInstanceKey(processInstanceKey);
-              filter.scopeKey(processInstanceKey);
-              selector.applyFilter(filter);
-            }));
+            filter ->
+                selector.applyFilter(
+                    filter.processInstanceKey(processInstanceKey).scopeKey(processInstanceKey))));
   }
 
   private List<Variable> findLocalVariablesBySelector(
@@ -493,11 +491,9 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
       final VariableSelector selector) {
     return ensureVariablesAreNotTruncated(
         dataSource.findVariables(
-            filter -> {
-              filter.processInstanceKey(processInstanceKey);
-              filter.scopeKey(elementInstanceKey);
-              selector.applyFilter(filter);
-            }));
+            filter ->
+                selector.applyFilter(
+                    filter.processInstanceKey(processInstanceKey).scopeKey(elementInstanceKey))));
   }
 
   private List<Variable> ensureVariablesAreNotTruncated(final List<Variable> variablesToCheck) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -25,7 +25,6 @@ import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import io.camunda.process.test.api.assertions.ElementSelector;
 import io.camunda.process.test.api.assertions.VariableSelector;
-import io.camunda.process.test.api.assertions.VariableSelectors;
 import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.impl.assertions.util.CamundaAssertJsonMapper;
 import io.camunda.process.test.impl.assertions.util.CamundaAssertJsonMapper.JsonMappingException;
@@ -111,16 +110,6 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   public void hasLocalVariable(
       final long processInstanceKey,
       final ElementSelector elementSelector,
-      final String variableName,
-      final Object variableValue) {
-
-    hasLocalVariable(
-        processInstanceKey, elementSelector, VariableSelectors.byName(variableName), variableValue);
-  }
-
-  public void hasLocalVariable(
-      final long processInstanceKey,
-      final ElementSelector elementSelector,
       final VariableSelector variableSelector,
       final Object variableValue) {
 
@@ -132,14 +121,8 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                 variableSelector,
                 variableValue,
                 () ->
-                    findVariablesBySelector(
+                    findLocalVariablesBySelector(
                         processInstanceKey, instance.getElementInstanceKey(), variableSelector)));
-  }
-
-  public void hasVariable(
-      final long processInstanceKey, final String variableName, final Object variableValue) {
-
-    hasVariable(processInstanceKey, VariableSelectors.byName(variableName), variableValue);
   }
 
   public void hasVariable(
@@ -150,7 +133,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
     hasVariable(
         variableSelector,
         variableValue,
-        () -> findVariablesBySelector(processInstanceKey, variableSelector));
+        () -> findGlobalVariablesBySelector(processInstanceKey, variableSelector));
   }
 
   private void hasVariable(
@@ -184,21 +167,6 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   public <T> void hasLocalVariableSatisfies(
       final long processInstanceKey,
       final ElementSelector elementSelector,
-      final String variableName,
-      final Class<T> variableValueType,
-      final ThrowingConsumer<T> requirement) {
-
-    hasLocalVariableSatisfies(
-        processInstanceKey,
-        elementSelector,
-        VariableSelectors.byName(variableName),
-        variableValueType,
-        requirement);
-  }
-
-  public <T> void hasLocalVariableSatisfies(
-      final long processInstanceKey,
-      final ElementSelector elementSelector,
       final VariableSelector variableSelector,
       final Class<T> variableValueType,
       final ThrowingConsumer<T> requirement) {
@@ -212,18 +180,8 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                 variableValueType,
                 requirement,
                 () ->
-                    findVariablesBySelector(
+                    findLocalVariablesBySelector(
                         processInstanceKey, instance.getElementInstanceKey(), variableSelector)));
-  }
-
-  public <T> void hasVariableSatisfies(
-      final long processInstanceKey,
-      final String variableName,
-      final Class<T> variableValueType,
-      final ThrowingConsumer<T> requirement) {
-
-    hasVariableSatisfies(
-        processInstanceKey, VariableSelectors.byName(variableName), variableValueType, requirement);
   }
 
   public <T> void hasVariableSatisfies(
@@ -236,7 +194,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
         variableSelector,
         variableValueType,
         requirement,
-        () -> findVariablesBySelector(processInstanceKey, variableSelector));
+        () -> findGlobalVariablesBySelector(processInstanceKey, variableSelector));
   }
 
   private void hasVariableSatisfies(
@@ -406,13 +364,6 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   }
 
   public void hasVariableSatisfiesJudge(
-      final long processInstanceKey, final String variableName, final String expectation) {
-
-    hasVariableSatisfiesJudge(
-        processInstanceKey, VariableSelectors.byName(variableName), expectation);
-  }
-
-  public void hasVariableSatisfiesJudge(
       final long processInstanceKey,
       final VariableSelector variableSelector,
       final String expectation) {
@@ -425,17 +376,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
         rawValue ->
             evaluateJudge(
                 variableSelector.describe(), expectation, judgeConfig.getThreshold(), rawValue),
-        () -> findVariablesBySelector(processInstanceKey, variableSelector));
-  }
-
-  public void hasLocalVariableSatisfiesJudge(
-      final long processInstanceKey,
-      final ElementSelector elementSelector,
-      final String variableName,
-      final String expectation) {
-
-    hasLocalVariableSatisfiesJudge(
-        processInstanceKey, elementSelector, VariableSelectors.byName(variableName), expectation);
+        () -> findGlobalVariablesBySelector(processInstanceKey, variableSelector));
   }
 
   public void hasLocalVariableSatisfiesJudge(
@@ -460,7 +401,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                         judgeConfig.getThreshold(),
                         rawValue),
                 () ->
-                    findVariablesBySelector(
+                    findLocalVariablesBySelector(
                         processInstanceKey, instance.getElementInstanceKey(), variableSelector)));
   }
 
@@ -535,17 +476,18 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
     return toMap(ensureVariablesAreNotTruncated(variables));
   }
 
-  private List<Variable> findVariablesBySelector(
+  private List<Variable> findGlobalVariablesBySelector(
       final long processInstanceKey, final VariableSelector selector) {
     return ensureVariablesAreNotTruncated(
         dataSource.findVariables(
             filter -> {
               filter.processInstanceKey(processInstanceKey);
+              filter.scopeKey(processInstanceKey);
               selector.applyFilter(filter);
             }));
   }
 
-  private List<Variable> findVariablesBySelector(
+  private List<Variable> findLocalVariablesBySelector(
       final long processInstanceKey,
       final long elementInstanceKey,
       final VariableSelector selector) {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JudgeAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JudgeAssertTest.java
@@ -93,8 +93,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"Hello, World!\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -112,8 +111,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"random text\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -136,8 +134,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"some text\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -154,8 +151,7 @@ public class JudgeAssertTest {
       final ChatModelAdapter mockModel = prompt -> "{\"score\": 1.0, \"reasoning\": \"ok\"}";
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.emptyList());
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.emptyList());
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -191,8 +187,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"borderline value\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -209,8 +204,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"some value\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -236,8 +230,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"some value\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -277,8 +270,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel).withThreshold(0.0));
 
       final Variable variable = newVariable("result", null);
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -300,8 +292,7 @@ public class JudgeAssertTest {
                       .build()));
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -320,8 +311,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel).withThreshold(0.8));
 
       final Variable variable = newVariable("result", "\"some value\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -538,8 +528,7 @@ public class JudgeAssertTest {
           JudgeConfig.of(mockModel).withCustomPrompt("You are a domain-specific evaluator."));
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -569,8 +558,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -600,8 +588,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(globalModel));
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -630,8 +617,7 @@ public class JudgeAssertTest {
 
       final Variable varA = newVariable("varA", "\"value A\"");
       final Variable varB = newVariable("varB", "\"value B\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Arrays.asList(varA, varB));
+      when(camundaDataSource.findVariables(any())).thenReturn(Arrays.asList(varA, varB));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -673,8 +659,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -695,8 +680,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"some text\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -718,8 +702,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel));
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -740,8 +723,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(mockModel).withThreshold(0.5));
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -760,8 +742,7 @@ public class JudgeAssertTest {
       final ChatModelAdapter mockModel = prompt -> "{\"score\": 0.9, \"reasoning\": \"match\"}";
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -801,8 +782,7 @@ public class JudgeAssertTest {
       CamundaAssert.setJudgeConfig(JudgeConfig.of(globalModel));
 
       final Variable variable = newVariable("result", "\"Hello\"");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -660,8 +660,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertStateAndVariables() {
       // given
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -688,8 +687,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertVariablesAndState() {
       // given
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -704,8 +702,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Collections.singletonList(activeElementInstance));
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -722,8 +719,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Collections.singletonList(activeElementInstance));
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertIT.java
@@ -220,10 +220,10 @@ public class VariableAssertIT {
   }
 
   @Test
-  void shouldMatchVariableWithCombinedNameAndValueContainsSelector() {
+  void shouldMatchVariableWithNameAndValueContainsSelector() {
     // Given
     final long processDefinitionKey = deployProcessModel(processModelWithVariables());
-    final Map<String, Object> variables = new HashMap<String, Object>();
+    final Map<String, Object> variables = new HashMap<>();
     variables.put("order_id", "order-123");
     variables.put("other", "value");
     final ProcessInstanceEvent processInstanceEvent =
@@ -236,23 +236,11 @@ public class VariableAssertIT {
 
     // Then
     assertThatProcessInstance(processInstanceEvent)
+        .hasVariable(VariableSelectors.byName("order_id"), "order-123")
+        .hasVariable(VariableSelectors.byValueContains("order"), "order-123")
         .hasVariable(
             VariableSelectors.byName("order_id").and(VariableSelectors.byValueContains("order")),
             "order-123");
-
-    withShortAwaitilityTimeouts(
-        () ->
-            Assertions.assertThatThrownBy(
-                    () ->
-                        assertThatProcessInstance(processInstanceEvent)
-                            .hasVariable(
-                                VariableSelectors.byName("order_id")
-                                    .and(VariableSelectors.byValueContains("unknown")),
-                                "order-123"))
-                .hasMessage(
-                    "Process instance [key: %s] should have a variable 'order_id, value contains: unknown'"
-                        + " with value '\"order-123\"' but the variable doesn't exist.",
-                    processInstanceEvent.getProcessInstanceKey()));
   }
 
   private void withShortAwaitilityTimeouts(final Runnable assertionFn) {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertIT.java
@@ -23,6 +23,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import io.camunda.process.test.api.assertions.VariableSelectors;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.Duration;
@@ -218,6 +219,42 @@ public class VariableAssertIT {
         .hasLocalVariables("user-task-child-id", expectedVariables);
   }
 
+  @Test
+  void shouldMatchVariableWithCombinedNameAndValueContainsSelector() {
+    // Given
+    final long processDefinitionKey = deployProcessModel(processModelWithVariables());
+    final Map<String, Object> variables = new HashMap<String, Object>();
+    variables.put("order_id", "order-123");
+    variables.put("other", "value");
+    final ProcessInstanceEvent processInstanceEvent =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(processDefinitionKey)
+            .variables(variables)
+            .send()
+            .join();
+
+    // Then
+    assertThatProcessInstance(processInstanceEvent)
+        .hasVariable(
+            VariableSelectors.byName("order_id").and(VariableSelectors.byValueContains("order")),
+            "order-123");
+
+    withShortAwaitilityTimeouts(
+        () ->
+            Assertions.assertThatThrownBy(
+                    () ->
+                        assertThatProcessInstance(processInstanceEvent)
+                            .hasVariable(
+                                VariableSelectors.byName("order_id")
+                                    .and(VariableSelectors.byValueContains("unknown")),
+                                "order-123"))
+                .hasMessage(
+                    "Process instance [key: %s] should have a variable 'order_id, value contains: unknown'"
+                        + " with value '\"order-123\"' but the variable doesn't exist.",
+                    processInstanceEvent.getProcessInstanceKey()));
+  }
+
   private void withShortAwaitilityTimeouts(final Runnable assertionFn) {
     CamundaAssert.setAssertionTimeout(Duration.ofSeconds(5));
 
@@ -267,6 +304,13 @@ public class VariableAssertIT {
         .zeebeOutputExpression("\"B\"", "shadowed_variable")
         .zeebeUserTask()
         .endEvent("child-end")
+        .done();
+  }
+
+  private BpmnModelInstance processModelWithVariables() {
+    return Bpmn.createExecutableProcess("test-process-variables")
+        .startEvent()
+        .endEvent("success-end")
         .done();
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -22,9 +22,11 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.assertions.ElementSelectors;
+import io.camunda.process.test.api.assertions.VariableSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.utils.CamundaAssertExpectFailure;
 import io.camunda.process.test.utils.CamundaAssertExtension;
@@ -36,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -47,6 +50,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -225,8 +231,7 @@ public class VariableAssertTest {
       // given
       final Variable variableA = newVariable("a", variableValue);
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variableA));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variableA));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -241,7 +246,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(variableB))
           .thenReturn(Arrays.asList(variableA, variableB));
 
@@ -251,8 +256,7 @@ public class VariableAssertTest {
       // then
       CamundaAssert.assertThatProcessInstance(processInstanceEvent).hasVariable("a", 1);
 
-      verify(camundaDataSource, times(2))
-          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findVariables(any());
     }
 
     @Test
@@ -260,7 +264,7 @@ public class VariableAssertTest {
       // given
       final Variable variableWithNull = newVariable("a", null);
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(variableWithNull));
 
       // when
@@ -276,7 +280,7 @@ public class VariableAssertTest {
       final Variable variableValue1 = newVariable("a", "1");
       final Variable variableValue2 = newVariable("a", "2");
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(variableValue1))
           .thenReturn(Collections.singletonList(variableValue2));
 
@@ -286,19 +290,14 @@ public class VariableAssertTest {
       // then
       CamundaAssert.assertThatProcessInstance(processInstanceEvent).hasVariable("a", 2);
 
-      verify(camundaDataSource, times(2))
-          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findVariables(any());
     }
 
     @Test
     @CamundaAssertExpectFailure
     void shouldFailIfVariableNotExist() {
       // given
-      final Variable variableA = newVariable("a", "1");
-      final Variable variableB = newVariable("b", "2");
-
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Arrays.asList(variableA, variableB));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -319,8 +318,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Arrays.asList(variableA, variableB));
+      when(camundaDataSource.findVariables(any())).thenReturn(Arrays.asList(variableA, variableB));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -341,8 +339,7 @@ public class VariableAssertTest {
       // given
       final Variable variableA = newVariable("a", variableValue);
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variableA));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variableA));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -625,7 +622,7 @@ public class VariableAssertTest {
     @SuppressWarnings("unchecked")
     void shouldSatisfyConditions() {
       // given
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(complexVariable));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -688,7 +685,7 @@ public class VariableAssertTest {
     @Test
     void shouldSatisfyConditionsWithJsonDeserialization() {
       // given
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(complexVariable));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -704,7 +701,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(variableB))
           .thenReturn(Arrays.asList(variableA, variableB));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -714,15 +711,14 @@ public class VariableAssertTest {
           .hasVariableSatisfies(
               "a", String.class, value -> Assertions.assertThat(value).isEqualTo("1"));
 
-      verify(camundaDataSource, times(2))
-          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findVariables(any());
     }
 
     @Test
     @CamundaAssertExpectFailure
     void shouldHaveSensibleErrorMessageWhenAssertionFails() {
       // given
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(complexVariable));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -759,7 +755,7 @@ public class VariableAssertTest {
     @CamundaAssertExpectFailure
     void shouldHaveSensibleErrorMessageWhenJsonMappingFails() {
       // given
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(complexVariable));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
@@ -781,8 +777,7 @@ public class VariableAssertTest {
     @CamundaAssertExpectFailure
     void shouldHaveSensibleErrorMessageWhenNoVariablesFound() {
       // given
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.emptyList());
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.emptyList());
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
@@ -801,7 +796,7 @@ public class VariableAssertTest {
     @CamundaAssertExpectFailure
     void shouldConvertCheckedExceptions() {
       // given
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariables(any()))
           .thenReturn(Collections.singletonList(complexVariable));
 
       // when
@@ -818,6 +813,266 @@ public class VariableAssertTest {
                             throw new Exception("Error");
                           }))
           .hasMessage("java.lang.Exception: Error");
+    }
+  }
+
+  @Nested
+  class VariableSource {
+
+    @Mock private VariableFilter variableFilter;
+
+    @Captor private ArgumentCaptor<Consumer<VariableFilter>> variableFilterCaptor;
+
+    @BeforeEach
+    void configureMocks() {
+      final Variable variableA = newVariable("a", "1");
+      final Variable variableB = newVariable("b", "2");
+
+      when(camundaDataSource.findVariables(any())).thenReturn(Arrays.asList(variableA, variableB));
+    }
+
+    @Test
+    void shouldUseByNameSelector() {
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariable(VariableSelectors.byName("a"), 1);
+
+      verify(camundaDataSource).findVariables(variableFilterCaptor.capture());
+
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).name("a");
+    }
+
+    @Test
+    void shouldUseByScopeKeySelector() {
+      // given
+      final long scopeKey = 42L;
+      final Variable variableWithScope =
+          VariableBuilder.newVariable("x", "\"hello\"").setScopeKey(scopeKey).build();
+
+      when(camundaDataSource.findVariables(any()))
+          .thenReturn(Collections.singletonList(variableWithScope));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariable(VariableSelectors.byScopeKey(scopeKey), "hello");
+
+      verify(camundaDataSource).findVariables(variableFilterCaptor.capture());
+
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).scopeKey(scopeKey);
+    }
+
+    @Test
+    void shouldUseByValueContainsSelector() {
+      // given
+      final Variable variableWithValue =
+          VariableBuilder.newVariable("order", "\"order-123\"").build();
+
+      when(camundaDataSource.findVariables(any()))
+          .thenReturn(Collections.singletonList(variableWithValue));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariable(VariableSelectors.byValueContains("order-123"), "order-123");
+
+      verify(camundaDataSource).findVariables(variableFilterCaptor.capture());
+
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).value(ArgumentMatchers.<Consumer>any());
+    }
+
+    @Test
+    void shouldUseCombinedSelector() {
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariable(
+              VariableSelectors.byName("a").and(VariableSelectors.byValueContains("1")), 1);
+
+      verify(camundaDataSource).findVariables(variableFilterCaptor.capture());
+
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).name("a");
+      verify(variableFilter).value(ArgumentMatchers.<Consumer>any());
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldFailIfNoVariableMatchesSelector() {
+      // given
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.emptyList());
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasVariable(VariableSelectors.byName("missing"), "value"))
+          .hasMessage(
+              "Process instance [key: %d] should have a variable 'missing' with value '\"value\"' but the variable doesn't exist.",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldFailWithScopeKeySelectorDescriptionInMessage() {
+      // given
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.emptyList());
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasVariable(VariableSelectors.byScopeKey(99L), "value"))
+          .hasMessage(
+              "Process instance [key: %d] should have a variable 'scopeKey: 99' with value '\"value\"' but the variable doesn't exist.",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldFailWithValueContainsSelectorDescriptionInMessage() {
+      // given
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.emptyList());
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasVariable(VariableSelectors.byValueContains("foo"), "bar"))
+          .hasMessage(
+              "Process instance [key: %d] should have a variable 'value contains: foo' with value '\"bar\"' but the variable doesn't exist.",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldHasVariableSatisfiesWithByNameSelector() {
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariableSatisfies(
+              VariableSelectors.byName("a"),
+              String.class,
+              value -> Assertions.assertThat(value).isEqualTo("1"));
+
+      verify(camundaDataSource).findVariables(variableFilterCaptor.capture());
+
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).name("a");
+    }
+
+    @Test
+    void shouldHasLocalVariableWithVariableSelector() {
+      // given
+      final String elementId = "element-id";
+      final ElementInstance elementInstance =
+          ElementInstanceBuilder.newActiveElementInstance(elementId, PROCESS_INSTANCE_KEY)
+              .setElementInstanceKey(10L)
+              .build();
+
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstance));
+      when(camundaDataSource.findVariables(any()))
+          .thenReturn(Collections.singletonList(newVariable("a", "1")));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasLocalVariable(ElementSelectors.byId(elementId), VariableSelectors.byName("a"), 1);
+
+      verify(camundaDataSource).findVariables(variableFilterCaptor.capture());
+
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).scopeKey(10L);
+      verify(variableFilter).name("a");
+    }
+
+    @Test
+    void shouldHasLocalVariableSatisfiesWithVariableSelector() {
+      // given
+      final String elementId = "element-id";
+      final ElementInstance elementInstance =
+          ElementInstanceBuilder.newActiveElementInstance(elementId, PROCESS_INSTANCE_KEY)
+              .setElementInstanceKey(10L)
+              .build();
+
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstance));
+      when(camundaDataSource.findVariables(any()))
+          .thenReturn(Collections.singletonList(newVariable("a", "\"hello\"")));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasLocalVariableSatisfies(
+              ElementSelectors.byId(elementId),
+              VariableSelectors.byName("a"),
+              String.class,
+              value -> Assertions.assertThat(value).isEqualTo("hello"));
+
+      verify(camundaDataSource).findVariables(variableFilterCaptor.capture());
+
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).scopeKey(10L);
+      verify(variableFilter).name("a");
+    }
+
+    @Test
+    void shouldDescribeCombinedSelector() {
+      // given
+      final long scopeKey = PROCESS_INSTANCE_KEY;
+      final Variable variableWithScope =
+          VariableBuilder.newVariable("a", "1")
+              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+              .setScopeKey(scopeKey)
+              .build();
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.findVariables(any()))
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.singletonList(variableWithScope));
+
+      // then: combined selector describe = "a, scopeKey: 1" - waits until variable matches
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariable(
+              VariableSelectors.byName("a").and(VariableSelectors.byScopeKey(scopeKey)), 1);
+
+      verify(camundaDataSource, times(2)).findVariables(any());
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.filter.VariableFilter;
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.assertions.ElementSelectors;
@@ -51,7 +52,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -297,7 +297,10 @@ public class VariableAssertTest {
     @CamundaAssertExpectFailure
     void shouldFailIfVariableNotExist() {
       // given
-      when(camundaDataSource.findVariables(any())).thenReturn(Collections.emptyList());
+      final Variable variableA = newVariable("a", "1");
+      final Variable variableB = newVariable("b", "2");
+
+      when(camundaDataSource.findVariables(any())).thenReturn(Arrays.asList(variableA, variableB));
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -820,8 +823,10 @@ public class VariableAssertTest {
   class VariableSource {
 
     @Mock private VariableFilter variableFilter;
+    @Mock private StringProperty stringProperty;
 
     @Captor private ArgumentCaptor<Consumer<VariableFilter>> variableFilterCaptor;
+    @Captor private ArgumentCaptor<Consumer<StringProperty>> stringPropertyCaptor;
 
     @BeforeEach
     void configureMocks() {
@@ -844,6 +849,7 @@ public class VariableAssertTest {
 
       variableFilterCaptor.getValue().accept(variableFilter);
       verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).scopeKey(PROCESS_INSTANCE_KEY);
       verify(variableFilter).name("a");
     }
 
@@ -891,7 +897,11 @@ public class VariableAssertTest {
 
       variableFilterCaptor.getValue().accept(variableFilter);
       verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
-      verify(variableFilter).value(ArgumentMatchers.<Consumer>any());
+      verify(variableFilter).scopeKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).value(stringPropertyCaptor.capture());
+
+      stringPropertyCaptor.getValue().accept(stringProperty);
+      verify(stringProperty).like("*order-123*");
     }
 
     @Test
@@ -908,8 +918,12 @@ public class VariableAssertTest {
 
       variableFilterCaptor.getValue().accept(variableFilter);
       verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).scopeKey(PROCESS_INSTANCE_KEY);
       verify(variableFilter).name("a");
-      verify(variableFilter).value(ArgumentMatchers.<Consumer>any());
+      verify(variableFilter).value(stringPropertyCaptor.capture());
+
+      stringPropertyCaptor.getValue().accept(stringProperty);
+      verify(stringProperty).like("*1*");
     }
 
     @Test
@@ -985,6 +999,7 @@ public class VariableAssertTest {
 
       variableFilterCaptor.getValue().accept(variableFilter);
       verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(variableFilter).scopeKey(PROCESS_INSTANCE_KEY);
       verify(variableFilter).name("a");
     }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -822,7 +823,9 @@ public class VariableAssertTest {
   @Nested
   class VariableSource {
 
-    @Mock private VariableFilter variableFilter;
+    @Mock(answer = Answers.RETURNS_SELF)
+    private VariableFilter variableFilter;
+
     @Mock private StringProperty stringProperty;
 
     @Captor private ArgumentCaptor<Consumer<VariableFilter>> variableFilterCaptor;


### PR DESCRIPTION
# Description
Backport of #48729 to `stable/8.9`.

relates to camunda/camunda#48358