### PR TITLE
fix: improve minor release docs by adding a todo-list

### DIFF
--- a/docs/monorepo-docs/index.md
+++ b/docs/monorepo-docs/index.md
@@ -76,7 +76,7 @@ Renovate dependency update PRs that require manual intervention:
 - GitHub Action workflows and automation
 - Benchmark tests and testing clusters
 - Change management and DRI responsibilities
-- Minor release considerations and learnings
+- Minor release readiness checklist (`MUST`/`SHOULD`/`NICE`) and watch-outs
 - Incident process and troubleshooting procedures
 - FAQ covering common release scenarios
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -316,15 +316,16 @@ Ownership model:
 
 - [ ] Send feature freeze communication before the last alpha using the [feature-freeze template](#feature-freeze-vs-code-freeze-minor-releases) and explicitly state that only bug fixes and stabilization are expected after freeze.
 - [ ] Create `stable/<minor>` from `main` before the last alpha according to the early-stable strategy (i.e. create the `stable/<minor>` branch before the last alpha and branch all subsequent alpha/RC/final release branches from `stable/<minor>` instead of `main`).
-- [ ] Mirror the same strategy in [zeebe-process-test](https://github.com/camunda/zeebe-process-test): create `stable/<minor>` from `main` and align release-branch handling.
-- [ ] Create `backport stable/<minor>` label in monorepo (and in ZPT where needed).
+- [ ] [DEPRECATED for +8.10] Mirror the same strategy in [zeebe-process-test](https://github.com/camunda/zeebe-process-test): create `stable/<minor>` from `main` and align release-branch handling.
+- [ ] Create `backport stable/<minor>` label in monorepo.
+- [ ] [DEPRECATED for +8.10] Create `backport stable/<minor>` label in ZPT.
 - [ ] Announce stable branch creation and backport procedure (label + `/backport`) in the relevant engineering channels.
 
 #### 2. Versioning and branch plumbing (after last alpha branch exists)
 
 - [ ] On monorepo `main`, bump all `pom.xml` versions to `8.(x+1).0-SNAPSHOT` using:
   - `./mvnw release:update-versions -DdevelopmentVersion=8.(x+1).0-SNAPSHOT`
-- [ ] On ZPT `main`, bump versions to the next minor snapshot line.
+- [ ] [DEPRECATED for +8.10] On ZPT `main`, bump versions to the next minor snapshot line.
 - [ ] Update upgrade and migration test configuration so the previous minor upgrades to the new minor line.
 - [ ] Confirm artifact expectations:
   - `stable/<minor>` produces `<minor>.0-SNAPSHOT`

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -311,7 +311,7 @@ Legend:
 #### 1. Around feature freeze / last alpha (branch strategy)
 
 - [ ] **[MUST]** Send feature freeze communication before the last alpha using the [feature-freeze template](#feature-freeze-vs-code-freeze-minor-releases) and explicitly state that only bug fixes and stabilization are expected after freeze.
-- [ ] **[MUST]** Create `stable/<minor>` from `main` before the last alpha according to the early-stable strategy.
+- [ ] **[MUST]** Create `stable/<minor>` from `main` before the last alpha according to the early-stable strategy (i.e. create the `stable/<minor>` branch before the last alpha and branch all subsequent alpha/RC/final release branches from `stable/<minor>` instead of `main`).
 - [ ] **[MUST]** Create `release-<minor>.0-alphaN` from `stable/<minor>` (not from `main`) for the last alpha.
 - [ ] **[MUST]** Mirror the same strategy in [zeebe-process-test](https://github.com/camunda/zeebe-process-test): create `stable/<minor>` from `main` and align release-branch handling.
 - [ ] **[MUST]** Create `backport stable/<minor>` label in monorepo (and in ZPT where needed).

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -283,59 +283,82 @@ For CI-related changes, refer to our [CI & Automation documentation](./ci.md) an
 
 ## Minor Release Considerations
 
-Minor releases happen less often than other release types, so not all steps are automated (yet) in the `camunda/camunda` monorepo:
+Use the following checklist as the operational source of truth for every minor release.
 
-1. Bump the `pom.xml` versions to `8.(x+1).0-SNAPHOT` on `main`, after the last `release-8.x.0-alphaN` branch is created
-   * This may reveal implicit assumptions or actual bugs in upgrade tests that check for clean upgrade behavior of the software between different minor versions!
-   * This can be done with the following command `./mvnw release:update-versions -DdevelopmentVersion=8.(x+1).0-SNAPSHOT`
-2. Create the `stable/8.x` release branch from latest `release-8.x.0-alphaN`, to enforce code freeze
-   * Ensure all expected SNAPSHOT artifacts are produced correctly.
+Legend:
 
-:::note
-For 8.9.0 we evaluate the following approach (to be decided if kept for future minor versions)
+- **[MUST]** = needed for a functional minor / correct process
+- **[SHOULD]** = strongly recommended, reduces risk and toil
+- **[NICE]** = improvements and automation, can slip if time-boxed
 
-- **Branch Strategy**: To allow continuous bug fix integration during the alpha release process, consider creating `stable/<minor>` branch from `main` early (at the latest alpha code freeze day), then creating the alpha release branch from `stable/<minor>` instead of directly from `main`
-  - ⚠️ **Important**: Any bug fixes merged to `main` after the last alpha release branch (`release-<version>-alpha<N>`) has been created must be backported to `stable/<minor>` to be included in the minor release
-    - Critical bug fixes merged after that point should be backported to both `stable/<minor>` and the active alpha release branch and may trigger a new Release Candidate
-  - **Bug Fix Handling After Last Alpha Release (Minor Version Feature Freeze)**:
-:::
+### Minor Release Readiness Checklist
 
-3. [Configure `unified-ci-merges-stable-branches` branch protection ruleset](https://github.com/camunda/infra-core/blob/stage/terraform/github/prod/rulesets-camunda-camunda.tf) to include new `stable/8.x` branch
+#### 0. Dates, ownership, and high-level alignment
 
-* This may need temporary admin permissions for the initial manual push of the new branch.
+- [ ] **[MUST]** Confirm official minor release, feature freeze, and code freeze dates from the [C8 Release Train](https://confluence.camunda.com/spaces/HAN/pages/201853752/C8+Release+Train). See [Feature Freeze vs Code Freeze](#feature-freeze-vs-code-freeze-minor-releases) for definitions and timing.
+- [ ] **[MUST]** Confirm the Monorepo Release Manager (MRM) is available for feature freeze week, code freeze / branch creation, and the final RC window.
+- [ ] **[SHOULD]** Check for major holidays during RC and final release weeks, then adjust expectations with release stakeholders.
 
-4. Bump configured versions in upgrade tests of the previous minor version to `8.x`
+#### 1. Around feature freeze / last alpha (branch strategy)
 
-* TODO: add references to known upgrade tests if possible
+- [ ] **[MUST]** Send feature freeze communication before the last alpha using the [feature-freeze template](#feature-freeze-vs-code-freeze-minor-releases) and explicitly state that only bug fixes and stabilization are expected after freeze.
+- [ ] **[MUST]** Create `stable/<minor>` from `main` before the last alpha according to the early-stable strategy.
+- [ ] **[MUST]** Create `release-<minor>.0-alphaN` from `stable/<minor>` (not from `main`) for the last alpha.
+- [ ] **[MUST]** Mirror the same strategy in [zeebe-process-test](https://github.com/camunda/zeebe-process-test): create `stable/<minor>` from `main` and align release-branch handling.
+- [ ] **[MUST]** Create `backport stable/<minor>` label in monorepo (and in ZPT where needed).
+- [ ] **[MUST]** Announce stable branch creation and backport procedure (label + `/backport`) in the relevant engineering channels.
 
-Also, we have to do similar steps for the [ZPT repository](https://github.com/camunda/zeebe-process-test) in coordination with stakeholders from Camunda Ex team:
+#### 2. Versioning and branch plumbing (after last alpha branch exists)
 
-1. Creating `stable/8.x` release branch from `main`, to enforce code freeze
-2. Bumping `pom.xml` versions to `8.(x+1).0-SNAPHOT` on `main`
+- [ ] **[MUST]** On monorepo `main`, bump all `pom.xml` versions to `8.(x+1).0-SNAPSHOT` using:
+  - `./mvnw release:update-versions -DdevelopmentVersion=8.(x+1).0-SNAPSHOT`
+- [ ] **[MUST]** On ZPT `main`, bump versions to the next minor snapshot line.
+- [ ] **[MUST]** Update upgrade and migration test configuration so the previous minor upgrades to the new minor line.
+- [ ] **[SHOULD]** If Zeebe upgrade tests fail with `SkippedMinorVersion[...]` after bumps, either fix assumptions or temporarily disable with explicit TODO and re-enable after final minor release.
+- [ ] **[MUST]** Confirm artifact expectations:
+  - `stable/<minor>` produces `<minor>.0-SNAPSHOT`
+  - `main` produces `<next-minor>.0-SNAPSHOT` (or generic `SNAPSHOT` where expected)
 
-#### Additional Minor Release Learnings (8.8+)
+#### 3. CI, protections, and release workflow wiring
 
-In addition to the standard steps above, recent minor releases have surfaced several process improvements and considerations worth incorporating into future release cycles:
+- [ ] **[MUST]** Add `stable/<minor>` to `unified-ci-merges-stable-branches` protection/ruleset configuration in infra-core.
+- [ ] **[MUST]** Confirm release BPMN configuration uses `stable/<minor>` as source branch for minor SHAs and merge-back behavior.
+- [ ] **[MUST]** Start a fresh BPMN instance for the last alpha and minor on the latest process version (avoid stale process instances).
+- [ ] **[MUST]** When starting a minor release BPMN instance, fill code freeze date, and monorepo release start date.
 
-- **Feature Freeze Communication**
-  - The freeze notice should clearly describe not just alpha branch behavior, but expectations for the entire minor release phase (including post-alpha, backports to `stable/<minor>`, etc.).
-  - Current notice is too narrow; see [engineering-processes#712](https://github.com/camunda/zeebe-engineering-processes/pull/712) and [Slack discussion](https://camunda.slack.com/archives/CHY2S7KDJ/p1758632876658599?thread_ts=1757683374.580399&cid=CHY2S7KDJ).
-  - **Action:** Iterate a more generic, minor-release–aware template for next minor releases.
-- **Benchmark Namespace Naming**
-  - Namespace for benchmarks during RCs may become `8-8-0` (when performing RC) instead of the expected `8-8-x`.
-  - Current handling is accepted; document and monitor naming in future minors for reproducibility.
-- **Merge-Back Conflicts**
-  - Merge conflicts can occur when merging the release branch back into `stable/<minor>`, especially due to timing of backports versus release branch changes.
-  - Reference: [Slack thread](https://camunda.slack.com/archives/C06UWQNCU7M/p1760046632109499?thread_ts=1760012606.937389&cid=C06UWQNCU7M)
-  - **Action:** Evaluate sources and refine merge sequencing guidelines.
-- **Heavy Merge-Back CI Load**
-  - Merge-back PRs currently run almost the full test matrix, resulting in long CI runtimes (see [example run](https://github.com/camunda/camunda/actions/runs/18385775955/job/52383810975)).
-  - **Action:** The task https://github.com/camunda/camunda/issues/39659 was created to fix the existing issue and optimize merge-back test scope or introduce selective module test strategies.
-- **Change of source branch**
-  - For 8.8 minor release the source branch `stable/8.8` based on `release-8.8.0-alpha8`
-  - Currently  an automated script decides the source branch for the release type, in case of change in future release process, the code needs to be adjusted [here](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/decide_dev_version_and_is_latest_for_release.bpmn#L39)
-- **Optimize Previous Version Management (8.9+)**
-  - Starting with 8.9, Optimize is included in the monorepo release process (`includeOptimize=true`).
+#### 4. Optimize, Docker images, and artifacts
+
+- [ ] **[MUST]** Confirm Optimize is included for the current minor in monorepo release (`includeOptimize=true`, 8.9+ strategy).
+- [ ] **[MUST]** Ensure stable branches build and publish Optimize Docker images for `<minor>-SNAPSHOT` and release tags.
+- [ ] **[SHOULD]** Verify CPT/integration consumers use existing `<minor>-SNAPSHOT` image names to avoid image-not-found failures.
+
+#### 5. Backports, RCs, and merge-backs
+
+- [ ] **[MUST]** Enforce bug-fix backport rule after last alpha branch cut: fixes merged to `main` must be backported to `stable/<minor>` to ship in that minor.
+- [ ] **[MUST]** For critical fixes after branch cut, backport to both `stable/<minor>` and active alpha/minor release branch; trigger a new RC if needed.
+- [ ] **[SHOULD]** Track minor backports via labels/board to avoid missing required fixes.
+- [ ] **[SHOULD]** Simulate release-branch merge-back to `stable/<minor>` early to detect predictable conflicts.
+
+#### 6. Documentation and communication hygiene
+
+- [ ] **[MUST]** Keep this file current for minor branch strategy, bug-fix backport rules, and feature freeze vs code freeze definitions.
+- [ ] **[MUST]** Keep [Monorepo docs index](./index.md) updated so this checklist remains discoverable as the release SSOT.
+
+#### 7. Watch-outs and sanity checks
+
+- [ ] **[SHOULD]** Watch Zeebe upgrade tests for `SkippedMinorVersion[from=..., to=...]` after version bumps and decide: fix assumptions vs temporary disable with follow-up.
+- [ ] **[SHOULD]** Verify CPT/integration tests pull image tags that exist for `<minor>-SNAPSHOT`.
+- [ ] **[SHOULD]** Before starting a new minor BPMN instance, verify no outdated temporary branch overrides/conditions remain from previous minors.
+
+### Minor Release References
+
+- [Release process documentation](./release.md)
+- [C8 Release Train](https://confluence.camunda.com/spaces/HAN/pages/201853752/C8+Release+Train)
+- [Minor Release Feature Freeze](https://confluence.camunda.com/spaces/HAN/pages/307894801/Minor+Release+Feature+Freeze)
+- [Issue #46249](https://github.com/camunda/camunda/issues/46249)
+- [Issue #40009](https://github.com/camunda/camunda/issues/40009)
+- [Issue #37374](https://github.com/camunda/camunda/issues/37374)
+- [Issue #38074](https://github.com/camunda/camunda/issues/38074)
 
 ### Feature Freeze vs Code Freeze (Minor Releases)
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -289,15 +289,18 @@ Use the following checklist as the operational source of truth for every minor r
 
 Legend:
 
-- **[MUST]** = needed for a functional minor / correct process
-- **[SHOULD]** = strongly recommended, reduces risk and toil
-- **[NICE]** = improvements and automation, can slip if time-boxed
+- **[MUST]** = manual action or validation the MRM is responsible for during this minor release
+- **[TEMP]** = temporary safeguard kept because this step recently failed, is still fragile, or is not automated yet
+- **[SHOULD]** = strongly recommended extra validation that reduces risk and toil
+- **[NICE]** = improvement or automation follow-up that can be time-boxed
+
+The checklist intentionally mixes recurring release-manager responsibilities with temporary safeguards for known weak spots in the current process. Temporary safeguards should be revisited and removed once the underlying process is stable or automated.
 
 ### Minor Release Readiness Checklist
 
 <PersistentTaskListEnabler
   storageKey="minor-release-readiness-checklist"
-  version="1"
+  version="2"
   startHeadingId="minor-release-readiness-checklist"
   endHeadingId="minor-release-references"
 />
@@ -312,7 +315,6 @@ Legend:
 
 - [ ] **[MUST]** Send feature freeze communication before the last alpha using the [feature-freeze template](#feature-freeze-vs-code-freeze-minor-releases) and explicitly state that only bug fixes and stabilization are expected after freeze.
 - [ ] **[MUST]** Create `stable/<minor>` from `main` before the last alpha according to the early-stable strategy (i.e. create the `stable/<minor>` branch before the last alpha and branch all subsequent alpha/RC/final release branches from `stable/<minor>` instead of `main`).
-- [ ] **[MUST]** Create `release-<minor>.0-alphaN` from `stable/<minor>` (not from `main`) for the last alpha.
 - [ ] **[MUST]** Mirror the same strategy in [zeebe-process-test](https://github.com/camunda/zeebe-process-test): create `stable/<minor>` from `main` and align release-branch handling.
 - [ ] **[MUST]** Create `backport stable/<minor>` label in monorepo (and in ZPT where needed).
 - [ ] **[MUST]** Announce stable branch creation and backport procedure (label + `/backport`) in the relevant engineering channels.
@@ -331,15 +333,13 @@ Legend:
 #### 3. CI, protections, and release workflow wiring
 
 - [ ] **[MUST]** Add `stable/<minor>` to `unified-ci-merges-stable-branches` protection/ruleset configuration in infra-core.
-- [ ] **[MUST]** Confirm release BPMN configuration uses `stable/<minor>` as source branch for minor SHAs and merge-back behavior.
-- [ ] **[MUST]** Start a fresh BPMN instance for the last alpha and minor on the latest process version (avoid stale process instances).
-- [ ] **[MUST]** When starting a minor release BPMN instance, fill code freeze date, and monorepo release start date.
+- [ ] **[TEMP]** Confirm release BPMN configuration uses `stable/<minor>` as source branch for minor SHAs and merge-back behavior.
+- [ ] **[TEMP]** When starting a minor release BPMN instance, fill code freeze date, and monorepo release start date.
 
 #### 4. Optimize, Docker images, and artifacts
 
-- [ ] **[MUST]** Confirm Optimize is included for the current minor in monorepo release (`includeOptimize=true`, 8.9+ strategy).
-- [ ] **[MUST]** Ensure stable branches build and publish Optimize Docker images for `<minor>-SNAPSHOT` and release tags.
-- [ ] **[SHOULD]** Verify CPT/integration consumers use existing `<minor>-SNAPSHOT` image names to avoid image-not-found failures.
+- [ ] **[TEMP]** Confirm Optimize is included for the current minor in monorepo release (`includeOptimize=true`, 8.9+ strategy).
+- [ ] **[TEMP]** Ensure stable branches build and publish Optimize Docker images for `<minor>-SNAPSHOT` and release tags.
 
 #### 5. Backports, RCs, and merge-backs
 
@@ -351,7 +351,6 @@ Legend:
 #### 6. Documentation and communication hygiene
 
 - [ ] **[MUST]** Keep this file current for minor branch strategy, bug-fix backport rules, and feature freeze vs code freeze definitions.
-- [ ] **[MUST]** Keep [Monorepo docs index](./index.md) updated so this checklist remains discoverable as the release SSOT.
 
 #### 7. Watch-outs and sanity checks
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -265,6 +265,10 @@ Some tasks during the release process are also taking care of other DRIs. The re
 
 The release manager is currently selected manually for each release.
 
+The acting subject for release-process tasks and checklist items is the Monorepo Release Manager currently on shift when the step becomes due. For minor releases that span multiple monthly rotations, responsibility is handed over as part of the regular shift change together with the current checklist state and any open follow-up items.
+
+The checklist itself is maintained collectively. Every MRM is expected to update it when a gap, obsolete step, or missing safeguard is discovered during their shift so the next handover starts from the latest known process.
+
 _Caveat: Some places still refer to this as “Zeebe release manager” although with 8.6+ the release manager is responsible for multiple components including Zeebe and C8 webapps._
 
 ### Others
@@ -287,76 +291,73 @@ import PersistentTaskListEnabler from '@site/src/components/PersistentTaskListEn
 
 Use the following checklist as the operational source of truth for every minor release.
 
-Legend:
+Ownership model:
 
-- **[MUST]** = manual action or validation the MRM is responsible for during this minor release
-- **[TEMP]** = temporary safeguard kept because this step recently failed, is still fragile, or is not automated yet
-- **[SHOULD]** = strongly recommended extra validation that reduces risk and toil
-- **[NICE]** = improvement or automation follow-up that can be time-boxed
-
-The checklist intentionally mixes recurring release-manager responsibilities with temporary safeguards for known weak spots in the current process. Temporary safeguards should be revisited and removed once the underlying process is stable or automated.
+- The checklist is owned collectively by the MRMs and evolves through updates from each shift.
+- The acting subject for each checklist item is the MRM on shift when that item becomes relevant, not necessarily the MRM who started preparing the minor.
+- Open checklist items and context should be explicitly handed over at monthly MRM rotation.
 
 ### Minor Release Readiness Checklist
 
 <PersistentTaskListEnabler
   storageKey="minor-release-readiness-checklist"
-  version="2"
+  version="3"
   startHeadingId="minor-release-readiness-checklist"
   endHeadingId="minor-release-references"
 />
 
 #### 0. Dates, ownership, and high-level alignment
 
-- [ ] **[MUST]** Confirm official minor release, feature freeze, and code freeze dates from the [C8 Release Train](https://confluence.camunda.com/spaces/HAN/pages/201853752/C8+Release+Train). See [Feature Freeze vs Code Freeze](#feature-freeze-vs-code-freeze-minor-releases) for definitions and timing.
-- [ ] **[MUST]** Confirm the Monorepo Release Manager (MRM) is available for feature freeze week, code freeze / branch creation, and the final RC window.
-- [ ] **[SHOULD]** Check for major holidays during RC and final release weeks, then adjust expectations with release stakeholders.
+- [ ] Confirm official minor release, feature freeze, and code freeze dates from the [C8 Release Train](https://confluence.camunda.com/spaces/HAN/pages/201853752/C8+Release+Train). See [Feature Freeze vs Code Freeze](#feature-freeze-vs-code-freeze-minor-releases) for definitions and timing.
+- [ ] Confirm the Monorepo Release Manager (MRM) is available for feature freeze week, code freeze / branch creation, and the final RC window.
+- [ ] Check for major holidays during RC and final release weeks, then adjust expectations with release stakeholders.
 
 #### 1. Around feature freeze / last alpha (branch strategy)
 
-- [ ] **[MUST]** Send feature freeze communication before the last alpha using the [feature-freeze template](#feature-freeze-vs-code-freeze-minor-releases) and explicitly state that only bug fixes and stabilization are expected after freeze.
-- [ ] **[MUST]** Create `stable/<minor>` from `main` before the last alpha according to the early-stable strategy (i.e. create the `stable/<minor>` branch before the last alpha and branch all subsequent alpha/RC/final release branches from `stable/<minor>` instead of `main`).
-- [ ] **[MUST]** Mirror the same strategy in [zeebe-process-test](https://github.com/camunda/zeebe-process-test): create `stable/<minor>` from `main` and align release-branch handling.
-- [ ] **[MUST]** Create `backport stable/<minor>` label in monorepo (and in ZPT where needed).
-- [ ] **[MUST]** Announce stable branch creation and backport procedure (label + `/backport`) in the relevant engineering channels.
+- [ ] Send feature freeze communication before the last alpha using the [feature-freeze template](#feature-freeze-vs-code-freeze-minor-releases) and explicitly state that only bug fixes and stabilization are expected after freeze.
+- [ ] Create `stable/<minor>` from `main` before the last alpha according to the early-stable strategy (i.e. create the `stable/<minor>` branch before the last alpha and branch all subsequent alpha/RC/final release branches from `stable/<minor>` instead of `main`).
+- [ ] Mirror the same strategy in [zeebe-process-test](https://github.com/camunda/zeebe-process-test): create `stable/<minor>` from `main` and align release-branch handling.
+- [ ] Create `backport stable/<minor>` label in monorepo (and in ZPT where needed).
+- [ ] Announce stable branch creation and backport procedure (label + `/backport`) in the relevant engineering channels.
 
 #### 2. Versioning and branch plumbing (after last alpha branch exists)
 
-- [ ] **[MUST]** On monorepo `main`, bump all `pom.xml` versions to `8.(x+1).0-SNAPSHOT` using:
+- [ ] On monorepo `main`, bump all `pom.xml` versions to `8.(x+1).0-SNAPSHOT` using:
   - `./mvnw release:update-versions -DdevelopmentVersion=8.(x+1).0-SNAPSHOT`
-- [ ] **[MUST]** On ZPT `main`, bump versions to the next minor snapshot line.
-- [ ] **[MUST]** Update upgrade and migration test configuration so the previous minor upgrades to the new minor line.
-- [ ] **[SHOULD]** If Zeebe upgrade tests fail with `SkippedMinorVersion[...]` after bumps, either fix assumptions or temporarily disable with explicit TODO and re-enable after final minor release.
-- [ ] **[MUST]** Confirm artifact expectations:
+- [ ] On ZPT `main`, bump versions to the next minor snapshot line.
+- [ ] Update upgrade and migration test configuration so the previous minor upgrades to the new minor line.
+- [ ] Confirm artifact expectations:
   - `stable/<minor>` produces `<minor>.0-SNAPSHOT`
   - `main` produces `<next-minor>.0-SNAPSHOT` (or generic `SNAPSHOT` where expected)
 
 #### 3. CI, protections, and release workflow wiring
 
-- [ ] **[MUST]** Add `stable/<minor>` to `unified-ci-merges-stable-branches` protection/ruleset configuration in infra-core.
-- [ ] **[TEMP]** Confirm release BPMN configuration uses `stable/<minor>` as source branch for minor SHAs and merge-back behavior.
-- [ ] **[TEMP]** When starting a minor release BPMN instance, fill code freeze date, and monorepo release start date.
+- [ ] Add `stable/<minor>` to `unified-ci-merges-stable-branches` protection/ruleset configuration in infra-core.
+- [ ] Verify release BPMN configuration uses `stable/<minor>` as source branch for minor SHAs and merge-back behavior before running the minor.
+- [ ] Verify code freeze date and monorepo release start date are filled correctly when starting a minor release BPMN instance.
+- [ ] Verify CI / SLO dashboards include `stable/<minor>` and surface regressions for that branch.
+- [ ] Ensure a scheduled release dry-run exists for `stable/<minor>` and is green before starting the minor.
 
 #### 4. Optimize, Docker images, and artifacts
 
-- [ ] **[TEMP]** Confirm Optimize is included for the current minor in monorepo release (`includeOptimize=true`, 8.9+ strategy).
-- [ ] **[TEMP]** Ensure stable branches build and publish Optimize Docker images for `<minor>-SNAPSHOT` and release tags.
+- [ ] Verify Optimize is included for the current minor in monorepo release (`includeOptimize=true`, 8.9+ strategy).
+- [ ] Verify stable branches build and publish Optimize Docker images for `<minor>-SNAPSHOT` and release tags.
 
 #### 5. Backports, RCs, and merge-backs
 
-- [ ] **[MUST]** Enforce bug-fix backport rule after last alpha branch cut: fixes merged to `main` must be backported to `stable/<minor>` to ship in that minor.
-- [ ] **[MUST]** For critical fixes after branch cut, backport to both `stable/<minor>` and active alpha/minor release branch; trigger a new RC if needed.
-- [ ] **[SHOULD]** Track minor backports via labels/board to avoid missing required fixes.
-- [ ] **[SHOULD]** Simulate release-branch merge-back to `stable/<minor>` early to detect predictable conflicts.
+- [ ] Enforce bug-fix backport rule after last alpha branch cut: fixes merged to `main` must be backported to `stable/<minor>` to ship in that minor.
+- [ ] For critical fixes after branch cut, backport to both `stable/<minor>` and active alpha/minor release branch; trigger a new RC if needed.
+- [ ] Track minor backports via labels/board to avoid missing required fixes.
+- [ ] Simulate release-branch merge-back to `stable/<minor>` early to detect predictable conflicts.
 
 #### 6. Documentation and communication hygiene
 
-- [ ] **[MUST]** Keep this file current for minor branch strategy, bug-fix backport rules, and feature freeze vs code freeze definitions.
+- [ ] Keep this file current for minor branch strategy, bug-fix backport rules, and feature freeze vs code freeze definitions.
 
 #### 7. Watch-outs and sanity checks
 
-- [ ] **[SHOULD]** Watch Zeebe upgrade tests for `SkippedMinorVersion[from=..., to=...]` after version bumps and decide: fix assumptions vs temporary disable with follow-up.
-- [ ] **[SHOULD]** Verify CPT/integration tests pull image tags that exist for `<minor>-SNAPSHOT`.
-- [ ] **[SHOULD]** Before starting a new minor BPMN instance, verify no outdated temporary branch overrides/conditions remain from previous minors.
+- [ ] Verify no outdated temporary branch overrides or conditions remain from previous minors before starting a new minor BPMN instance.
+- [ ] Verify preview/smoke-test workflows target `stable/<minor>` with existing `<minor>-SNAPSHOT` images.
 
 ### Minor Release References
 
@@ -367,6 +368,20 @@ The checklist intentionally mixes recurring release-manager responsibilities wit
 - [Issue #40009](https://github.com/camunda/camunda/issues/40009)
 - [Issue #37374](https://github.com/camunda/camunda/issues/37374)
 - [Issue #38074](https://github.com/camunda/camunda/issues/38074)
+
+### Possible Issues When Cutting The Stable Branch
+
+#### Zeebe update tests failing
+
+- Symptom: `IllegalStateException: Snapshot is not compatible with current version: SkippedMinorVersion[from=8.8.0, to=8.10.0]`
+- Context: recurring issue around the stable-branch cut and version-line switch. See Christian's note: "Hi folks, every 6 months the same question..."
+- Known workaround: disable the affected tests with an explicit follow-up and re-enable them after the final minor release is published.
+
+#### CPT integration tests failing
+
+- Symptom: `Can't get Docker image: RemoteDockerImage(imageName=camunda/camunda:8.9-SNAPSHOT)`
+- Context: this happened due to wrong test naming during the stable-branch transition. See Remco's note: `@monorepo-ci-medic Backports to stable/8.9...`
+- Known workaround: there is no generic workaround beyond fixing the incorrect test name or image reference.
 
 ### Feature Freeze vs Code Freeze (Minor Releases)
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -281,6 +281,8 @@ We want the release process for all supported versions 8.6+ to be as similar as 
 
 For CI-related changes, refer to our [CI & Automation documentation](./ci.md) and the [backporting guidelines](./ci.md#backporting-guidelines).
 
+import PersistentTaskListEnabler from '@site/src/components/PersistentTaskListEnabler';
+
 ## Minor Release Considerations
 
 Use the following checklist as the operational source of truth for every minor release.
@@ -292,6 +294,13 @@ Legend:
 - **[NICE]** = improvements and automation, can slip if time-boxed
 
 ### Minor Release Readiness Checklist
+
+<PersistentTaskListEnabler
+  storageKey="minor-release-readiness-checklist"
+  version="1"
+  startHeadingId="minor-release-readiness-checklist"
+  endHeadingId="minor-release-references"
+/>
 
 #### 0. Dates, ownership, and high-level alignment
 

--- a/monorepo-docs-site/src/components/PersistentTaskListEnabler.js
+++ b/monorepo-docs-site/src/components/PersistentTaskListEnabler.js
@@ -1,0 +1,89 @@
+import {useLocation} from '@docusaurus/router';
+import React, {useEffect} from 'react';
+
+const buildItemId = (item, index) => {
+  const normalized = item.textContent?.replace(/\s+/g, ' ').trim() ?? `item-${index}`;
+  let hash = 0;
+  for (let position = 0; position < normalized.length; position += 1) {
+    hash = (hash << 5) - hash + normalized.charCodeAt(position);
+    hash |= 0;
+  }
+  return `${index}-${Math.abs(hash)}`;
+};
+
+const collectCheckboxesBetweenHeadings = (startHeadingId, endHeadingId) => {
+  const startHeading = document.getElementById(startHeadingId);
+  if (!startHeading) {
+    return [];
+  }
+
+  const checkboxes = [];
+  let currentNode = startHeading.nextElementSibling;
+
+  while (currentNode) {
+    if (currentNode.id === endHeadingId) {
+      break;
+    }
+
+    checkboxes.push(
+      ...currentNode.querySelectorAll('li.task-list-item > input[type="checkbox"]'),
+    );
+    currentNode = currentNode.nextElementSibling;
+  }
+
+  return checkboxes;
+};
+
+export default function PersistentTaskListEnabler({
+  storageKey,
+  version = '1',
+  startHeadingId,
+  endHeadingId,
+}) {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const checkboxNodes = collectCheckboxesBetweenHeadings(startHeadingId, endHeadingId);
+    if (checkboxNodes.length === 0) {
+      return undefined;
+    }
+
+    const localStorageKey = `${storageKey}:v${version}`;
+    let persistedState = {};
+    try {
+      const rawState = window.localStorage.getItem(localStorageKey);
+      persistedState = rawState ? JSON.parse(rawState) : {};
+    } catch {
+      persistedState = {};
+    }
+
+    const cleanupHandlers = checkboxNodes.map((checkboxNode, index) => {
+      const listItem = checkboxNode.closest('li');
+      if (!listItem) {
+        return () => {};
+      }
+
+      const itemId = buildItemId(listItem, index);
+      checkboxNode.disabled = false;
+      checkboxNode.checked = Boolean(persistedState[itemId]);
+
+      const onChange = () => {
+        persistedState[itemId] = checkboxNode.checked;
+        window.localStorage.setItem(localStorageKey, JSON.stringify(persistedState));
+      };
+
+      checkboxNode.addEventListener('change', onChange);
+      return () => checkboxNode.removeEventListener('change', onChange);
+    });
+
+    return () => {
+      cleanupHandlers.forEach((cleanupHandler) => cleanupHandler());
+    };
+  }, [endHeadingId, location.pathname, startHeadingId, storageKey, version]);
+
+  return null;
+}


### PR DESCRIPTION
## Description

This pull request significantly improves the documentation for minor release processes in the monorepo by replacing the previous narrative and ad-hoc notes with a structured, actionable Minor Release Readiness Checklist. The checklist clarifies required steps, responsibilities, and critical watch-outs for each minor release, making the process more transparent and reducing the risk of missed actions or confusion.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
