### PR TITLE
Fix slack label and skip usage metrics test

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -568,6 +568,7 @@ jobs:
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
+          API_TESTS_ONLY: true
           VERSION: ${{ steps.sanitize.outputs.safe_branch  }}
           DATABASE: "RDBMS"
           DB_NAME: ${{ matrix.database.database-name }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -400,6 +400,12 @@ jobs:
           distribution: temurin
           java-version: '21'
 
+      - name: Python setup
+        if: always()
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
       - name: Sanitize branch name
         id: sanitize
         run: |
@@ -562,7 +568,9 @@ jobs:
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
+          VERSION: ${{ steps.sanitize.outputs.safe_branch  }}
           DATABASE: "RDBMS"
+          DB_NAME: ${{ matrix.database.database-name }}
           INCLUDE_SLACK_REPORTER: true
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
         run: DATABASE=RDBMS npm run test -- --project=api-tests

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -25,8 +25,10 @@ function getTestTypeLabel(): string {
   }
   if (isApiTestsOnly) {
     const database = process.env.DATABASE
-      ? ` - Database ${process.env.DATABASE}`
-      : '';
+        ? ` - Database ${process.env.DATABASE}${
+            process.env.DB_NAME ? ` (${process.env.DB_NAME})` : ''
+        }`
+        : '';
     return `Nightly API Test Results for Mono Repo - ${process.env.VERSION}${database}`;
   }
   const tasklistMode = isV2ModeEnabled ? 'V2' : 'V1';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -53,7 +53,8 @@ const LIMITED_ROLE_AUTHORIZATION = {
 };
 
 test.describe.serial('Get usage metrics API Tests', () => {
-  test('Get Usage Metrics Success', async ({request}) => {
+  //Skipped due to bug 49032: https://github.com/camunda/camunda/issues/49032
+  test.skip('Get Usage Metrics Success', async ({request}) => {
     const startOfTodayLocal = new Date();
     startOfTodayLocal.setHours(0, 0, 0, 0);
     const isoLocalMidnight = startOfTodayLocal.toISOString();


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the nightly E2E test workflow and the Playwright test suite for the orchestration cluster. The main changes include enhanced environment variable handling for database and versioning, improved test result labeling, and the temporary skipping of a failing test due to a known bug.

**Workflow and Environment Variable Improvements:**

* Added a Python setup step to the GitHub Actions workflow to ensure Python is available for subsequent steps.
* Updated the workflow to pass `VERSION` (from the sanitized branch name) and `DB_NAME` (from the database matrix) as environment variables to the test runner.

**Test Suite Enhancements:**

* Improved the `getTestTypeLabel` function in `playwright.config.ts` to include both `DATABASE` and `DB_NAME` in the nightly API test results label, providing clearer test context.

**Test Stability and Maintenance:**

* Skipped the `Get Usage Metrics Success` test in `usage-metrics-api.spec.ts` due to a known bug (issue #49032), to prevent false negatives in CI.