### PR TITLE
test: stabilize operate listeners assertions for new UI

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -167,7 +167,9 @@ class OperateProcessInstancePage {
     this.executionCountToggleOff = this.instanceHistory.getByLabel(
       'hide execution count',
     );
-    this.listenersTabButton = page.getByTestId('listeners-tab-button');
+    this.listenersTabButton = page
+      .getByLabel('Process Instance Bottom Panel Tabs')
+      .getByRole('link', {name: /^Listeners$/i});
     this.operationsLogTabButton = page.getByRole('tab', {
       name: /^Operations Log$/i,
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -54,7 +54,7 @@ test.beforeAll(async () => {
   await sleep(3000);
 });
 
-test.describe.skip('Process Instance Listeners', () => {
+test.describe('Process Instance Listeners', () => {
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
@@ -221,10 +221,20 @@ test.describe.skip('Process Instance Listeners', () => {
       const completeRes = await completeUserTask(request, userTaskKey);
       expect(completeRes.status()).toBe(204);
 
-      await expect(operateProcessInstancePage.stateOverlayActive).toBeHidden();
-      await expect(
-        operateProcessInstancePage.stateOverlayCompletedEndEvents,
-      ).toBeVisible();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.stateOverlayActive,
+          ).toBeHidden();
+          await expect(
+            operateProcessInstancePage.stateOverlayCompletedEndEvents,
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
       await sleep(1000);
       await operateProcessInstancePage.clickInstanceHistoryElement(
         'Service Task B',


### PR DESCRIPTION

## Summary
- update Operate listeners tab locator to match new tab markup
- stabilize post-user-task listener assertions with `waitForAssertion` + reload-on-failure

## Why
Operate UI updates changed listeners tab markup and timing around state overlay updates, which caused flaky assertions in listeners tests.

## Testing
- [on demand](https://github.com/camunda/camunda/actions/runs/23436356956)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later



closes #49232 