### PR TITLE
Fix directives header in test

### DIFF
--- a/qa/http/user-authorizations-tests.http
+++ b/qa/http/user-authorizations-tests.http
@@ -114,7 +114,7 @@ Accept: application/json
         "accelerometer=()", "ambient-light-sensor=()", "attribution-reporting=()",
         "autoplay=()", "bluetooth=()", "browsing-topics=()", "camera=()", "compute-pressure=()",
         "cross-origin-isolated=()", "deferred-fetch=()", "deferred-fetch-minimal=()", "display-capture=()",
-        "encrypted-media=()", "fullscreen=()", "gamepad=()", "geolocation=()", "gyroscope=()", "hid=()",
+        "encrypted-media=()", "fullscreen=(self)", "gamepad=()", "geolocation=()", "gyroscope=()", "hid=()",
         "identity-credentials-get=()", "idle-detection=()", "language-detector=()", "local-fonts=()",
         "magnetometer=()", "microphone=()", "midi=()", "otp-credentials=()", "payment=()",
         "picture-in-picture=()", "publickey-credentials-create=()", "publickey-credentials-get=()",


### PR DESCRIPTION
This pull request makes a small change to the permissions policy settings in the `qa/http/user-authorizations-tests.http` file. Specifically, it restricts the `fullscreen` permission to only allow the current origin (`self`). 

* Restricted the `fullscreen` permission to the current origin by changing its value from `fullscreen=()` to `fullscreen=(self)` in the permissions policy settings.