### PR TITLE
rafactor: Refactor Archiver Metrics

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/ArchiverJobMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/ArchiverJobMetrics.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.metrics;
+
+import static io.camunda.exporter.metrics.CamundaArchiverMetrics.ARCHIVE_OPERATION_STAGE_TAG_COPY;
+import static io.camunda.exporter.metrics.CamundaArchiverMetrics.ARCHIVE_OPERATION_STAGE_TAG_DELETE;
+import static io.camunda.exporter.metrics.CamundaArchiverMetrics.ARCHIVE_OPERATION_STAGE_TAG_READ;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
+
+/**
+ * Wrapper for CamundaArchiverMetrics along with the jobName. This simply call the respective method
+ * in CamundaArchiverMetrics with the specified jobName.
+ */
+public class ArchiverJobMetrics {
+
+  final String jobName;
+  final CamundaArchiverMetrics archiverMetrics;
+
+  public ArchiverJobMetrics(final String jobName, final CamundaArchiverMetrics archiverMetrics) {
+    this.jobName = jobName;
+    this.archiverMetrics = archiverMetrics;
+  }
+
+  public void measureArchivingSuccessDuration(final Sample timer) {
+    archiverMetrics.measureArchivingSuccessDuration(jobName, timer);
+  }
+
+  public void measureArchivingFailedDuration(final Sample timer) {
+    archiverMetrics.measureArchivingFailedDuration(jobName, timer);
+  }
+
+  public void measureArchivingBatchSize(final int batchSize) {
+    archiverMetrics.measureArchivingBatchSize(jobName, batchSize);
+  }
+
+  public void measureArchivedInstanceCount(final int batchSize) {
+    archiverMetrics.measureArchivedInstanceCount(jobName, batchSize);
+  }
+
+  public void measureArchiverRequestSearchDuration(final Timer.Sample sample) {
+    archiverMetrics.measureArchiverSearch(sample);
+  }
+
+  public void measureArchiverReindexDuration(final Sample timer) {
+    archiverMetrics.measureArchiverReindex(timer);
+  }
+
+  public void measureArchiverDeleteDuration(final Sample timer) {
+    archiverMetrics.measureArchiverDelete(timer);
+  }
+
+  public void measureArchiverReadSuccess(
+      final String sourceIdx, final Sample timer, final Long noOfDocs) {
+    archiverMetrics.measureSuccessfulArchiverStageMetrics(
+        jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, timer, noOfDocs);
+  }
+
+  public void measureArchiverReadFailure(
+      final String sourceIdx, final Sample timer, final Long noOfDocs, final Throwable throwable) {
+    archiverMetrics.measureFailedArchiverStageMetrics(
+        jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, timer, noOfDocs, throwable);
+  }
+
+  public void measureArchiverCopySuccess(
+      final String sourceIdx, final Sample timer, final Long noOfDocs) {
+    archiverMetrics.measureSuccessfulArchiverStageMetrics(
+        jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, timer, noOfDocs);
+  }
+
+  public void measureArchiverCopyFailure(
+      final String sourceIdx, final Sample timer, final Long noOfDocs, final Throwable throwable) {
+    archiverMetrics.measureFailedArchiverStageMetrics(
+        jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, timer, noOfDocs, throwable);
+  }
+
+  public void measureArchiverDeleteSuccess(
+      final String sourceIdx, final Sample timer, final Long noOfDocs) {
+    archiverMetrics.measureSuccessfulArchiverStageMetrics(
+        jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, timer, noOfDocs);
+  }
+
+  public void measureArchiverDeleteFailure(
+      final String sourceIdx, final Sample timer, final Long noOfDocs, final Throwable throwable) {
+    archiverMetrics.measureFailedArchiverStageMetrics(
+        jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, timer, noOfDocs, throwable);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaArchiverMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaArchiverMetrics.java
@@ -1,0 +1,483 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.metrics;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
+import java.net.SocketTimeoutException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+
+public class CamundaArchiverMetrics implements AutoCloseable {
+  private static final String COMPLETION_STATUS_FAILED = "failed";
+  private static final String COMPLETION_STATUS_SUCCESS = "success";
+  private static final String ARCHIVE_OPERATION_STAGE_TAG_READ = "read";
+  private static final String ARCHIVE_OPERATION_STAGE_TAG_COPY = "copy";
+  private static final String ARCHIVE_OPERATION_STAGE_TAG_DELETE = "delete";
+  private static final Map<Class<? extends Throwable>, String> HANDLED_ERROR_TAGS =
+      Map.of(
+          SocketTimeoutException.class, "timeout",
+          ElasticsearchException.class, "elasticsearch",
+          OpenSearchException.class, "opensearch",
+          Throwable.class, "other");
+
+  private final MeterRegistry meterRegistry;
+  private final Function<String, String> meterNameWrapper;
+
+  /** time spent on search operations with percentile histogram */
+  private final Timer archiverSearchTimer;
+
+  /** time spent on delete operations with percentile histogram */
+  private final Timer archiverDeleteTimer;
+
+  /** time spent on reindex operations with percentile histogram */
+  private final Timer archiverReindexTimer;
+
+  /** timer for overall archive job by status (success/fail) combination */
+  private final Map<String, Timer> archiverJobDurationTimersByKey = new ConcurrentHashMap<>();
+
+  /** distribution summary of batch size of top-level instances chosen per job */
+  private final Map<String, DistributionSummary> batchSizeSummaryByKey = new ConcurrentHashMap<>();
+
+  /** counter of top-level instances archived per job */
+  private final Map<String, Counter> archivedInstancesCounterByKey = new ConcurrentHashMap<>();
+
+  /**
+   * timer for how long each archiving operation take (read/copy/delete) by "job+index" combination
+   * (20 indexes) and with operation outcome status (success/failed) and recording percentiles for
+   * 50th, 75th, 90th and 99th.
+   */
+  private final Map<String, Timer> archiveOperationDurationTimersByKey = new ConcurrentHashMap<>();
+
+  /**
+   * distribution summary of how many actual documents "processed" during each archive operation //
+   * stage (read/copy/delete) by "job+index" combination (20 indexes) and with operation outcome //
+   * status (success/failed) and recording SLO's for 100, 500, 1_000, 10_000, 50_000, 100_000, //
+   * 500_000, 1_000_000, 1_500_000, 2_000_000 docs.
+   */
+  private final Map<String, DistributionSummary> archivedDocsCountSummaryByKey =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Count of errors by type (socket-timeout,elasticsearch,opensearch and other) during each //
+   * archive operation stage (read/copy/delete) for given source index
+   */
+  private final Map<String, Counter> archiveOperationErrorCounterByKey = new ConcurrentHashMap<>();
+
+  public CamundaArchiverMetrics(final MeterRegistry meterRegistry) {
+    this(meterRegistry, Function.identity());
+  }
+
+  public CamundaArchiverMetrics(
+      final MeterRegistry meterRegistry, final Function<String, String> meterNameWrapper) {
+
+    this.meterRegistry = meterRegistry;
+    this.meterNameWrapper = meterNameWrapper;
+
+    archiverSearchTimer =
+        Timer.builder(meterNameWrapper.apply("archiver.request.duration"))
+            .description(
+                "Duration of how long it takes to run the search request to resolve completed entities, that need to be archived.")
+            .tags("type", "search")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+
+    archiverDeleteTimer =
+        Timer.builder(meterNameWrapper.apply("archiver.request.duration"))
+            .description(
+                "Duration of how long it takes to run the delete request to remove completed entities, from old indices.")
+            .tags("type", "delete")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+
+    archiverReindexTimer =
+        Timer.builder(meterNameWrapper.apply("archiver.request.duration"))
+            .description(
+                "Duration of how long it takes to run the reindex request to copy over to the dated indices, from old indices.")
+            .tags("type", "reindex")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+  }
+
+  @Override
+  public void close() {
+    // clean up all registered meters
+    meterRegistry.remove(archiverSearchTimer);
+    meterRegistry.remove(archiverReindexTimer);
+    meterRegistry.remove(archiverDeleteTimer);
+
+    archiverJobDurationTimersByKey.values().forEach(meterRegistry::remove);
+    batchSizeSummaryByKey.values().forEach(meterRegistry::remove);
+    archivedInstancesCounterByKey.values().forEach(meterRegistry::remove);
+    archiveOperationDurationTimersByKey.values().forEach(meterRegistry::remove);
+    archivedDocsCountSummaryByKey.values().forEach(meterRegistry::remove);
+    archiveOperationErrorCounterByKey.values().forEach(meterRegistry::remove);
+  }
+
+  public void measureArchiverSearch(final Timer.Sample sample) {
+    sample.stop(archiverSearchTimer);
+  }
+
+  public void measureArchiverReindex(final Sample timer) {
+    timer.stop(archiverReindexTimer);
+  }
+
+  public void measureArchiverDelete(final Sample timer) {
+    timer.stop(archiverDeleteTimer);
+  }
+
+  public void measureArchivingSuccessDuration(final String jobName, final Sample timer) {
+    timer.stop(getArchiveDurationTimer(jobName, COMPLETION_STATUS_SUCCESS));
+  }
+
+  public void measureArchivingFailedDuration(final String jobName, final Sample timer) {
+    timer.stop(getArchiveDurationTimer(jobName, COMPLETION_STATUS_FAILED));
+  }
+
+  public void measureArchivingBatchSize(final String jobName, final int batchSize) {
+    getArchivingBatchSizeSummary(jobName).record(batchSize);
+  }
+
+  public void measureArchivedInstanceCount(final String jobName, final int batchSize) {
+    getArchivedInstancesCounter(jobName).increment(batchSize);
+  }
+
+  public void measureArchivingFailedCount(
+      final String jobName, final String sourceIndex, final Throwable throwable) {
+    getArchiveOperationErrorCounter(jobName, sourceIndex, throwable).increment();
+  }
+
+  private Timer getArchiveDurationTimer(final String jobName, final String status) {
+    return archiverJobDurationTimersByKey.compute(
+        getMeterKey(jobName, status),
+        (key, existingTimer) -> {
+          if (existingTimer == null) {
+            return Timer.builder(meterNameWrapper.apply("archiver.job.duration"))
+                .description(
+                    "Duration of how long it takes for an archiver job to run, from reading a "
+                        + "batch of top-level archivable instances to actually archiving and "
+                        + "deleting from main index, all in all together.")
+                .publishPercentiles()
+                .tag("job", jobName)
+                .tag("status", status)
+                .register(meterRegistry);
+          }
+          return existingTimer;
+        });
+  }
+
+  private DistributionSummary getArchivingBatchSizeSummary(final String jobName) {
+    return batchSizeSummaryByKey.compute(
+        getMeterKey(jobName),
+        (key, existing) -> {
+          if (existing == null) {
+            return DistributionSummary.builder(meterNameWrapper.apply("archiver.job.batch.size"))
+                .description(
+                    "Summary of the batch size of archivable instances selected for archiving. "
+                        + "These are top‑level instances and may fan out into many more archivable "
+                        + "documents, depending on the parent–child and dependent index structure.")
+                .tag("job", jobName)
+                .publishPercentileHistogram()
+                .register(meterRegistry);
+          }
+          return existing;
+        });
+  }
+
+  private Counter getArchivedInstancesCounter(final String jobName) {
+    return archivedInstancesCounterByKey.compute(
+        getMeterKey(jobName),
+        (key, existing) -> {
+          if (existing == null) {
+            return Counter.builder(meterNameWrapper.apply("archiver.job.archived.instances"))
+                .description("Count of archivable instances (top-level instances) archived.")
+                .tag("job", jobName)
+                .register(meterRegistry);
+          }
+          return existing;
+        });
+  }
+
+  private Timer getArchiveOperationDurationTimer(
+      final String jobName, final String sourceIdx, final String stage, final String status) {
+    return archiveOperationDurationTimersByKey.compute(
+        getMeterKey(jobName, sourceIdx, stage, status),
+        (key, existing) -> {
+          if (existing == null) {
+            return Timer.builder(meterNameWrapper.apply("archiver.operation.duration"))
+                .description(
+                    "Duration of how long it takes for each archive operation stage (read/copy/delete), "
+                        + "measured separately with operation outcome (success/failed), to better "
+                        + "understand where time is spent in the archiving process.")
+                .publishPercentiles(.5, .75, .90, .99)
+                .tag("job", jobName)
+                .tag("source_index", sourceIdx)
+                .tag("stage", stage)
+                .tag("status", status)
+                .register(meterRegistry);
+          }
+          return existing;
+        });
+  }
+
+  private DistributionSummary getArchiveOperationSummary(
+      final String jobName, final String sourceIdx, final String stage, final String status) {
+    return archivedDocsCountSummaryByKey.compute(
+        getMeterKey(jobName, sourceIdx, stage, status),
+        (key, existing) -> {
+          if (existing == null) {
+            return DistributionSummary.builder(meterNameWrapper.apply("archiver.operation.docs"))
+                .description(
+                    "Summary of archive docs \"processed\" in each archiving operation "
+                        + "stage (read/copy/delete), to understand the distribution actual docs "
+                        + "processed per index and the outcome to identify potential impact.")
+                .tag("job", jobName)
+                .tag("source_index", sourceIdx)
+                .tag("stage", stage)
+                .tag("status", status)
+                .serviceLevelObjectives(
+                    100, 500, 1_000, 10_000, 50_000, 100_000, 500_000, 1_000_000, 1_500_000,
+                    2_000_000)
+                .register(meterRegistry);
+          }
+          return existing;
+        });
+  }
+
+  private Counter getArchiveOperationErrorCounter(
+      final String jobName, final String sourceIdx, final Throwable throwable) {
+    final String errorType = extractErrorTag(throwable);
+    return getArchiveOperationErrorCounter(jobName, sourceIdx, errorType);
+  }
+
+  private Counter getArchiveOperationErrorCounter(
+      final String jobName, final String sourceIdx, final String errorType) {
+    return archiveOperationErrorCounterByKey.compute(
+        getMeterKey(sourceIdx, sourceIdx, errorType),
+        (key, existing) -> {
+          if (existing == null) {
+            return Counter.builder(meterNameWrapper.apply("archiver.operation.error"))
+                .description(
+                    "Count of errors occurred in during each archiving stage (copy & delete only), "
+                        + "to understand the types of errors affecting the archiving process.")
+                .tag("job", jobName)
+                .tag("source_index", sourceIdx)
+                .tag("error_type", errorType)
+                .register(meterRegistry);
+          }
+          return existing;
+        });
+  }
+
+  public Map<String, Counter> getArchiveOperationFailedCountersByKey(
+      final String jobName, final String sourceIndex) {
+    return Stream.of(
+            ARCHIVE_OPERATION_STAGE_TAG_READ,
+            ARCHIVE_OPERATION_STAGE_TAG_COPY,
+            ARCHIVE_OPERATION_STAGE_TAG_DELETE)
+        .flatMap(
+            stage ->
+                HANDLED_ERROR_TAGS.values().stream()
+                    .map(
+                        errorType ->
+                            Map.entry(
+                                getStageErrorMeterKey(stage, errorType),
+                                getArchiveOperationErrorCounter(jobName, sourceIndex, errorType))))
+        .collect(Collectors.toConcurrentMap(Entry::getKey, Entry::getValue));
+  }
+
+  private static String getStageErrorMeterKey(final String stage, final String errorType) {
+    return getMeterKey(stage, errorType);
+  }
+
+  private static String getMeterKey(final String... vals) {
+    return String.join("-", vals);
+  }
+
+  private static String extractErrorTag(final Throwable ex) {
+    if (ex != null && ex.getCause() != null) {
+      if (ex.getCause() instanceof SocketTimeoutException) {
+        return HANDLED_ERROR_TAGS.get(SocketTimeoutException.class);
+      } else if (ex.getCause() instanceof ElasticsearchException) {
+        return HANDLED_ERROR_TAGS.get(ElasticsearchException.class);
+      } else if (ex.getCause() instanceof OpenSearchException) {
+        return HANDLED_ERROR_TAGS.get(OpenSearchException.class);
+      } else {
+        return extractErrorTag(ex.getCause());
+      }
+    }
+    return HANDLED_ERROR_TAGS.get(Throwable.class);
+  }
+
+  public ArchiverJobContextMetrics getContextMetrics(final String jobName, final String sourceIdx) {
+    return new ArchiverJobContextMetrics(
+        archiverSearchTimer,
+        archiverReindexTimer,
+        archiverDeleteTimer,
+        getArchiveOperationDurationTimer(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, COMPLETION_STATUS_SUCCESS),
+        getArchiveOperationSummary(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, COMPLETION_STATUS_SUCCESS),
+        getArchiveOperationDurationTimer(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, COMPLETION_STATUS_FAILED),
+        getArchiveOperationSummary(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, COMPLETION_STATUS_FAILED),
+        getArchiveOperationDurationTimer(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, COMPLETION_STATUS_SUCCESS),
+        getArchiveOperationSummary(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, COMPLETION_STATUS_SUCCESS),
+        getArchiveOperationDurationTimer(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, COMPLETION_STATUS_FAILED),
+        getArchiveOperationSummary(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, COMPLETION_STATUS_FAILED),
+        getArchiveOperationDurationTimer(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, COMPLETION_STATUS_SUCCESS),
+        getArchiveOperationSummary(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, COMPLETION_STATUS_SUCCESS),
+        getArchiveOperationDurationTimer(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, COMPLETION_STATUS_FAILED),
+        getArchiveOperationSummary(
+            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, COMPLETION_STATUS_FAILED),
+        getArchiveOperationFailedCountersByKey(jobName, sourceIdx));
+  }
+
+  public static class ArchiverJobContextMetrics {
+    private final Timer archiverSearchTimer;
+    private final Timer archiverReindexTimer;
+    private final Timer archiverDeleteTimer;
+
+    private final Timer archiverReadSuccessTimer;
+    private final Timer archiverReadFailTimer;
+    private final Timer archiverCopySuccessTimer;
+    private final Timer archiverCopyFailTimer;
+    private final Timer archiverDeleteSuccessTimer;
+    private final Timer archiverDeleteFailTimer;
+
+    private final DistributionSummary archiverReadSuccessSummary;
+    private final DistributionSummary archiverReadFailSummary;
+    private final DistributionSummary archiverCopySuccessSummary;
+    private final DistributionSummary archiverCopyFailSummary;
+    private final DistributionSummary archiverDeleteSuccessSummary;
+    private final DistributionSummary archiverDeleteFailSummary;
+
+    private final Map<String, Counter> archiveOperationErrorCounterByKey;
+
+    public ArchiverJobContextMetrics(
+        final Timer archiverSearchTimer,
+        final Timer archiverReindexTimer,
+        final Timer archiverDeleteTimer,
+        final Timer archiverReadSuccessTimer,
+        final DistributionSummary archiverReadSuccessSummary,
+        final Timer archiverReadFailTimer,
+        final DistributionSummary archiverReadFailSummary,
+        final Timer archiverCopySuccessTimer,
+        final DistributionSummary archiverCopySuccessSummary,
+        final Timer archiverCopyFailTimer,
+        final DistributionSummary archiverCopyFailSummary,
+        final Timer archiverDeleteSuccessTimer,
+        final DistributionSummary archiverDeleteFailSummary,
+        final Timer archiverDeleteFailTimer,
+        final DistributionSummary archiverDeleteSuccessSummary,
+        final Map<String, Counter> archiveOperationErrorCounterByKey) {
+      this.archiverSearchTimer = archiverSearchTimer;
+      this.archiverReindexTimer = archiverReindexTimer;
+      this.archiverDeleteTimer = archiverDeleteTimer;
+      this.archiverReadSuccessTimer = archiverReadSuccessTimer;
+      this.archiverReadSuccessSummary = archiverReadSuccessSummary;
+      this.archiverReadFailTimer = archiverReadFailTimer;
+      this.archiverReadFailSummary = archiverReadFailSummary;
+      this.archiverCopySuccessTimer = archiverCopySuccessTimer;
+      this.archiverCopySuccessSummary = archiverCopySuccessSummary;
+      this.archiverCopyFailTimer = archiverCopyFailTimer;
+      this.archiverCopyFailSummary = archiverCopyFailSummary;
+      this.archiverDeleteSuccessTimer = archiverDeleteSuccessTimer;
+      this.archiverDeleteSuccessSummary = archiverDeleteSuccessSummary;
+      this.archiverDeleteFailTimer = archiverDeleteFailTimer;
+      this.archiverDeleteFailSummary = archiverDeleteFailSummary;
+      this.archiveOperationErrorCounterByKey = archiveOperationErrorCounterByKey;
+    }
+
+    public void measureArchiverSearch(final Timer.Sample sample) {
+      sample.stop(archiverSearchTimer);
+    }
+
+    public void measureArchiverReindex(final Sample timer) {
+      timer.stop(archiverReindexTimer);
+    }
+
+    public void measureArchiverDelete(final Sample timer) {
+      timer.stop(archiverDeleteTimer);
+    }
+
+    public void measureArchiverReadSuccess(final Sample timer, final Long noOfDocs) {
+      timer.stop(archiverReadSuccessTimer);
+      if (noOfDocs != null) {
+        archiverReadSuccessSummary.record(noOfDocs);
+      }
+    }
+
+    public void measureArchiverReadFail(
+        final Sample timer, final Long noOfDocs, final Throwable throwable) {
+      timer.stop(archiverReadFailTimer);
+      if (noOfDocs != null) {
+        archiverReadFailSummary.record(noOfDocs);
+      }
+      archiveOperationErrorCounterByKey
+          .get(getStageErrorMeterKey(ARCHIVE_OPERATION_STAGE_TAG_READ, extractErrorTag(throwable)))
+          .increment();
+    }
+
+    public void measureArchiverCopySuccess(final Sample timer, final Long noOfDocs) {
+      timer.stop(archiverCopySuccessTimer);
+      if (noOfDocs != null) {
+        archiverCopySuccessSummary.record(noOfDocs);
+      }
+    }
+
+    public void measureArchiverCopyFail(
+        final Sample timer, final Long noOfDocs, final Throwable throwable) {
+      timer.stop(archiverCopyFailTimer);
+      if (noOfDocs != null) {
+        archiverCopyFailSummary.record(noOfDocs);
+      }
+      archiveOperationErrorCounterByKey
+          .get(getStageErrorMeterKey(ARCHIVE_OPERATION_STAGE_TAG_COPY, extractErrorTag(throwable)))
+          .increment();
+    }
+
+    public void measureArchiverDeleteSuccess(final Sample timer, final Long noOfDocs) {
+      timer.stop(archiverDeleteSuccessTimer);
+      if (noOfDocs != null) {
+        archiverDeleteSuccessSummary.record(noOfDocs);
+      }
+    }
+
+    public void measureArchiverDeleteFail(
+        final Sample timer, final Long noOfDocs, final Throwable throwable) {
+      timer.stop(archiverDeleteFailTimer);
+
+      if (noOfDocs != null) {
+        archiverDeleteFailSummary.record(noOfDocs);
+      }
+
+      archiveOperationErrorCounterByKey
+          .get(
+              getStageErrorMeterKey(ARCHIVE_OPERATION_STAGE_TAG_DELETE, extractErrorTag(throwable)))
+          .increment();
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaArchiverMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaArchiverMetrics.java
@@ -15,19 +15,16 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Sample;
 import java.net.SocketTimeoutException;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 
 public class CamundaArchiverMetrics implements AutoCloseable {
+  public static final String ARCHIVE_OPERATION_STAGE_TAG_READ = "read";
+  public static final String ARCHIVE_OPERATION_STAGE_TAG_COPY = "copy";
+  public static final String ARCHIVE_OPERATION_STAGE_TAG_DELETE = "delete";
   private static final String COMPLETION_STATUS_FAILED = "failed";
   private static final String COMPLETION_STATUS_SUCCESS = "success";
-  private static final String ARCHIVE_OPERATION_STAGE_TAG_READ = "read";
-  private static final String ARCHIVE_OPERATION_STAGE_TAG_COPY = "copy";
-  private static final String ARCHIVE_OPERATION_STAGE_TAG_DELETE = "delete";
   private static final Map<Class<? extends Throwable>, String> HANDLED_ERROR_TAGS =
       Map.of(
           SocketTimeoutException.class, "timeout",
@@ -128,6 +125,10 @@ public class CamundaArchiverMetrics implements AutoCloseable {
     archiveOperationErrorCounterByKey.values().forEach(meterRegistry::remove);
   }
 
+  public ArchiverJobMetrics getArchiverJobMetrics(final String jobName) {
+    return new ArchiverJobMetrics(jobName, this);
+  }
+
   public void measureArchiverSearch(final Timer.Sample sample) {
     sample.stop(archiverSearchTimer);
   }
@@ -156,9 +157,37 @@ public class CamundaArchiverMetrics implements AutoCloseable {
     getArchivedInstancesCounter(jobName).increment(batchSize);
   }
 
-  public void measureArchivingFailedCount(
-      final String jobName, final String sourceIndex, final Throwable throwable) {
-    getArchiveOperationErrorCounter(jobName, sourceIndex, throwable).increment();
+  public void measureSuccessfulArchiverStageMetrics(
+      final String jobName,
+      final String sourceIdx,
+      final String stage,
+      final Sample timer,
+      final Long noOfDocs) {
+    timer.stop(
+        getArchiveOperationDurationTimer(jobName, sourceIdx, stage, COMPLETION_STATUS_SUCCESS));
+
+    if (noOfDocs != null) {
+      getArchiveOperationSummary(jobName, sourceIdx, stage, COMPLETION_STATUS_SUCCESS)
+          .record(noOfDocs);
+    }
+  }
+
+  public void measureFailedArchiverStageMetrics(
+      final String jobName,
+      final String sourceIdx,
+      final String stage,
+      final Sample timer,
+      final Long noOfDocs,
+      final Throwable throwable) {
+    timer.stop(
+        getArchiveOperationDurationTimer(jobName, sourceIdx, stage, COMPLETION_STATUS_FAILED));
+
+    if (noOfDocs != null) {
+      getArchiveOperationSummary(jobName, sourceIdx, stage, COMPLETION_STATUS_SUCCESS)
+          .record(noOfDocs);
+    }
+
+    getArchiveOperationErrorCounter(jobName, sourceIdx, stage, throwable).increment();
   }
 
   private Timer getArchiveDurationTimer(final String jobName, final String status) {
@@ -259,15 +288,10 @@ public class CamundaArchiverMetrics implements AutoCloseable {
   }
 
   private Counter getArchiveOperationErrorCounter(
-      final String jobName, final String sourceIdx, final Throwable throwable) {
+      final String jobName, final String sourceIdx, final String stage, final Throwable throwable) {
     final String errorType = extractErrorTag(throwable);
-    return getArchiveOperationErrorCounter(jobName, sourceIdx, errorType);
-  }
-
-  private Counter getArchiveOperationErrorCounter(
-      final String jobName, final String sourceIdx, final String errorType) {
     return archiveOperationErrorCounterByKey.compute(
-        getMeterKey(sourceIdx, sourceIdx, errorType),
+        getMeterKey(jobName, sourceIdx, stage, errorType),
         (key, existing) -> {
           if (existing == null) {
             return Counter.builder(meterNameWrapper.apply("archiver.operation.error"))
@@ -276,32 +300,12 @@ public class CamundaArchiverMetrics implements AutoCloseable {
                         + "to understand the types of errors affecting the archiving process.")
                 .tag("job", jobName)
                 .tag("source_index", sourceIdx)
+                .tag("stage", stage)
                 .tag("error_type", errorType)
                 .register(meterRegistry);
           }
           return existing;
         });
-  }
-
-  public Map<String, Counter> getArchiveOperationFailedCountersByKey(
-      final String jobName, final String sourceIndex) {
-    return Stream.of(
-            ARCHIVE_OPERATION_STAGE_TAG_READ,
-            ARCHIVE_OPERATION_STAGE_TAG_COPY,
-            ARCHIVE_OPERATION_STAGE_TAG_DELETE)
-        .flatMap(
-            stage ->
-                HANDLED_ERROR_TAGS.values().stream()
-                    .map(
-                        errorType ->
-                            Map.entry(
-                                getStageErrorMeterKey(stage, errorType),
-                                getArchiveOperationErrorCounter(jobName, sourceIndex, errorType))))
-        .collect(Collectors.toConcurrentMap(Entry::getKey, Entry::getValue));
-  }
-
-  private static String getStageErrorMeterKey(final String stage, final String errorType) {
-    return getMeterKey(stage, errorType);
   }
 
   private static String getMeterKey(final String... vals) {
@@ -321,163 +325,5 @@ public class CamundaArchiverMetrics implements AutoCloseable {
       }
     }
     return HANDLED_ERROR_TAGS.get(Throwable.class);
-  }
-
-  public ArchiverJobContextMetrics getContextMetrics(final String jobName, final String sourceIdx) {
-    return new ArchiverJobContextMetrics(
-        archiverSearchTimer,
-        archiverReindexTimer,
-        archiverDeleteTimer,
-        getArchiveOperationDurationTimer(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, COMPLETION_STATUS_SUCCESS),
-        getArchiveOperationSummary(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, COMPLETION_STATUS_SUCCESS),
-        getArchiveOperationDurationTimer(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, COMPLETION_STATUS_FAILED),
-        getArchiveOperationSummary(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_READ, COMPLETION_STATUS_FAILED),
-        getArchiveOperationDurationTimer(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, COMPLETION_STATUS_SUCCESS),
-        getArchiveOperationSummary(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, COMPLETION_STATUS_SUCCESS),
-        getArchiveOperationDurationTimer(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, COMPLETION_STATUS_FAILED),
-        getArchiveOperationSummary(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_COPY, COMPLETION_STATUS_FAILED),
-        getArchiveOperationDurationTimer(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, COMPLETION_STATUS_SUCCESS),
-        getArchiveOperationSummary(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, COMPLETION_STATUS_SUCCESS),
-        getArchiveOperationDurationTimer(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, COMPLETION_STATUS_FAILED),
-        getArchiveOperationSummary(
-            jobName, sourceIdx, ARCHIVE_OPERATION_STAGE_TAG_DELETE, COMPLETION_STATUS_FAILED),
-        getArchiveOperationFailedCountersByKey(jobName, sourceIdx));
-  }
-
-  public static class ArchiverJobContextMetrics {
-    private final Timer archiverSearchTimer;
-    private final Timer archiverReindexTimer;
-    private final Timer archiverDeleteTimer;
-
-    private final Timer archiverReadSuccessTimer;
-    private final Timer archiverReadFailTimer;
-    private final Timer archiverCopySuccessTimer;
-    private final Timer archiverCopyFailTimer;
-    private final Timer archiverDeleteSuccessTimer;
-    private final Timer archiverDeleteFailTimer;
-
-    private final DistributionSummary archiverReadSuccessSummary;
-    private final DistributionSummary archiverReadFailSummary;
-    private final DistributionSummary archiverCopySuccessSummary;
-    private final DistributionSummary archiverCopyFailSummary;
-    private final DistributionSummary archiverDeleteSuccessSummary;
-    private final DistributionSummary archiverDeleteFailSummary;
-
-    private final Map<String, Counter> archiveOperationErrorCounterByKey;
-
-    public ArchiverJobContextMetrics(
-        final Timer archiverSearchTimer,
-        final Timer archiverReindexTimer,
-        final Timer archiverDeleteTimer,
-        final Timer archiverReadSuccessTimer,
-        final DistributionSummary archiverReadSuccessSummary,
-        final Timer archiverReadFailTimer,
-        final DistributionSummary archiverReadFailSummary,
-        final Timer archiverCopySuccessTimer,
-        final DistributionSummary archiverCopySuccessSummary,
-        final Timer archiverCopyFailTimer,
-        final DistributionSummary archiverCopyFailSummary,
-        final Timer archiverDeleteSuccessTimer,
-        final DistributionSummary archiverDeleteFailSummary,
-        final Timer archiverDeleteFailTimer,
-        final DistributionSummary archiverDeleteSuccessSummary,
-        final Map<String, Counter> archiveOperationErrorCounterByKey) {
-      this.archiverSearchTimer = archiverSearchTimer;
-      this.archiverReindexTimer = archiverReindexTimer;
-      this.archiverDeleteTimer = archiverDeleteTimer;
-      this.archiverReadSuccessTimer = archiverReadSuccessTimer;
-      this.archiverReadSuccessSummary = archiverReadSuccessSummary;
-      this.archiverReadFailTimer = archiverReadFailTimer;
-      this.archiverReadFailSummary = archiverReadFailSummary;
-      this.archiverCopySuccessTimer = archiverCopySuccessTimer;
-      this.archiverCopySuccessSummary = archiverCopySuccessSummary;
-      this.archiverCopyFailTimer = archiverCopyFailTimer;
-      this.archiverCopyFailSummary = archiverCopyFailSummary;
-      this.archiverDeleteSuccessTimer = archiverDeleteSuccessTimer;
-      this.archiverDeleteSuccessSummary = archiverDeleteSuccessSummary;
-      this.archiverDeleteFailTimer = archiverDeleteFailTimer;
-      this.archiverDeleteFailSummary = archiverDeleteFailSummary;
-      this.archiveOperationErrorCounterByKey = archiveOperationErrorCounterByKey;
-    }
-
-    public void measureArchiverSearch(final Timer.Sample sample) {
-      sample.stop(archiverSearchTimer);
-    }
-
-    public void measureArchiverReindex(final Sample timer) {
-      timer.stop(archiverReindexTimer);
-    }
-
-    public void measureArchiverDelete(final Sample timer) {
-      timer.stop(archiverDeleteTimer);
-    }
-
-    public void measureArchiverReadSuccess(final Sample timer, final Long noOfDocs) {
-      timer.stop(archiverReadSuccessTimer);
-      if (noOfDocs != null) {
-        archiverReadSuccessSummary.record(noOfDocs);
-      }
-    }
-
-    public void measureArchiverReadFail(
-        final Sample timer, final Long noOfDocs, final Throwable throwable) {
-      timer.stop(archiverReadFailTimer);
-      if (noOfDocs != null) {
-        archiverReadFailSummary.record(noOfDocs);
-      }
-      archiveOperationErrorCounterByKey
-          .get(getStageErrorMeterKey(ARCHIVE_OPERATION_STAGE_TAG_READ, extractErrorTag(throwable)))
-          .increment();
-    }
-
-    public void measureArchiverCopySuccess(final Sample timer, final Long noOfDocs) {
-      timer.stop(archiverCopySuccessTimer);
-      if (noOfDocs != null) {
-        archiverCopySuccessSummary.record(noOfDocs);
-      }
-    }
-
-    public void measureArchiverCopyFail(
-        final Sample timer, final Long noOfDocs, final Throwable throwable) {
-      timer.stop(archiverCopyFailTimer);
-      if (noOfDocs != null) {
-        archiverCopyFailSummary.record(noOfDocs);
-      }
-      archiveOperationErrorCounterByKey
-          .get(getStageErrorMeterKey(ARCHIVE_OPERATION_STAGE_TAG_COPY, extractErrorTag(throwable)))
-          .increment();
-    }
-
-    public void measureArchiverDeleteSuccess(final Sample timer, final Long noOfDocs) {
-      timer.stop(archiverDeleteSuccessTimer);
-      if (noOfDocs != null) {
-        archiverDeleteSuccessSummary.record(noOfDocs);
-      }
-    }
-
-    public void measureArchiverDeleteFail(
-        final Sample timer, final Long noOfDocs, final Throwable throwable) {
-      timer.stop(archiverDeleteFailTimer);
-
-      if (noOfDocs != null) {
-        archiverDeleteFailSummary.record(noOfDocs);
-      }
-
-      archiveOperationErrorCounterByKey
-          .get(
-              getStageErrorMeterKey(ARCHIVE_OPERATION_STAGE_TAG_DELETE, extractErrorTag(throwable)))
-          .increment();
-    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaArchiverMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaArchiverMetrics.java
@@ -200,7 +200,7 @@ public class CamundaArchiverMetrics implements AutoCloseable {
                     "Duration of how long it takes for an archiver job to run, from reading a "
                         + "batch of top-level archivable instances to actually archiving and "
                         + "deleting from main index, all in all together.")
-                .publishPercentiles()
+                .publishPercentileHistogram()
                 .tag("job", jobName)
                 .tag("status", status)
                 .register(meterRegistry);
@@ -220,7 +220,8 @@ public class CamundaArchiverMetrics implements AutoCloseable {
                         + "These are top‑level instances and may fan out into many more archivable "
                         + "documents, depending on the parent–child and dependent index structure.")
                 .tag("job", jobName)
-                .publishPercentileHistogram()
+                .serviceLevelObjectives(
+                    1, 2, 5, 10, 20, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000)
                 .register(meterRegistry);
           }
           return existing;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -32,6 +32,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   private final CamundaArchiverMetrics archiverMetrics;
 
+  /** time spent on counting process instances awaiting archiving */
+  private final Timer processInstancesAwaitingArchivalTimer;
+
   private final Timer flushLatency;
 
   /** Count of incident updates that needed retrying. */
@@ -62,6 +65,14 @@ public class CamundaExporterMetrics implements AutoCloseable {
     this.meterRegistry = meterRegistry;
     this.streamClock = streamClock;
     archiverMetrics = new CamundaArchiverMetrics(meterRegistry, this::meterName);
+
+    processInstancesAwaitingArchivalTimer =
+        Timer.builder(meterName("process.instances.awaiting.archival.request.duration"))
+            .description(
+                "Duration of how long it takes to get the count of process instances that need to be archived.")
+            .tags("type", "search")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
 
     flushLatency =
         Timer.builder(meterName("flush.latency"))
@@ -124,6 +135,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
             AtomicInteger::get)
         .description("Number of process instances awaiting archival (approximate)")
         .register(meterRegistry);
+  }
+
+  public void measureProcessInstancesAwaitingArchivalDuration(final Timer.Sample sample) {
+    sample.stop(processInstancesAwaitingArchivalTimer);
   }
 
   public CloseableSilently measureFlushDuration() {
@@ -207,6 +222,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     archiverMetrics.close();
 
     // clean up all registered meters
+    meterRegistry.remove(processInstancesAwaitingArchivalTimer);
     meterRegistry.remove(flushLatency);
 
     meterRegistry.remove(incidentUpdatesRetriesNeeded);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -16,7 +16,6 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.Timer.Sample;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
@@ -31,43 +30,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private final MeterRegistry meterRegistry;
   private final InstantSource streamClock;
 
+  private final CamundaArchiverMetrics archiverMetrics;
+
   private final Timer flushLatency;
-
-  /** Count of completed process instances that are in progress of archiving. */
-  private final Counter processInstancesArchiving;
-
-  /** Count of completed process instances that have been archived. */
-  private final Counter processInstancesArchived;
-
-  /** Count of completed batch operations that are in progress of archiving. */
-  private final Counter batchOperationsArchiving;
-
-  /** Count of completed batch operations that have been archived. */
-  private final Counter batchOperationsArchived;
-
-  /** Count of usage-metrics that are in progress of archiving. */
-  private final Counter usageMetricsArchiving;
-
-  /** Count of usage-metrics that have been archived. */
-  private final Counter usageMetricsArchived;
-
-  /** Count of usage-metrics-task-users that are in progress of archiving. */
-  private final Counter usageMetricsTUArchiving;
-
-  /** Count of usage-metrics-task-users that have been archived. */
-  private final Counter usageMetricsTUArchived;
-
-  /** Count of standalone-decisions that are in progress of archiving. */
-  private final Counter standaloneDecisionsArchiving;
-
-  /** Count of standalone-decisions that have been archived. */
-  private final Counter standaloneDecisionsArchived;
-
-  /** Count of job-batch-metrics that are in progress of archiving. */
-  private final Counter jobBatchMetricsArchiving;
-
-  /** Count of job-batch-metrics that have been archived. */
-  private final Counter jobBatchMetricsArchived;
 
   /** Count of incident updates that needed retrying. */
   private final Counter incidentUpdatesRetriesNeeded;
@@ -78,19 +43,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of document updated when incident updates were processed. */
   private final Counter incidentUpdatesDocumentsUpdated;
 
-  /** Count of audit logs that are in progress of archiving. */
-  private final Counter auditLogsArchiving;
-
-  /** Count of audit logs that have been archived. */
-  private final Counter auditLogsArchived;
-
-  private final Timer archiverSearchTimer;
-  private final Timer archiverDeleteTimer;
-  private final Counter archiverDeletedDocs;
-  private final Counter archiverReindexedDocs;
-  private final Timer archiverReindexTimer;
   private Timer.Sample flushLatencyMeasurement;
-  private final Timer archivingDuration;
   private final DistributionSummary bulkSize;
   private final Counter bulkOperations;
   private final Timer flushDuration;
@@ -108,6 +61,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
       final MeterRegistry meterRegistry, final InstantSource streamClock) {
     this.meterRegistry = meterRegistry;
     this.streamClock = streamClock;
+    archiverMetrics = new CamundaArchiverMetrics(meterRegistry, this::meterName);
 
     flushLatency =
         Timer.builder(meterName("flush.latency"))
@@ -116,110 +70,6 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .publishPercentileHistogram()
             .register(meterRegistry);
 
-    processInstancesArchived =
-        Counter.builder(meterName("archiver.process.instances"))
-            .tag("state", "archived")
-            .description("Count of completed process instances, that have been archived.")
-            .register(meterRegistry);
-    processInstancesArchiving =
-        Counter.builder(meterName("archiver.process.instances"))
-            .tag("state", "archiving")
-            .description(
-                "Count of completed process instances that have been found, and are now in progress of archiving.")
-            .register(meterRegistry);
-    batchOperationsArchived =
-        Counter.builder(meterName("archiver.batch.operations"))
-            .tag("state", "archived")
-            .description("Count of completed batch operations, that have been archived.")
-            .register(meterRegistry);
-    batchOperationsArchiving =
-        Counter.builder(meterName("archiver.batch.operations"))
-            .tag("state", "archiving")
-            .description(
-                "Count of completed batch operations that have been found, and are now in progress of archiving.")
-            .register(meterRegistry);
-    usageMetricsArchived =
-        Counter.builder(meterName("archiver.usage.metrics"))
-            .tag("state", "archived")
-            .description("Count of completed usage-metrics, that have been archived.")
-            .register(meterRegistry);
-    usageMetricsArchiving =
-        Counter.builder(meterName("archiver.usage.metrics"))
-            .tag("state", "archiving")
-            .description(
-                "Count of completed usage-metrics that have been found, and are now in progress of archiving.")
-            .register(meterRegistry);
-    usageMetricsTUArchived =
-        Counter.builder(meterName("archiver.usage.metrics.tu"))
-            .tag("state", "archived")
-            .description("Count of completed usage-metrics-task-users, that have been archived.")
-            .register(meterRegistry);
-    usageMetricsTUArchiving =
-        Counter.builder(meterName("archiver.usage.metrics.tu"))
-            .tag("state", "archiving")
-            .description(
-                "Count of completed usage-metrics-task-users that have been found, and are now in progress of archiving.")
-            .register(meterRegistry);
-    standaloneDecisionsArchived =
-        Counter.builder(meterName("archiver.standalone.decisions"))
-            .tag("state", "archived")
-            .description("Count of completed standalone-decisions, that have been archived.")
-            .register(meterRegistry);
-    standaloneDecisionsArchiving =
-        Counter.builder(meterName("archiver.standalone.decisions"))
-            .tag("state", "archiving")
-            .description(
-                "Count of completed standalone-decisions that have been found, and are now in progress of archiving.")
-            .register(meterRegistry);
-    jobBatchMetricsArchived =
-        Counter.builder(meterName("archiver.job.batch.metrics"))
-            .tag("state", "archived")
-            .description("Count of completed job-batch-metrics, that have been archived.")
-            .register(meterRegistry);
-    jobBatchMetricsArchiving =
-        Counter.builder(meterName("archiver.job.batch.metrics"))
-            .tag("state", "archiving")
-            .description(
-                "Count of completed job-batch-metrics that have been found, and are now in progress of archiving.")
-            .register(meterRegistry);
-    archiverSearchTimer =
-        Timer.builder(meterName("archiver.request.duration"))
-            .description(
-                "Duration of how long it takes to run the search request to resolve completed entities, that need to be archived.")
-            .tags("type", "search")
-            .publishPercentileHistogram()
-            .register(meterRegistry);
-    archiverDeleteTimer =
-        Timer.builder(meterName("archiver.request.duration"))
-            .description(
-                "Duration of how long it takes to run the delete request to remove completed entities, from old indices.")
-            .tags("type", "delete")
-            .publishPercentileHistogram()
-            .register(meterRegistry);
-    archiverDeletedDocs =
-        Counter.builder(meterName("archiver.docs"))
-            .tags("type", "delete")
-            .description("Count of how many documents the archiver has deleted from old indices.")
-            .register(meterRegistry);
-    archiverReindexTimer =
-        Timer.builder(meterName("archiver.request.duration"))
-            .description(
-                "Duration of how long it takes to run the reindex request to copy over to the dated indices, from old indices.")
-            .tags("type", "reindex")
-            .publishPercentileHistogram()
-            .register(meterRegistry);
-    archiverReindexedDocs =
-        Counter.builder(meterName("archiver.docs"))
-            .tags("type", "reindex")
-            .description(
-                "Count of how many documents the archiver has reindexed to copy over to the dated indices, from old indices.")
-            .register(meterRegistry);
-    archivingDuration =
-        Timer.builder(meterName("archiver.duration"))
-            .description(
-                "Duration of how long it takes from resolving to archiving entities, all in all together.")
-            .publishPercentileHistogram()
-            .register(meterRegistry);
     incidentUpdatesRetriesNeeded =
         Counter.builder(meterName("incident.updates"))
             .tag("action", "retry")
@@ -262,17 +112,6 @@ public class CamundaExporterMetrics implements AutoCloseable {
                 "How much time it took to export a record from the moment it was written (not committed)")
             .serviceLevelObjectives(MicrometerUtil.defaultPrometheusBuckets())
             .register(meterRegistry);
-    auditLogsArchived =
-        Counter.builder(meterName("archiver.standalone.audit-logs"))
-            .tag("state", "archived")
-            .description("Count of standalone audit logs, that have been archived.")
-            .register(meterRegistry);
-    auditLogsArchiving =
-        Counter.builder(meterName("archiver.standalone.audit-logs"))
-            .tag("state", "archiving")
-            .description(
-                "Count of completed standalone audit logs that have been found, and are now in progress of archiving.")
-            .register(meterRegistry);
 
     TimeGauge.builder(
             meterName("since.last.flush.seconds"), this::secondSinceLastFlush, TimeUnit.SECONDS)
@@ -289,10 +128,6 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public CloseableSilently measureFlushDuration() {
     return MicrometerUtil.timer(flushDuration, Timer.start(meterRegistry));
-  }
-
-  public void measureArchiverSearch(final Timer.Sample sample) {
-    sample.stop(archiverSearchTimer);
   }
 
   public void recordBulkSize(final int bulkSize) {
@@ -315,62 +150,6 @@ public class CamundaExporterMetrics implements AutoCloseable {
     if (flushLatencyMeasurement != null) {
       flushLatencyMeasurement.stop(flushLatency);
     }
-  }
-
-  public void recordProcessInstancesArchived(final int count) {
-    processInstancesArchived.increment(count);
-  }
-
-  public void recordProcessInstancesArchiving(final int count) {
-    processInstancesArchiving.increment(count);
-  }
-
-  public void recordBatchOperationsArchived(final int count) {
-    batchOperationsArchived.increment(count);
-  }
-
-  public void recordBatchOperationsArchiving(final int count) {
-    batchOperationsArchiving.increment(count);
-  }
-
-  public void recordUsageMetricsArchived(final int count) {
-    usageMetricsArchived.increment(count);
-  }
-
-  public void recordUsageMetricsArchiving(final int count) {
-    usageMetricsArchiving.increment(count);
-  }
-
-  public void recordUsageMetricsTUArchived(final int count) {
-    usageMetricsTUArchived.increment(count);
-  }
-
-  public void recordUsageMetricsTUArchiving(final int count) {
-    usageMetricsTUArchiving.increment(count);
-  }
-
-  public void recordStandaloneDecisionsArchived(final int count) {
-    standaloneDecisionsArchived.increment(count);
-  }
-
-  public void recordStandaloneDecisionsArchiving(final int count) {
-    standaloneDecisionsArchiving.increment(count);
-  }
-
-  public void recordAuditLogsArchived(final int count) {
-    auditLogsArchived.increment(count);
-  }
-
-  public void recordAuditLogsArchiving(final int count) {
-    auditLogsArchiving.increment(count);
-  }
-
-  public void recordJobBatchMetricsArchived(final int count) {
-    jobBatchMetricsArchived.increment(count);
-  }
-
-  public void recordJobBatchMetricsArchiving(final int count) {
-    jobBatchMetricsArchiving.increment(count);
   }
 
   public void recordIncidentUpdatesRetriesNeeded(final int count) {
@@ -418,48 +197,27 @@ public class CamundaExporterMetrics implements AutoCloseable {
     return NAMESPACE + "." + name;
   }
 
-  public void measureArchiverDelete(final Long docsDeleted, final Sample timer) {
-    if (docsDeleted != null) {
-      archiverDeletedDocs.increment(docsDeleted);
-    }
-    timer.stop(archiverDeleteTimer);
-  }
-
-  public void measureArchiverReindex(final Long docsReindexed, final Sample timer) {
-    if (docsReindexed != null) {
-      archiverReindexedDocs.increment(docsReindexed);
-    }
-    timer.stop(archiverReindexTimer);
-  }
-
-  public void measureArchivingDuration(final Sample timer) {
-    timer.stop(archivingDuration);
+  public CamundaArchiverMetrics getArchiverMetrics() {
+    return archiverMetrics;
   }
 
   @Override
   public void close() {
+    // cleanup archiver metrics
+    archiverMetrics.close();
+
     // clean up all registered meters
     meterRegistry.remove(flushLatency);
-    meterRegistry.remove(processInstancesArchived);
-    meterRegistry.remove(processInstancesArchiving);
-    meterRegistry.remove(batchOperationsArchived);
-    meterRegistry.remove(batchOperationsArchiving);
-    meterRegistry.remove(archiverSearchTimer);
-    meterRegistry.remove(archiverDeleteTimer);
-    meterRegistry.remove(archiverDeletedDocs);
-    meterRegistry.remove(archiverReindexTimer);
-    meterRegistry.remove(archiverReindexedDocs);
-    meterRegistry.remove(archivingDuration);
+
+    meterRegistry.remove(incidentUpdatesRetriesNeeded);
+    meterRegistry.remove(incidentUpdatesProcessed);
+    meterRegistry.remove(incidentUpdatesDocumentsUpdated);
+
     meterRegistry.remove(bulkSize);
     meterRegistry.remove(bulkOperations);
     meterRegistry.remove(flushDuration);
     meterRegistry.remove(failedFlush);
     meterRegistry.remove(recordExportDuration);
-    meterRegistry.remove(incidentUpdatesRetriesNeeded);
-    meterRegistry.remove(incidentUpdatesProcessed);
-    meterRegistry.remove(incidentUpdatesDocumentsUpdated);
-    meterRegistry.remove(jobBatchMetricsArchiving);
-    meterRegistry.remove(jobBatchMetricsArchived);
 
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(meterName("since.last.flush.seconds"));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -203,7 +203,6 @@ public final class BackgroundTaskManagerFactory {
         asyncClient,
         genericClient,
         executor,
-        metrics.getArchiverMetrics(),
         logger);
   }
 
@@ -249,13 +248,7 @@ public final class BackgroundTaskManagerFactory {
   private ElasticsearchArchiverRepository createArchiverRepository(
       final ElasticsearchAsyncClient asyncClient) {
     return new ElasticsearchArchiverRepository(
-        partitionId,
-        config.getHistory(),
-        resourceProvider,
-        asyncClient,
-        executor,
-        metrics.getArchiverMetrics(),
-        logger);
+        partitionId, config.getHistory(), resourceProvider, asyncClient, executor, logger);
   }
 
   private List<RunnableTask> buildTasks() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -203,7 +203,7 @@ public final class BackgroundTaskManagerFactory {
         asyncClient,
         genericClient,
         executor,
-        metrics,
+        metrics.getArchiverMetrics(),
         logger);
   }
 
@@ -249,7 +249,13 @@ public final class BackgroundTaskManagerFactory {
   private ElasticsearchArchiverRepository createArchiverRepository(
       final ElasticsearchAsyncClient asyncClient) {
     return new ElasticsearchArchiverRepository(
-        partitionId, config.getHistory(), resourceProvider, asyncClient, executor, metrics, logger);
+        partitionId,
+        config.getHistory(),
+        resourceProvider,
+        asyncClient,
+        executor,
+        metrics.getArchiverMetrics(),
+        logger);
   }
 
   private List<RunnableTask> buildTasks() {
@@ -406,7 +412,7 @@ public final class BackgroundTaskManagerFactory {
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
             dependantTemplates,
-            metrics,
+            metrics.getArchiverMetrics(),
             logger,
             executor));
   }
@@ -423,7 +429,7 @@ public final class BackgroundTaskManagerFactory {
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class),
             dependantTemplates,
-            metrics,
+            metrics.getArchiverMetrics(),
             logger,
             executor));
   }
@@ -433,7 +439,7 @@ public final class BackgroundTaskManagerFactory {
         new UsageMetricArchiverJob(
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class),
-            metrics,
+            metrics.getArchiverMetrics(),
             logger,
             executor));
   }
@@ -443,7 +449,7 @@ public final class BackgroundTaskManagerFactory {
         new UsageMetricTUArchiverJob(
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class),
-            metrics,
+            metrics.getArchiverMetrics(),
             logger,
             executor));
   }
@@ -453,7 +459,7 @@ public final class BackgroundTaskManagerFactory {
         new JobBatchMetricsArchiverJob(
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class),
-            metrics,
+            metrics.getArchiverMetrics(),
             logger,
             executor));
   }
@@ -469,7 +475,7 @@ public final class BackgroundTaskManagerFactory {
         new StandaloneDecisionArchiverJob(
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class),
-            metrics,
+            metrics.getArchiverMetrics(),
             logger,
             executor,
             dependantTemplates));
