### PR TITLE
perf: serialize json into buffer directly

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -243,7 +243,6 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -255,7 +254,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -289,7 +289,8 @@ public class CamundaExporter implements Exporter {
 
   private void setupExporterResources() {
     metrics = new CamundaExporterMetrics(context.getMeterRegistry(), context.clock());
-    clientAdapter = ClientAdapter.of(configuration.getConnect());
+    clientAdapter =
+        ClientAdapter.of(configuration.getConnect(), configuration.getBulk().isUseStreamingBulk());
     if (metadata == null) {
       metadata = new ExporterMetadata(clientAdapter.objectMapper());
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ClientAdapter.java
@@ -18,9 +18,15 @@ import java.io.IOException;
 public interface ClientAdapter extends AutoCloseable {
 
   static ClientAdapter of(final ConnectConfiguration configuration) {
+    return of(configuration, false);
+  }
+
+  static ClientAdapter of(
+      final ConnectConfiguration configuration, final boolean useStreamingRequest) {
     final var databaseType = configuration.getTypeEnum();
     return switch (databaseType) {
-      case DatabaseType.ELASTICSEARCH -> new ElasticsearchAdapter(configuration);
+      case DatabaseType.ELASTICSEARCH ->
+          new ElasticsearchAdapter(configuration, useStreamingRequest);
       case DatabaseType.OPENSEARCH -> new OpensearchAdapter(configuration);
       default -> throw new IllegalArgumentException("Unsupported databaseType: " + databaseType);
     };

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.adapters;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
@@ -18,6 +20,7 @@ import io.camunda.exporter.cache.form.ElasticSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.ElasticSearchProcessCacheLoader;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.ElasticsearchBatchRequest;
+import io.camunda.exporter.store.StreamingElasticsearchBatchRequest;
 import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
@@ -26,19 +29,27 @@ import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import java.io.IOException;
+import org.elasticsearch.client.RestClient;
 
 class ElasticsearchAdapter implements ClientAdapter {
   private final ElasticsearchClient client;
   private final ElasticsearchEngineClient searchEngineClient;
   private final ElasticsearchExporterEntityCacheProvider entityCacheLoader;
   private final ObjectMapper objectMapper;
+  private final RestClient restClient;
+  private final JsonpMapper jsonpMapper;
+  private final boolean useStreamingBulk;
 
-  ElasticsearchAdapter(final ConnectConfiguration configuration) {
+  ElasticsearchAdapter(final ConnectConfiguration configuration, final boolean useStreamingBulk) {
+    this.useStreamingBulk = useStreamingBulk;
     final var connector = new ElasticsearchConnector(configuration);
     client = connector.createClient();
     objectMapper = connector.objectMapper();
     searchEngineClient = new ElasticsearchEngineClient(client, objectMapper);
     entityCacheLoader = new ElasticsearchExporterEntityCacheProvider(client);
+    final var transport = (RestClientTransport) client._transport();
+    restClient = transport.restClient();
+    jsonpMapper = client._jsonpMapper();
   }
 
   @Override
@@ -53,6 +64,14 @@ class ElasticsearchAdapter implements ClientAdapter {
 
   @Override
   public BatchRequest createBatchRequest() {
+    if (useStreamingBulk) {
+      return new StreamingElasticsearchBatchRequest(
+          restClient,
+          jsonpMapper,
+          objectMapper,
+          new BulkRequest.Builder(),
+          new ElasticsearchScriptBuilder());
+    }
     return new ElasticsearchBatchRequest(
         client, new BulkRequest.Builder(), new ElasticsearchScriptBuilder());
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -158,6 +158,7 @@ public class ExporterConfiguration {
     private int size = 5_000;
     // bulk memory utilisation before flush (in Mb)
     private int memoryLimit = 20;
+    private boolean useStreamingBulk = false;
 
     public int getDelay() {
       return delay;
@@ -175,6 +176,14 @@ public class ExporterConfiguration {
       this.size = size;
     }
 
+    public boolean isUseStreamingBulk() {
+      return useStreamingBulk;
+    }
+
+    public void setUseStreamingBulk(final boolean useStreamingBulk) {
+      this.useStreamingBulk = useStreamingBulk;
+    }
+
     @Override
     public String toString() {
       return "BulkConfiguration{"
@@ -184,6 +193,8 @@ public class ExporterConfiguration {
           + size
           + ", memoryLimit="
           + memoryLimit
+          + ", useStreamingBulk="
+          + useStreamingBulk
           + '}';
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -56,11 +56,6 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public void executeWithRefresh() throws PersistenceException {
-    execute(null, true);
-  }
-
-  @Override
   public BatchRequest add(final String index, final ExporterEntity entity) {
     return addWithId(index, entity.getId(), entity);
   }
@@ -246,6 +241,11 @@ public class ElasticsearchBatchRequest implements BatchRequest {
     execute(customErrorHandlers, false);
   }
 
+  @Override
+  public void executeWithRefresh() throws PersistenceException {
+    execute(null, true);
+  }
+
   private void execute(
       final BiConsumer<String, Error> customErrorHandlers, final boolean shouldRefresh)
       throws PersistenceException {
@@ -323,7 +323,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
         });
   }
 
-  protected record ErrorValues(List<String> indexes, List<String> ids) {}
+  private record ErrorValues(List<String> indexes, List<String> ids) {}
 
-  protected record ErrorKey(OperationType operationType, String errorReason) {}
+  private record ErrorKey(OperationType operationType, String errorReason) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -33,10 +33,12 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   public static final int UPDATE_RETRY_COUNT = 3;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchBatchRequest.class);
+
+  protected final BulkRequest.Builder bulkRequestBuilder;
+  protected final ElasticsearchScriptBuilder scriptBuilder;
+  protected CamundaExporterMetrics metrics;
+
   private final ElasticsearchClient esClient;
-  private final BulkRequest.Builder bulkRequestBuilder;
-  private final ElasticsearchScriptBuilder scriptBuilder;
-  private CamundaExporterMetrics metrics;
 
   public ElasticsearchBatchRequest(
       final ElasticsearchClient esClient,
@@ -51,6 +53,11 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   public BatchRequest withMetrics(final CamundaExporterMetrics metrics) {
     this.metrics = metrics;
     return this;
+  }
+
+  @Override
+  public void executeWithRefresh() throws PersistenceException {
+    execute(null, true);
   }
 
   @Override
@@ -239,11 +246,6 @@ public class ElasticsearchBatchRequest implements BatchRequest {
     execute(customErrorHandlers, false);
   }
 
-  @Override
-  public void executeWithRefresh() throws PersistenceException {
-    execute(null, true);
-  }
-
   private void execute(
       final BiConsumer<String, Error> customErrorHandlers, final boolean shouldRefresh)
       throws PersistenceException {
@@ -267,7 +269,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
     }
   }
 
-  private void validateNoErrors(
+  protected void validateNoErrors(
       final List<BulkResponseItem> items, final BiConsumer<String, Error> customErrorHandlers) {
     final var errorItems = items.stream().filter(item -> item.error() != null).toList();
     if (errorItems.isEmpty()) {
@@ -321,7 +323,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
         });
   }
 
-  private record ErrorValues(List<String> indexes, List<String> ids) {}
+  protected record ErrorValues(List<String> indexes, List<String> ids) {}
 
-  private record ErrorKey(OperationType operationType, String errorReason) {}
+  protected record ErrorKey(OperationType operationType, String errorReason) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import co.elastic.clients.elasticsearch._types.ErrorCause;
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.NdJsonpSerializable;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.errorhandling.Error;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
+import jakarta.json.stream.JsonGenerator;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiConsumer;
+import org.apache.http.entity.EntityTemplate;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Executes bulk requests by streaming NDJSON directly to the HTTP socket via the low-level {@link
+ * RestClient}, eliminating intermediate byte[] allocations.
+ *
+ * <p>This approach was originally used in the old Zeebe Elasticsearch exporter. See {@code
+ * io.camunda.zeebe.exporter.ElasticsearchClient} and {@code
+ * io.camunda.zeebe.exporter.BulkIndexRequest} in the {@code elasticsearch-exporter} module for the
+ * reference implementation using {@link org.apache.http.entity.ContentProducer}.
+ */
+public final class StreamingElasticsearchBatchRequest extends ElasticsearchBatchRequest {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(StreamingElasticsearchBatchRequest.class);
+
+  private final RestClient restClient;
+  private final JsonpMapper jsonpMapper;
+  private final ObjectMapper objectMapper;
+
+  public StreamingElasticsearchBatchRequest(
+      final RestClient restClient,
+      final JsonpMapper jsonpMapper,
+      final ObjectMapper objectMapper,
+      final BulkRequest.Builder bulkRequestBuilder,
+      final ElasticsearchScriptBuilder scriptBuilder) {
+    super(null, bulkRequestBuilder, scriptBuilder);
+    this.restClient = restClient;
+    this.jsonpMapper = jsonpMapper;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void executeWithRefresh() throws PersistenceException {
+    executeStreaming(null, true);
+  }
+
+  @Override
+  public void execute(final BiConsumer<String, Error> customErrorHandlers)
+      throws PersistenceException {
+    executeStreaming(customErrorHandlers, false);
+  }
+
+  private void executeStreaming(
+      final BiConsumer<String, Error> customErrorHandlers, final boolean shouldRefresh)
+      throws PersistenceException {
+    if (shouldRefresh) {
+      bulkRequestBuilder.refresh(Refresh.True);
+    }
+    final var bulkRequest = bulkRequestBuilder.build();
+    if (bulkRequest.operations().isEmpty()) {
+      return;
+    }
+
+    try {
+      final EntityTemplate entity = new EntityTemplate(out -> writeNdJson(out, bulkRequest));
+      entity.setContentType("application/x-ndjson");
+      final Request request = new Request("POST", "/_bulk");
+      request.setEntity(entity);
+      final var response = restClient.performRequest(request);
+
+      final BulkIndexResponse bulkIndexResponse;
+      try (final var responseStream = response.getEntity().getContent()) {
+        bulkIndexResponse = objectMapper.readValue(responseStream, BulkIndexResponse.class);
+      }
+
+      if (bulkIndexResponse.errors()) {
+        final List<BulkResponseItem> items = toBulkResponseItems(bulkIndexResponse);
+        validateNoErrors(items, customErrorHandlers);
+      }
+      if (metrics != null) {
+        metrics.recordBulkOperations(bulkRequest.operations().size());
+      }
+    } catch (final Exception ex) {
+      throw new PersistenceException(
+          "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
+    }
+  }
+
+  /**
+   * Writes the request as NDJson lines. Taken from {@link
+   * co.elastic.clients.transport.ElasticsearchTransportBase#collectNdJsonLines}
+   */
+  private void writeNdJson(final OutputStream out, final NdJsonpSerializable value)
+      throws IOException {
+    final Iterator<?> it = value._serializables();
+    while (it.hasNext()) {
+      final Object item = it.next();
+      if (item == null) {
+        continue;
+      }
+      if (item instanceof NdJsonpSerializable nested && nested != value) {
+        writeNdJson(out, nested);
+      } else {
+        final JsonGenerator generator = jsonpMapper.jsonProvider().createGenerator(out);
+        jsonpMapper.serialize(item, generator);
+        generator.flush();
+        out.write('\n');
+      }
+    }
+  }
+
+  /** Maps our DTO items to the ES client's {@link BulkResponseItem} to reuse error handling. */
+  private List<BulkResponseItem> toBulkResponseItems(final BulkIndexResponse response) {
+    return response.items().stream()
+        .map(
+            item -> {
+              final var detail = item.detail();
+              if (detail == null) {
+                return null;
+              }
+              return BulkResponseItem.of(
+                  b -> {
+                    b.index(detail._index()).id(detail._id()).status(detail.status());
+                    if (detail.error() != null) {
+                      b.error(
+                          ErrorCause.of(
+                              e -> e.type(detail.error().type()).reason(detail.error().reason())));
+                    }
+                    return b;
+                  });
+            })
+        .filter(item -> item != null)
+        .toList();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequest.java
@@ -61,14 +61,14 @@ public final class StreamingElasticsearchBatchRequest extends ElasticsearchBatch
   }
 
   @Override
-  public void executeWithRefresh() throws PersistenceException {
-    executeStreaming(null, true);
-  }
-
-  @Override
   public void execute(final BiConsumer<String, Error> customErrorHandlers)
       throws PersistenceException {
     executeStreaming(customErrorHandlers, false);
+  }
+
+  @Override
+  public void executeWithRefresh() throws PersistenceException {
+    executeStreaming(null, true);
   }
 
   private void executeStreaming(
@@ -77,10 +77,8 @@ public final class StreamingElasticsearchBatchRequest extends ElasticsearchBatch
     if (shouldRefresh) {
       bulkRequestBuilder.refresh(Refresh.True);
     }
+
     final var bulkRequest = bulkRequestBuilder.build();
-    if (bulkRequest.operations().isEmpty()) {
-      return;
-    }
 
     try {
       final EntityTemplate entity = new EntityTemplate(out -> writeNdJson(out, bulkRequest));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequest.java
@@ -7,24 +7,25 @@
  */
 package io.camunda.exporter.store;
 
-import co.elastic.clients.elasticsearch._types.ErrorCause;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
-import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.NdJsonpSerializable;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
-import java.util.List;
 import java.util.function.BiConsumer;
 import org.apache.http.entity.EntityTemplate;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,16 +87,21 @@ public final class StreamingElasticsearchBatchRequest extends ElasticsearchBatch
       entity.setContentType("application/x-ndjson");
       final Request request = new Request("POST", "/_bulk");
       request.setEntity(entity);
-      final var response = restClient.performRequest(request);
+      final Response response = restClient.performRequest(request);
 
-      final BulkIndexResponse bulkIndexResponse;
+      // Buffer the response bytes so we can do a two-pass parse: first only the "errors" flag,
+      // then the full response with all items only when there are actual errors.
+      final byte[] responseBody;
       try (final var responseStream = response.getEntity().getContent()) {
-        bulkIndexResponse = objectMapper.readValue(responseStream, BulkIndexResponse.class);
+        responseBody = responseStream.readAllBytes();
       }
 
-      if (bulkIndexResponse.errors()) {
-        final List<BulkResponseItem> items = toBulkResponseItems(bulkIndexResponse);
-        validateNoErrors(items, customErrorHandlers);
+      final var summary = objectMapper.readValue(responseBody, BulkErrorSummary.class);
+      if (summary.errors()) {
+        final var parser =
+            jsonpMapper.jsonProvider().createParser(new ByteArrayInputStream(responseBody));
+        final var bulkIndexResponse = BulkResponse._DESERIALIZER.deserialize(parser, jsonpMapper);
+        validateNoErrors(bulkIndexResponse.items(), customErrorHandlers);
       }
       if (metrics != null) {
         metrics.recordBulkOperations(bulkRequest.operations().size());
@@ -118,7 +124,7 @@ public final class StreamingElasticsearchBatchRequest extends ElasticsearchBatch
       if (item == null) {
         continue;
       }
-      if (item instanceof NdJsonpSerializable nested && nested != value) {
+      if (item instanceof final NdJsonpSerializable nested && nested != value) {
         writeNdJson(out, nested);
       } else {
         final JsonGenerator generator = jsonpMapper.jsonProvider().createGenerator(out);
@@ -129,27 +135,6 @@ public final class StreamingElasticsearchBatchRequest extends ElasticsearchBatch
     }
   }
 
-  /** Maps our DTO items to the ES client's {@link BulkResponseItem} to reuse error handling. */
-  private List<BulkResponseItem> toBulkResponseItems(final BulkIndexResponse response) {
-    return response.items().stream()
-        .map(
-            item -> {
-              final var detail = item.detail();
-              if (detail == null) {
-                return null;
-              }
-              return BulkResponseItem.of(
-                  b -> {
-                    b.index(detail._index()).id(detail._id()).status(detail.status());
-                    if (detail.error() != null) {
-                      b.error(
-                          ErrorCause.of(
-                              e -> e.type(detail.error().type()).reason(detail.error().reason())));
-                    }
-                    return b;
-                  });
-            })
-        .filter(item -> item != null)
-        .toList();
-  }
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private record BulkErrorSummary(boolean errors) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -68,7 +69,7 @@ final class CamundaExporterTest {
   void beforeEach() {
     stubbedClientAdapterInUse = new StubClientAdapter();
     mockedClientAdapterFactory
-        .when(() -> ClientAdapter.of(configuration.getConnect()))
+        .when(() -> ClientAdapter.of(configuration.getConnect(), anyBoolean()))
         .thenReturn(stubbedClientAdapterInUse);
     doReturn(emptyList()).when(resourceProvider).getIndexDescriptors();
     doReturn(emptyList()).when(resourceProvider).getIndexTemplateDescriptors();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -69,7 +69,7 @@ final class CamundaExporterTest {
   void beforeEach() {
     stubbedClientAdapterInUse = new StubClientAdapter();
     mockedClientAdapterFactory
-        .when(() -> ClientAdapter.of(configuration.getConnect(), anyBoolean()))
+        .when(() -> ClientAdapter.of(any(), anyBoolean()))
         .thenReturn(stubbedClientAdapterInUse);
     doReturn(emptyList()).when(resourceProvider).getIndexDescriptors();
     doReturn(emptyList()).when(resourceProvider).getIndexTemplateDescriptors();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequestTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -172,15 +171,6 @@ class StreamingElasticsearchBatchRequestTest {
     assertThat(action.has("delete")).isTrue();
     assertThat(action.get("delete").get("_index").asText()).isEqualTo(INDEX);
     assertThat(action.get("delete").get("_id").asText()).isEqualTo(ID);
-  }
-
-  @Test
-  void shouldNotSendRequestForEmptyBatch() throws IOException, PersistenceException {
-    // when
-    batchRequest.execute();
-
-    // then
-    verify(restClient, never()).performRequest(any(Request.class));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequestTest.java
@@ -85,10 +85,10 @@ class StreamingElasticsearchBatchRequestTest {
     final String[] lines = ndJson.split("\n");
     assertThat(lines).hasSize(2);
 
-    final String actionLine = lines[0];
-    assertThat(actionLine).contains("\"index\"");
-    assertThat(actionLine).contains("\"_index\"");
-    assertThat(actionLine).contains("\"_id\"");
+    final JsonNode action = parseJson(lines[0]);
+    assertThat(action.has("index")).isTrue();
+    assertThat(action.get("index").get("_index").asText()).isEqualTo(INDEX);
+    assertThat(action.get("index").get("_id").asText()).isEqualTo(ID);
   }
 
   @Test
@@ -106,14 +106,14 @@ class StreamingElasticsearchBatchRequestTest {
     final Request request = captor.getValue();
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getEndpoint()).isEqualTo("/_bulk");
-    assertThat(request.getEntity().getContentType().getValue()).containsIgnoringCase("ndjson");
+    assertThat(request.getEntity().getContentType().getValue()).isEqualTo("application/x-ndjson");
   }
 
   @Test
   void shouldStreamIndexWithRouting() throws IOException, PersistenceException {
     // given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
-    final String routing = "routing";
+    final String routing = "my-routing";
 
     // when
     batchRequest.addWithRouting(INDEX, entity, routing);
@@ -124,9 +124,11 @@ class StreamingElasticsearchBatchRequestTest {
     final String[] lines = ndJson.split("\n");
     assertThat(lines).hasSize(2);
 
-    final String actionLine = lines[0];
-    assertThat(actionLine).contains("\"index\"");
-    assertThat(actionLine).contains(routing);
+    final JsonNode action = parseJson(lines[0]);
+    assertThat(action.has("index")).isTrue();
+    assertThat(action.get("index").get("_index").asText()).isEqualTo(INDEX);
+    assertThat(action.get("index").get("_id").asText()).isEqualTo(ID);
+    assertThat(action.get("index").get("routing").asText()).isEqualTo(routing);
   }
 
   @Test
@@ -136,7 +138,7 @@ class StreamingElasticsearchBatchRequestTest {
     final Map<String, Object> updateFields = Map.of("id", "id2");
 
     // when
-    batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, "routing");
+    batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, "my-routing");
     batchRequest.execute();
 
     // then
@@ -144,11 +146,15 @@ class StreamingElasticsearchBatchRequestTest {
     final String[] lines = ndJson.split("\n");
     assertThat(lines).hasSize(2);
 
-    final String actionLine = lines[0];
-    assertThat(actionLine).contains("\"update\"");
+    final JsonNode action = parseJson(lines[0]);
+    assertThat(action.has("update")).isTrue();
+    assertThat(action.get("update").get("_index").asText()).isEqualTo(INDEX);
+    assertThat(action.get("update").get("_id").asText()).isEqualTo(ID);
+    assertThat(action.get("update").get("routing").asText()).isEqualTo("my-routing");
 
-    final String bodyLine = lines[1];
-    assertThat(bodyLine).contains("upsert");
+    final JsonNode body = parseJson(lines[1]);
+    assertThat(body.has("upsert")).isTrue();
+    assertThat(body.has("doc")).isTrue();
   }
 
   @Test
@@ -162,10 +168,10 @@ class StreamingElasticsearchBatchRequestTest {
     final String[] lines = ndJson.split("\n");
     assertThat(lines).hasSize(1);
 
-    final String actionLine = lines[0];
-    assertThat(actionLine).contains("\"delete\"");
-    assertThat(actionLine).contains("\"_index\"");
-    assertThat(actionLine).contains("\"_id\"");
+    final JsonNode action = parseJson(lines[0]);
+    assertThat(action.has("delete")).isTrue();
+    assertThat(action.get("delete").get("_index").asText()).isEqualTo(INDEX);
+    assertThat(action.get("delete").get("_id").asText()).isEqualTo(ID);
   }
 
   @Test
@@ -264,9 +270,13 @@ class StreamingElasticsearchBatchRequestTest {
     // delete: 1 action line only = 1 line
     assertThat(lines).hasSize(5);
 
-    assertThat(lines[0]).contains("\"index\"");
-    assertThat(lines[2]).contains("\"update\"");
-    assertThat(lines[4]).contains("\"delete\"");
+    assertThat(parseJson(lines[0]).has("index")).isTrue();
+    assertThat(parseJson(lines[2]).has("update")).isTrue();
+    assertThat(parseJson(lines[4]).has("delete")).isTrue();
+  }
+
+  private JsonNode parseJson(final String json) throws JsonProcessingException {
+    return objectMapper.readTree(json);
   }
 
   private String captureNdJsonBody() throws IOException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/StreamingElasticsearchBatchRequestTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.entities.TestExporterEntity;
+import io.camunda.exporter.errorhandling.Error;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class StreamingElasticsearchBatchRequestTest {
+
+  private static final String ID = "id";
+  private static final String INDEX = "index";
+
+  private RestClient restClient;
+  private ObjectMapper objectMapper;
+  private JacksonJsonpMapper jsonpMapper;
+  private ElasticsearchScriptBuilder scriptBuilder;
+  private BulkRequest.Builder bulkRequestBuilder;
+  private StreamingElasticsearchBatchRequest batchRequest;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    restClient = mock(RestClient.class);
+    objectMapper = new ObjectMapper();
+    jsonpMapper = new JacksonJsonpMapper(objectMapper);
+    scriptBuilder = mock(ElasticsearchScriptBuilder.class);
+    bulkRequestBuilder = new BulkRequest.Builder();
+    batchRequest =
+        new StreamingElasticsearchBatchRequest(
+            restClient, jsonpMapper, objectMapper, bulkRequestBuilder, scriptBuilder);
+
+    final var mockResponse = mock(org.elasticsearch.client.Response.class);
+    final var mockEntity = mock(org.apache.http.HttpEntity.class);
+    when(mockResponse.getEntity()).thenReturn(mockEntity);
+    when(mockEntity.getContent())
+        .thenReturn(
+            new ByteArrayInputStream(
+                """
+                {"errors":false,"items":[]}"""
+                    .getBytes(StandardCharsets.UTF_8)));
+    when(restClient.performRequest(any(Request.class))).thenReturn(mockResponse);
+  }
+
+  @Test
+  void shouldStreamIndexOperationAsNdJson() throws IOException, PersistenceException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    // when
+    batchRequest.add(INDEX, entity);
+    batchRequest.execute();
+
+    // then
+    final String ndJson = captureNdJsonBody();
+    final String[] lines = ndJson.split("\n");
+    assertThat(lines).hasSize(2);
+
+    final String actionLine = lines[0];
+    assertThat(actionLine).contains("\"index\"");
+    assertThat(actionLine).contains("\"_index\"");
+    assertThat(actionLine).contains("\"_id\"");
+  }
+
+  @Test
+  void shouldVerifyRequestMethodAndEndpoint() throws IOException, PersistenceException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    // when
+    batchRequest.add(INDEX, entity);
+    batchRequest.execute();
+
+    // then
+    final ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+    verify(restClient).performRequest(captor.capture());
+    final Request request = captor.getValue();
+    assertThat(request.getMethod()).isEqualTo("POST");
+    assertThat(request.getEndpoint()).isEqualTo("/_bulk");
+    assertThat(request.getEntity().getContentType().getValue()).containsIgnoringCase("ndjson");
+  }
+
+  @Test
+  void shouldStreamIndexWithRouting() throws IOException, PersistenceException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final String routing = "routing";
+
+    // when
+    batchRequest.addWithRouting(INDEX, entity, routing);
+    batchRequest.execute();
+
+    // then
+    final String ndJson = captureNdJsonBody();
+    final String[] lines = ndJson.split("\n");
+    assertThat(lines).hasSize(2);
+
+    final String actionLine = lines[0];
+    assertThat(actionLine).contains("\"index\"");
+    assertThat(actionLine).contains(routing);
+  }
+
+  @Test
+  void shouldStreamUpsertOperation() throws IOException, PersistenceException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final Map<String, Object> updateFields = Map.of("id", "id2");
+
+    // when
+    batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, "routing");
+    batchRequest.execute();
+
+    // then
+    final String ndJson = captureNdJsonBody();
+    final String[] lines = ndJson.split("\n");
+    assertThat(lines).hasSize(2);
+
+    final String actionLine = lines[0];
+    assertThat(actionLine).contains("\"update\"");
+
+    final String bodyLine = lines[1];
+    assertThat(bodyLine).contains("upsert");
+  }
+
+  @Test
+  void shouldStreamDeleteOperation() throws IOException, PersistenceException {
+    // when
+    batchRequest.delete(INDEX, ID);
+    batchRequest.execute();
+
+    // then
+    final String ndJson = captureNdJsonBody();
+    final String[] lines = ndJson.split("\n");
+    assertThat(lines).hasSize(1);
+
+    final String actionLine = lines[0];
+    assertThat(actionLine).contains("\"delete\"");
+    assertThat(actionLine).contains("\"_index\"");
+    assertThat(actionLine).contains("\"_id\"");
+  }
+
+  @Test
+  void shouldNotSendRequestForEmptyBatch() throws IOException, PersistenceException {
+    // when
+    batchRequest.execute();
+
+    // then
+    verify(restClient, never()).performRequest(any(Request.class));
+  }
+
+  @Test
+  void shouldThrowOnBulkErrors() throws IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    final String errorJson =
+        """
+        {"took":1,"errors":true,"items":[{"index":{"_index":"test","_id":"1",\
+        "status":400,"error":{"type":"mapper_parsing_exception",\
+        "reason":"failed to parse"}}}]}""";
+
+    final var errorResponse = mock(org.elasticsearch.client.Response.class);
+    final var errorEntity = mock(org.apache.http.HttpEntity.class);
+    when(errorResponse.getEntity()).thenReturn(errorEntity);
+    when(errorEntity.getContent())
+        .thenReturn(new ByteArrayInputStream(errorJson.getBytes(StandardCharsets.UTF_8)));
+    when(restClient.performRequest(any(Request.class))).thenReturn(errorResponse);
+
+    // when
+    batchRequest.add(INDEX, entity);
+
+    // then
+    assertThatThrownBy(() -> batchRequest.execute())
+        .isInstanceOf(PersistenceException.class)
+        .hasMessageContaining("failed to parse");
+  }
+
+  @Test
+  void shouldCallCustomErrorHandler() throws IOException, PersistenceException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    final String errorJson =
+        """
+        {"took":1,"errors":true,"items":[{"index":{"_index":"%s","_id":"%s",\
+        "status":400,"error":{"type":"mapper_parsing_exception",\
+        "reason":"failed to parse"}}}]}"""
+            .formatted(INDEX, ID);
+
+    final var errorResponse = mock(org.elasticsearch.client.Response.class);
+    final var errorEntity = mock(org.apache.http.HttpEntity.class);
+    when(errorResponse.getEntity()).thenReturn(errorEntity);
+    when(errorEntity.getContent())
+        .thenReturn(new ByteArrayInputStream(errorJson.getBytes(StandardCharsets.UTF_8)));
+    when(restClient.performRequest(any(Request.class))).thenReturn(errorResponse);
+
+    @SuppressWarnings("unchecked")
+    final BiConsumer<String, Error> errorHandler = mock(BiConsumer.class);
+
+    // when
+    batchRequest.add(INDEX, entity);
+    batchRequest.execute(errorHandler);
+
+    // then
+    final ArgumentCaptor<String> indexCaptor = ArgumentCaptor.forClass(String.class);
+    final ArgumentCaptor<Error> errorCaptor = ArgumentCaptor.forClass(Error.class);
+    verify(errorHandler).accept(indexCaptor.capture(), errorCaptor.capture());
+
+    assertThat(indexCaptor.getValue()).isEqualTo(INDEX);
+    final Error capturedError = errorCaptor.getValue();
+    assertThat(capturedError.type()).isEqualTo("mapper_parsing_exception");
+    assertThat(capturedError.status()).isEqualTo(400);
+    assertThat(capturedError.message()).contains("failed to parse");
+  }
+
+  @Test
+  void shouldStreamMultipleOperationsInBatch() throws IOException, PersistenceException {
+    // given
+    final TestExporterEntity entity1 = new TestExporterEntity().setId("id1");
+    final TestExporterEntity entity2 = new TestExporterEntity().setId("id2");
+    final Map<String, Object> updateFields = Map.of("id", "id3");
+
+    // when
+    batchRequest.add(INDEX, entity1);
+    batchRequest.upsert(INDEX, "id2", entity2, updateFields);
+    batchRequest.delete(INDEX, "id3");
+    batchRequest.execute();
+
+    // then
+    final String ndJson = captureNdJsonBody();
+    final String[] lines = ndJson.split("\n");
+
+    // index: 1 action + 1 doc = 2 lines
+    // update: 1 action + 1 doc = 2 lines
+    // delete: 1 action line only = 1 line
+    assertThat(lines).hasSize(5);
+
+    assertThat(lines[0]).contains("\"index\"");
+    assertThat(lines[2]).contains("\"update\"");
+    assertThat(lines[4]).contains("\"delete\"");
+  }
+
+  private String captureNdJsonBody() throws IOException {
+    final ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+    verify(restClient).performRequest(captor.capture());
+    final Request request = captor.getValue();
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    request.getEntity().writeTo(baos);
+    return baos.toString(StandardCharsets.UTF_8);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITTemplateExtension.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITTemplateExtension.java
@@ -58,9 +58,13 @@ public class CamundaExporterITTemplateExtension
     final var openSearchAwsInstanceUrl =
         Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL)).orElse("");
     if (openSearchAwsInstanceUrl.isEmpty()) {
+      final var esConfig = getConfigWithConnectionDetails(ELASTICSEARCH);
+      final var esStreamingConfig = getConfigWithConnectionDetails(ELASTICSEARCH);
+      esStreamingConfig.getBulk().setUseStreamingBulk(true);
       return Stream.of(
           invocationContext(getConfigWithConnectionDetails(OPENSEARCH), osClientAdapter),
-          invocationContext(getConfigWithConnectionDetails(ELASTICSEARCH), elsClientAdapter));
+          invocationContext(esConfig, elsClientAdapter),
+          invocationContext(esStreamingConfig, elsClientAdapter, " [streaming]"));
     } else {
       return Stream.of(
           invocationContext(getConfigWithConnectionDetails(OPENSEARCH), osClientAdapter));
@@ -105,11 +109,18 @@ public class CamundaExporterITTemplateExtension
 
   private TestTemplateInvocationContext invocationContext(
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter) {
+    return invocationContext(config, clientAdapter, "");
+  }
+
+  private TestTemplateInvocationContext invocationContext(
+      final ExporterConfiguration config,
+      final SearchClientAdapter clientAdapter,
+      final String displayNameSuffix) {
     return new TestTemplateInvocationContext() {
 
       @Override
       public String getDisplayName(final int invocationIndex) {
-        return config.getConnect().getType();
+        return config.getConnect().getType() + displayNameSuffix;
       }
 
       @Override


### PR DESCRIPTION
## Description
  - Streaming bulk requests: Added `StreamingElasticsearchBatchRequest` that writes NDJSON directly to the HTTP socket via the low-level RestClient, eliminating intermediate byte[] allocations
  from the high-level ES client's serialization. Disabled by default (useStreamingBulk=false), can be enabled via `ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_USESTREAMINGBULK=true`.
    - Extends `ElasticsearchBatchRequest` to keep most of the logic there.
  - Lazy response deserialization: On the happy path (errors=false), only a lightweight `BulkErrorSummary` is deserialized from the response, skipping the full `BulkResponse` with all items. The
  full response is only parsed using the ES client's `BulkResponse._DESERIALIZER` when errors are present.
  - Test coverage: Added unit tests for `StreamingElasticsearchBatchRequest` with precise JSON-parsed assertions. Extended the IT template extension to run ES integration tests in both
  streaming and non-streaming modes.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
