### PR TITLE
Update zeebe qa to camunda image

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -62,7 +62,7 @@ jobs:
                     end
                   )
                 ' \
-              | jq -c --arg main "main" '. | [{"branch":$main,"generation_template":"Zeebe SNAPSHOT"}] + .'
+              | jq -c --arg main "main" '. | [{"branch":$main,"generation_template":"Camunda SNAPSHOT"}] + .'
           )
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "Matrix output: $matrix"  # Debug output for inspection

--- a/.github/workflows/zeebe-dispatch-qa.yaml
+++ b/.github/workflows/zeebe-dispatch-qa.yaml
@@ -20,5 +20,5 @@ jobs:
     uses: ./.github/workflows/zeebe-qa-testbench.yaml
     with:
       branch: ${{ github.event.client_payload.branch }}
-      generation: Zeebe SNAPSHOT
+      generation: Camunda SNAPSHOT
     secrets: inherit

--- a/.github/workflows/zeebe-e2e-testbench.yaml
+++ b/.github/workflows/zeebe-e2e-testbench.yaml
@@ -15,7 +15,7 @@ on:
       generation:
         description: 'Specifies the generation template which should be used by the testbench run'
         required: false
-        default: 'Zeebe SNAPSHOT'
+        default: 'Camunda SNAPSHOT'
         type: string
       branch:
         description: 'Specifies the branch, for which the E2E run should be executed'
@@ -51,7 +51,7 @@ on:
       generation:
         description: 'Specifies the generation template which should be used by the testbench run'
         required: false
-        default: 'Zeebe SNAPSHOT'
+        default: 'Camunda SNAPSHOT'
         type: string
       branch:
         description: 'Specifies the branch, for which the E2E run should be executed'
@@ -83,7 +83,7 @@ jobs:
       variables: >
         {
           "zeebeImage": "$IMAGE",
-          "generationTemplate": "${{ inputs.generation || 'Zeebe SNAPSHOT' }}",
+          "generationTemplate": "${{ inputs.generation || 'Camunda SNAPSHOT' }}",
           "channel": "Internal Dev",
           "branch": "${{ inputs.branch || 'main' }}",
           "build":  "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",

--- a/.github/workflows/zeebe-qa-testbench.yaml
+++ b/.github/workflows/zeebe-qa-testbench.yaml
@@ -10,7 +10,7 @@ on:
       generation:
         description: 'Specifies the generation template which should be used by the testbench run'
         required: false
-        default: 'Zeebe SNAPSHOT'
+        default: 'Camunda SNAPSHOT'
         type: string
       branch:
         description: 'Specifies the branch, for which the QA Testbench run should be executed'
@@ -22,7 +22,7 @@ on:
       generation:
         description: 'Specifies the generation template which should be used by the testbench run'
         required: false
-        default: 'Zeebe SNAPSHOT'
+        default: 'Camunda SNAPSHOT'
         type: string
       branch:
         description: 'Specifies the branch, for which the QA Testbench run should be executed'

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -164,6 +164,6 @@ jobs:
               \"variables\": $variables
             }"
         env:
-          IMAGE: zeebe-io/zeebe:${{ steps.image-tag.outputs.image-tag }}
+          IMAGE: zeebe-io/camunda:${{ steps.image-tag.outputs.image-tag }}
           access_token: ${{ env.access_token }}
 

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -109,7 +109,7 @@ jobs:
         with:
           maven-extra-args: -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
-        id: build-zeebe-docker
+        id: build-camunda-docker
         with:
           repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/camunda
           version: ${{ steps.image-tag.outputs.image-tag }}

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -111,10 +111,11 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         id: build-zeebe-docker
         with:
-          repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/zeebe
+          repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/camunda
           version: ${{ steps.image-tag.outputs.image-tag }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
+          dockerfile: 'camunda.Dockerfile'
       - name: Build and Push Starter Image
         run: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="gcr.io/zeebe-io/starter:${{ steps.image-tag.outputs.image-tag }}"
       - name: Build and Push Worker Image

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -58,7 +58,7 @@ jobs:
           - ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}
         include:
           - branch: main
-            generation_template: "Zeebe SNAPSHOT"
+            generation_template: "Camunda SNAPSHOT"
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
             generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.latest-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/zeebe-e2e-testbench.yaml
     with:
       branch: main
-      generation: Zeebe SNAPSHOT
+      generation: Camunda SNAPSHOT
       maxTestDuration: P1D
       clusterPlan: Multiregion test simulation
       fault: '"2-region-dataloss-failover"'
@@ -91,7 +91,7 @@ jobs:
     uses: ./.github/workflows/zeebe-e2e-testbench.yaml
     with:
       branch: main
-      generation: Zeebe SNAPSHOT
+      generation: Camunda SNAPSHOT
       maxTestDuration: PT2H
       clusterPlan: Production - M
       fault: '"scale-brokers"'
@@ -103,7 +103,7 @@ jobs:
     uses: ./.github/workflows/zeebe-e2e-testbench.yaml
     with:
       branch: main
-      generation: Zeebe SNAPSHOT
+      generation: Camunda SNAPSHOT
       maxTestDuration: PT2H
       clusterPlan: Production - M
       fault: '"scale-partitions"'


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Our testbench still deployed `zeebe` images, instead of `camunda` images. With this PR we change this, using the `camunda.Dockerfile` instead of the `Dockerfile`. We also now base the temp generations of the `Camunda SNAPSHOT` generation. I have created this generation in SaaS.

Note that the image is still pushed the `zeebe-io` project.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

N/A
