### PR TITLE
fix: increase shards and add step timeouts for version compatibility workflow

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -19,10 +19,11 @@ jobs:
   released-versions:
     name: Released Versions
     runs-on: ubuntu-latest
+    timeout-minutes: 330
     strategy:
       fail-fast: false
       matrix:
-        shards: [ 1, 2, 3] # Values are not used, we just need an array of the right length
+        shards: [ 1, 2, 3, 4, 5, 6] # Values are not used, we just need an array of the right length
     steps:
       - uses: actions/checkout@v6
       - name: Generate cache key with current hour
@@ -60,6 +61,7 @@ jobs:
         with:
           maven-extra-args: -PskipFrontendBuild
       - name: Test rolling update
+        timeout-minutes: 300
         run: >
           ./mvnw -B --no-snapshot-updates -pl zeebe/qa/update-tests
           -D it.test=io.camunda.zeebe.test.RollingUpdateTest
@@ -111,6 +113,7 @@ jobs:
         with:
           version: current-test
       - name: Test snapshot
+        timeout-minutes: 300
         run: >
           ./mvnw -B --no-snapshot-updates -pl zeebe/qa/update-tests
           -D it.test=io.camunda.zeebe.test.RollingUpdateTest


### PR DESCRIPTION
## Description

The zeebe-version-compatibility workflow has been timing out consistently due to the growing version matrix (~1.5k upgrade paths) exceeding the 6-hour GitHub Actions job limit across all 3 shards.

When the job-level timeout kills the runner, the report upload step never executes, destroying the incremental cache. This creates a vicious cycle: no cache → no skipping → guaranteed timeout on the next run.

Changes:
- Increase shards from 3 to 6 to halve the work per runner
- Add timeout-minutes: 300 to test steps so only the step fails, not the job, allowing the if: always() report upload to preserve partial progress
- Add timeout-minutes: 330 at the job level for 30 min of post-test headroom

closes https://github.com/camunda/camunda/issues/49193