### PR TITLE
ci: add missing checkout step in calculate-scenario-config

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -243,6 +243,9 @@ jobs:
       load-test-load: ${{ steps.config.outputs.load-test-load }}
       platform-additional-config: ${{ steps.config.outputs.platform-additional-config }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
       - name: Calculate configuration based on scenario
         id: config
         run: |


### PR DESCRIPTION
## Description

The "Observe build status" step is failing because we don't checkout the code before ; the error is silent due to the option passed to this specific step.

Saw the error in https://github.com/camunda/camunda/actions/runs/23437932817/job/68180728912#step:3:1
<img width="1177" height="746" alt="image" src="https://github.com/user-attachments/assets/cae106eb-50ac-4199-ba23-6930c1fb2ca4" />

## Checklist

## Related issues

--