@@ -514,7 +520,7 @@ public final class BackgroundTaskManagerFactory {
             auditLogArchiverRepository,
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(AuditLogTemplate.class),
-            metrics,
+            metrics.getArchiverMetrics(),
             config.getHistory(),
             logger,
             executor));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.BackgroundTask;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.zeebe.util.FunctionUtil;
@@ -17,7 +18,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 
 /**
@@ -28,26 +28,19 @@ import org.slf4j.Logger;
 public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundTask {
 
   private final ArchiverRepository archiverRepository;
-  private final CamundaExporterMetrics exporterMetrics;
+  private final CamundaArchiverMetrics archiverMetrics;
   private final Logger logger;
   private final Executor executor;
 
-  private final Consumer<Integer> recordArchivingMetric;
-  private final Consumer<Integer> recordArchivedMetric;
-
   public ArchiverJob(
       final ArchiverRepository archiverRepository,
-      final CamundaExporterMetrics exporterMetrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger,
-      final Executor executor,
-      final Consumer<Integer> recordArchivingMetric,
-      final Consumer<Integer> recordArchivedMetric) {
+      final Executor executor) {
     this.archiverRepository = archiverRepository;
-    this.exporterMetrics = exporterMetrics;
+    this.archiverMetrics = archiverMetrics;
     this.logger = logger;
     this.executor = executor;
-    this.recordArchivingMetric = recordArchivingMetric;
-    this.recordArchivedMetric = recordArchivedMetric;
   }
 
   /**
@@ -68,7 +61,7 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
   abstract IndexTemplateDescriptor getTemplateDescriptor();
 
   @Override
-  public CompletionStage<Integer> execute() {
+  public final CompletionStage<Integer> execute() {
     final var timer = Timer.start();
 
     return getNextBatch()
@@ -77,12 +70,14 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
         // measure the time it takes all in all, including searching, reindexing, deletion
         // There is some overhead with the scheduling at the executor, but this
         // should be negligible
-        .thenComposeAsync(
-            count -> {
-              exporterMetrics.measureArchivingDuration(timer);
-              return CompletableFuture.completedFuture(count);
-            },
-            executor);
+        .whenComplete(
+            (val, err) -> {
+              if (err != null) {
+                archiverMetrics.measureArchivingFailedDuration(getJobName(), timer);
+              } else {
+                archiverMetrics.measureArchivingSuccessDuration(getJobName(), timer);
+              }
+            });
   }
 
   @Override
@@ -101,16 +96,20 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
   protected CompletionStage<Integer> archiveBatch(final B batch) {
     if (batch == null || batch.finishDate() == null || batch.isEmpty()) {
       logger.trace("No {}s to archive", getJobName());
+      archiverMetrics.measureArchivingBatchSize(getJobName(), 0);
       return CompletableFuture.completedFuture(0);
     }
 
     logger.trace("Following {}s are found for archiving: {}", getJobName(), batch);
-    recordArchivingMetric.accept(batch.size());
+    archiverMetrics.measureArchivingBatchSize(getJobName(), batch.size());
 
     return archive(getTemplateDescriptor(), batch)
         // we want to make sure the rescheduling happens after we update the metrics, so we peek
         // instead of creating an additional pipeline on the interim future
-        .thenApplyAsync(FunctionUtil.peek(recordArchivedMetric), executor);
+        .thenApplyAsync(
+            FunctionUtil.peek(
+                val -> archiverMetrics.measureArchivedInstanceCount(getJobName(), batch.size())),
+            executor);
   }
 
   /**
@@ -133,8 +132,12 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
     final var sourceIdxName = templateDescriptor.getFullQualifiedName();
     final var idsMap = createIdsByFieldMap(templateDescriptor, batch);
     final var finishDate = batch.finishDate();
+
+    final ArchiverJobContextMetrics archiveMetrics =
+        archiverMetrics.getContextMetrics(getJobName(), sourceIdxName);
     return archiverRepository
-        .moveDocuments(sourceIdxName, sourceIdxName + finishDate, idsMap, filters, executor)
+        .moveDocuments(
+            sourceIdxName, sourceIdxName + finishDate, idsMap, filters, archiveMetrics, executor)
         .thenApplyAsync(ok -> batch.size(), executor);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.BackgroundTask;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.zeebe.util.FunctionUtil;
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundTask {
 
   private final ArchiverRepository archiverRepository;
-  private final CamundaArchiverMetrics archiverMetrics;
+  private final ArchiverJobMetrics archiverJobMetrics;
   private final Logger logger;
   private final Executor executor;
 
@@ -38,7 +38,7 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
       final Logger logger,
       final Executor executor) {
     this.archiverRepository = archiverRepository;
-    this.archiverMetrics = archiverMetrics;
+    archiverJobMetrics = archiverMetrics.getArchiverJobMetrics(getJobName());
     this.logger = logger;
     this.executor = executor;
   }
@@ -50,13 +50,17 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
    */
   abstract String getJobName();
 
