### PR TITLE
refactor: remove `allowImportingTsExtensions` from TS configs

### DIFF
--- a/operate/client/tsconfig.base.json
+++ b/operate/client/tsconfig.base.json
@@ -7,7 +7,6 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/operate/client/tsconfig.node.json
+++ b/operate/client/tsconfig.node.json
@@ -8,7 +8,6 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
## Description

Removes the setting `allowImportingTsExtensions` from Operate's TS configs. Since we do not set `rewriteRelativeImportExtensions` the default value will be `false` - just as intended.

## Related issues

closes #48845
