### PR TITLE
48200 archive bulk get batches

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -403,6 +403,7 @@ public final class BackgroundTaskManagerFactory {
 
     return buildReschedulingArchiverTask(
         new ProcessInstanceArchiverJob(
+            config.getHistory(),
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
             dependantTemplates,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -38,6 +38,10 @@ public interface ArchiveBatch {
     }
 
     public List<ProcessInstanceArchiveBatch> chunk(final int chunkSize) {
+      if (isEmpty()) {
+        return List.of(this);
+      }
+
       final var chunks = new ArrayList<ProcessInstanceArchiveBatch>();
 
       List<Long> currentRootProcessInstanceKeys = new ArrayList<>();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -34,6 +35,44 @@ public interface ArchiveBatch {
     @Override
     public int size() {
       return processInstanceKeys.size() + rootProcessInstanceKeys.size();
+    }
+
+    public List<ProcessInstanceArchiveBatch> chunk(final int chunkSize) {
+      final var chunks = new ArrayList<ProcessInstanceArchiveBatch>();
+
+      List<Long> currentRootProcessInstanceKeys = new ArrayList<>();
+      List<Long> currentProcessInstanceKeys = new ArrayList<>();
+
+      for (final var rootPi : rootProcessInstanceKeys()) {
+        if (currentRootProcessInstanceKeys.size() >= chunkSize) {
+          chunks.add(
+              new ProcessInstanceArchiveBatch(
+                  finishDate, currentProcessInstanceKeys, currentRootProcessInstanceKeys));
+          currentRootProcessInstanceKeys = new ArrayList<>();
+          currentProcessInstanceKeys = new ArrayList<>();
+        }
+        currentRootProcessInstanceKeys.add(rootPi);
+      }
+
+      for (final var pi : processInstanceKeys()) {
+        if (currentRootProcessInstanceKeys.size() + currentProcessInstanceKeys.size()
+            >= chunkSize) {
+          chunks.add(
+              new ProcessInstanceArchiveBatch(
+                  finishDate, currentProcessInstanceKeys, currentRootProcessInstanceKeys));
+          currentRootProcessInstanceKeys = new ArrayList<>();
+          currentProcessInstanceKeys = new ArrayList<>();
+        }
+        currentProcessInstanceKeys.add(pi);
+      }
+
+      if (!currentRootProcessInstanceKeys.isEmpty() || !currentProcessInstanceKeys.isEmpty()) {
+        chunks.add(
+            new ProcessInstanceArchiveBatch(
+                finishDate, currentProcessInstanceKeys, currentRootProcessInstanceKeys));
+      }
+
+      return chunks;
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -29,7 +29,7 @@ public interface ArchiverRepository extends AutoCloseable {
           UsageMetricTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName,
           UsageMetricTUTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName);
 
-  CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch();
+  CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(final int size);
 
   CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -129,8 +129,9 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @Override
-  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
-    final var searchRequest = createFinishedInstancesSearchRequest();
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      final int size) {
+    final var searchRequest = createFinishedInstancesSearchRequest(size);
 
     final var timer = Timer.start();
     return client
@@ -423,10 +424,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenApplyAsync(response -> new ArrayList<>(response.result().keySet()), executor);
   }
 
-  private SearchRequest createFinishedInstancesSearchRequest() {
+  private SearchRequest createFinishedInstancesSearchRequest(final int size) {
     return createSearchRequest(
         listViewTemplateDescriptor.getFullQualifiedName(),
         finishedProcessInstancesQuery(config.getArchivingTimePoint(), partitionId),
+        size,
         ListViewTemplate.END_DATE,
         ListViewTemplate.ROOT_PROCESS_INSTANCE_KEY);
   }
@@ -684,6 +686,16 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final Query filterQuery,
       final String sortField,
       final String... extraFields) {
+    return createSearchRequest(
+        indexName, filterQuery, config.getRolloverBatchSize(), sortField, extraFields);
+  }
+
+  private SearchRequest createSearchRequest(
+      final String indexName,
+      final Query filterQuery,
+      final int size,
+      final String sortField,
+      final String... extraFields) {
     logger.trace(
         "Create search request against index '{}', with filter '{}' and sortField '{}'",
         indexName,
@@ -703,7 +715,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .fields(fields -> fields.field(sortField).format(config.getElsRolloverDateFormat()))
         .query(query -> query.bool(q -> q.filter(filterQuery)))
         .sort(sort -> sort.field(field -> field.field(sortField).order(SortOrder.Asc)))
-        .size(config.getRolloverBatchSize())
+        .size(size)
         .build();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -138,8 +138,9 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   }
 
   @Override
-  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
-    final var request = createFinishedProcessInstancesSearchRequest();
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      final int size) {
+    final var request = createFinishedProcessInstancesSearchRequest(size);
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(request, ProcessInstanceForListViewEntity.class))
@@ -552,10 +553,11 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     return CompletableFuture.completedFuture(null);
   }
 
-  private SearchRequest createFinishedProcessInstancesSearchRequest() {
+  private SearchRequest createFinishedProcessInstancesSearchRequest(final int size) {
     return createSearchRequest(
         listViewTemplateDescriptor.getFullQualifiedName(),
         finishedProcessInstancesQuery(config.getArchivingTimePoint(), partitionId),
+        size,
         ListViewTemplate.END_DATE,
         ListViewTemplate.ROOT_PROCESS_INSTANCE_KEY);
   }
@@ -800,6 +802,16 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final Query filterQuery,
       final String sortField,
       final String... extraFields) {
+    return createSearchRequest(
+        indexName, filterQuery, config.getRolloverBatchSize(), sortField, extraFields);
+  }
+
+  private SearchRequest createSearchRequest(
+      final String indexName,
+      final Query filterQuery,
+      final int size,
+      final String sortField,
+      final String... extraFields) {
     logger.trace(
         "Create search request against index '{}', with filter '{}' and sortField '{}'",
         indexName,
@@ -819,7 +831,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .fields(fields -> fields.field(sortField).format(config.getElsRolloverDateFormat()))
         .query(query -> query.bool(q -> q.filter(filterQuery)))
         .sort(sort -> sort.field(field -> field.field(sortField).order(SortOrder.Asc)))
-        .size(config.getRolloverBatchSize())
+        .size(size)
         .build();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -63,7 +63,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
 
   @Override
   CompletableFuture<ProcessInstanceArchiveBatch> getNextBatch() {
-    return getArchiverRepository().getProcessInstancesNextBatch();
+    return getArchiverRepository().getProcessInstancesNextBatch(config.getRolloverBatchSize());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -18,6 +18,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
@@ -28,10 +29,14 @@ import org.slf4j.Logger;
  * node instances, variable updates, etc).
  */
 public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchiveBatch> {
+  private static final int MAX_LARGE_BATCH_SIZE = 5_000;
+  private static final int SUB_BATCHES_PER_LARGE_BATCH = 10;
 
   private final HistoryConfiguration config;
   private final ListViewTemplate processInstanceTemplate;
   private final List<ProcessInstanceDependant> processInstanceDependants;
+  private final Queue<ProcessInstanceArchiveBatch> pendingBatches =
+      new java.util.concurrent.ConcurrentLinkedQueue<>();
 
   public ProcessInstanceArchiverJob(
       final HistoryConfiguration config,
@@ -63,7 +68,18 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
 
   @Override
   CompletableFuture<ProcessInstanceArchiveBatch> getNextBatch() {
-    return getArchiverRepository().getProcessInstancesNextBatch(config.getRolloverBatchSize());
+    if (!pendingBatches.isEmpty()) {
+      return CompletableFuture.completedFuture(pendingBatches.poll());
+    }
+    return getArchiverRepository()
+        .getProcessInstancesNextBatch(largeBatchSize())
+        .thenApply(
+            batch -> {
+              final var chunks = batch.chunk(config.getRolloverBatchSize());
+              final var first = chunks.removeFirst();
+              pendingBatches.addAll(chunks);
+              return first;
+            });
   }
 
   @Override
@@ -108,6 +124,11 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
           batch.rootProcessInstanceKeys().stream().map(String::valueOf).toList());
     }
     return idsMap;
+  }
+
+  private int largeBatchSize() {
+    return Math.min(
+        MAX_LARGE_BATCH_SIZE, SUB_BATCHES_PER_LARGE_BATCH * config.getRolloverBatchSize());
   }
 
   private CompletableFuture<Void> archiveProcessDependants(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -127,8 +127,11 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
   }
 
   private int largeBatchSize() {
-    return Math.min(
-        MAX_LARGE_BATCH_SIZE, SUB_BATCHES_PER_LARGE_BATCH * config.getRolloverBatchSize());
+    final int rolloverBatchSize = config.getRolloverBatchSize();
+    final int largeBatchSize =
+        Math.min(MAX_LARGE_BATCH_SIZE, SUB_BATCHES_PER_LARGE_BATCH * rolloverBatchSize);
+    // just in case rollover batch size is configured very high
+    return Math.max(largeBatchSize, rolloverBatchSize);
   }
 
   private CompletableFuture<Void> archiveProcessDependants(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -28,10 +29,12 @@ import org.slf4j.Logger;
  */
 public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchiveBatch> {
 
+  private final HistoryConfiguration config;
   private final ListViewTemplate processInstanceTemplate;
   private final List<ProcessInstanceDependant> processInstanceDependants;
 
   public ProcessInstanceArchiverJob(
+      final HistoryConfiguration config,
       final ArchiverRepository repository,
       final ListViewTemplate processInstanceTemplate,
       final List<ProcessInstanceDependant> processInstanceDependants,
@@ -45,6 +48,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
         executor,
         metrics::recordProcessInstancesArchiving,
         metrics::recordProcessInstancesArchived);
+    this.config = config;
     this.processInstanceTemplate = processInstanceTemplate;
     this.processInstanceDependants =
         processInstanceDependants.stream()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
@@ -57,7 +57,9 @@ abstract class AbstractArchiverRepositoryTest {
 
   static Stream<Named<Function<ArchiverRepository, CompletableFuture<?>>>> archiveBatchSuppliers() {
     return Stream.of(
-        Named.of("getProcessInstancesNextBatch", ArchiverRepository::getProcessInstancesNextBatch),
+        Named.of(
+            "getProcessInstancesNextBatch",
+            archiverRepository -> archiverRepository.getProcessInstancesNextBatch(100)),
         Named.of("getBatchOperationsNextBatch", ArchiverRepository::getBatchOperationsNextBatch),
         Named.of("getUsageMetricTUNextBatch", ArchiverRepository::getUsageMetricTUNextBatch),
         Named.of("getUsageMetricNextBatch", ArchiverRepository::getUsageMetricNextBatch),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
@@ -11,11 +11,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ArchiveBatchTest {
+
+  @Test
+  void shouldChunkEmptyProcessInstanceBatch() {
+    final var batch =
+        new ArchiveBatch.ProcessInstanceArchiveBatch("finished-date", List.of(), List.of());
+
+    assertThat(batch.chunk(10))
+        .isEqualTo(
+            List.of(
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(), List.of())));
+  }
 
   @ParameterizedTest
   @MethodSource("shouldChunkProcessInstanceBatchArguments")

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ArchiveBatchTest {
+
+  @ParameterizedTest
+  @MethodSource("shouldChunkProcessInstanceBatchArguments")
+  void shouldChunkProcessInstanceBatch(
+      final int chunkSize, final List<ArchiveBatch.ProcessInstanceArchiveBatch> expected) {
+    final var batch =
+        new ArchiveBatch.ProcessInstanceArchiveBatch(
+            "finished-date", List.of(1L, 2L, 3L), List.of(1L, 2L, 3L));
+
+    assertThat(batch.chunk(chunkSize)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> shouldChunkProcessInstanceBatchArguments() {
+    return Stream.of(
+        Arguments.of(
+            10,
+            List.of(
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(1L, 2L, 3L), List.of(1L, 2L, 3L)))),
+        Arguments.of(
+            6,
+            List.of(
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(1L, 2L, 3L), List.of(1L, 2L, 3L)))),
+        Arguments.of(
+            5,
+            List.of(
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(1L, 2L), List.of(1L, 2L, 3L)),
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(3L), List.of()))),
+        Arguments.of(
+            3,
+            List.of(
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(), List.of(1L, 2L, 3L)),
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(1L, 2L, 3L), List.of()))),
+        Arguments.of(
+            1,
+            List.of(
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(), List.of(1L)),
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(), List.of(2L)),
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(), List.of(3L)),
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(1L), List.of()),
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(2L), List.of()),
+                new ArchiveBatch.ProcessInstanceArchiveBatch(
+                    "finished-date", List.of(3L), List.of()))));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.LongStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpHost;
 import org.awaitility.Awaitility;
@@ -530,10 +531,9 @@ final class ElasticsearchArchiverRepositoryIT {
     createProcessInstanceIndex();
     documents.forEach(doc -> index(processInstanceIndex, doc));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
-    config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getProcessInstancesNextBatch();
+    final var result = repository.getProcessInstancesNextBatch(100);
 
     // then - we expect only the first document created two hours ago to be returned
     final var dateFormatter =
@@ -542,6 +542,44 @@ final class ElasticsearchArchiverRepositoryIT {
     final var batch = result.join();
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+  }
+
+  @Test
+  void shouldLimitGetProcessInstancesNextBatch() throws IOException {
+    // given - multiple finished PIs
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        LongStream.rangeClosed(1, 10)
+            .mapToObj(
+                id ->
+                    new TestProcessInstance(
+                        String.valueOf(id),
+                        twoHoursAgo,
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION,
+                        1,
+                        null,
+                        null))
+            .toList();
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when
+    final var resultLimit20 = repository.getProcessInstancesNextBatch(20);
+    final var resultLimit5 = repository.getProcessInstancesNextBatch(5);
+
+    // then - the size used should limit the number of returned documents
+    assertThat(resultLimit20).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(resultLimit5).succeedsWithin(Duration.ofSeconds(30));
+    final var batch20 = resultLimit20.join();
+    assertThat(batch20.processInstanceKeys()).hasSize(10);
+    final var batch5 = resultLimit5.join();
+    assertThat(batch5.processInstanceKeys()).hasSize(5);
   }
 
   @Test
@@ -564,7 +602,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     // PI mode: Should select all 3 (since end date matches).
@@ -593,7 +631,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     // Legacy -> "10"
@@ -623,7 +661,7 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     assertThat(batch.processInstanceKeys()).isEmpty();
@@ -1365,7 +1403,7 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when
     // ensure PI batch is processed first to assert that both dates are maintained separately
-    final var piBatch = repository.getProcessInstancesNextBatch().join();
+    final var piBatch = repository.getProcessInstancesNextBatch(100).join();
     final var batchOperationBatch = repository.getBatchOperationsNextBatch().join();
 
     // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -91,7 +91,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         .thenReturn(CompletableFuture.completedFuture(mock(SearchResponse.class)));
 
     // when
-    repository.getProcessInstancesNextBatch();
+    repository.getProcessInstancesNextBatch(100);
 
     // then
     final var captor = ArgumentCaptor.forClass(SearchRequest.class);
@@ -121,7 +121,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     assertThat(batch.processInstanceKeys()).containsExactly(1L, 2L);
@@ -143,7 +143,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
@@ -167,7 +167,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then - purely based on mapping logic which splits by root key presence
     assertThat(batch.processInstanceKeys()).containsExactly(1L);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
@@ -15,7 +15,8 @@ import java.util.concurrent.CompletableFuture;
 public class NoopArchiverRepository implements ArchiverRepository {
 
   @Override
-  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      final int size) {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.ProcessInstanceArchiveBatch("2024-01-01", List.of(), List.of()));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.LongStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hc.core5.http.HttpHost;
 import org.awaitility.Awaitility;
@@ -516,10 +517,9 @@ final class OpenSearchArchiverRepositoryIT {
     createProcessInstanceIndex();
     documents.forEach(doc -> index(processInstanceIndex, doc));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
-    config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getProcessInstancesNextBatch();
+    final var result = repository.getProcessInstancesNextBatch(100);
 
     // then - we expect only the first document created two hours ago to be returned
     final var dateFormatter =
@@ -528,6 +528,44 @@ final class OpenSearchArchiverRepositoryIT {
     final var batch = result.join();
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+  }
+
+  @Test
+  void shouldLimitGetProcessInstancesNextBatch() throws IOException {
+    // given - multiple finished PIs
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        LongStream.rangeClosed(1, 10)
+            .mapToObj(
+                id ->
+                    new TestProcessInstance(
+                        String.valueOf(id),
+                        twoHoursAgo,
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION,
+                        1,
+                        null,
+                        null))
+            .toList();
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when
+    final var resultLimit20 = repository.getProcessInstancesNextBatch(20);
+    final var resultLimit5 = repository.getProcessInstancesNextBatch(5);
+
+    // then - the size used should limit the number of returned documents
+    assertThat(resultLimit20).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(resultLimit5).succeedsWithin(Duration.ofSeconds(30));
+    final var batch20 = resultLimit20.join();
+    assertThat(batch20.processInstanceKeys()).hasSize(10);
+    final var batch5 = resultLimit5.join();
+    assertThat(batch5.processInstanceKeys()).hasSize(5);
   }
 
   @Test
@@ -550,7 +588,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     // PI mode: Should select all 3 (since end date matches).
@@ -579,7 +617,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     // Legacy -> "10"
@@ -609,7 +647,7 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     assertThat(batch.processInstanceKeys()).isEmpty();
@@ -1208,7 +1246,7 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when
     // ensure PI batch is processed first to assert that both dates are maintained separately
-    final var piBatch = repository.getProcessInstancesNextBatch().join();
+    final var piBatch = repository.getProcessInstancesNextBatch(100).join();
     final var batchOperationBatch = repository.getBatchOperationsNextBatch().join();
 
     // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -91,7 +91,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         .thenReturn(CompletableFuture.completedFuture(mock(SearchResponse.class)));
 
     // when
-    repository.getProcessInstancesNextBatch();
+    repository.getProcessInstancesNextBatch(100);
 
     // then
     final var captor = ArgumentCaptor.forClass(SearchRequest.class);
@@ -115,7 +115,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     assertThat(batch.processInstanceKeys()).containsExactly(1L, 2L);
@@ -137,7 +137,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
@@ -160,7 +160,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         .thenReturn(CompletableFuture.completedFuture(response));
 
     // when
-    final var batch = repository.getProcessInstancesNextBatch().join();
+    final var batch = repository.getProcessInstancesNextBatch(100).join();
 
     // then - purely based on mapping logic which splits by root key presence
     assertThat(batch.processInstanceKeys()).containsExactly(1L);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -8,6 +8,9 @@
 package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
@@ -22,6 +25,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +39,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   private final Executor executor = Runnable::run;
 
   private final HistoryConfiguration historyConfiguration = new HistoryConfiguration();
-  private final TestRepository repository = new TestRepository();
+  private final TestRepository repository = spy(new TestRepository());
   private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
   private final DecisionInstanceTemplate decisionInstanceTemplate =
       new DecisionInstanceTemplate("", true);
@@ -198,6 +202,64 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
         .contains(
             new DocumentMove(
                 "foo_", "foo_" + "2024-01-01", Map.of("bar", List.of("1", "2")), executor));
+  }
+
+  @Test
+  void shouldRequestLargeBatchAndChunkIt() {
+    // given
+    repository.batch =
+        new ProcessInstanceArchiveBatch(
+            "2024-01-01", LongStream.rangeClosed(1L, 300L).boxed().toList(), List.of());
+
+    // when
+    final var first = job.getNextBatch().toCompletableFuture().join();
+    final var second = job.getNextBatch().toCompletableFuture().join();
+    final var third = job.getNextBatch().toCompletableFuture().join();
+
+    // then
+    assertThat(first)
+        .isEqualTo(
+            new ProcessInstanceArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(1L, 100L).boxed().toList(), List.of()));
+    assertThat(second)
+        .isEqualTo(
+            new ProcessInstanceArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(101L, 200L).boxed().toList(), List.of()));
+    assertThat(third)
+        .isEqualTo(
+            new ProcessInstanceArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(201L, 300L).boxed().toList(), List.of()));
+
+    verify(repository).getProcessInstancesNextBatch(1_000);
+  }
+
+  @Test
+  void shouldRequestAgainWhenChunksExhausted() {
+    // given
+    repository.batch =
+        new ProcessInstanceArchiveBatch(
+            "2024-01-01", LongStream.rangeClosed(1L, 200L).boxed().toList(), List.of());
+
+    // when
+    final var first = job.getNextBatch().toCompletableFuture().join();
+    final var second = job.getNextBatch().toCompletableFuture().join();
+    final var third = job.getNextBatch().toCompletableFuture().join();
+
+    // then
+    assertThat(first)
+        .isEqualTo(
+            new ProcessInstanceArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(1L, 100L).boxed().toList(), List.of()));
+    assertThat(second)
+        .isEqualTo(
+            new ProcessInstanceArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(101L, 200L).boxed().toList(), List.of()));
+    assertThat(third)
+        .isEqualTo(
+            new ProcessInstanceArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(1L, 100L).boxed().toList(), List.of()));
+
+    verify(repository, times(2)).getProcessInstancesNextBatch(1_000);
   }
 
   private static final class WeirdlyNamedDependant implements ProcessInstanceDependant {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
@@ -33,6 +34,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
 
   private final Executor executor = Runnable::run;
 
+  private final HistoryConfiguration historyConfiguration = new HistoryConfiguration();
   private final TestRepository repository = new TestRepository();
   private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
   private final DecisionInstanceTemplate decisionInstanceTemplate =
@@ -45,6 +47,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
 
   private final ProcessInstanceArchiverJob job =
       new ProcessInstanceArchiverJob(
+          historyConfiguration,
           repository,
           processInstanceTemplate,
           List.of(decisionInstanceTemplate, sequenceFlowTemplate, auditLogTemplate),
@@ -84,7 +87,13 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     // given
     final ProcessInstanceArchiverJob processInstanceJob =
         new ProcessInstanceArchiverJob(
-            repository, processInstanceTemplate, List.of(), metrics, LOGGER, executor);
+            historyConfiguration,
+            repository,
+            processInstanceTemplate,
+            List.of(),
+            metrics,
+            LOGGER,
+            executor);
 
     // when
     final int count = processInstanceJob.execute().toCompletableFuture().join();
@@ -169,7 +178,13 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     final var dependant = new WeirdlyNamedDependant();
     final var job =
         new ProcessInstanceArchiverJob(
-            repository, processInstanceTemplate, List.of(dependant), metrics, LOGGER, executor);
+            historyConfiguration,
+            repository,
+            processInstanceTemplate,
+            List.of(dependant),
+            metrics,
+            LOGGER,
+            executor);
     repository.batch = new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L), List.of());
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -24,7 +24,8 @@ final class TestRepository extends NoopArchiverRepository {
   }
 
   @Override
-  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
+      final int size) {
     return CompletableFuture.completedFuture((ProcessInstanceArchiveBatch) batch);
   }
 


### PR DESCRIPTION
When under a heavy write load the process instance archive job will often end up seeing the same process instances that it has already archived - even though it has already deleted them.  This happens because the deletes can take a while to be visible.

To mitigate that, this PR changes things so we request a much larger (10x) batch of process instances to archive, which we then break up into smaller chunks to actually archive.  This means that by the time we get to the last chunk the deletes for the previous chunks should be visible and we will then end up re-processing fewer of the same process instances.

The other big benefit is we can then reduce the time between archive job calls (default 2 seconds)  as we are much less likely to see the same process instances each time.

This doesn't fully solve the duplicate/repeated process instance archiving issue, but it does reduce it by a lot.

## Related issues

Refs #48200