+  ArchiverJobMetrics getArchiverJobMetrics() {
+    return archiverJobMetrics;
+  }
+
   /**
    * Fetches the next batch of records to be archived
    *
    * @return a future completed with the next batch to be archived, or null/empty if there is
    *     nothing to archive
    */
-  abstract CompletableFuture<B> getNextBatch();
+  abstract CompletableFuture<B> getNextBatch(ArchiverJobMetrics archiverJobMetrics);
 
   abstract IndexTemplateDescriptor getTemplateDescriptor();
 
@@ -64,7 +68,7 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
   public final CompletionStage<Integer> execute() {
     final var timer = Timer.start();
 
-    return getNextBatch()
+    return getNextBatch(archiverJobMetrics)
         .thenComposeAsync(this::archiveBatch, executor)
         // we schedule gathering timer metrics after the archiveBatch future - to correctly
         // measure the time it takes all in all, including searching, reindexing, deletion
@@ -73,9 +77,9 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
         .whenComplete(
             (val, err) -> {
               if (err != null) {
-                archiverMetrics.measureArchivingFailedDuration(getJobName(), timer);
+                archiverJobMetrics.measureArchivingFailedDuration(timer);
               } else {
-                archiverMetrics.measureArchivingSuccessDuration(getJobName(), timer);
+                archiverJobMetrics.measureArchivingSuccessDuration(timer);
               }
             });
   }
