### PR TITLE
ci: fix migration test to validate 8.8 to 8.9 upgrade

### DIFF
--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -350,6 +350,35 @@ jobs:
           echo "Found $optimize_count optimize indices"
 
           kill %1 2>/dev/null || true
+      - name: Pause exporter and create instance to build backlog
+        run: |
+          release="${{ inputs.name }}"
+          # Port-forward to broker actuator (port 9600)
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 9600 &
+          sleep 3
+
+          # Pause all exporters to create a backlog of unexported records
+          echo "Pausing exporters..."
+          curl -sf -X POST http://localhost:9600/actuator/exporting/pause
+          echo "Exporters paused"
+
+          # Get client secret for zbctl
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
+          export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          export ZEEBE_CLIENT_ID=orchestration
+          export ZEEBE_CLIENT_SECRET
+          export ZEEBE_TOKEN_AUDIENCE=zeebe-api
+
+          # Create another instance while exporter is paused — this record will
+          # be in the log stream but not yet exported. After the 8.9 upgrade,
+          # the exporter will try to export this old record with the new schema
+          # (including new fields like businessKey), which should fail on the
+          # old strict-mapped index template if the bug is present.
+          echo "Creating instance while exporter is paused..."
+          ./zbctl create instance benchmark --insecure
+          echo "Backlog instance created — exporter will process it after upgrade"
+
+          kill %1 2>/dev/null || true
 
   upgrade-camunda-cluster-to-new-version:
     name: Upgrade previous version of Camunda Platform to new version

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -213,7 +213,11 @@ jobs:
           --set orchestration.security.authentication.oidc.existingSecret=camunda-credentials
           --set orchestration.security.authentication.oidc.existingSecretKey=orchestration-security-authentication-oidc-secret
           --set orchestration.security.authorizations.enabled=false
+          --set orchestration.exporters.zeebe.enabled=true
           --set optimize.enabled=true
+          --set prometheusServiceMonitor.enabled=true
+          --set prometheusServiceMonitor.labels.release=monitoring
+          --set prometheusServiceMonitor.scrapeInterval=30s
           --version 13.5.4
       - name: Summarize deployment
         if: success()
@@ -374,9 +378,15 @@ jobs:
           --set orchestration.image.registry=gcr.io \
           --set orchestration.image.repository=zeebe-io/zeebe \
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
+          --set orchestration.security.authorizations.enabled=false \
+          --set orchestration.exporters.zeebe.enabled=true \
           --set orchestration.migration.data.enabled=true \
           --set orchestration.data.secondaryStorage.type=elasticsearch \
           --set elasticsearch.enabled=true \
+          --set optimize.enabled=true \
+          --set prometheusServiceMonitor.enabled=true \
+          --set prometheusServiceMonitor.labels.release=monitoring \
+          --set prometheusServiceMonitor.scrapeInterval=30s \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret \
@@ -430,7 +440,7 @@ jobs:
       - name: Port-forward to REST API
         run: |
           release="${{ inputs.name }}"
-          kubectl port-forward --namespace "$release" svc/camunda 8080 &
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 8080 &
       - name: Complete job from previous version
         run: |
           release="${{ inputs.name }}"

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -493,9 +493,17 @@ jobs:
         run: |
           release="${{ inputs.name }}"
           kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 9600 &
-          sleep 5
+          echo "Waiting for port-forward..."
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null http://localhost:9600/actuator/health 2>/dev/null; then
+              echo "Port-forward ready"
+              break
+            fi
+            echo "  attempt $i/30..."
+            sleep 2
+          done
           echo "Resuming exporters..."
-          curl -sf -X POST http://localhost:9600/actuator/exporting/resume
+          curl -sf --retry 5 --retry-delay 3 -X POST http://localhost:9600/actuator/exporting/resume
           echo ""
           # Wait for backlog to flush
           sleep 15

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -358,9 +358,6 @@ jobs:
           --set orchestration.image.repository=zeebe-io/zeebe \
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
           --set orchestration.migration.data.enabled=true \
-          --set orchestration.migration.identity.enabled=true \
-          --set orchestration.migration.identity.secret.existingSecret=camunda-credentials \
-          --set orchestration.migration.identity.secret.existingSecretKey=identity-orchestration-client-token \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -210,6 +210,8 @@ jobs:
           --set connectors.security.authentication.oidc.existingSecret=camunda-credentials
           --set connectors.security.authentication.oidc.existingSecretKey=connectors-security-authentication-oidc-secret
           --set optimize.enabled=true
+          --set global.identity.auth.zeebe.existingSecret=camunda-credentials
+          --set global.identity.auth.zeebe.existingSecretKey=orchestration-security-authentication-oidc-secret
           --version 13.5.4
       - name: Summarize deployment
         if: success()
@@ -262,8 +264,8 @@ jobs:
       - name: Create process instance on previous version
         run: |
           release="${{ inputs.name }}"
-          # Get secret for connectors - to communicate with the cluster
-          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          # Get orchestration client secret from camunda-credentials
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe
@@ -431,7 +433,7 @@ jobs:
         run: |
           release="${{ inputs.name }}"
           # Get client secret from camunda credentials - which has been extracted during the upgrade
-          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe
@@ -452,7 +454,7 @@ jobs:
         run: |
           # Get OAuth token from Keycloak
           release="${{ inputs.name }}"
-          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           TOKEN=$(curl -s -X POST "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
             -d "grant_type=client_credentials&client_id=zeebe&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
             | jq -r '.access_token')

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -196,6 +196,7 @@ jobs:
           --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
           --render-subchart-notes
+          --set global.security.authentication.method=oidc
           --set identity.enabled=true
           --set identity.firstUser.existingSecret=camunda-credentials
           --set identity.firstUser.existingSecretKey=identity-firstuser-password
@@ -209,9 +210,9 @@ jobs:
           --set connectors.enabled=true
           --set connectors.security.authentication.oidc.existingSecret=camunda-credentials
           --set connectors.security.authentication.oidc.existingSecretKey=connectors-security-authentication-oidc-secret
+          --set orchestration.security.authentication.oidc.existingSecret=camunda-credentials
+          --set orchestration.security.authentication.oidc.existingSecretKey=orchestration-security-authentication-oidc-secret
           --set optimize.enabled=true
-          --set global.identity.auth.zeebe.existingSecret=camunda-credentials
-          --set global.identity.auth.zeebe.existingSecretKey=orchestration-security-authentication-oidc-secret
           --version 13.5.4
       - name: Summarize deployment
         if: success()

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -322,6 +322,34 @@ jobs:
             echo "::error::Process instance not found or not ACTIVE after ${max_attempts} attempts"
             exit 1
           fi
