### PR TITLE
ci: validate Docker image tag exists before deploying load test

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -426,6 +426,7 @@ jobs:
     # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
+      needs.calculate-image-tag.result == 'success' &&
       (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
     runs-on: ubuntu-latest

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -189,16 +189,50 @@ jobs:
         id: image-tag
         run: |
           echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Validate Docker image tag exists
+      - name: Validate Docker image tags exist
         if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag != '' }}
         env:
           TAG: ${{ inputs.reuse-tag }}
+          ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
         run: |
-          if ! docker manifest inspect "camunda/camunda:${TAG}" > /dev/null 2>&1; then
-            echo "::error::Docker image camunda/camunda:${TAG} does not exist on Docker Hub"
-            exit 1
+          validate_image() {
+            local image="$1"
+            local max_retries=3
+            local retry_delay=5
+            local attempt=1
+
+            while true; do
+              echo "Validating Docker image ${image} (attempt ${attempt}/${max_retries})"
+              manifest_output=$(docker manifest inspect "${image}" 2>&1 >/dev/null)
+              status=$?
+
+              if [ "${status}" -eq 0 ]; then
+                echo "Docker image ${image} exists"
+                return 0
+              fi
+
+              # Distinguish missing tag from transient errors
+              if echo "${manifest_output}" | grep -qiE "manifest unknown|no such manifest|not found"; then
+                echo "::error::Docker image ${image} does not exist on Docker Hub"
+                return 1
+              fi
+
+              if [ "${attempt}" -ge "${max_retries}" ]; then
+                echo "::error::Failed to validate Docker image ${image} after ${max_retries} attempts: ${manifest_output}"
+                return "${status}"
+              fi
+
+              echo "Transient error (attempt ${attempt}/${max_retries}), retrying in ${retry_delay}s..."
+              sleep "${retry_delay}"
+              attempt=$((attempt + 1))
+            done
+          }
+
+          validate_image "camunda/camunda:${TAG}" || exit 1
+
+          if [[ "${ENABLE_OPTIMIZE}" == "true" ]]; then
+            validate_image "camunda/optimize:${TAG}" || exit 1
           fi
-          echo "Docker image camunda/camunda:${TAG} exists"
 
   calculate-scenario-config:
     name: Calculate Scenario Configuration

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -189,6 +189,16 @@ jobs:
         id: image-tag
         run: |
           echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Validate Docker image tag exists
+        if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag != '' }}
+        env:
+          TAG: ${{ inputs.reuse-tag }}
+        run: |
+          if ! docker manifest inspect "camunda/camunda:${TAG}" > /dev/null 2>&1; then
+            echo "::error::Docker image camunda/camunda:${TAG} does not exist on Docker Hub"
+            exit 1
+          fi
+          echo "Docker image camunda/camunda:${TAG} exists"
 
   calculate-scenario-config:
     name: Calculate Scenario Configuration


### PR DESCRIPTION
## Description

Adds a sanity check to the load test workflow that validates whether the specified
Docker image tag exists on Docker Hub before proceeding with deployment. This check
only runs when `use-official-docker-images` is `true` and a `reuse-tag` is provided.

This prevents wasting time and resources deploying a load test that will fail because
the Docker image doesn't exist (e.g., typo in tag, optimize SNAPSHOT not published).

Related to #47622

## Checklist

- [ ] Enable backports when necessary