### PR TITLE
fix: updated the identitykeycloak config according to 8.10 platform helm chart

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -34,6 +34,12 @@ global:
       - name: harbor-registry
   # Identity authentication is enabled for Optimize
   identity:
+    keycloak:
+      auth:
+        adminUser: admin
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-keycloak-admin-password
     auth:
       enabled: true
       optimize:


### PR DESCRIPTION
## Description

This pull request makes a configuration update to the `global.identity.keycloak` section in `load-tests/camunda-platform-values.yaml` to improve secret management for authentication.

Configuration improvements:

* Configured `global.identity.keycloak.auth` to use an existing Kubernetes secret (`camunda-credentials`) and key (`identity-keycloak-admin-password`) for authentication, enhancing security and externalizing sensitive credentials.


closes [Thread](https://camunda.slack.com/archives/C0807665N8G/p1774257367186729)
