### PR TITLE
[Backport stable/8.9] fix: use process instance perms instead of process definition perms in process definition element statistics endpoint

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionStatisticsDbReader.java
@@ -37,6 +37,11 @@ public class ProcessDefinitionStatisticsDbReader
       final ProcessDefinitionFlowNodeStatisticsQuery query,
       final ResourceAccessChecks resourceAccessChecks) {
     LOG.trace("[RDBMS DB] Query process definition flow node statistics with filter {}", query);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return List.of();
+    }
+
     return processDefinitionMapper.flowNodeStatistics(query.filter());
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessDefinitionStatisticsDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessDefinitionStatisticsDbReaderTest.java
@@ -10,13 +10,17 @@ package io.camunda.db.rdbms.read.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +32,42 @@ class ProcessDefinitionStatisticsDbReaderTest {
           processDefinitionMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
+  void shouldReturnEmptyStatisticsWhenAuthorizedResourceIdsIsNull() {
+    // given
+    final ProcessDefinitionFlowNodeStatisticsQuery query =
+        new ProcessDefinitionFlowNodeStatisticsQuery(null);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(Authorization.of(a -> a.readProcessInstance().read())),
+            TenantCheck.disabled());
+
+    // when
+    final var result = reader.aggregate(query, resourceAccessChecks);
+
+    // then
+    assertThat(result).isEmpty();
+    verify(processDefinitionMapper, never()).flowNodeStatistics(any());
+  }
+
+  @Test
+  void shouldReturnEmptyStatisticsWhenAuthorizedTenantIdsIsNull() {
+    // given
+    final ProcessDefinitionFlowNodeStatisticsQuery query =
+        new ProcessDefinitionFlowNodeStatisticsQuery(null);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    // when
+    final var result = reader.aggregate(query, resourceAccessChecks);
+
+    // then
+    assertThat(result).isEmpty();
+    verify(processDefinitionMapper, never()).flowNodeStatistics(any());
+  }
+
+  @Test
   void shouldReturnStatistics() {
+    // given
     final var expected =
         List.of(
             new ProcessFlowNodeStatisticsEntity("node1", 10L, 5L, 2L, 3L),
@@ -39,8 +78,10 @@ class ProcessDefinitionStatisticsDbReaderTest {
         new ProcessDefinitionFlowNodeStatisticsQuery(null);
     final ResourceAccessChecks resourceAccessChecks = ResourceAccessChecks.disabled();
 
+    // when
     final var result = reader.aggregate(query, resourceAccessChecks);
 
+    // then
     assertThat(result).isEqualTo(expected);
     verify(processDefinitionMapper).flowNodeStatistics(any());
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessDefinitionStatisticsAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessDefinitionStatisticsAuthorizationIT.java
@@ -41,7 +41,6 @@ class ProcessDefinitionStatisticsAuthorizationIT {
   private static final String TEST_USERNAME_READ_PROCESS_INSTANCE = "testUserReadProcessInstance";
   private static final String TEST_USERNAME_READ_SPECIFIC_PROCESS_INSTANCE =
       "testUserReadSpecificProcessInstance";
-
   private static final String SPECIFIC_PROCESS_ID = "process-auth-specific";
 
   @UserDefinition
@@ -83,17 +82,11 @@ class ProcessDefinitionStatisticsAuthorizationIT {
   void shouldReturnEmptyStatisticsForReadProcessDefinitionPermission(
       @Authenticated(TEST_USERNAME_READ_PROCESS_DEFINITION) final CamundaClient userClient) {
     // given
-    final var processDefinitionKey = deployCompleteBPMN();
-    createInstance(processDefinitionKey);
-    createInstance(processDefinitionKey);
-    waitForProcessInstances(
-        camundaClient,
-        f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED),
-        2);
+    final long processDefinitionKey = createProcessInstances(deployCompleteBPMN(), 2);
 
     // when
     final var actual =
-        userClient.newProcessDefinitionElementStatisticsRequest(processDefinitionKey).send().join();
+        userClient.newProcessDefinitionElementStatisticsRequest(processDefinitionKey).execute();
 
     // then
     assertThat(actual).isEmpty();
@@ -103,17 +96,11 @@ class ProcessDefinitionStatisticsAuthorizationIT {
   void shouldAllowReadProcessInstancePermission(
       @Authenticated(TEST_USERNAME_READ_PROCESS_INSTANCE) final CamundaClient userClient) {
     // given
-    final var processDefinitionKey = deployCompleteBPMN();
-    createInstance(processDefinitionKey);
-    createInstance(processDefinitionKey);
-    waitForProcessInstances(
-        camundaClient,
-        f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED),
-        2);
+    final long processDefinitionKey = createProcessInstances(deployCompleteBPMN(), 2);
 
     // when
     final var actual =
-        userClient.newProcessDefinitionElementStatisticsRequest(processDefinitionKey).send().join();
+        userClient.newProcessDefinitionElementStatisticsRequest(processDefinitionKey).execute();
 
     // then
     assertThat(actual).hasSize(2);
@@ -123,24 +110,8 @@ class ProcessDefinitionStatisticsAuthorizationIT {
   void shouldAllowReadProcessInstancePermissionForSpecificProcess(
       @Authenticated(TEST_USERNAME_READ_SPECIFIC_PROCESS_INSTANCE) final CamundaClient userClient) {
     // given
-    final var allowedProcessDefinitionKey = deployCompleteSpecificBPMN();
-    final var notAllowedProcessDefinitionKey = deployCompleteBPMN();
-    createInstance(allowedProcessDefinitionKey);
-    createInstance(allowedProcessDefinitionKey);
-    createInstance(notAllowedProcessDefinitionKey);
-
-    waitForProcessInstances(
-        camundaClient,
-        f ->
-            f.processDefinitionKey(allowedProcessDefinitionKey)
-                .state(ProcessInstanceState.COMPLETED),
-        2);
-    waitForProcessInstances(
-        camundaClient,
-        f ->
-            f.processDefinitionKey(notAllowedProcessDefinitionKey)
-                .state(ProcessInstanceState.COMPLETED),
-        1);
+    final var allowedProcessDefinitionKey = createProcessInstances(deployCompleteSpecificBPMN(), 1);
+    final var notAllowedProcessDefinitionKey = createProcessInstances(deployCompleteBPMN(), 2);
 
     // when
     final var allowedActual =
@@ -150,13 +121,29 @@ class ProcessDefinitionStatisticsAuthorizationIT {
             .join();
     final var notAllowedActual =
         userClient
-            .newProcessDefinitionElementStatisticsRequest(allowedProcessDefinitionKey)
+            .newProcessDefinitionElementStatisticsRequest(notAllowedProcessDefinitionKey)
             .send()
             .join();
 
     // then
     assertThat(allowedActual).hasSize(2);
     assertThat(notAllowedActual).isEmpty();
+  }
+
+  private long createProcessInstances(
+      final long processDefinitionKey, final int numberOfInstances) {
+    for (int i = 0; i < numberOfInstances; i++) {
+      camundaClient
+          .newCreateInstanceCommand()
+          .processDefinitionKey(processDefinitionKey)
+          .send()
+          .join();
+    }
+    waitForProcessInstances(
+        camundaClient,
+        f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED),
+        numberOfInstances);
+    return processDefinitionKey;
   }
 
   private static long deployCompleteBPMN() {
@@ -175,14 +162,6 @@ class ProcessDefinitionStatisticsAuthorizationIT {
         .getProcesses()
         .getFirst()
         .getProcessDefinitionKey();
-  }
-
-  private static void createInstance(final long processDefinitionKey) {
-    camundaClient
-        .newCreateInstanceCommand()
-        .processDefinitionKey(processDefinitionKey)
-        .send()
-        .join();
   }
 
   private static io.camunda.client.api.response.DeploymentEvent deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessDefinitionStatisticsAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessDefinitionStatisticsAuthorizationIT.java
@@ -39,6 +39,10 @@ class ProcessDefinitionStatisticsAuthorizationIT {
   private static final String TEST_USERNAME_READ_PROCESS_DEFINITION =
       "testUserReadProcessDefinition";
   private static final String TEST_USERNAME_READ_PROCESS_INSTANCE = "testUserReadProcessInstance";
+  private static final String TEST_USERNAME_READ_SPECIFIC_PROCESS_INSTANCE =
+      "testUserReadSpecificProcessInstance";
+
+  private static final String SPECIFIC_PROCESS_ID = "process-auth-specific";
 
   @UserDefinition
   private static final TestUser TEST_USER_WITH_READ_PROCESS_DEFINITION =
@@ -61,6 +65,17 @@ class ProcessDefinitionStatisticsAuthorizationIT {
                   ResourceType.PROCESS_DEFINITION,
                   PermissionType.READ_PROCESS_INSTANCE,
                   List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser TEST_USER_WITH_READ_SPECIFIC_INSTANCE =
+      new TestUser(
+          TEST_USERNAME_READ_SPECIFIC_PROCESS_INSTANCE,
+          "password",
+          List.of(
+              new Permissions(
+                  ResourceType.PROCESS_DEFINITION,
+                  PermissionType.READ_PROCESS_INSTANCE,
+                  List.of(SPECIFIC_PROCESS_ID))));
 
   private static CamundaClient camundaClient;
 
@@ -104,10 +119,59 @@ class ProcessDefinitionStatisticsAuthorizationIT {
     assertThat(actual).hasSize(2);
   }
 
+  @Test
+  void shouldAllowReadProcessInstancePermissionForSpecificProcess(
+      @Authenticated(TEST_USERNAME_READ_SPECIFIC_PROCESS_INSTANCE) final CamundaClient userClient) {
+    // given
+    final var allowedProcessDefinitionKey = deployCompleteSpecificBPMN();
+    final var notAllowedProcessDefinitionKey = deployCompleteBPMN();
+    createInstance(allowedProcessDefinitionKey);
+    createInstance(allowedProcessDefinitionKey);
+    createInstance(notAllowedProcessDefinitionKey);
+
+    waitForProcessInstances(
+        camundaClient,
+        f ->
+            f.processDefinitionKey(allowedProcessDefinitionKey)
+                .state(ProcessInstanceState.COMPLETED),
+        2);
+    waitForProcessInstances(
+        camundaClient,
+        f ->
+            f.processDefinitionKey(notAllowedProcessDefinitionKey)
+                .state(ProcessInstanceState.COMPLETED),
+        1);
+
+    // when
+    final var allowedActual =
+        userClient
+            .newProcessDefinitionElementStatisticsRequest(allowedProcessDefinitionKey)
+            .send()
+            .join();
+    final var notAllowedActual =
+        userClient
+            .newProcessDefinitionElementStatisticsRequest(allowedProcessDefinitionKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(allowedActual).hasSize(2);
+    assertThat(notAllowedActual).isEmpty();
+  }
+
   private static long deployCompleteBPMN() {
     final var processId = "process-auth-" + UUID.randomUUID();
     final var processModel = Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
     return deployResource(processModel, "complete-auth.bpmn")
+        .getProcesses()
+        .getFirst()
+        .getProcessDefinitionKey();
+  }
+
+  private static long deployCompleteSpecificBPMN() {
+    final var processModel =
+        Bpmn.createExecutableProcess(SPECIFIC_PROCESS_ID).startEvent().endEvent().done();
+    return deployResource(processModel, SPECIFIC_PROCESS_ID + ".bpmn")
         .getProcesses()
         .getFirst()
         .getProcessDefinitionKey();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessDefinitionStatisticsAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessDefinitionStatisticsAuthorizationIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.it.util.TestHelper.waitForProcessInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class ProcessDefinitionStatisticsAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  private static final String TEST_USERNAME_READ_PROCESS_DEFINITION =
+      "testUserReadProcessDefinition";
+  private static final String TEST_USERNAME_READ_PROCESS_INSTANCE = "testUserReadProcessInstance";
+
+  @UserDefinition
+  private static final TestUser TEST_USER_WITH_READ_PROCESS_DEFINITION =
+      new TestUser(
+          TEST_USERNAME_READ_PROCESS_DEFINITION,
+          "password",
+          List.of(
+              new Permissions(
+                  ResourceType.PROCESS_DEFINITION,
+                  PermissionType.READ_PROCESS_DEFINITION,
+                  List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser TEST_USER_WITH_READ_PROCESS_INSTANCE =
+      new TestUser(
+          TEST_USERNAME_READ_PROCESS_INSTANCE,
+          "password",
+          List.of(
+              new Permissions(
+                  ResourceType.PROCESS_DEFINITION,
+                  PermissionType.READ_PROCESS_INSTANCE,
+                  List.of("*"))));
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldReturnEmptyStatisticsForReadProcessDefinitionPermission(
+      @Authenticated(TEST_USERNAME_READ_PROCESS_DEFINITION) final CamundaClient userClient) {
+    // given
+    final var processDefinitionKey = deployCompleteBPMN();
+    createInstance(processDefinitionKey);
+    createInstance(processDefinitionKey);
+    waitForProcessInstances(
+        camundaClient,
+        f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED),
+        2);
+
+    // when
+    final var actual =
+        userClient.newProcessDefinitionElementStatisticsRequest(processDefinitionKey).send().join();
+
+    // then
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void shouldAllowReadProcessInstancePermission(
+      @Authenticated(TEST_USERNAME_READ_PROCESS_INSTANCE) final CamundaClient userClient) {
+    // given
+    final var processDefinitionKey = deployCompleteBPMN();
+    createInstance(processDefinitionKey);
+    createInstance(processDefinitionKey);
+    waitForProcessInstances(
+        camundaClient,
+        f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED),
+        2);
+
+    // when
+    final var actual =
+        userClient.newProcessDefinitionElementStatisticsRequest(processDefinitionKey).send().join();
+
+    // then
+    assertThat(actual).hasSize(2);
+  }
+
+  private static long deployCompleteBPMN() {
+    final var processId = "process-auth-" + UUID.randomUUID();
+    final var processModel = Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+    return deployResource(processModel, "complete-auth.bpmn")
+        .getProcesses()
+        .getFirst()
+        .getProcessDefinitionKey();
+  }
+
+  private static void createInstance(final long processDefinitionKey) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .processDefinitionKey(processDefinitionKey)
+        .send()
+        .join();
+  }
+
+  private static io.camunda.client.api.response.DeploymentEvent deployResource(
+      final BpmnModelInstance processModel, final String resourceName) {
+    return camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(processModel, resourceName)
+        .send()
+        .join();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessDefinitionStatisticsAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessDefinitionStatisticsAuthorizationIT.java
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
+// TODO: Re-enable for RDBMS when authorization checks are implemented
+// see https://github.com/camunda/camunda/issues/48780
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class ProcessDefinitionStatisticsAuthorizationIT {
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
@@ -140,7 +140,8 @@ public class ProcessDefinitionStatisticsFilterTransformer
 
   @Override
   protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
-    return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
+    return hasParentQuery(
+        PROCESS_INSTANCE_JOIN_RELATION, stringTerms(BPMN_PROCESS_ID, authorization.resourceIds()));
   }
 
   private static SearchQuery hasRetriesLeftQuery(final Boolean value) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformerTest.java
@@ -24,7 +24,6 @@ import io.camunda.security.auth.Authorization;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
-import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.template.JobTemplate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -294,12 +293,14 @@ public final class ProcessDefinitionStatisticsFilterTransformerTest
                       query ->
                           assertThat(query.queryOption())
                               .isInstanceOfSatisfying(
-                                  SearchTermsQuery.class,
-                                  (termsQuery) -> {
-                                    assertThat(termsQuery.field())
-                                        .isEqualTo(ProcessIndex.BPMN_PROCESS_ID);
+                                  SearchHasParentQuery.class,
+                                  (parentQuery) -> {
+                                    assertThat(parentQuery.parentType())
+                                        .isEqualTo("processInstance");
+                                    final SearchTermsQuery searchTermsQuery =
+                                        (SearchTermsQuery) parentQuery.query().queryOption();
                                     assertThat(
-                                            termsQuery.values().stream()
+                                            searchTermsQuery.values().stream()
                                                 .map(TypedValue::stringValue)
                                                 .toList())
                                         .containsExactlyInAnyOrder("1", "2");

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -75,7 +75,7 @@ public class ProcessDefinitionServices
             processDefinitionSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication, PROCESS_DEFINITION_READ_AUTHORIZATION))
+                        authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
                 .processDefinitionFlowNodeStatistics(filter));
   }
 

--- a/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
+import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
+import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -125,5 +127,23 @@ public class ProcessDefinitionServiceTest {
                         && q.filter().processDefinitionId() != null
                         && processDefinitionId.equals(q.filter().processDefinitionId())
                         && q.filter().tenantId() == null));
+  }
+
+  @Test
+  public void shouldReturnElementStatistics() {
+    // given
+    final var processDefinitionKey = 123L;
+    final var filter = new ProcessDefinitionStatisticsFilter.Builder(processDefinitionKey).build();
+    final var statistics = List.of(new ProcessFlowNodeStatisticsEntity("task", 1L, 0L, 0L, 1L));
+
+    when(processDefinitionSearchClient.processDefinitionFlowNodeStatistics(filter))
+        .thenReturn(statistics);
+
+    // when
+    final var result = services.elementStatistics(filter, authentication);
+
+    // then
+    assertThat(result).isEqualTo(statistics);
+    verify(processDefinitionSearchClient).processDefinitionFlowNodeStatistics(filter);
   }
 }


### PR DESCRIPTION
# Description
Backport of #48304 to `stable/8.9`.

relates to #38198