### PR TITLE
fix: stale incidents UI after incidents resolve

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
@@ -9,6 +9,7 @@
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'modules/testing-library';
@@ -27,6 +28,7 @@ import {mockProcessInstance} from 'modules/mocks/api/v2/mocks/processInstance';
 import {createIncident, searchResult} from 'modules/testUtils';
 import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 import {getIncidentErrorName} from 'modules/utils/incidents';
+import {LocationLog} from 'modules/utils/LocationLog';
 
 const PROCESS_INSTANCE_ID = mockProcessInstance.processInstanceKey;
 
@@ -47,11 +49,15 @@ function getWrapper(searchParams?: Record<string, string>) {
     <QueryClientProvider client={getMockQueryClient()}>
       <MemoryRouter
         initialEntries={[
-          `${Paths.processInstance(PROCESS_INSTANCE_ID)}?${params.toString()}`,
+          `${Paths.processInstanceIncidents({processInstanceId: PROCESS_INSTANCE_ID})}?${params.toString()}`,
         ]}
       >
         <Routes>
-          <Route path={Paths.processInstance()} element={children} />
+          <Route path={Paths.processInstanceIncidents()} element={children} />
+          <Route
+            path={Paths.processInstanceVariables()}
+            element={<LocationLog />}
+          />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>
@@ -70,6 +76,25 @@ describe('IncidentsTab', () => {
 
   afterEach(() => {
     incidentsPanelStore.clearSelection();
+  });
+
+  it('should redirect to variables when the process instance has no incidents', async () => {
+    const mockInstanceWithoutIncidents = {
+      ...mockProcessInstance,
+      hasIncident: false,
+    };
+    mockFetchProcessInstance().withSuccess(mockInstanceWithoutIncidents);
+    render(<IncidentsTab />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname')).toHaveTextContent(
+        Paths.processInstanceVariables({
+          processInstanceId: PROCESS_INSTANCE_ID,
+        }),
+      ),
+    );
   });
 
   it('should render the incidents table with correct columns', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -26,12 +26,13 @@ import {IncidentsTable} from './IncidentsTable';
 import {PanelHeader} from 'modules/components/PanelHeader';
 import {Container} from './styled';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
-import {Navigate} from 'react-router-dom';
+import {Navigate, useLocation} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 
 const ROW_HEIGHT = 32;
 
 const IncidentsTab: React.FC = observer(() => {
+  const location = useLocation();
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const {data: processInstance} = useProcessInstance();
   const {selectedElementId, resolvedElementInstance, isFetchingElement} =

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -26,6 +26,8 @@ import {IncidentsTable} from './IncidentsTable';
 import {PanelHeader} from 'modules/components/PanelHeader';
 import {Container} from './styled';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {Navigate} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
 
 const ROW_HEIGHT = 32;
 
@@ -57,7 +59,7 @@ const IncidentsTab: React.FC = observer(() => {
     {
       enabled:
         !isElementInstanceSelected &&
-        processInstance !== undefined &&
+        !!processInstance?.hasIncident &&
         !isFetchingElement,
       enablePeriodicRefetch,
       payload: {sort, filter},
@@ -67,7 +69,7 @@ const IncidentsTab: React.FC = observer(() => {
   const elementInstanceResult = useGetIncidentsByElementInstancePaginated(
     resolvedElementInstanceKey ?? '',
     {
-      enabled: isElementInstanceSelected && processInstance !== undefined,
+      enabled: isElementInstanceSelected && !!processInstance?.hasIncident,
       enablePeriodicRefetch,
       payload: {
         sort,
@@ -89,6 +91,18 @@ const IncidentsTab: React.FC = observer(() => {
   } = mapQueryResultToIncidentsHandle(result);
 
   const enhancedIncidents = useEnhancedIncidents(incidents);
+
+  if (processInstance?.hasIncident === false) {
+    return (
+      <Navigate
+        to={{
+          ...location,
+          pathname: Paths.processInstanceVariables({processInstanceId}),
+        }}
+        replace
+      />
+    );
+  }
 
   return (
     <Container>

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
@@ -107,7 +107,7 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
     <InstanceHeader
       state={processInstanceState}
       instanceName={getProcessDefinitionName(processInstance)}
-      incidentsCount={incidentsCount}
+      incidentsCount={hasIncident ? incidentsCount : 0}
       headerColumns={headerColumns.filter((name) => {
         if (name === 'Tenant') {
           return isMultiTenancyEnabled;

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/index.test.tsx
@@ -127,6 +127,40 @@ describe('InstanceHeader', () => {
     ).toBeInTheDocument();
   });
 
+  it('should not render an incidents count after incidents are resolved', async () => {
+    const failedInstance = {
+      ...mockInstance,
+      state: 'ACTIVE',
+      hasIncident: true,
+    } satisfies typeof mockInstance;
+    mockSearchIncidentsByProcessInstance(
+      failedInstance.processInstanceKey,
+    ).withSuccess(searchResult([createIncident(), createIncident()]));
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+
+    const {rerender} = render(
+      <ProcessInstanceHeader processInstance={failedInstance} />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(await screen.findByText('2 incidents')).toBeInTheDocument();
+    expect(screen.getByTestId(`INCIDENT-icon`)).toBeInTheDocument();
+
+    const resolvedInstance = {
+      ...mockInstance,
+      state: 'ACTIVE',
+      hasIncident: false,
+    } satisfies typeof mockInstance;
+
+    rerender(<ProcessInstanceHeader processInstance={resolvedInstance} />);
+
+    expect(screen.queryByText('2 incidents')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`INCIDENT-icon`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`ACTIVE-icon`)).toBeInTheDocument();
+  });
+
   it('should render "View All" link for call activity process', async () => {
     mockFetchProcessDefinitionXml().withSuccess(mockCallActivityProcessXML);
 


### PR DESCRIPTION
## Description

- Hides the incident count in instance header when `processInstance.hasIncident` is false
- Redirects the bottom panel to the variables tab when `processInstance.hasIncident` is false

## Related issues

closes #49220
