### PR TITLE
fix: use correct repo in version compatibility cache lookup

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Find previous report
         id: get-last-run-id
         run: |
-          runs=$(gh api /repos/camunda/zeebe/actions/workflows/zeebe-version-compatibility.yml/runs)
+          runs=$(gh api /repos/${{ github.repository }}/actions/workflows/zeebe-version-compatibility.yml/runs)
           last_run_id=$(echo "$runs" | jq 'first(.workflow_runs[] | select(.status=="completed").id)')
           echo "last_run_id=$last_run_id" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
## Description

After [merging](https://github.com/camunda/camunda/issues/49193) the shard increase (3 → 6) and step-level timeouts, run [#734](https://github.com/camunda/camunda/actions/runs/23397256081) confirmed that partial reports are now uploaded correctly — but **all 6 shards still timed out** because every run starts from scratch with no cached results.

The root cause: the `Find previous report` step queries the wrong GitHub API endpoint.

## Root Cause

```yaml
# Before (broken)
gh api /repos/camunda/zeebe/actions/workflows/zeebe-version-compatibility.yml/runs
#              ^^^^^^^^^^^^^^ old repo name
```

The repository was renamed from `camunda/zeebe` to `camunda/camunda`, so this API call returns nothing useful. The `Download previous report` step then fails silently (`continue-on-error: true`), and every run starts from scratch.

The workflow is designed around **incremental testing** — the `CachedTestResultsExtension` caches which test+version combinations passed and skips them on subsequent runs. Without the cache, all ~4,500 test cases (1,500+ combinations × 3 test methods) execute every time, which far exceeds the 300-minute step timeout.

## Fix

```yaml
# After (fixed)
gh api /repos/${{ github.repository }}/actions/workflows/zeebe-version-compatibility.yml/runs
```

Using `github.repository` ensures it always resolves to the correct repo name.

## Expected Behavior After Merge

1. **Run 1 (cold start):** Shards time out at 300 min
2. **Run 2:** Loads cache from Run 1, skips already-tested paths, makes further progress
3. **Run 3-4:** Matrix approaches full coverage, shards start finishing within the timeout
4. **Steady state:** Daily runs finish in minutes (all combinations cached, only new versions need testing)

related to https://github.com/camunda/camunda/issues/49193
