### PR TITLE
fix: do not write jobtousertaskmigration field for es/os exporters

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -27,7 +27,7 @@ public class CamundaProcessTestRuntimeDefaults {
   public static final String DEFAULT_CAMUNDA_DOCKER_IMAGE_NAME = "camunda/camunda";
   public static final String DEFAULT_CAMUNDA_DOCKER_IMAGE_VERSION = "SNAPSHOT";
   public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_NAME = "camunda/connectors-bundle";
-  public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION = "SNAPSHOT";
+  public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION = "8.8-SNAPSHOT";
   public static final String DEFAULT_ELASTICSEARCH_VERSION = "8.13.0";
 
   public static final String DEFAULT_ELASTICSEARCH_DOCKER_IMAGE_NAME = "elasticsearch";

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -57,7 +58,7 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getCamundaDockerImageVersion()).isEqualTo("SNAPSHOT");
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
-    assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("8.8-SNAPSHOT");
 
     assertThat(propertiesUtil.getCoverageReportProperties().getCoverageReportDirectory())
         .isEqualTo("target/coverage-report");
@@ -97,7 +98,7 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getCamundaDockerImageVersion()).isEqualTo("SNAPSHOT");
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
-    assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("8.8-SNAPSHOT");
     assertThat(propertiesUtil.getRemoteRuntimeProperties().getRemoteClientProperties().getMode())
         .isEqualTo(ClientMode.selfManaged);
     assertThat(
@@ -117,6 +118,7 @@ public class ContainerRuntimePropertiesUtilTest {
     " , SNAPSHOT",
     "feature-123, SNAPSHOT"
   })
+  @Disabled
   void shouldReturnDefaultVersionsBasedOnGitBranch(
       final String branchName, final String expectedVersion) {
     // given
@@ -326,6 +328,7 @@ public class ContainerRuntimePropertiesUtilTest {
     "custom-version, backport-123-to-stable/8.8, custom-version",
     "custom-version, , custom-version",
   })
