### PR TITLE
ci: update load test helm chart to camunda-platform-8.10

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -162,7 +162,7 @@ on:
 env:
   CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe  # change this to "infra-benchmark-dev-github-action-zeebe" when experimenting
-  HELM_CHART: camunda-platform-8.9
+  HELM_CHART: camunda-platform-8.10
   # Namespaces MUST start with c8 due to access policy
   NAMESPACE: ${{ startsWith(inputs.name, 'c8-') && inputs.name || format('c8-{0}', inputs.name) }}
   IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -1,6 +1,6 @@
 namespace ?= __NAMESPACE__
 secondary_storage ?= __STORAGE_TYPE__
-helm_chart ?= camunda-platform-8.9
+helm_chart ?= camunda-platform-8.10
 enable_optimize ?= __ENABLE_OPTIMIZE__
 curl_image ?= curlimages/curl:7.87.0
 camunda_management_url ?= http://camunda:9600

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -39,7 +39,7 @@ fi
 ### First parameter is used as namespace name
 ### For a new namespace a new folder will be created
 
-helm_chart="camunda-platform-8.9"
+helm_chart="camunda-platform-8.10"
 namespace="$1"
 
 # Add c8- prefix if not present


### PR DESCRIPTION
## Summary
- Update Helm chart reference from `camunda-platform-8.9` to `camunda-platform-8.10` across all load test configuration files
- The 8.10 chart is now available at https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform-8.10

## Changed files
- `load-tests/setup/default/Makefile`
- `load-tests/setup/newLoadTest.sh`
- `.github/workflows/camunda-load-test.yml`

## Test plan
- [ ] Verify load test workflow triggers correctly with the new chart
- [ ] Confirm `newLoadTest.sh` pulls the 8.10 chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)