### PR TITLE
feat: async flushing to ES/OS for camunda exporter

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -278,8 +278,9 @@ orchestration:
         # We need to configure it for the ES exporter AND the CamundaExporter
         zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
         zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: "1h"
-        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 1000
         zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+        zeebe.broker.exporters.camundaexporter.args.history.archiveByIdEnabled: "true"
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -367,7 +367,7 @@ public class CamundaExporter implements Exporter {
       final long now = context.clock().millis();
       final long lastFlushTimestamp = updateAndGetLastActiveFlushTimestamp(now);
       if ((now - lastFlushTimestamp) >= flushDelayMs) {
-        metrics.recordFlushReasonScheduled();
+        metrics.recordFlushReasonDelay();
         return true;
       }
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -363,10 +363,12 @@ public class CamundaExporter implements Exporter {
       metrics.recordFlushReasonBatchMemory();
       return true;
     }
-    if (writer.getBatchSize() > 0
-        && (context.clock().millis() - lastFlushTimestamp) >= flushDelayMs) {
-      metrics.recordFlushReasonScheduled();
-      return true;
+    if (writer.getBatchSize() > 0) {
+      final long lastFlushTimestamp = updateAndGetLastFlushTimestamp();
+      if ((context.clock().millis() - lastFlushTimestamp) >= flushDelayMs) {
+        metrics.recordFlushReasonScheduled();
+        return true;
+      }
     }
     return false;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -74,6 +74,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
@@ -189,6 +190,35 @@ public class CamundaExporter implements Exporter {
       }
     }
 
+    if (taskManager != null) {
+      CloseHelper.close(error -> LOG.warn("Failed to close background tasks", error), taskManager);
+      taskManager = null;
+    }
+
+    if (pendingFlush != null) {
+      try {
+        pendingFlush.waitForCompletion();
+      } catch (final Exception e) {
+        LOG.warn("Pending flush failed when closing exporter.", e);
+      }
+      pendingFlush = null;
+    }
+
+    if (flushExecutor != null) {
+      flushExecutor.shutdown();
+      try {
+        if (!flushExecutor.awaitTermination(10L, TimeUnit.SECONDS)) {
+          LOG.warn("Flush executor failed to terminate within timeout");
+        }
+      } catch (final Exception e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        LOG.warn("Erroring terminating flush executor", e);
+      }
+      flushExecutor = null;
+    }
+
     if (clientAdapter != null) {
       CloseHelper.close(
           error -> LOG.warn("Failed to close elasticsearch client", error), clientAdapter);
@@ -202,17 +232,6 @@ public class CamundaExporter implements Exporter {
     }
 
     provider.reset();
-
-    if (taskManager != null) {
-      CloseHelper.close(error -> LOG.warn("Failed to close background tasks", error), taskManager);
-      taskManager = null;
-    }
-
-    if (flushExecutor != null) {
-      flushExecutor.shutdown();
-      CloseHelper.close(error -> LOG.warn("Failed to close flush executor", error), flushExecutor);
-      flushExecutor = null;
-    }
 
     LOG.info("Exporter resources closed");
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -99,7 +99,7 @@ public class CamundaExporter implements Exporter {
   private Context context;
   private long flushDelayMs;
   private ScheduledTask scheduledFlushTask;
-  private long lastFlushTimestamp = 0L;
+  private long lastFlushActiveTimestamp = 0L;
   private PendingFlush pendingFlush;
 
   public CamundaExporter() {
@@ -163,7 +163,7 @@ public class CamundaExporter implements Exporter {
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
       final long now = context.clock().millis();
-      lastFlushTimestamp = now;
+      lastFlushActiveTimestamp = now;
       scheduleDelayedFlush(now);
 
       LOG.info("Exporter opened");
@@ -364,8 +364,9 @@ public class CamundaExporter implements Exporter {
       return true;
     }
     if (writer.getBatchSize() > 0) {
-      final long lastFlushTimestamp = updateAndGetLastFlushTimestamp();
-      if ((context.clock().millis() - lastFlushTimestamp) >= flushDelayMs) {
+      final long now = context.clock().millis();
+      final long lastFlushTimestamp = updateAndGetLastActiveFlushTimestamp(now);
+      if ((now - lastFlushTimestamp) >= flushDelayMs) {
         metrics.recordFlushReasonScheduled();
         return true;
       }
@@ -381,20 +382,22 @@ public class CamundaExporter implements Exporter {
     return builder.build();
   }
 
-  private void updateLastFlushTimestamp(final PendingFlush pendingFlush) {
-    lastFlushTimestamp = pendingFlush.maybeFlushTimeMillis().orElse(lastFlushTimestamp);
+  private void updateLastActiveFlushTimestamp(final PendingFlush pendingFlush, final long now) {
+    // if the flush has not completed we use the current time - as a way to indicate the flush
+    // is still going on, so we can avoid triggering another flush before this one has finished
+    lastFlushActiveTimestamp = pendingFlush.maybeFlushTimeMillis().orElse(now);
   }
 
-  private long updateAndGetLastFlushTimestamp() {
+  private long updateAndGetLastActiveFlushTimestamp(final long now) {
     if (pendingFlush != null) {
-      updateLastFlushTimestamp(pendingFlush);
+      updateLastActiveFlushTimestamp(pendingFlush, now);
     }
-    return lastFlushTimestamp;
+    return lastFlushActiveTimestamp;
   }
 
   private void scheduleDelayedFlush(final long now) {
     long nextDelayMs = flushDelayMs;
-    final long lastFlushTimestamp = updateAndGetLastFlushTimestamp();
+    final long lastFlushTimestamp = updateAndGetLastActiveFlushTimestamp(now);
     if (lastFlushTimestamp > 0) {
       nextDelayMs = Math.max(0, flushDelayMs - (now - lastFlushTimestamp));
     }
@@ -407,7 +410,7 @@ public class CamundaExporter implements Exporter {
   private void flushAndReschedule() {
     final var now = context.clock().millis();
     try {
-      final long lastFlushTimestamp = updateAndGetLastFlushTimestamp();
+      final long lastFlushTimestamp = updateAndGetLastActiveFlushTimestamp(now);
       if (now - lastFlushTimestamp >= flushDelayMs) {
         metrics.recordFlushReasonScheduled();
         flush();
@@ -425,7 +428,7 @@ public class CamundaExporter implements Exporter {
       // Update the record counters only after the flush was successful. If the asynchronous flush
       // fails then the exporter will be invoked with the same record again.
       updateLastExportedPosition(pendingFlush.getLastPosition());
-      updateLastFlushTimestamp(pendingFlush);
+      updateLastActiveFlushTimestamp(pendingFlush, context.clock().millis());
       pendingFlush = null;
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -420,18 +420,16 @@ public class CamundaExporter implements Exporter {
   void waitForPendingFlush() {
     if (pendingFlush != null) {
       pendingFlush.waitForCompletion();
-    }
-  }
-
-  private void flush() {
-    if (pendingFlush != null) {
-      pendingFlush.waitForCompletion();
       // Update the record counters only after the flush was successful. If the asynchronous flush
       // fails then the exporter will be invoked with the same record again.
       updateLastExportedPosition(pendingFlush.getLastPosition());
       updateLastFlushTimestamp(pendingFlush);
       pendingFlush = null;
     }
+  }
+
+  private void flush() {
+    waitForPendingFlush();
 
     final var currentWriter = writer;
     pendingFlush =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -365,13 +365,22 @@ public class CamundaExporter implements Exporter {
     }
     if (writer.getBatchSize() > 0) {
       final long now = context.clock().millis();
-      final long lastFlushTimestamp = updateAndGetLastActiveFlushTimestamp(now);
-      if ((now - lastFlushTimestamp) >= flushDelayMs) {
-        metrics.recordFlushReasonDelay();
-        return true;
+      // do an optimistic check with the cached value
+      if (exceedsDelay(lastFlushActiveTimestamp, now)) {
+        // then only check the dynamic value to confirm, so we
+        // avoid tying threads together for every check
+        final long lastFlushTimestamp = updateAndGetLastActiveFlushTimestamp(now);
+        if (exceedsDelay(lastFlushTimestamp, now)) {
+          metrics.recordFlushReasonDelay();
+          return true;
+        }
       }
     }
     return false;
+  }
+
+  private boolean exceedsDelay(final long lastFlushTimestamp, final long now) {
+    return (now - lastFlushTimestamp) >= flushDelayMs;
   }
 
   private ExporterBatchWriter createBatchWriter() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -48,6 +48,7 @@ import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.ExporterBatchWriter;
+import io.camunda.exporter.store.PendingFlush;
 import io.camunda.exporter.tasks.CamundaBackgroundTaskManager;
 import io.camunda.exporter.tasks.CamundaBackgroundTaskManagerFactory;
 import io.camunda.search.schema.MappingSource;
@@ -71,6 +72,9 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,6 +82,8 @@ import org.slf4j.LoggerFactory;
 public class CamundaExporter implements Exporter {
   private static final Logger LOG = LoggerFactory.getLogger(CamundaExporter.class);
 
+  private final Supplier<ExecutorService> flushExecutorSupplier;
+  private ExecutorService flushExecutor;
   private Controller controller;
   private ExporterConfiguration configuration;
   private ClientAdapter clientAdapter;
@@ -90,14 +96,14 @@ public class CamundaExporter implements Exporter {
   private SearchEngineClient searchEngineClient;
   private int partitionId;
   private Context context;
-  private long lastFlushTimestamp = 0L;
-
   private long flushDelayMs;
   private ScheduledTask scheduledFlushTask;
+  private long lastFlushTimestamp = 0L;
+  private PendingFlush pendingFlush;
 
   public CamundaExporter() {
     // the metadata will be initialized on open
-    this(new DefaultExporterResourceProvider(), null);
+    this(new DefaultExporterResourceProvider());
   }
 
   @VisibleForTesting
@@ -106,9 +112,22 @@ public class CamundaExporter implements Exporter {
   }
 
   @VisibleForTesting
-  public CamundaExporter(final ExporterResourceProvider provider, final ExporterMetadata metadata) {
+  CamundaExporter(final ExporterResourceProvider provider, final ExporterMetadata metadata) {
+    this(provider, metadata, CamundaExporter::createFlushExecutor);
+  }
+
+  @VisibleForTesting
+  CamundaExporter(
+      final ExporterResourceProvider provider,
+      final ExporterMetadata metadata,
+      final Supplier<ExecutorService> flushExecutorSupplier) {
     this.provider = provider;
     this.metadata = metadata;
+    this.flushExecutorSupplier = flushExecutorSupplier;
+  }
+
+  private static ExecutorService createFlushExecutor() {
+    return Executors.newVirtualThreadPerTaskExecutor();
   }
 
   @Override
@@ -139,6 +158,7 @@ public class CamundaExporter implements Exporter {
       }
 
       writer = createBatchWriter();
+      pendingFlush = null;
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
       final long now = context.clock().millis();
@@ -187,6 +207,13 @@ public class CamundaExporter implements Exporter {
       CloseHelper.close(error -> LOG.warn("Failed to close background tasks", error), taskManager);
       taskManager = null;
     }
+
+    if (flushExecutor != null) {
+      flushExecutor.shutdown();
+      CloseHelper.close(error -> LOG.warn("Failed to close flush executor", error), flushExecutor);
+      flushExecutor = null;
+    }
+
     LOG.info("Exporter resources closed");
   }
 
@@ -282,6 +309,8 @@ public class CamundaExporter implements Exporter {
                 provider.getProcessCache(),
                 context.clock())
             .build();
+
+    flushExecutor = flushExecutorSupplier.get();
   }
 
   private SchemaManager createSchemaManager() {
@@ -331,8 +360,20 @@ public class CamundaExporter implements Exporter {
     return builder.build();
   }
 
+  private void updateLastFlushTimestamp(final PendingFlush pendingFlush) {
+    lastFlushTimestamp = pendingFlush.maybeFlushTimeMillis().orElse(lastFlushTimestamp);
+  }
+
+  private long updateAndGetLastFlushTimestamp() {
+    if (pendingFlush != null) {
+      updateLastFlushTimestamp(pendingFlush);
+    }
+    return lastFlushTimestamp;
+  }
+
   private void scheduleDelayedFlush(final long now) {
     long nextDelayMs = flushDelayMs;
+    final long lastFlushTimestamp = updateAndGetLastFlushTimestamp();
     if (lastFlushTimestamp > 0) {
       nextDelayMs = Math.max(0, flushDelayMs - (now - lastFlushTimestamp));
     }
@@ -345,6 +386,7 @@ public class CamundaExporter implements Exporter {
   private void flushAndReschedule() {
     final var now = context.clock().millis();
     try {
+      final long lastFlushTimestamp = updateAndGetLastFlushTimestamp();
       if (now - lastFlushTimestamp >= flushDelayMs) {
         metrics.recordFlushReasonScheduled();
         flush();
@@ -355,7 +397,32 @@ public class CamundaExporter implements Exporter {
     scheduleDelayedFlush(now);
   }
 
+  @VisibleForTesting
+  void waitForPendingFlush() {
+    if (pendingFlush != null) {
+      pendingFlush.waitForCompletion();
+    }
+  }
+
   private void flush() {
+    if (pendingFlush != null) {
+      pendingFlush.waitForCompletion();
+      // Update the record counters only after the flush was successful. If the asynchronous flush
+      // fails then the exporter will be invoked with the same record again.
+      updateLastExportedPosition(pendingFlush.getLastPosition());
+      updateLastFlushTimestamp(pendingFlush);
+      pendingFlush = null;
+    }
+
+    final var currentWriter = writer;
+    pendingFlush =
+        new PendingFlush(
+            flushExecutor, context.clock(), () -> flushWriter(currentWriter), lastPosition);
+
+    writer = createBatchWriter();
+  }
+
+  private void flushWriter(final ExporterBatchWriter writer) {
     if (writer.getBatchSize() > 0) {
       try (final var ignored = metrics.measureFlushDuration()) {
         metrics.recordBulkSize(writer.getBatchSize());
@@ -363,6 +430,7 @@ public class CamundaExporter implements Exporter {
         final BatchRequest batchRequest =
             clientAdapter.createBatchRequest().withMetrics(metrics).withMaxBytes(maxBulkBytes);
         writer.flush(batchRequest);
+
         metrics.recordFlushOccurrence(Instant.now());
         metrics.stopFlushLatencyMeasurement();
       } catch (final PersistenceException ex) {
@@ -370,11 +438,6 @@ public class CamundaExporter implements Exporter {
         throw new ExporterException(ex.getMessage(), ex);
       }
     }
-
-    // Update record counters and lastFlushTimestamp only after the flush attempt was successful.
-    // If the synchronous flush fails then the exporter will be invoked with the same record again.
-    lastFlushTimestamp = context.clock().millis();
-    updateLastExportedPosition(lastPosition);
   }
 
   private void updateLastExportedPosition(final long lastPosition) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -113,6 +113,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private final Counter bulkOperations;
   private final Counter flushReasonBatchSize;
   private final Counter flushReasonBatchMemory;
+  private final Counter flushReasonDelay;
   private final Counter flushReasonScheduled;
   private final Timer flushDuration;
   private final Counter failedFlush;
@@ -307,6 +308,11 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .description("Number of flushes due to batch memory limit being exceeded")
             .tag("reason", "memory")
             .register(meterRegistry);
+    flushReasonDelay =
+        Counter.builder(flushReasonName)
+            .description("Number of delay-based flushes")
+            .tag("reason", "delay")
+            .register(meterRegistry);
     flushReasonScheduled =
         Counter.builder(flushReasonName)
             .description("Number of scheduled/time-based flushes")
@@ -363,6 +369,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void recordFlushReasonScheduled() {
     flushReasonScheduled.increment();
+  }
+
+  public void recordFlushReasonDelay() {
+    flushReasonDelay.increment();
   }
 
   public CloseableSilently measureFlushDuration() {
@@ -589,6 +599,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(flushReasonBatchSize);
     meterRegistry.remove(flushReasonBatchMemory);
     meterRegistry.remove(flushReasonScheduled);
+    meterRegistry.remove(flushReasonDelay);
     meterRegistry.remove(flushDuration);
     meterRegistry.remove(failedFlush);
     meterRegistry.remove(recordExportDuration);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/PendingFlush.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/PendingFlush.java
@@ -42,6 +42,7 @@ public class PendingFlush {
 
   private void start() {
     updateState(State.PENDING);
+    flushTimeMillis.set(null);
     pending =
         CompletableFuture.runAsync(
             () -> {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/PendingFlush.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/PendingFlush.java
@@ -45,8 +45,11 @@ public class PendingFlush {
     pending =
         CompletableFuture.runAsync(
             () -> {
-              flush.run();
-              flushTimeMillis.set(clock.millis());
+              try {
+                flush.run();
+              } finally {
+                flushTimeMillis.set(clock.millis());
+              }
             },
             executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/PendingFlush.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/PendingFlush.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import io.camunda.zeebe.exporter.api.ExporterException;
+import java.time.InstantSource;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PendingFlush {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PendingFlush.class);
+
+  private final Executor executor;
+  private final InstantSource clock;
+  private final Runnable flush;
+  private final long lastPosition;
+  private final AtomicReference<State> state = new AtomicReference<>(null);
+  private final AtomicReference<Long> flushTimeMillis = new AtomicReference<>(null);
+  private CompletableFuture<Void> pending;
+
+  public PendingFlush(
+      final Executor executor,
+      final InstantSource clock,
+      final Runnable flush,
+      final long lastPosition) {
+    this.executor = executor;
+    this.clock = clock;
+    this.flush = flush;
+    this.lastPosition = lastPosition;
+    start();
+  }
+
+  private void start() {
+    updateState(State.PENDING);
+    pending =
+        CompletableFuture.runAsync(
+            () -> {
+              flush.run();
+              flushTimeMillis.set(clock.millis());
+            },
+            executor);
+  }
+
+  public long getLastPosition() {
+    return lastPosition;
+  }
+
+  public OptionalLong maybeFlushTimeMillis() {
+    final Long flushTime = flushTimeMillis.get();
+    return flushTime != null ? OptionalLong.of(flushTime) : OptionalLong.empty();
+  }
+
+  public void waitForCompletion() {
+    final State currentState = state.get();
+    switch (currentState) {
+      case PENDING -> waitForPending();
+      case ERRORED -> retryAndWait();
+      case COMPLETED -> {
+        // do nothing, batch request already completed successfully
+      }
+      default -> {
+        throw new IllegalStateException("Unexpected state: " + currentState);
+      }
+    }
+  }
+
+  private void retryAndWait() {
+    LOGGER.debug("Retrying failed flush for position {}", lastPosition);
+    start();
+    waitForPending();
+  }
+
+  private void waitForPending() {
+    try {
+      pending.join();
+      updateState(State.COMPLETED);
+    } catch (final CompletionException e) {
+      updateState(State.ERRORED); // fail now, but allow retry next time
+      final Throwable cause = e.getCause();
+      if (cause instanceof ExporterException) {
+        throw (ExporterException) cause;
+      } else {
+        throw new IllegalStateException("Unexpected exception during flush", cause);
+      }
+    }
+  }
+
+  private void updateState(final State newState) {
+    state.updateAndGet(
+        existing -> {
+          if (newState == State.PENDING && (existing == null || existing == State.ERRORED)) {
+            return newState;
+          }
+          if (existing == State.PENDING) {
+            return newState;
+          }
+          throw new IllegalStateException(
+              "Invalid state transition from " + existing + " to " + newState);
+        });
+  }
+
+  enum State {
+    PENDING,
+    ERRORED,
+    COMPLETED;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -29,13 +29,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.UserCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.VariableHandler;
 import io.camunda.exporter.utils.CamundaExporterITTemplateExtension;
+import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -55,16 +58,20 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.camunda.zeebe.util.ObjectSizeEstimator;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -85,6 +92,7 @@ import org.testcontainers.containers.GenericContainer;
  */
 @TestInstance(Lifecycle.PER_CLASS)
 final class CamundaExporterIT {
+  private static final AtomicLong NEXT_POSITION = new AtomicLong(1);
 
   @RegisterExtension private static SearchDBExtension searchDB = SearchDBExtension.create();
 
@@ -160,6 +168,9 @@ final class CamundaExporterIT {
 
     exporter.export(record);
 
+    // force the pending flush to complete
+    exporter.close();
+
     // then
     assertThat(exporterController.getPosition()).isEqualTo(record.getPosition());
   }
@@ -184,10 +195,20 @@ final class CamundaExporterIT {
 
     exporter.export(record);
     exporter.export(record2);
+
+    // force the pending flush to complete
+    exporter.close();
+
     // then
+    await()
+        .untilAsserted(
+            () -> assertThat(controllerSpy.getPosition()).isEqualTo(record2.getPosition()));
+
     verify(controllerSpy, never())
         .updateLastExportedRecordPosition(eq(record.getPosition()), any());
     verify(controllerSpy).updateLastExportedRecordPosition(eq(record2.getPosition()), any());
+
+    await().untilAsserted(() -> verifyUsersStored(config, record, record2));
   }
 
   @ParameterizedTest
@@ -214,9 +235,16 @@ final class CamundaExporterIT {
     container.stop();
     await().until(() -> !container.isRunning());
 
-    final var record = generateRecordWithSupportedBrokerVersion(ValueType.USER, UserIntent.CREATED);
+    final var record1 =
+        generateRecordWithSupportedBrokerVersion(ValueType.USER, UserIntent.CREATED);
 
-    assertThatThrownBy(() -> exporter.export(record))
+    exporter.export(record1);
+
+    final var record2 =
+        generateRecordWithSupportedBrokerVersion(ValueType.USER, UserIntent.CREATED);
+
+    // need to trigger another flush so we see the actual error
+    assertThatThrownBy(() -> exporter.export(record2))
         .isInstanceOf(ExporterException.class)
         .hasMessageContaining("Connection refused");
 
@@ -226,12 +254,17 @@ final class CamundaExporterIT {
         .setPortBindings(List.of(currentPort + ":9200"));
     container.start();
 
-    final var record2 =
+    final var record3 =
         generateRecordWithSupportedBrokerVersion(ValueType.USER, UserIntent.CREATED);
-    exporter.export(record2);
+    exporter.export(record3);
+
+    // force the pending flush to complete
+    exporter.close();
 
     await()
-        .untilAsserted(() -> assertThat(controller.getPosition()).isEqualTo(record2.getPosition()));
+        .untilAsserted(() -> assertThat(controller.getPosition()).isEqualTo(record3.getPosition()));
+
+    await().untilAsserted(() -> verifyUsersStored(config, record1, record2, record3));
   }
 
   @TestTemplate
@@ -296,6 +329,9 @@ final class CamundaExporterIT {
     // when
     camundaExporter.export(record);
 
+    // force the pending flush to complete
+    camundaExporter.close();
+
     // then
     assertThat(expectedHandlers).isNotEmpty();
     expectedHandlers.forEach(
@@ -354,7 +390,13 @@ final class CamundaExporterIT {
     camundaExporter.open(new ExporterTestController());
 
     // act
-    assertThatCode(() -> camundaExporter.export(record)).doesNotThrowAnyException();
+    assertThatCode(
+            () -> {
+              camundaExporter.export(record);
+              // export the same record so we ensure we get any error from the pending flush
+              camundaExporter.export(record);
+            })
+        .doesNotThrowAnyException();
   }
 
   @TestTemplate
@@ -389,7 +431,12 @@ final class CamundaExporterIT {
     camundaExporter.open(new ExporterTestController());
 
     // act
-    assertThatThrownBy(() -> camundaExporter.export(record))
+    assertThatThrownBy(
+            () -> {
+              camundaExporter.export(record);
+              // export the same record so we ensure we get any error from the pending flush
+              camundaExporter.export(record);
+            })
         .isInstanceOf(ExporterException.class)
         .cause()
         .isInstanceOf(PersistenceException.class);
@@ -430,6 +477,9 @@ final class CamundaExporterIT {
             r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()),
             UserIntent.CREATED);
     exporter.export(record);
+
+    // Force the pending flush to complete
+    exporter.close();
 
     // Position updated
     assertThat(secondController.getPosition()).isEqualTo(record.getPosition());
@@ -474,7 +524,10 @@ final class CamundaExporterIT {
 
   private Record<?> generateRecordWithSupportedBrokerVersion(
       final ValueType valueType, final Intent intent) {
-    return factory.generateRecord(valueType, r -> r.withBrokerVersion("8.8.0"), intent);
+    return factory.generateRecord(
+        valueType,
+        r -> r.withBrokerVersion("8.8.0").withPosition(NEXT_POSITION.getAndIncrement()),
+        intent);
   }
 
   private static Stream<Arguments> containerProvider() {
@@ -608,5 +661,46 @@ final class CamundaExporterIT {
 
     // act
     assertThatCode(() -> camundaExporter.export(record)).doesNotThrowAnyException();
+  }
+
+  private void verifyUsersStored(final ExporterConfiguration config, final Record<?>... records)
+      throws IOException {
+    final var expectedUsernames =
+        Arrays.stream(records).map(this::userName).collect(Collectors.toSet());
+
+    final var actualUserNames =
+        getStoredEntitiesForHandler(config, UserCreatedUpdatedHandler.class, expectedUsernames)
+            .stream()
+            .map(entity -> entity.get("username"))
+            .collect(Collectors.toSet());
+    assertThat(actualUserNames).isEqualTo(expectedUsernames);
+  }
+
+  private String userName(final Record<?> record) {
+    return ((UserRecordValue) record.getValue()).getUsername();
+  }
+
+  private List<Map<String, Object>> getStoredEntitiesForHandler(
+      final ExporterConfiguration config, final Class<?> handlerClass, final Set<String> ids)
+      throws IOException {
+
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(config.getConnect());
+        final SearchEngineClient searchEngineClient = clientAdapter.getSearchEngineClient()) {
+      final var handler =
+          getHandlers(config).stream()
+              .filter(h -> handlerClass.isAssignableFrom(h.getClass()))
+              .findFirst()
+              .orElseThrow();
+
+      // For simplicity, we assume that the handler generates a single ID per record
+      // In a real scenario, you might need to adapt this to handle multiple IDs or different ID
+      // generation logic
+      return ids.stream()
+          .map(
+              id -> {
+                return searchEngineClient.getDocument(handler.getIndexName(), id);
+              })
+          .toList();
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -12,12 +12,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -318,11 +320,12 @@ final class CamundaExporterTest {
   @Nested
   final class CloseTest {
     @Test
-    void shouldShutdownFlushExecutorBeforeClosing() {
+    void shouldShutdownFlushExecutorBeforeClosing() throws Exception {
       // given
       final Supplier<ExecutorService> executorServiceSupplier = mock(Supplier.class);
-      final ExecutorService executorService = mock(ExecutorService.class);
-      when(executorServiceSupplier.get()).thenReturn(executorService);
+      final ExecutorService configureExecutorService = mock(ExecutorService.class);
+      final ExecutorService openExecutorService = spy(new RunImmediately());
+      when(executorServiceSupplier.get()).thenReturn(configureExecutorService, openExecutorService);
 
       exporter =
           new CamundaExporter(
@@ -339,8 +342,19 @@ final class CamundaExporterTest {
 
       // NB called twice because configure creates and closes things to verify config
       verify(executorServiceSupplier, times(2)).get();
-      verify(executorService, times(2)).shutdown();
-      verify(executorService, times(2)).close();
+
+      final var inOrder = Mockito.inOrder(configureExecutorService, openExecutorService);
+
+      inOrder.verify(configureExecutorService).shutdown();
+      inOrder.verify(configureExecutorService).awaitTermination(anyLong(), any());
+      verifyNoMoreInteractions(configureExecutorService);
+
+      // pending flush will have been triggered when closing
+      // so we'll verify that has happened
+      inOrder.verify(openExecutorService).execute(any(Runnable.class));
+      inOrder.verify(openExecutorService).shutdown();
+      inOrder.verify(openExecutorService).awaitTermination(anyLong(), any());
+      verifyNoMoreInteractions(openExecutorService);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -9,10 +9,16 @@ package io.camunda.exporter;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
@@ -20,6 +26,7 @@ import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.schema.SearchEngineClient;
@@ -27,6 +34,7 @@ import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
@@ -40,6 +48,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -126,6 +138,41 @@ final class CamundaExporterTest {
         });
   }
 
+  static class RunImmediately extends AbstractExecutorService {
+    private boolean shutdown;
+
+    @Override
+    public void shutdown() {
+      shutdown = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      shutdown();
+      return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return shutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return shutdown;
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+      return shutdown;
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+      command.run();
+    }
+  }
+
   private static final class NoopExporterEntityCacheProvider
       implements ExporterEntityCacheProvider {
 
@@ -185,6 +232,45 @@ final class CamundaExporterTest {
     public void close() {}
   }
 
+  private static final class FailingBatchRequestClientAdapter implements ClientAdapter {
+    private final ExporterEntityCacheProvider entityCacheProvider =
+        new NoopExporterEntityCacheProvider();
+    private final SearchEngineClient client =
+        mock(
+            SearchEngineClient.class,
+            Mockito.withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+
+    @Override
+    public ObjectMapper objectMapper() {
+      return TestObjectMapper.objectMapper();
+    }
+
+    @Override
+    public SearchEngineClient getSearchEngineClient() {
+      return client;
+    }
+
+    @Override
+    public BatchRequest createBatchRequest() {
+      final var request =
+          mock(BatchRequest.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF));
+      try {
+        doThrow(new PersistenceException("simulated flush failure")).when(request).execute(any());
+      } catch (final PersistenceException e) {
+        throw new RuntimeException(e);
+      }
+      return request;
+    }
+
+    @Override
+    public ExporterEntityCacheProvider getExporterEntityCacheProvider() {
+      return entityCacheProvider;
+    }
+
+    @Override
+    public void close() {}
+  }
+
   private static final class MutableClock implements InstantSource {
     private long millis;
 
@@ -209,7 +295,7 @@ final class CamundaExporterTest {
       // given
       final var expected = new ExporterMetadata(TestObjectMapper.objectMapper());
       final var metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
-      exporter = new CamundaExporter(resourceProvider, metadata);
+      exporter = new CamundaExporter(resourceProvider, metadata, RunImmediately::new);
       expected.setLastIncidentUpdatePosition(3);
       expected.setFirstUserTaskKey(TaskImplementation.JOB_WORKER, 5);
       expected.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, 5);
@@ -230,6 +316,35 @@ final class CamundaExporterTest {
   }
 
   @Nested
+  final class CloseTest {
+    @Test
+    void shouldShutdownFlushExecutorBeforeClosing() {
+      // given
+      final Supplier<ExecutorService> executorServiceSupplier = mock(Supplier.class);
+      final ExecutorService executorService = mock(ExecutorService.class);
+      when(executorServiceSupplier.get()).thenReturn(executorService);
+
+      exporter =
+          new CamundaExporter(
+              resourceProvider,
+              new ExporterMetadata(TestObjectMapper.objectMapper()),
+              executorServiceSupplier);
+
+      // when
+      exporter.configure(testContext);
+      exporter.open(testController);
+      exporter.close();
+
+      // then
+
+      // NB called twice because configure creates and closes things to verify config
+      verify(executorServiceSupplier, times(2)).get();
+      verify(executorService, times(2)).shutdown();
+      verify(executorService, times(2)).close();
+    }
+  }
+
+  @Nested
   final class FlushTest {
     @Test
     void shouldUpdateMetadataOnFlush() {
@@ -239,7 +354,8 @@ final class CamundaExporterTest {
 
       // given
       final var expected = new ExporterMetadata(TestObjectMapper.objectMapper());
-      exporter = new CamundaExporter(resourceProvider, expected);
+
+      exporter = new CamundaExporter(resourceProvider, expected, RunImmediately::new);
 
       expected.setLastIncidentUpdatePosition(5);
       expected.setFirstUserTaskKey(TaskImplementation.JOB_WORKER, 10);
@@ -250,7 +366,11 @@ final class CamundaExporterTest {
       exporter.open(testController);
 
       clock.advance(1001);
+
       testController.runScheduledTasks(Duration.ofHours(1));
+
+      // force wait for pending flush to update metadata
+      exporter.close();
 
       // then
       final var actual = new ExporterMetadata(TestObjectMapper.objectMapper());
@@ -278,7 +398,9 @@ final class CamundaExporterTest {
       configuration.getBulk().setDelay(5);
       exporter =
           new CamundaExporter(
-              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+              resourceProvider,
+              new ExporterMetadata(TestObjectMapper.objectMapper()),
+              RunImmediately::new);
 
       // when
       exporter.configure(testContext);
@@ -301,7 +423,9 @@ final class CamundaExporterTest {
       configuration.getBulk().setDelay(1);
       exporter =
           new CamundaExporter(
-              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+              resourceProvider,
+              new ExporterMetadata(TestObjectMapper.objectMapper()),
+              RunImmediately::new);
       exporter.configure(testContext);
       exporter.open(testController);
 
@@ -376,7 +500,9 @@ final class CamundaExporterTest {
       configuration.getBulk().setDelay(1); // 1 second
       exporter =
           new CamundaExporter(
-              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+              resourceProvider,
+              new ExporterMetadata(TestObjectMapper.objectMapper()),
+              RunImmediately::new);
       exporter.configure(testContext);
       exporter.open(testController);
 
@@ -436,6 +562,204 @@ final class CamundaExporterTest {
       exporter.close();
 
       assertThat(flushTask.isCanceled()).isEqualTo(true);
+    }
+  }
+
+  @Nested
+  final class AsyncFlushTest {
+
+    private final ProtocolFactory factory = new ProtocolFactory();
+
+    private Record<?> stubRecord() {
+      return factory.generateRecord(ValueType.VARIABLE);
+    }
+
+    @Test
+    void shouldUpdatePositionAfterAsyncFlushOnNextExport() {
+      // given
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      final var record = stubRecord();
+
+      // when
+      exporter.export(record);
+      final var record2 = stubRecord();
+      exporter.export(record2);
+
+      // then
+      assertThat(testController.getPosition()).isEqualTo(record.getPosition());
+    }
+
+    @Test
+    void shouldUpdatePositionAfterAsyncFlushOnClose() {
+      // given
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      final var record = stubRecord();
+
+      // when
+      exporter.export(record);
+      exporter.close();
+
+      // then
+      assertThat(testController.getPosition()).isEqualTo(record.getPosition());
+    }
+
+    @Test
+    void shouldPropagateAsyncFlushErrorOnNextExport() {
+      // given
+      final var failingAdapter = new FailingBatchRequestClientAdapter();
+      mockedClientAdapterFactory
+          .when(() -> ClientAdapter.of(configuration.getConnect()))
+          .thenReturn(failingAdapter);
+
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      exporter.export(stubRecord());
+
+      // then
+      assertThatThrownBy(() -> exporter.export(stubRecord()))
+          .isInstanceOf(ExporterException.class)
+          .hasRootCauseInstanceOf(PersistenceException.class);
+    }
+
+    @Test
+    void shouldNotUpdatePositionOnFailedAsyncFlush() {
+      // given
+      final var failingAdapter = new FailingBatchRequestClientAdapter();
+      mockedClientAdapterFactory
+          .when(() -> ClientAdapter.of(configuration.getConnect()))
+          .thenReturn(failingAdapter);
+
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+      final var initialPosition = testController.getPosition();
+
+      // when
+      exporter.export(stubRecord());
+
+      // then
+      try {
+        exporter.export(stubRecord());
+      } catch (final ExporterException expected) {
+        assertThat(expected).hasRootCauseInstanceOf(PersistenceException.class);
+      }
+      assertThat(testController.getPosition()).isEqualTo(initialPosition);
+    }
+
+    @Test
+    void shouldSwapWriterOnFlushAndContinueBatching() {
+      // given
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      final var record1 = stubRecord();
+      exporter.export(record1);
+
+      final var record2 = stubRecord();
+      exporter.export(record2);
+
+      final var record3 = stubRecord();
+      exporter.export(record3);
+
+      // then
+      assertThat(testController.getPosition()).isGreaterThanOrEqualTo(record2.getPosition());
+    }
+
+    @Test
+    void shouldNotPropagateAsyncFlushErrorOnScheduledFlush() {
+      // given
+      final var failingAdapter = spy(new FailingBatchRequestClientAdapter());
+      mockedClientAdapterFactory
+          .when(() -> ClientAdapter.of(configuration.getConnect()))
+          .thenReturn(failingAdapter);
+
+      // don't flush immediately on export, so we can verify scheduled flush behavior
+      configuration.getBulk().setSize(100);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      exporter.export(stubRecord());
+
+      // then
+      final var initialPosition = testController.getPosition();
+      testController.runScheduledTasks(Duration.ofHours(1));
+      assertThat(testController.getPosition()).isEqualTo(initialPosition);
+
+      waitForPendingFlush();
+
+      // verify flush was attempted
+      verify(failingAdapter).createBatchRequest();
+    }
+
+    @Test
+    void shouldRetryFlushAfterError() {
+      // given
+      final var failingAdapter = spy(new FailingBatchRequestClientAdapter());
+      mockedClientAdapterFactory
+          .when(() -> ClientAdapter.of(configuration.getConnect()))
+          .thenReturn(failingAdapter);
+
+      configuration.getBulk().setSize(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      exporter.export(stubRecord());
+
+      // then
+
+      // verify flush was attempted
+      waitForPendingFlush();
+      verify(failingAdapter).createBatchRequest();
+
+      // and exception thrown for next export attempt
+      assertThatThrownBy(() -> exporter.export(stubRecord()))
+          .isInstanceOf(ExporterException.class)
+          .hasRootCauseInstanceOf(PersistenceException.class);
+
+      // which should trigger a retry
+      verify(failingAdapter, times(2)).createBatchRequest();
+    }
+
+    private void waitForPendingFlush() {
+      try {
+        exporter.waitForPendingFlush();
+      } catch (final ExporterException expected) {
+        assertThat(expected).hasRootCauseInstanceOf(PersistenceException.class);
+      }
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -468,7 +468,9 @@ final class CamundaExporterTest {
       configuration.getBulk().setDelay(1);
       exporter =
           new CamundaExporter(
-              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+              resourceProvider,
+              new ExporterMetadata(TestObjectMapper.objectMapper()),
+              RunImmediately::new);
       exporter.configure(testContext);
       exporter.open(testController);
 
@@ -481,6 +483,9 @@ final class CamundaExporterTest {
       // advance clock to trigger scheduled flush task at t=1000
       clock.advance(500);
       testController.runScheduledTasks(Duration.ofSeconds(1));
+
+      // wait for exporter to update positions
+      exporter.waitForPendingFlush();
 
       // then — validate record1 was exported (position updated after timed flush)
       assertThat(testController.getPosition())
@@ -495,6 +500,9 @@ final class CamundaExporterTest {
       final var record2 =
           protocolFactory.generateRecord(ValueType.VARIABLE, b -> b.withPosition(2L));
       exporter.export(record2);
+
+      // wait for exporter to update positions
+      exporter.waitForPendingFlush();
 
       // then — validate record2 was exported (position updated after flush)
       assertThat(testController.getPosition())
@@ -546,7 +554,9 @@ final class CamundaExporterTest {
       configuration.getBulk().setDelay(1); // 1 second
       exporter =
           new CamundaExporter(
-              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+              resourceProvider,
+              new ExporterMetadata(TestObjectMapper.objectMapper()),
+              RunImmediately::new);
       exporter.configure(testContext);
       exporter.open(testController);
 
@@ -713,6 +723,9 @@ final class CamundaExporterTest {
           .when(() -> ClientAdapter.of(configuration.getConnect()))
           .thenReturn(failingAdapter);
 
+      final var clock = new MutableClock(1000);
+      testContext.setClock(clock);
+      configuration.getBulk().setDelay(1);
       // don't flush immediately on export, so we can verify scheduled flush behavior
       configuration.getBulk().setSize(100);
       exporter =
@@ -725,13 +738,13 @@ final class CamundaExporterTest {
       exporter.export(stubRecord());
 
       // then
+      clock.advance(1001);
       final var initialPosition = testController.getPosition();
       testController.runScheduledTasks(Duration.ofHours(1));
       assertThat(testController.getPosition()).isEqualTo(initialPosition);
 
-      waitForPendingFlush();
-
       // verify flush was attempted
+      waitForPendingFlushToFail();
       verify(failingAdapter).createBatchRequest();
     }
 
@@ -756,7 +769,7 @@ final class CamundaExporterTest {
       // then
 
       // verify flush was attempted
-      waitForPendingFlush();
+      waitForPendingFlushToFail();
       verify(failingAdapter).createBatchRequest();
 
       // and exception thrown for next export attempt
@@ -768,12 +781,10 @@ final class CamundaExporterTest {
       verify(failingAdapter, times(2)).createBatchRequest();
     }
 
-    private void waitForPendingFlush() {
-      try {
-        exporter.waitForPendingFlush();
-      } catch (final ExporterException expected) {
-        assertThat(expected).hasRootCauseInstanceOf(PersistenceException.class);
-      }
+    private void waitForPendingFlushToFail() {
+      assertThatThrownBy(() -> exporter.waitForPendingFlush())
+          .isInstanceOf(ExporterException.class)
+          .hasRootCauseInstanceOf(PersistenceException.class);
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -49,8 +49,11 @@ import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -172,6 +175,58 @@ final class CamundaExporterTest {
     @Override
     public void execute(final Runnable command) {
       command.run();
+    }
+  }
+
+  static class RunLater extends AbstractExecutorService {
+    private boolean shutdown;
+    private final Queue<Runnable> tasks = new ConcurrentLinkedQueue<>();
+
+    int runTasks() {
+      var run = 0;
+      while (!tasks.isEmpty()) {
+        final var next = tasks.poll();
+        next.run();
+        run++;
+      }
+      return run;
+    }
+
+    @Override
+    public void shutdown() {
+      shutdown = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      shutdown();
+      return new ArrayList<>(tasks);
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return shutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return shutdown;
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+      return shutdown;
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+      if (shutdown) {
+        // when shutdown we'll change behaviour
+        // otherwise we can end up blocking the tests from finishing
+        command.run();
+      } else {
+        tasks.add(command);
+      }
     }
   }
 
@@ -779,6 +834,54 @@ final class CamundaExporterTest {
 
       // which should trigger a retry
       verify(failingAdapter, times(2)).createBatchRequest();
+    }
+
+    @Test
+    void shouldNotPerformScheduledFlushIfPendingFlushCompletedRecently() {
+      // given
+      final StubClientAdapter clientAdapter = spy(new StubClientAdapter());
+      mockedClientAdapterFactory
+          .when(() -> ClientAdapter.of(configuration.getConnect()))
+          .thenReturn(clientAdapter);
+
+      final var clock = new MutableClock(1000);
+      testContext.setClock(clock);
+      configuration.getBulk().setDelay(1);
+      try (final var executor = new RunLater()) {
+        final Supplier<ExecutorService> flushExecutorSupplier = mock(Supplier.class);
+        // first executor is created and shutdown to check config, so returning a mock for
+        // for that so the RunLater executor is not shutdown before we want it to be
+        when(flushExecutorSupplier.get()).thenReturn(mock(ExecutorService.class), executor);
+        exporter =
+            new CamundaExporter(
+                resourceProvider,
+                new ExporterMetadata(TestObjectMapper.objectMapper()),
+                flushExecutorSupplier);
+        exporter.configure(testContext);
+        exporter.open(testController);
+
+        // when
+
+        // this should trigger a flush
+        configuration.getBulk().setSize(1);
+        exporter.export(stubRecord());
+
+        clock.advance(1001);
+        final var ran = executor.runTasks();
+        assertThat(ran).isEqualTo(1);
+
+        verify(clientAdapter).createBatchRequest();
+
+        // this should not trigger a flush as the async flush completed recently
+        // and the batch size has not been exceeded
+        configuration.getBulk().setSize(100);
+        exporter.export(stubRecord());
+
+        // then
+        // still only the initial flush
+        assertThat(executor.runTasks()).isEqualTo(0);
+        verify(clientAdapter).createBatchRequest();
+      }
     }
 
     private void waitForPendingFlushToFail() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/PendingFlushTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/PendingFlushTest.java
@@ -22,13 +22,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class PendingFlushTest {
+  private static final long TIME0 = 789L;
+  private static final long TIME1 = 890L;
 
   private final Runnable flush = mock(Runnable.class);
   private final InstantSource clock = mock(InstantSource.class);
 
   @BeforeEach
   void setup() {
-    when(clock.millis()).thenReturn(789L, 890L);
+    when(clock.millis()).thenReturn(TIME0, TIME1);
   }
 
   @Test
@@ -41,11 +43,11 @@ class PendingFlushTest {
 
     // then
     verify(flush).run();
-    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(789L);
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME0);
   }
 
   @Test
-  void shouldFlushTimeDoesNotUpdateIfNotFlushed() {
+  void shouldNotUpdateFlushTimeIfNotFlushed() {
     // given
     final var pendingFlush =
         new PendingFlush(
@@ -73,7 +75,7 @@ class PendingFlushTest {
     // then
     verify(flush).run();
     // flush time should not have been updated by the second waitForCompletion call
-    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(789L);
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME0);
   }
 
   @Test
@@ -89,7 +91,7 @@ class PendingFlushTest {
         .hasMessage("flush failed");
     verify(flush).run();
 
-    assertThat(pendingFlush.maybeFlushTimeMillis()).isEmpty();
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME0);
   }
 
   @Test
@@ -108,7 +110,7 @@ class PendingFlushTest {
         .hasMessage("flush failed");
     verify(flush).run();
 
-    assertThat(pendingFlush.maybeFlushTimeMillis()).isEmpty();
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME0);
   }
 
   @Test
@@ -122,7 +124,7 @@ class PendingFlushTest {
         .isInstanceOf(ExporterException.class)
         .hasMessage("flush failed");
 
-    assertThat(pendingFlush.maybeFlushTimeMillis()).isEmpty();
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME0);
 
     // when
     pendingFlush.waitForCompletion();
@@ -130,6 +132,7 @@ class PendingFlushTest {
     // then
     verify(flush, times(2)).run();
 
-    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(789L);
+    // retried so we should be on the next time for the flush
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME1);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/PendingFlushTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/PendingFlushTest.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -18,6 +20,10 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.exporter.api.ExporterException;
 import java.time.InstantSource;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -133,6 +139,53 @@ class PendingFlushTest {
     verify(flush, times(2)).run();
 
     // retried so we should be on the next time for the flush
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME1);
+  }
+
+  @Test
+  public void shouldResetFlushTimeWhenRetryingFlush() {
+    // given
+    doThrow(new ExporterException("flush failed")).doNothing().when(flush).run();
+
+    // use this to let us control exactly when the tasks run
+    final var semaphore = new Semaphore(1);
+    final Executor executor = mock(Executor.class);
+    doAnswer(
+            invocation -> {
+              semaphore.acquire();
+              final Runnable task = invocation.getArgument(0);
+              task.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any());
+
+    final var pendingFlush = new PendingFlush(executor, clock, flush, 123L);
+
+    assertThatThrownBy(pendingFlush::waitForCompletion)
+        .isInstanceOf(ExporterException.class)
+        .hasMessage("flush failed");
+
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME0);
+
+    // when
+
+    // pendingFlush::waitForCompletion will block so we can confirm the time gets reset
+    final var waitingForCompletion = CompletableFuture.runAsync(pendingFlush::waitForCompletion);
+
+    // then
+    Awaitility.await()
+        .untilAsserted(() -> assertThat(pendingFlush.maybeFlushTimeMillis()).isEmpty());
+
+    // second flush not run yet
+    verify(flush).run();
+
+    // now let things continue
+    semaphore.release();
+
+    waitingForCompletion.join();
+
+    verify(flush, times(2)).run();
     assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(TIME1);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/PendingFlushTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/PendingFlushTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.api.ExporterException;
+import java.time.InstantSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PendingFlushTest {
+
+  private final Runnable flush = mock(Runnable.class);
+  private final InstantSource clock = mock(InstantSource.class);
+
+  @BeforeEach
+  void setup() {
+    when(clock.millis()).thenReturn(789L, 890L);
+  }
+
+  @Test
+  void shouldWaitForCompletionOfSuccessfulRun() {
+    // given
+    final var pendingFlush = new PendingFlush(Runnable::run, clock, flush, 123L);
+
+    // when
+    pendingFlush.waitForCompletion();
+
+    // then
+    verify(flush).run();
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(789L);
+  }
+
+  @Test
+  void shouldFlushTimeDoesNotUpdateIfNotFlushed() {
+    // given
+    final var pendingFlush =
+        new PendingFlush(
+            task -> {
+              /* no-op */
+            },
+            clock,
+            flush,
+            123L);
+
+    // then
+    verify(flush, never()).run();
+    assertThat(pendingFlush.maybeFlushTimeMillis()).isEmpty();
+  }
+
+  @Test
+  void shouldWaitForCompletionOfAlreadyCompletedRun() {
+    // given
+    final var pendingFlush = new PendingFlush(Runnable::run, clock, flush, 123L);
+    pendingFlush.waitForCompletion();
+
+    // when
+    pendingFlush.waitForCompletion();
+
+    // then
+    verify(flush).run();
+    // flush time should not have been updated by the second waitForCompletion call
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(789L);
+  }
+
+  @Test
+  void shouldThrowExportExceptionWhenWaitingForFailedRun() {
+    // given
+    doThrow(new ExporterException("flush failed")).when(flush).run();
+
+    final var pendingFlush = new PendingFlush(Runnable::run, clock, flush, 123L);
+
+    // when + then
+    assertThatThrownBy(pendingFlush::waitForCompletion)
+        .isInstanceOf(ExporterException.class)
+        .hasMessage("flush failed");
+    verify(flush).run();
+
+    assertThat(pendingFlush.maybeFlushTimeMillis()).isEmpty();
+  }
+
+  @Test
+  void shouldThrowIllegalStateExceptionWhenWaitingForFailedRun() {
+    // given
+    doThrow(new RuntimeException("flush failed")).when(flush).run();
+
+    final var pendingFlush = new PendingFlush(Runnable::run, clock, flush, 123L);
+
+    // when + then
+    assertThatThrownBy(pendingFlush::waitForCompletion)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Unexpected exception during flush")
+        .hasCauseInstanceOf(RuntimeException.class)
+        .cause()
+        .hasMessage("flush failed");
+    verify(flush).run();
+
+    assertThat(pendingFlush.maybeFlushTimeMillis()).isEmpty();
+  }
+
+  @Test
+  public void shouldRetryFlushAfterFailure() {
+    // given
+    doThrow(new ExporterException("flush failed")).doNothing().when(flush).run();
+
+    final var pendingFlush = new PendingFlush(Runnable::run, clock, flush, 123L);
+
+    assertThatThrownBy(pendingFlush::waitForCompletion)
+        .isInstanceOf(ExporterException.class)
+        .hasMessage("flush failed");
+
+    assertThat(pendingFlush.maybeFlushTimeMillis()).isEmpty();
+
+    // when
+    pendingFlush.waitForCompletion();
+
+    // then
+    verify(flush, times(2)).run();
+
+    assertThat(pendingFlush.maybeFlushTimeMillis()).hasValue(789L);
+  }
+}


### PR DESCRIPTION
This is pretty similar to what we tried in https://github.com/camunda/camunda/pull/48362.

The only real difference is the logic around errors.  Previously errors would propagate during scheduled flushes and this would cause the exporter threads to die.  Fixing that alone was not enough though - we also needed to ensure that a failed flush would be re-attempted again later.

## Related issues

refs #41206
