### PR TITLE
fix: Update Spring-related dependencies

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -108,8 +108,10 @@
     <version.dmn-scala>1.11.0</version.dmn-scala>
     <version.rest-assured>6.0.0</version.rest-assured>
     <version.spring>7.0.6</version.spring>
-    <version.spring-security>7.0.3</version.spring-security>
-    <version.spring-boot>4.0.3</version.spring-boot>
+    <version.spring-security>7.0.4</version.spring-security>
+    <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
+    <spring-security.version>${version.spring-security}</spring-security.version>
+    <version.spring-boot>4.0.4</version.spring-boot>
     <version.spring-ai>2.0.0-M3</version.spring-ai>
     <version.mcp-sdk>1.1.0</version.mcp-sdk>
     <version.jsonschema-generator>5.0.0</version.jsonschema-generator>


### PR DESCRIPTION
## Description

Bumping the versions of some Spring dependencies in order to address some vulnerabilities. See relevant ticket for more information.

From the CVE descriptions and remediation suggestions and local testing it looks like we need:
* Spring Boot 4.0.4 (in this PR)
* Spring Security 7.0.4 (in this PR)
* Spring Framework 7.0.6 (already updated)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/49253
