### PR TITLE
[Backport stable/8.6] ci: route load test Slack notifications to reliability-testing channel

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -84,7 +84,7 @@ jobs:
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -49,7 +49,7 @@ jobs:
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -105,7 +105,7 @@ jobs:
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -109,7 +109,7 @@ jobs:
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
           webhook-type: incoming-webhook
           payload: |
             {


### PR DESCRIPTION
# Description
Backport of #49113 to `stable/8.6`.

relates to 