### PR TITLE
ci: skip full CI for load-test workflow changes

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -15,7 +15,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true'
+        steps.filter-common.outputs.actionlint-related-change == 'true'
       }}
   commitlint:
     description: Output whether commit messages should be linted based on GitHub event
@@ -35,7 +35,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.markdown-change == 'true'
@@ -56,7 +56,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
       }}
@@ -66,7 +66,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
   operate-backend-changes:
@@ -75,7 +75,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -87,7 +87,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-frontend-change == 'true'
       }}
   tasklist-frontend-changes:
@@ -96,7 +96,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
       }}
   tasklist-backend-changes:
@@ -105,7 +105,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -117,7 +117,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-frontend-change == 'true'
       }}
   optimize-backend-changes:
@@ -126,7 +126,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
@@ -137,7 +137,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.dockerfile-change == 'true' ||
@@ -149,7 +149,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
       }}
@@ -159,7 +159,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-zeebe.outputs.zeebe-change == 'true'
@@ -177,7 +177,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
   stable-branch-changes:
@@ -193,7 +193,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.rdbms-change == 'true'
@@ -204,7 +204,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.renovate-config-change == 'true'
       }}
   client-components-changes:
@@ -213,7 +213,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-client-components.outputs.client-components-change == 'true'
       }}
   docs-changes:
@@ -233,13 +233,13 @@ runs:
       base: ${{ github.event.merge_group.base_ref || '' }}
       ref: ${{ github.event.merge_group.head_ref || github.ref }}
       filters: |
-        github-actions-change:
+        actionlint-related-change:
           - '.github/actions/**'
           - '.github/workflows/**'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 
-        ci-workflow-change:
+        github-actions-change:
           - '.github/actions/**'
           - '.github/workflows/**'
           - '!.github/workflows/*load-test*'

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -35,7 +35,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.markdown-change == 'true'
@@ -56,7 +56,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
       }}
@@ -66,7 +66,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
   operate-backend-changes:
@@ -75,7 +75,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -87,7 +87,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-operate.outputs.operate-frontend-change == 'true'
       }}
   tasklist-frontend-changes:
@@ -96,7 +96,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
       }}
   tasklist-backend-changes:
@@ -105,7 +105,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -117,7 +117,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-optimize.outputs.optimize-frontend-change == 'true'
       }}
   optimize-backend-changes:
@@ -126,7 +126,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
@@ -137,7 +137,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.dockerfile-change == 'true' ||
@@ -149,7 +149,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
       }}
@@ -159,7 +159,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-zeebe.outputs.zeebe-change == 'true'
@@ -177,7 +177,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
   stable-branch-changes:
@@ -193,7 +193,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.rdbms-change == 'true'
@@ -204,7 +204,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.renovate-config-change == 'true'
       }}
   client-components-changes:
@@ -213,7 +213,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-client-components.outputs.client-components-change == 'true'
       }}
   docs-changes:
@@ -236,6 +236,14 @@ runs:
         github-actions-change:
           - '.github/actions/**'
           - '.github/workflows/**'
+          - '.github/actionlint*'
+          - '.github/conftest-*.rego'
+
+        ci-workflow-change:
+          - '.github/actions/**'
+          - '.github/workflows/**'
+          - '!.github/workflows/*load-test*'
+          - '!.github/workflows/*load_test*'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -244,6 +244,8 @@ runs:
           - '.github/workflows/**'
           - '!.github/workflows/*load-test*'
           - '!.github/workflows/*load_test*'
+          - '!.github/workflows/*benchmark*'
+          - '!.github/workflows/*testbench*'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 


### PR DESCRIPTION
## Summary
- Adds a `ci-workflow-change` path filter that mirrors `github-actions-change` but excludes workflow files matching `*load-test*` / `*load_test*` via picomatch negation globs
- Replaces `github-actions-change` with `ci-workflow-change` in all 16 test job output conditions, so load-test-only PRs no longer trigger the full monorepo test suite
- Keeps `actionlint` on the broad `github-actions-change` filter to ensure all workflow files are still linted
- Merge queue safe: `check-results` (the only required check) treats skipped jobs as passing

## Why
- **Improves velocity** — load test workflow changes no longer require waiting for the full CI suite to pass on unrelated test jobs
- **Reduces CI cost** — avoids running the entire monorepo test suite for changes that cannot affect test results
- **Reduces environmental footprint** — less unnecessary compute means lower energy consumption and carbon emissions #greenci

## Test plan
- [ ] Verify this PR itself only triggers `actionlint`, `commitlint`, `codeowners-check`, and `check-results` (not the full test suite)
- [ ] Verify a PR changing `ci.yml` still triggers all test jobs as before
- [ ] Verify the flaky test summary comment is not posted when no tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)