### PR TITLE
[Backport stable/8.9] fix: allow fullscreen api in permissions-policy header

### DIFF
--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -72,7 +72,9 @@ const useFullscreen = (
       return;
     }
 
-    el.requestFullscreen();
+    el.requestFullscreen().catch(() => {
+      // Fullscreen blocked by Permissions Policy — silently ignore
+    });
   }, [diagramRef]);
 
   useEffect(() => {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/headers/PermissionsPolicyConfig.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/headers/PermissionsPolicyConfig.java
@@ -46,7 +46,7 @@ public class PermissionsPolicyConfig {
           + "deferred-fetch-minimal=(), "
           + "display-capture=(), "
           + "encrypted-media=(), "
-          + "fullscreen=(), "
+          + "fullscreen=(self), "
           + "gamepad=(), "
           + "geolocation=(), "
           + "gyroscope=(), "
@@ -80,7 +80,7 @@ public class PermissionsPolicyConfig {
    * <p>Default: accelerometer=(), ambient-light-sensor=(), attribution-reporting=(), autoplay=(),
    * bluetooth=(), browsing-topics=(), camera=(), compute-pressure=(), cross-origin-isolated=(),
    * deferred-fetch=(), deferred-fetch-minimal=(), display-capture=(), encrypted-media=(),
-   * fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(),
+   * fullscreen=(self), gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(),
    * idle-detection=(), language-detector=(), local-fonts=(), magnetometer=(), microphone=(),
    * midi=(), otp-credentials=(), payment=(), picture-in-picture=(),
    * publickey-credentials-create=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(),

--- a/security/security-core/src/main/java/io/camunda/security/configuration/headers/PermissionsPolicyConfig.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/headers/PermissionsPolicyConfig.java
@@ -80,9 +80,9 @@ public class PermissionsPolicyConfig {
    * <p>Default: accelerometer=(), ambient-light-sensor=(), attribution-reporting=(), autoplay=(),
    * bluetooth=(), browsing-topics=(), camera=(), compute-pressure=(), cross-origin-isolated=(),
    * deferred-fetch=(), deferred-fetch-minimal=(), display-capture=(), encrypted-media=(),
-   * fullscreen=(self), gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(),
-   * idle-detection=(), language-detector=(), local-fonts=(), magnetometer=(), microphone=(),
-   * midi=(), otp-credentials=(), payment=(), picture-in-picture=(),
+   * fullscreen=(self), gamepad=(), geolocation=(), gyroscope=(), hid=(),
+   * identity-credentials-get=(), idle-detection=(), language-detector=(), local-fonts=(),
+   * magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(),
    * publickey-credentials-create=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(),
    * speaker-selection=(), storage-access=(), summarizer=(), translator=(), usb=(), web-share=(),
    * window-management=(), xr-spatial-tracking=() which disables all features by default.


### PR DESCRIPTION
# Description
Backport of #48938 to `stable/8.9`.

relates to #48823