### PR TITLE
[Backport stable/8.9] fix: acknowledge ignored records in RdbmsExporter by always updating lastPosition

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -105,10 +105,23 @@ public class DefaultExecutionQueue implements ExecutionQueue {
   @Override
   public int flush() {
     synchronized (queue) {
+      // Call pre-flush listeners before checking if the queue is empty.
+      // Pre-flush listeners may add items to the queue (e.g., exporter position updates),
+      // ensuring they are persisted even when no handler-processed records were queued
+      // in the current flush interval (e.g., all records were ignored).
+      if (!preFlushListeners.isEmpty()) {
+        LOG.trace("[RDBMS ExecutionQueue, Partition {}] Call pre flush listeners", partitionId);
+        preFlushListeners.forEach(PreFlushListener::onPreFlush);
+      }
+
       if (queue.isEmpty()) {
         LOG.trace(
             "[RDBMS ExecutionQueue, Partition {}] Skip Flushing because execution queue is empty",
             partitionId);
+        // Still call post-flush listeners so the broker position gets updated.
+        if (!postFlushListeners.isEmpty()) {
+          postFlushListeners.forEach(PostFlushListener::onPostFlush);
+        }
         return 0;
       }
 
@@ -214,11 +227,6 @@ public class DefaultExecutionQueue implements ExecutionQueue {
         queue.size());
 
     final var startMillis = System.currentTimeMillis();
-
-    if (!preFlushListeners.isEmpty()) {
-      LOG.trace("[RDBMS ExecutionQueue, Partition {}] Call pre flush listeners", partitionId);
-      preFlushListeners.forEach(PreFlushListener::onPreFlush);
-    }
 
     final var session =
         sessionFactory.openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -176,6 +176,55 @@ class DefaultExecutionQueueTest {
   }
 
   @Test
+  public void whenFlushIsCalledOnEmptyQueuePreAndPostFlushListenersShouldBeCalled() {
+    // given
+    final var preFlushListener = mock(PreFlushListener.class);
+    final var postFlushListener = mock(PostFlushListener.class);
+    executionQueue.registerPreFlushListener(preFlushListener);
+    executionQueue.registerPostFlushListener(postFlushListener);
+
+    // when
+    executionQueue.flush();
+
+    // then - listeners are called even when queue is empty
+    verify(preFlushListener).onPreFlush();
+    verify(postFlushListener).onPostFlush();
+    verifyNoInteractions(sqlSessionFactory);
+  }
+
+  @Test
+  public void whenFlushIsCalledOnEmptyQueueAndPreFlushListenerAddsItemTheItemIsFlushed() {
+    // given
+    final var preFlushItem =
+        new QueueItem(
+            ContextType.EXPORTER_POSITION,
+            WriteStatementType.UPDATE,
+            1L,
+            "statement1",
+            "parameter1");
+    final var preFlushListener = mock(PreFlushListener.class);
+    final var postFlushListener = mock(PostFlushListener.class);
+    Mockito.doAnswer(
+            invocation -> {
+              executionQueue.executeInQueue(preFlushItem);
+              return null;
+            })
+        .when(preFlushListener)
+        .onPreFlush();
+    executionQueue.registerPreFlushListener(preFlushListener);
+    executionQueue.registerPostFlushListener(postFlushListener);
+
+    // when
+    executionQueue.flush();
+
+    // then - item added by pre-flush listener is flushed and post-flush listener is called
+    verify(preFlushListener).onPreFlush();
+    verify(session).update(preFlushItem.statementId(), preFlushItem.parameter());
+    verify(session).commit();
+    verify(postFlushListener).onPostFlush();
+  }
+
+  @Test
   public void whenFlushIsCalledFlushListenersAreCalled() {
     final var item1 =
         new QueueItem(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.LiquibaseSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
@@ -105,6 +106,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.test.util.Strings;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -144,6 +146,7 @@ class RdbmsExporterIT {
           });
   @Autowired private LiquibaseSchemaManager liquibaseSchemaManager;
   @Autowired private RdbmsService rdbmsService;
+  @Autowired private ExporterPositionMapper exporterPositionMapper;
   private RdbmsExporterWrapper exporter;
 
   @BeforeEach
@@ -1438,6 +1441,49 @@ class RdbmsExporterIT {
     assertThat(auditLog.operationType()).isEqualTo(AuditLogOperationType.CREATE);
     assertThat(auditLog.result()).isEqualTo(AuditLogOperationResult.SUCCESS);
     assertThat(auditLog.category()).isEqualTo(AuditLogOperationCategory.DEPLOYED_RESOURCES);
+  }
+
+  @Test
+  public void shouldUpdatePositionForIgnoredRecordsWithIntervalFlush() {
+    // given - create a separate exporter with interval-based flush (queueSize > 0, not per-record)
+    // Use partitionId=2 to avoid interfering with other tests that use partitionId=1
+    final var intervalController = new ExporterTestController();
+    final var intervalExporter =
+        new RdbmsExporterWrapper(rdbmsService, liquibaseSchemaManager, vendorDatabaseProperties);
+    intervalExporter.configure(
+        new ExporterContext(
+            null,
+            new ExporterConfiguration("interval-flush-test", Map.of("queueSize", 100)),
+            2,
+            Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
+            null));
+    intervalExporter.open(intervalController);
+
+    // a record with ValueType.TIMER has no registered handler: the exporter updates lastPosition
+    // for it but does not enqueue any data write operations (the record is skipped for data export)
+    final var skippedRecord =
+        ImmutableRecord.<RecordValue>builder()
+            .from(RecordFixtures.FACTORY.generateRecord(ValueType.TIMER))
+            .withPosition(42L)
+            .withPartitionId(2)
+            .withTimestamp(System.currentTimeMillis())
+            .build();
+
+    // when - export the record (no handler → no data queued, but lastPosition is still updated)
+    intervalExporter.export(skippedRecord);
+
+    // then - trigger the scheduled interval flush (flushInterval defaults to 500ms)
+    intervalController.runScheduledTasks(Duration.ofSeconds(1));
+
+    // then - broker position is updated even though no data handler processed the record
+    assertThat(intervalController.getPosition()).isEqualTo(42L);
+
+    // then - RDBMS position is updated: the pre-flush listener adds the position update
+    // to the queue before the empty-queue check, so it is persisted even though the queue
+    // contained no data writes
+    final var rdbmsPosition = exporterPositionMapper.findOne(2);
+    assertThat(rdbmsPosition).isNotNull();
+    assertThat(rdbmsPosition.lastExportedPosition()).isEqualTo(42L);
   }
 
   private static void verifyRootProcessInstanceKey(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -218,14 +218,16 @@ public final class RdbmsExporter {
               record.getValueType());
         }
       }
-      // Update lastPosition once per record, after all handlers have processed it
-      lastPosition = record.getPosition();
     } else {
       LOG.trace(
           "[RDBMS Exporter P{}] No registered handler found for {}",
           partitionId,
           record.getValueType());
     }
+
+    // Always update lastPosition for every record, including ignored ones, so that the exporter
+    // position is advanced even when no handler processes the record.
+    lastPosition = record.getPosition();
 
     if (exported) {
       // Track the oldest record timestamp in the current batch

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -180,7 +180,7 @@ class RdbmsExporterTest {
   }
 
   @Test
-  void shouldNotUpdatePositionOnFlushWhenNoRecordsHandled() {
+  void shouldUpdatePositionOnFlushEvenWhenNoRecordsHandled() {
     // given
     createExporter(b -> b);
 
@@ -189,8 +189,8 @@ class RdbmsExporterTest {
     exporter.export(mockRecord(ValueType.JOB, 2));
     executionQueue.flush();
 
-    // then
-    verify(positionService, never()).update(any());
+    // then - position should be updated even for ignored records
+    verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 2));
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #49025 to `stable/8.9`.

relates to camunda/camunda#49024