### PR TITLE
[Backport stable/optimize-8.6] ci: switch check-licenses runner to non-preemptible longrunning

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -14,7 +14,7 @@ jobs:
   analyze:
     name: Analyze dependencies
     permissions: {}
-    runs-on: gcp-core-8-default
+    runs-on: gcp-core-8-longrunning
     strategy:
       # The matrix is necessary to run separate analyses
       matrix:


### PR DESCRIPTION
# Description
Backport of #48995 to `stable/optimize-8.6`.

relates to 