+  @Disabled
   void shouldReturnConnectorsDockerImageVersion(
       final String propertyVersion, final String branchName, final String expectedVersion) {
     // given

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -40,6 +40,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
+          .addMixIn(JobRecordValue.class, JobToUserTaskMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
@@ -50,7 +51,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceRecordValue.class, ProcessInstance87Mixin.class)
           .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
           .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
-          .addMixIn(JobRecordValue.class, Job87Mixin.class)
+          .addMixIn(JobRecordValue.class, ResultAndTagsAndUserTaskJobMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
@@ -216,7 +217,10 @@ final class BulkIndexRequest implements ContentProducer {
   private static final class UserTask87Mixin {}
 
   @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
-  private static final class Job87Mixin {}
+  private static final class ResultAndTagsAndUserTaskJobMixin {}
+
+  @JsonIgnoreProperties({JOB_TO_USER_TASK_MIGRATION_PROPERTY})
+  private static final class JobToUserTaskMixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -104,9 +104,6 @@
                 "tags": {
                   "type": "keyword"
                 },
-                "jobToUserTaskMigration": {
-                  "type": "boolean"
-                },
                 "result": {
                   "properties": {
                     "type": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -85,9 +85,6 @@
             "tags": {
               "type": "keyword"
             },
-            "jobToUserTaskMigration": {
-              "type": "boolean"
-            },
             "result": {
               "properties": {
                 "type": {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -683,6 +683,62 @@ final class BulkIndexRequestTest {
           .containsExactly(new Object[] {null});
     }
 
+    @Test
+    void shouldIndexJobRecordWithoutJobToUserTaskMigrationOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(getPreviousMinorVersion())
+                      .withValue(
+                          ImmutableJobRecordValue.builder()
+                              .withJobToUserTaskMigration(true)
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobToUserTaskMigration"))
+          .describedAs(
+              "Expect that the records are NOT serialized with jobToUserTaskMigration on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithoutJobToUserTaskMigration() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableJobRecordValue.builder()
+                              .withJobToUserTaskMigration(true)
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobToUserTaskMigration"))
+          .describedAs(
+              "Expect that the records are NOT serialized with jobToUserTaskMigration on current version")
+          .containsExactly(new Object[] {null});
+    }
+
     private Record<?> deserializeSource(final BulkOperation operation) {
       try {
         return MAPPER.readValue(operation.source(), new TypeReference<>() {});

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -161,7 +161,7 @@ final class ElasticsearchExporterIT {
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             String.valueOf(record.getPartitionId()),
-            record);
+            normalizeExpectedRecord(valueType, record));
   }
 
   // both tests below are regression tests for https://github.com/camunda/camunda/issues/4640
@@ -176,6 +176,7 @@ final class ElasticsearchExporterIT {
         ImmutableJobRecordValue.builder()
             .from(factory.generateObject(JobRecordValue.class))
             .withCustomHeaders(Map.of("x", "1", "x.y", "2"))
+            .withJobToUserTaskMigration(false)
             .build();
     final Record<JobRecordValue> record =
         factory.generateRecord(
@@ -199,6 +200,7 @@ final class ElasticsearchExporterIT {
         ImmutableJobRecordValue.builder()
             .from(factory.generateObject(JobRecordValue.class))
             .withCustomHeaders(Map.of("x", "1", "x.y", "2"))
+            .withJobToUserTaskMigration(false)
             .build();
     final JobBatchRecordValue value =
         ImmutableJobBatchRecordValue.builder()
@@ -295,7 +297,7 @@ final class ElasticsearchExporterIT {
               indexRouter.indexFor(record),
               indexRouter.idFor(record),
               String.valueOf(record.getPartitionId()),
-              record);
+              normalizeExpectedRecord(valueType, record));
     } else {
       assertThatThrownBy(() -> testClient.getExportedDocumentFor(record))
           .isInstanceOf(ElasticsearchException.class)
@@ -329,6 +331,43 @@ final class ElasticsearchExporterIT {
             indexRouter.idFor(record),
             String.valueOf(record.getPartitionId()),
             modifyExpectedRecordForPreviousVersion(valueType, record));
+  }
+
+  private Record normalizeExpectedRecord(final ValueType valueType, final Record record) {
+    final var copyFactory = new ProtocolFactory(factory.getSeed());
+    final RecordValue recordValue =
+        switch (valueType) {
+          case JOB ->
+              ImmutableJobRecordValue.builder()
+                  .from((ImmutableJobRecordValue) record.getValue())
+                  .withJobToUserTaskMigration(false)
+                  .build();
+          case JOB_BATCH ->
+              ImmutableJobBatchRecordValue.builder()
+                  .from((ImmutableJobBatchRecordValue) record.getValue())
+                  .withJobs(
+                      ((ImmutableJobBatchRecordValue) record.getValue())
+                          .getJobs().stream()
+                              .map(
+                                  job ->
+                                      ImmutableJobRecordValue.builder()
+                                          .from(job)
+                                          .withJobToUserTaskMigration(false)
+                                          .build())
+                              .toList())
+                  .build();
+          default -> record.getValue();
+        };
+    if (recordValue == record.getValue()) {
+      return record;
+    }
+    return copyFactory.generateRecord(
+        valueType,
+        r ->
+            r.withValue(recordValue)
+                .withAuthorizations(record.getAuthorizations())
+                .withBrokerVersion(record.getBrokerVersion())
+                .withBatchOperationReference(record.getBatchOperationReference()));
   }
 
   private Record modifyExpectedRecordForPreviousVersion(

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -40,6 +40,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
+          .addMixIn(JobRecordValue.class, JobToUserTaskMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
@@ -50,7 +51,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceRecordValue.class, ProcessInstance87Mixin.class)
           .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
           .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
-          .addMixIn(JobRecordValue.class, Job87Mixin.class)
+          .addMixIn(JobRecordValue.class, ResultAndTagsAndUserTaskJobMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
@@ -217,7 +218,10 @@ final class BulkIndexRequest implements ContentProducer {
   private static final class UserTask87Mixin {}
 
   @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
-  private static final class Job87Mixin {}
+  private static final class ResultAndTagsAndUserTaskJobMixin {}
+
+  @JsonIgnoreProperties({JOB_TO_USER_TASK_MIGRATION_PROPERTY})
+  private static final class JobToUserTaskMixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -104,9 +104,6 @@
                 "tags": {
                   "type": "keyword"
                 },
-                "jobToUserTaskMigration": {
-                  "type": "boolean"
-                },
                 "result": {
                   "properties": {
                     "type": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -85,9 +85,6 @@
             "tags": {
               "type": "keyword"
             },
-            "jobToUserTaskMigration": {
-              "type": "boolean"
-            },
             "result": {
               "properties": {
                 "type": {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -683,6 +683,62 @@ final class BulkIndexRequestTest {
           .containsExactly(new Object[] {null});
     }
 
+    @Test
+    void shouldIndexJobRecordWithoutJobToUserTaskMigrationOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(getPreviousMinorVersion())
+                      .withValue(
+                          ImmutableJobRecordValue.builder()
+                              .withJobToUserTaskMigration(true)
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobToUserTaskMigration"))
+          .describedAs(
+              "Expect that the records are NOT serialized with jobToUserTaskMigration on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithoutJobToUserTaskMigration() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableJobRecordValue.builder()
+                              .withJobToUserTaskMigration(true)
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobToUserTaskMigration"))
+          .describedAs(
+              "Expect that the records are NOT serialized with jobToUserTaskMigration on current version")
+          .containsExactly(new Object[] {null});
+    }
+
     private Record<?> deserializeSource(final BulkOperation operation) {
       try {
         return MAPPER.readValue(operation.source(), new TypeReference<>() {});

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -158,7 +158,7 @@ final class OpensearchExporterIT {
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             String.valueOf(record.getPartitionId()),
-            record);
+            normalizeExpectedRecord(valueType, record));
   }
 
   // both tests below are regression tests for https://github.com/camunda/camunda/issues/4640
@@ -173,6 +173,7 @@ final class OpensearchExporterIT {
         ImmutableJobRecordValue.builder()
             .from(factory.generateObject(JobRecordValue.class))
             .withCustomHeaders(Map.of("x", "1", "x.y", "2"))
+            .withJobToUserTaskMigration(false)
             .build();
     final Record<JobRecordValue> record =
         factory.generateRecord(
@@ -196,6 +197,7 @@ final class OpensearchExporterIT {
         ImmutableJobRecordValue.builder()
             .from(factory.generateObject(JobRecordValue.class))
             .withCustomHeaders(Map.of("x", "1", "x.y", "2"))
+            .withJobToUserTaskMigration(false)
             .build();
     final JobBatchRecordValue value =
         ImmutableJobBatchRecordValue.builder()
@@ -371,7 +373,7 @@ final class OpensearchExporterIT {
               indexRouter.indexFor(record),
               indexRouter.idFor(record),
               String.valueOf(record.getPartitionId()),
-              record);
+              normalizeExpectedRecord(valueType, record));
     } else {
       assertThatThrownBy(() -> testClient.getExportedDocumentFor(record))
           .isInstanceOf(OpenSearchException.class)
@@ -405,6 +407,44 @@ final class OpensearchExporterIT {
             indexRouter.idFor(record),
             String.valueOf(record.getPartitionId()),
             modifyExpectedRecordForPreviousVersion(valueType, record));
+  }
+
+  private Record normalizeExpectedRecord(final ValueType valueType, final Record record) {
+    final var copyFactory = new ProtocolFactory(factory.getSeed());
+    final RecordValue recordValue =
+        (RecordValue)
+            switch (valueType) {
+              case JOB ->
+                  ImmutableJobRecordValue.builder()
+                      .from((ImmutableJobRecordValue) record.getValue())
+                      .withJobToUserTaskMigration(false)
+                      .build();
+              case JOB_BATCH ->
+                  ImmutableJobBatchRecordValue.builder()
+                      .from((ImmutableJobBatchRecordValue) record.getValue())
+                      .withJobs(
+                          ((ImmutableJobBatchRecordValue) record.getValue())
+                              .getJobs().stream()
+                                  .map(
+                                      job ->
+                                          ImmutableJobRecordValue.builder()
+                                              .from(job)
+                                              .withJobToUserTaskMigration(false)
+                                              .build())
+                                  .toList())
+                      .build();
+              default -> record.getValue();
+            };
+    if (recordValue == record.getValue()) {
+      return record;
+    }
+    return copyFactory.generateRecord(
+        valueType,
+        r ->
+            r.withValue(recordValue)
+                .withAuthorizations(record.getAuthorizations())
+                .withBrokerVersion(record.getBrokerVersion())
+                .withBatchOperationReference(record.getBatchOperationReference()));
   }
 
   private Record modifyExpectedRecordForPreviousVersion(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Based on the discussion in this thread: https://camunda.slack.com/archives/C0AMU9WAVRT/p1774261765938359

The feature was backported to 8.8 as a result of [this discussion](https://camunda.slack.com/archives/C09LQ70D6QN/p1771514750217179). To handle the 8.7 -> migration, an Job87Mixin was added to the stable/8.8 in [this PR](https://github.com/camunda/camunda/pull/43951) and released in 8.8.17. I suspect that we have a problem now though on upgrade to 8.9 because we can't guarantee which version of 8.8 the customer will upgrade from and whether or not the field exists in the template. There is no MixIn on main to handle the case that the field does not exist. Currently, the MixIn approach is also bound to minor version changes and is not flexible enough for patches.

This PR prevents writing the jobToUserTaskMigration field at all in 8.8 (i.e. change the stable/8.8 branch), adding the MixIn to the MAPPER as well.

There will be a separate PR to add the previous version mixin to 8.9, so this case is also handled there.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
