### PR TITLE
test(qa): stabilize Operate process instance key lookup

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -586,11 +586,23 @@ class OperateProcessInstancePage {
   }
 
   async getProcessInstanceKey(): Promise<string> {
-    const processInstanceKey = this.page
-      .getByTestId('instance-header')
-      .locator('table tbody tr td')
-      .nth(1);
-    return (await processInstanceKey.textContent()) ?? '';
+    const table = this.page.getByTestId('instance-header').locator('table');
+    const headers = await table.locator('thead tr th').allTextContents();
+    const keyColumnIndex = headers.findIndex((header) =>
+      /process\s+instance\s+key/i.test(header.trim()),
+    );
+
+    if (keyColumnIndex === -1) {
+      throw new Error('Could not find Process Instance Key column in header');
+    }
+
+    const keyCell = table
+      .locator('tbody tr')
+      .first()
+      .locator('td')
+      .nth(keyColumnIndex);
+    await expect(keyCell).toBeVisible();
+    return (await keyCell.textContent())?.trim() ?? '';
   }
 
   async gotoProcessInstancePage({id}: {id: string}): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -90,7 +90,7 @@ test.describe('Process Instance Variables', () => {
     });
   });
 
-  test.skip('Add variables', async ({
+  test('Add variables', async ({
     page,
     operateProcessInstancePage,
     operateHomePage,


### PR DESCRIPTION
## Summary

Make process instance key retrieval in Operate more robust and re-enable the `Add variables` test.

### Changes
- Resolve the table column dynamically via header text instead of relying on a fixed index  
- Trim the extracted key value and ensure it is visible before using it  
- Re-enable the `Add variables` Operate test  

## Why

The previous implementation depended on a hardcoded table cell index, which could break or return incorrect values if the column order changed. This update makes the locator resilient to UI changes and improves test reliability.

## Testing

- [On-demand run](https://github.com/camunda/camunda/actions/runs/23430006820/job/68153909649)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later

Relates to #49095 