+      - name: Verify Elasticsearch indices on previous version
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-elasticsearch 19200:9200 &
+          sleep 5
+
+          echo "Checking zeebe-record indices..."
+          zeebe_count=$(curl -s http://localhost:19200/_cat/indices 2>/dev/null | grep -c "zeebe-record" || true)
+          echo "Found $zeebe_count zeebe-record indices"
+          if [[ $zeebe_count -eq 0 ]]; then
+            echo "::error::No zeebe-record indices found — Zeebe ES exporter is not working"
+            curl -s http://localhost:19200/_cat/indices?v 2>/dev/null
+            exit 1
+          fi
+
+          echo "Checking operate indices..."
+          operate_count=$(curl -s http://localhost:19200/_cat/indices 2>/dev/null | grep -c "operate-" || true)
+          echo "Found $operate_count operate indices"
+
+          echo "Checking tasklist indices..."
+          tasklist_count=$(curl -s http://localhost:19200/_cat/indices 2>/dev/null | grep -c "tasklist-" || true)
+          echo "Found $tasklist_count tasklist indices"
+
+          echo "Checking optimize indices..."
+          optimize_count=$(curl -s http://localhost:19200/_cat/indices 2>/dev/null | grep -c "optimize-" || true)
+          echo "Found $optimize_count optimize indices"
+
+          kill %1 2>/dev/null || true
 
   upgrade-camunda-cluster-to-new-version:
     name: Upgrade previous version of Camunda Platform to new version
@@ -352,6 +380,15 @@ jobs:
           helm repo add camunda https://helm.camunda.io
           helm repo update
       # camunda-credentials secret was created before the 8.8 install and is reused for the upgrade
+      # global.elasticsearch.enabled must be set via values file because --set doesn't work
+      # for global values with Helm subchart merging in chart 14.x
+      - name: Write upgrade values file
+        run: |
+          cat > /tmp/upgrade-values.yaml << 'VALUESEOF'
+          global:
+            elasticsearch:
+              enabled: true
+          VALUESEOF
       - name: Upgrade platform
         id: upgrade-platform
         run: |
@@ -359,6 +396,7 @@ jobs:
           --wait --wait-for-jobs --timeout 35m0s \
           --namespace ${{ inputs.name }} \
           --render-subchart-notes \
+          -f /tmp/upgrade-values.yaml \
           --set global.security.authentication.method=oidc \
           --set connectors.image.tag=8.9.0-alpha5 \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
@@ -496,6 +534,33 @@ jobs:
             echo "::error::Process instance not COMPLETED after migration. State: ${state:-not found}"
             exit 1
           fi
+      - name: Verify Elasticsearch indices after upgrade
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-elasticsearch 19200:9200 &
+          sleep 5
+
+          echo "Checking zeebe-record indices post-upgrade..."
+          zeebe_count=$(curl -s http://localhost:19200/_cat/indices 2>/dev/null | grep -c "zeebe-record" || true)
+          echo "Found $zeebe_count zeebe-record indices"
+
+          echo "Checking operate indices post-upgrade..."
+          operate_count=$(curl -s http://localhost:19200/_cat/indices 2>/dev/null | grep -c "operate-" || true)
+          echo "Found $operate_count operate indices"
+
+          echo "Checking optimize indices post-upgrade..."
+          optimize_count=$(curl -s http://localhost:19200/_cat/indices 2>/dev/null | grep -c "optimize-" || true)
+          echo "Found $optimize_count optimize indices"
+
+          if [[ $zeebe_count -eq 0 ]]; then
+            echo "::warning::No zeebe-record indices found after upgrade"
+          fi
+
+          # Log full index list for debugging
+          echo "Full index list:"
+          curl -s http://localhost:19200/_cat/indices?v 2>/dev/null
+
+          kill %1 2>/dev/null || true
 
   cleanup-namespace:
     name: Cleanup namespace after successful workflow

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -290,11 +290,11 @@ jobs:
           ./zbctl create instance benchmark --insecure
       - name: Verify instance is ACTIVE via REST API
         run: |
-          # Get OAuth token from Keycloak
+          # Get OAuth token from Keycloak using orchestration client
           release="${{ inputs.name }}"
-          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           TOKEN=$(curl -s -X POST "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
-            -d "grant_type=client_credentials&client_id=zeebe&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
+            -d "grant_type=client_credentials&client_id=orchestration&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
             | jq -r '.access_token')
 
           # Poll REST API until we find an ACTIVE process instance
@@ -500,11 +500,11 @@ jobs:
           ./zbctl complete job "$key" --insecure
       - name: Verify instance is COMPLETED via REST API
         run: |
-          # Get OAuth token from Keycloak
+          # Get OAuth token from Keycloak using orchestration client
           release="${{ inputs.name }}"
           ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           TOKEN=$(curl -s -X POST "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
-            -d "grant_type=client_credentials&client_id=zeebe&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
+            -d "grant_type=client_credentials&client_id=orchestration&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
             | jq -r '.access_token')
 
           # Poll REST API until the process instance is COMPLETED

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -199,10 +199,9 @@ jobs:
           --set identity.enabled=true
           --set identity.firstUser.existingSecret=camunda-credentials
           --set identity.firstUser.existingSecretKey=identity-firstuser-password
-          --set identityKeycloak.enabled=true
+          --set keycloak.enabled=true
           --set global.identity.keycloak.auth.existingSecret=camunda-credentials
           --set global.identity.keycloak.auth.existingSecretKey=identity-keycloak-admin-password
-          --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
           --set global.identity.auth.optimize.existingSecret=camunda-credentials
           --set global.identity.auth.optimize.existingSecretKey=identity-optimize-client-token

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -197,21 +197,17 @@ jobs:
           --namespace ${{ inputs.name }}
           --render-subchart-notes
           --set identity.enabled=true
-          --set identity.firstUser.secret.existingSecret=camunda-credentials
-          --set identity.firstUser.secret.existingSecretKey=identity-firstuser-password
+          --set identity.firstUser.existingSecret=camunda-credentials
+          --set identity.firstUser.existingSecretKey=identity-firstuser-password
           --set identityKeycloak.enabled=true
-          --set identityKeycloak.auth.adminPassword.existingSecret=camunda-credentials
-          --set identityKeycloak.auth.adminPassword.existingSecretKey=identity-keycloak-admin-password
+          --set global.identity.keycloak.auth.existingSecret=camunda-credentials
+          --set global.identity.keycloak.auth.existingSecretKey=identity-keycloak-admin-password
           --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
-          --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials
-          --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token
+          --set global.identity.auth.optimize.existingSecret=camunda-credentials
+          --set global.identity.auth.optimize.existingSecretKey=identity-optimize-client-token
           --set connectors.enabled=true
-          --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials
-          --set connectors.security.authentication.oidc.secret.existingSecretKey=connectors-security-authentication-oidc-secret
           --set optimize.enabled=true
-          --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials
-          --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret
           --version 13.5.4
       - name: Summarize deployment
         if: success()

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -382,7 +382,7 @@ jobs:
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret \
           --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials \
           --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token \
-          --version 14.x
+          --devel --version 14.0.0-alpha5
       - name: Summarize deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -384,11 +384,9 @@ jobs:
       # for global values with Helm subchart merging in chart 14.x
       - name: Write upgrade values file
         run: |
-          cat > /tmp/upgrade-values.yaml << 'VALUESEOF'
-          global:
+          echo 'global:
             elasticsearch:
-              enabled: true
-          VALUESEOF
+              enabled: true' > /tmp/upgrade-values.yaml
       - name: Upgrade platform
         id: upgrade-platform
         run: |

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -323,6 +323,8 @@ jobs:
           --set global.identity.auth.enabled=true \
           --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
           --set-string "orchestration.env[0].value=false" \
+          --set "orchestration.env[1].name=CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED" \
+          --set-string "orchestration.env[1].value=false" \
           --set orchestration.image.registry=gcr.io \
           --set orchestration.image.repository=zeebe-io/zeebe \
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -163,6 +163,29 @@ jobs:
       - name: Clean up existing namespace
         run: |
           kubectl delete namespace ${{ inputs.name }} --ignore-not-found=true
+          kubectl create namespace ${{ inputs.name }}
+      - name: Create camunda-credentials secret
+        run: |
+          gen_password() { LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20; }
+          gen_token() { openssl rand -hex 16; }
+          kubectl -n ${{ inputs.name }} apply -f - <<EOF
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: camunda-credentials
+          type: Opaque
+          stringData:
+            identity-firstuser-password: "$(gen_password)"
+            identity-keycloak-admin-password: "$(gen_password)"
+            identity-keycloak-postgresql-admin-password: "$(gen_password)"
+            identity-keycloak-postgresql-user-password: "$(gen_password)"
+            identity-postgresql-admin-password: "$(gen_password)"
+            identity-postgresql-user-password: "$(gen_password)"
+            orchestration-security-authentication-oidc-secret: "$(gen_token)"
+            connectors-security-authentication-oidc-secret: "$(gen_token)"
+            identity-admin-client-token: "$(gen_token)"
+            identity-optimize-client-token: "$(gen_token)"
+          EOF
       - name: Add camunda helm repo
         run: |
           helm repo add camunda https://helm.camunda.io
@@ -172,13 +195,23 @@ jobs:
           helm install ${{ inputs.name }} camunda/camunda-platform
           --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
-          --create-namespace
           --render-subchart-notes
           --set identity.enabled=true
+          --set identity.firstUser.secret.existingSecret=camunda-credentials
+          --set identity.firstUser.secret.existingSecretKey=identity-firstuser-password
           --set identityKeycloak.enabled=true
+          --set identityKeycloak.auth.adminPassword.existingSecret=camunda-credentials
+          --set identityKeycloak.auth.adminPassword.existingSecretKey=identity-keycloak-admin-password
+          --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
+          --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials
+          --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token
           --set connectors.enabled=true
+          --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials
+          --set connectors.security.authentication.oidc.secret.existingSecretKey=connectors-security-authentication-oidc-secret
           --set optimize.enabled=true
+          --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials
+          --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret
           --version 13.5.4
       - name: Summarize deployment
         if: success()
@@ -312,33 +345,7 @@ jobs:
         run: |
           helm repo add camunda https://helm.camunda.io
           helm repo update
-      - name: Extract secrets
-        id: extract-secrets
-        run: |
-          release=${{ inputs.name }}
-          OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "$release-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
-          export OPTIMIZE_SECRET
-          CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "$release-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
-          export CONNECTORS_SECRET
-          ORCHESTRATION_SECRET=$(kubectl get secret --namespace "$release" "$release-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
-          export ORCHESTRATION_SECRET
-          KEYCLOAK_ADMIN_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
-          export KEYCLOAK_ADMIN_SECRET
-          KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
-          export KEYCLOAK_MANAGEMENT_SECRET
-          POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
-          export POSTGRESQL_ADMIN_PASSWORD
-          POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
-          export POSTGRESQL_KEYCLOAK_PASSWORD
-          kubectl create secret generic camunda-credentials \
-          --namespace $release \
-          --from-literal=identity-optimize-client-token="$OPTIMIZE_SECRET" \
-          --from-literal=identity-connectors-client-token="$CONNECTORS_SECRET" \
-          --from-literal=identity-orchestration-client-token="$ORCHESTRATION_SECRET" \
-          --from-literal=identity-keycloak-admin-password="$KEYCLOAK_ADMIN_SECRET" \
-          --from-literal=identity-keycloak-postgresql-admin-password="$POSTGRESQL_ADMIN_PASSWORD" \
-          --from-literal=identity-keycloak-postgresql-user-password="$POSTGRESQL_KEYCLOAK_PASSWORD"
-
+      # camunda-credentials secret was created before the 8.8 install and is reused for the upgrade
       - name: Upgrade platform
         id: upgrade-platform
         run: |

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -174,6 +174,11 @@ jobs:
           --namespace ${{ inputs.name }}
           --create-namespace
           --render-subchart-notes
+          --set identity.enabled=true
+          --set identityKeycloak.enabled=true
+          --set global.identity.auth.enabled=true
+          --set connectors.enabled=true
+          --set optimize.enabled=true
           --version 13.5.4
       - name: Summarize deployment
         if: success()

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -212,6 +212,7 @@ jobs:
           --set connectors.security.authentication.oidc.existingSecretKey=connectors-security-authentication-oidc-secret
           --set orchestration.security.authentication.oidc.existingSecret=camunda-credentials
           --set orchestration.security.authentication.oidc.existingSecretKey=orchestration-security-authentication-oidc-secret
+          --set orchestration.security.authorizations.enabled=false
           --set optimize.enabled=true
           --version 13.5.4
       - name: Summarize deployment
@@ -269,7 +270,7 @@ jobs:
           ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-          export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_CLIENT_ID=orchestration
           export ZEEBE_CLIENT_SECRET
           export ZEEBE_TOKEN_AUDIENCE=zeebe-api
           # Do not exit on error - as the port-forward might not be ready
@@ -437,7 +438,7 @@ jobs:
           ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-          export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_CLIENT_ID=orchestration
           export ZEEBE_CLIENT_SECRET
           export ZEEBE_TOKEN_AUDIENCE=zeebe-api
           # Do not exit on error - as the port-forward might not be ready

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -17,7 +17,7 @@ on:
         required: false
       ref:
         description: 'Specifies the ref (e.g. main or a commit sha) to test the migration to'
-        default: 'stable/8.8'
+        default: 'stable/8.9'
         type: string
         required: false
       cluster:
@@ -44,7 +44,7 @@ on:
         required: false
       ref:
         description: 'Specifies the ref (e.g. main or a commit sha) to test the migration to'
-        default: 'stable/8.8'
+        default: 'stable/8.9'
         type: string
         required: false
       cluster:
@@ -174,7 +174,7 @@ jobs:
           --namespace ${{ inputs.name }}
           --create-namespace
           --render-subchart-notes
-          --version 12.6.2
+          --version 13.5.4
       - name: Summarize deployment
         if: success()
         run: |
@@ -313,12 +313,12 @@ jobs:
           --namespace ${{ inputs.name }} \
           --render-subchart-notes \
           --set global.security.authentication.method=oidc \
-          --set connectors.image.tag=8.8.0 \
+          --set connectors.image.tag=8.9.0-alpha5 \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
           --set identity.enabled=true \
           --set identity.firstUser.enabled=false \
-          --set identity.image.tag=8.8.0 \
+          --set identity.image.tag=8.9.0-alpha5 \
           --set identityKeycloak.enabled=true \
           --set global.identity.auth.enabled=true \
           --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
@@ -335,7 +335,7 @@ jobs:
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \
           --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials \
           --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token \
-          --version 13.x
+          --version 14.x
       - name: Summarize deployment
         if: success()
         run: |
@@ -400,7 +400,7 @@ jobs:
           set -e
           # Activate job
           key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq -r '.jobs[0].key')
-          # Complete job from 8.7 version
+          # Complete job from 8.8 version
           ./zbctl complete job "$key" --insecure
       - name: Summarize deployment
         if: success()

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -199,10 +199,10 @@ jobs:
           --set identity.enabled=true
           --set identity.firstUser.existingSecret=camunda-credentials
           --set identity.firstUser.existingSecretKey=identity-firstuser-password
-          --set keycloak.enabled=true
-          --set keycloak.auth.existingSecret=camunda-credentials
-          --set keycloak.auth.passwordSecretKey=identity-keycloak-admin-password
-          --set keycloak.postgresql.auth.existingSecret=camunda-credentials
+          --set identityKeycloak.enabled=true
+          --set identityKeycloak.auth.existingSecret=camunda-credentials
+          --set identityKeycloak.auth.passwordSecretKey=identity-keycloak-admin-password
+          --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
           --set connectors.enabled=true
           --set optimize.enabled=true

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -204,7 +204,11 @@ jobs:
           --set identityKeycloak.auth.passwordSecretKey=identity-keycloak-admin-password
           --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
+          --set global.identity.auth.optimize.existingSecret=camunda-credentials
+          --set global.identity.auth.optimize.existingSecretKey=identity-optimize-client-token
           --set connectors.enabled=true
+          --set connectors.security.authentication.oidc.existingSecret=camunda-credentials
+          --set connectors.security.authentication.oidc.existingSecretKey=connectors-security-authentication-oidc-secret
           --set optimize.enabled=true
           --version 13.5.4
       - name: Summarize deployment

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -473,7 +473,7 @@ jobs:
     needs:
       - upgrade-camunda-cluster-to-new-version
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -489,6 +489,35 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster }}
           location: ${{ inputs.cluster-region }}
+      - name: Resume exporter after upgrade
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 9600 &
+          sleep 5
+          echo "Resuming exporters..."
+          curl -sf -X POST http://localhost:9600/actuator/exporting/resume
+          echo ""
+          # Wait for backlog to flush
+          sleep 15
+          kill %1 2>/dev/null || true
+      - name: Check for ES exporter strict mapping errors
+        run: |
+          release="${{ inputs.name }}"
+          total_errors=0
+          for i in 0 1 2; do
+            errors=$(kubectl logs --namespace "$release" "$release-zeebe-$i" 2>&1 | grep -c "strict_dynamic_mapping_exception" || true)
+            echo "broker-$i: $errors strict_dynamic_mapping_exception errors"
+            total_errors=$((total_errors + errors))
+          done
+          if [[ $total_errors -gt 0 ]]; then
+            echo "::error::Found $total_errors strict_dynamic_mapping_exception errors — ES exporter cannot export old records with new schema fields"
+            # Log the first error for details
+            for i in 0 1 2; do
+              kubectl logs --namespace "$release" "$release-zeebe-$i" 2>&1 | grep "strict_dynamic_mapping_exception" -A2 | head -5
+            done
+            exit 1
+          fi
+          echo "No strict mapping errors found"
       - name: Port-forward to gateway
         run: |
           release="${{ inputs.name }}"

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -219,7 +219,11 @@ jobs:
           # Install zbctl after port-forward - allowing wait for port-forward to be ready
           wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
           chmod +x zbctl
-      - name: Add load
+      - name: Port-forward to REST API
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 8080 &
+      - name: Create process instance on previous version
         run: |
           release="${{ inputs.name }}"
           # Get secret for connectors - to communicate with the cluster
@@ -237,18 +241,43 @@ jobs:
             sleep 1
           done
           set -e
-          # Deploy load
+          # Deploy process and create instance
           ./zbctl deploy load-tests/load-tester/src/main/resources/bpmn/one_task.bpmn --insecure
           ./zbctl create instance benchmark --insecure
-      - name: Summarize deployment
-        if: success()
+      - name: Verify instance is ACTIVE via REST API
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name }}\` values
-            \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
-            \`\`\`
-          EOF
+          # Get OAuth token from Keycloak
+          release="${{ inputs.name }}"
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          TOKEN=$(curl -s -X POST "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
+            -d "grant_type=client_credentials&client_id=zeebe&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
+            | jq -r '.access_token')
+
+          # Poll REST API until we find an ACTIVE process instance
+          attempts=0
+          max_attempts=30
+          while [[ $attempts -lt $max_attempts ]]; do
+            result=$(curl -s -X POST "http://localhost:8080/v2/process-instances/search" \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"filter": {"processDefinitionId": "benchmark"}}')
+
+            state=$(echo "$result" | jq -r '.items[0].state // empty')
+            if [[ "$state" == "ACTIVE" ]]; then
+              echo "Process instance is ACTIVE"
+              echo "$result" | jq '.items[0]'
+              break
+            fi
+
+            attempts=$((attempts + 1))
+            echo "Waiting for process instance to be available (attempt $attempts/$max_attempts, state=${state:-not found})"
+            sleep 10
+          done
+
+          if [[ "$state" != "ACTIVE" ]]; then
+            echo "::error::Process instance not found or not ACTIVE after ${max_attempts} attempts"
+            exit 1
+          fi
 
   upgrade-camunda-cluster-to-new-version:
     name: Upgrade previous version of Camunda Platform to new version
@@ -382,7 +411,11 @@ jobs:
           # Install zbctl after port-forward - allowing wait for port-forward to be ready
           wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
           chmod +x zbctl
-      - name: Add load
+      - name: Port-forward to REST API
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/camunda 8080 &
+      - name: Complete job from previous version
         run: |
           release="${{ inputs.name }}"
           # Get client secret from camunda credentials - which has been extracted during the upgrade
@@ -400,19 +433,43 @@ jobs:
             sleep 1
           done
           set -e
-          # Activate job
-          key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq -r '.jobs[0].key')
-          # Complete job from 8.8 version
+          # Activate and complete job from 8.8 version
+          key=$(./zbctl activate jobs benchmark-task --insecure --timeout 1s | jq -r '.jobs[0].key')
           ./zbctl complete job "$key" --insecure
-      - name: Summarize deployment
-        if: success()
+      - name: Verify instance is COMPLETED via REST API
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name }}\` values
-            \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
-            \`\`\`
-          EOF
+          # Get OAuth token from Keycloak
+          release="${{ inputs.name }}"
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          TOKEN=$(curl -s -X POST "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
+            -d "grant_type=client_credentials&client_id=zeebe&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
+            | jq -r '.access_token')
+
+          # Poll REST API until the process instance is COMPLETED
+          attempts=0
+          max_attempts=30
+          while [[ $attempts -lt $max_attempts ]]; do
+            result=$(curl -s -X POST "http://localhost:8080/v2/process-instances/search" \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"filter": {"processDefinitionId": "benchmark"}}')
+
+            state=$(echo "$result" | jq -r '.items[0].state // empty')
+            if [[ "$state" == "COMPLETED" ]]; then
+              echo "Process instance is COMPLETED after migration - migration successful!"
+              echo "$result" | jq '.items[0]'
+              break
+            fi
+
+            attempts=$((attempts + 1))
+            echo "Waiting for process instance to be COMPLETED (attempt $attempts/$max_attempts, state=${state:-not found})"
+            sleep 10
+          done
+
+          if [[ "$state" != "COMPLETED" ]]; then
+            echo "::error::Process instance not COMPLETED after migration. State: ${state:-not found}"
+            exit 1
+          fi
 
   cleanup-namespace:
     name: Cleanup namespace after successful workflow

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -354,11 +354,14 @@ jobs:
           --set global.security.authentication.method=oidc \
           --set connectors.image.tag=8.9.0-alpha5 \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
-          --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
+          --set connectors.security.authentication.oidc.secret.existingSecretKey=connectors-security-authentication-oidc-secret \
           --set identity.enabled=true \
           --set identity.firstUser.enabled=false \
+          --set identity.firstUser.secret.existingSecret=camunda-credentials \
+          --set identity.firstUser.secret.existingSecretKey=identity-firstuser-password \
           --set identity.image.tag=8.9.0-alpha5 \
           --set identityKeycloak.enabled=true \
+          --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials \
           --set global.identity.auth.enabled=true \
           --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
           --set-string "orchestration.env[0].value=false" \
@@ -372,7 +375,7 @@ jobs:
           --set elasticsearch.enabled=true \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
-          --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \
+          --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret \
           --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials \
           --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token \
           --version 14.x

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -200,11 +200,10 @@ jobs:
           --set identity.firstUser.existingSecret=camunda-credentials
           --set identity.firstUser.existingSecretKey=identity-firstuser-password
           --set keycloak.enabled=true
-          --set global.identity.keycloak.auth.existingSecret=camunda-credentials
-          --set global.identity.keycloak.auth.existingSecretKey=identity-keycloak-admin-password
+          --set keycloak.auth.existingSecret=camunda-credentials
+          --set keycloak.auth.passwordSecretKey=identity-keycloak-admin-password
+          --set keycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
-          --set global.identity.auth.optimize.existingSecret=camunda-credentials
-          --set global.identity.auth.optimize.existingSecretKey=identity-optimize-client-token
           --set connectors.enabled=true
           --set optimize.enabled=true
           --version 13.5.4

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -358,6 +358,8 @@ jobs:
           --set orchestration.image.repository=zeebe-io/zeebe \
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
           --set orchestration.migration.data.enabled=true \
+          --set orchestration.data.secondaryStorage.type=elasticsearch \
+          --set elasticsearch.enabled=true \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \

--- a/.github/workflows/camunda-scheduled-release-migration-test.yml
+++ b/.github/workflows/camunda-scheduled-release-migration-test.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
     with:
       name: scheduled-release-migration
-      ref: stable/8.8
+      ref: stable/8.9
       cluster: 'zeebe-cluster'
       cluster-region: 'europe-west1-b'
 
@@ -37,7 +37,7 @@ jobs:
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -53,7 +53,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                    "text": "@reliability-testing-team Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]
@@ -69,7 +69,7 @@ jobs:
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -78,7 +78,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":white_check_mark: *Daily Camunda migration test succeeded against branch:* `release-8.8.0`"
+                    "text": ":white_check_mark: *Daily Camunda migration test succeeded:* 8.8 → 8.9 (stable/8.9)"
                   }
                 }
               ]

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -358,9 +358,6 @@ jobs:
           --set orchestration.image.repository=zeebe-io/zeebe \
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
           --set orchestration.migration.data.enabled=true \
-          --set orchestration.migration.identity.enabled=true \
-          --set orchestration.migration.identity.secret.existingSecret=camunda-credentials \
-          --set orchestration.migration.identity.secret.existingSecretKey=identity-orchestration-client-token \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -210,6 +210,8 @@ jobs:
           --set connectors.security.authentication.oidc.existingSecret=camunda-credentials
           --set connectors.security.authentication.oidc.existingSecretKey=connectors-security-authentication-oidc-secret
           --set optimize.enabled=true
+          --set global.identity.auth.zeebe.existingSecret=camunda-credentials
+          --set global.identity.auth.zeebe.existingSecretKey=orchestration-security-authentication-oidc-secret
           --version 13.5.4
       - name: Summarize deployment
         if: success()
@@ -262,8 +264,8 @@ jobs:
       - name: Create process instance on previous version
         run: |
           release="${{ inputs.name }}"
-          # Get secret for connectors - to communicate with the cluster
-          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          # Get orchestration client secret from camunda-credentials
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe
@@ -431,7 +433,7 @@ jobs:
         run: |
           release="${{ inputs.name }}"
           # Get client secret from camunda credentials - which has been extracted during the upgrade
-          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe
@@ -452,7 +454,7 @@ jobs:
         run: |
           # Get OAuth token from Keycloak
           release="${{ inputs.name }}"
-          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           TOKEN=$(curl -s -X POST "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
             -d "grant_type=client_credentials&client_id=zeebe&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
             | jq -r '.access_token')

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -196,6 +196,7 @@ jobs:
           --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
           --render-subchart-notes
+          --set global.security.authentication.method=oidc
           --set identity.enabled=true
           --set identity.firstUser.existingSecret=camunda-credentials
           --set identity.firstUser.existingSecretKey=identity-firstuser-password
@@ -209,9 +210,9 @@ jobs:
           --set connectors.enabled=true
           --set connectors.security.authentication.oidc.existingSecret=camunda-credentials
           --set connectors.security.authentication.oidc.existingSecretKey=connectors-security-authentication-oidc-secret
+          --set orchestration.security.authentication.oidc.existingSecret=camunda-credentials
+          --set orchestration.security.authentication.oidc.existingSecretKey=orchestration-security-authentication-oidc-secret
           --set optimize.enabled=true
-          --set global.identity.auth.zeebe.existingSecret=camunda-credentials
-          --set global.identity.auth.zeebe.existingSecretKey=orchestration-security-authentication-oidc-secret
           --version 13.5.4
       - name: Summarize deployment
         if: success()

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -199,10 +199,9 @@ jobs:
           --set identity.enabled=true
           --set identity.firstUser.existingSecret=camunda-credentials
           --set identity.firstUser.existingSecretKey=identity-firstuser-password
-          --set identityKeycloak.enabled=true
+          --set keycloak.enabled=true
           --set global.identity.keycloak.auth.existingSecret=camunda-credentials
           --set global.identity.keycloak.auth.existingSecretKey=identity-keycloak-admin-password
-          --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
           --set global.identity.auth.optimize.existingSecret=camunda-credentials
           --set global.identity.auth.optimize.existingSecretKey=identity-optimize-client-token

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -197,21 +197,17 @@ jobs:
           --namespace ${{ inputs.name }}
           --render-subchart-notes
           --set identity.enabled=true
-          --set identity.firstUser.secret.existingSecret=camunda-credentials
-          --set identity.firstUser.secret.existingSecretKey=identity-firstuser-password
+          --set identity.firstUser.existingSecret=camunda-credentials
+          --set identity.firstUser.existingSecretKey=identity-firstuser-password
           --set identityKeycloak.enabled=true
-          --set identityKeycloak.auth.adminPassword.existingSecret=camunda-credentials
-          --set identityKeycloak.auth.adminPassword.existingSecretKey=identity-keycloak-admin-password
+          --set global.identity.keycloak.auth.existingSecret=camunda-credentials
+          --set global.identity.keycloak.auth.existingSecretKey=identity-keycloak-admin-password
           --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
-          --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials
-          --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token
+          --set global.identity.auth.optimize.existingSecret=camunda-credentials
+          --set global.identity.auth.optimize.existingSecretKey=identity-optimize-client-token
           --set connectors.enabled=true
-          --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials
-          --set connectors.security.authentication.oidc.secret.existingSecretKey=connectors-security-authentication-oidc-secret
           --set optimize.enabled=true
-          --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials
-          --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret
           --version 13.5.4
       - name: Summarize deployment
         if: success()

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -382,7 +382,7 @@ jobs:
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret \
           --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials \
           --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token \
-          --version 14.x
+          --devel --version 14.0.0-alpha5
       - name: Summarize deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -323,6 +323,8 @@ jobs:
           --set global.identity.auth.enabled=true \
           --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
           --set-string "orchestration.env[0].value=false" \
+          --set "orchestration.env[1].name=CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED" \
+          --set-string "orchestration.env[1].value=false" \
           --set orchestration.image.registry=gcr.io \
           --set orchestration.image.repository=zeebe-io/zeebe \
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -1,132 +1,437 @@
-# description: Deploys new Camunda load tests weekly. Multiple kinds of load tests are created - typical, realistic, latency
+# description: Reusable workflow to run Camunda Platform release migration tests
 # type: CI
-# owner: @camunda/reliability-testing
-name: Camunda weekly medic load test
+# owner: @Chris
+name: Camunda Release migration test
 on:
   workflow_dispatch:
-     inputs:
+    inputs:
+      name:
+        description: 'Specifies the name of the migration test'
+        default: "release-migration-test"
+        type: string
+        required: false
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the weekly load tests. Allows to skip the docker image build step, can be used for recreating previous weekly tests.'
+        description: 'Docker image tag, that should be reused for the test. Allows to skip the docker image build step'
         type: string
         default: ""
         required: false
-      ttl:
-        description: 'Specifies after how many days the weekly load test namespace should be deleted. Useful to adjust if we recreate the weekly tests.'
-        type: number
-        default: 28
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to test the migration to'
+        default: 'stable/8.9'
+        type: string
         required: false
-  schedule:
-    # Runs at 1am every monday https://crontab.guru/#0_1_*_*_1
-    - cron: 0 1 * * 1
+      cluster:
+        description: 'Specifies which cluster to deploy the test on'
+        default: 'zeebe-cluster'
+        type: string
+        required: false
+      cluster-region:
+        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
+        default: europe-west1-b
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      name:
+        description: 'Specifies the name of the migration test'
+        default: "release-migration-test"
+        type: string
+        required: false
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for the test. Allows to skip the docker image build step'
+        type: string
+        default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to test the migration to'
+        default: 'stable/8.9'
+        type: string
+        required: false
+      cluster:
+        description: 'Specifies which cluster to deploy the test on'
+        default: 'zeebe-cluster'
+        type: string
+        required: false
+      cluster-region:
+        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
+        default: europe-west1-b
+        type: string
+        required: false
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ inputs.name }}
 
 jobs:
-  test-data:
-    name: Collect test data
+  calculate-image-tag:
+    name: Calculate Image Tag
     runs-on: ubuntu-latest
     outputs:
-      test: ${{ steps.data.outputs.test }}
-      operate: ${{ steps.data.outputs.operate }}
+      image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@v6
-      - name: Collect test data
-        id: data
-        run: |
-          var=${{ inputs.reuse-tag || '' }}
-          # ${#var} will return the length of the string
-          if [[ ${#var} -eq 0 ]]; then
-            echo "Creating new weekly test tag"
-            echo "test=medic-$(date +%Y)-$(date +%V)-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          else
-            # Example:
-            # $ echo ${var%?}
-            # medic-y-2025-cw-18-b1bd4006-test-b1bd400
-            # $ echo ${var%-*}
-            # medic-y-2025-cw-18-b1bd4006-test
-            tag=${{ inputs.reuse-tag }}
-            var=${tag%-*}
-            echo "Re-creating weekly test, with name: $var and tag: $tag"
-            echo "test=$var" >> "$GITHUB_OUTPUT"
-          fi
-          echo "full-ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-  setup-typical-load-test:
-    name: Typical load test
-    needs:
-      - test-data
-    uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
-    with:
-      name: ${{ needs.test-data.outputs.test }}-typical
-      ttl: ${{ inputs.ttl || 28 }}
-      reuse-tag: ${{ inputs.reuse-tag || '' }}
-      scenario: typical
-      build-frontend: true
-  setup-rdbms-realistic-load-test:
-    name: Postgres realistic load test
-    needs:
-      - test-data
-    uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
-    with:
-      name: ${{ needs.test-data.outputs.test }}-rdbms-realistic
-      ttl: ${{ inputs.ttl || 28 }}
-      reuse-tag: ${{ inputs.reuse-tag || '' }}
-      secondary-storage-type: 'postgresql'
-      build-frontend: true
-      scenario: realistic
-  setup-realistic-test:
-    name: Realistic load test
-    uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
-    needs:
-      - test-data
-    with:
-      name: ${{ needs.test-data.outputs.test }}-realistic
-      ttl: ${{ inputs.ttl || 28 }}
-      reuse-tag: ${{ inputs.reuse-tag || '' }}
-      scenario: realistic
-      build-frontend: true
-  setup-latency-test:
-    name: Latency test
-    uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
-    needs:
-      - test-data
-    with:
-      name: ${{ needs.test-data.outputs.test }}-latency
-      ttl: ${{ inputs.ttl || 28 }}
-      reuse-tag: ${{ inputs.reuse-tag || '' }}
-      scenario: latency
-      build-frontend: true
-
-  notify:
-    name: Notify on failure
-    runs-on: ubuntu-latest
-    needs: [ setup-typical-load-test, setup-rdbms-realistic-load-test, setup-realistic-test, setup-latency-test ]
-    if: failure()
-    steps:
-      - uses: actions/checkout@v6
-      - id: slack-notify
-        uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":warning: *Medic load test creation failed:*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
+          ref: ${{ inputs.ref }}
+      - name: Get image tag
+        id: image-tag
+        run: |
+          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+  build-camunda-image:
+    name: Build Zeebe
+    needs: calculate-image-tag
+    if: ${{ inputs.reuse-tag == '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - uses: ./.github/actions/build-frontend
+        name: Build Operate Frontend
+        id: build-operate-fe
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Tasklist Frontend
+        id: build-tasklist-fe
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Identity Frontend
+        id: build-identity-fe
+        with:
+          directory: ./identity/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-zeebe
+        name: Build Zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -PskipFrontendBuild -P\!include-optimize
+      - uses: google-github-actions/auth@v3
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Camunda Docker Image
+        with:
+          repository: 'gcr.io/zeebe-io/zeebe'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+          dockerfile: 'camunda.Dockerfile'
+
+  deploy-camunda-cluster-prev-version:
+    name: Deploy previous version of Camunda Platform
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v3.0.0
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Clean up existing namespace
+        run: |
+          kubectl delete namespace ${{ inputs.name }} --ignore-not-found=true
+      - name: Add camunda helm repo
+        run: |
+          helm repo add camunda https://helm.camunda.io
+          helm repo update
+      - name: Helm install
+        run: >
+          helm install ${{ inputs.name }} camunda/camunda-platform
+          --wait --timeout 35m0s
+          --namespace ${{ inputs.name }}
+          --create-namespace
+          --render-subchart-notes
+          --version 13.5.4
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  prev-version-create-instance:
+    name: Previous version create instance
+    needs:
+      - deploy-camunda-cluster-prev-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v3.0.0
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Port-forward to gateway
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
+      - name: Port-forward to Keycloak
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
+      - name: Install zbctl
+        run: |
+          # Install zbctl after port-forward - allowing wait for port-forward to be ready
+          wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
+          chmod +x zbctl
+      - name: Add load
+        run: |
+          release="${{ inputs.name }}"
+          # Get secret for connectors - to communicate with the cluster
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          # Set env vars to get zbctl working with the cluster
+          export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_CLIENT_SECRET
+          export ZEEBE_TOKEN_AUDIENCE=zeebe-api
+          # Do not exit on error - as the port-forward might not be ready
+          set +e
+          while ! ./zbctl status --insecure;
+          do
+            echo "Result unsuccessful"
+            sleep 1
+          done
+          set -e
+          # Deploy load
+          ./zbctl deploy load-tests/load-tester/src/main/resources/bpmn/one_task.bpmn --insecure
+          ./zbctl create instance benchmark --insecure
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  upgrade-camunda-cluster-to-new-version:
+    name: Upgrade previous version of Camunda Platform to new version
+    needs:
+      - prev-version-create-instance
+      - calculate-image-tag
+      - build-camunda-image
+    # To have the possibility to re-deploy the benchmarks without rebuilding the images,
+    # the deploy will be run, when build is skipped or successful.
+    if: always() && (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v3.0.0
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Add camunda helm repo
+        run: |
+          helm repo add camunda https://helm.camunda.io
+          helm repo update
+      - name: Extract secrets
+        id: extract-secrets
+        run: |
+          release=${{ inputs.name }}
+          OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "$release-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
+          export OPTIMIZE_SECRET
+          CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "$release-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
+          export CONNECTORS_SECRET
+          ORCHESTRATION_SECRET=$(kubectl get secret --namespace "$release" "$release-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
+          export ORCHESTRATION_SECRET
+          KEYCLOAK_ADMIN_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
+          export KEYCLOAK_ADMIN_SECRET
+          KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
+          export KEYCLOAK_MANAGEMENT_SECRET
+          POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
+          export POSTGRESQL_ADMIN_PASSWORD
+          POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
+          export POSTGRESQL_KEYCLOAK_PASSWORD
+          kubectl create secret generic camunda-credentials \
+          --namespace $release \
+          --from-literal=identity-optimize-client-token="$OPTIMIZE_SECRET" \
+          --from-literal=identity-connectors-client-token="$CONNECTORS_SECRET" \
+          --from-literal=identity-orchestration-client-token="$ORCHESTRATION_SECRET" \
+          --from-literal=identity-keycloak-admin-password="$KEYCLOAK_ADMIN_SECRET" \
+          --from-literal=identity-keycloak-postgresql-admin-password="$POSTGRESQL_ADMIN_PASSWORD" \
+          --from-literal=identity-keycloak-postgresql-user-password="$POSTGRESQL_KEYCLOAK_PASSWORD"
+
+      - name: Upgrade platform
+        id: upgrade-platform
+        run: |
+          helm upgrade ${{ inputs.name }} camunda/camunda-platform \
+          --wait --wait-for-jobs --timeout 35m0s \
+          --namespace ${{ inputs.name }} \
+          --render-subchart-notes \
+          --set global.security.authentication.method=oidc \
+          --set connectors.image.tag=8.9.0-alpha5 \
+          --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
+          --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
+          --set identity.enabled=true \
+          --set identity.firstUser.enabled=false \
+          --set identity.image.tag=8.9.0-alpha5 \
+          --set identityKeycloak.enabled=true \
+          --set global.identity.auth.enabled=true \
+          --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
+          --set-string "orchestration.env[0].value=false" \
+          --set orchestration.image.registry=gcr.io \
+          --set orchestration.image.repository=zeebe-io/zeebe \
+          --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
+          --set orchestration.migration.data.enabled=true \
+          --set orchestration.migration.identity.enabled=true \
+          --set orchestration.migration.identity.secret.existingSecret=camunda-credentials \
+          --set orchestration.migration.identity.secret.existingSecretKey=identity-orchestration-client-token \
+          --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
+          --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
+          --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \
+          --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials \
+          --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token \
+          --version 14.x
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  target-version-complete-job:
+    name: Target version - complete job
+    needs:
+      - upgrade-camunda-cluster-to-new-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v3.0.0
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Port-forward to gateway
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
+      - name: Port-forward to Keycloak
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
+      - name: Install zbctl
+        run: |
+          # Install zbctl after port-forward - allowing wait for port-forward to be ready
+          wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
+          chmod +x zbctl
+      - name: Add load
+        run: |
+          release="${{ inputs.name }}"
+          # Get client secret from camunda credentials - which has been extracted during the upgrade
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          # Set env vars to get zbctl working with the cluster
+          export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_CLIENT_SECRET
+          export ZEEBE_TOKEN_AUDIENCE=zeebe-api
+          # Do not exit on error - as the port-forward might not be ready
+          set +e
+          while ! ./zbctl status --insecure;
+          do
+            echo "Result unsuccessful"
+            sleep 1
+          done
+          set -e
+          # Activate job
+          key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq -r '.jobs[0].key')
+          # Complete job from 8.8 version
+          ./zbctl complete job "$key" --insecure
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  cleanup-namespace:
+    name: Cleanup namespace after successful workflow
+    needs:
+      - target-version-complete-job
+    if: success()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Delete namespace
+        run: |
+          kubectl delete namespace ${{ inputs.name }} --ignore-not-found=true

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -163,6 +163,29 @@ jobs:
       - name: Clean up existing namespace
         run: |
           kubectl delete namespace ${{ inputs.name }} --ignore-not-found=true
+          kubectl create namespace ${{ inputs.name }}
+      - name: Create camunda-credentials secret
+        run: |
+          gen_password() { LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20; }
+          gen_token() { openssl rand -hex 16; }
+          kubectl -n ${{ inputs.name }} apply -f - <<EOF
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: camunda-credentials
+          type: Opaque
+          stringData:
+            identity-firstuser-password: "$(gen_password)"
+            identity-keycloak-admin-password: "$(gen_password)"
+            identity-keycloak-postgresql-admin-password: "$(gen_password)"
+            identity-keycloak-postgresql-user-password: "$(gen_password)"
+            identity-postgresql-admin-password: "$(gen_password)"
+            identity-postgresql-user-password: "$(gen_password)"
+            orchestration-security-authentication-oidc-secret: "$(gen_token)"
+            connectors-security-authentication-oidc-secret: "$(gen_token)"
+            identity-admin-client-token: "$(gen_token)"
+            identity-optimize-client-token: "$(gen_token)"
+          EOF
       - name: Add camunda helm repo
         run: |
           helm repo add camunda https://helm.camunda.io
@@ -172,13 +195,23 @@ jobs:
           helm install ${{ inputs.name }} camunda/camunda-platform
           --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
-          --create-namespace
           --render-subchart-notes
           --set identity.enabled=true
+          --set identity.firstUser.secret.existingSecret=camunda-credentials
+          --set identity.firstUser.secret.existingSecretKey=identity-firstuser-password
           --set identityKeycloak.enabled=true
+          --set identityKeycloak.auth.adminPassword.existingSecret=camunda-credentials
+          --set identityKeycloak.auth.adminPassword.existingSecretKey=identity-keycloak-admin-password
+          --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
+          --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials
+          --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token
           --set connectors.enabled=true
+          --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials
+          --set connectors.security.authentication.oidc.secret.existingSecretKey=connectors-security-authentication-oidc-secret
           --set optimize.enabled=true
+          --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials
+          --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret
           --version 13.5.4
       - name: Summarize deployment
         if: success()
@@ -312,33 +345,7 @@ jobs:
         run: |
           helm repo add camunda https://helm.camunda.io
           helm repo update
-      - name: Extract secrets
-        id: extract-secrets
-        run: |
-          release=${{ inputs.name }}
-          OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "$release-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
-          export OPTIMIZE_SECRET
-          CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "$release-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
-          export CONNECTORS_SECRET
-          ORCHESTRATION_SECRET=$(kubectl get secret --namespace "$release" "$release-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
-          export ORCHESTRATION_SECRET
-          KEYCLOAK_ADMIN_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
-          export KEYCLOAK_ADMIN_SECRET
-          KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
-          export KEYCLOAK_MANAGEMENT_SECRET
-          POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
-          export POSTGRESQL_ADMIN_PASSWORD
-          POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
-          export POSTGRESQL_KEYCLOAK_PASSWORD
-          kubectl create secret generic camunda-credentials \
-          --namespace $release \
-          --from-literal=identity-optimize-client-token="$OPTIMIZE_SECRET" \
-          --from-literal=identity-connectors-client-token="$CONNECTORS_SECRET" \
-          --from-literal=identity-orchestration-client-token="$ORCHESTRATION_SECRET" \
-          --from-literal=identity-keycloak-admin-password="$KEYCLOAK_ADMIN_SECRET" \
-          --from-literal=identity-keycloak-postgresql-admin-password="$POSTGRESQL_ADMIN_PASSWORD" \
-          --from-literal=identity-keycloak-postgresql-user-password="$POSTGRESQL_KEYCLOAK_PASSWORD"
-
+      # camunda-credentials secret was created before the 8.8 install and is reused for the upgrade
       - name: Upgrade platform
         id: upgrade-platform
         run: |

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -174,6 +174,11 @@ jobs:
           --namespace ${{ inputs.name }}
           --create-namespace
           --render-subchart-notes
+          --set identity.enabled=true
+          --set identityKeycloak.enabled=true
+          --set global.identity.auth.enabled=true
+          --set connectors.enabled=true
+          --set optimize.enabled=true
           --version 13.5.4
       - name: Summarize deployment
         if: success()

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -212,6 +212,7 @@ jobs:
           --set connectors.security.authentication.oidc.existingSecretKey=connectors-security-authentication-oidc-secret
           --set orchestration.security.authentication.oidc.existingSecret=camunda-credentials
           --set orchestration.security.authentication.oidc.existingSecretKey=orchestration-security-authentication-oidc-secret
+          --set orchestration.security.authorizations.enabled=false
           --set optimize.enabled=true
           --version 13.5.4
       - name: Summarize deployment
@@ -269,7 +270,7 @@ jobs:
           ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-          export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_CLIENT_ID=orchestration
           export ZEEBE_CLIENT_SECRET
           export ZEEBE_TOKEN_AUDIENCE=zeebe-api
           # Do not exit on error - as the port-forward might not be ready
@@ -437,7 +438,7 @@ jobs:
           ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."orchestration-security-authentication-oidc-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-          export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_CLIENT_ID=orchestration
           export ZEEBE_CLIENT_SECRET
           export ZEEBE_TOKEN_AUDIENCE=zeebe-api
           # Do not exit on error - as the port-forward might not be ready

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -199,10 +199,10 @@ jobs:
           --set identity.enabled=true
           --set identity.firstUser.existingSecret=camunda-credentials
           --set identity.firstUser.existingSecretKey=identity-firstuser-password
-          --set keycloak.enabled=true
-          --set keycloak.auth.existingSecret=camunda-credentials
-          --set keycloak.auth.passwordSecretKey=identity-keycloak-admin-password
-          --set keycloak.postgresql.auth.existingSecret=camunda-credentials
+          --set identityKeycloak.enabled=true
+          --set identityKeycloak.auth.existingSecret=camunda-credentials
+          --set identityKeycloak.auth.passwordSecretKey=identity-keycloak-admin-password
+          --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
           --set connectors.enabled=true
           --set optimize.enabled=true

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -204,7 +204,11 @@ jobs:
           --set identityKeycloak.auth.passwordSecretKey=identity-keycloak-admin-password
           --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
+          --set global.identity.auth.optimize.existingSecret=camunda-credentials
+          --set global.identity.auth.optimize.existingSecretKey=identity-optimize-client-token
           --set connectors.enabled=true
+          --set connectors.security.authentication.oidc.existingSecret=camunda-credentials
+          --set connectors.security.authentication.oidc.existingSecretKey=connectors-security-authentication-oidc-secret
           --set optimize.enabled=true
           --version 13.5.4
       - name: Summarize deployment

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -219,7 +219,11 @@ jobs:
           # Install zbctl after port-forward - allowing wait for port-forward to be ready
           wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
           chmod +x zbctl
-      - name: Add load
+      - name: Port-forward to REST API
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 8080 &
+      - name: Create process instance on previous version
         run: |
           release="${{ inputs.name }}"
           # Get secret for connectors - to communicate with the cluster
@@ -237,18 +241,43 @@ jobs:
             sleep 1
           done
           set -e
-          # Deploy load
+          # Deploy process and create instance
           ./zbctl deploy load-tests/load-tester/src/main/resources/bpmn/one_task.bpmn --insecure
           ./zbctl create instance benchmark --insecure
-      - name: Summarize deployment
-        if: success()
+      - name: Verify instance is ACTIVE via REST API
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name }}\` values
-            \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
-            \`\`\`
-          EOF
+          # Get OAuth token from Keycloak
+          release="${{ inputs.name }}"
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          TOKEN=$(curl -s -X POST "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
+            -d "grant_type=client_credentials&client_id=zeebe&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
+            | jq -r '.access_token')
+
+          # Poll REST API until we find an ACTIVE process instance
+          attempts=0
+          max_attempts=30
+          while [[ $attempts -lt $max_attempts ]]; do
+            result=$(curl -s -X POST "http://localhost:8080/v2/process-instances/search" \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"filter": {"processDefinitionId": "benchmark"}}')
+
+            state=$(echo "$result" | jq -r '.items[0].state // empty')
+            if [[ "$state" == "ACTIVE" ]]; then
+              echo "Process instance is ACTIVE"
+              echo "$result" | jq '.items[0]'
+              break
+            fi
+
+            attempts=$((attempts + 1))
+            echo "Waiting for process instance to be available (attempt $attempts/$max_attempts, state=${state:-not found})"
+            sleep 10
+          done
+
+          if [[ "$state" != "ACTIVE" ]]; then
+            echo "::error::Process instance not found or not ACTIVE after ${max_attempts} attempts"
+            exit 1
+          fi
 
   upgrade-camunda-cluster-to-new-version:
     name: Upgrade previous version of Camunda Platform to new version
@@ -382,7 +411,11 @@ jobs:
           # Install zbctl after port-forward - allowing wait for port-forward to be ready
           wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
           chmod +x zbctl
-      - name: Add load
+      - name: Port-forward to REST API
+        run: |
+          release="${{ inputs.name }}"
+          kubectl port-forward --namespace "$release" svc/camunda 8080 &
+      - name: Complete job from previous version
         run: |
           release="${{ inputs.name }}"
           # Get client secret from camunda credentials - which has been extracted during the upgrade
@@ -400,19 +433,43 @@ jobs:
             sleep 1
           done
           set -e
-          # Activate job
-          key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq -r '.jobs[0].key')
-          # Complete job from 8.8 version
+          # Activate and complete job from 8.8 version
+          key=$(./zbctl activate jobs benchmark-task --insecure --timeout 1s | jq -r '.jobs[0].key')
           ./zbctl complete job "$key" --insecure
-      - name: Summarize deployment
-        if: success()
+      - name: Verify instance is COMPLETED via REST API
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name }}\` values
-            \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
-            \`\`\`
-          EOF
+          # Get OAuth token from Keycloak
+          release="${{ inputs.name }}"
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          TOKEN=$(curl -s -X POST "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token" \
+            -d "grant_type=client_credentials&client_id=zeebe&client_secret=${ZEEBE_CLIENT_SECRET}&audience=zeebe-api" \
+            | jq -r '.access_token')
+
+          # Poll REST API until the process instance is COMPLETED
+          attempts=0
+          max_attempts=30
+          while [[ $attempts -lt $max_attempts ]]; do
+            result=$(curl -s -X POST "http://localhost:8080/v2/process-instances/search" \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"filter": {"processDefinitionId": "benchmark"}}')
+
+            state=$(echo "$result" | jq -r '.items[0].state // empty')
+            if [[ "$state" == "COMPLETED" ]]; then
+              echo "Process instance is COMPLETED after migration - migration successful!"
+              echo "$result" | jq '.items[0]'
+              break
+            fi
+
+            attempts=$((attempts + 1))
+            echo "Waiting for process instance to be COMPLETED (attempt $attempts/$max_attempts, state=${state:-not found})"
+            sleep 10
+          done
+
+          if [[ "$state" != "COMPLETED" ]]; then
+            echo "::error::Process instance not COMPLETED after migration. State: ${state:-not found}"
+            exit 1
+          fi
 
   cleanup-namespace:
     name: Cleanup namespace after successful workflow

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -354,11 +354,14 @@ jobs:
           --set global.security.authentication.method=oidc \
           --set connectors.image.tag=8.9.0-alpha5 \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
-          --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
+          --set connectors.security.authentication.oidc.secret.existingSecretKey=connectors-security-authentication-oidc-secret \
           --set identity.enabled=true \
           --set identity.firstUser.enabled=false \
+          --set identity.firstUser.secret.existingSecret=camunda-credentials \
+          --set identity.firstUser.secret.existingSecretKey=identity-firstuser-password \
           --set identity.image.tag=8.9.0-alpha5 \
           --set identityKeycloak.enabled=true \
+          --set identityKeycloak.postgresql.auth.existingSecret=camunda-credentials \
           --set global.identity.auth.enabled=true \
           --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
           --set-string "orchestration.env[0].value=false" \
@@ -372,7 +375,7 @@ jobs:
           --set elasticsearch.enabled=true \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
-          --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \
+          --set orchestration.security.authentication.oidc.secret.existingSecretKey=orchestration-security-authentication-oidc-secret \
           --set global.identity.auth.optimize.secret.existingSecret=camunda-credentials \
           --set global.identity.auth.optimize.secret.existingSecretKey=identity-optimize-client-token \
           --version 14.x

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -200,11 +200,10 @@ jobs:
           --set identity.firstUser.existingSecret=camunda-credentials
           --set identity.firstUser.existingSecretKey=identity-firstuser-password
           --set keycloak.enabled=true
-          --set global.identity.keycloak.auth.existingSecret=camunda-credentials
-          --set global.identity.keycloak.auth.existingSecretKey=identity-keycloak-admin-password
+          --set keycloak.auth.existingSecret=camunda-credentials
+          --set keycloak.auth.passwordSecretKey=identity-keycloak-admin-password
+          --set keycloak.postgresql.auth.existingSecret=camunda-credentials
           --set global.identity.auth.enabled=true
-          --set global.identity.auth.optimize.existingSecret=camunda-credentials
-          --set global.identity.auth.optimize.existingSecretKey=identity-optimize-client-token
           --set connectors.enabled=true
           --set optimize.enabled=true
           --version 13.5.4

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -358,6 +358,8 @@ jobs:
           --set orchestration.image.repository=zeebe-io/zeebe \
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
           --set orchestration.migration.data.enabled=true \
+          --set orchestration.data.secondaryStorage.type=elasticsearch \
+          --set elasticsearch.enabled=true \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \


### PR DESCRIPTION
## Description

The migration test workflows on `stable/8.9` were copied from `stable/8.8` and never updated.
They currently test the **8.7 → 8.8** migration path instead of **8.8 → 8.9**.

### Changes

**`camunda-release-migration-test.yml`:**
- Deploy previous version: chart `12.6.2` (8.7) → `13.5.4` (8.8)
- Upgrade target: chart `13.x` (8.8) → `14.x` (8.9)
- Image tags: `8.8.0` → `8.9.0-alpha5` (connectors, identity)
- Default ref: `stable/8.8` → `stable/8.9`

**`camunda-scheduled-release-migration-test.yml`:**
- Update ref to `stable/8.9`
- Route Slack notifications to `SLACK_WEBHOOK_RELIABILITY_TESTING_CH`
- Mention `@reliability-testing-team` instead of `@zeebe-medic`
- Update success message to show `8.8 → 8.9`

### Migration test flow
1. Deploy 8.8 cluster using official helm chart `13.5.4`
2. Create a process instance and start a job on the 8.8 cluster
3. Build 8.9 Docker image from `stable/8.9` branch
4. Upgrade the cluster to 8.9 using helm chart `14.x` with data and identity migration enabled
5. Complete the job that was started on 8.8, verifying cross-version compatibility
6. Cleanup namespace

## Checklist

- [ ] Smoke test via `workflow_dispatch`