@@ -96,19 +100,18 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
   protected CompletionStage<Integer> archiveBatch(final B batch) {
     if (batch == null || batch.finishDate() == null || batch.isEmpty()) {
       logger.trace("No {}s to archive", getJobName());
-      archiverMetrics.measureArchivingBatchSize(getJobName(), 0);
+      archiverJobMetrics.measureArchivingBatchSize(0);
       return CompletableFuture.completedFuture(0);
     }
 
     logger.trace("Following {}s are found for archiving: {}", getJobName(), batch);
-    archiverMetrics.measureArchivingBatchSize(getJobName(), batch.size());
+    archiverJobMetrics.measureArchivingBatchSize(batch.size());
 
     return archive(getTemplateDescriptor(), batch)
         // we want to make sure the rescheduling happens after we update the metrics, so we peek
         // instead of creating an additional pipeline on the interim future
         .thenApplyAsync(
-            FunctionUtil.peek(
-                val -> archiverMetrics.measureArchivedInstanceCount(getJobName(), batch.size())),
+            FunctionUtil.peek(val -> archiverJobMetrics.measureArchivedInstanceCount(batch.size())),
             executor);
   }
 
@@ -132,12 +135,14 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
     final var sourceIdxName = templateDescriptor.getFullQualifiedName();
     final var idsMap = createIdsByFieldMap(templateDescriptor, batch);
     final var finishDate = batch.finishDate();
-
-    final ArchiverJobContextMetrics archiveMetrics =
-        archiverMetrics.getContextMetrics(getJobName(), sourceIdxName);
     return archiverRepository
         .moveDocuments(
-            sourceIdxName, sourceIdxName + finishDate, idsMap, filters, archiveMetrics, executor)
+            sourceIdxName,
+            sourceIdxName + finishDate,
+            idsMap,
+            filters,
+            archiverJobMetrics,
+            executor)
         .thenApplyAsync(ok -> batch.size(), executor);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -30,17 +30,23 @@ public interface ArchiverRepository extends AutoCloseable {
           UsageMetricTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName,
           UsageMetricTUTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName);
 
-  CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch();
+  CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      ArchiverJobMetrics archiverJobMetrics);
 
-  CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch();
+  CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch(
+      ArchiverJobMetrics archiverJobMetrics);
 
-  CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch();
+  CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch(
+      ArchiverJobMetrics archiverJobMetrics);
 
-  CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch();
+  CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch(
+      ArchiverJobMetrics archiverJobMetrics);
 
-  CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch();
+  CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch(
+      ArchiverJobMetrics archiverJobMetrics);
 
-  CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch();
+  CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch(
+      ArchiverJobMetrics archiverJobMetrics);
 
   CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName);
 
@@ -50,20 +56,20 @@ public interface ArchiverRepository extends AutoCloseable {
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics archiveMetrics);
+      final ArchiverJobMetrics archiveMetrics);
 
   CompletableFuture<Void> reindexDocuments(
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics archiveMetrics);
+      final ArchiverJobMetrics archiveMetrics);
 
   default CompletableFuture<Void> moveDocuments(
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final ArchiverJobContextMetrics archiveMetrics,
+      final ArchiverJobMetrics archiveMetrics,
       final Executor executor) {
     return moveDocuments(
         sourceIndexName, destinationIndexName, keysByField, Map.of(), archiveMetrics, executor);
@@ -74,7 +80,7 @@ public interface ArchiverRepository extends AutoCloseable {
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics archiveMetrics,
+      final ArchiverJobMetrics archiveMetrics,
       final Executor executor) {
     return reindexDocuments(
             sourceIndexName, destinationIndexName, keysByField, filters, archiveMetrics)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -46,30 +47,26 @@ public interface ArchiverRepository extends AutoCloseable {
   CompletableFuture<Void> setLifeCycleToAllIndexes();
 
   CompletableFuture<Void> deleteDocuments(
-      final String sourceIndexName, final Map<String, List<String>> keysByField);
-
-  CompletableFuture<Void> deleteDocuments(
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters);
-
-  CompletableFuture<Void> reindexDocuments(
-      final String sourceIndexName,
-      final String destinationIndexName,
-      final Map<String, List<String>> keysByField);
+      final Map<String, String> filters,
+      final ArchiverJobContextMetrics archiveMetrics);
 
   CompletableFuture<Void> reindexDocuments(
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters);
+      final Map<String, String> filters,
+      final ArchiverJobContextMetrics archiveMetrics);
 
   default CompletableFuture<Void> moveDocuments(
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
+      final ArchiverJobContextMetrics archiveMetrics,
       final Executor executor) {
-    return moveDocuments(sourceIndexName, destinationIndexName, keysByField, Map.of(), executor);
+    return moveDocuments(
+        sourceIndexName, destinationIndexName, keysByField, Map.of(), archiveMetrics, executor);
   }
 
   default CompletableFuture<Void> moveDocuments(
@@ -77,10 +74,13 @@ public interface ArchiverRepository extends AutoCloseable {
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
+      final ArchiverJobContextMetrics archiveMetrics,
       final Executor executor) {
-    return reindexDocuments(sourceIndexName, destinationIndexName, keysByField, filters)
+    return reindexDocuments(
+            sourceIndexName, destinationIndexName, keysByField, filters, archiveMetrics)
         .thenComposeAsync(ok -> setIndexLifeCycle(destinationIndexName), executor)
-        .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, keysByField, filters), executor);
+        .thenComposeAsync(
+            ok -> deleteDocuments(sourceIndexName, keysByField, filters, archiveMetrics), executor);
   }
 
   CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
@@ -8,7 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
@@ -28,17 +28,11 @@ public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
       final AuditLogArchiverRepository repository,
       final ArchiverRepository archiverRepository,
       final AuditLogTemplate auditLogTemplate,
-      final CamundaExporterMetrics exporterMetrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final HistoryConfiguration historyConfig,
       final Logger logger,
       final Executor executor) {
-    super(
-        archiverRepository,
-        exporterMetrics,
-        logger,
-        executor,
-        exporterMetrics::recordAuditLogsArchiving,
-        exporterMetrics::recordAuditLogsArchived);
+    super(archiverRepository, archiverMetrics, logger, executor);
     this.repository = repository;
     this.auditLogTemplate = auditLogTemplate;
     this.historyConfig = historyConfig;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJob.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -44,8 +45,9 @@ public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
   }
 
   @Override
-  CompletableFuture<AuditLogCleanupBatch> getNextBatch() {
-    return repository.getNextBatch();
+  CompletableFuture<AuditLogCleanupBatch> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
+    return repository.getNextBatch(archiverJobMetrics);
   }
 
   @Override
@@ -90,6 +92,6 @@ public class AuditLogArchiverJob extends ArchiverJob<AuditLogCleanupBatch> {
     if (batch.auditLogCleanupIds().isEmpty()) {
       return CompletableFuture.completedFuture(0);
     }
-    return repository.deleteAuditLogCleanupMetadata(batch);
+    return repository.deleteAuditLogCleanupMetadata(batch, getArchiverJobMetrics());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import java.util.concurrent.CompletableFuture;
 
@@ -17,12 +18,13 @@ public interface AuditLogArchiverRepository extends AutoCloseable {
    *
    * @return a {@link CompletableFuture} containing the next batch of audit logs to be archived
    */
-  CompletableFuture<AuditLogCleanupBatch> getNextBatch();
+  CompletableFuture<AuditLogCleanupBatch> getNextBatch(final ArchiverJobMetrics archiverJobMetrics);
 
   /**
    * Deletes the documents for the given batch from the audit log cleanup index.
    *
    * @return a {@link CompletableFuture} containing the number of documents deleted
    */
-  CompletableFuture<Integer> deleteAuditLogCleanupMetadata(final AuditLogCleanupBatch batch);
+  CompletableFuture<Integer> deleteAuditLogCleanupMetadata(
+      final AuditLogCleanupBatch batch, final ArchiverJobMetrics archiverJobMetrics);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -29,16 +29,10 @@ public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArc
       final ArchiverRepository repository,
       final BatchOperationTemplate batchOperationTemplate,
       final List<BatchOperationDependant> batchOperationDependants,
-      final CamundaExporterMetrics metrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger,
       final Executor executor) {
-    super(
-        repository,
-        metrics,
-        logger,
-        executor,
-        metrics::recordBatchOperationsArchiving,
-        metrics::recordBatchOperationsArchived);
+    super(repository, archiverMetrics, logger, executor);
     this.batchOperationTemplate = batchOperationTemplate;
     this.batchOperationDependants =
         batchOperationDependants.stream()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
@@ -46,8 +47,9 @@ public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArc
   }
 
   @Override
-  CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch() {
-    return getArchiverRepository().getBatchOperationsNextBatch();
+  CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
+    return getArchiverRepository().getBatchOperationsNextBatch(archiverJobMetrics);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -34,7 +34,8 @@ import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
@@ -74,7 +75,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private final IndexTemplateDescriptor jobMetricsBatchTemplateDescriptor;
   private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
-  private final CamundaExporterMetrics metrics;
+  private final CamundaArchiverMetrics archiverMetrics;
   private final Map<String, String> lastHistoricalArchiverDates = new ConcurrentHashMap<>();
   private final Cache<String, String> lifeCyclePolicyApplied;
 
@@ -84,7 +85,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final ExporterResourceProvider resourceProvider,
       @WillCloseWhenClosed final ElasticsearchAsyncClient client,
       final Executor executor,
-      final CamundaExporterMetrics metrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger) {
     super(client, executor, logger);
     this.partitionId = partitionId;
@@ -102,7 +103,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class);
     decisionInstanceTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
-    this.metrics = metrics;
+    this.archiverMetrics = archiverMetrics;
     lifeCyclePolicyApplied = buildLifeCycleAppliedCache(config.getRetention(), logger);
   }
 
@@ -135,7 +136,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return client
         .search(searchRequest, ProcessInstanceForListViewEntity.class)
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             (response) ->
                 createProcessInstanceBatch(
@@ -150,7 +152,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return client
         .search(searchRequest, Object.class)
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             (response) ->
                 createBasicBatch(
@@ -169,7 +172,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return client
         .search(searchRequest, Object.class)
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createBasicBatch(
@@ -191,7 +195,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return client
         .search(searchRequest, Object.class)
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createBasicBatch(
@@ -209,7 +214,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return client
         .search(searchRequest, Object.class)
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createBasicBatch(
@@ -224,7 +230,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return client
         .search(searchRequest, Object.class)
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createBasicBatch(
@@ -284,15 +291,10 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
   @Override
   public CompletableFuture<Void> deleteDocuments(
-      final String sourceIndexName, final Map<String, List<String>> keysByField) {
-    return deleteDocuments(sourceIndexName, keysByField, Map.of());
-  }
-
-  @Override
-  public CompletableFuture<Void> deleteDocuments(
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters) {
+      final Map<String, String> filters,
+      final ArchiverJobContextMetrics jobContextMetrics) {
     if (keysByField.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
@@ -309,8 +311,17 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client
         .deleteByQuery(request)
         .whenCompleteAsync(
-            (response, error) ->
-                metrics.measureArchiverDelete(response != null ? response.total() : null, timer),
+            (response, error) -> {
+              jobContextMetrics.measureArchiverDelete(timer);
+
+              if (error != null) {
+                jobContextMetrics.measureArchiverDeleteFail(timer, null, error);
+              } else {
+                // if successful, no reason for response to be null
+                jobContextMetrics.measureArchiverDeleteSuccess(
+                    timer, response != null ? response.deleted() : null);
+              }
+            },
             executor)
         .thenApplyAsync(DeleteByQueryResponse::total, executor)
         .thenApplyAsync(ok -> null, executor);
@@ -320,16 +331,9 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   public CompletableFuture<Void> reindexDocuments(
       final String sourceIndexName,
       final String destinationIndexName,
-      final Map<String, List<String>> keysByField) {
-    return reindexDocuments(sourceIndexName, destinationIndexName, keysByField, Map.of());
-  }
-
-  @Override
-  public CompletableFuture<Void> reindexDocuments(
-      final String sourceIndexName,
-      final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters) {
+      final Map<String, String> filters,
+      final ArchiverJobContextMetrics jobContextMetrics) {
     if (keysByField.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
@@ -347,8 +351,17 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client
         .reindex(request)
         .whenCompleteAsync(
-            (response, error) ->
-                metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
+            (response, error) -> {
+              jobContextMetrics.measureArchiverReindex(timer);
+
+              if (error != null) {
+                jobContextMetrics.measureArchiverCopyFail(timer, null, error);
+              } else {
+                // if successful, no reason for response to be null
+                jobContextMetrics.measureArchiverCopySuccess(
+                    timer, response != null ? response.total() : null);
+              }
+            },
             executor)
         .thenApplyAsync(ignored -> null, executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -34,8 +34,7 @@ import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
@@ -58,6 +57,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import javax.annotation.WillCloseWhenClosed;
 import org.slf4j.Logger;
 
@@ -75,7 +75,6 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private final IndexTemplateDescriptor jobMetricsBatchTemplateDescriptor;
   private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
-  private final CamundaArchiverMetrics archiverMetrics;
   private final Map<String, String> lastHistoricalArchiverDates = new ConcurrentHashMap<>();
   private final Cache<String, String> lifeCyclePolicyApplied;
 
@@ -85,7 +84,6 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final ExporterResourceProvider resourceProvider,
       @WillCloseWhenClosed final ElasticsearchAsyncClient client,
       final Executor executor,
-      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger) {
     super(client, executor, logger);
     this.partitionId = partitionId;
@@ -103,7 +101,6 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class);
     decisionInstanceTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
-    this.archiverMetrics = archiverMetrics;
     lifeCyclePolicyApplied = buildLifeCycleAppliedCache(config.getRetention(), logger);
   }
 
@@ -130,115 +127,103 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @Override
-  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createFinishedInstancesSearchRequest();
-
-    final var timer = Timer.start();
-    return client
-        .search(searchRequest, ProcessInstanceForListViewEntity.class)
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            (response) ->
-                createProcessInstanceBatch(
-                    response, ListViewTemplate.END_DATE, listViewTemplateDescriptor),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        ProcessInstanceForListViewEntity.class,
+        listViewTemplateDescriptor,
+        response ->
+            createProcessInstanceBatch(
+                response, ListViewTemplate.END_DATE, listViewTemplateDescriptor));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createFinishedBatchOperationsSearchRequest();
-
-    final var timer = Timer.start();
-    return client
-        .search(searchRequest, Object.class)
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            (response) ->
-                createBasicBatch(
-                    response, BatchOperationTemplate.END_DATE, batchOperationTemplateDescriptor),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        batchOperationTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response, BatchOperationTemplate.END_DATE, batchOperationTemplateDescriptor));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest =
         createUsageMetricSearchRequest(
             usageMetricTUTemplateDescriptor.getFullQualifiedName(),
             UsageMetricTUTemplate.END_TIME,
             UsageMetricTUTemplate.PARTITION_ID);
-
-    final var timer = Timer.start();
-    return client
-        .search(searchRequest, Object.class)
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            response ->
-                createBasicBatch(
-                    response,
-                    UsageMetricTUTemplate.END_TIME,
-                    usageMetricTUTemplateDescriptor,
-                    config.getUsageMetricsRolloverInterval()),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        usageMetricTUTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response,
+                UsageMetricTUTemplate.END_TIME,
+                usageMetricTUTemplateDescriptor,
+                config.getUsageMetricsRolloverInterval()));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest =
         createUsageMetricSearchRequest(
             usageMetricTemplateDescriptor.getFullQualifiedName(),
             UsageMetricTemplate.END_TIME,
             UsageMetricTemplate.PARTITION_ID);
-
-    final var timer = Timer.start();
-    return client
-        .search(searchRequest, Object.class)
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            response ->
-                createBasicBatch(
-                    response,
-                    UsageMetricTemplate.END_TIME,
-                    usageMetricTemplateDescriptor,
-                    config.getUsageMetricsRolloverInterval()),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        usageMetricTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response,
+                UsageMetricTemplate.END_TIME,
+                usageMetricTemplateDescriptor,
+                config.getUsageMetricsRolloverInterval()));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createJobBatchMetricsSearchRequest();
-
-    final var timer = Timer.start();
-    return client
-        .search(searchRequest, Object.class)
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            response ->
-                createBasicBatch(
-                    response, JobMetricsBatchTemplate.END_TIME, jobMetricsBatchTemplateDescriptor),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        jobMetricsBatchTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response, JobMetricsBatchTemplate.END_TIME, jobMetricsBatchTemplateDescriptor));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createStandaloneDecisionSearchRequest();
-
-    final var timer = Timer.start();
-    return client
-        .search(searchRequest, Object.class)
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            response ->
-                createBasicBatch(
-                    response,
-                    DecisionInstanceTemplate.EVALUATION_DATE,
-                    decisionInstanceTemplateDescriptor),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        decisionInstanceTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response,
+                DecisionInstanceTemplate.EVALUATION_DATE,
+                decisionInstanceTemplateDescriptor));
   }
 
   @Override
