### PR TITLE
[Backport stable/8.6] ci: replace localstack latest with fixed version

### DIFF
--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
@@ -42,7 +42,7 @@ final class BackupUploadIT {
 
   @Container
   private static final LocalStackContainer S3 =
-      new LocalStackContainer(DockerImageName.parse("localstack/localstack"))
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
           .withServices(Service.S3)
           .withEnv("LS_LOG", "trace");
 


### PR DESCRIPTION
# Description
Backport of #49252 to `stable/8.6`.

relates to 