### PR TITLE
fix: add explicit keycloak auth secret for 8.10 chart compatibility

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -34,6 +34,11 @@ global:
       - name: harbor-registry
   # Identity authentication is enabled for Optimize
   identity:
+    keycloak:
+      auth:
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-keycloak-admin-password
     auth:
       enabled: true
       optimize:


### PR DESCRIPTION
## Summary
- The 8.10 Helm chart removed the `identity.keycloak.authPasswordConfig` helper template that previously provided a 3-tier fallback for resolving the Keycloak admin password (including falling back to the Keycloak subchart's auto-generated secret).
- Without explicit configuration, Identity cannot authenticate to Keycloak and fails to set up the `camunda-platform` realm.
- Adds `global.identity.keycloak.auth.secret` pointing to `camunda-credentials` / `identity-keycloak-admin-password` in the load test values file.

## Test plan
- [ ] Deploy load test with 8.10 chart and verify Identity connects to Keycloak successfully
- [ ] Verify `camunda-platform` realm is properly configured in Keycloak

🤖 Generated with [Claude Code](https://claude.com/claude-code)