### PR TITLE
test: add business ID uniqueness toggle transition tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessToggleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessToggleTest.java
@@ -28,7 +28,14 @@ import org.junit.Test;
  */
 public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(
+              config -> {
+                // Several tests depend on this specific default as the starting point
+                config.setBusinessIdUniquenessEnabled(false);
+              });
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessToggleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessToggleTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for toggle transitions of the {@code businessIdUniquenessEnabled} configuration. The
+ * business ID index is always maintained regardless of the toggle — only validation is gated. These
+ * tests verify that validation behaves correctly after toggle transitions.
+ */
+public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldRejectDuplicateAfterEnablingUniqueness() {
+    // given — uniqueness OFF (default)
+    final String processId = helper.getBpmnProcessId();
+    final String businessId = "biz-1";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+    ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withBusinessId(businessId)
+        .withTags("duplicate")
+        .create();
+
+    // when — toggle ON
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    ENGINE.start();
+
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withBusinessId(businessId)
+        .withTags("afterToggle")
+        .expectRejection()
+        .create();
+
+    // then — new create with same businessId is rejected
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .onlyCommandRejections()
+                .withTags("afterToggle")
+                .withBpmnProcessId(processId)
+                .getFirst())
+        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionReason(
+            """
+            Expected to create instance of process with business id '%s', \
+            but an instance with this business id already exists for process definition '%s'\
+            """
+                .formatted(businessId, processId));
+
+    // cleanup — disable uniqueness for other tests
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+    ENGINE.start();
+  }
+
+  @Test
+  public void shouldAllowDuplicateAfterDisablingUniqueness() {
+    // given — toggle ON
+    final String processId = helper.getBpmnProcessId();
+    final String businessId = "biz-1";
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    ENGINE.start();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+    ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+
+    // when — toggle OFF
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+    ENGINE.start();
+
+    // then — duplicate is allowed
+    final var secondInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withBusinessId(businessId)
+            .withTags("afterToggle")
+            .create();
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withBpmnProcessId(processId)
+                .withTags("afterToggle")
+                .getFirst()
+                .getValue())
+        .hasBusinessId(businessId)
+        .hasProcessInstanceKey(secondInstanceKey);
+  }
+
+  @Test
+  public void shouldAllowReuseAfterDuplicateCompletesAndUniquenessEnabled() {
+    // given — uniqueness OFF (default)
+    final String processId = helper.getBpmnProcessId();
+    final String businessId = "biz-1";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+    final var instanceKeyA =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+    final var instanceKeyB =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+
+    // when — toggle ON, then complete both instances
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    ENGINE.start();
+    ENGINE.userTask().ofInstance(instanceKeyA).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(instanceKeyA)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+    ENGINE.userTask().ofInstance(instanceKeyB).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(instanceKeyB)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then — business ID is freed, new create succeeds
+    final var instanceKeyC =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withBusinessId(businessId)
+            .withTags("afterCompletion")
+            .create();
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withBpmnProcessId(processId)
+                .withTags("afterCompletion")
+                .getFirst()
+                .getValue())
+        .hasBusinessId(businessId)
+        .hasProcessInstanceKey(instanceKeyC);
+
+    // cleanup — disable uniqueness for other tests
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+    ENGINE.start();
+  }
+
+  @Test
+  public void shouldFreeBusinessIdWhenInstanceCompletesDuringDisabledWindow() {
+    // given — toggle ON
+    final String processId = helper.getBpmnProcessId();
+    final String businessId = "biz-1";
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    ENGINE.start();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+    final var instanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+
+    // when — toggle OFF, complete instance, toggle ON
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+    ENGINE.start();
+    ENGINE.userTask().ofInstance(instanceKey).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(instanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    ENGINE.start();
+
+    // then — business ID is freed
+    final var newInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withBusinessId(businessId)
+            .withTags("afterReEnable")
+            .create();
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withBpmnProcessId(processId)
+                .withTags("afterReEnable")
+                .getFirst()
+                .getValue())
+        .hasBusinessId(businessId)
+        .hasProcessInstanceKey(newInstanceKey);
+
+    // cleanup — disable uniqueness for other tests
+    ENGINE.stop();
+    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+    ENGINE.start();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessToggleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessToggleTest.java
@@ -16,10 +16,8 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -30,20 +28,18 @@ import org.junit.Test;
  */
 public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
-  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
-
   @Test
   public void shouldRejectDuplicateAfterEnablingUniqueness() {
     // given — uniqueness OFF (default)
-    final String processId = helper.getBpmnProcessId();
+    final String processId = "process";
     final String businessId = "biz-1";
-    ENGINE
+    engine
         .deployment()
         .withXmlResource(
             Bpmn.createExecutableProcess(processId)
@@ -52,8 +48,8 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
                 .endEvent()
                 .done())
         .deploy();
-    ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
-    ENGINE
+    engine.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+    engine
         .processInstance()
         .ofBpmnProcessId(processId)
         .withBusinessId(businessId)
@@ -61,11 +57,11 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
         .create();
 
     // when — toggle ON
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
-    ENGINE.start();
+    engine.stop();
+    engine.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    engine.start();
 
-    ENGINE
+    engine
         .processInstance()
         .ofBpmnProcessId(processId)
         .withBusinessId(businessId)
@@ -87,22 +83,17 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
             but an instance with this business id already exists for process definition '%s'\
             """
                 .formatted(businessId, processId));
-
-    // cleanup — disable uniqueness for other tests
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
-    ENGINE.start();
   }
 
   @Test
   public void shouldAllowDuplicateAfterDisablingUniqueness() {
     // given — toggle ON
-    final String processId = helper.getBpmnProcessId();
+    final String processId = "process";
     final String businessId = "biz-1";
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
-    ENGINE.start();
-    ENGINE
+    engine.stop();
+    engine.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    engine.start();
+    engine
         .deployment()
         .withXmlResource(
             Bpmn.createExecutableProcess(processId)
@@ -111,16 +102,16 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
                 .endEvent()
                 .done())
         .deploy();
-    ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+    engine.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
 
     // when — toggle OFF
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
-    ENGINE.start();
+    engine.stop();
+    engine.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+    engine.start();
 
     // then — duplicate is allowed
     final var secondInstanceKey =
-        ENGINE
+        engine
             .processInstance()
             .ofBpmnProcessId(processId)
             .withBusinessId(businessId)
@@ -140,9 +131,9 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
   @Test
   public void shouldAllowReuseAfterDuplicateCompletesAndUniquenessEnabled() {
     // given — uniqueness OFF (default)
-    final String processId = helper.getBpmnProcessId();
+    final String processId = "process";
     final String businessId = "biz-1";
-    ENGINE
+    engine
         .deployment()
         .withXmlResource(
             Bpmn.createExecutableProcess(processId)
@@ -152,20 +143,20 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
                 .done())
         .deploy();
     final var instanceKeyA =
-        ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+        engine.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
     final var instanceKeyB =
-        ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+        engine.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
 
     // when — toggle ON, then complete both instances
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
-    ENGINE.start();
-    ENGINE.userTask().ofInstance(instanceKeyA).complete();
+    engine.stop();
+    engine.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    engine.start();
+    engine.userTask().ofInstance(instanceKeyA).complete();
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
         .withProcessInstanceKey(instanceKeyA)
         .withElementType(BpmnElementType.PROCESS)
         .await();
-    ENGINE.userTask().ofInstance(instanceKeyB).complete();
+    engine.userTask().ofInstance(instanceKeyB).complete();
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
         .withProcessInstanceKey(instanceKeyB)
         .withElementType(BpmnElementType.PROCESS)
@@ -173,7 +164,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
 
     // then — business ID is freed, new create succeeds
     final var instanceKeyC =
-        ENGINE
+        engine
             .processInstance()
             .ofBpmnProcessId(processId)
             .withBusinessId(businessId)
@@ -188,22 +179,17 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
                 .getValue())
         .hasBusinessId(businessId)
         .hasProcessInstanceKey(instanceKeyC);
-
-    // cleanup — disable uniqueness for other tests
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
-    ENGINE.start();
   }
 
   @Test
   public void shouldFreeBusinessIdWhenInstanceCompletesDuringDisabledWindow() {
     // given — toggle ON
-    final String processId = helper.getBpmnProcessId();
+    final String processId = "process";
     final String businessId = "biz-1";
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
-    ENGINE.start();
-    ENGINE
+    engine.stop();
+    engine.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    engine.start();
+    engine
         .deployment()
         .withXmlResource(
             Bpmn.createExecutableProcess(processId)
@@ -213,24 +199,24 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
                 .done())
         .deploy();
     final var instanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
+        engine.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
 
     // when — toggle OFF, complete instance, toggle ON
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
-    ENGINE.start();
-    ENGINE.userTask().ofInstance(instanceKey).complete();
+    engine.stop();
+    engine.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+    engine.start();
+    engine.userTask().ofInstance(instanceKey).complete();
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
         .withProcessInstanceKey(instanceKey)
         .withElementType(BpmnElementType.PROCESS)
         .await();
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
-    ENGINE.start();
+    engine.stop();
+    engine.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+    engine.start();
 
     // then — business ID is freed
     final var newInstanceKey =
-        ENGINE
+        engine
             .processInstance()
             .ofBpmnProcessId(processId)
             .withBusinessId(businessId)
@@ -245,10 +231,5 @@ public final class CreateProcessInstanceBusinessIdUniquenessToggleTest {
                 .getValue())
         .hasBusinessId(businessId)
         .hasProcessInstanceKey(newInstanceKey);
-
-    // cleanup — disable uniqueness for other tests
-    ENGINE.stop();
-    ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
-    ENGINE.start();
   }
 }


### PR DESCRIPTION
## Description

Add isolated tests for toggle transitions of the `businessIdUniquenessEnabled` configuration, covering the edge cases identified in #48262. The business ID index is always maintained regardless of the toggle — only validation is gated — so these tests verify that validation behaves correctly after toggling on/off.

Four tests cover:
- **Off → On**: pre-existing duplicates cause rejection after enabling
- **On → Off**: duplicates are accepted after disabling
- **Off → On + completion**: duplicates created while off are freed by completion after enabling
- **On → Off → On**: instance completing during the "off" window correctly frees the business ID

## For reviewers

This test was written using AI according to a plan that was produced after some research. It can be handy during the review if things are unclear. However, if needed to clarify things, please still let me know so we can improve it in comments or the commit message.

<details><summary>Research</summary>
<p>

# Research: Business ID Uniqueness Implementation and Toggle in Zeebe Engine

## Research Question

How is business ID uniqueness currently implemented and toggled in the Zeebe engine — where is the configuration/toggle, how is uniqueness enforced (what code paths check for duplicates), what errors are produced on conflict, and what existing tests already cover this behavior (in particular toggling on and off the uniqueness enforcement)?

## Summary

Business ID uniqueness is an **opt-in feature** (disabled by default) that prevents multiple active root process instances from sharing the same business ID, scoped per `(businessId, processDefinitionId, tenantId)`. The toggle is a configuration property `businessIdUniquenessEnabled` that gates only the **validation** step — the underlying index in the state store is **always maintained** regardless of the toggle. On conflict, the engine rejects with `RejectionType.ALREADY_EXISTS`. Comprehensive tests exist for both enabled and disabled states, including one test that dynamically toggles the feature on and off.

## Detailed Findings

### 1. Configuration / Toggle

The feature is controlled by `businessIdUniquenessEnabled`, defaulting to `false`.

**Unified configuration (primary path):**
- `configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java:12-44`
- YAML property: `camunda.process-instance-creation.business-id-uniqueness-enabled`
- Env var: `CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED`
- Default: `false` (line 14)
- Uses `BackwardsCompatibilityMode.SUPPORTED` to also read the legacy property.

**Legacy broker configuration:**
- `zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ProcessInstanceCreationCfg.java:14-33`
- YAML property: `zeebe.broker.experimental.engine.processInstanceCreation.businessIdUniquenessEnabled`
- Default: inherits from `EngineConfiguration.DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED` (false)

**Defaults YAML:**
- `dist/src/main/config/defaults.yaml:1017` — `business-id-uniqueness-enabled: false`

**Configuration flow:**
```
YAML / Env Var
  → ProcessInstanceCreation (unified) or ProcessInstanceCreationCfg (broker)
    → EngineCfg.createEngineConfiguration() (line 207)
      → EngineConfiguration.businessIdUniquenessEnabled (line 118)
        → BpmnProcessors (line 280)
          → ProcessInstanceCreationHelper constructor (line 86)
```

**Engine default constant:**
- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java:64`
  ```java
  public static final boolean DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED = false;
  ```

### 2. Uniqueness Enforcement (Code Paths)

#### Entry Points

Two processors handle process instance creation, both delegating to `ProcessInstanceCreationHelper`:
- `ProcessInstanceCreationCreateProcessor.java` — handles `CREATE` command
- `ProcessInstanceCreationCreateWithAwaitingResultProcessor.java` — handles `CREATE_WITH_AWAITING_RESULT`

#### Validation Chain

In `ProcessInstanceCreationHelper.java:202-223`, `validateCommand()` chains:
1. `validateBusinessIdFormat` (line 403): rejects if business ID > 256 characters
2. `validateBusinessIdUniqueness` (line 419): the core uniqueness check

#### Core Uniqueness Check

`ProcessInstanceCreationHelper.java:419-437`:
- **Short-circuits** if `!businessIdUniquenessEnabled` OR if businessId is null/empty (line 422)
- Calls `elementInstanceState.hasActiveProcessInstanceWithBusinessId(businessId, processDefinitionId, tenantId, bannedInstanceState::isProcessInstanceBanned)` (line 427-428)
- On conflict → returns `Either.left(RejectionType.ALREADY_EXISTS)`

#### State Lookup

`DbElementInstanceState.java:624-644` — `hasActiveProcessInstanceWithBusinessId()`:
- Prefix scan on `[businessId | processDefinitionId | tenantId]`
- Iterates matches, skipping banned instances (via `ignoreWhen` predicate)
- Returns `true` if any non-ignored entry found

### 3. Column Family / State Storage

**Column family:** `PROCESS_INSTANCE_KEY_BY_BUSINESS_ID` (ordinal 139, `PARTITION_LOCAL`)
- `zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java:272`

**Key structure:** `[businessId | processDefinitionId | tenantId | processInstanceKey] → NIL`
- Defined in `DbElementInstanceState.java:80-88, 660-693`

**Index lifecycle** (always runs regardless of toggle):
| Event | Applier | Action |
|-------|---------|--------|
| ELEMENT_ACTIVATING | `ProcessInstanceElementActivatingV3Applier.java:63-66, 327-333` | Insert (root instances with non-empty businessId) |
| ELEMENT_COMPLETED | `ProcessInstanceElementCompletedV2Applier.java:71-74, 143-149` | Delete |
| ELEMENT_TERMINATED | `ProcessInstanceElementTerminatedV2Applier.java:55-58, 79-85` | Delete |
| ELEMENT_MIGRATED | `ProcessInstanceElementMigratedV3Applier.java:63-70, 117-138` | Delete old + insert new (if processDefinitionId changed) |

### 4. Error Produced on Conflict

**Rejection type:** `RejectionType.ALREADY_EXISTS`

**Message** (`ProcessInstanceCreationHelper.java:55-56`):
```
"Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'"
```

**Gateway-level mapping:**
- REST: HTTP 409 CONFLICT (`ProblemException`)
- gRPC: `ALREADY_EXISTS` status code

### 5. Scoping Rules

- **Per `(businessId, processDefinitionId, tenantId)`** — spans all versions of the same process definition
- **Root process instances only** — child instances (call activities) are not indexed and do not block
- **Partition-local** — enforced within a single partition only
- **Banned instances excluded** — via the `ignoreWhen` predicate

### 6. Key Design Decisions

1. **Index always populated**: State appliers insert/delete entries regardless of the toggle. Only the validation is gated. This means enabling the toggle starts enforcing immediately for new instances, and pre-existing instances are already tracked.
2. **Migration does NOT enforce uniqueness**: `ProcessInstanceElementMigratedV3Applier` updates the index without checking for conflicts — two instances can share a business ID on the same process definition after migration.
3. **Not retroactive**: Instances created before enabling are tracked in the index (if they had a business ID), so enabling the toggle catches future duplicates.

## Tests

### Primary: Uniqueness Enabled

**`zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java`**
- Configures `businessIdUniquenessEnabled=true` (line 38)
- 15 tests covering:

| Test | Coverage |
|------|----------|
| `shouldRejectCreateProcessInstanceWithBusinessIdInUse` (line 47) | Basic duplicate rejection |
| `shouldRejectCreateProcessInstanceWithBusinessIdInUseByOtherVersion` (line 88) | Cross-version rejection |
| `shouldCreateProcessInstanceWithBusinessIdInUseForOtherTenant` (line 143) | Tenant isolation |
| `shouldAllowSameBusinessIdForDifferentProcessDefinitions` (line 187) | Different process defs allowed |
| `shouldCreateProcessInstanceWithBusinessIdNoLongerInUseDueToCompletion` (line 237) | Reuse after completion |
| `shouldCreateProcessInstanceWithBusinessIdNoLongerInUseDueToCancellation` (line 281) | Reuse after cancellation |
| `shouldCreateProcessInstanceWithBusinessIdNoLongerInUseDueToBanning` (line 325) | Reuse after banning |
| `shouldAllowMultipleChildProcessInstancesWithSameBusinessId` (line 366) | Child instances can share |
| `shouldAllowCallActivityToCreateProcessInstanceWithBusinessIdInUse` (line 413) | Call activity bypasses check |
| `shouldAllowCreateProcessInstanceWithBusinessIdInUseOnlyByChildInstance` (line 473) | Child-only use not blocking |
| `shouldCreateProcessInstanceWithBusinessIdOfSourceProcessDefinitionAfterMigration` (line 534) | Migration frees source |
| `shouldRejectCreateProcessInstanceWithBusinessIdOfTargetProcessDefinitionAfterMigration` (line 603) | Migration holds target |
| `shouldAllowMigrationWhenTargetProcessDefinitionAlreadyHasActiveInstanceWithSameBusinessId` (line 676) | Migration skips uniqueness |
| `shouldRejectCreateProcessInstanceWithBusinessIdOfOldVersionAfterVersionMigration` (line 757) | Version migration scoping |
| `shouldAllowVersionMigrationWhenAnotherInstanceOfSameProcessHasSameBusinessId` (line 831) | **Dynamically toggles on/off** (lines 861-883) |

### Uniqueness Disabled (Default)

**`zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java`**
| Test | Coverage |
|------|----------|
| `shouldCreateProcessInstanceWithBusinessId` (line 269) | Happy path with business ID |
| `shouldAllowDuplicateBusinessIdWhenUniquenessCheckDisabled` (line 582) | Explicit: duplicates allowed when disabled |

### Business ID Validation

**`zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdValidationTest.java`**
| Test | Coverage |
|------|----------|
| `shouldRejectBusinessIdExceedingMaxLength` (line 43) | > 256 chars rejected |
| `shouldAcceptBusinessIdWithMaxLength` (line 75) | Exactly 256 chars accepted |
| `shouldAcceptEmptyBusinessId` (line 106) | Empty is valid |

### Migration with Uniqueness Disabled

**`zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceTest.java`**
| Test | Coverage |
|------|----------|
| `shouldMigrateWhenBusinessIdAlreadyInUseButUniquenessDisabled` (line 212) | Migration succeeds with duplicates when disabled |

### Integration Tests

**`zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java`**
- Configures `businessIdUniquenessEnabled=true` (line 52)
- `shouldRejectCreateWithDuplicateBusinessIdOverRest` (line 191) — HTTP 409
- `shouldRejectCreateWithDuplicateBusinessIdOverGrpc` (line 232) — gRPC ALREADY_EXISTS

**`zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsBusinessIdUniquenessTest.java`**
- Configures `businessIdUniquenessEnabled=true` (line 56)
- `shouldEnforceBusinessIdUniquenessAfterScalingUp` (line 75) — survives partition scaling

### Toggle-Specific Test Coverage

Tests that explicitly exercise toggling on/off:
1. `CreateProcessInstanceBusinessIdUniquenessTest.shouldAllowVersionMigrationWhenAnotherInstanceOfSameProcessHasSameBusinessId` (line 831) — **dynamically stops engine, toggles off, creates duplicates, toggles on, verifies rejection**
2. `CreateProcessInstanceTest.shouldAllowDuplicateBusinessIdWhenUniquenessCheckDisabled` (line 582) — verifies disabled state allows duplicates

### Toggle Transition Edge Case Analysis (Issue #48262)

Issue [#48262](https://github.com/camunda/camunda/issues/48262) requests comprehensive tests for toggle transitions. The existing toggle test (line 831) covers one compound scenario (Off → On combined with migration) but does not isolate toggle transitions cleanly. Below is a gap analysis.

**Design context:** The index (`PROCESS_INSTANCE_KEY_BY_BUSINESS_ID`) is always maintained by state appliers regardless of the toggle. Only the validation in `ProcessInstanceCreationHelper.validateBusinessIdUniqueness` is gated. This means toggle transitions are inherently safe at the data level — the question is whether validation behaves correctly after a transition.

#### Covered edge cases

| # | Scenario | Test |
|---|----------|------|
| 1 | Off → On + migration | `shouldAllowVersionMigrationWhen...` (line 831) — toggles off, creates duplicates, toggles back on, verifies new creates are rejected and migration still succeeds |
| 2 | Always off, duplicates allowed | `shouldAllowDuplicateBusinessIdWhenUniquenessCheckDisabled` (line 582) |

#### Uncovered edge cases

| # | Edge Case | Description | Why It Matters |
|---|-----------|-------------|----------------|
| 3 | **Off → On (simple)** | Create duplicates while off; toggle on; new create with same business ID is rejected | The existing test (line 831) covers this but conflates it with migration. No isolated test exists for this basic transition. |
| 4 | **On → Off** | Uniqueness enforced; toggle off; verify duplicates are now accepted | The reverse direction is never tested. No test starts with `enabled=true` and switches to `false`. |
| 5 | **Off → On, pre-existing duplicates complete/cancel** | Two duplicates created while off; toggle on; one completes or is cancelled; verify the business ID is freed for reuse | Validates that applier-driven index cleanup works correctly across toggle transitions and that freed IDs become available. |
| 6 | **On → Off → On, instance completes during "off" window** | Create instance while on; toggle off; instance completes; toggle on; create new instance with same business ID — should succeed | Verifies index cleanup during the "off" period is correct, and the business ID is properly freed even though uniqueness was disabled when the instance completed. |
| 7 | **Off → On, no false positives after transition** | Toggle on; verify that instances with different business IDs or different process definitions are not incorrectly rejected | Partially covered by always-on tests, but not after a toggle transition. A smoke test after transition would increase confidence. |

#### Edge cases that are not meaningful (by design)

- **Toggle during in-flight processing**: The toggle is read at validation time per-command. The engine restart inherently serializes this, so there is no race condition.
- **Index corruption across toggles**: The index is always maintained regardless of the toggle, so it is inherently consistent. However, no test explicitly verifies that entries created while off are still present and queryable when toggled on (covered implicitly by edge case 3).

## Code References

- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java:64,118,468` — Default, field, getter
- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java:55-56,86,202-223,403,419-437` — Validation and rejection
- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java:280` — Wiring
- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java:80-88,166-171,382-408,624-644,660-693` — State store and lookup
- `zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java:272` — Column family
- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV3Applier.java:63-66,327-333` — Index insert
- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedV2Applier.java:71-74,143-149` — Index delete on completion
- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedV2Applier.java:55-58,79-85` — Index delete on termination
- `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV3Applier.java:63-70,117-138` — Index migration
- `configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java:12-44` — Unified config
- `zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ProcessInstanceCreationCfg.java:14-33` — Broker config
- `dist/src/main/config/defaults.yaml:1017` — Default YAML

## Architecture Insights

1. **Separation of concerns**: The index is always maintained (in state appliers) while only the validation is gated by the toggle. This is a clean separation that allows enabling the feature without data backfill.
2. **Partition-local enforcement**: Business ID uniqueness is only enforced within a single partition. The gateway uses hash-based dispatch on business ID to route creation requests to the same partition, making this effective in practice.
3. **Not a FeatureFlag**: Despite being a toggleable behavior, this uses the standard `EngineConfiguration` property system rather than the `FeatureFlags` mechanism used elsewhere in the engine.
4. **Backwards compatibility**: The unified config reads both the new and legacy YAML paths via `BackwardsCompatibilityMode.SUPPORTED`.

## Open Questions

1. How does the gateway's hash-based dispatch on business ID ensure all creation requests for the same business ID land on the same partition? (See `HashBasedDispatchStrategy` — uses business ID for hashing.)
2. Should migration enforce uniqueness when it re-indexes to a new process definition ID? Currently it does not, which could create conflicts.
3. Issue #48262 requests toggle transition tests. The most impactful uncovered edge cases are: On → Off (reverse direction never tested), and instance lifecycle during "off" window (complete/cancel while off, then toggle on). See "Toggle Transition Edge Case Analysis" section above for the full gap analysis.

</p>
</details> 

<details><summary>Plan</summary>
<p>

# Business ID Uniqueness Toggle Edge Case Tests

## Overview

Add tests for toggle transitions of the `businessIdUniquenessEnabled` configuration, as requested in [#48262](https://github.com/camunda/camunda/issues/48262). The index is always maintained regardless of the toggle — only validation is gated. These tests verify that validation behaves correctly after toggle transitions.

## Current State Analysis

- The toggle gates only the validation in `ProcessInstanceCreationHelper.validateBusinessIdUniqueness` (line 419-437)
- The index (`PROCESS_INSTANCE_KEY_BY_BUSINESS_ID`) is always maintained by state appliers
- One existing test dynamically toggles (line 831), but it conflates the toggle with migration
- No isolated toggle transition tests exist
- The toggle mechanism works via `ENGINE.stop()` → `ENGINE.withEngineConfig(...)` → `ENGINE.start()`

## Desired End State

A new test class with isolated tests for each meaningful toggle transition edge case, all passing. The tests should be in:
`zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessToggleTest.java`

## What We're NOT Doing

- Not testing "toggle during in-flight processing" — the engine restart serializes this, no race possible
- Not testing "index corruption across toggles" — the index is always maintained, inherently consistent
- Not duplicating existing always-on or always-off tests
- Not modifying any production code

## Implementation Approach

Create a single new test class with `businessIdUniquenessEnabled` starting as `false` (default). Each test that needs a specific starting state will toggle via engine restart. This avoids a `@ClassRule` that locks the toggle for the entire class.

## Phase 1: New Test Class

### Overview
Add `CreateProcessInstanceBusinessIdUniquenessToggleTest.java` with 4 focused tests covering the meaningful edge cases from the research gap analysis.

### Changes Required

#### 1. New test class
**File**: `zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessToggleTest.java`

The class uses `EngineRule.singlePartition()` with default config (uniqueness disabled). Tests toggle as needed via `ENGINE.stop()` / `ENGINE.start()`.

#### Test 1: `shouldRejectDuplicateAfterEnablingUniqueness` (Off → On, simple)
**Edge case 3 from research**: Create duplicates while off; toggle on; new create with same business ID is rejected.

```
// given — uniqueness OFF (default)
deploy process with user task
create instance A with businessId "biz-1"
create instance B with businessId "biz-1" (allowed, uniqueness off)

// when — toggle ON
ENGINE.stop()
ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true))
ENGINE.start()

// then — new create with same businessId is rejected
create instance C with businessId "biz-1" → expectRejection(ALREADY_EXISTS)
```

**Why this matters**: Validates that pre-existing index entries (populated while off) are correctly used for validation after enabling. This is the most fundamental toggle transition.

#### Test 2: `shouldAllowDuplicateAfterDisablingUniqueness` (On → Off)
**Edge case 4 from research**: Uniqueness enforced; toggle off; duplicates now accepted.

```
// given — toggle ON
ENGINE.stop()
ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true))
ENGINE.start()
deploy process with user task
create instance A with businessId "biz-1"

// when — toggle OFF
ENGINE.stop()
ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false))
ENGINE.start()

// then — duplicate is allowed
create instance B with businessId "biz-1" → succeeds
```

**Why this matters**: The reverse direction is never tested. Confirms the toggle actually disables validation.

#### Test 3: `shouldAllowReuseAfterDuplicateCompletesAndUniquenessEnabled` (Off → On, pre-existing duplicates complete)
**Edge case 5 from research**: Two duplicates created while off; toggle on; one completes; verify the business ID is freed for reuse.

```
// given — uniqueness OFF (default)
deploy process with user task
create instance A with businessId "biz-1"
create instance B with businessId "biz-1"

// when — toggle ON, then complete both instances
ENGINE.stop()
ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true))
ENGINE.start()
complete user task for instance A → instance A completes
complete user task for instance B → instance B completes

// then — business ID is freed, new create succeeds
create instance C with businessId "biz-1" → succeeds
```

**Why this matters**: Validates that applier-driven index cleanup works correctly across toggle transitions. The index deletes entries on completion regardless of the toggle — this confirms those deletions are visible to validation after enabling.

#### Test 4: `shouldFreeBusinessIdWhenInstanceCompletesDuringDisabledWindow` (On → Off → On, instance completes during "off" window)
**Edge case 6 from research**: Create instance while on; toggle off; instance completes; toggle on; create with same business ID succeeds.

```
// given — toggle ON
ENGINE.stop()
ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true))
ENGINE.start()
deploy process with user task
create instance A with businessId "biz-1"

// when — toggle OFF, complete instance, toggle ON
ENGINE.stop()
ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false))
ENGINE.start()
complete user task for instance A → instance A completes
ENGINE.stop()
ENGINE.withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true))
ENGINE.start()

// then — business ID is freed
create instance B with businessId "biz-1" → succeeds
```

**Why this matters**: Verifies that index cleanup during the "off" period is correct. The applier always removes the entry on completion, regardless of toggle state — this confirms the absence of the entry is correctly detected as "available" when re-enabled.

### Success Criteria

#### Automated Verification:
- [ ] Tests pass: `./mvnw verify -pl zeebe/engine -Dtest=CreateProcessInstanceBusinessIdUniquenessToggleTest -DskipTests=false -DskipITs -Dquickly -T1C`
- [ ] Formatting passes: `./mvnw spotless:check -pl zeebe/engine -T1C`

#### Manual Verification:
- [ ] Each test isolates exactly one toggle transition scenario
- [ ] No overlap with existing tests in `CreateProcessInstanceBusinessIdUniquenessTest`

## Testing Strategy

All 4 tests are engine-level unit tests using `EngineRule`, consistent with the existing test suite. No integration tests needed — the toggle mechanism is purely engine-internal.

### Edge cases explicitly excluded (not meaningful):
- **No false positives after transition**: Already covered implicitly — each test that expects success after a toggle IS a no-false-positive check. A dedicated test would duplicate.

</p>
</details> 

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #48262