### PR TITLE
fix: nested variable output mapping

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
+import io.camunda.zeebe.msgpack.MsgPackUtil;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.Either;
@@ -133,12 +134,20 @@ public final class BpmnVariableMappingBehavior {
             variables);
       }
 
-      // apply the output mappings
       return expressionProcessor
           .evaluateVariableMappingExpression(
               outputMappingExpression.get(), elementInstanceKey, tenantId)
           .map(
-              result -> {
+              localScopeVars -> {
+                // For multi-instance inner activities, scopeKey == elementInstanceKey.
+                final DirectBuffer resultDoc;
+                if (isMultiInstanceActivity(elementInstanceKey)) {
+                  resultDoc = localScopeVars;
+                } else {
+                  final DirectBuffer parentScopeVars =
+                      variablesState.getVariablesAsDocument(scopeKey);
+                  resultDoc = MsgPackUtil.mergeMsgPackDocuments(parentScopeVars, localScopeVars);
+                }
                 variableBehavior.mergeDocument(
                     scopeKey,
                     processDefinitionKey,
@@ -146,7 +155,7 @@ public final class BpmnVariableMappingBehavior {
                     rootProcessInstanceKey,
                     bpmnProcessId,
                     context.getTenantId(),
-                    result);
+                    resultDoc);
                 return null;
               });
 
@@ -183,9 +192,13 @@ public final class BpmnVariableMappingBehavior {
 
     // an inner multi-instance activity needs to read from/write to its own scope
     // to access the input and output element variables
-    final var isMultiInstanceActivity =
-        elementInstanceState.getInstance(elementInstanceKey).getMultiInstanceLoopCounter() > 0;
-    return isMultiInstanceActivity ? elementInstanceKey : context.getFlowScopeKey();
+    return isMultiInstanceActivity(elementInstanceKey)
+        ? elementInstanceKey
+        : context.getFlowScopeKey();
+  }
+
+  private boolean isMultiInstanceActivity(final long elementInstanceKey) {
+    return elementInstanceState.getInstance(elementInstanceKey).getMultiInstanceLoopCounter() > 0;
   }
 
   private boolean isConnectedToEventBasedGateway(final ExecutableFlowNode element) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -51,28 +51,35 @@ import java.util.stream.Collectors;
  *   }
  * </pre>
  *
