### PR TITLE
[Backport stable/8.7] ci: add workflow_call trigger to release load test workflow

### DIFF
--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -88,7 +88,7 @@ jobs:
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -1,8 +1,7 @@
 # description: Create a Camunda load test for a given release.
 #              Abstraction layer of the actual load test creation process, to define a clear API between release process and the load test workflows.
 #              Public API - accepting inputs for test name and tag.
-#              To validate that load test creation works; we regularly run this workflow via schedule.
-#              The create load test (created by scheduled) is deleted after a fixed time (15 mins) to avoid unnecessary costs.
+#              Called by: camunda-scheduled-release-load-tests.yml (daily schedule)
 # type: CI
 # owner @camunda/reliability-testing
 name: Camunda Release load test workflow
@@ -17,9 +16,16 @@ on:
         description: 'Specifies the tag that should be used for the release load test'
         type: string
         required: true
-# This workflow is also scheduled to run daily with default values for the test name and tag, allowing for regular sanity check whether load testing creation works
-  schedule:
-    - cron: '0 4 * * *' # every day at 04:00
+  workflow_call:
+    inputs:
+      name:
+        description: 'Specifies the name of the load test'
+        type: string
+        required: true
+      tag:
+        description: 'Specifies the tag that should be used for the release load test'
+        type: string
+        required: true
 
 defaults:
   run:
@@ -27,7 +33,6 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
-# Define environment variables for the workflow, allowing for default values (used on schedule) that can be overridden by workflow inputs
 env:
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
@@ -45,11 +50,10 @@ jobs:
       - id: sanitize
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main
         with:
-          branch: ${{ inputs.name || 'dry-run-release-8-8-x' }}
+          branch: ${{ inputs.name }}
           max_length: 50  # reduced to account for load-test prefix "c8-" and potential suffixes for uniqueness
-      # We prepare the tag to default to '8.8.3' if not provided, to ensure that the load test creation can proceed with a valid tag even in the case of missing input (e.g., during schedule runs)
       - id: prepare_tag
-        run: echo "test-tag=${{ inputs.tag || '8.7.3' }}" >> "$GITHUB_OUTPUT"
+        run: echo "test-tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -73,65 +77,10 @@ jobs:
       use-official-docker-images: true
       scenario: 'realistic'
 
-  await-load-test:
-    name: Await Load Test
-    needs: [sanitize-inputs, create-load-test]
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Wait for load test to stabilize
-        run: sleep 900  # 15 minutes
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
-  delete-load-test:
-    name: Benchmark Cleanup
-    needs: [sanitize-inputs, await-load-test, create-load-test]
-    if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Set up Teleport
-        uses: teleport-actions/setup@v1
-        with:
-          version: 17.2.2
-
-      - name: Authenticate to Cluster using Teleport
-        uses: teleport-actions/auth-k8s@v2
-        with:
-          proxy: camunda.teleport.sh:443
-          token: ${{ env.TELEPORT_JOIN_TOKEN }}
-          kubernetes-cluster: ${{ env.CLUSTER }}
-
-      - name: Delete benchmarks
-        run: |
-          kubectl delete ns "${{ needs.sanitize-inputs.outputs.sanitized-name }}"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
   notify-on-failure:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [sanitize-inputs, create-load-test, await-load-test, delete-load-test]
+    needs: [sanitize-inputs, create-load-test]
     if: failure()
     permissions: {}
     steps:
@@ -148,7 +97,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: *${{ github.event_name != 'workflow_dispatch' && '[Dry-run]:' || ':alarm:' }}Release load test creation failed:*"
+                    "text": ":alarm: *Release load test creation failed:*"
                   }
                 },
                 {

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -71,7 +71,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}
-      ref: ${{ needs.sanitize-inputs.outputs.test-tag }}
+      ref: stable/8.7
       reuse-tag: ${{ needs.sanitize-inputs.outputs.test-tag }}
       ttl: 60
       use-official-docker-images: true


### PR DESCRIPTION
## Description

Backport for `stable/8.7`: Add `workflow_call` trigger to `camunda-release-load-test.yaml` so it can be called as a reusable workflow from the new scheduled release load test workflow on main (#48904).

The scheduled workflow uses `camunda/camunda/.github/workflows/camunda-release-load-test.yaml@stable/8.7` to call each stable branch's own version of the workflow. This ensures the workflow file, `camunda-load-test.yml`, and all infrastructure (Makefiles, helm values, paths) match the branch.

### Changes
- Add `workflow_call` trigger with `name` and `tag` inputs
- Remove `schedule` trigger (replaced by the scheduler on main)
- Remove `await-load-test` and `delete-load-test` jobs (handled by scheduler)
- Remove dry-run defaults
- Use stable branch ref for infrastructure checkout instead of release tag
- Route Slack notifications to `SLACK_WEBHOOK_RELIABILITY_TESTING_CH`

## Prerequisites

Main PR: #48904

## Related issues

Related to #47622