### PR TITLE
Fix: update process instance history and process Instance Incidents tests to match new UI updates

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -8,7 +8,6 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {sleep} from 'utils/sleep';
-import {waitForAssertion} from 'utils/waitForAssertion';
 
 class OperateProcessInstancePage {
   private page: Page;
@@ -68,7 +67,6 @@ class OperateProcessInstancePage {
   readonly stateOverlayActive: Locator;
   readonly stateOverlayCompletedEndEvents: Locator;
   readonly cancelInstanceButton: (instanceId: string) => Locator;
-  readonly incidentBannerButton: (count: number) => Locator;
   readonly incidentTypeFilter: Locator;
   readonly cancellationScheduledToast: Locator;
   readonly executionCountToggle: Locator;
@@ -90,13 +88,7 @@ class OperateProcessInstancePage {
   readonly viewParentInstanceLink: Locator;
   readonly incidentIconsInHistory: Locator;
   readonly modifyDialog: Locator;
-  readonly metadataPopover: Locator;
-  readonly incidentSection: Locator;
-  readonly rootCauseProcessName: Locator;
-  readonly rootCauseProcessId: Locator;
-  readonly incidentErrorType: Locator;
   readonly incidentErrorIndicators: Locator;
-  readonly incidentErrorMessage: Locator;
   readonly modifyDialogContinueButton: Locator;
   private variableValueCellLocator: (name: string) => Locator;
   private variableButtonsCellLocator: (name: string) => Locator;
@@ -254,10 +246,6 @@ class OperateProcessInstancePage {
     );
     this.cancelInstanceButton = (instanceId: string) =>
       page.getByRole('button', {name: `Cancel Instance ${instanceId}`});
-    this.incidentBannerButton = (count: number) =>
-      page.getByRole('button', {
-        name: new RegExp(`view ${count} incidents in instance`, 'i'),
-      });
     this.incidentTypeFilter = page.getByRole('combobox', {
       name: /filter by incident type/i,
     });
@@ -355,16 +343,6 @@ class OperateProcessInstancePage {
       },
     });
     this.incidentErrorIndicators = page.getByTestId('incident-error-indicator');
-    this.metadataPopover = page.getByTestId('popover');
-    this.incidentErrorType = this.metadataPopover
-      .getByText('Type')
-      .locator('xpath=following-sibling::*[1]');
-    this.incidentErrorMessage = this.metadataPopover.locator('text=/error/i');
-    this.incidentSection = page.getByText(/incident\s*view/i);
-    this.rootCauseProcessName = this.metadataPopover.getByText(
-      /root cause process name/i,
-    );
-    this.rootCauseProcessId = this.metadataPopover.getByRole('link').first();
   }
 
   async checkExistingVariableErrorMessageText(
@@ -379,14 +357,6 @@ class OperateProcessInstancePage {
       this.existingVariableByName(variableName).editVariableModal
         .valueErrorMessage;
     await expect(errorMessage!).toHaveText(message);
-  }
-
-  async connectorResultVariableName(name: string): Promise<Locator> {
-    return this.page.getByTestId(name);
-  }
-
-  async connectorResultVariableValue(variableName: string): Promise<Locator> {
-    return this.page.getByTestId(variableName).locator('td').last();
   }
 
   private async waitForIconWithRetry(
@@ -464,10 +434,6 @@ class OperateProcessInstancePage {
 
   async clickReviewModifications() {
     await this.reviewModificationsButton.click();
-  }
-
-  async clickAddVariable() {
-    await this.addVariableModificationButton.click();
   }
 
   async clickDeleteVariableModification() {
@@ -565,16 +531,6 @@ class OperateProcessInstancePage {
     await this.page.keyboard.press('Tab');
   }
 
-  async navigateToProcessInstance(id: string) {
-    await this.page.goto(`operate/processes/${id}`);
-  }
-
-  async getNthTreeNodeTestId(n: number) {
-    return this.page
-      .getByTestId(/^tree-node-/)
-      .nth(n)
-      .getAttribute('data-testid');
-  }
   async clickEditVariableButton(variableName: string): Promise<void> {
     const editVariableButton = 'Edit variable ' + variableName;
     await this.page.getByLabel(editVariableButton).click();
@@ -790,10 +746,6 @@ class OperateProcessInstancePage {
     await this.applyButton.click();
   }
 
-  async clickIncidentBanner(count: number): Promise<void> {
-    await this.incidentBannerButton(count).click();
-  }
-
   async toggleExecutionCount(): Promise<void> {
     await this.executionCountToggle.waitFor({state: 'visible'});
     if (
@@ -846,52 +798,8 @@ class OperateProcessInstancePage {
     await this.viewParentInstanceLink.click();
   }
 
-  async getAllIncidentIconsAmountInHistory(): Promise<number> {
-    return await this.incidentIconsInHistory.count();
-  }
-
   async clickIncidentsTab(): Promise<void> {
     await this.incidentsTab.click();
-  }
-
-  async getIncidentRowByErrorMessage(errorMessage: string) {
-    const legacyRow = this.incidentsTable.getByRole('row').filter({
-      has: this.page
-        .getByTestId('cell-errorMessage')
-        .filter({hasText: errorMessage}),
-    });
-
-    if ((await legacyRow.count()) > 0) {
-      return legacyRow.first();
-    }
-
-    const parentRows = this.incidentsTable.locator(
-      'tr[data-parent-row="true"]',
-    );
-    const parentRowsCount = await parentRows.count();
-
-    for (let i = 0; i < parentRowsCount; i++) {
-      const parentRow = parentRows.nth(i);
-      const expandButton = parentRow.getByRole('button', {
-        name: /expand current row/i,
-      });
-
-      await expandButton.click();
-      const expandedRowId = await expandButton.getAttribute('aria-controls');
-
-      if (!expandedRowId) {
-        continue;
-      }
-
-      const expandedRow = this.incidentsTable.locator(`#${expandedRowId}`);
-      if ((await expandedRow.getByText(errorMessage).count()) > 0) {
-        return parentRow;
-      }
-    }
-
-    return this.incidentsTable.getByRole('row').filter({
-      has: this.page.getByText(errorMessage),
-    });
   }
 
   async getIncidentRowByErrorType(errorType: string) {
@@ -922,12 +830,6 @@ class OperateProcessInstancePage {
     });
   }
 
-  async retryIncidentByErrorMessage(errorMessage: string) {
-    const incidentRow = await this.getIncidentRowByErrorMessage(errorMessage);
-    const retryButton = incidentRow.getByTestId('retry-operation');
-    await retryButton.click();
-  }
-
   async retryIncidentByErrorType(errorType: string) {
     const incidentRow = await this.getIncidentRowByErrorType(errorType);
     const retryButton = incidentRow.getByTestId('retry-operation');
@@ -940,13 +842,6 @@ class OperateProcessInstancePage {
 
   async clickModifyDialogContinueButton(): Promise<void> {
     await this.modifyDialogContinueButton.click();
-  }
-
-  async getAllInstanceHistoryNodeDetails(): Promise<Locator[]> {
-    return this.instanceHistory
-      .getByRole('treeitem')
-      .getByTestId(/^node-details-/)
-      .all();
   }
 
   async checkIfPresentExpandeingElementsInMainProcess(
@@ -1059,21 +954,6 @@ class OperateProcessInstancePage {
     await this.clickDiagramElement(elementId);
   }
 
-  async closeIncidentsPanel(): Promise<void> {
-    await waitForAssertion({
-      assertion: async () => {
-        await expect(this.incidentsViewHeader).toBeHidden({
-          timeout: 3000,
-        });
-      },
-      onFailure: async () => {
-        await this.detailsTabButton.scrollIntoViewIfNeeded();
-        await this.detailsTabButton.click();
-      },
-      maxRetries: 3,
-    });
-  }
-
   async getIncidentCount(): Promise<number> {
     await expect(this.incidentsViewHeader).toBeVisible();
     const headingText = await this.incidentsViewHeader.innerText();
@@ -1088,21 +968,6 @@ class OperateProcessInstancePage {
   async verifyIncidentCount(expectedCount: number): Promise<void> {
     const actualCount = await this.getIncidentCount();
     expect(actualCount).toBe(expectedCount);
-  }
-  getCalledProcessLink(processName: string): Locator {
-    return this.page.getByRole('link', {name: processName});
-  }
-  async clickOnRootCauseProcessName(): Promise<void> {
-    await expect(this.rootCauseProcessName).toBeVisible();
-    await this.rootCauseProcessId.click();
-  }
-
-  async clickCalledProcessLink(processName: string): Promise<void> {
-    await this.getCalledProcessLink(processName).click();
-  }
-
-  getIncidentErrorMessageByText(errorText: string): Locator {
-    return this.metadataPopover.getByText(errorText);
   }
 
   getOperationsLogTableRowCount(): Promise<number> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -563,22 +563,31 @@ class OperateProcessInstancePage {
 
   async getProcessInstanceKey(): Promise<string> {
     const table = this.page.getByTestId('instance-header').locator('table');
+    const firstRow = table.locator('tbody tr').first();
+    await expect(firstRow).toBeVisible();
+
     const headers = await table.locator('thead tr th').allTextContents();
     const keyColumnIndex = headers.findIndex((header) =>
       /process\s+instance\s+key/i.test(header.trim()),
     );
 
-    if (keyColumnIndex === -1) {
-      throw new Error('Could not find Process Instance Key column in header');
+    if (keyColumnIndex !== -1) {
+      const keyCell = firstRow.locator('td').nth(keyColumnIndex);
+      await expect(keyCell).toBeVisible();
+      return (await keyCell.textContent())?.trim() ?? '';
     }
 
-    const keyCell = table
-      .locator('tbody tr')
-      .first()
-      .locator('td')
-      .nth(keyColumnIndex);
-    await expect(keyCell).toBeVisible();
-    return (await keyCell.textContent())?.trim() ?? '';
+    const firstCell = firstRow.locator('td').first();
+    await expect(firstCell).toBeVisible();
+    const fallbackKey = (await firstCell.textContent())?.trim() ?? '';
+
+    if (fallbackKey) {
+      return fallbackKey;
+    }
+
+    throw new Error(
+      'Could not extract Process Instance Key from instance header table',
+    );
   }
 
   async gotoProcessInstancePage({id}: {id: string}): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -27,7 +27,7 @@ class OperateProcessInstancePage {
   readonly incidentsTable: Locator;
   readonly incidentsTableOperationSpinner: Locator;
   readonly incidentsTableRows: Locator;
-  readonly incidentsBanner: Locator;
+  readonly incidentsTab: Locator;
   readonly variablePanelEmptyText: Locator;
   readonly addVariableButton: Locator;
   readonly saveVariableButton: Locator;
@@ -39,6 +39,8 @@ class OperateProcessInstancePage {
   readonly executionCountToggleOn: Locator;
   readonly executionCountToggleOff: Locator;
   readonly listenersTabButton: Locator;
+  readonly detailsTabButton: Locator;
+  readonly variablesTabButton: Locator;
   readonly operationsLogTabButton: Locator;
   readonly operationsLogTable: Locator;
   readonly operationsLogTableRow: Locator;
@@ -68,6 +70,7 @@ class OperateProcessInstancePage {
   readonly cancelInstanceButton: (instanceId: string) => Locator;
   readonly incidentBannerButton: (count: number) => Locator;
   readonly incidentTypeFilter: Locator;
+  readonly cancellationScheduledToast: Locator;
   readonly executionCountToggle: Locator;
   readonly executionCountToggleLabel: Locator;
   readonly endDateField: Locator;
@@ -147,7 +150,9 @@ class OperateProcessInstancePage {
     this.incidentsTableOperationSpinner =
       this.incidentsTable.getByTestId('operation-spinner');
     this.incidentsTableRows = this.incidentsTable.getByRole('row');
-    this.incidentsBanner = page.getByTestId('incidents-banner');
+    this.incidentsTab = page
+      .getByLabel('Process Instance Bottom Panel Tabs')
+      .getByRole('link', {name: /^Incidents$/i});
     this.incidentIconsInHistory = this.instanceHistory
       .getByRole('treeitem')
       .getByTestId('INCIDENT-icon');
@@ -170,6 +175,12 @@ class OperateProcessInstancePage {
     this.listenersTabButton = page
       .getByLabel('Process Instance Bottom Panel Tabs')
       .getByRole('link', {name: /^Listeners$/i});
+    this.detailsTabButton = page
+      .getByLabel('Process Instance Bottom Panel Tabs')
+      .getByRole('link', {name: /^Details$/i});
+    this.variablesTabButton = page
+      .getByLabel('Process Instance Bottom Panel Tabs')
+      .getByRole('link', {name: /^Variables$/i});
     this.operationsLogTabButton = page.getByRole('tab', {
       name: /^Operations Log$/i,
     });
@@ -250,8 +261,13 @@ class OperateProcessInstancePage {
     this.incidentTypeFilter = page.getByRole('combobox', {
       name: /filter by incident type/i,
     });
+    this.cancellationScheduledToast = page
+      .getByRole('status')
+      .getByText('Instance is scheduled for cancellation');
     this.endDateField = this.instanceHeader.getByTestId('end-date');
-    this.incidentsViewHeader = page.getByText(/incidents\s+-\s+/i);
+    this.incidentsViewHeader = page.getByRole('heading', {
+      name: /^\d+\s+results?$/i,
+    });
     this.modificationModeText = page.getByText(
       'Process Instance Modification Mode',
     );
@@ -684,6 +700,14 @@ class OperateProcessInstancePage {
     await this.listenersTabButton.click();
   }
 
+  async clickVariablesTab(): Promise<void> {
+    await this.variablesTabButton.click();
+  }
+
+  async clickDetailsTab(): Promise<void> {
+    await this.detailsTabButton.click();
+  }
+
   async verifyListenersTabVisible(): Promise<void> {
     await expect(this.listenersTabButton).toBeVisible();
   }
@@ -826,23 +850,86 @@ class OperateProcessInstancePage {
     return await this.incidentIconsInHistory.count();
   }
 
-  async clickIncidentsBanner(): Promise<void> {
-    await this.incidentsBanner.click();
+  async clickIncidentsTab(): Promise<void> {
+    await this.incidentsTab.click();
   }
 
   async getIncidentRowByErrorMessage(errorMessage: string) {
-    return this.incidentsTable.getByRole('row').filter({
+    const legacyRow = this.incidentsTable.getByRole('row').filter({
       has: this.page
         .getByTestId('cell-errorMessage')
         .filter({hasText: errorMessage}),
+    });
+
+    if ((await legacyRow.count()) > 0) {
+      return legacyRow.first();
+    }
+
+    const parentRows = this.incidentsTable.locator(
+      'tr[data-parent-row="true"]',
+    );
+    const parentRowsCount = await parentRows.count();
+
+    for (let i = 0; i < parentRowsCount; i++) {
+      const parentRow = parentRows.nth(i);
+      const expandButton = parentRow.getByRole('button', {
+        name: /expand current row/i,
+      });
+
+      await expandButton.click();
+      const expandedRowId = await expandButton.getAttribute('aria-controls');
+
+      if (!expandedRowId) {
+        continue;
+      }
+
+      const expandedRow = this.incidentsTable.locator(`#${expandedRowId}`);
+      if ((await expandedRow.getByText(errorMessage).count()) > 0) {
+        return parentRow;
+      }
+    }
+
+    return this.incidentsTable.getByRole('row').filter({
+      has: this.page.getByText(errorMessage),
+    });
+  }
+
+  async getIncidentRowByErrorType(errorType: string) {
+    const parentRows = this.incidentsTable.locator(
+      'tr[data-parent-row="true"]',
+    );
+
+    const exactParentRow = parentRows.filter({
+      has: this.page
+        .getByTestId('cell-errorType')
+        .filter({hasText: new RegExp(`^${errorType}$`, 'i')}),
+    });
+
+    if ((await exactParentRow.count()) > 0) {
+      return exactParentRow.first();
+    }
+
+    const partialParentRow = parentRows.filter({
+      has: this.page.getByTestId('cell-errorType').filter({hasText: errorType}),
+    });
+
+    if ((await partialParentRow.count()) > 0) {
+      return partialParentRow.first();
+    }
+
+    return this.incidentsTable.getByRole('row').filter({
+      has: this.page.getByTestId('cell-errorType').filter({hasText: errorType}),
     });
   }
 
   async retryIncidentByErrorMessage(errorMessage: string) {
     const incidentRow = await this.getIncidentRowByErrorMessage(errorMessage);
-    console.log(
-      await incidentRow.getByTestId('cell-flowNodeName').allInnerTexts(),
-    );
+    const retryButton = incidentRow.getByTestId('retry-operation');
+    await retryButton.click();
+  }
+
+  async retryIncidentByErrorType(errorType: string) {
+    const incidentRow = await this.getIncidentRowByErrorType(errorType);
     const retryButton = incidentRow.getByTestId('retry-operation');
     await retryButton.click();
   }
@@ -973,26 +1060,23 @@ class OperateProcessInstancePage {
   }
 
   async closeIncidentsPanel(): Promise<void> {
-    await expect(this.incidentsBanner).toContainText(/hide/i, {
-      timeout: 10000,
-    });
-
     await waitForAssertion({
       assertion: async () => {
-        await expect(this.incidentsBanner).toContainText(/view/i, {
+        await expect(this.incidentsViewHeader).toBeHidden({
           timeout: 3000,
         });
       },
       onFailure: async () => {
-        await this.incidentsBanner.scrollIntoViewIfNeeded();
-        await this.incidentsBanner.click();
+        await this.detailsTabButton.scrollIntoViewIfNeeded();
+        await this.detailsTabButton.click();
       },
       maxRetries: 3,
     });
   }
 
   async getIncidentCount(): Promise<number> {
-    const headingText = await this.incidentsViewHeader.textContent();
+    await expect(this.incidentsViewHeader).toBeVisible();
+    const headingText = await this.incidentsViewHeader.innerText();
     if (!headingText) {
       return 0;
     }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -127,15 +127,15 @@ test.describe('Multi Instance Flow Node Selection', () => {
     });
 
     await test.step('Verify incidents banner shows 25 incidents', async () => {
-      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
-      await expect(operateProcessInstancePage.incidentsBanner).toContainText(
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+      await expect(operateProcessInstancePage.incidentsTab).toContainText(
         '25 Incidents occurred',
       );
     });
 
     await test.step('Click incidents banner to open incidents table', async () => {
       await operateProcessInstancePage.navigateToRootScope();
-      await operateProcessInstancePage.incidentsBanner.click();
+      await operateProcessInstancePage.incidentsTab.click();
       await expect(
         operateProcessInstancePage.incidentsViewHeader,
       ).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -16,22 +16,16 @@ import {
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
-import {defaultAssertionOptions} from 'utils/constants';
 
 type ProcessInstance = {processInstanceKey: number};
 
 let incidentProcessInstance: ProcessInstance;
 let embeddedSubprocessInstance: ProcessInstance;
 
-const startEventStartGlobal = 'StartGlobal';
 const activityNode = 'Node';
 const activityFirstSubprocess = 'FirstSubprocess';
-const eventStartFirstSubProcess = 'StartFirstSubProcess';
 const activityCollectMoney = 'CollectMoney';
-const activityFetchItems = 'FetchItems';
 const eventEndFirstSubProcess = 'EndFirstSubProcess';
-const eventOrderCancelled = 'OrderCanceled';
-const eventOrderCancelledEnd = 'OrderCancelledEnd';
 const activitySecondSubprocess = 'SecondSubprocess';
 const eventStartSecondSubProcess = 'StartSecondSubProcess';
 const activitySendItems = 'SendItems';
@@ -65,7 +59,7 @@ test.beforeAll(async () => {
   };
 });
 
-test.describe.skip('Process Instance History', () => {
+test.describe('Process Instance History', () => {
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
@@ -154,9 +148,7 @@ test.describe.skip('Process Instance History', () => {
       await expect(operateProcessInstancePage.instanceHistory).toBeVisible();
       await waitForAssertion({
         assertion: async () => {
-          await expect(
-            operateProcessInstancePage.incidentsBanner,
-          ).toBeVisible();
+          await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();
@@ -177,6 +169,7 @@ test.describe.skip('Process Instance History', () => {
     });
 
     await test.step('Add variable to the process', async () => {
+      await operateProcessInstancePage.clickVariablesTab();
       await operateProcessInstancePage.clickAddVariableButton();
       await operateProcessInstancePage.fillNewVariable('goUp', '6');
       await operateProcessInstancePage.clickSaveVariableButton();
@@ -184,18 +177,16 @@ test.describe.skip('Process Instance History', () => {
     });
 
     await test.step('Retry incident', async () => {
-      await operateProcessInstancePage.clickIncidentsBanner();
-      const errorMessage = "Expected result of the expression 'goUp < 0'";
-      await operateProcessInstancePage.retryIncidentByErrorMessage(
-        errorMessage,
-      );
+      await operateProcessInstancePage.clickIncidentsTab();
+      const errorType = 'Extract value error.';
+      await operateProcessInstancePage.retryIncidentByErrorType(errorType);
     });
 
     await test.step('Verify incident is resolved in Instance History', async () => {
       await page.waitForTimeout(12000);
       await waitForAssertion({
         assertion: async () => {
-          await expect(operateProcessInstancePage.incidentsBanner).toBeHidden();
+          await expect(operateProcessInstancePage.incidentsTab).toBeHidden();
         },
         onFailure: async () => {
           await page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -68,10 +68,7 @@ test.describe('Process Instance', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test.skip('Resolve an incident', async ({
-    page,
-    operateProcessInstancePage,
-  }) => {
+  test('Resolve an incident', async ({page, operateProcessInstancePage}) => {
     await test.step('Navigate to process instance with incident', async () => {
       await operateProcessInstancePage.gotoProcessInstancePage({
         id: instanceWithIncidentToResolve.processInstanceKey,
@@ -79,18 +76,18 @@ test.describe('Process Instance', () => {
       await sleep(1000);
     });
 
-    await test.step('Verify incident banner is visible', async () => {
-      await expect(
-        operateProcessInstancePage.incidentBannerButton(2),
-      ).toBeVisible();
+    await test.step('Verify incidents tab is visible', async () => {
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
     });
 
-    await test.step('Click and expand incident bar', async () => {
-      await operateProcessInstancePage.clickIncidentBanner(2);
+    await test.step('Open incidents tab', async () => {
+      await operateProcessInstancePage.clickIncidentsTab();
       await expect(operateProcessInstancePage.incidentTypeFilter).toBeVisible();
+      await operateProcessInstancePage.verifyIncidentCount(2);
     });
 
     await test.step('Edit goUp variable', async () => {
+      await operateProcessInstancePage.clickVariablesTab();
       await operateProcessInstancePage.editVariableButtonInList.click();
 
       await operateProcessInstancePage.editVariableValueField.clear();
@@ -104,12 +101,18 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Retry one incident to resolve it', async () => {
-      await operateProcessInstancePage.retryIncident(/Condition error/i);
+      await operateProcessInstancePage.clickIncidentsTab();
+      const firstErrorType = 'Condition error.';
+      const remainingErrorType = 'Extract value error.';
+
+      await operateProcessInstancePage.retryIncidentByErrorType(firstErrorType);
 
       await expect(
-        operateProcessInstancePage.getIncidentRowOperationSpinner(
-          /Condition error/i,
-        ),
+        (
+          await operateProcessInstancePage.getIncidentRowByErrorType(
+            firstErrorType,
+          )
+        ).getByTestId('operation-spinner'),
       ).toBeVisible();
       await waitForAssertion({
         assertion: async () => {
@@ -127,18 +130,23 @@ test.describe('Process Instance', () => {
       });
 
       await expect
-        .poll(() => operateProcessInstancePage.incidentsTableRows.count())
+        .poll(async () => await operateProcessInstancePage.getIncidentCount())
         .toBe(1);
 
       await expect(
-        operateProcessInstancePage.incidentsTable.getByText(/is cool\?/i),
-      ).toBeVisible();
+        await operateProcessInstancePage.getIncidentRowByErrorType(
+          firstErrorType,
+        ),
+      ).toHaveCount(0);
       await expect(
-        operateProcessInstancePage.incidentsTable.getByText(/where to go\?/i),
-      ).toBeHidden();
+        await operateProcessInstancePage.getIncidentRowByErrorType(
+          remainingErrorType,
+        ),
+      ).toBeVisible();
     });
 
     await test.step('Add variable isCool', async () => {
+      await operateProcessInstancePage.clickVariablesTab();
       await operateProcessInstancePage.addVariableButton.click();
 
       await operateProcessInstancePage.newVariableNameField.type('isCool');
@@ -152,19 +160,25 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Retry second incident to resolve it', async () => {
-      await operateProcessInstancePage.retryIncident(/Extract value error/i);
+      await operateProcessInstancePage.clickIncidentsTab();
+      const secondErrorType = 'Extract value error.';
+      await operateProcessInstancePage.retryIncidentByErrorType(
+        secondErrorType,
+      );
 
       await expect(
-        operateProcessInstancePage.getIncidentRowOperationSpinner(
-          /Extract value error/i,
-        ),
+        (
+          await operateProcessInstancePage.getIncidentRowByErrorType(
+            secondErrorType,
+          )
+        ).getByTestId('operation-spinner'),
       ).toBeVisible();
     });
 
     await test.step('Expect all incidents resolved', async () => {
       await waitForAssertion({
         assertion: async () => {
-          await expect(operateProcessInstancePage.incidentsBanner).toBeHidden();
+          await expect(operateProcessInstancePage.incidentsTab).toBeHidden();
         },
         onFailure: async () => {
           await page.reload();
@@ -176,10 +190,7 @@ test.describe('Process Instance', () => {
     });
   });
 
-  test.skip('Cancel an instance', async ({
-    operateProcessInstancePage,
-    page,
-  }) => {
+  test('Cancel an instance', async ({operateProcessInstancePage, page}) => {
     const instanceId = instanceWithIncidentToCancel.processInstanceKey;
 
     await test.step('Navigate to process instance with incident', async () => {
@@ -189,25 +200,25 @@ test.describe('Process Instance', () => {
       await sleep(1000);
     });
 
-    await test.step('Verify incident banner is visible', async () => {
-      await expect(
-        operateProcessInstancePage.incidentBannerButton(3),
-      ).toBeVisible();
+    await test.step('Verify incidents tab is visible', async () => {
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+      await operateProcessInstancePage.clickIncidentsTab();
+      await expect(operateProcessInstancePage.incidentTypeFilter).toBeVisible();
+      await operateProcessInstancePage.verifyIncidentCount(3);
     });
 
     await test.step('Cancel the instance', async () => {
       await operateProcessInstancePage.cancelInstance(instanceId);
 
-      await expect(operateProcessInstancePage.operationSpinner).toBeVisible();
-      await expect(operateProcessInstancePage.operationSpinner).toBeHidden();
+      await expect(
+        operateProcessInstancePage.cancellationScheduledToast,
+      ).toBeVisible();
     });
 
     await test.step('Verify instance is canceled', async () => {
       await waitForAssertion({
         assertion: async () => {
-          await expect(
-            operateProcessInstancePage.incidentBannerButton(3),
-          ).toBeHidden();
+          await expect(operateProcessInstancePage.incidentsTab).toBeHidden();
         },
         onFailure: async () => {
           await page.reload();
@@ -223,10 +234,9 @@ test.describe('Process Instance', () => {
     });
   });
 
-  test.skip('Should render collapsed sub process and navigate between planes', async ({
+  test('Should render collapsed sub process and navigate between planes', async ({
     page,
     operateProcessInstancePage,
-    operateDiagramPage,
   }) => {
     const {diagramHelper} = operateProcessInstancePage;
 
@@ -239,6 +249,7 @@ test.describe('Process Instance', () => {
 
     await test.step('Click on startEvent in instance history', async () => {
       await operateProcessInstancePage.clickTreeItem('startEvent');
+      await operateProcessInstancePage.clickDetailsTab();
       await expect(page.getByText(/execution duration/i)).toBeVisible();
     });
 
@@ -254,20 +265,6 @@ test.describe('Process Instance', () => {
       await page.keyboard.press('ArrowRight');
       await operateProcessInstancePage.clickTreeItem(/fill form/i);
       await expect(diagramHelper.getFlowNode('fill form')).toBeVisible();
-      await operateProcessInstancePage.clickTreeItem(/fill form/i);
-
-      await waitForAssertion({
-        assertion: async () => {
-          await operateDiagramPage.popover.waitFor({
-            state: 'visible',
-          });
-        },
-        onFailure: async () => {
-          await operateProcessInstancePage.clickTreeItem(/fill form/i);
-        },
-      });
-
-      await expect(page.getByText(/retries left/i)).toBeVisible();
     });
 
     await test.step('Click on collapsed sub process', async () => {
@@ -368,7 +365,7 @@ test.describe('Process Instance Incident', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test.skip('Verify Incident root cause instance', async ({
+  test('Verify Incident root cause instance', async ({
     operateProcessInstancePage,
     operateHomePage,
     operateProcessesPage,
@@ -387,20 +384,12 @@ test.describe('Process Instance Incident', () => {
         timeout: 30000,
       });
 
-      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
-      await operateProcessInstancePage.clickIncidentsBanner();
-
-      await expect(
-        operateProcessInstancePage.incidentsViewHeader,
-      ).toBeVisible();
-
-      const incidentCount = await operateProcessInstancePage.getIncidentCount();
-      expect(incidentCount).toBeGreaterThan(0);
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+      await operateProcessInstancePage.clickIncidentsTab();
 
       await operateProcessInstancePage.verifyIncidentCount(4);
 
-      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
-      await operateProcessInstancePage.closeIncidentsPanel();
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
     });
 
     await test.step('Click IO mapping Error and verify Error Type', async () => {
@@ -408,18 +397,11 @@ test.describe('Process Instance Incident', () => {
         'Task_IOMapping',
       );
 
-      await expect(operateProcessInstancePage.metadataPopover).toBeVisible();
-
-      await expect(operateProcessInstancePage.incidentSection).toBeVisible();
       await expect(
-        operateProcessInstancePage.getIncidentErrorMessageByText(
-          'IO mapping error.',
+        operateProcessInstancePage.getSelectedIncidentRow(
+          /IO mapping error\./i,
         ),
       ).toBeVisible();
-      await operateProcessInstancePage.clickOnElementInDiagram(
-        'Task_IOMapping',
-      );
-      await expect(operateProcessInstancePage.metadataPopover).toBeHidden();
     });
 
     await test.step('Click ExclusiveGatewayError and verify Error Type', async () => {
@@ -427,42 +409,21 @@ test.describe('Process Instance Incident', () => {
         'Gateway_Expression',
       );
 
-      await expect(operateProcessInstancePage.metadataPopover).toBeVisible();
-
-      await expect(operateProcessInstancePage.incidentSection).toBeVisible();
       await expect(
-        operateProcessInstancePage.getIncidentErrorMessageByText(
-          'Extract value error.',
+        operateProcessInstancePage.getSelectedIncidentRow(
+          /Extract value error\./i,
         ),
       ).toBeVisible();
     });
 
-    await operateProcessInstancePage.clickOnElementInDiagram(
-      'Gateway_Expression',
-    );
-
-    await expect(operateProcessInstancePage.metadataPopover).toBeHidden();
-
     await test.step('Click Call Activity and verify the error type', async () => {
-      await operateProcessInstancePage.clickOnElementInDiagram(
-        'Task_CallActivity',
-      );
-
-      await expect(operateProcessInstancePage.metadataPopover).toBeVisible();
-
-      await expect(operateProcessInstancePage.incidentSection).toBeVisible();
+      await operateProcessInstancePage
+        .getDiagramElement('Task_CallActivity')
+        .dblclick();
 
       await expect(
-        operateProcessInstancePage.getIncidentErrorMessageByText(
-          'Called element error.',
-        ),
+        operateProcessInstancePage.getIncidentRow(/Called element error\./i),
       ).toBeVisible();
-
-      await operateProcessInstancePage.clickCalledProcessLink(
-        'call-level-1-process',
-      );
-      await operateProcessInstancePage.viewParentInstanceLink.click();
-      await expect(operateProcessInstancePage.metadataPopover).toBeHidden();
     });
   });
 });


### PR DESCRIPTION
## Description
Align Operate process instance tests with the new UI and clean up outdated page object code.

## Changes
- Updated `processInstanceHistory` and `processInstanceIncidents` tests for new tabs and incidents table behavior.
- Replaced legacy metadata/popover and banner checks with stable incidents-row and count assertions.
- Added page-object support for Details tab and cancellation toast assertions.
- Removed unused legacy locators and methods from `OperateProcessInstancePage`.

## Why
Operate UI updates changed tab markup and incident interaction flows, causing failing/flaky tests.

## Testing
- [On-demand](https://github.com/camunda/camunda/actions/runs/23444095082/job/68203128890)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #49230 , #49231 