@@ -294,7 +279,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics jobContextMetrics) {
+      final ArchiverJobMetrics archiverJobMetrics) {
     if (keysByField.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
@@ -312,14 +297,15 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .deleteByQuery(request)
         .whenCompleteAsync(
             (response, error) -> {
-              jobContextMetrics.measureArchiverDelete(timer);
+              archiverJobMetrics.measureArchiverDeleteDuration(timer);
 
               if (error != null) {
-                jobContextMetrics.measureArchiverDeleteFail(timer, null, error);
+                archiverJobMetrics.measureArchiverDeleteFailure(
+                    sourceIndexName, timer, null, error);
               } else {
                 // if successful, no reason for response to be null
-                jobContextMetrics.measureArchiverDeleteSuccess(
-                    timer, response != null ? response.deleted() : null);
+                archiverJobMetrics.measureArchiverDeleteSuccess(
+                    sourceIndexName, timer, response != null ? response.deleted() : null);
               }
             },
             executor)
@@ -333,7 +319,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics jobContextMetrics) {
+      final ArchiverJobMetrics archiverJobMetrics) {
     if (keysByField.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
@@ -352,14 +338,14 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .reindex(request)
         .whenCompleteAsync(
             (response, error) -> {
-              jobContextMetrics.measureArchiverReindex(timer);
+              archiverJobMetrics.measureArchiverReindexDuration(timer);
 
               if (error != null) {
-                jobContextMetrics.measureArchiverCopyFail(timer, null, error);
+                archiverJobMetrics.measureArchiverCopyFailure(sourceIndexName, timer, null, error);
               } else {
                 // if successful, no reason for response to be null
-                jobContextMetrics.measureArchiverCopySuccess(
-                    timer, response != null ? response.total() : null);
+                archiverJobMetrics.measureArchiverCopySuccess(
+                    sourceIndexName, timer, response != null ? response.total() : null);
               }
             },
             executor)
@@ -458,6 +444,34 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .build();
 
     return client.indices().putSettings(settingsRequest);
+  }
+
+  private <BatchType, EntityType> CompletableFuture<BatchType> searchDocuments(
+      final ArchiverJobMetrics archiverJobMetrics,
+      final SearchRequest searchRequest,
+      final Class<EntityType> responseEntityType,
+      final IndexTemplateDescriptor templateDescriptor,
+      final Function<SearchResponse<EntityType>, CompletableFuture<BatchType>> responseComposer) {
+    final var timer = Timer.start();
+    return client
+        .search(searchRequest, responseEntityType)
+        .whenCompleteAsync(
+            (response, error) -> {
+              archiverJobMetrics.measureArchiverRequestSearchDuration(timer);
+
+              if (error != null) {
+                archiverJobMetrics.measureArchiverReadFailure(
+                    templateDescriptor.getFullQualifiedName(), timer, null, error);
+              } else {
+                // if successful, no reason for response to be null
+                archiverJobMetrics.measureArchiverReadSuccess(
+                    templateDescriptor.getFullQualifiedName(),
+                    timer,
+                    response != null ? (long) response.hits().hits().size() : null);
+              }
+            },
+            executor)
+        .thenComposeAsync(responseComposer::apply, executor);
   }
 
   private CompletableFuture<ProcessInstanceArchiveBatch> createProcessInstanceBatch(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchAuditLogArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchAuditLogArchiverRepository.java
@@ -15,6 +15,7 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -22,6 +23,7 @@ import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
+import io.micrometer.core.instrument.Timer;
 import java.time.InstantSource;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -59,9 +61,11 @@ public class ElasticsearchAuditLogArchiverRepository extends ElasticsearchReposi
   }
 
   @Override
-  public CompletableFuture<AuditLogCleanupBatch> getNextBatch() {
+  public CompletableFuture<AuditLogCleanupBatch> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createAuditLogCleanupEntitiesSearchRequest();
 
+    final var timer = Timer.start();
     return client
         .search(searchRequest, AuditLogCleanupEntity.class)
         .thenComposeAsync(
@@ -76,6 +80,21 @@ public class ElasticsearchAuditLogArchiverRepository extends ElasticsearchReposi
 
               return client
                   .search(createAuditLogEntitiesSearchRequest(cleanupEntities), Object.class)
+                  .whenCompleteAsync(
+                      (response, error) -> {
+                        archiverJobMetrics.measureArchiverRequestSearchDuration(timer);
+
+                        if (error != null) {
+                          archiverJobMetrics.measureArchiverReadFailure(
+                              auditLogCleanupIndex.getFullQualifiedName(), timer, null, error);
+                        } else {
+                          // if successful, no reason for response to be null
+                          archiverJobMetrics.measureArchiverReadSuccess(
+                              auditLogCleanupIndex.getFullQualifiedName(),
+                              timer,
+                              response != null ? (long) response.hits().hits().size() : null);
+                        }
+                      })
                   .thenComposeAsync(
                       auditLogResponse -> {
                         final var finishDate =
@@ -97,7 +116,7 @@ public class ElasticsearchAuditLogArchiverRepository extends ElasticsearchReposi
 
   @Override
   public CompletableFuture<Integer> deleteAuditLogCleanupMetadata(
-      final AuditLogCleanupBatch batch) {
+      final AuditLogCleanupBatch batch, final ArchiverJobMetrics archiverJobMetrics) {
     final var bulkRequestBuilder = new BulkRequest.Builder();
     final var sourceIndexName = auditLogCleanupIndex.getFullQualifiedName();
     final var ids = batch.auditLogCleanupIds();
@@ -105,8 +124,25 @@ public class ElasticsearchAuditLogArchiverRepository extends ElasticsearchReposi
     ids.forEach(
         id -> bulkRequestBuilder.operations(op -> op.delete(d -> d.index(sourceIndexName).id(id))));
 
+    final var timer = Timer.start();
     return client
         .bulk(bulkRequestBuilder.build())
+        .whenCompleteAsync(
+            (response, error) -> {
+              archiverJobMetrics.measureArchiverDeleteDuration(timer);
+
+              if (error != null) {
+                archiverJobMetrics.measureArchiverDeleteFailure(
+                    sourceIndexName, timer, null, error);
+              } else {
+                // if successful, no reason for response to be null
+                archiverJobMetrics.measureArchiverDeleteSuccess(
+                    sourceIndexName,
+                    timer,
+                    response != null ? (long) response.items().size() : null);
+              }
+            },
+            executor)
         .thenComposeAsync(
             response -> {
               if (response.errors()) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
@@ -24,16 +24,10 @@ public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
   public JobBatchMetricsArchiverJob(
       final ArchiverRepository repository,
       final JobMetricsBatchTemplate jobMetricsBatchTemplate,
-      final CamundaExporterMetrics exporterMetrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger,
       final Executor executor) {
-    super(
-        repository,
-        exporterMetrics,
-        logger,
-        executor,
-        exporterMetrics::recordJobBatchMetricsArchiving,
-        exporterMetrics::recordJobBatchMetricsArchived);
+    super(repository, archiverMetrics, logger, executor);
     this.jobMetricsBatchTemplate = jobMetricsBatchTemplate;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -37,8 +38,9 @@ public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getNextBatch() {
-    return getArchiverRepository().getJobBatchMetricsNextBatch();
+  public CompletableFuture<BasicArchiveBatch> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
+    return getArchiverRepository().getJobBatchMetricsNextBatch(archiverJobMetrics);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -16,8 +16,7 @@ import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
@@ -42,6 +41,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -81,7 +81,6 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private final IndexTemplateDescriptor jobMetricsBatchTemplateDescriptor;
   private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
-  private final CamundaArchiverMetrics archiverMetrics;
   private final OpenSearchGenericClient genericClient;
   private final Map<String, String> lastHistoricalArchiverDates = new ConcurrentHashMap<>();
   private final Cache<String, String> lifeCyclePolicyApplied;
@@ -93,7 +92,6 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       @WillCloseWhenClosed final OpenSearchAsyncClient client,
       final OpenSearchGenericClient genericClient,
       final Executor executor,
-      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger) {
     super(client, executor, logger);
     this.partitionId = partitionId;
@@ -111,7 +109,6 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class);
     decisionInstanceTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
-    this.archiverMetrics = archiverMetrics;
     this.genericClient = genericClient;
     lifeCyclePolicyApplied = buildLifeCycleAppliedCache(config.getRetention(), logger);
   }
@@ -139,109 +136,103 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   }
 
   @Override
-  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
-    final var request = createFinishedProcessInstancesSearchRequest();
-
-    final var timer = Timer.start();
-    return sendRequestAsync(() -> client.search(request, ProcessInstanceForListViewEntity.class))
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            (response) ->
-                createProcessInstanceBatch(
-                    response, ListViewTemplate.END_DATE, listViewTemplateDescriptor),
-            executor);
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
+    final var searchRequest = createFinishedProcessInstancesSearchRequest();
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        ProcessInstanceForListViewEntity.class,
+        listViewTemplateDescriptor,
+        response ->
+            createProcessInstanceBatch(
+                response, ListViewTemplate.END_DATE, listViewTemplateDescriptor));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createFinishedBatchOperationsSearchRequest();
-
-    final var timer = Timer.start();
-    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            (response) ->
-                createBasicBatch(
-                    response, BatchOperationTemplate.END_DATE, batchOperationTemplateDescriptor),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        batchOperationTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response, BatchOperationTemplate.END_DATE, batchOperationTemplateDescriptor));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest =
         createUsageMetricSearchRequest(
             usageMetricTUTemplateDescriptor.getFullQualifiedName(),
             UsageMetricTUTemplate.END_TIME,
             UsageMetricTUTemplate.PARTITION_ID);
-
-    final var timer = Timer.start();
-    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            response ->
-                createBasicBatch(
-                    response,
-                    UsageMetricTUTemplate.END_TIME,
-                    usageMetricTUTemplateDescriptor,
-                    config.getUsageMetricsRolloverInterval()),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        usageMetricTUTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response,
+                UsageMetricTUTemplate.END_TIME,
+                usageMetricTUTemplateDescriptor,
+                config.getUsageMetricsRolloverInterval()));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest =
         createUsageMetricSearchRequest(
             usageMetricTemplateDescriptor.getFullQualifiedName(),
             UsageMetricTemplate.END_TIME,
             UsageMetricTemplate.PARTITION_ID);
-
-    final var timer = Timer.start();
-    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            response ->
-                createBasicBatch(
-                    response,
-                    UsageMetricTemplate.END_TIME,
-                    usageMetricTemplateDescriptor,
-                    config.getUsageMetricsRolloverInterval()),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        usageMetricTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response,
+                UsageMetricTemplate.END_TIME,
+                usageMetricTemplateDescriptor,
+                config.getUsageMetricsRolloverInterval()));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createJobBatchMetricsSearchRequest();
-
-    final var timer = Timer.start();
-    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            response ->
-                createBasicBatch(
-                    response, JobMetricsBatchTemplate.END_TIME, jobMetricsBatchTemplateDescriptor),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        jobMetricsBatchTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response, JobMetricsBatchTemplate.END_TIME, jobMetricsBatchTemplateDescriptor));
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createStandaloneDecisionSearchRequest();
-
-    final var timer = Timer.start();
-    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync(
-            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            response ->
-                createBasicBatch(
-                    response,
-                    DecisionInstanceTemplate.EVALUATION_DATE,
-                    decisionInstanceTemplateDescriptor),
-            executor);
+    return searchDocuments(
+        archiverJobMetrics,
+        searchRequest,
+        Object.class,
+        decisionInstanceTemplateDescriptor,
+        response ->
+            createBasicBatch(
+                response,
+                DecisionInstanceTemplate.EVALUATION_DATE,
+                decisionInstanceTemplateDescriptor));
   }
 
   @Override
@@ -297,7 +288,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics jobContextMetrics) {
+      final ArchiverJobMetrics archiverJobMetrics) {
     if (keysByField.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
@@ -314,14 +305,15 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     return sendRequestAsync(() -> client.deleteByQuery(request))
         .whenCompleteAsync(
             (response, error) -> {
-              jobContextMetrics.measureArchiverDelete(timer);
+              archiverJobMetrics.measureArchiverDeleteDuration(timer);
 
               if (error != null) {
-                jobContextMetrics.measureArchiverDeleteFail(timer, null, error);
+                archiverJobMetrics.measureArchiverDeleteFailure(
+                    sourceIndexName, timer, null, error);
               } else {
                 // if successful, no reason for response to be null
-                jobContextMetrics.measureArchiverDeleteSuccess(
-                    timer, response != null ? response.deleted() : null);
+                archiverJobMetrics.measureArchiverDeleteSuccess(
+                    sourceIndexName, timer, response != null ? response.deleted() : null);
               }
             },
             executor)
@@ -335,7 +327,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics jobContextMetrics) {
+      final ArchiverJobMetrics archiverJobMetrics) {
     if (keysByField.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
@@ -353,14 +345,14 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     return sendRequestAsync(() -> client.reindex(request))
         .whenCompleteAsync(
             (response, error) -> {
-              jobContextMetrics.measureArchiverReindex(timer);
+              archiverJobMetrics.measureArchiverReindexDuration(timer);
 
               if (error != null) {
-                jobContextMetrics.measureArchiverCopyFail(timer, null, error);
+                archiverJobMetrics.measureArchiverCopyFailure(sourceIndexName, timer, null, error);
               } else {
                 // if successful, no reason for response to be null
-                jobContextMetrics.measureArchiverCopySuccess(
-                    timer, response != null ? response.total() : null);
+                archiverJobMetrics.measureArchiverCopySuccess(
+                    sourceIndexName, timer, response != null ? response.total() : null);
               }
             },
             executor)
@@ -382,6 +374,34 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
+  }
+
+  private <BatchType, EntityType> CompletableFuture<BatchType> searchDocuments(
+      final ArchiverJobMetrics archiverJobMetrics,
+      final SearchRequest searchRequest,
+      final Class<EntityType> responseEntityType,
+      final IndexTemplateDescriptor templateDescriptor,
+      final Function<SearchResponse<EntityType>, CompletableFuture<BatchType>> responseComposer) {
+    final var timer = Timer.start();
+
+    return sendRequestAsync(() -> client.search(searchRequest, responseEntityType))
+        .whenCompleteAsync(
+            (response, error) -> {
+              archiverJobMetrics.measureArchiverRequestSearchDuration(timer);
+
+              if (error != null) {
+                archiverJobMetrics.measureArchiverReadFailure(
+                    templateDescriptor.getFullQualifiedName(), timer, null, error);
+              } else {
+                // if successful, no reason for response to be null
+                archiverJobMetrics.measureArchiverReadSuccess(
+                    templateDescriptor.getFullQualifiedName(),
+                    timer,
+                    response != null ? (long) response.hits().hits().size() : null);
+              }
+            },
+            executor)
+        .thenComposeAsync(responseComposer::apply, executor);
   }
 
   private SearchRequest createUsageMetricSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -16,7 +16,8 @@ import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
@@ -80,7 +81,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private final IndexTemplateDescriptor jobMetricsBatchTemplateDescriptor;
   private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
-  private final CamundaExporterMetrics metrics;
+  private final CamundaArchiverMetrics archiverMetrics;
   private final OpenSearchGenericClient genericClient;
   private final Map<String, String> lastHistoricalArchiverDates = new ConcurrentHashMap<>();
   private final Cache<String, String> lifeCyclePolicyApplied;
@@ -92,7 +93,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       @WillCloseWhenClosed final OpenSearchAsyncClient client,
       final OpenSearchGenericClient genericClient,
       final Executor executor,
-      final CamundaExporterMetrics metrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger) {
     super(client, executor, logger);
     this.partitionId = partitionId;
@@ -110,7 +111,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class);
     decisionInstanceTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
-    this.metrics = metrics;
+    this.archiverMetrics = archiverMetrics;
     this.genericClient = genericClient;
     lifeCyclePolicyApplied = buildLifeCycleAppliedCache(config.getRetention(), logger);
   }
