### PR TITLE
fix: adjust I/O mapping tab padding

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -292,7 +292,6 @@ const DetailsTab: React.FC = () => {
         )}
       <StructuredList
         label="Element Instance Details"
-        isFlush={false}
         headerSize="sm"
         headerColumns={[
           {cellContent: 'Property', width: '30%'},

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/styled.ts
@@ -19,6 +19,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--cds-spacing-05);
+  padding-inline: var(--cds-spacing-05);
 `;
 
 export {EmptyMessageContainer, Container};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/IOMappingInfoBanner.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/IOMappingInfoBanner.tsx
@@ -6,8 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ActionableNotification} from '@carbon/react';
 import {storeStateLocally} from 'modules/utils/localStorage';
+import {FullSizeActionableNotification} from './styled';
 
 type Props = {
   type: 'Input' | 'Output';
@@ -17,7 +17,7 @@ type Props = {
 
 const IOMappingInfoBanner: React.FC<Props> = ({type, text, onClose}) => {
   return (
-    <ActionableNotification
+    <FullSizeActionableNotification
       kind="info"
       inline
       lowContrast

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputOutputMappings/styled.ts
@@ -8,6 +8,7 @@
 
 import styled, {css} from 'styled-components';
 import {EmptyMessage as BaseEmptyMessage} from 'modules/components/EmptyMessage';
+import {ActionableNotification} from '@carbon/react';
 
 type ContentProps = {
   $isInfoBannerVisible: boolean;
@@ -17,6 +18,7 @@ const Content = styled.div<ContentProps>`
   ${({$isInfoBannerVisible}) => {
     return css`
       height: 100%;
+      padding-inline: var(--cds-spacing-05);
       overflow: hidden;
       display: grid;
       grid-template-rows: ${$isInfoBannerVisible ? 'auto 1fr' : '1fr'};
@@ -28,9 +30,17 @@ const Content = styled.div<ContentProps>`
   }}
 `;
 
+const FullSizeActionableNotification = styled(ActionableNotification)`
+  max-inline-size: unset;
+
+  .cds--actionable-notification__text-wrapper {
+    max-inline-size: 80ch; /* Keep text at a readable length */
+  }
+`;
+
 const EmptyMessage = styled(BaseEmptyMessage)`
   align-self: center;
   margin: auto;
 `;
 
-export {Content, EmptyMessage};
+export {Content, FullSizeActionableNotification, EmptyMessage};


### PR DESCRIPTION
## Description

- Aligns "Details" tab design with "Variables" and "Listeners", i.e. padding and flush table
- Adds padding to I/O mapping tab
- Makes I/O info banner span the full width

## Related issues

closes #48801