- * <p>Output variable mappings differ from input mappings that the result variables needs to be
- * merged with the existing variables if the variable is a JSON object. The merging is done by
- * calling the FEEL function 'context merge()' and referencing the variable.
+ * <p>Output variable mappings build up a {@code _camunda_output_context} context incrementally
+ * using {@code context put()}. Each mapping first assigns the source expression to a local variable
+ * (so that subsequent mappings can reference it), then adds that variable to the accumulating
+ * {@code _camunda_output_context} context.
  *
  * <pre>
  *   {
  *     a: x,
- *     b: if (b = null)
- *        then {
- *          c: y,
- *          d: z
- *        }
- *        else context merge(b, {
- *          c: y,
- *          d: z
- *       })
- *   }
+ *     _camunda_output_context: context put({}, "a", a),
+ *     b: a + 1,
+ *     _camunda_output_context: context put(_camunda_output_context, "b", b)
+ *   }._camunda_output_context
+ * </pre>
+ *
+ * <p>For nested target paths (e.g. {@code b.c}), {@code context put()} is called with a path list:
+ *
+ * <pre>
+ *   {
+ *     c: y,
+ *     _camunda_output_context: context put({}, ["b","c"], c),
+ *     d: z,
+ *     _camunda_output_context: context put(_camunda_output_context, ["b","d"], d)
+ *   }._camunda_output_context
  * </pre>
  */
 public final class VariableMappingTransformer {
 
   private static final String EXPRESSION_MARKER = "=";
+  private static final String RESULT_CONTEXT = "_camunda_output_context";
 
   public Expression transformInputMappings(
       final Collection<? extends ZeebeMapping> inputMappings,
@@ -90,9 +97,51 @@ public final class VariableMappingTransformer {
       final ExpressionLanguage expressionLanguage) {
 
     final var mappings = toMappings(outputMappings, expressionLanguage);
-    final var context = asContext(mappings);
-    final var contextExpression = asFeelContextExpression(context, this::mergeContextExpression);
-    return parseExpression(contextExpression, expressionLanguage);
+
+    return buildLocalOutputMappingExpression(mappings, expressionLanguage);
+  }
+
+  private Expression buildLocalOutputMappingExpression(
+      final List<Mapping> mappings, final ExpressionLanguage expressionLanguage) {
+
+    if (mappings.isEmpty()) {
+      return parseExpression("{}", expressionLanguage);
+    }
+
+    final var sb = new StringBuilder("{");
+
+    for (int i = 0; i < mappings.size(); i++) {
+      final var mapping = mappings.get(i);
+      final var parts = splitPathExpression(mapping.target);
+      final var sourceExpr = formatSourceExpression(mapping.source);
+      final var base = (i == 0) ? "{}" : RESULT_CONTEXT;
+      final var targetName = parts.getLast();
+
+      if (i > 0) {
+        sb.append(",");
+      }
+
+      // First, assign the variable so it's available in context for subsequent expressions
+      sb.append(String.format("%s:%s,", targetName, sourceExpr));
+
+      // Then, add it to the _camunda_output_context context referencing the just-assigned variable
+      if (parts.size() == 1) {
+        sb.append(
+            String.format(
+                "%s:context put(%s,\"%s\",%s)",
+                RESULT_CONTEXT, base, parts.getFirst(), targetName));
+      } else {
+        final var pathList =
+            parts.stream().map(p -> "\"" + p + "\"").collect(Collectors.joining(","));
+        sb.append(
+            String.format(
+                "%s:context put(%s,[%s],%s)", RESULT_CONTEXT, base, pathList, targetName));
+      }
+    }
+
+    sb.append(String.format("}.%s", RESULT_CONTEXT));
+
+    return parseExpression(sb.toString(), expressionLanguage);
   }
 
   private List<Mapping> toMappings(
@@ -155,18 +204,7 @@ public final class VariableMappingTransformer {
     return new MappingContextVisitor<>() {
       @Override
       public String onEntry(final String targetKey, final Expression sourceExpression) {
-        final String expression;
-
-        if (sourceExpression instanceof StaticExpression) {
-          // due to a regression (https://github.com/camunda/camunda/issues/16043) all the double
-          // quotes inside the static expression must be escaped
-          expression =
-              String.format("\"%s\"", sourceExpression.getExpression().replaceAll("\"", "\\\\\""));
-        } else {
-          expression = sourceExpression.getExpression();
-        }
-
-        return targetKey + ":" + expression;
+        return targetKey + ":" + formatSourceExpression(sourceExpression);
       }
 
       @Override
@@ -182,15 +220,13 @@ public final class VariableMappingTransformer {
     };
   }
 
-  private String mergeContextExpression(
-      final String nestedContext, final List<String> contextPath) {
-    // for a nested target mapping 'x -> a.b', append the nested property 'b' to
-    // the existing context variable 'a' (instead of overriding 'a')
-    // example: x = 1 and a = {'c':2} results in a = {'b':1, 'c':2}
-    final var existingContext = String.join(".", contextPath);
-    return String.format(
-        "if (%s != null) then context merge(%s,%s) else %s",
-        existingContext, existingContext, nestedContext, nestedContext);
+  private static String formatSourceExpression(final Expression sourceExpression) {
+    if (sourceExpression instanceof StaticExpression) {
+      // due to a regression (https://github.com/camunda/camunda/issues/16043) all the double
+      // quotes inside the static expression must be escaped
+      return String.format("\"%s\"", sourceExpression.getExpression().replaceAll("\"", "\\\\\""));
+    }
+    return sourceExpression.getExpression();
   }
 
   private Expression parseExpression(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTaskElementsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerTaskElementsTest.java
@@ -584,7 +584,7 @@ public class ExecutionListenerTaskElementsTest {
           .hasErrorType(ErrorType.IO_MAPPING_ERROR)
           .hasErrorMessage(
               """
-                Assertion failure on evaluate the expression '{o_var_1:assert(some_var, some_var != null)}': \
+                Assertion failure on evaluate the expression '{o_var_1:assert(some_var, some_var != null),_camunda_output_context:context put({},"o_var_1",o_var_1)}._camunda_output_context': \
                 The condition is not fulfilled The evaluation reported the following warnings:
                 [NO_VARIABLE_FOUND] No variable found with name 'some_var'
                 [NO_VARIABLE_FOUND] No variable found with name 'some_var'

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/MsgPackDocumentMergeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/MsgPackDocumentMergeTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
+import static io.camunda.zeebe.test.util.MsgPackUtil.assertEquality;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import io.camunda.zeebe.msgpack.MsgPackUtil;
+import java.util.stream.Stream;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit tests for {@link MsgPackUtil#mergeMsgPackDocuments(DirectBuffer, DirectBuffer)}.
+ *
+ * <p>These tests verify the deep-merge semantics at the MsgPack binary level, independently of FEEL
+ * expression evaluation or engine integration. They guard against regressions in:
+ *
+ * <ul>
+ *   <li>Content-based key comparison (ByteBuffer vs UnsafeBuffer equality)
+ *   <li>Recursive merging of nested map values
+ *   <li>Override-wins semantics for leaf values
+ *   <li>Preservation of base-only keys at every nesting level
+ * </ul>
+ */
+class MsgPackDocumentMergeTest {
+
+  static Stream<Arguments> shouldMergeDocuments() {
+    return Stream.of(
+        // Flat map merging
+        Arguments.of(
+            Named.of("should return base when override is empty", "{'a':1,'b':2}"),
+            "{}",
+            "{'a':1,'b':2}"),
+        Arguments.of(
+            Named.of("should return override when base is empty", "{}"), "{'x':10}", "{'x':10}"),
+        Arguments.of(Named.of("should merge disjoint keys", "{'a':1}"), "{'b':2}", "{'a':1,'b':2}"),
+        Arguments.of(
+            Named.of("should override matching leaf keys", "{'a':1,'b':2}"),
+            "{'a':99}",
+            "{'a':99,'b':2}"),
+        Arguments.of(
+            Named.of("should override all matching keys", "{'a':1,'b':2,'c':3}"),
+            "{'a':10,'b':20,'c':30}",
+            "{'a':10,'b':20,'c':30}"),
+        Arguments.of(
+            Named.of("should handle string values", "{'name':'Alice','role':'admin'}"),
+            "{'name':'Bob'}",
+            "{'name':'Bob','role':'admin'}"),
+
+        // One-level nested map merging
+        Arguments.of(
+            Named.of(
+                "should deep merge nested maps preserving base-only keys",
+                "{'data':{'a':1,'b':2}}"),
+            "{'data':{'c':3}}",
+            "{'data':{'a':1,'b':2,'c':3}}"),
+        Arguments.of(
+            Named.of("should deep merge overriding matching nested keys", "{'data':{'a':1,'b':2}}"),
+            "{'data':{'b':99}}",
+            "{'data':{'a':1,'b':99}}"),
+        Arguments.of(
+            Named.of(
+                "should preserve sibling map when only one branch is overridden",
+                "{'processData':{'salary':{'beneficial':2},'humanTask':{'outcome':'OLD'}}}"),
+            "{'processData':{'humanTask':{'outcome':'NEW'}}}",
+            "{'processData':{'salary':{'beneficial':2},'humanTask':{'outcome':'NEW'}}}"),
+
+        // Multi-level deep nesting
+        Arguments.of(
+            Named.of("should deep merge at three levels", "{'a':{'b':{'c':1,'d':2},'e':3}}"),
+            "{'a':{'b':{'c':99}}}",
+            "{'a':{'b':{'c':99,'d':2},'e':3}}"),
+        Arguments.of(
+            Named.of(
+                "should deep merge at four levels",
+                "{'l1':{'l2':{'l3':{'l4_a':'keep','l4_b':'keep'},'l3_sib':'keep'}}}"),
+            "{'l1':{'l2':{'l3':{'l4_a':'changed'}}}}",
+            "{'l1':{'l2':{'l3':{'l4_a':'changed','l4_b':'keep'},'l3_sib':'keep'}}}"),
+
+        // Mixed value types
+        Arguments.of(
+            Named.of("should override map with scalar", "{'x':{'nested':1}}"),
+            "{'x':42}",
+            "{'x':42}"),
+        Arguments.of(
+            Named.of("should override scalar with map", "{'x':42}"),
+            "{'x':{'nested':1}}",
+            "{'x':{'nested':1}}"),
+        Arguments.of(
+            Named.of(
+                "should handle array values (replace entirely)", "{'arr':[1,2],'other':'keep'}"),
+            "{'arr':[3,4,5]}",
+            "{'arr':[3,4,5],'other':'keep'}"),
+        Arguments.of(
+            Named.of("should handle boolean values", "{'active':false,'name':'test'}"),
+            "{'active':true}",
+            "{'active':true,'name':'test'}"),
+        Arguments.of(
+            Named.of("should handle null values", "{'a':1,'b':2}"),
+            "{'a':null}",
+            "{'a':null,'b':2}"),
+
+        // Edge cases
+        Arguments.of(Named.of("should merge two empty documents", "{}"), "{}", "{}"),
+        Arguments.of(
+            Named.of("should merge identical documents", "{'a':1,'b':{'c':2}}"),
+            "{'a':1,'b':{'c':2}}",
+            "{'a':1,'b':{'c':2}}"),
+        Arguments.of(
+            Named.of("should handle nested empty maps", "{'a':{},'b':{'c':1}}"),
+            "{'a':{'x':1},'b':{}}",
+            "{'a':{'x':1},'b':{'c':1}}"),
+        Arguments.of(
+            Named.of("should handle override adding new nested branch", "{'existing':{'a':1}}"),
+            "{'newBranch':{'x':10}}",
+            "{'existing':{'a':1},'newBranch':{'x':10}}"));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource
+  void shouldMergeDocuments(final String base, final String overrides, final String expected) {
+    // given
+    final DirectBuffer baseDoc = asMsgPack(base);
+    final DirectBuffer overrideDoc = asMsgPack(overrides);
+
+    // when
+    final DirectBuffer merged = MsgPackUtil.mergeMsgPackDocuments(baseDoc, overrideDoc);
+
+    // then
+    assertEquality(merged, expected);
+  }
+
+  @Nested
+  @DisplayName("Large and boundary cases")
+  class LargeAndBoundaryCases {
+
+    @Test
+    @DisplayName("should handle large number of keys")
+    void shouldHandleLargeNumberOfKeys() {
+      // given — 20 keys, override changes only one
+      final var baseJson = new StringBuilder("{");
+      for (int i = 0; i < 20; i++) {
+        if (i > 0) {
+          baseJson.append(",");
+        }
+        baseJson.append("\"k").append(i).append("\":").append(i);
+      }
+      baseJson.append("}");
+
+      final DirectBuffer base = asMsgPack(baseJson.toString());
+      final DirectBuffer overrides = asMsgPack("{\"k10\":999}");
+
+      // when
+      final DirectBuffer merged = MsgPackUtil.mergeMsgPackDocuments(base, overrides);
+
+      // then
+      final var expectedJson = new StringBuilder("{");
+      for (int i = 0; i < 20; i++) {
+        if (i > 0) {
+          expectedJson.append(",");
+        }
+        expectedJson.append("\"k").append(i).append("\":").append(i == 10 ? 999 : i);
+      }
+      expectedJson.append("}");
+      assertEquality(merged, expectedJson.toString());
+    }
+
+    @Test
+    @DisplayName("Deep recursion (999 levels) with siblings preserved at every level")
+    void shouldDeepMerge999LevelsWithSiblingsPreserved() {
+      // given
+      final int depth = 999;
+
+      final var baseJson = new StringBuilder("{");
+      for (int i = 0; i < depth; i++) {
+        if (i > 0) {
+          baseJson.append(",");
+        }
+        baseJson.append("\"l").append(i).append("\":{\"sibling").append(i).append("\":").append(i);
+      }
+      baseJson.append(",\"leaf\":\"old\"");
+      baseJson.append("}".repeat(depth + 1));
+
+      final var overrideJson = new StringBuilder();
+      for (int i = 0; i < depth; i++) {
+        overrideJson.append("{\"l").append(i).append("\":");
+      }
+      overrideJson.append("{\"leaf\":\"new\"}");
+      overrideJson.append("}".repeat(depth));
+
+      final DirectBuffer base = asMsgPack(baseJson.toString());
+      final DirectBuffer overrides = asMsgPack(overrideJson.toString());
+
+      // when
+      final DirectBuffer merged = MsgPackUtil.mergeMsgPackDocuments(base, overrides);
+
+      // then
+      final var expectedJson = new StringBuilder("{");
+      for (int i = 0; i < depth; i++) {
+        if (i > 0) {
+          expectedJson.append(",");
+        }
+        expectedJson
+            .append("\"l")
+            .append(i)
+            .append("\":{\"sibling")
+            .append(i)
+            .append("\":")
+            .append(i);
+      }
+      expectedJson.append(",\"leaf\":\"new\"");
+      expectedJson.append("}".repeat(depth + 1));
+      assertEquality(merged, expectedJson.toString());
+    }
+
+    @Test
+    @DisplayName("Deep recursion (1001 levels) throws StreamConstraintsException")
+    void shouldDeepMerge1001LevelsThrowsStreamConstraintsException() {
+      // given
+      final int depth = 1000;
+
+      final var baseJson = new StringBuilder("{");
+      for (int i = 0; i < depth; i++) {
+        if (i > 0) {
+          baseJson.append(",");
+        }
+        baseJson.append("\"l").append(i).append("\":{\"sibling").append(i).append("\":").append(i);
+      }
+      baseJson.append(",\"leaf\":\"old\"");
+      baseJson.append("}".repeat(depth + 1));
+
+      final String json = baseJson.toString();
+
+      // when / then
+      assertThatThrownBy(() -> asMsgPack(json))
+          .isInstanceOf(RuntimeException.class)
+          .hasCauseInstanceOf(StreamConstraintsException.class);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Parameterized tests for variable output mapping using path-based expression merging.
+ *
+ * <p>Each test deploys a process with an embedded subprocess that completes immediately
+ * (start→end). Output mappings on the subprocess map source expressions to target paths. The engine
+ * deep-merges the result into the parent scope, preserving unmapped sibling keys.
+ */
+@RunWith(Parameterized.class)
+public final class VariableOutputMappingTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final AtomicInteger COUNTER = new AtomicInteger();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Parameterized.Parameter() public String testName;
+
+  @Parameterized.Parameter(1)
+  public String[][] outputMappings;
+
+  @Parameterized.Parameter(2)
+  public String processVariables;
+
+  @Parameterized.Parameter(3)
+  public String expectedVarName;
+
+  @Parameterized.Parameter(4)
+  public String expectedVarValue;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> parameters() {
+    return List.of(
+
+        // ---- Flat output mappings ----
+        new Object[] {
+          "should map flat variable to new name",
+          new String[][] {{"a", "b"}},
+          "{\"a\": 42}",
+          "b",
+          "42"
+        },
+        new Object[] {
+          "should map flat variable to same name",
+          new String[][] {{"b", "a"}},
+          "{\"a\": 1, \"b\": 99}",
+          "a",
+          "99"
+        },
+        new Object[] {
+          "should map multiple flat variables (check first)",
+          new String[][] {{"a", "c"}, {"b", "d"}},
+          "{\"a\": 10, \"b\": 20}",
+          "c",
+          "10"
+        },
+        new Object[] {
+          "should map multiple flat variables (check second)",
+          new String[][] {{"a", "c"}, {"b", "d"}},
+          "{\"a\": 10, \"b\": 20}",
+          "d",
+          "20"
+        },
+        new Object[] {
+          "should map flat variable containing object value",
+          new String[][] {{"a", "b"}},
+          "{\"a\": {\"c\": 1, \"d\": 2}}",
+          "b",
+          "{\"c\":1,\"d\":2}"
+        },
+        new Object[] {
+          "should map computed expression to flat target",
+          new String[][] {{"a + b", "c"}},
+          "{\"a\": 7, \"b\": 3}",
+          "c",
+          "10"
+        },
+        new Object[] {
+          "should map flat string variable",
+          new String[][] {{"a", "b"}},
+          "{\"a\": \"c\"}",
+          "b",
+          "\"c\""
+        },
+        new Object[] {
+          "should map flat boolean variable",
+          new String[][] {{"a", "b"}},
+          "{\"a\": true}",
+          "b",
+          "true"
+        },
+        new Object[] {
+          "should map flat list variable",
+          new String[][] {{"a", "b"}},
+          "{\"a\": [1, 2, 3]}",
+          "b",
+          "[1,2,3]"
+        },
+
+        // ---- Nested output mappings ----
+
+        new Object[] {
+          "should preserve unmapped sibling keys in nested output",
+          new String[][] {{"e", "a.b.c"}, {"f", "a.d.c"}},
+          "{\"a\": {\"g\": {\"c\": 1, \"d\": 2}, \"b\": {\"c\": \"old\"}, \"d\": {\"c\": []}},"
+              + " \"e\": \"new\", \"f\": [\"h\"]}",
+          "a",
+          "{\"g\":{\"c\":1,\"d\":2},\"b\":{\"c\":\"new\"},\"d\":{\"c\":[\"h\"]}}"
+        },
+        new Object[] {
+          "should preserve all siblings when only one nested key is mapped",
+          new String[][] {{"d", "a.c"}},
+          "{\"a\": {\"b\": 1, \"c\": 2}, \"d\": 42}",
+          "a",
+          "{\"b\":1,\"c\":42}"
+        },
+        new Object[] {
+          "should preserve sibling keys at three levels deep",
+          new String[][] {{"e", "a.b.c.d"}},
+          "{\"a\": {\"b\": {\"c\": {\"d\": \"old\", \"f\": \"keep\"}, \"g\": \"untouched\"}},"
+              + " \"e\": \"new\"}",
+          "a",
+          "{\"b\":{\"c\":{\"d\":\"new\",\"f\":\"keep\"},\"g\":\"untouched\"}}"
+        },
+        new Object[] {
+          "should preserve unmapped keys across multiple top-level variables (check a)",
+          new String[][] {{"e", "a.b"}, {"f", "c.d"}},
+          "{\"a\": {\"b\": 1, \"g\": 2}, \"c\": {\"d\": 3, \"h\": 4}, \"e\": 10, \"f\": 20}",
+          "a",
+          "{\"b\":10,\"g\":2}"
+        },
+        new Object[] {
+          "should preserve unmapped keys across multiple top-level variables (check c)",
+          new String[][] {{"e", "a.b"}, {"f", "c.d"}},
+          "{\"a\": {\"b\": 1, \"g\": 2}, \"c\": {\"d\": 3, \"h\": 4}, \"e\": 10, \"f\": 20}",
+          "c",
+          "{\"d\":20,\"h\":4}"
+        },
+        new Object[] {
+          "should apply computed expression to nested target and preserve siblings",
+          new String[][] {{"a + b", "c.d"}},
+          "{\"c\": {\"d\": 0, \"e\": 1}, \"a\": 10, \"b\": 20}",
+          "c",
+          "{\"d\":30,\"e\":1}"
+        },
+        new Object[] {
+          "should create nested structure when parent variable does not exist",
+          new String[][] {{"c", "a.b.d"}},
+          "{\"c\": \"e\"}",
+          "a",
+          "{\"b\":{\"d\":\"e\"}}"
+        },
+        new Object[] {
+          "should map list value into nested target and preserve siblings",
+          new String[][] {{"d", "a.b"}},
+          "{\"a\": {\"b\": [1], \"c\": 2}, \"d\": [1, 2, 3]}",
+          "a",
+          "{\"b\":[1,2,3],\"c\":2}"
+        },
+        new Object[] {
+          "should handle mixed nesting depth mappings",
+          new String[][] {{"e", "a.b"}, {"f", "a.c.d"}},
+          "{\"a\": {\"b\": 0, \"c\": {\"d\": 0, \"g\": 1}, \"h\": 2}, \"e\": 10, \"f\": 20}",
+          "a",
+          "{\"b\":10,\"c\":{\"d\":20,\"g\":1},\"h\":2}"
+        },
+        new Object[] {
+          "should preserve unmapped branches when multiple branches mapped",
+          new String[][] {{"g", "a.b.c"}, {"h", "a.b.d"}, {"i", "a.e.f"}},
+          "{\"a\": {\"b\": {\"c\": 0, \"d\": 0, \"j\": 9}, \"e\": {\"f\": []}, \"k\": {\"l\": 1}},"
+              + " \"g\": 1, \"h\": 2, \"i\": [3]}",
+          "a",
+          "{\"b\":{\"c\":1,\"d\":2,\"j\":9},\"e\":{\"f\":[3]},\"k\":{\"l\":1}}"
+        },
+        new Object[] {
+          "should handle boolean values in nested mapping",
+          new String[][] {{"c", "a.b"}},
+          "{\"a\": {\"b\": false, \"d\": true}, \"c\": true}",
+          "a",
+          "{\"b\":true,\"d\":true}"
+        },
+        new Object[] {
+          "should map from source variable to nested target and preserve siblings",
+          new String[][] {{"c", "a.b"}},
+          "{\"a\": {\"b\": 1, \"d\": 2}, \"c\": 99}",
+          "a",
+          "{\"b\":99,\"d\":2}"
+        },
+        new Object[] {
+          "should map string value into nested target preserving other keys",
+          new String[][] {{"c", "a.b"}},
+          "{\"a\": {\"b\": \"old\", \"d\": \"keep\"}, \"c\": \"new\"}",
+          "a",
+          "{\"b\":\"new\",\"d\":\"keep\"}"
+        });
+  }
+
+  @Test
+  public void shouldApplyOutputMappings() throws Exception {
+    // given
+    final String processId = "proc" + COUNTER.incrementAndGet();
+    final BpmnModelInstance process = buildProcess(processId, outputMappings);
+
+    ENGINE_RULE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(processVariables)
+            .create();
+
+    // when/then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .limit(1)
+        .await();
+
+    final boolean isNewVariable = !OBJECT_MAPPER.readTree(processVariables).has(expectedVarName);
+    final var intent = isNewVariable ? VariableIntent.CREATED : VariableIntent.UPDATED;
+
+    final String actualJson =
+        RecordingExporter.variableRecords(intent)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName(expectedVarName)
+            .getFirst()
+            .getValue()
+            .getValue();
+
+    assertThat(OBJECT_MAPPER.readTree(actualJson))
+        .isEqualTo(OBJECT_MAPPER.readTree(expectedVarValue));
+  }
+
+  private static BpmnModelInstance buildProcess(final String processId, final String[][] mappings) {
+    final var sub = Bpmn.createExecutableProcess(processId).startEvent().subProcess("sub");
+    for (final String[] mapping : mappings) {
+      sub.zeebeOutputExpression(mapping[0], mapping[1]);
+    }
+    return sub.embeddedSubProcess().startEvent().endEvent().subProcessDone().endEvent().done();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -16,12 +16,16 @@ import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
-import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.msgpack.MsgPackUtil;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
 import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,101 +39,136 @@ public final class VariableOutputMappingTransformerTest {
 
   public static Object[][] parametersSuccessfulEvaluationToObject() {
     return new Object[][] {
+      // {mappings, localVars, parentScopeVars, expectedOutput}
       // no mappings
-      {List.of(), Map.of(), "{}"},
+      {List.of(), Map.of(), Map.of(), "{}"},
       // direct mapping
-      {List.of(mapping("x", "x")), Map.of("x", asMsgPack("1")), "{'x':1}"},
-      {List.of(mapping("x", "a")), Map.of("x", asMsgPack("1")), "{'a':1}"},
-      {List.of(mapping("_x", "_b")), Map.of("_x", asMsgPack("1")), "{'_b':1}"},
+      {List.of(mapping("x", "x")), Map.of("x", asMsgPack("1")), Map.of(), "{'x':1}"},
+      {List.of(mapping("x", "a")), Map.of("x", asMsgPack("1")), Map.of(), "{'a':1}"},
+      {List.of(mapping("_x", "_b")), Map.of("_x", asMsgPack("1")), Map.of(), "{'_b':1}"},
       {
         List.of(mapping("x", "a"), mapping("y", "b")),
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),
+        Map.of(),
         "{'a':1, 'b':2}"
       },
-      {List.of(mapping("x", "a")), Map.of("x", asMsgPack("{'y':1}")), "{'a':{'y':1}}"},
+      {List.of(mapping("x", "a")), Map.of("x", asMsgPack("{'y':1}")), Map.of(), "{'a':{'y':1}}"},
       // nested target
-      {List.of(mapping("x", "a.b")), Map.of("x", asMsgPack("1")), "{'a':{'b':1}}"},
+      {List.of(mapping("x", "a.b")), Map.of("x", asMsgPack("1")), Map.of(), "{'a':{'b':1}}"},
       {
         List.of(mapping("x", "a.b"), mapping("y", "a.c")),
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),
+        Map.of(),
         "{'a':{'b':1, 'c':2}}"
       },
-      {List.of(mapping("x", "a.b.c")), Map.of("x", asMsgPack("1")), "{'a':{'b':{'c':1}}}"},
+      {
+        List.of(mapping("x", "a.b.c")), Map.of("x", asMsgPack("1")), Map.of(), "{'a':{'b':{'c':1}}}"
+      },
       {
         List.of(mapping("x", "a.b")),
-        Map.of("x", asMsgPack("1"), "a", asMsgPack("{}")),
+        Map.of("x", asMsgPack("1")),
+        Map.of("a", asMsgPack("{}")),
         "{'a':{'b':1}}"
       },
       // nested source
-      {List.of(mapping("x.y", "a")), Map.of("x", asMsgPack("{'y':1}")), "{'a':1}"},
+      {List.of(mapping("x.y", "a")), Map.of("x", asMsgPack("{'y':1}")), Map.of(), "{'a':1}"},
       {
         List.of(mapping("x.y", "a"), mapping("x.z", "b")),
         Map.of("x", asMsgPack("{'y':1, 'z':2}")),
+        Map.of(),
         "{'a':1, 'b':2}"
       },
       {
         List.of(mapping("x.y", "a.b"), mapping("x.z", "a.c")),
         Map.of("x", asMsgPack("{'y':1, 'z':2}")),
+        Map.of(),
         "{'a': {'b':1, 'c':2}}"
       },
-      // override variable
+      {
+        List.of(mapping("x.y.z", "a.b.c")),
+        Map.of("x", asMsgPack("{'y':{'z':2}, 'w':3}")),
+        Map.of(),
+        "{'a': {'b':{'c':2}}}"
+      },
+      // override variable in parent scope
       {
         List.of(mapping("x", "a")),
-        Map.of("x", asMsgPack("1"), "a", asMsgPack("{'b':2}")),
+        Map.of("x", asMsgPack("1")),
+        Map.of("a", asMsgPack("{'b':2}")),
         "{'a':1}"
       },
-      // merge target with variable
+      // merge target with parent scope variable
       {
         List.of(mapping("x", "a.b")),
-        Map.of("x", asMsgPack("1"), "a", asMsgPack("{'c':2}")),
+        Map.of("x", asMsgPack("1")),
+        Map.of("a", asMsgPack("{'c':2}")),
         "{'a':{'b':1,'c':2}}"
       },
       {
         List.of(mapping("x", "a.b.c")),
-        Map.of("x", asMsgPack("1"), "a", asMsgPack("{'b':{'d':2}, 'e':3}")),
+        Map.of("x", asMsgPack("1")),
+        Map.of("a", asMsgPack("{'b':{'d':2}, 'e':3}")),
         "{'a':{'b':{'c':1, 'd':2}, 'e':3}}"
       },
-      // override nested property
+      // override nested property in parent scope
       {
         List.of(mapping("x", "a.b")),
-        Map.of("x", asMsgPack("1"), "a", asMsgPack("{'b':2}")),
+        Map.of("x", asMsgPack("1")),
+        Map.of("a", asMsgPack("{'b':2}")),
         "{'a':{'b':1}}"
       },
       {
         List.of(mapping("x", "a.b"), mapping("x", "a.c")),
-        Map.of("x", asMsgPack("1"), "a", asMsgPack("{'d':2}")),
+        Map.of("x", asMsgPack("1")),
+        Map.of("a", asMsgPack("{'d':2}")),
         "{'a':{'b':1, 'c':1, 'd':2}}"
+      },
+      {
+        List.of(mapping("x.y.z", "a.b.c")),
+        Map.of("x", asMsgPack("{'y':{'z':4}, 'w':4}")),
+        Map.of("a", asMsgPack("{'b':{'c':3}, 'w':5}")),
+        "{'a': {'b':{'c':4}, 'w':5}}"
       },
       // evaluate mappings in order
       {
         List.of(mapping("x", "a"), mapping("a + 1", "b")),
         Map.of("x", asMsgPack("1")),
+        Map.of(),
         "{'a':1, 'b':2}"
       },
       // override previous mapping
       {
         List.of(mapping("x", "a"), mapping("y", "a")),
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),
+        Map.of(),
         "{'a':2}"
       },
       {
         List.of(mapping("x", "a"), mapping("y", "a.b")),
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),
+        Map.of(),
         "{'a':{'b':2}}"
       },
       // source FEEL expression
-      {List.of(mapping("1", "a")), Map.of(), "{'a':1}"},
-      {List.of(mapping("\"foo\"", "a")), Map.of(), "{'a':'foo'}"},
-      {List.of(mapping("[1,2,3]", "a")), Map.of(), "{'a':[1,2,3]}"},
-      {List.of(mapping("x + y", "a")), Map.of("x", asMsgPack("1"), "y", asMsgPack("2")), "{'a':3}"},
+      {List.of(mapping("1", "a")), Map.of(), Map.of(), "{'a':1}"},
+      {List.of(mapping("\"foo\"", "a")), Map.of(), Map.of(), "{'a':'foo'}"},
+      {List.of(mapping("[1,2,3]", "a")), Map.of(), Map.of(), "{'a':[1,2,3]}"},
+      {
+        List.of(mapping("x + y", "a")),
+        Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),
+        Map.of(),
+        "{'a':3}"
+      },
       {
         List.of(mapping("{x:x, y:y}", "a")),
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),
+        Map.of(),
         "{'a':{'x':1, 'y':2}}"
       },
       {
         List.of(mapping("append(x, y)", "a")),
         Map.of("x", asMsgPack("[1,2]"), "y", asMsgPack("3")),
+        Map.of(),
         "{'a':[1,2,3]}"
       },
     };
@@ -142,17 +181,18 @@ public final class VariableOutputMappingTransformerTest {
         Map.of(),
         """
         Assertion failure on evaluate the expression \
-        '{a:if (a != null) then context merge(a,{b: assert(x, x != null)}) else {b: assert(x, x != null)}}': \
+        '{b: assert(x, x != null),_camunda_output_context:context put({},["a","b"],b)}._camunda_output_context': \
         The condition is not fulfilled"""
       }, // #9543
     };
   }
 
-  @ParameterizedTest(name = "{index}: with {0} to {2}")
+  @ParameterizedTest(name = "{index}: with {0} to {3}")
   @MethodSource("parametersSuccessfulEvaluationToObject")
   public void shouldEvaluateToObject(
       final List<ZeebeMapping> mappings,
-      final Map<String, DirectBuffer> variables,
+      final Map<String, DirectBuffer> localVars,
+      final Map<String, DirectBuffer> parentScopeVars,
       final String expectedOutput) {
     // given
     final var expression = transformer.transformOutputMappings(mappings, expressionLanguage);
@@ -161,14 +201,19 @@ public final class VariableOutputMappingTransformerTest {
         .describedAs("Expected valid expression: %s", expression.getFailureMessage())
         .isTrue();
 
-    // when
+    // when — mirror runtime: evaluate expression against local scope, then merge with parent scope
     final var result =
-        expressionLanguage.evaluateExpression(expression, name -> Either.left(variables.get(name)));
+        expressionLanguage.evaluateExpression(expression, name -> Either.left(localVars.get(name)));
 
     // then
     assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
 
-    MsgPackUtil.assertEquality(result.toBuffer(), expectedOutput);
+    final DirectBuffer localScopeResult = result.toBuffer();
+    final DirectBuffer parentScopeDocument = variablesAsDocument(parentScopeVars);
+    final DirectBuffer merged =
+        MsgPackUtil.mergeMsgPackDocuments(parentScopeDocument, localScopeResult);
+
+    io.camunda.zeebe.test.util.MsgPackUtil.assertEquality(merged, expectedOutput);
   }
 
   @ParameterizedTest(name = "{index}: mapping {0} fails with: {2}")
@@ -192,6 +237,18 @@ public final class VariableOutputMappingTransformerTest {
     assertThat(result.isFailure()).isTrue();
 
     Assertions.assertThat(result.getFailureMessage()).isEqualTo(failureMessage);
+  }
+
+  private static DirectBuffer variablesAsDocument(final Map<String, DirectBuffer> variables) {
+    final var buffer = new ExpandableArrayBuffer();
+    final var writer = new MsgPackWriter();
+    writer.wrap(buffer, 0);
+    writer.writeMapHeader(variables.size());
+    for (final var entry : variables.entrySet()) {
+      writer.writeString(BufferUtil.wrapString(entry.getKey()));
+      writer.writeRaw(entry.getValue());
+    }
+    return new UnsafeBuffer(buffer, 0, writer.getOffset());
   }
 
   private static ZeebeMapping mapping(final String source, final String target) {

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/MsgPackUtil.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/MsgPackUtil.java
@@ -10,13 +10,17 @@ package io.camunda.zeebe.msgpack;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapArray;
 
+import io.camunda.zeebe.msgpack.spec.MsgPackCodes;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackToken;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -50,6 +54,103 @@ public final class MsgPackUtil {
     final MsgPackReader reader = new MsgPackReader();
     reader.wrap(buffer, offset, length);
     return (Map<String, Object>) deserializeElement(reader);
+  }
+
+  /**
+   * Deep-merges two MsgPack map documents.
+   *
+   * <p>Entries from {@code base} are included first, then {@code overrides} are applied. If both
+   * documents contain a map for the same key, the maps are merged recursively. Otherwise, the
+   * override value replaces the base.
+   *
+   * <p>Keys are compared using {@link ByteBuffer}, which uses content-based equality (unlike {@link
+   * UnsafeBuffer}, which uses reference identity).
+   */
+  public static DirectBuffer mergeMsgPackDocuments(
+      final DirectBuffer base, final DirectBuffer overrides) {
+    final Map<ByteBuffer, DirectBuffer> baseEntries = new LinkedHashMap<>();
+    readMsgPackMapEntries(base, baseEntries);
+
+    final Map<ByteBuffer, DirectBuffer> overrideEntries = new LinkedHashMap<>();
+    readMsgPackMapEntries(overrides, overrideEntries);
+
+    // Deep merge: start with base, apply overrides
+    final Map<ByteBuffer, DirectBuffer> merged = new LinkedHashMap<>(baseEntries);
+    for (final var entry : overrideEntries.entrySet()) {
+      final ByteBuffer key = entry.getKey();
+      final DirectBuffer overrideValue = entry.getValue();
+      final DirectBuffer baseValue = merged.get(key);
+
+      if (baseValue != null && isMsgPackMap(baseValue) && isMsgPackMap(overrideValue)) {
+        // Both values are maps — recursively deep-merge them
+        merged.put(key, mergeMsgPackDocuments(baseValue, overrideValue));
+      } else {
+        // Override replaces base (or key only exists in override)
+        merged.put(key, overrideValue);
+      }
+    }
+
+    return writeMsgPackMap(merged);
+  }
+
+  /** Checks whether the given MsgPack-encoded value starts with a map header. */
+  private static boolean isMsgPackMap(final DirectBuffer value) {
+    if (value.capacity() == 0) {
+      return false;
+    }
+    final byte header = value.getByte(0);
+    return MsgPackCodes.isFixedMap(header)
+        || header == MsgPackCodes.MAP16
+        || header == MsgPackCodes.MAP32;
+  }
+
+  /**
+   * Writes a map of raw MsgPack key-value pairs into a single MsgPack map document. Keys are stored
+   * as {@link ByteBuffer} for reliable content-based equality; each key's backing byte array is
+   * written directly as raw MsgPack bytes.
+   */
+  private static DirectBuffer writeMsgPackMap(final Map<ByteBuffer, DirectBuffer> entries) {
+    final var resultBuffer = new ExpandableArrayBuffer();
+    final var writer = new MsgPackWriter();
+    writer.wrap(resultBuffer, 0);
+
+    writer.writeMapHeader(entries.size());
+    for (final var entry : entries.entrySet()) {
+      final ByteBuffer key = entry.getKey();
+      writer.writeRaw(new UnsafeBuffer(key.array(), key.arrayOffset(), key.remaining()));
+      writer.writeRaw(entry.getValue());
+    }
+
+    return new UnsafeBuffer(resultBuffer, 0, writer.getOffset());
+  }
+
+  /**
+   * Reads all key-value entries from a MsgPack map document and puts them into the given map. Each
+   * key is extracted as a {@link ByteBuffer} (content-based equality) and each value as a cloned
+   * {@link DirectBuffer} containing the raw MsgPack-encoded bytes. If a key already exists in the
+   * map it is overwritten.
+   */
+  private static void readMsgPackMapEntries(
+      final DirectBuffer document, final Map<ByteBuffer, DirectBuffer> entries) {
+    final var reader = new MsgPackReader();
+    reader.wrap(document, 0, document.capacity());
+
+    final int mapSize = reader.readMapHeader();
+    for (int i = 0; i < mapSize; i++) {
+      final int keyStart = reader.getOffset();
+      reader.skipValue();
+      final int keyEnd = reader.getOffset();
+      final var keyBytes = new byte[keyEnd - keyStart];
+      document.getBytes(keyStart, keyBytes, 0, keyEnd - keyStart);
+
+      final int valueStart = reader.getOffset();
+      reader.skipValue();
+      final int valueEnd = reader.getOffset();
+      final var valueBuffer = new UnsafeBuffer(new byte[valueEnd - valueStart]);
+      document.getBytes(valueStart, valueBuffer, 0, valueEnd - valueStart);
+
+      entries.put(ByteBuffer.wrap(keyBytes), valueBuffer);
+    }
   }
 
   private static Object deserializeElement(final MsgPackReader reader) {


### PR DESCRIPTION
### Problem
Using FEEL `context merge()` with the local scope variable here (previous implementation) would pull all local scope fields, **including unmapped ones**, into the output, leaking them into the parent scope.

### Suggested Fix
Alter `transformOutputMappings` to use a flat/path-based way to create `Expression` instead of tree-based.
Then evaluate expression and merge with parent scope variables from state.

With more details
1. alter `transformOutputMappings` to create Expression using `context put()`
2. use parent scope variables from state to get DirectBuffer
3. evaluate 1. Expression to identify output mappings from local scope variables 
5. merge 2. and 3. DirectBuffer -- goal: parent ones and local only existing in output mapping overriding
6. `mergeDocument()`

### Notes
- `VariableOutputMappingTransformerTest` had to be updated since final outcome is not based on a single expression evaluation from local scope, but also taking into consideration parent scope variables and merging at `BpmnVariableMappingBehavior#applyOutputMappings`
- `MultiInstanceCallActivityTest` brought up a bug -- multi instance scopeKey == elementInstanceKey are the same -- no merging needed

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related links

- relates #35251
- [#ask-orchestration-cluster](https://camunda.slack.com/archives/C08MRKHJ0CD/p1774970082930999)
- [#nested-output-mapping-fix](https://camunda.slack.com/archives/C0AT8KNG494)
- FEEL Expression playground ([ref](https://camunda.github.io/feel-scala/docs/playground/))