@@ -143,7 +144,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(request, ProcessInstanceForListViewEntity.class))
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             (response) ->
                 createProcessInstanceBatch(
@@ -157,7 +159,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             (response) ->
                 createBasicBatch(
@@ -175,7 +178,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createBasicBatch(
@@ -196,7 +200,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createBasicBatch(
@@ -213,7 +218,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createBasicBatch(
@@ -227,7 +233,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
-        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .whenCompleteAsync(
+            (ignored, error) -> archiverMetrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createBasicBatch(
@@ -287,15 +294,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
   @Override
   public CompletableFuture<Void> deleteDocuments(
-      final String sourceIndexName, final Map<String, List<String>> keysByField) {
-    return deleteDocuments(sourceIndexName, keysByField, Map.of());
-  }
-
-  @Override
-  public CompletableFuture<Void> deleteDocuments(
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters) {
+      final Map<String, String> filters,
+      final ArchiverJobContextMetrics jobContextMetrics) {
     if (keysByField.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
@@ -311,8 +313,17 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.deleteByQuery(request))
         .whenCompleteAsync(
-            (response, error) ->
-                metrics.measureArchiverDelete(response != null ? response.total() : null, timer),
+            (response, error) -> {
+              jobContextMetrics.measureArchiverDelete(timer);
+
+              if (error != null) {
+                jobContextMetrics.measureArchiverDeleteFail(timer, null, error);
+              } else {
+                // if successful, no reason for response to be null
+                jobContextMetrics.measureArchiverDeleteSuccess(
+                    timer, response != null ? response.deleted() : null);
+              }
+            },
             executor)
         .thenApplyAsync(DeleteByQueryResponse::total, executor)
         .thenApplyAsync(ok -> null, executor);
@@ -322,16 +333,9 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   public CompletableFuture<Void> reindexDocuments(
       final String sourceIndexName,
       final String destinationIndexName,
-      final Map<String, List<String>> keysByField) {
-    return reindexDocuments(sourceIndexName, destinationIndexName, keysByField, Map.of());
-  }
-
-  @Override
-  public CompletableFuture<Void> reindexDocuments(
-      final String sourceIndexName,
-      final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters) {
+      final Map<String, String> filters,
+      final ArchiverJobContextMetrics jobContextMetrics) {
     if (keysByField.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
@@ -348,8 +352,17 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.reindex(request))
         .whenCompleteAsync(
-            (response, error) ->
-                metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
+            (response, error) -> {
+              jobContextMetrics.measureArchiverReindex(timer);
+
+              if (error != null) {
+                jobContextMetrics.measureArchiverCopyFail(timer, null, error);
+              } else {
+                // if successful, no reason for response to be null
+                jobContextMetrics.measureArchiverCopySuccess(
+                    timer, response != null ? response.total() : null);
+              }
+            },
             executor)
         .thenApplyAsync(ignored -> null, executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepository.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -16,6 +17,7 @@ import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
+import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
 import java.time.InstantSource;
 import java.time.LocalDate;
@@ -61,9 +63,11 @@ public class OpensearchAuditLogArchiverRepository extends OpensearchRepository
   }
 
   @Override
-  public CompletableFuture<AuditLogCleanupBatch> getNextBatch() {
+  public CompletableFuture<AuditLogCleanupBatch> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     final var searchRequest = createAuditLogCleanupEntitiesSearchRequest();
 
+    final var timer = Timer.start();
     return sendRequestAsync(
         () ->
             client
@@ -84,6 +88,27 @@ public class OpensearchAuditLogArchiverRepository extends OpensearchRepository
                                   .search(
                                       createAuditLogEntitiesSearchRequest(cleanupEntities),
                                       Object.class)
+                                  .whenCompleteAsync(
+                                      (response, error) -> {
+                                        archiverJobMetrics.measureArchiverRequestSearchDuration(
+                                            timer);
+
+                                        if (error != null) {
+                                          archiverJobMetrics.measureArchiverReadFailure(
+                                              auditLogCleanupIndex.getFullQualifiedName(),
+                                              timer,
+                                              null,
+                                              error);
+                                        } else {
+                                          // if successful, no reason for response to be null
+                                          archiverJobMetrics.measureArchiverReadSuccess(
+                                              auditLogCleanupIndex.getFullQualifiedName(),
+                                              timer,
+                                              response != null
+                                                  ? (long) response.hits().hits().size()
+                                                  : null);
+                                        }
+                                      })
                                   .thenComposeAsync(
                                       auditLogResponse -> {
                                         final var finishDate =
@@ -108,7 +133,7 @@ public class OpensearchAuditLogArchiverRepository extends OpensearchRepository
 
   @Override
   public CompletableFuture<Integer> deleteAuditLogCleanupMetadata(
-      final AuditLogCleanupBatch batch) {
+      final AuditLogCleanupBatch batch, final ArchiverJobMetrics archiverJobMetrics) {
     final var bulkRequestBuilder = new BulkRequest.Builder();
     final var sourceIndexName = auditLogCleanupIndex.getFullQualifiedName();
     final var ids = batch.auditLogCleanupIds();
@@ -116,10 +141,27 @@ public class OpensearchAuditLogArchiverRepository extends OpensearchRepository
     ids.forEach(
         id -> bulkRequestBuilder.operations(op -> op.delete(d -> d.index(sourceIndexName).id(id))));
 
+    final var timer = Timer.start();
     return sendRequestAsync(
         () ->
             client
                 .bulk(bulkRequestBuilder.build())
+                .whenCompleteAsync(
+                    (response, error) -> {
+                      archiverJobMetrics.measureArchiverDeleteDuration(timer);
+
+                      if (error != null) {
+                        archiverJobMetrics.measureArchiverDeleteFailure(
+                            sourceIndexName, timer, null, error);
+                      } else {
+                        // if successful, no reason for response to be null
+                        archiverJobMetrics.measureArchiverDeleteSuccess(
+                            sourceIndexName,
+                            timer,
+                            response != null ? (long) response.items().size() : null);
+                      }
+                    },
+                    executor)
                 .thenComposeAsync(
                     response -> {
                       if (response.errors()) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -52,8 +53,9 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
   }
 
   @Override
-  CompletableFuture<ProcessInstanceArchiveBatch> getNextBatch() {
-    return getArchiverRepository().getProcessInstancesNextBatch();
+  CompletableFuture<ProcessInstanceArchiveBatch> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
+    return getArchiverRepository().getProcessInstancesNextBatch(archiverJobMetrics);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
@@ -35,16 +35,10 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
       final ArchiverRepository repository,
       final ListViewTemplate processInstanceTemplate,
       final List<ProcessInstanceDependant> processInstanceDependants,
-      final CamundaExporterMetrics metrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger,
       final Executor executor) {
-    super(
-        repository,
-        metrics,
-        logger,
-        executor,
-        metrics::recordProcessInstancesArchiving,
-        metrics::recordProcessInstancesArchived);
+    super(repository, archiverMetrics, logger, executor);
     this.processInstanceTemplate = processInstanceTemplate;
     this.processInstanceDependants =
         processInstanceDependants.stream()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceToBeArchivedCountJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceToBeArchivedCountJob.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.BackgroundTask;
+import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.CompletionStage;
 import org.slf4j.Logger;
 
@@ -31,6 +32,7 @@ public class ProcessInstanceToBeArchivedCountJob implements BackgroundTask {
 
   @Override
   public CompletionStage<Integer> execute() {
+    final var timer = Timer.start();
     return repository
         .getCountOfProcessInstancesAwaitingArchival()
         .whenCompleteAsync(
@@ -40,6 +42,7 @@ public class ProcessInstanceToBeArchivedCountJob implements BackgroundTask {
               } else {
                 logger.warn("Failed to count number of process instances awaiting archival", err);
               }
+              metrics.measureProcessInstancesAwaitingArchivalDuration(timer);
             });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -28,17 +28,11 @@ public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch
   public StandaloneDecisionArchiverJob(
       final ArchiverRepository repository,
       final DecisionInstanceTemplate decisionInstanceTemplate,
-      final CamundaExporterMetrics metrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger,
       final Executor executor,
       final List<DecisionInstanceDependant> decisionInstanceDependants) {
-    super(
-        repository,
-        metrics,
-        logger,
-        executor,
-        metrics::recordStandaloneDecisionsArchiving,
-        metrics::recordStandaloneDecisionsArchived);
+    super(repository, archiverMetrics, logger, executor);
     this.decisionInstanceTemplate = decisionInstanceTemplate;
     this.decisionInstanceDependants =
         decisionInstanceDependants.stream()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
@@ -47,8 +48,8 @@ public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch
   }
 
   @Override
-  CompletableFuture<BasicArchiveBatch> getNextBatch() {
-    return getArchiverRepository().getStandaloneDecisionNextBatch();
+  CompletableFuture<BasicArchiveBatch> getNextBatch(final ArchiverJobMetrics archiverJobMetrics) {
+    return getArchiverRepository().getStandaloneDecisionNextBatch(archiverJobMetrics);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -37,8 +38,9 @@ public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch() {
-    return getArchiverRepository().getUsageMetricNextBatch();
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
+    return getArchiverRepository().getUsageMetricNextBatch(archiverJobMetrics);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
@@ -24,16 +24,10 @@ public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
   public UsageMetricArchiverJob(
       final ArchiverRepository repository,
       final UsageMetricTemplate usageMetricTemplate,
-      final CamundaExporterMetrics exporterMetrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger,
       final Executor executor) {
-    super(
-        repository,
-        exporterMetrics,
-        logger,
-        executor,
-        exporterMetrics::recordUsageMetricsArchiving,
-        exporterMetrics::recordUsageMetricsArchived);
+    super(repository, archiverMetrics, logger, executor);
     this.usageMetricTemplate = usageMetricTemplate;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
@@ -36,8 +37,9 @@ public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArch
   }
 
   @Override
-  CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch() {
-    return getArchiverRepository().getUsageMetricTUNextBatch();
+  CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
+    return getArchiverRepository().getUsageMetricTUNextBatch(archiverJobMetrics);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import java.util.List;
@@ -23,16 +23,10 @@ public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArch
   public UsageMetricTUArchiverJob(
       final ArchiverRepository repository,
       final UsageMetricTUTemplate usageMetricTUTemplate,
-      final CamundaExporterMetrics metrics,
+      final CamundaArchiverMetrics archiverMetrics,
       final Logger logger,
       final Executor executor) {
-    super(
-        repository,
-        metrics,
-        logger,
-        executor,
-        metrics::recordUsageMetricsTUArchiving,
-        metrics::recordUsageMetricsTUArchived);
+    super(repository, archiverMetrics, logger, executor);
     this.usageMetricTUTemplate = usageMetricTUTemplate;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
@@ -9,12 +9,15 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.search.schema.config.RetentionConfiguration;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.ConnectException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +29,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 abstract class AbstractArchiverRepositoryTest {
 
   final RetentionConfiguration retention = new RetentionConfiguration();
+  final ArchiverJobMetrics archiverJobMetrics =
+      new ArchiverJobMetrics("jobName", new CamundaArchiverMetrics(new SimpleMeterRegistry()));
   ArchiverRepository repository;
 
   @BeforeEach
@@ -43,9 +48,10 @@ abstract class AbstractArchiverRepositoryTest {
   @ParameterizedTest
   @MethodSource("archiveBatchSuppliers")
   void shouldReturnFailedFutureWhenGetNextBatchFails(
-      final Function<ArchiverRepository, CompletableFuture<?>> archiveBatchSupplier) {
+      final BiFunction<ArchiverRepository, ArchiverJobMetrics, CompletableFuture<?>>
+          archiveBatchSupplier) {
     // when
-    final var result = archiveBatchSupplier.apply(repository);
+    final var result = archiveBatchSupplier.apply(repository, archiverJobMetrics);
 
     // then fails when it tries to access ES/OS, since there is no backing database
     assertThat(result)
@@ -55,7 +61,8 @@ abstract class AbstractArchiverRepositoryTest {
         .withRootCauseInstanceOf(ConnectException.class);
   }
 
-  static Stream<Named<Function<ArchiverRepository, CompletableFuture<?>>>> archiveBatchSuppliers() {
+  static Stream<Named<BiFunction<ArchiverRepository, ArchiverJobMetrics, CompletableFuture<?>>>>
+      archiveBatchSuppliers() {
     return Stream.of(
         Named.of("getProcessInstancesNextBatch", ArchiverRepository::getProcessInstancesNextBatch),
         Named.of("getBatchOperationsNextBatch", ArchiverRepository::getBatchOperationsNextBatch),
@@ -78,6 +85,10 @@ abstract class AbstractArchiverRepositoryTest {
     assertThat(result)
         .as("did not try connecting to non existent ES/OS")
         .succeedsWithin(Duration.ofSeconds(5));
+  }
+
+  ArchiverJobMetrics getArchiverJobMetrics() {
+    return archiverJobMetrics;
   }
 
   abstract ArchiverRepository createRepository();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobRecordingMetricsAbstractTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobRecordingMetricsAbstractTest.java
@@ -20,7 +20,7 @@ public abstract class ArchiverJobRecordingMetricsAbstractTest {
 
   abstract SimpleMeterRegistry getMeterRegistry();
 
-  abstract String getJobMetricName();
+  abstract String getJobNameTag();
 
   @Test
   void shouldRecordMetrics() {
@@ -47,15 +47,22 @@ public abstract class ArchiverJobRecordingMetricsAbstractTest {
   }
 
   void assertArchivingCounts(final int expected) {
-    assertThat(getMeterRegistry().counter(getJobMetricName(), "state", "archiving").count())
+    assertThat(
+            getMeterRegistry()
+                .summary("archiver.job.batch.size", "job", getJobNameTag())
+                .totalAmount())
         .isEqualTo(expected);
-    assertThat(getMeterRegistry().counter(getJobMetricName(), "state", "archived").count())
+    assertThat(
+            getMeterRegistry()
+                .counter("archiver.job.archived.instances", "job", getJobNameTag())
+                .count())
         .isEqualTo(expected);
   }
 
   void assertArchiverTimer(final int expectedInvocations) {
     final Timer archiverTimer =
-        getMeterRegistry().timer("zeebe.camunda.exporter.archiver.duration");
+        getMeterRegistry()
+            .timer("archiver.job.duration", "job", getJobNameTag(), "status", "success");
     assertThat(archiverTimer.count()).isEqualTo(expectedInvocations);
     assertThat(archiverTimer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
@@ -9,12 +9,13 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,9 +40,15 @@ final class ArchiverJobTest {
 
   private final TestRepository repository = new TestRepository();
   private final CamundaArchiverMetrics metrics = mock(CamundaArchiverMetrics.class);
+  private final ArchiverJobMetrics archiverJobMetrics = mock(ArchiverJobMetrics.class);
 
-  private final IdxTemplateArchiver job =
-      new IdxTemplateArchiver(repository, metrics, LOGGER, executor);
+  private IdxTemplateArchiver job;
+
+  @BeforeEach
+  public void setup() {
+    when(metrics.getArchiverJobMetrics(anyString())).thenReturn(archiverJobMetrics);
+    job = new IdxTemplateArchiver(repository, metrics, LOGGER, executor);
+  }
 
   @Test
   void shouldReturnZeroIfNoBatchGiven() {
@@ -55,9 +63,9 @@ final class ArchiverJobTest {
     assertThat(repository.moves).isEmpty();
 
     // then verify recording metrics
-    verify(metrics).measureArchivingBatchSize(job.getJobName(), 0);
-    verify(metrics).measureArchivingSuccessDuration(eq(job.getJobName()), any());
-    verifyNoMoreInteractions(metrics);
+    verify(archiverJobMetrics).measureArchivingBatchSize(0);
+    verify(archiverJobMetrics).measureArchivingSuccessDuration(any());
+    verifyNoMoreInteractions(archiverJobMetrics);
   }
 
   @Test
@@ -72,10 +80,10 @@ final class ArchiverJobTest {
     assertThat(count).isEqualTo(0);
     assertThat(repository.moves).isEmpty();
 
-    // then verify recording metrics
-    verify(metrics).measureArchivingBatchSize(job.getJobName(), 0);
-    verify(metrics).measureArchivingSuccessDuration(eq(job.getJobName()), any());
-    verifyNoMoreInteractions(metrics);
+    // then verify recording archiverJobMetrics
+    verify(archiverJobMetrics).measureArchivingBatchSize(0);
+    verify(archiverJobMetrics).measureArchivingSuccessDuration(any());
+    verifyNoMoreInteractions(archiverJobMetrics);
   }
 
   @Test
@@ -96,10 +104,10 @@ final class ArchiverJobTest {
                 Map.of(ID_FIELD_NAME, List.of("1", "2", "3")),
                 executor));
 
-    // then verify recording metrics
-    verify(metrics).measureArchivingBatchSize(job.getJobName(), 3);
-    verify(metrics).measureArchivedInstanceCount(job.getJobName(), 3);
-    verify(metrics).measureArchivingSuccessDuration(eq(job.getJobName()), any());
+    // then verify recording archiverJobMetrics
+    verify(archiverJobMetrics).measureArchivingBatchSize(3);
+    verify(archiverJobMetrics).measureArchivedInstanceCount(3);
+    verify(archiverJobMetrics).measureArchivingSuccessDuration(any());
   }
 
   static class IdxTemplateArchiver extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -123,8 +131,9 @@ final class ArchiverJobTest {
     }
 
     @Override
-    CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch() {
-      return ((TestRepository) getArchiverRepository()).getNextBatch();
+    CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch(
+        final ArchiverJobMetrics archiverJobMetrics) {
+      return ((TestRepository) getArchiverRepository()).getNextBatch(archiverJobMetrics);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
@@ -9,12 +9,13 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -22,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,17 +37,10 @@ final class ArchiverJobTest {
   private final Executor executor = Runnable::run;
 
   private final TestRepository repository = new TestRepository();
-  private final CamundaExporterMetrics metrics = mock(CamundaExporterMetrics.class);
-
-  @SuppressWarnings("unchecked")
-  private final Consumer<Integer> recordArchiving = mock(Consumer.class);
-
-  @SuppressWarnings("unchecked")
-  private final Consumer<Integer> recordArchived = mock(Consumer.class);
+  private final CamundaArchiverMetrics metrics = mock(CamundaArchiverMetrics.class);
 
   private final IdxTemplateArchiver job =
-      new IdxTemplateArchiver(
-          repository, metrics, LOGGER, executor, recordArchiving, recordArchived);
+      new IdxTemplateArchiver(repository, metrics, LOGGER, executor);
 
   @Test
   void shouldReturnZeroIfNoBatchGiven() {
@@ -62,9 +55,9 @@ final class ArchiverJobTest {
     assertThat(repository.moves).isEmpty();
 
     // then verify recording metrics
-    verifyNoInteractions(recordArchiving);
-    verifyNoInteractions(recordArchived);
-    verify(metrics).measureArchivingDuration(any());
+    verify(metrics).measureArchivingBatchSize(job.getJobName(), 0);
+    verify(metrics).measureArchivingSuccessDuration(eq(job.getJobName()), any());
+    verifyNoMoreInteractions(metrics);
   }
 
   @Test
@@ -80,9 +73,9 @@ final class ArchiverJobTest {
     assertThat(repository.moves).isEmpty();
 
     // then verify recording metrics
-    verifyNoInteractions(recordArchiving);
-    verifyNoInteractions(recordArchived);
-    verify(metrics).measureArchivingDuration(any());
+    verify(metrics).measureArchivingBatchSize(job.getJobName(), 0);
+    verify(metrics).measureArchivingSuccessDuration(eq(job.getJobName()), any());
+    verifyNoMoreInteractions(metrics);
   }
 
   @Test
@@ -104,9 +97,9 @@ final class ArchiverJobTest {
                 executor));
 
     // then verify recording metrics
-    verify(recordArchiving).accept(3);
-    verify(recordArchived).accept(3);
-    verify(metrics).measureArchivingDuration(any());
+    verify(metrics).measureArchivingBatchSize(job.getJobName(), 3);
+    verify(metrics).measureArchivedInstanceCount(job.getJobName(), 3);
+    verify(metrics).measureArchivingSuccessDuration(eq(job.getJobName()), any());
   }
 
   static class IdxTemplateArchiver extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
@@ -115,18 +108,10 @@ final class ArchiverJobTest {
 
     public IdxTemplateArchiver(
         final ArchiverRepository archiverRepository,
-        final CamundaExporterMetrics exporterMetrics,
+        final CamundaArchiverMetrics archiverMetrics,
         final Logger logger,
-        final Executor executor,
-        final Consumer<Integer> recordArchivingMetric,
-        final Consumer<Integer> recordArchivedMetric) {
-      super(
-          archiverRepository,
-          exporterMetrics,
-          logger,
-          executor,
-          recordArchivingMetric,
-          recordArchivedMetric);
+        final Executor executor) {
+      super(archiverRepository, archiverMetrics, logger, executor);
       indexTemplateDescriptor = mock(IndexTemplateDescriptor.class);
       when(indexTemplateDescriptor.getIdField()).thenReturn(ID_FIELD_NAME);
       when(indexTemplateDescriptor.getFullQualifiedName()).thenReturn(SOURCE_INDEX_NAME);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
@@ -10,7 +10,7 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -36,7 +36,7 @@ class AuditLogArchiverJobTest {
   private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
   private final HistoryConfiguration config = new HistoryConfiguration();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final CamundaArchiverMetrics metrics = new CamundaArchiverMetrics(meterRegistry);
   private final AuditLogArchiverJob job =
       new AuditLogArchiverJob(
           auditLogArchiverRepository,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
@@ -206,13 +207,14 @@ class AuditLogArchiverJobTest {
     AuditLogCleanupBatch deletedBatch;
 
     @Override
-    public CompletableFuture<AuditLogCleanupBatch> getNextBatch() {
+    public CompletableFuture<AuditLogCleanupBatch> getNextBatch(
+        final ArchiverJobMetrics archiverJobMetrics) {
       return CompletableFuture.completedFuture(batch);
     }
 
     @Override
     public CompletableFuture<Integer> deleteAuditLogCleanupMetadata(
-        final AuditLogCleanupBatch batch) {
+        final AuditLogCleanupBatch batch, final ArchiverJobMetrics archiverJobMetrics) {
       deletedBatch = batch;
       return CompletableFuture.completedFuture(batch.auditLogCleanupIds().size());
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
@@ -34,7 +34,7 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
       new BatchOperationTemplate("", true);
   private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final CamundaArchiverMetrics metrics = new CamundaArchiverMetrics(meterRegistry);
 
   private final BatchOperationArchiverJob job =
       new BatchOperationArchiverJob(
@@ -62,8 +62,8 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
   }
 
   @Override
-  String getJobMetricName() {
-    return "zeebe.camunda.exporter.archiver.batch.operations";
+  String getJobNameTag() {
+    return job.getJobName();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -23,8 +23,7 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
@@ -44,7 +43,6 @@ import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
@@ -85,8 +83,7 @@ final class ElasticsearchArchiverRepositoryIT {
   @RegisterExtension private static final SearchDBExtension SEARCH_DB = SearchDBExtension.create();
 
   @AutoClose private final RestClientTransport transport = createRestClient();
-  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final ArchiverJobContextMetrics archiveMetrics = mock(ArchiverJobContextMetrics.class);
+  private final ArchiverJobMetrics archiverJobMetrics = mock(ArchiverJobMetrics.class);
   private final HistoryConfiguration config = new HistoryConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
   private String indexPrefix;
@@ -137,7 +134,7 @@ final class ElasticsearchArchiverRepositoryIT {
             indexName,
             Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
             Map.of(),
-            archiveMetrics);
+            archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -171,7 +168,7 @@ final class ElasticsearchArchiverRepositoryIT {
             auditLogIndex,
             Map.of("id", List.of("1", "2", "3")),
             Map.of("entityType", "A"),
-            archiveMetrics);
+            archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -211,7 +208,7 @@ final class ElasticsearchArchiverRepositoryIT {
             destIndexName,
             Map.of("id", List.of("1", "2", "3")),
             Map.of("entityType", "A"),
-            archiveMetrics);
+            archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -250,7 +247,7 @@ final class ElasticsearchArchiverRepositoryIT {
             destIndexName,
             Map.of("id", List.of("1", "2", "3")),
             Map.of("entityType", "A"),
-            archiveMetrics,
+            archiverJobMetrics,
             Runnable::run);
 
     // then
@@ -454,7 +451,7 @@ final class ElasticsearchArchiverRepositoryIT {
             destIndexName,
             Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
             Map.of(),
-            archiveMetrics);
+            archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -493,7 +490,7 @@ final class ElasticsearchArchiverRepositoryIT {
             sourceIndexName,
             destIndexName,
             Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
-            archiveMetrics,
+            archiverJobMetrics,
             Runnable::run);
 
     // then
@@ -546,7 +543,7 @@ final class ElasticsearchArchiverRepositoryIT {
     config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getProcessInstancesNextBatch();
+    final var result = repository.getProcessInstancesNextBatch(archiverJobMetrics);
 
     // then - we expect only the first document created two hours ago to be returned
     final var dateFormatter =
@@ -577,7 +574,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(archiverJobMetrics).join();
 
     // then
     // PI mode: Should select all 3 (since end date matches).
@@ -606,7 +603,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(archiverJobMetrics).join();
 
     // then
     // Legacy -> "10"
@@ -636,7 +633,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(archiverJobMetrics).join();
 
     // then
     assertThat(batch.processInstanceKeys()).isEmpty();
@@ -679,7 +676,7 @@ final class ElasticsearchArchiverRepositoryIT {
     config.setRolloverBatchSize(5);
 
     // when
-    final var result = repository.getUsageMetricNextBatch();
+    final var result = repository.getUsageMetricNextBatch(archiverJobMetrics);
 
     // then
     final var dateFormatter =
@@ -719,7 +716,7 @@ final class ElasticsearchArchiverRepositoryIT {
     config.setRolloverBatchSize(5);
 
     // when
-    final var result = repository.getUsageMetricTUNextBatch();
+    final var result = repository.getUsageMetricTUNextBatch(archiverJobMetrics);
 
     // then
     final var dateFormatter =
@@ -754,7 +751,7 @@ final class ElasticsearchArchiverRepositoryIT {
     config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getBatchOperationsNextBatch();
+    final var result = repository.getBatchOperationsNextBatch(archiverJobMetrics);
 
     // then - we expect only the first two documents created two hours ago to be returned
     final var dateFormatter =
@@ -793,7 +790,7 @@ final class ElasticsearchArchiverRepositoryIT {
     config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getStandaloneDecisionNextBatch();
+    final var result = repository.getStandaloneDecisionNextBatch(archiverJobMetrics);
 
     // then - we expect only the first two documents created two hours ago to be returned
     final var dateFormatter =
@@ -824,7 +821,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(batchOperationIndex));
 
     // when
-    final var firstBatch = repository.getBatchOperationsNextBatch();
+    final var firstBatch = repository.getBatchOperationsNextBatch(archiverJobMetrics);
     Awaitility.await("waiting for first batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
@@ -839,7 +836,7 @@ final class ElasticsearchArchiverRepositoryIT {
             batchOperationIndex,
             destIndexName,
             Map.of("id", List.of("1", "2")),
-            archiveMetrics,
+            archiverJobMetrics,
             Runnable::run)
         .join();
 
@@ -850,7 +847,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(batchOperationIndex));
 
     // then
-    final var secondBatch = repository.getBatchOperationsNextBatch();
+    final var secondBatch = repository.getBatchOperationsNextBatch(archiverJobMetrics);
     Awaitility.await("waiting for second batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
@@ -867,7 +864,7 @@ final class ElasticsearchArchiverRepositoryIT {
             batchOperationIndex,
             destIndexName,
             Map.of("id", List.of("3", "4")),
-            archiveMetrics,
+            archiverJobMetrics,
             Runnable::run)
         .join();
 
@@ -880,7 +877,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(batchOperationIndex));
 
     // then
-    final var thirdBatch = repository.getBatchOperationsNextBatch();
+    final var thirdBatch = repository.getBatchOperationsNextBatch(archiverJobMetrics);
 
     Awaitility.await("waiting for third batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
@@ -920,7 +917,7 @@ final class ElasticsearchArchiverRepositoryIT {
     config.setRolloverInterval("3d");
 
     // then the batch finish date should not update:
-    final var batch = repository.getBatchOperationsNextBatch().join();
+    final var batch = repository.getBatchOperationsNextBatch(archiverJobMetrics).join();
     assertThat(batch.ids()).containsExactly("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(3))));
   }
@@ -948,7 +945,7 @@ final class ElasticsearchArchiverRepositoryIT {
     config.setRolloverInterval("3d");
 
     // then the batch finish date should update since zeebe index should be excluded:
-    final var batch = repository.getBatchOperationsNextBatch().join();
+    final var batch = repository.getBatchOperationsNextBatch(archiverJobMetrics).join();
     assertThat(batch.ids()).containsExactly("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(1))));
   }
@@ -1196,10 +1193,8 @@ final class ElasticsearchArchiverRepositoryIT {
 
   private ElasticsearchArchiverRepository createRepository(
       final ElasticsearchAsyncClient client, final int partitionId) {
-    final var metrics = new CamundaArchiverMetrics(meterRegistry);
-
     return new ElasticsearchArchiverRepository(
-        partitionId, config, resourceProvider, client, Runnable::run, metrics, LOGGER);
+        partitionId, config, resourceProvider, client, Runnable::run, LOGGER);
   }
 
   private RestClientTransport createRestClient() {
@@ -1386,8 +1381,9 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when
     // ensure PI batch is processed first to assert that both dates are maintained separately
-    final var piBatch = repository.getProcessInstancesNextBatch().join();
-    final var batchOperationBatch = repository.getBatchOperationsNextBatch().join();
+    final var piBatch = repository.getProcessInstancesNextBatch(archiverJobMetrics).join();
+    final var batchOperationBatch =
+        repository.getBatchOperationsNextBatch(archiverJobMetrics).join();
 
     // then
     assertThat(piBatch.isEmpty()).isFalse();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -23,7 +23,8 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
@@ -85,6 +86,7 @@ final class ElasticsearchArchiverRepositoryIT {
 
   @AutoClose private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final ArchiverJobContextMetrics archiveMetrics = mock(ArchiverJobContextMetrics.class);
   private final HistoryConfiguration config = new HistoryConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
   private String indexPrefix;
@@ -132,7 +134,10 @@ final class ElasticsearchArchiverRepositoryIT {
     // when - delete the first two documents
     final var result =
         repository.deleteDocuments(
-            indexName, Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()));
+            indexName,
+            Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
+            Map.of(),
+            archiveMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -163,7 +168,10 @@ final class ElasticsearchArchiverRepositoryIT {
     // when - delete documents with ids [1, 2, 3], but only if the type is "A"
     final var result =
         repository.deleteDocuments(
-            auditLogIndex, Map.of("id", List.of("1", "2", "3")), Map.of("entityType", "A"));
+            auditLogIndex,
+            Map.of("id", List.of("1", "2", "3")),
+            Map.of("entityType", "A"),
+            archiveMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -202,7 +210,8 @@ final class ElasticsearchArchiverRepositoryIT {
             sourceIndexName,
             destIndexName,
             Map.of("id", List.of("1", "2", "3")),
-            Map.of("entityType", "A"));
+            Map.of("entityType", "A"),
+            archiveMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -241,6 +250,7 @@ final class ElasticsearchArchiverRepositoryIT {
             destIndexName,
             Map.of("id", List.of("1", "2", "3")),
             Map.of("entityType", "A"),
+            archiveMetrics,
             Runnable::run);
 
     // then
@@ -442,7 +452,9 @@ final class ElasticsearchArchiverRepositoryIT {
         repository.reindexDocuments(
             sourceIndexName,
             destIndexName,
-            Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()));
+            Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
+            Map.of(),
+            archiveMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -481,6 +493,7 @@ final class ElasticsearchArchiverRepositoryIT {
             sourceIndexName,
             destIndexName,
             Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
+            archiveMetrics,
             Runnable::run);
 
     // then
@@ -823,7 +836,11 @@ final class ElasticsearchArchiverRepositoryIT {
             });
     repository
         .moveDocuments(
-            batchOperationIndex, destIndexName, Map.of("id", List.of("1", "2")), Runnable::run)
+            batchOperationIndex,
+            destIndexName,
+            Map.of("id", List.of("1", "2")),
+            archiveMetrics,
+            Runnable::run)
         .join();
 
     final var secondBatchDocuments =
@@ -847,7 +864,11 @@ final class ElasticsearchArchiverRepositoryIT {
     // difference of both batches is only 2 days.
     repository
         .moveDocuments(
-            batchOperationIndex, destIndexName, Map.of("id", List.of("3", "4")), Runnable::run)
+            batchOperationIndex,
+            destIndexName,
+            Map.of("id", List.of("3", "4")),
+            archiveMetrics,
+            Runnable::run)
         .join();
 
     // we create another batch of documents, which is two hours ago, since the default archive point
@@ -1175,7 +1196,7 @@ final class ElasticsearchArchiverRepositoryIT {
 
   private ElasticsearchArchiverRepository createRepository(
       final ElasticsearchAsyncClient client, final int partitionId) {
-    final var metrics = new CamundaExporterMetrics(meterRegistry);
+    final var metrics = new CamundaArchiverMetrics(meterRegistry);
 
     return new ElasticsearchArchiverRepository(
         partitionId, config, resourceProvider, client, Runnable::run, metrics, LOGGER);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -26,7 +26,7 @@ import co.elastic.clients.json.SimpleJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -62,7 +62,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   @Override
   ElasticsearchArchiverRepository createRepository() {
     final var client = new ElasticsearchAsyncClient(transport);
-    final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
+    final var metrics = new CamundaArchiverMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();
     config.setRetention(retention);
     return new ElasticsearchArchiverRepository(
@@ -192,7 +192,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         new TestExporterResourceProvider("testPrefix", true),
         client,
         Runnable::run,
-        new CamundaExporterMetrics(new SimpleMeterRegistry()),
+        new CamundaArchiverMetrics(new SimpleMeterRegistry()),
         LOGGER);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -26,11 +26,9 @@ import co.elastic.clients.json.SimpleJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.json.Json;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +60,6 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   @Override
   ElasticsearchArchiverRepository createRepository() {
     final var client = new ElasticsearchAsyncClient(transport);
-    final var metrics = new CamundaArchiverMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();
     config.setRetention(retention);
     return new ElasticsearchArchiverRepository(
@@ -71,7 +68,6 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         new TestExporterResourceProvider("testPrefix", true),
         client,
         Runnable::run,
-        metrics,
         LOGGER);
   }
 
@@ -91,7 +87,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         .thenReturn(CompletableFuture.completedFuture(mock(SearchResponse.class)));
 
     // when
-    repository.getProcessInstancesNextBatch();
+    repository.getProcessInstancesNextBatch(getArchiverJobMetrics());
 
     // then
     final var captor = ArgumentCaptor.forClass(SearchRequest.class);
@@ -121,7 +117,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(getArchiverJobMetrics()).join();
 
     // then
     assertThat(batch.processInstanceKeys()).containsExactly(1L, 2L);
@@ -143,7 +139,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(getArchiverJobMetrics()).join();
 
     // then
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
@@ -167,7 +163,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(getArchiverJobMetrics()).join();
 
     // then - purely based on mapping logic which splits by root key presence
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
@@ -192,7 +188,6 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         new TestExporterResourceProvider("testPrefix", true),
         client,
         Runnable::run,
-        new CamundaArchiverMetrics(new SimpleMeterRegistry()),
         LOGGER);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchAuditLogArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchAuditLogArchiverRepositoryIT.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -16,6 +17,7 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
@@ -57,6 +59,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
 
   @AutoClose private final RestClientTransport transport = createRestClient();
   private final HistoryConfiguration config = new HistoryConfiguration();
+  private final ArchiverJobMetrics archiverJobMetrics = mock(ArchiverJobMetrics.class);
   private String auditLogIndex;
   private String auditLogCleanupIndex;
   private TestExporterResourceProvider resourceProvider;
@@ -88,7 +91,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
     final var repository = createRepository();
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -117,7 +120,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -153,7 +156,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -194,7 +197,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -228,7 +231,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -270,7 +273,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -307,7 +310,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -343,7 +346,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
             "2026-02-19", List.of("cleanup-1", "cleanup-2"), List.of());
 
     // when
-    final var result = repository.deleteAuditLogCleanupMetadata(batch);
+    final var result = repository.deleteAuditLogCleanupMetadata(batch, archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -389,7 +392,7 @@ final class ElasticsearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
@@ -34,7 +34,7 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
   private final JobMetricsBatchTemplate jobMetricsBatchTemplate =
       new JobMetricsBatchTemplate("", true);
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final CamundaArchiverMetrics metrics = new CamundaArchiverMetrics(meterRegistry);
 
   private final JobBatchMetricsArchiverJob job =
       new JobBatchMetricsArchiverJob(
@@ -62,8 +62,8 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
   }
 
   @Override
-  String getJobMetricName() {
-    return "zeebe.camunda.exporter.archiver.job.batch.metrics";
+  String getJobNameTag() {
+    return job.getJobName();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import java.util.List;
 import java.util.Map;
@@ -62,23 +63,10 @@ public class NoopArchiverRepository implements ArchiverRepository {
 
   @Override
   public CompletableFuture<Void> deleteDocuments(
-      final String sourceIndexName, final Map<String, List<String>> keysByField) {
-    return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public CompletableFuture<Void> deleteDocuments(
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters) {
-    return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public CompletableFuture<Void> reindexDocuments(
-      final String sourceIndexName,
-      final String destinationIndexName,
-      final Map<String, List<String>> keysByField) {
+      final Map<String, String> filters,
+      final ArchiverJobContextMetrics archiveMetrics) {
     return CompletableFuture.completedFuture(null);
   }
 
@@ -87,7 +75,8 @@ public class NoopArchiverRepository implements ArchiverRepository {
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters) {
+      final Map<String, String> filters,
+      final ArchiverJobContextMetrics archiveMetrics) {
     return CompletableFuture.completedFuture(null);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import java.util.List;
 import java.util.Map;
@@ -16,37 +16,43 @@ import java.util.concurrent.CompletableFuture;
 public class NoopArchiverRepository implements ArchiverRepository {
 
   @Override
-  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.ProcessInstanceArchiveBatch("2024-01-01", List.of(), List.of()));
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getBatchOperationsNextBatch() {
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getBatchOperationsNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getUsageMetricTUNextBatch() {
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getUsageMetricTUNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getUsageMetricNextBatch() {
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getUsageMetricNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getJobBatchMetricsNextBatch() {
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getJobBatchMetricsNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getStandaloneDecisionNextBatch() {
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getStandaloneDecisionNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
   }
@@ -66,7 +72,7 @@ public class NoopArchiverRepository implements ArchiverRepository {
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics archiveMetrics) {
+      final ArchiverJobMetrics archiveMetrics) {
     return CompletableFuture.completedFuture(null);
   }
 
@@ -76,7 +82,7 @@ public class NoopArchiverRepository implements ArchiverRepository {
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics archiveMetrics) {
+      final ArchiverJobMetrics archiveMetrics) {
     return CompletableFuture.completedFuture(null);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -12,6 +12,7 @@ import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OP
 import static io.camunda.search.test.utils.SearchDBExtension.create;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,7 +20,8 @@ import static org.mockito.Mockito.verify;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
@@ -92,6 +94,7 @@ final class OpenSearchArchiverRepositoryIT {
   private static final ObjectMapper MAPPER = TestObjectMapper.objectMapper();
   @AutoClose private final OpenSearchTransport transport = createTransport();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final ArchiverJobContextMetrics archiveMetrics = mock(ArchiverJobContextMetrics.class);
   private final HistoryConfiguration config = new HistoryConfiguration();
   private final ConnectConfiguration connectConfiguration = new ConnectConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
@@ -140,7 +143,10 @@ final class OpenSearchArchiverRepositoryIT {
     // when - delete the first two documents
     final var result =
         repository.deleteDocuments(
-            indexName, Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()));
+            indexName,
+            Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
+            Map.of(),
+            archiveMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -171,7 +177,10 @@ final class OpenSearchArchiverRepositoryIT {
     // when - delete documents with ids [1, 2, 3], but only if the type is "A"
     final var result =
         repository.deleteDocuments(
-            auditLogIndex, Map.of("id", List.of("1", "2", "3")), Map.of("entityType", "A"));
+            auditLogIndex,
+            Map.of("id", List.of("1", "2", "3")),
+            Map.of("entityType", "A"),
+            archiveMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -210,7 +219,8 @@ final class OpenSearchArchiverRepositoryIT {
             sourceIndexName,
             destIndexName,
             Map.of("id", List.of("1", "2", "3")),
-            Map.of("entityType", "A"));
+            Map.of("entityType", "A"),
+            archiveMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -249,6 +259,7 @@ final class OpenSearchArchiverRepositoryIT {
             destIndexName,
             Map.of("id", List.of("1", "2", "3")),
             Map.of("entityType", "A"),
+            archiveMetrics,
             Runnable::run);
 
     // then
@@ -428,7 +439,9 @@ final class OpenSearchArchiverRepositoryIT {
         repository.reindexDocuments(
             sourceIndexName,
             destIndexName,
-            Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()));
+            Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
+            Map.of(),
+            archiveMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -467,6 +480,7 @@ final class OpenSearchArchiverRepositoryIT {
             sourceIndexName,
             destIndexName,
             Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
+            archiveMetrics,
             Runnable::run);
 
     // then
@@ -728,7 +742,11 @@ final class OpenSearchArchiverRepositoryIT {
             });
     repository
         .moveDocuments(
-            batchOperationIndex, destIndexName, Map.of("id", List.of("1", "2")), Runnable::run)
+            batchOperationIndex,
+            destIndexName,
+            Map.of("id", List.of("1", "2")),
+            archiveMetrics,
+            Runnable::run)
         .join();
 
     final var secondBatchDocuments =
@@ -752,7 +770,11 @@ final class OpenSearchArchiverRepositoryIT {
     // difference of both batches is only 2 days.
     repository
         .moveDocuments(
-            batchOperationIndex, destIndexName, Map.of("id", List.of("3", "4")), Runnable::run)
+            batchOperationIndex,
+            destIndexName,
+            Map.of("id", List.of("3", "4")),
+            archiveMetrics,
+            Runnable::run)
         .join();
 
     // we create another batch of documents, which is two hours ago, since the default archive point
@@ -1423,7 +1445,7 @@ final class OpenSearchArchiverRepositoryIT {
   private OpenSearchArchiverRepository createRepository(
       final OpenSearchGenericClient genericClient, final int partitionId) {
     final var client = createOpenSearchAsyncClient();
-    final var metrics = new CamundaExporterMetrics(meterRegistry);
+    final var metrics = new CamundaArchiverMetrics(meterRegistry);
 
     return new OpenSearchArchiverRepository(
         partitionId,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -20,8 +20,7 @@ import static org.mockito.Mockito.verify;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
@@ -41,7 +40,6 @@ import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -93,8 +91,7 @@ final class OpenSearchArchiverRepositoryIT {
   @RegisterExtension private static final SearchDBExtension SEARCH_DB = create();
   private static final ObjectMapper MAPPER = TestObjectMapper.objectMapper();
   @AutoClose private final OpenSearchTransport transport = createTransport();
-  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final ArchiverJobContextMetrics archiveMetrics = mock(ArchiverJobContextMetrics.class);
+  private final ArchiverJobMetrics archiverJobMetrics = mock(ArchiverJobMetrics.class);
   private final HistoryConfiguration config = new HistoryConfiguration();
   private final ConnectConfiguration connectConfiguration = new ConnectConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
@@ -146,7 +143,7 @@ final class OpenSearchArchiverRepositoryIT {
             indexName,
             Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
             Map.of(),
-            archiveMetrics);
+            archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -180,7 +177,7 @@ final class OpenSearchArchiverRepositoryIT {
             auditLogIndex,
             Map.of("id", List.of("1", "2", "3")),
             Map.of("entityType", "A"),
-            archiveMetrics);
+            archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -220,7 +217,7 @@ final class OpenSearchArchiverRepositoryIT {
             destIndexName,
             Map.of("id", List.of("1", "2", "3")),
             Map.of("entityType", "A"),
-            archiveMetrics);
+            archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -259,7 +256,7 @@ final class OpenSearchArchiverRepositoryIT {
             destIndexName,
             Map.of("id", List.of("1", "2", "3")),
             Map.of("entityType", "A"),
-            archiveMetrics,
+            archiverJobMetrics,
             Runnable::run);
 
     // then
@@ -441,7 +438,7 @@ final class OpenSearchArchiverRepositoryIT {
             destIndexName,
             Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
             Map.of(),
-            archiveMetrics);
+            archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -480,7 +477,7 @@ final class OpenSearchArchiverRepositoryIT {
             sourceIndexName,
             destIndexName,
             Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
-            archiveMetrics,
+            archiverJobMetrics,
             Runnable::run);
 
     // then
@@ -533,7 +530,7 @@ final class OpenSearchArchiverRepositoryIT {
     config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getProcessInstancesNextBatch();
+    final var result = repository.getProcessInstancesNextBatch(archiverJobMetrics);
 
     // then - we expect only the first document created two hours ago to be returned
     final var dateFormatter =
@@ -564,7 +561,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(archiverJobMetrics).join();
 
     // then
     // PI mode: Should select all 3 (since end date matches).
@@ -593,7 +590,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(archiverJobMetrics).join();
 
     // then
     // Legacy -> "10"
@@ -623,7 +620,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(archiverJobMetrics).join();
 
     // then
     assertThat(batch.processInstanceKeys()).isEmpty();
@@ -660,7 +657,7 @@ final class OpenSearchArchiverRepositoryIT {
     config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getBatchOperationsNextBatch();
+    final var result = repository.getBatchOperationsNextBatch(archiverJobMetrics);
 
     // then - we expect only the first two documents created two hours ago to be returned
     final var dateFormatter =
@@ -699,7 +696,7 @@ final class OpenSearchArchiverRepositoryIT {
     config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getStandaloneDecisionNextBatch();
+    final var result = repository.getStandaloneDecisionNextBatch(archiverJobMetrics);
 
     // then - we expect only the first two documents created two hours ago to be returned
     final var dateFormatter =
@@ -730,7 +727,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(batchOperationIndex));
 
     // when
-    final var firstBatch = repository.getBatchOperationsNextBatch();
+    final var firstBatch = repository.getBatchOperationsNextBatch(archiverJobMetrics);
     Awaitility.await("waiting for first batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
@@ -745,7 +742,7 @@ final class OpenSearchArchiverRepositoryIT {
             batchOperationIndex,
             destIndexName,
             Map.of("id", List.of("1", "2")),
-            archiveMetrics,
+            archiverJobMetrics,
             Runnable::run)
         .join();
 
@@ -756,7 +753,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(batchOperationIndex));
 
     // then
-    final var secondBatch = repository.getBatchOperationsNextBatch();
+    final var secondBatch = repository.getBatchOperationsNextBatch(archiverJobMetrics);
     Awaitility.await("waiting for second batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
@@ -773,7 +770,7 @@ final class OpenSearchArchiverRepositoryIT {
             batchOperationIndex,
             destIndexName,
             Map.of("id", List.of("3", "4")),
-            archiveMetrics,
+            archiverJobMetrics,
             Runnable::run)
         .join();
 
@@ -786,7 +783,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(batchOperationIndex));
 
     // then
-    final var thirdBatch = repository.getBatchOperationsNextBatch();
+    final var thirdBatch = repository.getBatchOperationsNextBatch(archiverJobMetrics);
 
     Awaitility.await("waiting for third batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
@@ -826,7 +823,7 @@ final class OpenSearchArchiverRepositoryIT {
     config.setRolloverInterval("3d");
 
     // then the batch finish date should not update:
-    final var batch = repository.getBatchOperationsNextBatch().join();
+    final var batch = repository.getBatchOperationsNextBatch(archiverJobMetrics).join();
     assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(3))));
   }
@@ -855,7 +852,7 @@ final class OpenSearchArchiverRepositoryIT {
     config.setRolloverInterval("3d");
 
     // then the batch finish date should update since zeebe index should be excluded:
-    final var batch = repository.getBatchOperationsNextBatch().join();
+    final var batch = repository.getBatchOperationsNextBatch(archiverJobMetrics).join();
     assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(1))));
   }
@@ -885,7 +882,7 @@ final class OpenSearchArchiverRepositoryIT {
     config.setRolloverBatchSize(5);
 
     // when
-    final var result = repository.getUsageMetricNextBatch();
+    final var result = repository.getUsageMetricNextBatch(archiverJobMetrics);
 
     // then
     final var dateFormatter =
@@ -925,7 +922,7 @@ final class OpenSearchArchiverRepositoryIT {
     config.setRolloverBatchSize(5);
 
     // when
-    final var result = repository.getUsageMetricTUNextBatch();
+    final var result = repository.getUsageMetricTUNextBatch(archiverJobMetrics);
 
     // then
     final var dateFormatter =
@@ -1230,8 +1227,9 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when
     // ensure PI batch is processed first to assert that both dates are maintained separately
-    final var piBatch = repository.getProcessInstancesNextBatch().join();
-    final var batchOperationBatch = repository.getBatchOperationsNextBatch().join();
+    final var piBatch = repository.getProcessInstancesNextBatch(archiverJobMetrics).join();
+    final var batchOperationBatch =
+        repository.getBatchOperationsNextBatch(archiverJobMetrics).join();
 
     // then
     assertThat(piBatch.isEmpty()).isFalse();
@@ -1445,17 +1443,9 @@ final class OpenSearchArchiverRepositoryIT {
   private OpenSearchArchiverRepository createRepository(
       final OpenSearchGenericClient genericClient, final int partitionId) {
     final var client = createOpenSearchAsyncClient();
-    final var metrics = new CamundaArchiverMetrics(meterRegistry);
 
     return new OpenSearchArchiverRepository(
-        partitionId,
-        config,
-        resourceProvider,
-        client,
-        genericClient,
-        Runnable::run,
-        metrics,
-        LOGGER);
+        partitionId, config, resourceProvider, client, genericClient, Runnable::run, LOGGER);
   }
 
   private void createAuditLogIndex() throws IOException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -65,7 +65,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   @Override
   OpenSearchArchiverRepository createRepository() {
     final var client = new OpenSearchAsyncClient(transport);
-    final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
+    final var metrics = new CamundaArchiverMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();
     config.setRetention(retention);
 
@@ -196,7 +196,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         client,
         mock(OpenSearchGenericClient.class),
         Runnable::run,
-        new CamundaExporterMetrics(new SimpleMeterRegistry()),
+        new CamundaArchiverMetrics(new SimpleMeterRegistry()),
         LOGGER);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -16,11 +16,9 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
-import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.json.Json;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -65,7 +63,6 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   @Override
   OpenSearchArchiverRepository createRepository() {
     final var client = new OpenSearchAsyncClient(transport);
-    final var metrics = new CamundaArchiverMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();
     config.setRetention(retention);
 
@@ -76,7 +73,6 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         client,
         new OpenSearchGenericClient(client._transport(), client._transportOptions()),
         Runnable::run,
-        metrics,
         LOGGER);
   }
 
@@ -91,7 +87,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         .thenReturn(CompletableFuture.completedFuture(mock(SearchResponse.class)));
 
     // when
-    repository.getProcessInstancesNextBatch();
+    repository.getProcessInstancesNextBatch(getArchiverJobMetrics());
 
     // then
     final var captor = ArgumentCaptor.forClass(SearchRequest.class);
@@ -115,7 +111,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(getArchiverJobMetrics()).join();
 
     // then
     assertThat(batch.processInstanceKeys()).containsExactly(1L, 2L);
@@ -137,7 +133,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(getArchiverJobMetrics()).join();
 
     // then
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
@@ -160,7 +156,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(getArchiverJobMetrics()).join();
 
     // then - purely based on mapping logic which splits by root key presence
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
@@ -196,7 +192,6 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         client,
         mock(OpenSearchGenericClient.class),
         Runnable::run,
-        new CamundaArchiverMetrics(new SimpleMeterRegistry()),
         LOGGER);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepositoryIT.java
@@ -10,9 +10,11 @@ package io.camunda.exporter.tasks.archiver;
 import static io.camunda.search.test.utils.SearchDBExtension.ARCHIVER_IDX_PREFIX;
 import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -66,6 +68,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
 
   @AutoClose private final OpenSearchTransport transport = createTransport();
   private final HistoryConfiguration config = new HistoryConfiguration();
+  private final ArchiverJobMetrics archiverJobMetrics = mock(ArchiverJobMetrics.class);
   private String auditLogIndex;
   private String auditLogCleanupIndex;
   private TestExporterResourceProvider resourceProvider;
@@ -99,7 +102,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
     final var repository = createRepository();
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -128,7 +131,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -164,7 +167,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -205,7 +208,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -239,7 +242,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -281,7 +284,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -318,7 +321,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -354,7 +357,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
             "2026-02-19", List.of("cleanup-1", "cleanup-2"), List.of());
 
     // when
-    final var result = repository.deleteAuditLogCleanupMetadata(batch);
+    final var result = repository.deleteAuditLogCleanupMetadata(batch, archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -400,7 +403,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(auditLogCleanupIndex, auditLogIndex));
 
     // when
-    final var result = repository.getNextBatch();
+    final var result = repository.getNextBatch(archiverJobMetrics);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
@@ -41,7 +41,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
 
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final CamundaArchiverMetrics metrics = new CamundaArchiverMetrics(meterRegistry);
 
   private final ProcessInstanceArchiverJob job =
       new ProcessInstanceArchiverJob(
@@ -75,8 +75,8 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   }
 
   @Override
-  String getJobMetricName() {
-    return "zeebe.camunda.exporter.archiver.process.instances";
+  String getJobNameTag() {
+    return job.getJobName();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
@@ -38,7 +38,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
   private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
 
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final CamundaArchiverMetrics metrics = new CamundaArchiverMetrics(meterRegistry);
 
   private final StandaloneDecisionArchiverJob job =
       new StandaloneDecisionArchiverJob(
@@ -71,8 +71,8 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
   }
 
   @Override
-  String getJobMetricName() {
-    return "zeebe.camunda.exporter.archiver.standalone.decisions";
+  String getJobNameTag() {
+    return job.getJobName();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
+import io.camunda.exporter.metrics.ArchiverJobMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import java.util.ArrayList;
@@ -20,37 +20,44 @@ final class TestRepository extends NoopArchiverRepository {
   final List<DocumentMove> moves = new ArrayList<>();
   ArchiveBatch batch;
 
-  public <T extends ArchiveBatch> CompletableFuture<T> getNextBatch() {
+  public <T extends ArchiveBatch> CompletableFuture<T> getNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture((T) batch);
   }
 
   @Override
-  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture((ProcessInstanceArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch() {
+  public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch(
+      final ArchiverJobMetrics archiverJobMetrics) {
     return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
@@ -60,7 +67,7 @@ final class TestRepository extends NoopArchiverRepository {
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final ArchiverJobContextMetrics archiveMetrics,
+      final ArchiverJobMetrics archiveMetrics,
       final Executor executor) {
     moves.add(
         new DocumentMove(sourceIndexName, destinationIndexName, keysByField, filters, executor));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.metrics.CamundaArchiverMetrics.ArchiverJobContextMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import java.util.ArrayList;
@@ -59,6 +60,7 @@ final class TestRepository extends NoopArchiverRepository {
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
+      final ArchiverJobContextMetrics archiveMetrics,
       final Executor executor) {
     moves.add(
         new DocumentMove(sourceIndexName, destinationIndexName, keysByField, filters, executor));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
@@ -32,7 +32,7 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   private final TestRepository repository = new TestRepository();
   private final UsageMetricTemplate usageMetricTemplate = new UsageMetricTemplate("", true);
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final CamundaArchiverMetrics metrics = new CamundaArchiverMetrics(meterRegistry);
 
   private final UsageMetricArchiverJob job =
       new UsageMetricArchiverJob(repository, usageMetricTemplate, metrics, LOGGER, executor);
@@ -59,8 +59,8 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   }
 
   @Override
-  String getJobMetricName() {
-    return "zeebe.camunda.exporter.archiver.usage.metrics";
+  String getJobNameTag() {
+    return job.getJobName();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.metrics.CamundaArchiverMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
@@ -31,7 +31,7 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   private final TestRepository repository = new TestRepository();
   private final UsageMetricTUTemplate usageMetricTUTemplate = new UsageMetricTUTemplate("", true);
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final CamundaArchiverMetrics metrics = new CamundaArchiverMetrics(meterRegistry);
 
   private final UsageMetricTUArchiverJob job =
       new UsageMetricTUArchiverJob(repository, usageMetricTUTemplate, metrics, LOGGER, executor);
@@ -58,8 +58,8 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   }
 
   @Override
-  String getJobMetricName() {
-    return "zeebe.camunda.exporter.archiver.usage.metrics.tu";
+  String getJobNameTag() {
+    return job.getJobName();
   }
 
   @Test


### PR DESCRIPTION

## Description

This change splits the archiver-related metrics out of `CamundaExporterMetrics` into a dedicated `CamundaArchiverMetrics` class. As part of this, the metrics are refactored to be tagged by job name, removing the need to create a separate set of counters/metrics for each new job.

Additional tag dimensions, such as status (success/failure), are added so we can compare success and failure modes separately.

We are also adding index-level metrics to track how many records we read, copy (reindex), and delete, as well as how long each operation takes. These metrics also indicate whether the call succeeded or failed.

In addition, we introduce metrics to track the number of errors encountered, categorised by error class, for example, timeouts, Elasticsearch/OpenSearch errors, and all other errors.

Overall, this is a refactor of all archiver-related metrics.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to https://github.com/camunda/camunda/issues/51578 
