### PR TITLE
[Backport stable/8.6] perf: eliminate thundering herd in long-polling job activation

### DIFF
--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -173,7 +173,7 @@ public final class LongPollingActivateJobsTest {
   }
 
   @Test
-  public void shouldUnblockAllRequestsWhenJobsAvailable() throws Exception {
+  public void shouldUnblockOneRequestPerNotificationAndCascade() throws Exception {
     // given
     final int amount = FAILED_RESPONSE_THRESHOLD;
     activateJobsAndWaitUntilBlocked(amount);
@@ -187,14 +187,13 @@ public final class LongPollingActivateJobsTest {
 
     // then
 
-    // the job available notification triggers all three requests again
-    final int invTriggeredByNotification = amount * partitionsCount;
-    // the one request which has a result, re-triggers the remaining requests
-    final int invTriggeredBySuccessfulRequest = (amount - 1) * partitionsCount;
+    // the notification wakes one request, which activates jobs on all partitions
+    final int invTriggeredByNotification = partitionsCount;
+    // that request finds jobs and cascades to the next, which finds nothing and stops
+    final int invTriggeredByCascade = partitionsCount;
     verify(
             activateJobsStub,
-            timeout(2000)
-                .times(firstRound + invTriggeredByNotification + invTriggeredBySuccessfulRequest))
+            timeout(2000).times(firstRound + invTriggeredByNotification + invTriggeredByCascade))
         .handle(any());
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -198,6 +198,60 @@ public final class LongPollingActivateJobsTest {
   }
 
   @Test
+  public void shouldSkipCancelledRequestAndUnblockNext() {
+    // given
+    final InflightActivateJobsRequest<ActivateJobsResponse> cancelledRequest =
+        getLongPollingActivateJobsRequest();
+    final InflightActivateJobsRequest<ActivateJobsResponse> liveRequest =
+        getLongPollingActivateJobsRequest();
+
+    handler.internalActivateJobsRetry(cancelledRequest);
+    handler.internalActivateJobsRetry(liveRequest);
+    waitUntil(cancelledRequest::hasScheduledTimer);
+    waitUntil(liveRequest::hasScheduledTimer);
+
+    // when — first request's worker disconnects, then jobs become available
+    doReturn(true).when(cancelledRequest.getResponseObserver()).isCancelled();
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    brokerClient.notifyJobsAvailable(TYPE);
+    Awaitility.await().until(liveRequest::isCompleted);
+
+    // then — the cancelled request is skipped, the live one gets the jobs
+    verify(cancelledRequest.getResponseObserver(), never()).onNext(any());
+    verify(liveRequest.getResponseObserver(), times(1)).onNext(any());
+    verify(liveRequest.getResponseObserver(), times(1)).onCompleted();
+  }
+
+  @Test
+  public void shouldCleanUpJobTypeStateWhenAllPendingRequestsCancelled() {
+    // given
+    final InflightActivateJobsRequest<ActivateJobsResponse> request1 =
+        getLongPollingActivateJobsRequest();
+    final InflightActivateJobsRequest<ActivateJobsResponse> request2 =
+        getLongPollingActivateJobsRequest();
+
+    handler.internalActivateJobsRetry(request1);
+    handler.internalActivateJobsRetry(request2);
+    waitUntil(request1::hasScheduledTimer);
+    waitUntil(request2::hasScheduledTimer);
+
+    // when — all workers disconnect, then a notification arrives
+    doReturn(true).when(request1.getResponseObserver()).isCancelled();
+    doReturn(true).when(request2.getResponseObserver()).isCancelled();
+    brokerClient.notifyJobsAvailable(TYPE);
+
+    // then — a new request for the same type should still work
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    final InflightActivateJobsRequest<ActivateJobsResponse> freshRequest =
+        getLongPollingActivateJobsRequest();
+    handler.internalActivateJobsRetry(freshRequest);
+    Awaitility.await().until(freshRequest::isCompleted);
+
+    verify(freshRequest.getResponseObserver(), times(1)).onNext(any());
+    verify(freshRequest.getResponseObserver(), times(1)).onCompleted();
+  }
+
+  @Test
   public void shouldCompleteAfterRequestTimeout() {
     // given
     final InflightActivateJobsRequest<ActivateJobsResponse> longPollingRequest =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -198,7 +198,7 @@ public class LongPollingActivateJobsRestTest {
   }
 
   @Test
-  void shouldUnblockAllRequestsWhenJobsAvailable() throws Exception {
+  void shouldUnblockOneRequestPerNotificationAndCascade() throws Exception {
     // given
     final int amount = FAILED_RESPONSE_THRESHOLD;
     activateJobsAndWaitUntilBlocked(amount);
@@ -212,14 +212,13 @@ public class LongPollingActivateJobsRestTest {
 
     // then
 
-    // the job available notification triggers all three requests again
-    final int invTriggeredByNotification = amount * partitionsCount;
-    // the one request which has a result, re-triggers the remaining requests
-    final int invTriggeredBySuccessfulRequest = (amount - 1) * partitionsCount;
+    // the notification wakes one request, which activates jobs on all partitions
+    final int invTriggeredByNotification = partitionsCount;
+    // that request finds jobs and cascades to the next, which finds nothing and stops
+    final int invTriggeredByCascade = partitionsCount;
     verify(
             activateJobsStub,
-            timeout(2000)
-                .times(firstRound + invTriggeredByNotification + invTriggeredBySuccessfulRequest))
+            timeout(2000).times(firstRound + invTriggeredByNotification + invTriggeredByCascade))
         .handle(any());
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -223,6 +223,60 @@ public class LongPollingActivateJobsRestTest {
   }
 
   @Test
+  void shouldSkipCancelledRequestAndUnblockNext() {
+    // given
+    final InflightActivateJobsRequest<JobActivationResponse> cancelledRequest =
+        getLongPollingJobActivationRequest();
+    final InflightActivateJobsRequest<JobActivationResponse> liveRequest =
+        getLongPollingJobActivationRequest();
+
+    handler.internalActivateJobsRetry(cancelledRequest);
+    handler.internalActivateJobsRetry(liveRequest);
+    waitUntil(cancelledRequest::hasScheduledTimer);
+    waitUntil(liveRequest::hasScheduledTimer);
+
+    // when — first request's worker disconnects, then jobs become available
+    doReturn(true).when(cancelledRequest.getResponseObserver()).isCancelled();
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    brokerClient.notifyJobsAvailable(TYPE);
+    Awaitility.await().until(liveRequest::isCompleted);
+
+    // then — the cancelled request is skipped, the live one gets the jobs
+    verify(cancelledRequest.getResponseObserver(), never()).onNext(any());
+    verify(liveRequest.getResponseObserver(), times(1)).onNext(any());
+    verify(liveRequest.getResponseObserver(), times(1)).onCompleted();
+  }
+
+  @Test
+  void shouldCleanUpJobTypeStateWhenAllPendingRequestsCancelled() {
+    // given
+    final InflightActivateJobsRequest<JobActivationResponse> request1 =
+        getLongPollingJobActivationRequest();
+    final InflightActivateJobsRequest<JobActivationResponse> request2 =
+        getLongPollingJobActivationRequest();
+
+    handler.internalActivateJobsRetry(request1);
+    handler.internalActivateJobsRetry(request2);
+    waitUntil(request1::hasScheduledTimer);
+    waitUntil(request2::hasScheduledTimer);
+
+    // when — all workers disconnect, then a notification arrives
+    doReturn(true).when(request1.getResponseObserver()).isCancelled();
+    doReturn(true).when(request2.getResponseObserver()).isCancelled();
+    brokerClient.notifyJobsAvailable(TYPE);
+
+    // then — a new request for the same type should still work
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    final InflightActivateJobsRequest<JobActivationResponse> freshRequest =
+        getLongPollingJobActivationRequest();
+    handler.internalActivateJobsRetry(freshRequest);
+    Awaitility.await().until(freshRequest::isCompleted);
+
+    verify(freshRequest.getResponseObserver(), times(1)).onNext(any());
+    verify(freshRequest.getResponseObserver(), times(1)).onCompleted();
+  }
+
+  @Test
   void shouldCompleteAfterRequestTimeout() {
     // given
     final InflightActivateJobsRequest<JobActivationResponse> longPollingRequest =

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class InFlightLongPollingActivateJobsRequestsState<T> {
 
@@ -23,8 +22,6 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
   private final Set<InflightActivateJobsRequest<T>> activeRequestsToBeRepeated = new HashSet<>();
   private int failedAttempts;
   private long lastUpdatedTime;
-
-  private final AtomicBoolean ongoingNotification = new AtomicBoolean(false);
 
   public InFlightLongPollingActivateJobsRequestsState(
       final String jobType, final LongPollingMetrics metrics) {
@@ -121,13 +118,5 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
    */
   public boolean shouldBeRepeated(final InflightActivateJobsRequest<T> request) {
     return activeRequestsToBeRepeated.contains(request) && !request.isLongPollingDisabled();
-  }
-
-  public boolean shouldNotifyAndStartNotification() {
-    return ongoingNotification.compareAndSet(false, true);
-  }
-
-  public void completeNotification() {
-    ongoingNotification.set(false);
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -17,7 +17,7 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
 
   private final String jobType;
   private final LongPollingMetrics metrics;
-  private final Set<InflightActivateJobsRequest<T>> activeRequests = new LinkedHashSet<>();
+  private final Set<InflightActivateJobsRequest<T>> activeRequests = new HashSet<>();
   private final SequencedSet<InflightActivateJobsRequest<T>> pendingRequests =
       new LinkedHashSet<>();
   private final Set<InflightActivateJobsRequest<T>> activeRequestsToBeRepeated = new HashSet<>();

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -9,16 +9,15 @@ package io.camunda.zeebe.gateway.impl.job;
 
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.Queue;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public final class InFlightLongPollingActivateJobsRequestsState<T> {
 
   private final String jobType;
   private final LongPollingMetrics metrics;
-  private final Queue<InflightActivateJobsRequest<T>> activeRequests = new LinkedList<>();
-  private final Queue<InflightActivateJobsRequest<T>> pendingRequests = new LinkedList<>();
+  private final Set<InflightActivateJobsRequest<T>> activeRequests = new LinkedHashSet<>();
+  private final Set<InflightActivateJobsRequest<T>> pendingRequests = new LinkedHashSet<>();
   private final Set<InflightActivateJobsRequest<T>> activeRequestsToBeRepeated = new HashSet<>();
   private int failedAttempts;
   private long lastUpdatedTime;
@@ -58,9 +57,7 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
   }
 
   public void enqueueRequest(final InflightActivateJobsRequest<T> request) {
-    if (!pendingRequests.contains(request)) {
-      pendingRequests.offer(request);
-    }
+    pendingRequests.add(request);
     updatePendingMetrics();
   }
 
@@ -70,13 +67,16 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
   }
 
   public InflightActivateJobsRequest<T> getNextPendingRequest() {
-    final InflightActivateJobsRequest<T> request = pendingRequests.poll();
+    if (pendingRequests.isEmpty()) {
+      return null;
+    }
+    final var request = pendingRequests.removeFirst();
     updatePendingMetrics();
     return request;
   }
 
   public void addActiveRequest(final InflightActivateJobsRequest<T> request) {
-    activeRequests.offer(request);
+    activeRequests.add(request);
     pendingRequests.remove(request);
     activeRequestsToBeRepeated.remove(request);
     updatePendingMetrics();

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -61,37 +61,17 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
     if (!pendingRequests.contains(request)) {
       pendingRequests.offer(request);
     }
-    removeObsoleteRequestsAndUpdateMetrics();
-  }
-
-  public Queue<InflightActivateJobsRequest<T>> getPendingRequests() {
-    removeObsoleteRequestsAndUpdateMetrics();
-    return pendingRequests;
-  }
-
-  private void removeObsoleteRequestsAndUpdateMetrics() {
-    pendingRequests.removeIf(this::isObsolete);
-    activeRequests.removeIf(this::isObsolete);
-    activeRequestsToBeRepeated.removeIf(this::isObsolete);
-    metrics.setBlockedRequestsCount(jobType, pendingRequests.size());
-  }
-
-  private boolean isObsolete(final InflightActivateJobsRequest<T> request) {
-    return request.isTimedOut()
-        || request.isCanceled()
-        || request.isCompleted()
-        || request.isAborted();
+    updatePendingMetrics();
   }
 
   public void removeRequest(final InflightActivateJobsRequest<T> request) {
     pendingRequests.remove(request);
-    removeObsoleteRequestsAndUpdateMetrics();
+    updatePendingMetrics();
   }
 
   public InflightActivateJobsRequest<T> getNextPendingRequest() {
-    removeObsoleteRequestsAndUpdateMetrics();
     final InflightActivateJobsRequest<T> request = pendingRequests.poll();
-    metrics.setBlockedRequestsCount(jobType, pendingRequests.size());
+    updatePendingMetrics();
     return request;
   }
 
@@ -99,6 +79,7 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
     activeRequests.offer(request);
     pendingRequests.remove(request);
     activeRequestsToBeRepeated.remove(request);
+    updatePendingMetrics();
   }
 
   public void removeActiveRequest(final InflightActivateJobsRequest<T> request) {
@@ -107,8 +88,11 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
   }
 
   public boolean hasActiveRequests() {
-    removeObsoleteRequestsAndUpdateMetrics();
     return !activeRequests.isEmpty();
+  }
+
+  private void updatePendingMetrics() {
+    metrics.setBlockedRequestsCount(jobType, pendingRequests.size());
   }
 
   /**

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.impl.job;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.SequencedSet;
 import java.util.Set;
 
 public final class InFlightLongPollingActivateJobsRequestsState<T> {
@@ -17,7 +18,8 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
   private final String jobType;
   private final LongPollingMetrics metrics;
   private final Set<InflightActivateJobsRequest<T>> activeRequests = new LinkedHashSet<>();
-  private final Set<InflightActivateJobsRequest<T>> pendingRequests = new LinkedHashSet<>();
+  private final SequencedSet<InflightActivateJobsRequest<T>> pendingRequests =
+      new LinkedHashSet<>();
   private final Set<InflightActivateJobsRequest<T>> activeRequestsToBeRepeated = new HashSet<>();
   private int failedAttempts;
   private long lastUpdatedTime;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.scheduler.ScheduledTimer;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -119,7 +118,7 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
    * |           |      |                      |                                               |              |          |                            |                        |
    * |           |      |                      |                                               |              |          |Retrieved                   |                        |
    * |           |      |                      |                                               |              |          |notify                      |                        |
-   * |           |      |                      |  For all pending requests                     |              |          |in between                  |                        |
+   * |           |      |                      |  For next pending request                     |              |          |in between                  |                        |
    * |           |      |                      |                                       +-------|--------------|-------+  |                            |                        |
    * |           |      |                      +---------------------------------------> Internal Activate Jobs Retry <--+                            |                        |
    * |           |      |                                                              +------------------------------+                               |                        |
@@ -294,29 +293,22 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
     // get to avoid the creation of a state instance.
     final var state = jobTypeState.get(jobType);
 
-    if (state != null && state.shouldNotifyAndStartNotification()) {
+    if (state != null) {
       LOG.trace("Handle jobs available notification for type {}.", jobType);
       actor.run(
           () -> {
             state.resetFailedAttempts();
             handlePendingRequests(state, jobType);
-            state.completeNotification();
           });
-    } else {
-      LOG.trace("Ignore jobs available notification for type {}.", jobType);
     }
   }
 
   private void handlePendingRequests(
       final InFlightLongPollingActivateJobsRequestsState<T> state, final String jobType) {
-    final Queue<InflightActivateJobsRequest<T>> pendingRequests = state.getPendingRequests();
-
-    if (!pendingRequests.isEmpty()) {
-      pendingRequests.forEach(
-          nextPendingRequest -> {
-            LOG.trace("Unblocking ActivateJobsRequest {}", nextPendingRequest.getRequest());
-            internalActivateJobsRetry(nextPendingRequest);
-          });
+    final var nextPending = state.getNextPendingRequest();
+    if (nextPending != null) {
+      LOG.trace("Unblocking ActivateJobsRequest {}", nextPending.getRequest());
+      internalActivateJobsRetry(nextPending);
     } else {
       if (!state.hasActiveRequests()) {
         jobTypeState.remove(jobType);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -305,14 +305,12 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
 
   private void handlePendingRequests(
       final InFlightLongPollingActivateJobsRequestsState<T> state, final String jobType) {
-    final var nextPending = state.getNextPendingRequest();
+    final var nextPending = getNextOpenPendingRequest(state);
     if (nextPending != null) {
       LOG.trace("Unblocking ActivateJobsRequest {}", nextPending.getRequest());
       internalActivateJobsRetry(nextPending);
-    } else {
-      if (!state.hasActiveRequests()) {
-        jobTypeState.remove(jobType);
-      }
+    } else if (!state.hasActiveRequests()) {
+      jobTypeState.remove(jobType);
     }
   }
 
@@ -348,7 +346,7 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
     jobTypeState.forEach(
         (type, state) -> {
           if (state.getLastUpdatedTime() < (now - probeTimeoutMillis)) {
-            final InflightActivateJobsRequest<T> probeRequest = state.getNextPendingRequest();
+            final InflightActivateJobsRequest<T> probeRequest = getNextOpenPendingRequest(state);
             if (probeRequest != null) {
               tryToActivateJobsOnAllPartitions(state, probeRequest);
             } else {
@@ -359,6 +357,17 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
             }
           }
         });
+  }
+
+  private InflightActivateJobsRequest<T> getNextOpenPendingRequest(
+      final InFlightLongPollingActivateJobsRequestsState<T> state) {
+    InflightActivateJobsRequest<T> request;
+    while ((request = state.getNextPendingRequest()) != null) {
+      if (request.isOpen()) {
+        return request;
+      }
+    }
+    return null;
   }
 
   public static <T> Builder<T> newBuilder() {


### PR DESCRIPTION
# Description
Backport of #48998 to `stable/8.6`.

relates to #8317 #7659