### PR TITLE
Use JsonMapper (Jackson 3) for MCP observability context

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -661,6 +661,11 @@
     </dependency>
 
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.application.commons.mcp;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
 import io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration;
 import io.camunda.gateway.mcp.config.CamundaMcpToolSpecificationsAutoConfiguration;
@@ -26,6 +25,7 @@ import org.springframework.http.server.observation.ServerRequestObservationConve
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Configuration for the MCP gateway implemented in the {@code gateway-mcp} module.
@@ -52,9 +52,9 @@ public class McpGatewayConfiguration {
    */
   @Bean
   public ServerRequestObservationConvention mcpRequestObservationConvention(
-      final ObservationProperties observationProperties, final ObjectMapper objectMapper) {
+      final ObservationProperties observationProperties, final JsonMapper jsonMapper) {
     return new McpServerRequestObservationConvention(
-        observationProperties.getHttp().getServer().getRequests().getName(), objectMapper);
+        observationProperties.getHttp().getServer().getRequests().getName(), jsonMapper);
   }
 
   /**

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpServerRequestObservationConvention.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpServerRequestObservationConvention.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.application.commons.mcp;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +16,7 @@ import org.springframework.http.server.observation.DefaultServerRequestObservati
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.lang.NonNull;
 import org.springframework.web.util.ContentCachingRequestWrapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Extends the default server request observation convention to add MCP-specific data to the URI tag
@@ -33,11 +33,11 @@ public class McpServerRequestObservationConvention
 
   private static final String KEY_URI = "uri";
 
-  private final ObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
 
-  public McpServerRequestObservationConvention(final String name, final ObjectMapper objectMapper) {
+  public McpServerRequestObservationConvention(final String name, final JsonMapper jsonMapper) {
     super(name);
-    this.objectMapper = objectMapper;
+    this.jsonMapper = jsonMapper;
   }
 
   /** Extends the default low cardinality key values to include MCP-specific URI information. */
@@ -45,12 +45,12 @@ public class McpServerRequestObservationConvention
   public @NonNull KeyValues getLowCardinalityKeyValues(
       final @NonNull ServerRequestObservationContext context) {
     final var lowCardinalityKeyValues = super.getLowCardinalityKeyValues(context);
-    final var newLowCardinalityKeyValues = getMcpRequestLowCardinalityValues(context, objectMapper);
+    final var newLowCardinalityKeyValues = getMcpRequestLowCardinalityValues(context, jsonMapper);
     return lowCardinalityKeyValues.and(newLowCardinalityKeyValues);
   }
 
   protected static KeyValues getMcpRequestLowCardinalityValues(
-      final ServerRequestObservationContext context, final ObjectMapper objectMapper) {
+      final ServerRequestObservationContext context, final JsonMapper jsonMapper) {
     final HttpServletRequest carrier = context.getCarrier();
     if (carrier == null || !isMcpRequest(carrier)) {
       // don't adjust the URI tag value
@@ -69,7 +69,7 @@ public class McpServerRequestObservationConvention
 
       // fetch MCP metadata to enrich the URI tag as much as possible
       final McpRequestMetadata mcpMetadata =
-          objectMapper.readValue(requestBody, McpRequestMetadata.class);
+          jsonMapper.readValue(requestBody, McpRequestMetadata.class);
       if (mcpMetadata == null) {
         // there is no metadata we could use
         return baseMcpUriValue;

--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
@@ -10,7 +10,6 @@ package io.camunda.application.commons.mcp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.commons.service.CamundaServicesConfiguration;
 import io.camunda.application.initializers.McpGatewayInitializer;
 import io.camunda.gateway.mcp.tool.cluster.ClusterTools;
@@ -26,6 +25,7 @@ import org.springframework.boot.micrometer.observation.autoconfigure.Observation
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import tools.jackson.databind.json.JsonMapper;
 
 class McpGatewayConfigurationTest {
 
@@ -49,8 +49,8 @@ class McpGatewayConfigurationTest {
         .map(Method::getReturnType)
         .forEach(mockBeans::add);
 
-    // add mocks needed for McpGatewayConfiguration
-    mockBeans.add(ObjectMapper.class);
+    // mock JsonMapper used in MCP observation convention
+    mockBeans.add(JsonMapper.class);
 
     for (final Class<?> mockedBean : mockBeans) {
       runner = addMockedBean(runner, mockedBean);

--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpServerRequestObservationConventionTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpServerRequestObservationConventionTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import java.util.stream.Stream;
@@ -22,10 +21,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.web.util.ContentCachingRequestWrapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class McpServerRequestObservationConventionTest {
 
-  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  static final JsonMapper JSON_MAPPER = new JsonMapper();
 
   @Test
   void tracksNonMcpInObservationTags() {
@@ -40,7 +40,7 @@ class McpServerRequestObservationConventionTest {
     // when
     final KeyValues keyValues =
         McpServerRequestObservationConvention.getMcpRequestLowCardinalityValues(
-            observationContext, OBJECT_MAPPER);
+            observationContext, JSON_MAPPER);
     // then
     assertThat(keyValues).isEmpty();
   }
@@ -61,7 +61,7 @@ class McpServerRequestObservationConventionTest {
     // when
     final KeyValues keyValues =
         McpServerRequestObservationConvention.getMcpRequestLowCardinalityValues(
-            observationContext, OBJECT_MAPPER);
+            observationContext, JSON_MAPPER);
     // then
     assertThat(keyValues).containsExactly(KeyValue.of("uri", expectedUriTag));
   }


### PR DESCRIPTION
## Description

Follow-up to #48855 to move all MCP integration paths to Jackson 3.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
