### PR TITLE
[Backport stable/8.9] fix: POST /groups/search 500 response uses bare $ref to schema instead of proper Response Object

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -59,11 +59,7 @@ paths:
         "403":
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
-          description: "An internal error occurred while processing the request."
-          content:
-            application/problem+json:
-              schema:
-                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 
   /groups/{groupId}:
     get:

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -59,7 +59,11 @@ paths:
         "403":
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
-          $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
+          description: "An internal error occurred while processing the request."
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
 
   /groups/{groupId}:
     get:


### PR DESCRIPTION
# Description
Backport of #49198 to `stable/8.9`.

relates to camunda/camunda#49197