### PR TITLE
docs: add copilot review instructions for load tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -135,5 +135,5 @@ Additional instruction files are auto-loaded when you edit matching paths:
 
 - Frontend code (`client/` directories) → `.github/instructions/frontend.instructions.md`
 - MCP gateway (`gateways/gateway-mcp/`) → `.github/instructions/gateway-mcp-tools.instructions.md`
-- Load tests (`load-tests/`, `zeebe/load-tests/`, load test workflows) → `.github/instructions/load-tests.instructions.md`
+- Load tests (`load-tests/`, load test workflows) → `.github/instructions/load-tests.instructions.md`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -135,4 +135,5 @@ Additional instruction files are auto-loaded when you edit matching paths:
 
 - Frontend code (`client/` directories) → `.github/instructions/frontend.instructions.md`
 - MCP gateway (`gateways/gateway-mcp/`) → `.github/instructions/gateway-mcp-tools.instructions.md`
+- Load tests (`load-tests/`, `zeebe/load-tests/`, load test workflows) → `.github/instructions/load-tests.instructions.md`
 

--- a/.github/instructions/load-tests.instructions.md
+++ b/.github/instructions/load-tests.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "load-tests/**,zeebe/load-tests/**,.github/workflows/*load-test*,.github/scripts/*load*"
+---
+
+# Load Test Review Guidelines
+
+## Required Review Checks
+
+When reviewing changes to load tests, workflows, or load test infrastructure:
+
+1. **Smoke test**: Changes must be smoke tested before merging. Run the affected
+   load test at least once to verify it works as expected.
+2. **Backport**: Load test changes must be backported to all active maintenance
+   branches (currently 8.9, 8.8, 8.7). Ensure the changes are compatible with each
+   target branch.

--- a/.github/instructions/load-tests.instructions.md
+++ b/.github/instructions/load-tests.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "load-tests/**,zeebe/load-tests/**,.github/workflows/*load-test*,.github/scripts/*load*"
+applyTo: "load-tests/**,.github/workflows/*load-test*,.github/scripts/*load*"
 ---
 
 # Load Test Review Guidelines
@@ -11,5 +11,4 @@ When reviewing changes to load tests, workflows, or load test infrastructure:
 1. **Smoke test**: Changes must be smoke tested before merging. Run the affected
    load test at least once to verify it works as expected.
 2. **Backport**: Load test changes must be backported to all active maintenance
-   branches (currently 8.9, 8.8, 8.7). Ensure the changes are compatible with each
-   target branch.
+   branches. Ensure the changes are compatible with each target branch.


### PR DESCRIPTION
## Summary

- Adds scoped GitHub Copilot instructions for load test files (`load-tests/`, load test workflows)
- Reminds reviewers to **smoke test** changes and **backport** to active maintenance branches (8.9, 8.8, 8.7)
- Updates `copilot-instructions.md` to document the new scoped instruction file

## Test plan

- [ ] Verify Copilot review picks up the instructions when reviewing PRs touching load test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>