### PR TITLE
fix: do not throw exception in scheduled flush

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -345,8 +345,6 @@ public class CamundaExporter implements Exporter {
       if (now - lastFlushTimestamp >= flushDelayMs) {
         flush();
       }
-    } catch (final ExporterException e) {
-      throw e;
     } catch (final Exception e) {
       LOG.warn("Unexpected exception occurred on periodically flushing bulk, will retry later.", e);
       now = context.clock().millis();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -245,11 +245,11 @@ final class CamundaExporterIT {
 
     final var record = generateRecordWithSupportedBrokerVersion(ValueType.USER, UserIntent.CREATED);
 
+    // first one won't fail as the flush is async
     exporter.export(record);
 
-    // the export above fails in the async supplier, and it requires a call to .join that future so
-    // that the error is surfaced
-    assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(1)))
+    // the actual error will only be observed on the next flush attempt
+    assertThatThrownBy(() -> exporter.export(record))
         .isInstanceOf(ExporterException.class)
         .hasMessageContaining("Connection refused");
 
@@ -262,7 +262,7 @@ final class CamundaExporterIT {
     final var record2 =
         generateRecordWithSupportedBrokerVersion(ValueType.USER, UserIntent.CREATED);
     exporter.export(record2);
-    exporter.close();
+    exporter.close(); // forces a flush and wait for it to complete
 
     await()
         .untilAsserted(() -> assertThat(controller.getPosition()).isEqualTo(record2.getPosition()));
@@ -419,10 +419,14 @@ final class CamundaExporterIT {
 
     // act
     exporter.export(record);
-    assertThatThrownBy(() -> controller.runScheduledTasks(Duration.ofSeconds(1)))
+    // flushes are async so calling 2nd time to ensure the first record is flushed and error is
+    // observed
+    assertThatThrownBy(() -> exporter.export(record))
         .isInstanceOf(ExporterException.class)
         .rootCause()
         .isInstanceOf(PersistenceException.class);
+
+    assertThat(controller.getPosition()).isEqualTo(-1L);
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -73,7 +73,7 @@ final class CamundaExporterTest {
 
   @BeforeEach
   void beforeEach() {
-    stubbedClientAdapterInUse = new StubClientAdapter();
+    stubbedClientAdapterInUse = spy(new StubClientAdapter());
     mockedClientAdapterFactory
         .when(() -> ClientAdapter.of(configuration.getConnect()))
         .thenReturn(stubbedClientAdapterInUse);
@@ -514,7 +514,7 @@ final class CamundaExporterTest {
     }
 
     @Test
-    void shouldPropagateAsyncFlushErrorOnScheduledFlush() {
+    void shouldNotPropagateAsyncFlushErrorOnScheduledFlush() {
       // given
       final var failingAdapter = new FailingBatchRequestClientAdapter();
       mockedClientAdapterFactory
@@ -533,9 +533,8 @@ final class CamundaExporterTest {
 
       // then
       final var initialPosition = testController.getPosition();
-      assertThatThrownBy(() -> testController.runScheduledTasks(Duration.ofHours(1)))
-          .isInstanceOf(ExporterException.class)
-          .hasRootCauseInstanceOf(PersistenceException.class);
+      testController.runScheduledTasks(Duration.ofHours(1));
+
       assertThat(testController.getPosition()).isEqualTo(initialPosition);
     }
   }


### PR DESCRIPTION
we'll rely on retrying later instead

## Related issues

Refs #49033
