### PR TITLE
refactor: log skipped ranges at info level to explain restore failures

### DIFF
--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestorePointResolver.java
@@ -339,7 +339,7 @@ public class RestorePointResolver {
                         .formatted(range, metadata.partitionId(), metadata.checkpoints().size()));
               }
               if (from != null && startInfo.checkpointTimestamp().isAfter(from)) {
-                LOG.atTrace()
+                LOG.atInfo()
                     .addKeyValue("partition", metadata.partitionId())
                     .log(
                         "Skipping range [{}, {}] because it starts at {}, after requested time {}",
@@ -351,7 +351,7 @@ public class RestorePointResolver {
               }
               if (effectiveExportedPosition != null
                   && startInfo.getFirstLogPositionOrDefault() > effectiveExportedPosition) {
-                LOG.atTrace()
+                LOG.atInfo()
                     .addKeyValue("partition", metadata.partitionId())
                     .log(
                         "Skipping range [{}, {}] because the first log position {} is after required exported position {}",
@@ -363,7 +363,7 @@ public class RestorePointResolver {
               }
               if (effectiveExportedPosition != null
                   && endInfo.checkpointPosition() < effectiveExportedPosition) {
-                LOG.atTrace()
+                LOG.atInfo()
                     .addKeyValue("partition", metadata.partitionId())
                     .log(
                         "Skipping range [{}, {}] because the last log position {} is before the required exported position {}",


### PR DESCRIPTION
We don't expect to have many ranges and every skipped one could be interesting for users trying to figure out why they couldn't restore.