### PR TITLE
feat: manually expose MCP servers

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -90,7 +90,9 @@ spring.autoconfigure.exclude=\
   org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration, \
   org.springframework.boot.security.autoconfigure.actuate.web.servlet.ManagementWebSecurityAutoConfiguration, \
   org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration, \
-  org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration
+  org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration, \
+  org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration, \
+  org.springframework.ai.mcp.server.webmvc.autoconfigure.McpServerStatelessWebMvcAutoConfiguration
 
 # Spring metrics configuration
 management.metrics.distribution.percentiles-histogram.http.server.requests=true

--- a/dist/src/main/resources/mcp/mcp-gateway.yaml
+++ b/dist/src/main/resources/mcp/mcp-gateway.yaml
@@ -3,33 +3,11 @@ spring:
     mcp:
       server:
         enabled: true
-        name: Camunda 8 Orchestration API MCP Server
-        version: '${project.version}'
-        instructions: |
-          This server exposes APIs of a Camunda 8 Orchestration Cluster. All operations are
-          scoped to the permissions of the authenticated user.
-
-          Most tools return eventually consistent data. Recently written data may not appear
-          immediately in subsequent reads.
-
-          Process instances, incidents, and user tasks are related. A process instance can have
-          active incidents and user tasks. Use the process instance key to correlate across
-          domains. To understand the structure of a process, retrieve its BPMN XML.
-
-          When starting a process instance with awaitCompletion, a timeout does NOT mean the
-          process failed — the instance was created and continues running. Tag each instance
-          (e.g. "mcp-tool:<operation>-<timestamp>") so you can find it later. Poll the instance
-          state: if COMPLETED, retrieve result variables; if it has an incident, investigate
-          using the process instance key. Variables can be retrieved at any time, including
-          while the instance is still running.
         type: sync
         protocol: stateless
         annotation-scanner:
           enabled: true
-        streamable-http:
-          mcp-endpoint: /mcp/cluster
-        capabilities:
-          completion: false
-          prompt: true
-          resource: true
-          tool: true
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
+      - org.springframework.ai.mcp.server.webmvc.autoconfigure.McpServerStatelessWebMvcAutoConfiguration

--- a/dist/src/main/resources/mcp/mcp-gateway.yaml
+++ b/dist/src/main/resources/mcp/mcp-gateway.yaml
@@ -7,7 +7,3 @@ spring:
         protocol: stateless
         annotation-scanner:
           enabled: true
-  autoconfigure:
-    exclude:
-      - org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
-      - org.springframework.ai.mcp.server.webmvc.autoconfigure.McpServerStatelessWebMvcAutoConfiguration

