### PR TITLE
[Backport stable/8.9] fix: correct variables description in DecisionEvaluationById and DecisionEvaluationByKey OpenAPI schemas

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/cache/rest-api.yaml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/cache/rest-api.yaml
@@ -10607,7 +10607,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/DecisionDefinitionId'
         variables:
-          description: The message variables as JSON document.
+          description: The decision evaluation variables as JSON document.
           additionalProperties: true
           type: object
         tenantId:
@@ -10624,7 +10624,7 @@ components:
         decisionDefinitionKey:
           $ref: '#/components/schemas/DecisionDefinitionKey'
         variables:
-          description: The message variables as JSON document.
+          description: The decision evaluation variables as JSON document.
           additionalProperties: true
           type: object
         tenantId:

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -320,7 +320,7 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/DecisionDefinitionId'
         variables:
-          description: The message variables as JSON document.
+          description: The decision evaluation variables as JSON document.
           type: object
           additionalProperties: true
         tenantId:
@@ -340,7 +340,7 @@ components:
         variables:
           type: object
           additionalProperties: true
-          description: The message variables as JSON document.
+          description: The decision evaluation variables as JSON document.
         tenantId:
           description: The tenant ID of the decision.
           allOf:


### PR DESCRIPTION
# Description
Backport of #49191 to `stable/8.9`.

relates to camunda/camunda#49190