### PR TITLE
Cluster Sizing Metrics: improve PROCESS_INSTANCE_EXECUTION buckets to track log running PIs.

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -9104,9 +9104,9 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (partition, le))",
               "instant": false,
-              "legendFormat": "quantile-50th",
+              "legendFormat": "Partition: {{partition}} quantile-50th",
               "range": true,
               "refId": "C"
             },
@@ -9116,9 +9116,9 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (partition, le))",
               "instant": false,
-              "legendFormat": "quantile-90th",
+              "legendFormat": "Partition: {{partition}} quantile-90th",
               "range": true,
               "refId": "D"
             },
@@ -9128,9 +9128,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (partition, le))",
               "instant": false,
-              "legendFormat": "quantile-99th",
+              "legendFormat": "Partition: {{partition}} quantile-99th",
               "range": true,
               "refId": "E"
             }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -8993,7 +8993,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Shows the execution time of a process instance. This means the time (latency) between creating the instance and completing it.",
+          "description": "Shows the execution time of a process instance. This means the time (latency) between creating the instance and completing it. This metric is only tracked in memory, therefore if the PI was started before the last broker restart it wont be included in the metric.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -9113,6 +9113,18 @@
             {
               "datasource": {
                 "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "instant": false,
+              "legendFormat": "quantile-90th",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
@@ -9120,7 +9132,7 @@
               "instant": false,
               "legendFormat": "quantile-99th",
               "range": true,
-              "refId": "D"
+              "refId": "E"
             }
           ],
           "title": "Process Instance Execution Time (avg)",
@@ -9131,7 +9143,7 @@
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
           },
-          "description": "Shows the time (latency) between creating the job and activating it.",
+          "description": "Shows the time (latency) between creating the job and activating it. This metric is only tracked in memory, therefore if the PI was started before the last broker restart it wont be included in the metric.",
           "fieldConfig": {
             "defaults": {
               "custom": {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -54,19 +54,21 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
   PROCESS_INSTANCE_EXECUTION {
     private static final Duration[] BUCKETS = {
       Duration.ofMillis(50),
-      Duration.ofMillis(75),
       Duration.ofMillis(100),
       Duration.ofMillis(250),
       Duration.ofMillis(500),
-      Duration.ofMillis(750),
       Duration.ofSeconds(1),
-      Duration.ofMillis(2500),
+      Duration.ofSeconds(2),
       Duration.ofSeconds(5),
       Duration.ofSeconds(10),
-      Duration.ofSeconds(15),
       Duration.ofSeconds(30),
-      Duration.ofSeconds(45),
-      Duration.ofMinutes(1)
+      Duration.ofMinutes(1),
+      Duration.ofMinutes(5),
+      Duration.ofMinutes(10),
+      Duration.ofMinutes(30),
+      Duration.ofHours(1),
+      Duration.ofHours(6),
+      Duration.ofHours(24),
     };
 
     @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -54,21 +54,19 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
   PROCESS_INSTANCE_EXECUTION {
     private static final Duration[] BUCKETS = {
       Duration.ofMillis(50),
+      Duration.ofMillis(75),
       Duration.ofMillis(100),
       Duration.ofMillis(250),
       Duration.ofMillis(500),
+      Duration.ofMillis(750),
       Duration.ofSeconds(1),
-      Duration.ofSeconds(2),
+      Duration.ofMillis(2500),
       Duration.ofSeconds(5),
       Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
       Duration.ofSeconds(30),
-      Duration.ofMinutes(1),
-      Duration.ofMinutes(5),
-      Duration.ofMinutes(10),
-      Duration.ofMinutes(30),
-      Duration.ofHours(1),
-      Duration.ofHours(6),
-      Duration.ofHours(24),
+      Duration.ofSeconds(45),
+      Duration.ofMinutes(1)
     };
 
     @Override


### PR DESCRIPTION
## Description

We already have metrics that track in-memory process instance duration times, namely `zeebe.process.instance.execution.time`. This PR just extends the bucket of the existing metric to be able to track longer-running process instances. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/49063