--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
@@ -52,6 +52,9 @@ class McpGatewayConfigurationTest {
     // mock JsonMapper used in MCP observation convention
     mockBeans.add(JsonMapper.class);
 
+    // mock qualified JsonMapper dependency used in MCP transports
+    runner = runner.withBean("mcpServerJsonMapper", JsonMapper.class, () -> mock(JsonMapper.class));
+
     for (final Class<?> mockedBean : mockBeans) {
       runner = addMockedBean(runner, mockedBean);
     }

--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -78,6 +78,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
     </dependency>
 
@@ -95,8 +99,16 @@
       <artifactId>spring-ai-mcp-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>mcp-spring-webmvc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.modelcontextprotocol.sdk</groupId>
       <artifactId>mcp-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp-json-jackson3</artifactId>
     </dependency>
 
     <!-- Various dependencies -->

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
@@ -38,16 +38,9 @@ import tools.jackson.databind.json.JsonMapper;
  * <p>Each server has its own transport provider and tool specifications, allowing independent
  * configuration and management.
  */
-@AutoConfiguration(
-    afterName = {
-      "org.springframework.ai.mcp.server.common.autoconfigure.McpServerJsonMapperAutoConfiguration",
-      "org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration",
-      "org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration",
-      "org.springframework.ai.mcp.server.autoconfigure.McpServerStatelessWebFluxAutoConfiguration",
-      "org.springframework.ai.mcp.server.autoconfigure.McpServerStatelessWebMvcAutoConfiguration"
-    })
+@AutoConfiguration
 @ConditionalOnMcpGatewayEnabled
-public class McpServersConfiguration {
+public class CamundaMcpServersAutoConfiguration {
 
   /**
    * Transport provider for the cluster MCP server at {@code /mcp/cluster}.

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
@@ -47,6 +47,9 @@ public class CamundaMcpServersAutoConfiguration {
    *
    * <p>Handles MCP protocol messages for cluster-wide operations and general Camunda API access.
    *
+   * <p>The MCP JsonMapper is provided by Spring AI auto-configuration. We tie into that to reuse
+   * what Spring AI is using for tool schema definitions.
+   *
    * @param jsonMapper the JSON mapper to use for MCP message serialization and deserialization
    */
   @Bean(name = "clusterTransportProvider")
@@ -78,7 +81,7 @@ public class CamundaMcpServersAutoConfiguration {
   @Bean
   public McpStatelessSyncServer clusterMcpServer(
       @Qualifier("clusterTransportProvider") final McpStatelessServerTransport clusterTransport,
-      @Qualifier("mcpGatewayToolSpecifications")
+      @Qualifier("clusterMcpToolSpecifications")
           final List<SyncToolSpecification> toolSpecifications) {
 
     final var capabilities =
@@ -119,6 +122,11 @@ public class CamundaMcpServersAutoConfiguration {
    * Transport provider for the processes MCP server at {@code /mcp/processes}.
    *
    * <p>Handles MCP protocol messages for processes exposed as tools.
+   *
+   * <p>The MCP JsonMapper is provided by Spring AI auto-configuration. We tie into that to reuse
+   * what Spring AI is using for tool schema definitions.
+   *
+   * @param jsonMapper the JSON mapper to use for MCP message serialization and deserialization
    */
   @Bean(name = "processesTransportProvider")
   public WebMvcStatelessServerTransport processesTransportProvider(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
@@ -42,7 +42,7 @@ public class CamundaMcpToolSpecificationsAutoConfiguration {
     return new CamundaJsonSchemaGenerator(JsonParser.getJsonMapper());
   }
 
-  @Bean(name = "mcpGatewayToolSpecifications")
+  @Bean(name = "clusterMcpToolSpecifications")
   public List<SyncToolSpecification> mcpGatewayToolSpecifications(
       final CamundaMcpToolAnnotatedBeans annotatedBeans,
       final CamundaJsonSchemaGenerator jsonSchemaGenerator) {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
@@ -42,7 +42,7 @@ public class CamundaMcpToolSpecificationsAutoConfiguration {
     return new CamundaJsonSchemaGenerator(JsonParser.getJsonMapper());
   }
 
-  @Bean
+  @Bean(name = "mcpGatewayToolSpecifications")
   public List<SyncToolSpecification> mcpGatewayToolSpecifications(
       final CamundaMcpToolAnnotatedBeans annotatedBeans,
       final CamundaJsonSchemaGenerator jsonSchemaGenerator) {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/McpServersConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/McpServersConfiguration.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.config;
+
+import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
+import io.camunda.zeebe.util.VersionUtil;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import java.util.List;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Configuration for multiple MCP server instances with their own transports.
+ *
+ * <p>This configuration creates MCP servers programmatically:
+ *
+ * <ul>
+ *   <li>{@code /mcp/cluster} - Static tools from {@link CamundaMcpTool} annotated methods
+ *   <li>{@code /mcp/processes} - Process definitions as tools based on permissions and deployments
+ * </ul>
+ *
+ * <p>Each server has its own transport provider and tool specifications, allowing independent
+ * configuration and management.
+ */
+@AutoConfiguration(
+    afterName = {
+      "org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration",
+      "org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration",
+      "org.springframework.ai.mcp.server.autoconfigure.McpServerStatelessWebFluxAutoConfiguration",
+      "org.springframework.ai.mcp.server.autoconfigure.McpServerStatelessWebMvcAutoConfiguration"
+    })
+@ConditionalOnMcpGatewayEnabled
+public class McpServersConfiguration {
+
+  /**
+   * Transport provider for the cluster MCP server at {@code /mcp/cluster}.
+   *
+   * <p>Handles MCP protocol messages for cluster-wide operations and general Camunda API access.
+   *
+   * @param jsonMapper the JSON mapper to use for MCP message serialization and deserialization
+   */
+  @Bean(name = "clusterTransportProvider")
+  public WebMvcStatelessServerTransport clusterTransportProvider(
+      @Qualifier("mcpServerJsonMapper") final JsonMapper jsonMapper) {
+    return WebMvcStatelessServerTransport.builder()
+        .jsonMapper(new JacksonMcpJsonMapper(jsonMapper))
+        .messageEndpoint("/mcp/cluster")
+        .build();
+  }
+
+  /**
+   * Router function for the cluster MCP server to tie in with the web server stack.
+   *
+   * @param clusterTransportProvider the associated transport provider
+   */
+  @Bean
+  public RouterFunction<ServerResponse> clusterRouterFunction(
+      @Qualifier("clusterTransportProvider")
+          final WebMvcStatelessServerTransport clusterTransportProvider) {
+    return clusterTransportProvider.getRouterFunction();
+  }
+
+  /**
+   * MCP server for general cluster-wide operations.
+   *
+   * <p>Provides static tools defined via {@link CamundaMcpTool} annotations.
+   */
+  @Bean
+  public McpStatelessSyncServer clusterMcpServer(
+      @Qualifier("clusterTransportProvider") final McpStatelessServerTransport clusterTransport,
+      @Qualifier("mcpGatewayToolSpecifications")
+          final List<SyncToolSpecification> toolSpecifications) {
+
+    final var capabilities =
+        McpSchema.ServerCapabilities.builder()
+            .tools(false)
+            .resources(false, false)
+            .prompts(false)
+            .build();
+
+    return McpServer.sync(clusterTransport)
+        .serverInfo("Camunda 8 Orchestration API MCP Server", VersionUtil.getVersion())
+        .instructions(
+            """
+          This server exposes APIs of a Camunda 8 Orchestration Cluster. All operations are
+          scoped to the permissions of the authenticated user.
+
+          Most tools return eventually consistent data. Recently written data may not appear
+          immediately in subsequent reads.
+
+          Process instances, incidents, and user tasks are related. A process instance can have
+          active incidents and user tasks. Use the process instance key to correlate across
+          domains. To understand the structure of a process, retrieve its BPMN XML.
+
+          When starting a process instance with awaitCompletion, a timeout does NOT mean the
+          process failed — the instance was created and continues running. Tag each instance
+          (e.g. "mcp-tool:<operation>-<timestamp>") so you can find it later. Poll the instance
+          state: if COMPLETED, retrieve result variables; if it has an incident, investigate
+          using the process instance key. Variables can be retrieved at any time, including
+          while the instance is still running.
+          """)
+        .capabilities(capabilities)
+        .tools(toolSpecifications)
+        .immediateExecution(true)
+        .build();
+  }
+
+  /**
+   * Transport provider for the processes MCP server at {@code /mcp/processes}.
+   *
+   * <p>Handles MCP protocol messages for processes exposed as tools.
+   */
+  @Bean(name = "processesTransportProvider")
+  public WebMvcStatelessServerTransport processesTransportProvider(
+      @Qualifier("mcpServerJsonMapper") final JsonMapper jsonMapper) {
+    return WebMvcStatelessServerTransport.builder()
+        .jsonMapper(new JacksonMcpJsonMapper(jsonMapper))
+        .messageEndpoint("/mcp/processes")
+        .build();
+  }
+
+  /**
+   * Router function for the processes MCP server to tie in with the web server stack.
+   *
+   * @param processesTransportProvider the associated transport provider
+   */
+  @Bean
+  public RouterFunction<ServerResponse> processesRouterFunction(
+      @Qualifier("processesTransportProvider")
+          final WebMvcStatelessServerTransport processesTransportProvider) {
+    return processesTransportProvider.getRouterFunction();
+  }
+
+  /**
+   * MCP server for processes as tools.
+   *
+   * <p>Provides processes as MCP tools based on permissions and current deployments
+   */
+  @Bean
+  public McpStatelessSyncServer processesMcpServer(
+      @Qualifier("processesTransportProvider")
+          final McpStatelessServerTransport processesTransport) {
+
+    final var capabilities =
+        McpSchema.ServerCapabilities.builder()
+            .tools(false)
+            .resources(false, false)
+            .prompts(false)
+            .build();
+
+    // TODO: this server doesn't have any tools yet, will follow with
+    // https://github.com/camunda/camunda/issues/48509
+    return McpServer.sync(processesTransport)
+        .serverInfo("Camunda 8 Orchestration API Processes MCP Server", VersionUtil.getVersion())
+        .instructions(
+            """
+          This server exposes Camunda 8 processes as tools. All operations are scoped to the
+          permissions of the authenticated user.
+
+          Tools are based on eventually consistent data, i.e., deployed process definitions that are
+          configured to be exposed as MCP tools. Recently written data may not appear immediately
+          in subsequent reads.
+
+          Invoking a process exposed as tool starts a new process instance of the related process
+          definition. The tool returns the internal key of the newly created instance for follow-up
+          operations.
+          """)
+        .capabilities(capabilities)
+        .immediateExecution(true)
+        .build();
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/McpServersConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/McpServersConfiguration.java
@@ -40,6 +40,7 @@ import tools.jackson.databind.json.JsonMapper;
  */
 @AutoConfiguration(
     afterName = {
+      "org.springframework.ai.mcp.server.common.autoconfigure.McpServerJsonMapperAutoConfiguration",
       "org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration",
       "org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration",
       "org.springframework.ai.mcp.server.autoconfigure.McpServerStatelessWebFluxAutoConfiguration",

--- a/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,3 @@
+io.camunda.gateway.mcp.config.CamundaMcpServersAutoConfiguration
 io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration
 io.camunda.gateway.mcp.config.CamundaMcpToolSpecificationsAutoConfiguration
-io.camunda.gateway.mcp.config.McpServersConfiguration

--- a/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration
 io.camunda.gateway.mcp.config.CamundaMcpToolSpecificationsAutoConfiguration
+io.camunda.gateway.mcp.config.McpServersConfiguration

--- a/gateways/gateway-mcp/src/test/resources/application.yaml
+++ b/gateways/gateway-mcp/src/test/resources/application.yaml
@@ -3,20 +3,14 @@ spring:
     mcp:
       server:
         enabled: true
-        name: Camunda 8 Orchestration API Test MCP Server
-        version: '${project.version}'
         type: sync
         protocol: stateless
         annotation-scanner:
           enabled: true
-        streamable-http:
-          mcp-endpoint: /mcp/cluster
-        capabilities:
-          completion: false
-          prompt: false
-          resource: false
-          tool: true
-
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
+      - org.springframework.ai.mcp.server.webmvc.autoconfigure.McpServerStatelessWebMvcAutoConfiguration
 camunda:
   mcp:
     enabled: true

--- a/gateways/gateway-mcp/src/test/resources/application.yaml
+++ b/gateways/gateway-mcp/src/test/resources/application.yaml
@@ -7,6 +7,10 @@ spring:
         protocol: stateless
         annotation-scanner:
           enabled: true
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
+      - org.springframework.ai.mcp.server.webmvc.autoconfigure.McpServerStatelessWebMvcAutoConfiguration
 camunda:
   mcp:
     enabled: true

--- a/gateways/gateway-mcp/src/test/resources/application.yaml
+++ b/gateways/gateway-mcp/src/test/resources/application.yaml
@@ -7,10 +7,6 @@ spring:
         protocol: stateless
         annotation-scanner:
           enabled: true
-  autoconfigure:
-    exclude:
-      - org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
-      - org.springframework.ai.mcp.server.webmvc.autoconfigure.McpServerStatelessWebMvcAutoConfiguration
 camunda:
   mcp:
     enabled: true

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class McpServerConfigurationIT {
 
@@ -33,7 +33,7 @@ public class McpServerConfigurationIT {
         new TestCamundaApplication().withProperty("camunda.mcp.enabled", true);
 
     @ParameterizedTest
-    @ValueSource(strings = {"cluster", "processes"})
+    @MethodSource("io.camunda.it.mcp.McpServerTest#mcpServersToTest")
     public void mcpInitializeRequestReturnsInitializationResponse(final String mcpServer) {
       try (final McpSyncClient mcpClient =
           createMcpClient(mcpServer, TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
@@ -69,7 +69,7 @@ public class McpServerConfigurationIT {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"cluster", "processes"})
+    @MethodSource("io.camunda.it.mcp.McpServerTest#mcpServersToTest")
     public void mcpInitializeRequestReturnsInitializationResponse(final String mcpServer) {
       try (final McpSyncClient mcpClient =
           createMcpClient(mcpServer, TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
@@ -88,7 +88,7 @@ public class McpServerConfigurationIT {
     static final TestCamundaApplication TEST_INSTANCE = new TestCamundaApplication();
 
     @ParameterizedTest
-    @ValueSource(strings = {"cluster", "processes"})
+    @MethodSource("io.camunda.it.mcp.McpServerTest#mcpServersToTest")
     public void mcpInitializeRequestReturnsNotFoundResponse(final String mcpServer) {
       try (final McpSyncClient mcpClient =
           createMcpClient(mcpServer, TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
@@ -19,7 +19,8 @@ import io.modelcontextprotocol.client.McpSyncClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class McpServerConfigurationIT {
 
@@ -31,10 +32,11 @@ public class McpServerConfigurationIT {
     static final TestCamundaApplication TEST_INSTANCE =
         new TestCamundaApplication().withProperty("camunda.mcp.enabled", true);
 
-    @Test
-    public void mcpInitializeRequestReturnsInitializationResponse() {
+    @ParameterizedTest
+    @ValueSource(strings = {"cluster", "processes"})
+    public void mcpInitializeRequestReturnsInitializationResponse(final String mcpServer) {
       try (final McpSyncClient mcpClient =
-          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
+          createMcpClient(mcpServer, TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
 
         final var initializeResult = mcpClient.initialize();
         assertThat(initializeResult).isNotNull();
@@ -66,10 +68,11 @@ public class McpServerConfigurationIT {
       TEST_INSTANCE.stop();
     }
 
-    @Test
-    public void mcpInitializeRequestReturnsInitializationResponse() {
+    @ParameterizedTest
+    @ValueSource(strings = {"cluster", "processes"})
+    public void mcpInitializeRequestReturnsInitializationResponse(final String mcpServer) {
       try (final McpSyncClient mcpClient =
-          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
+          createMcpClient(mcpServer, TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
 
         final var initializeResult = mcpClient.initialize();
         assertThat(initializeResult).isNotNull();
@@ -84,10 +87,11 @@ public class McpServerConfigurationIT {
     @MultiDbTestApplication
     static final TestCamundaApplication TEST_INSTANCE = new TestCamundaApplication();
 
-    @Test
-    public void mcpInitializeRequestReturnsNotFoundResponse() {
+    @ParameterizedTest
+    @ValueSource(strings = {"cluster", "processes"})
+    public void mcpInitializeRequestReturnsNotFoundResponse(final String mcpServer) {
       try (final McpSyncClient mcpClient =
-          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
+          createMcpClient(mcpServer, TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
 
         final Throwable throwable = catchThrowable(mcpClient::initialize);
         assertThat(throwable.getCause())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerTest.java
@@ -12,26 +12,15 @@ import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.List;
 
 public abstract class McpServerTest {
 
   public static final McpSyncHttpClientRequestCustomizer DEFAULT_REQUEST_CUSTOMIZER =
       (builder, method, endpoint, body, context) -> {};
 
-  protected McpSyncClient mcpClient;
-
-  @BeforeEach
-  void createMcpClient() {
-    mcpClient = createMcpClient(testInstance(), createMcpClientRequestCustomizer());
-  }
-
-  @AfterEach
-  void closeMcpClient() {
-    if (mcpClient != null) {
-      mcpClient.close();
-    }
+  protected static List<String> mcpServersToTest() {
+    return List.of("cluster", "processes");
   }
 
   protected abstract TestCamundaApplication testInstance();
@@ -41,11 +30,12 @@ public abstract class McpServerTest {
   }
 
   public static McpSyncClient createMcpClient(
+      final String mcpServer,
       final TestCamundaApplication testInstance,
       final McpSyncHttpClientRequestCustomizer httpClientRequestCustomizer) {
     final HttpClientStreamableHttpTransport.Builder transportBuilder =
         HttpClientStreamableHttpTransport.builder("%s".formatted(testInstance.restAddress()))
-            .endpoint("/mcp/cluster")
+            .endpoint("/mcp/" + mcpServer)
             .openConnectionOnStartup(false);
 
     if (httpClientRequestCustomizer != null) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 abstract class AuthenticatedMcpServerTest extends McpServerAuthenticationTest {
 
@@ -71,11 +73,12 @@ abstract class AuthenticatedMcpServerTest extends McpServerAuthenticationTest {
   protected abstract McpSyncHttpClientRequestCustomizer
       createRestrictedMcpClientRequestCustomizer();
 
-  @Test
-  void failsOnUnauthenticatedRequest() {
+  @ParameterizedTest
+  @MethodSource("mcpServersToTest")
+  void failsOnUnauthenticatedRequest(final String mcpServer) {
     assertThatThrownBy(
             () -> {
-              try (final var client = createMcpClient(testInstance(), null)) {
+              try (final var client = createMcpClient(mcpServer, testInstance(), null)) {
                 client.listTools();
               }
             })
@@ -85,14 +88,17 @@ abstract class AuthenticatedMcpServerTest extends McpServerAuthenticationTest {
 
   @Test
   void searchProcessDefinitionsReturnsAllProcessDefinitionsForUnrestrictedClient() {
-    assertThat(searchProcessDefinitionIds(mcpClient))
-        .containsExactlyInAnyOrderElementsOf(EXPECTED_UNRESTRICTED_PROCESS_DEFINITION_IDS);
+    try (final McpSyncClient mcpClient =
+        createMcpClient("cluster", testInstance(), createMcpClientRequestCustomizer())) {
+      assertThat(searchProcessDefinitionIds(mcpClient))
+          .containsExactlyInAnyOrderElementsOf(EXPECTED_UNRESTRICTED_PROCESS_DEFINITION_IDS);
+    }
   }
 
   @Test
   void searchProcessDefinitionsReturnsLimitedProcessDefinitionsForRestrictedClient() {
     try (final var restrictedClient =
-        createMcpClient(testInstance(), createRestrictedMcpClientRequestCustomizer())) {
+        createMcpClient("cluster", testInstance(), createRestrictedMcpClientRequestCustomizer())) {
       assertThat(searchProcessDefinitionIds(restrictedClient))
           .containsExactlyInAnyOrderElementsOf(EXPECTED_RESTRICTED_PROCESS_DEFINITION_IDS);
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.protocol.model.TopologyResponse;
 import io.camunda.it.mcp.McpServerTest;
+import io.camunda.zeebe.util.VersionUtil;
+import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
@@ -20,78 +22,96 @@ import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 abstract class McpServerAuthenticationTest extends McpServerTest {
 
   protected final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Test
-  void returnsConfiguredInfoAndCapabilities() {
-    final var initializeResult = mcpClient.initialize();
-    assertThat(initializeResult).isNotNull();
+  @ParameterizedTest
+  @MethodSource("mcpServersToTest")
+  void returnsConfiguredInfoAndCapabilities(final String mcpServer) {
+    try (final McpSyncClient mcpClient =
+        createMcpClient(mcpServer, testInstance(), createMcpClientRequestCustomizer())) {
+      final var initializeResult = mcpClient.initialize();
+      assertThat(initializeResult).isNotNull();
 
-    assertThat(initializeResult.serverInfo().name())
-        .isEqualTo("Camunda 8 Orchestration API MCP Server");
-    assertThat(initializeResult.serverInfo().version()).startsWith("8.");
+      assertThat(initializeResult.serverInfo().name())
+          .contains("Camunda 8 Orchestration API")
+          .contains("MCP Server");
+      assertThat(initializeResult.serverInfo().version()).isEqualTo(VersionUtil.getVersion());
+      assertThat(initializeResult.instructions()).isNotBlank();
 
-    assertThat(initializeResult.capabilities())
-        .extracting(
-            ServerCapabilities::completions,
-            ServerCapabilities::experimental,
-            ServerCapabilities::logging)
-        .allMatch(Objects::isNull);
+      assertThat(initializeResult.capabilities())
+          .extracting(
+              ServerCapabilities::completions,
+              ServerCapabilities::experimental,
+              ServerCapabilities::logging)
+          .allMatch(Objects::isNull);
 
-    assertThat(initializeResult.capabilities().tools())
-        .isNotNull()
-        .satisfies(tools -> assertThat(tools.listChanged()).isFalse());
+      assertThat(initializeResult.capabilities().tools())
+          .isNotNull()
+          .satisfies(tools -> assertThat(tools.listChanged()).isFalse());
 
-    assertThat(initializeResult.capabilities().prompts())
-        .isNotNull()
-        .satisfies(prompts -> assertThat(prompts.listChanged()).isFalse());
+      assertThat(initializeResult.capabilities().prompts())
+          .isNotNull()
+          .satisfies(prompts -> assertThat(prompts.listChanged()).isFalse());
 
-    assertThat(initializeResult.capabilities().resources())
-        .isNotNull()
-        .satisfies(
-            resources -> {
-              assertThat(resources.listChanged()).isFalse();
-              assertThat(resources.subscribe()).isFalse();
-            });
+      assertThat(initializeResult.capabilities().resources())
+          .isNotNull()
+          .satisfies(
+              resources -> {
+                assertThat(resources.listChanged()).isFalse();
+                assertThat(resources.subscribe()).isFalse();
+              });
+    }
   }
 
   @Test
   void registersAllExpectedTools() {
-    final ListToolsResult listToolsResult = mcpClient.listTools();
-    assertThat(listToolsResult.tools())
-        .extracting(Tool::name)
-        .contains("getClusterStatus", "getTopology");
+    try (final McpSyncClient mcpClient =
+        createMcpClient("cluster", testInstance(), createMcpClientRequestCustomizer())) {
+      final ListToolsResult listToolsResult = mcpClient.listTools();
+      assertThat(listToolsResult.tools())
+          .extracting(Tool::name)
+          .contains("getClusterStatus", "getTopology");
+    }
   }
 
   @Test
   void fetchesClusterStatus() {
-    final CallToolResult result =
-        mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
+    try (final McpSyncClient mcpClient =
+        createMcpClient("cluster", testInstance(), createMcpClientRequestCustomizer())) {
+      final CallToolResult result =
+          mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
 
-    assertThat(result.isError()).isFalse();
-    assertThat(result.content())
-        .hasSize(1)
-        .first()
-        .isInstanceOfSatisfying(
-            TextContent.class, textContent -> assertThat(textContent.text()).isEqualTo("HEALTHY"));
+      assertThat(result.isError()).isFalse();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent -> assertThat(textContent.text()).isEqualTo("HEALTHY"));
+    }
   }
 
   @Test
   void fetchesTopology() {
-    final CallToolResult result =
-        mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
+    try (final McpSyncClient mcpClient =
+        createMcpClient("cluster", testInstance(), createMcpClientRequestCustomizer())) {
+      final CallToolResult result =
+          mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
 
-    assertThat(result.isError()).isFalse();
-    assertThat(result.structuredContent()).isNotNull();
+      assertThat(result.isError()).isFalse();
+      assertThat(result.structuredContent()).isNotNull();
 
-    final var topology =
-        objectMapper.convertValue(result.structuredContent(), TopologyResponse.class);
-    assertThat(topology.getClusterSize()).isEqualTo(1);
-    assertThat(topology.getBrokers()).hasSize(1);
-    assertThat(topology.getBrokers().getFirst().getNodeId().toString())
-        .isEqualTo(testInstance().nodeId().id());
+      final var topology =
+          objectMapper.convertValue(result.structuredContent(), TopologyResponse.class);
+      assertThat(topology.getClusterSize()).isEqualTo(1);
+      assertThat(topology.getBrokers()).hasSize(1);
+      assertThat(topology.getBrokers().getFirst().getNodeId().toString())
+          .isEqualTo(testInstance().nodeId().id());
+    }
   }
 }


### PR DESCRIPTION
## Description

- Adjusts the MCP gateway configuration to expose the existing `/mcp/cluster` server manually, not relying on Spring AI autoconfiguration for the server itself.
- Still relies on Spring AI autoconfiguration to handle all other aspects, like JsonMapper creation and registering routes with the WebMVC stack. This way, security setups work as before.
- Adds a second MCP server at `/mcp/processes`. This server doesn't contain any tools yet. It will be extended in follow-ups.

## Related issues

closes #48503 