### PR TITLE
test: fix Operate modification locator and re-enable specs

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -208,7 +208,9 @@ class OperateProcessInstancePage {
         name: /process instance/i,
       });
     this.metadataModal = this.page.getByRole('dialog', {name: 'metadata'});
-    this.modifyInstanceButton = page.getByTestId('enter-modification-mode');
+    this.modifyInstanceButton = this.instanceHeader.getByRole('button', {
+      name: /modify instance/i,
+    });
     this.modifyDialog = this.page.getByLabel(
       'Process Instance Modification Mode',
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -102,7 +102,7 @@ test.describe('Process Instance Modifications', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test.skip('Should apply/remove edit variable modifications', async ({
+  test('Should apply/remove edit variable modifications', async ({
     operateProcessInstancePage,
     operateProcessInstanceViewModificationModePage,
   }) => {
@@ -294,7 +294,7 @@ test.describe('Process Instance Modifications', () => {
     });
   });
 
-  test.skip('Verify Variables functionality in Modification mode', async ({
+  test('Verify Variables functionality in Modification mode', async ({
     operateProcessInstancePage,
     page,
     operateProcessInstanceViewModificationModePage,
@@ -648,7 +648,7 @@ test.describe('Process Instance Modifications', () => {
     });
   });
 
-  test.skip('Should apply/remove add variable modifications', async ({
+  test('Should apply/remove add variable modifications', async ({
     page,
     operateProcessInstancePage,
     operateProcessInstanceViewModificationModePage,


### PR DESCRIPTION
## Description
Use a role-based Modify Instance button locator scoped to the instance header and unskip process instance modification tests.



## Testing
[on-demand run](https://github.com/camunda/camunda/actions/runs/23431579303)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to https://github.com/camunda/camunda/issues/49095
closes https://github.com/camunda/camunda/issues/49234
