### PR TITLE
[Backport stable/8.9] feat(cpt): Configure assertion timeout globally with local override

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
@@ -105,4 +105,12 @@ public interface CamundaAssertAwaitBehavior {
    * @param assertionTimeout the assertion's timeout
    */
   void setAssertionTimeout(final Duration assertionTimeout);
+
+  /**
+   * Creates a new assertion behavior with the given timeout.
+   *
+   * @param assertionTimeout the assertion's timeout
+   * @return a new assertion behavior
+   */
+  CamundaAssertAwaitBehavior withAssertionTimeout(Duration assertionTimeout);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
@@ -79,11 +79,11 @@ public interface CamundaAssertAwaitBehavior {
   }
 
   /**
-   * Set the timeout of the assertion.
+   * Returns the configured interval between assertion attempts.
    *
-   * @param assertionTimeout the assertion's timeout
+   * @return the assertion interval
    */
-  void setAssertionTimeout(final Duration assertionTimeout);
+  Duration getAssertionInterval();
 
   /**
    * Set the interval between the assertion attempts.
@@ -93,9 +93,16 @@ public interface CamundaAssertAwaitBehavior {
   void setAssertionInterval(final Duration assertionInterval);
 
   /**
-   * Returns the configured interval between assertion attempts.
+   * Returns the configured timeout of the assertion.
    *
-   * @return the assertion interval
+   * @return the assertion timeout
    */
-  Duration getAssertionInterval();
+  Duration getAssertionTimeout();
+
+  /**
+   * Set the timeout of the assertion.
+   *
+   * @param assertionTimeout the assertion's timeout
+   */
+  void setAssertionTimeout(final Duration assertionTimeout);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -194,11 +194,10 @@ public class CamundaProcessTestExtension
     store.put(STORE_KEY_RUNTIME, runtime);
     store.put(STORE_KEY_CONTEXT, camundaProcessTestContext);
 
-    // initialize json mapper
+    // initializations
     initializeJsonMapper(jsonMapper, zeebeJsonMapper);
-
-    // initialize judge config
     initializeJudgeConfig();
+    initializeAssertions(runtimeBuilder);
   }
 
   private CamundaManagementClient createManagementClient(
@@ -247,6 +246,11 @@ public class CamundaProcessTestExtension
                     CamundaProcessTestRuntimeDefaults.JUDGE_PROPERTIES.getThreshold(),
                     CamundaProcessTestRuntimeDefaults.JUDGE_PROPERTIES.getCustomPrompt()))
         .ifPresent(CamundaAssert::setJudgeConfig);
+  }
+
+  private void initializeAssertions(final CamundaProcessTestRuntimeBuilder runtimeBuilder) {
+    runtimeBuilder.getAssertionTimeout().ifPresent(CamundaAssert::setAssertionTimeout);
+    runtimeBuilder.getAssertionInterval().ifPresent(CamundaAssert::setAssertionInterval);
   }
 
   private boolean hasProcessTestExtension(final ExtensionContext context) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionInstanceAssert.java
@@ -16,7 +16,7 @@
 package io.camunda.process.test.api.assertions;
 
 /** The assertion object to verify a decision. */
-public interface DecisionInstanceAssert {
+public interface DecisionInstanceAssert extends WithAssertionConfiguration<DecisionInstanceAssert> {
   /**
    * Verifies that the decision is evaluated. The verification fails if the decision is not
    * evaluated or if the evaluation fails.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -21,7 +21,7 @@ import java.util.function.UnaryOperator;
 import org.assertj.core.api.ThrowingConsumer;
 
 /** The assertion object to verify a process instance. */
-public interface ProcessInstanceAssert {
+public interface ProcessInstanceAssert extends WithAssertionConfiguration<ProcessInstanceAssert> {
 
   /**
    * Verifies that the process instance is active. The verification fails if the process instance is

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/UserTaskAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/UserTaskAssert.java
@@ -18,7 +18,7 @@ package io.camunda.process.test.api.assertions;
 import java.util.List;
 
 /** The assertion object to verify a user task. */
-public interface UserTaskAssert {
+public interface UserTaskAssert extends WithAssertionConfiguration<UserTaskAssert> {
   /**
    * Verifies that the user task is created. The verification fails if the task is completed,
    * cancelled, failed or not created.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/WithAssertionConfiguration.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/WithAssertionConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.assertions;
+
+import java.time.Duration;
+
+/**
+ * A base class for assertions to configure the assertion behavior.
+ *
+ * @param <SELF> the type of the assertion class
+ */
+public interface WithAssertionConfiguration<SELF> {
+
+  /**
+   * Configures the time how long an assertion waits until the expected state is reached. The
+   * configuration overrides the global setting for subsequent assertions in this chain. The global
+   * setting is not changed.
+   *
+   * @param assertionTimeout the timeout for subsequent assertions
+   * @return the assertion object
+   */
+  SELF withAssertionTimeout(Duration assertionTimeout);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/DecisionInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/DecisionInstanceAssertj.java
@@ -23,6 +23,7 @@ import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import io.camunda.process.test.api.assertions.DecisionInstanceAssert;
 import io.camunda.process.test.api.assertions.DecisionSelector;
 import io.camunda.process.test.impl.assertions.util.CamundaAssertJsonMapper;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
@@ -32,7 +33,7 @@ public class DecisionInstanceAssertj
     implements DecisionInstanceAssert {
 
   private final CamundaDataSource dataSource;
-  private final CamundaAssertAwaitBehavior awaitBehavior;
+  private CamundaAssertAwaitBehavior awaitBehavior;
   private final DecisionMatchedRulesAssertj decisionMatchedRulesAssertj;
   private final DecisionOutputAssertj decisionOutputAssertj;
 
@@ -51,6 +52,12 @@ public class DecisionInstanceAssertj
     this.awaitBehavior = awaitBehavior;
     decisionMatchedRulesAssertj = new DecisionMatchedRulesAssertj(failureMessagePrefix);
     decisionOutputAssertj = new DecisionOutputAssertj(jsonMapper, failureMessagePrefix);
+  }
+
+  @Override
+  public DecisionInstanceAssert withAssertionTimeout(final Duration assertionTimeout) {
+    awaitBehavior = awaitBehavior.withAssertionTimeout(assertionTimeout);
+    return this;
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.assertj.core.api.AbstractAssert;
@@ -35,11 +36,11 @@ import org.assertj.core.api.AbstractAssert;
 public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
 
   private final CamundaDataSource dataSource;
-  private final CamundaAssertAwaitBehavior awaitBehavior;
+  private final Supplier<CamundaAssertAwaitBehavior> awaitBehavior;
 
   protected ElementAssertj(
       final CamundaDataSource dataSource,
-      final CamundaAssertAwaitBehavior awaitBehavior,
+      final Supplier<CamundaAssertAwaitBehavior> awaitBehavior,
       final String failureMessagePrefix) {
     super(failureMessagePrefix, ElementAssertj.class);
     this.dataSource = dataSource;
@@ -282,7 +283,7 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
       final Consumer<ElementInstanceFilter> filter,
       final Consumer<List<ElementInstance>> assertion) {
 
-    awaitBehavior.untilAsserted(() -> dataSource.findElementInstances(filter), assertion);
+    awaitBehavior.get().untilAsserted(() -> dataSource.findElementInstances(filter), assertion);
   }
 
   private static List<ElementInstance> getInstancesInState(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/IncidentAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/IncidentAssertj.java
@@ -25,6 +25,7 @@ import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
@@ -36,11 +37,11 @@ public class IncidentAssertj extends AbstractAssert<ElementAssertj, String> {
       Arrays.asList(IncidentState.ACTIVE, IncidentState.PENDING, IncidentState.MIGRATED);
 
   private final CamundaDataSource dataSource;
-  private final CamundaAssertAwaitBehavior awaitBehavior;
+  private final Supplier<CamundaAssertAwaitBehavior> awaitBehavior;
 
   protected IncidentAssertj(
       final CamundaDataSource dataSource,
-      final CamundaAssertAwaitBehavior awaitBehavior,
+      final Supplier<CamundaAssertAwaitBehavior> awaitBehavior,
       final String failureMessagePrefix) {
     super(failureMessagePrefix, IncidentAssertj.class);
     this.dataSource = dataSource;
@@ -82,7 +83,7 @@ public class IncidentAssertj extends AbstractAssert<ElementAssertj, String> {
 
   private void awaitIncidentAssertion(
       final Consumer<IncidentFilter> filter, final Consumer<List<Incident>> assertion) {
-    awaitBehavior.untilAsserted(() -> dataSource.findIncidents(filter), assertion);
+    awaitBehavior.get().untilAsserted(() -> dataSource.findIncidents(filter), assertion);
   }
 
   private String collectIncidentReports(final List<Incident> incidents) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
@@ -25,16 +25,17 @@ import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.assertj.core.api.AbstractAssert;
 
 public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscriptionAssertj, String> {
 
   private final CamundaDataSource dataSource;
-  private final CamundaAssertAwaitBehavior awaitBehavior;
+  private final Supplier<CamundaAssertAwaitBehavior> awaitBehavior;
 
   public MessageSubscriptionAssertj(
       final CamundaDataSource dataSource,
-      final CamundaAssertAwaitBehavior awaitBehavior,
+      final Supplier<CamundaAssertAwaitBehavior> awaitBehavior,
       final String failureMessagePrefix) {
     super(failureMessagePrefix, MessageSubscriptionAssertj.class);
     this.dataSource = dataSource;
@@ -134,11 +135,13 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
       final Consumer<MessageSubscriptionFilter> filter,
       final Consumer<List<MessageSubscription>> assertionCallback) {
 
-    awaitBehavior.untilAsserted(
-        () ->
-            dataSource.findMessageSubscriptions(
-                f -> filter.accept(f.processInstanceKey(processInstanceKey))),
-        assertionCallback);
+    awaitBehavior
+        .get()
+        .untilAsserted(
+            () ->
+                dataSource.findMessageSubscriptions(
+                    f -> filter.accept(f.processInstanceKey(processInstanceKey))),
+            assertionCallback);
   }
 
   private void awaitCorrelatedMessages(
@@ -146,10 +149,12 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
       final Consumer<CorrelatedMessageSubscriptionFilter> filter,
       final Consumer<List<CorrelatedMessageSubscription>> assertionCallback) {
 
-    awaitBehavior.untilAsserted(
-        () ->
-            dataSource.findCorrelatedMessages(
-                f -> filter.accept(f.processInstanceKey(processInstanceKey))),
-        assertionCallback);
+    awaitBehavior
+        .get()
+        .untilAsserted(
+            () ->
+                dataSource.findCorrelatedMessages(
+                    f -> filter.accept(f.processInstanceKey(processInstanceKey))),
+            assertionCallback);
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -28,6 +28,7 @@ import io.camunda.process.test.api.assertions.VariableSelector;
 import io.camunda.process.test.api.assertions.VariableSelectors;
 import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.impl.assertions.util.CamundaAssertJsonMapper;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,7 @@ public class ProcessInstanceAssertj
     implements ProcessInstanceAssert {
 
   private final CamundaDataSource dataSource;
-  private final CamundaAssertAwaitBehavior awaitBehavior;
+  private CamundaAssertAwaitBehavior awaitBehavior;
 
   private final ElementAssertj elementAssertj;
   private final VariableAssertj variableAssertj;
@@ -85,13 +86,23 @@ public class ProcessInstanceAssertj
     failureMessagePrefix =
         String.format("Process instance [%s]", processInstanceSelector.describe());
     this.elementSelector = elementSelector;
-    elementAssertj = new ElementAssertj(dataSource, awaitBehavior, failureMessagePrefix);
+    elementAssertj = new ElementAssertj(dataSource, this::getAwaitBehavior, failureMessagePrefix);
     variableAssertj =
         new VariableAssertj(
-            dataSource, awaitBehavior, jsonMapper, judgeConfig, failureMessagePrefix);
-    incidentAssertj = new IncidentAssertj(dataSource, awaitBehavior, failureMessagePrefix);
+            dataSource, this::getAwaitBehavior, jsonMapper, judgeConfig, failureMessagePrefix);
+    incidentAssertj = new IncidentAssertj(dataSource, this::getAwaitBehavior, failureMessagePrefix);
     messageSubscriptionAssertj =
-        new MessageSubscriptionAssertj(dataSource, awaitBehavior, failureMessagePrefix);
+        new MessageSubscriptionAssertj(dataSource, this::getAwaitBehavior, failureMessagePrefix);
+  }
+
+  private CamundaAssertAwaitBehavior getAwaitBehavior() {
+    return awaitBehavior;
+  }
+
+  @Override
+  public ProcessInstanceAssert withAssertionTimeout(final Duration assertionTimeout) {
+    awaitBehavior = awaitBehavior.withAssertionTimeout(assertionTimeout);
+    return this;
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/UserTaskAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/UserTaskAssertj.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.search.response.UserTask;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import io.camunda.process.test.api.assertions.UserTaskAssert;
 import io.camunda.process.test.api.assertions.UserTaskSelector;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -31,7 +32,7 @@ public class UserTaskAssertj extends AbstractAssert<UserTaskAssertj, UserTaskSel
     implements UserTaskAssert {
 
   private final CamundaDataSource dataSource;
-  private final CamundaAssertAwaitBehavior awaitBehavior;
+  private CamundaAssertAwaitBehavior awaitBehavior;
 
   public UserTaskAssertj(
       final CamundaDataSource dataSource,
@@ -40,6 +41,12 @@ public class UserTaskAssertj extends AbstractAssert<UserTaskAssertj, UserTaskSel
     super(selector, UserTaskAssert.class);
     this.dataSource = dataSource;
     this.awaitBehavior = awaitBehavior;
+  }
+
+  @Override
+  public UserTaskAssertj withAssertionTimeout(final Duration assertionTimeout) {
+    awaitBehavior = awaitBehavior.withAssertionTimeout(assertionTimeout);
+    return this;
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -49,13 +49,13 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   private static final Logger LOG = LoggerFactory.getLogger(VariableAssertj.class);
 
   private final CamundaDataSource dataSource;
-  private final CamundaAssertAwaitBehavior awaitBehavior;
+  private final Supplier<CamundaAssertAwaitBehavior> awaitBehavior;
   private final CamundaAssertJsonMapper jsonMapper;
   private JudgeConfig judgeConfig;
 
   public VariableAssertj(
       final CamundaDataSource dataSource,
-      final CamundaAssertAwaitBehavior awaitBehavior,
+      final Supplier<CamundaAssertAwaitBehavior> awaitBehavior,
       final CamundaAssertJsonMapper jsonMapper,
       final JudgeConfig judgeConfig,
       final String failureMessagePrefix) {
@@ -89,23 +89,25 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   private void hasVariableNames(
       final Supplier<Map<String, String>> actualVariablesSupplier, final String... variableNames) {
 
-    awaitBehavior.untilAsserted(
-        () -> {
-          final Map<String, String> variables = actualVariablesSupplier.get();
+    awaitBehavior
+        .get()
+        .untilAsserted(
+            () -> {
+              final Map<String, String> variables = actualVariablesSupplier.get();
 
-          final List<String> missingVariableNames =
-              Arrays.stream(variableNames)
-                  .filter(variableName -> !variables.containsKey(variableName))
-                  .collect(Collectors.toList());
+              final List<String> missingVariableNames =
+                  Arrays.stream(variableNames)
+                      .filter(variableName -> !variables.containsKey(variableName))
+                      .collect(Collectors.toList());
 
-          assertThat(missingVariableNames)
-              .withFailMessage(
-                  "%s should have the variables %s but %s don't exist.",
-                  actual,
-                  AssertFormatUtil.formatNames(variableNames),
-                  AssertFormatUtil.formatNames(missingVariableNames))
-              .isEmpty();
-        });
+              assertThat(missingVariableNames)
+                  .withFailMessage(
+                      "%s should have the variables %s but %s don't exist.",
+                      actual,
+                      AssertFormatUtil.formatNames(variableNames),
+                      AssertFormatUtil.formatNames(missingVariableNames))
+                  .isEmpty();
+            });
   }
 
   public void hasLocalVariable(
@@ -143,26 +145,28 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
       final Supplier<List<Variable>> actualVariablesSupplier) {
     final JsonNode expectedValue = jsonMapper.toJsonNode(variableValue);
 
-    awaitBehavior.untilAsserted(
-        () -> {
-          final List<Variable> variables = actualVariablesSupplier.get();
+    awaitBehavior
+        .get()
+        .untilAsserted(
+            () -> {
+              final List<Variable> variables = actualVariablesSupplier.get();
 
-          final Optional<Variable> matchingVariable =
-              variables.stream().filter(variableSelector::test).findFirst();
+              final Optional<Variable> matchingVariable =
+                  variables.stream().filter(variableSelector::test).findFirst();
 
-          assertThat(matchingVariable)
-              .withFailMessage(
-                  "%s should have a variable '%s' with value '%s' but the variable doesn't exist.",
-                  actual, variableSelector.describe(), expectedValue)
-              .isPresent();
+              assertThat(matchingVariable)
+                  .withFailMessage(
+                      "%s should have a variable '%s' with value '%s' but the variable doesn't exist.",
+                      actual, variableSelector.describe(), expectedValue)
+                  .isPresent();
 
-          final JsonNode actualValue = jsonMapper.readJson(matchingVariable.get().getValue());
-          assertThat(actualValue)
-              .withFailMessage(
-                  "%s should have a variable '%s' with value '%s' but was '%s'.",
-                  actual, variableSelector.describe(), expectedValue, actualValue)
-              .isEqualTo(expectedValue);
-        });
+              final JsonNode actualValue = jsonMapper.readJson(matchingVariable.get().getValue());
+              assertThat(actualValue)
+                  .withFailMessage(
+                      "%s should have a variable '%s' with value '%s' but was '%s'.",
+                      actual, variableSelector.describe(), expectedValue, actualValue)
+                  .isEqualTo(expectedValue);
+            });
   }
 
   public <T> void hasLocalVariableSatisfies(
@@ -203,11 +207,14 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
       final ThrowingConsumer<String> rawRequirement,
       final Supplier<List<Variable>> actualVariablesSupplier) {
 
-    awaitBehavior.untilAsserted(
-        () -> {
-          final String rawValue = assertVariableExists(variableSelector, actualVariablesSupplier);
-          rawRequirement.accept(rawValue);
-        });
+    awaitBehavior
+        .get()
+        .untilAsserted(
+            () -> {
+              final String rawValue =
+                  assertVariableExists(variableSelector, actualVariablesSupplier);
+              rawRequirement.accept(rawValue);
+            });
   }
 
   private <T> void hasVariableSatisfies(
@@ -281,37 +288,39 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
 
     final Set<String> expectedVariableNames = expectedVariables.keySet();
 
-    awaitBehavior.untilAsserted(
-        () -> {
-          final Map<String, JsonNode> actualValues =
-              actualVariablesSupplier.get().entrySet().stream()
-                  .filter(entry -> expectedVariableNames.contains(entry.getKey()))
-                  .collect(
-                      Collectors.toMap(
-                          Entry::getKey, entry -> jsonMapper.readJson(entry.getValue())));
+    awaitBehavior
+        .get()
+        .untilAsserted(
+            () -> {
+              final Map<String, JsonNode> actualValues =
+                  actualVariablesSupplier.get().entrySet().stream()
+                      .filter(entry -> expectedVariableNames.contains(entry.getKey()))
+                      .collect(
+                          Collectors.toMap(
+                              Entry::getKey, entry -> jsonMapper.readJson(entry.getValue())));
 
-          final List<String> missingVariables =
-              expectedVariableNames.stream()
-                  .filter(variableName -> !actualValues.containsKey(variableName))
-                  .collect(Collectors.toList());
+              final List<String> missingVariables =
+                  expectedVariableNames.stream()
+                      .filter(variableName -> !actualValues.containsKey(variableName))
+                      .collect(Collectors.toList());
 
-          assertThat(missingVariables)
-              .withFailMessage(
-                  "%s should have the variables %s but was %s. The variables %s don't exist.",
-                  actual,
-                  jsonMapper.toJsonNode(expectedVariables),
-                  jsonMapper.toJsonNode(actualValues),
-                  AssertFormatUtil.formatNames(missingVariables))
-              .isEmpty();
+              assertThat(missingVariables)
+                  .withFailMessage(
+                      "%s should have the variables %s but was %s. The variables %s don't exist.",
+                      actual,
+                      jsonMapper.toJsonNode(expectedVariables),
+                      jsonMapper.toJsonNode(actualValues),
+                      AssertFormatUtil.formatNames(missingVariables))
+                  .isEmpty();
 
-          assertThat(actualValues)
-              .withFailMessage(
-                  "%s should have the variables %s but was %s.",
-                  actual,
-                  jsonMapper.toJsonNode(expectedVariables),
-                  jsonMapper.toJsonNode(actualValues))
-              .containsAllEntriesOf(expectedValues);
-        });
+              assertThat(actualValues)
+                  .withFailMessage(
+                      "%s should have the variables %s but was %s.",
+                      actual,
+                      jsonMapper.toJsonNode(expectedVariables),
+                      jsonMapper.toJsonNode(actualValues))
+                  .containsAllEntriesOf(expectedValues);
+            });
   }
 
   private void withLocalVariableAssertion(
@@ -341,7 +350,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   private void awaitElementInstanceAssertion(
       final Consumer<ElementInstanceFilter> filter,
       final Consumer<List<ElementInstance>> assertion) {
-    awaitBehavior.untilAsserted(() -> dataSource.findElementInstances(filter), assertion);
+    awaitBehavior.get().untilAsserted(() -> dataSource.findElementInstances(filter), assertion);
   }
 
   // --- Judge evaluation methods ---
@@ -403,8 +412,10 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
       final VariableSelector variableSelector,
       final Supplier<List<Variable>> actualVariablesSupplier) {
     final AtomicReference<String> result = new AtomicReference<>();
-    awaitBehavior.untilAsserted(
-        () -> result.set(assertVariableExists(variableSelector, actualVariablesSupplier)));
+    awaitBehavior
+        .get()
+        .untilAsserted(
+            () -> result.set(assertVariableExists(variableSelector, actualVariablesSupplier)));
     return result.get();
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
@@ -91,4 +91,12 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
   public void setAssertionTimeout(final Duration assertionTimeout) {
     this.assertionTimeout = assertionTimeout;
   }
+
+  @Override
+  public CamundaAssertAwaitBehavior withAssertionTimeout(final Duration assertionTimeout) {
+    final AwaitilityBehavior newInstance = new AwaitilityBehavior();
+    newInstance.setAssertionTimeout(assertionTimeout);
+    newInstance.setAssertionInterval(assertionInterval);
+    return newInstance;
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
@@ -73,8 +73,8 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
   }
 
   @Override
-  public void setAssertionTimeout(final Duration assertionTimeout) {
-    this.assertionTimeout = assertionTimeout;
+  public Duration getAssertionInterval() {
+    return assertionInterval;
   }
 
   @Override
@@ -83,7 +83,12 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
   }
 
   @Override
-  public Duration getAssertionInterval() {
-    return assertionInterval;
+  public Duration getAssertionTimeout() {
+    return assertionTimeout;
+  }
+
+  @Override
+  public void setAssertionTimeout(final Duration assertionTimeout) {
+    this.assertionTimeout = assertionTimeout;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/InstantProbeAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/InstantProbeAwaitBehavior.java
@@ -42,8 +42,8 @@ public class InstantProbeAwaitBehavior implements CamundaAssertAwaitBehavior {
   }
 
   @Override
-  public void setAssertionTimeout(final Duration assertionTimeout) {
-    // no-op — instant probing has no timeout
+  public Duration getAssertionInterval() {
+    return Duration.ZERO;
   }
 
   @Override
@@ -52,7 +52,12 @@ public class InstantProbeAwaitBehavior implements CamundaAssertAwaitBehavior {
   }
 
   @Override
-  public Duration getAssertionInterval() {
+  public Duration getAssertionTimeout() {
     return Duration.ZERO;
+  }
+
+  @Override
+  public void setAssertionTimeout(final Duration assertionTimeout) {
+    // no-op — instant probing has no timeout
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/InstantProbeAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/InstantProbeAwaitBehavior.java
@@ -63,8 +63,7 @@ public class InstantProbeAwaitBehavior implements CamundaAssertAwaitBehavior {
 
   @Override
   public CamundaAssertAwaitBehavior withAssertionTimeout(final Duration assertionTimeout) {
-    final InstantProbeAwaitBehavior newInstance = new InstantProbeAwaitBehavior();
-    newInstance.setAssertionTimeout(assertionTimeout);
-    return newInstance;
+    // ignore - instant probing has no timeout
+    return new InstantProbeAwaitBehavior();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/InstantProbeAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/InstantProbeAwaitBehavior.java
@@ -60,4 +60,11 @@ public class InstantProbeAwaitBehavior implements CamundaAssertAwaitBehavior {
   public void setAssertionTimeout(final Duration assertionTimeout) {
     // no-op — instant probing has no timeout
   }
+
+  @Override
+  public CamundaAssertAwaitBehavior withAssertionTimeout(final Duration assertionTimeout) {
+    final InstantProbeAwaitBehavior newInstance = new InstantProbeAwaitBehavior();
+    newInstance.setAssertionTimeout(assertionTimeout);
+    return newInstance;
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -101,6 +102,11 @@ public class CamundaProcessTestRuntimeBuilder {
   private CamundaClientBuilderFactory camundaClientBuilderFactory =
       CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_BUILDER_FACTORY;
   private Consumer<CamundaClientBuilder> camundaClientOverrides = cb -> {};
+
+  private Optional<Duration> assertionTimeout =
+      CamundaProcessTestRuntimeDefaults.ASSERTION_PROPERTIES.getAssertionTimeout();
+  private Optional<Duration> assertionInterval =
+      CamundaProcessTestRuntimeDefaults.ASSERTION_PROPERTIES.getAssertionInterval();
 
   // ============ For testing =================
 
@@ -288,6 +294,16 @@ public class CamundaProcessTestRuntimeBuilder {
     return this;
   }
 
+  public CamundaProcessTestRuntimeBuilder withAssertionTimeout(final Duration assertionTimeout) {
+    this.assertionTimeout = Optional.ofNullable(assertionTimeout);
+    return this;
+  }
+
+  public CamundaProcessTestRuntimeBuilder withAssertionInterval(final Duration assertionInterval) {
+    this.assertionInterval = Optional.ofNullable(assertionInterval);
+    return this;
+  }
+
   // ============ Build =================
 
   private void loadContainerProvidersFromServiceLoader() {
@@ -443,5 +459,13 @@ public class CamundaProcessTestRuntimeBuilder {
 
   public boolean isContainerProvidersServiceLoaderEnabled() {
     return containerProvidersServiceLoaderEnabled;
+  }
+
+  public Optional<Duration> getAssertionTimeout() {
+    return assertionTimeout;
+  }
+
+  public Optional<Duration> getAssertionInterval() {
+    return assertionInterval;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.runtime;
 
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.impl.runtime.properties.AssertionProperties;
 import io.camunda.process.test.impl.runtime.properties.JudgeProperties;
 import java.net.URI;
 import java.time.Duration;
@@ -96,6 +97,9 @@ public class CamundaProcessTestRuntimeDefaults {
       PROPERTIES_UTIL.getCoverageReportProperties().getCoverageReportDirectory();
   public static final List<String> COVERAGE_EXCLUDED_PROCESSES =
       PROPERTIES_UTIL.getCoverageReportProperties().getCoverageExcludedProcesses();
+
+  public static final AssertionProperties ASSERTION_PROPERTIES =
+      PROPERTIES_UTIL.getAssertionProperties();
 
   public static final JudgeProperties JUDGE_PROPERTIES = PROPERTIES_UTIL.getJudgeProperties();
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -21,6 +21,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.impl.runtime.properties.AssertionProperties;
 import io.camunda.process.test.impl.runtime.properties.CamundaContainerRuntimeProperties;
 import io.camunda.process.test.impl.runtime.properties.CamundaProcessTestClientProperties;
 import io.camunda.process.test.impl.runtime.properties.ConnectorsContainerRuntimeProperties;
@@ -58,6 +59,7 @@ public final class ContainerRuntimePropertiesUtil {
   private final CoverageReportProperties coverageReportProperties;
   private final JudgeProperties judgeProperties;
   private final CamundaProcessTestClientProperties camundaProcessTestClientProperties;
+  private final AssertionProperties assertionProperties;
 
   private final CamundaProcessTestRuntimeMode runtimeMode;
   private final boolean multiTenancyEnabled;
@@ -83,6 +85,7 @@ public final class ContainerRuntimePropertiesUtil {
     coverageReportProperties = new CoverageReportProperties(properties);
     judgeProperties = new JudgeProperties(properties);
     camundaProcessTestClientProperties = new CamundaProcessTestClientProperties(properties);
+    assertionProperties = new AssertionProperties(properties);
 
     runtimeMode =
         getPropertyOrDefault(
@@ -262,5 +265,9 @@ public final class ContainerRuntimePropertiesUtil {
 
   public JudgeProperties getJudgeProperties() {
     return judgeProperties;
+  }
+
+  public AssertionProperties getAssertionProperties() {
+    return assertionProperties;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/AssertionProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/AssertionProperties.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.properties;
+
+import io.camunda.process.test.impl.runtime.util.PropertiesUtil;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Properties;
+
+public class AssertionProperties {
+
+  public static final String PROPERTY_NAME_ASSERTION_TIMEOUT = "assertion.timeout";
+  public static final String PROPERTY_NAME_ASSERTION_INTERVAL = "assertion.interval";
+
+  private final Duration assertionTimeout;
+  private final Duration assertionInterval;
+
+  public AssertionProperties(final Properties properties) {
+    assertionTimeout =
+        PropertiesUtil.getPropertyOrNull(
+            properties, PROPERTY_NAME_ASSERTION_TIMEOUT, Duration::parse);
+
+    assertionInterval =
+        PropertiesUtil.getPropertyOrNull(
+            properties, PROPERTY_NAME_ASSERTION_INTERVAL, Duration::parse);
+  }
+
+  public Optional<Duration> getAssertionTimeout() {
+    return Optional.ofNullable(assertionTimeout);
+  }
+
+  public Optional<Duration> getAssertionInterval() {
+    return Optional.ofNullable(assertionInterval);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/AssertionConfigurationTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/AssertionConfigurationTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.camunda.client.api.search.response.DecisionInstance;
+import io.camunda.process.test.api.assertions.DecisionSelectors;
+import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import io.camunda.process.test.api.assertions.UserTaskSelectors;
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.DecisionInstanceBuilder;
+import io.camunda.process.test.utils.ElementInstanceBuilder;
+import io.camunda.process.test.utils.MessageSubscriptionBuilder;
+import io.camunda.process.test.utils.ProcessInstanceBuilder;
+import io.camunda.process.test.utils.UserTaskBuilder;
+import io.camunda.process.test.utils.VariableBuilder;
+import java.time.Duration;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AssertionConfigurationTest {
+
+  private static final Duration ASSERTION_TIMEOUT_OVERRIDE = Duration.ofMinutes(1);
+
+  @Spy
+  private CamundaAssertAwaitBehavior globalAwaitBehavior = CamundaAssert.DEFAULT_AWAIT_BEHAVIOR;
+
+  @Spy
+  private CamundaAssertAwaitBehavior overrideAwaitBehavior = CamundaAssert.DEFAULT_AWAIT_BEHAVIOR;
+
+  @Mock private CamundaDataSource camundaDataSource;
+
+  @BeforeEach
+  void configureMocks() {
+    CamundaAssert.initialize(camundaDataSource);
+
+    CamundaAssert.setAwaitBehavior(globalAwaitBehavior);
+
+    lenient()
+        .when(globalAwaitBehavior.withAssertionTimeout(any()))
+        .thenReturn(overrideAwaitBehavior);
+  }
+
+  @AfterEach
+  void resetAssertion() {
+    CamundaAssert.setAwaitBehavior(CamundaAssert.DEFAULT_AWAIT_BEHAVIOR);
+  }
+
+  @Nested
+  class ProcessAssertionTests {
+
+    private static final long PROCESS_INSTANCE_KEY = 100L;
+
+    @BeforeEach
+    void configureDataSource() {
+      // given
+      lenient()
+          .when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(
+                  ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      lenient()
+          .when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(
+              Collections.singletonList(
+                  ElementInstanceBuilder.newActiveElementInstance(
+                          "fly-space-shuttle", PROCESS_INSTANCE_KEY)
+                      .build()));
+
+      lenient()
+          .when(camundaDataSource.findVariables(any()))
+          .thenReturn(
+              Collections.singletonList(
+                  VariableBuilder.newVariable("location", "\"moon\"").build()));
+
+      lenient()
+          .when(camundaDataSource.findMessageSubscriptions(any()))
+          .thenReturn(
+              Collections.singletonList(
+                  MessageSubscriptionBuilder.newActiveMessageSubscription(
+                          "landing permitted", "Artemis")
+                      .build()));
+    }
+
+    @Test
+    void shouldUseGlobalTimeout() {
+      // when
+      CamundaAssert.assertThatProcessInstance(ProcessInstanceSelectors.byKey(PROCESS_INSTANCE_KEY))
+          .isActive();
+
+      // then
+      verify(globalAwaitBehavior).untilAsserted(any());
+      verifyNoInteractions(overrideAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeout() {
+      // when
+      CamundaAssert.assertThatProcessInstance(ProcessInstanceSelectors.byKey(PROCESS_INSTANCE_KEY))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isActive();
+
+      // then
+      verify(globalAwaitBehavior).withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE);
+      verify(overrideAwaitBehavior).untilAsserted(any());
+      verifyNoMoreInteractions(globalAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeoutForCompleteChain() {
+      // when
+      CamundaAssert.assertThatProcessInstance(ProcessInstanceSelectors.byKey(PROCESS_INSTANCE_KEY))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isActive()
+          .hasActiveElements("fly-space-shuttle")
+          .hasVariable("location", "moon")
+          .isWaitingForMessage("landing permitted")
+          .hasNoActiveIncidents();
+
+      // then
+      verify(globalAwaitBehavior).withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE);
+      verify(overrideAwaitBehavior, times(5)).untilAsserted(any());
+      verifyNoMoreInteractions(globalAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeoutInChain() {
+      // when
+      CamundaAssert.assertThatProcessInstance(ProcessInstanceSelectors.byKey(PROCESS_INSTANCE_KEY))
+          .isActive()
+          .hasActiveElements("fly-space-shuttle")
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .hasVariable("location", "moon")
+          .isWaitingForMessage("landing permitted")
+          .hasNoActiveIncidents();
+
+      // then
+      final InOrder inOrder = inOrder(globalAwaitBehavior, overrideAwaitBehavior);
+      inOrder.verify(globalAwaitBehavior, times(2)).untilAsserted(any());
+      inOrder.verify(overrideAwaitBehavior, times(3)).untilAsserted(any());
+    }
+
+    @Test
+    void shouldNotOverrideGlobalTimeout() {
+      // when
+      CamundaAssert.assertThatProcessInstance(ProcessInstanceSelectors.byKey(PROCESS_INSTANCE_KEY))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isActive();
+
+      CamundaAssert.assertThatProcessInstance(ProcessInstanceSelectors.byKey(PROCESS_INSTANCE_KEY))
+          .isActive();
+
+      // then
+      final InOrder inOrder = inOrder(globalAwaitBehavior, overrideAwaitBehavior);
+      inOrder.verify(overrideAwaitBehavior, times(1)).untilAsserted(any());
+      inOrder.verify(globalAwaitBehavior, times(1)).untilAsserted(any());
+    }
+  }
+
+  @Nested
+  class DecisionInstanceAssertionTests {
+
+    private static final long DECISION_INSTANCE_KEY = 200L;
+    private static final String DECISION_INSTANCE_ID = "200";
+    private static final String DECISION_ID = "decide-astronaut";
+
+    @BeforeEach
+    void configureDataSource() {
+      // given
+      final DecisionInstance decisionInstance =
+          DecisionInstanceBuilder.newEvaluatedDecisionInstance(DECISION_INSTANCE_KEY)
+              .setDecisionInstanceId(DECISION_INSTANCE_ID)
+              .setDecisionDefinitionId(DECISION_ID)
+              .setResult("\"Zee\"")
+              .build();
+
+      lenient()
+          .when(camundaDataSource.findDecisionInstances(any()))
+          .thenReturn(Collections.singletonList(decisionInstance));
+
+      lenient()
+          .when(camundaDataSource.getDecisionInstance(DECISION_INSTANCE_ID))
+          .thenReturn(decisionInstance);
+    }
+
+    @Test
+    void shouldUseGlobalTimeout() {
+      // when
+      CamundaAssert.assertThatDecision(DecisionSelectors.byId(DECISION_ID)).isEvaluated();
+
+      // then
+      verify(globalAwaitBehavior).untilAsserted(any());
+      verifyNoInteractions(overrideAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeout() {
+      // when
+      CamundaAssert.assertThatDecision(DecisionSelectors.byId(DECISION_ID))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isEvaluated();
+
+      // then
+      verify(globalAwaitBehavior).withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE);
+      verify(overrideAwaitBehavior).untilAsserted(any());
+      verifyNoMoreInteractions(globalAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeoutForCompleteChain() {
+      // when
+      CamundaAssert.assertThatDecision(DecisionSelectors.byId(DECISION_ID))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isEvaluated()
+          .hasOutput("Zee");
+
+      // then
+      verify(globalAwaitBehavior).withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE);
+      verify(overrideAwaitBehavior, times(2)).untilAsserted(any());
+      verifyNoMoreInteractions(globalAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeoutInChain() {
+      // when
+      CamundaAssert.assertThatDecision(DecisionSelectors.byId(DECISION_ID))
+          .isEvaluated()
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .hasOutput("Zee");
+
+      // then
+      final InOrder inOrder = inOrder(globalAwaitBehavior, overrideAwaitBehavior);
+      inOrder.verify(globalAwaitBehavior, times(1)).untilAsserted(any());
+      inOrder.verify(overrideAwaitBehavior, times(1)).untilAsserted(any());
+    }
+
+    @Test
+    void shouldNotOverrideGlobalTimeout() {
+      // when
+      CamundaAssert.assertThatDecision(DecisionSelectors.byId(DECISION_ID))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isEvaluated();
+
+      CamundaAssert.assertThatDecision(DecisionSelectors.byId(DECISION_ID)).isEvaluated();
+
+      // then
+      final InOrder inOrder = inOrder(globalAwaitBehavior, overrideAwaitBehavior);
+      inOrder.verify(overrideAwaitBehavior, times(1)).untilAsserted(any());
+      inOrder.verify(globalAwaitBehavior, times(1)).untilAsserted(any());
+    }
+  }
+
+  @Nested
+  class UserTaskAssertionTests {
+
+    private static final long USER_TASK_KEY = 300L;
+    private static final String ELEMENT_ID = "perform-astronaut-training";
+
+    @BeforeEach
+    void configureDataSource() {
+      // given
+      lenient()
+          .when(camundaDataSource.findUserTasks(any()))
+          .thenReturn(
+              Collections.singletonList(
+                  UserTaskBuilder.newCreatedUserTask(USER_TASK_KEY)
+                      .setElementId(ELEMENT_ID)
+                      .setAssignee("Zee")
+                      .build()));
+    }
+
+    @Test
+    void shouldUseGlobalTimeout() {
+      // when
+      CamundaAssert.assertThatUserTask(UserTaskSelectors.byElementId(ELEMENT_ID)).isCreated();
+
+      // then
+      verify(globalAwaitBehavior).untilAsserted(any());
+      verifyNoInteractions(overrideAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeout() {
+      // when
+      CamundaAssert.assertThatUserTask(UserTaskSelectors.byElementId(ELEMENT_ID))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isCreated();
+
+      // then
+      verify(globalAwaitBehavior).withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE);
+      verify(overrideAwaitBehavior).untilAsserted(any());
+      verifyNoMoreInteractions(globalAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeoutForCompleteChain() {
+      // when
+      CamundaAssert.assertThatUserTask(UserTaskSelectors.byElementId(ELEMENT_ID))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isCreated()
+          .hasAssignee("Zee");
+
+      // then
+      verify(globalAwaitBehavior).withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE);
+      verify(overrideAwaitBehavior, times(2)).untilAsserted(any());
+      verifyNoMoreInteractions(globalAwaitBehavior);
+    }
+
+    @Test
+    void shouldOverrideTimeoutInChain() {
+      // when
+      CamundaAssert.assertThatUserTask(UserTaskSelectors.byElementId(ELEMENT_ID))
+          .isCreated()
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .hasAssignee("Zee");
+
+      // then
+      final InOrder inOrder = inOrder(globalAwaitBehavior, overrideAwaitBehavior);
+      inOrder.verify(globalAwaitBehavior, times(1)).untilAsserted(any());
+      inOrder.verify(overrideAwaitBehavior, times(1)).untilAsserted(any());
+    }
+
+    @Test
+    void shouldNotOverrideGlobalTimeout() {
+      // when
+      CamundaAssert.assertThatUserTask(UserTaskSelectors.byElementId(ELEMENT_ID))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isCreated();
+
+      CamundaAssert.assertThatUserTask(UserTaskSelectors.byElementId(ELEMENT_ID)).isCreated();
+
+      // then
+      final InOrder inOrder = inOrder(globalAwaitBehavior, overrideAwaitBehavior);
+      inOrder.verify(overrideAwaitBehavior, times(1)).untilAsserted(any());
+      inOrder.verify(globalAwaitBehavior, times(1)).untilAsserted(any());
+    }
+  }
+
+  @Nested
+  class AwaitBehaviorTests {
+
+    @Test
+    void shouldCreateInstanceWithTimeout() {
+      // given
+      final CamundaAssertAwaitBehavior awaitBehavior = CamundaAssert.DEFAULT_AWAIT_BEHAVIOR;
+
+      // when
+      final CamundaAssertAwaitBehavior awaitBehaviorWithOverride =
+          awaitBehavior.withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE);
+
+      // then
+      assertThat(awaitBehaviorWithOverride.getAssertionTimeout())
+          .isEqualTo(ASSERTION_TIMEOUT_OVERRIDE);
+      assertThat(awaitBehaviorWithOverride.getAssertionInterval())
+          .isEqualTo(awaitBehavior.getAssertionInterval());
+
+      assertThat(awaitBehavior.getAssertionTimeout())
+          .isEqualTo(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
+      assertThat(awaitBehavior.getAssertionInterval())
+          .isEqualTo(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -38,13 +38,16 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -485,5 +488,59 @@ public class JunitExtensionTest {
   @CamundaProcessTest
   private static final class MainProcessTest {
     static class NestedProcessTest {}
+  }
+
+  @Nested
+  class AssertionConfigurationTest {
+
+    @AfterEach
+    void resetAssertion() {
+      CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
+      CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
+    }
+
+    @Test
+    void shouldSetAssertionTimeoutFromConfig() throws Exception {
+      // given
+      final Duration assertionTimeout = Duration.ofMinutes(5);
+      final Duration assertionInterval = Duration.ofMillis(123);
+
+      when(camundaRuntimeBuilder.getAssertionTimeout()).thenReturn(Optional.of(assertionTimeout));
+      when(camundaRuntimeBuilder.getAssertionInterval()).thenReturn(Optional.of(assertionInterval));
+
+      final CamundaProcessTestExtension extension =
+          new CamundaProcessTestExtension(camundaRuntimeBuilder, processCoverageBuilder, NOOP);
+
+      // when
+      extension.beforeAll(extensionContext);
+      extension.beforeEach(extensionContext);
+
+      // then
+      final CamundaAssertAwaitBehavior awaitBehavior = CamundaAssert.getAwaitBehavior();
+      assertThat(awaitBehavior.getAssertionTimeout()).isEqualTo(assertionTimeout);
+      assertThat(awaitBehavior.getAssertionInterval()).isEqualTo(assertionInterval);
+    }
+
+    @Test
+    void shouldNotOverrideAssertionTimeoutIfNotSetInConfig() throws Exception {
+      // given
+      final Duration assertionTimeout = Duration.ofMinutes(1);
+      final Duration assertionInterval = Duration.ofMillis(50);
+
+      CamundaAssert.setAssertionTimeout(assertionTimeout);
+      CamundaAssert.setAssertionInterval(assertionInterval);
+
+      final CamundaProcessTestExtension extension =
+          new CamundaProcessTestExtension(camundaRuntimeBuilder, processCoverageBuilder, NOOP);
+
+      // when
+      extension.beforeAll(extensionContext);
+      extension.beforeEach(extensionContext);
+
+      // then
+      final CamundaAssertAwaitBehavior awaitBehavior = CamundaAssert.getAwaitBehavior();
+      assertThat(awaitBehavior.getAssertionTimeout()).isEqualTo(assertionTimeout);
+      assertThat(awaitBehavior.getAssertionInterval()).isEqualTo(assertionInterval);
+    }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.impl.runtime.properties.AssertionProperties;
 import io.camunda.process.test.impl.runtime.properties.CamundaClientWorkerProperties;
 import io.camunda.process.test.impl.runtime.properties.CamundaContainerRuntimeProperties;
 import io.camunda.process.test.impl.runtime.properties.CamundaProcessTestClientProperties;
@@ -585,6 +586,55 @@ public class ContainerRuntimePropertiesUtilTest {
       // The tenantIds are not assigned when in RuntimeMode.REMOTE
       // assertThat(clientBuilder.getDefaultJobWorkerTenantIds()).containsExactlyInAnyOrder("customTenantA", "customTenantB");
       assertThat(clientBuilder.getDefaultJobWorkerStreamEnabled()).isTrue();
+    }
+  }
+
+  @Nested
+  class AssertionPropertiesTest {
+
+    @Test
+    void shouldReturnDefaults() {
+      // given
+      final Properties properties = new Properties();
+
+      // when
+      final ContainerRuntimePropertiesUtil propertiesUtil =
+          new ContainerRuntimePropertiesUtil(properties, emptyGitProperties);
+
+      // then
+      final AssertionProperties assertionProperties = propertiesUtil.getAssertionProperties();
+      assertThat(assertionProperties.getAssertionTimeout()).isEmpty();
+      assertThat(assertionProperties.getAssertionInterval()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnProperties() {
+      // given
+      final Properties properties = new Properties();
+      properties.put(AssertionProperties.PROPERTY_NAME_ASSERTION_TIMEOUT, "PT1M");
+      properties.put(AssertionProperties.PROPERTY_NAME_ASSERTION_INTERVAL, "PT1S");
+
+      // when
+      final ContainerRuntimePropertiesUtil propertiesUtil =
+          new ContainerRuntimePropertiesUtil(properties, emptyGitProperties);
+
+      // then
+      final AssertionProperties assertionProperties = propertiesUtil.getAssertionProperties();
+      assertThat(assertionProperties.getAssertionTimeout()).hasValue(Duration.ofMinutes(1));
+      assertThat(assertionProperties.getAssertionInterval()).hasValue(Duration.ofSeconds(1));
+    }
+
+    @Test
+    void shouldReadPropertiesFile() {
+      // when
+      final ContainerRuntimePropertiesUtil propertiesUtil =
+          ContainerRuntimePropertiesUtil.readProperties(
+              "/containerRuntimePropertiesUtil/", emptyGitProperties);
+
+      // then
+      final AssertionProperties assertionProperties = propertiesUtil.getAssertionProperties();
+      assertThat(assertionProperties.getAssertionTimeout()).hasValue(Duration.ofMinutes(5));
+      assertThat(assertionProperties.getAssertionInterval()).hasValue(Duration.ofMillis(500));
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DecisionInstanceBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DecisionInstanceBuilder.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.utils;
+
+import io.camunda.client.api.response.EvaluatedDecisionInput;
+import io.camunda.client.api.response.MatchedDecisionRule;
+import io.camunda.client.api.search.response.DecisionDefinitionType;
+import io.camunda.client.api.search.response.DecisionInstance;
+import io.camunda.client.api.search.response.DecisionInstanceState;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class DecisionInstanceBuilder implements DecisionInstance {
+
+  private static final OffsetDateTime EVALUATION_DATE =
+      OffsetDateTime.parse("2025-03-20T13:26:00Z");
+
+  private long decisionInstanceKey;
+  private String decisionInstanceId;
+  private DecisionInstanceState state;
+  private OffsetDateTime evaluationDate;
+  private String evaluationFailure;
+  private Long processDefinitionKey;
+  private Long processInstanceKey;
+  private Long rootProcessInstanceKey;
+  private Long elementInstanceKey;
+  private long decisionDefinitionKey;
+  private String decisionDefinitionId;
+  private String decisionDefinitionName;
+  private int decisionDefinitionVersion;
+  private DecisionDefinitionType decisionDefinitionType;
+  private long rootDecisionDefinitionKey;
+  private String tenantId;
+  private List<EvaluatedDecisionInput> evaluatedInputs;
+  private List<MatchedDecisionRule> matchedRules;
+  private String result;
+
+  @Override
+  public long getDecisionInstanceKey() {
+    return decisionInstanceKey;
+  }
+
+  @Override
+  public String getDecisionInstanceId() {
+    return decisionInstanceId;
+  }
+
+  @Override
+  public DecisionInstanceState getState() {
+    return state;
+  }
+
+  @Override
+  public OffsetDateTime getEvaluationDate() {
+    return evaluationDate;
+  }
+
+  @Override
+  public String getEvaluationFailure() {
+    return evaluationFailure;
+  }
+
+  @Override
+  public Long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  @Override
+  public Long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  @Override
+  public long getDecisionDefinitionKey() {
+    return decisionDefinitionKey;
+  }
+
+  @Override
+  public String getDecisionDefinitionId() {
+    return decisionDefinitionId;
+  }
+
+  @Override
+  public String getDecisionDefinitionName() {
+    return decisionDefinitionName;
+  }
+
+  @Override
+  public int getDecisionDefinitionVersion() {
+    return decisionDefinitionVersion;
+  }
+
+  @Override
+  public DecisionDefinitionType getDecisionDefinitionType() {
+    return decisionDefinitionType;
+  }
+
+  @Override
+  public long getRootDecisionDefinitionKey() {
+    return rootDecisionDefinitionKey;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public List<EvaluatedDecisionInput> getEvaluatedInputs() {
+    return evaluatedInputs;
+  }
+
+  @Override
+  public List<MatchedDecisionRule> getMatchedRules() {
+    return matchedRules;
+  }
+
+  @Override
+  public String getResult() {
+    return result;
+  }
+
+  @Override
+  public String toJson() {
+    return "{}";
+  }
+
+  public DecisionInstanceBuilder setResult(final String result) {
+    this.result = result;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setMatchedRules(final List<MatchedDecisionRule> matchedRules) {
+    this.matchedRules = matchedRules;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setEvaluatedInputs(
+      final List<EvaluatedDecisionInput> evaluatedInputs) {
+    this.evaluatedInputs = evaluatedInputs;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setRootDecisionDefinitionKey(
+      final long rootDecisionDefinitionKey) {
+    this.rootDecisionDefinitionKey = rootDecisionDefinitionKey;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setDecisionDefinitionType(
+      final DecisionDefinitionType decisionDefinitionType) {
+    this.decisionDefinitionType = decisionDefinitionType;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setDecisionDefinitionVersion(final int decisionDefinitionVersion) {
+    this.decisionDefinitionVersion = decisionDefinitionVersion;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setDecisionDefinitionName(final String decisionDefinitionName) {
+    this.decisionDefinitionName = decisionDefinitionName;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setDecisionDefinitionId(final String decisionDefinitionId) {
+    this.decisionDefinitionId = decisionDefinitionId;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setDecisionDefinitionKey(final long decisionDefinitionKey) {
+    this.decisionDefinitionKey = decisionDefinitionKey;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setElementInstanceKey(final Long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setProcessInstanceKey(final Long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setProcessDefinitionKey(final Long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setEvaluationFailure(final String evaluationFailure) {
+    this.evaluationFailure = evaluationFailure;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setEvaluationDate(final OffsetDateTime evaluationDate) {
+    this.evaluationDate = evaluationDate;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setState(final DecisionInstanceState state) {
+    this.state = state;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setDecisionInstanceId(final String decisionInstanceId) {
+    this.decisionInstanceId = decisionInstanceId;
+    return this;
+  }
+
+  public DecisionInstanceBuilder setDecisionInstanceKey(final long decisionInstanceKey) {
+    this.decisionInstanceKey = decisionInstanceKey;
+    return this;
+  }
+
+  public DecisionInstance build() {
+    return this;
+  }
+
+  public static DecisionInstanceBuilder newEvaluatedDecisionInstance(
+      final long decisionInstanceKey) {
+    return new DecisionInstanceBuilder()
+        .setDecisionInstanceKey(decisionInstanceKey)
+        .setState(DecisionInstanceState.EVALUATED)
+        .setEvaluationDate(EVALUATION_DATE);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
@@ -111,4 +111,12 @@ public final class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
   public void setAssertionTimeout(final Duration assertionTimeout) {
     this.assertionTimeout = assertionTimeout;
   }
+
+  @Override
+  public CamundaAssertAwaitBehavior withAssertionTimeout(final Duration assertionTimeout) {
+    final DevAwaitBehavior newInstance = new DevAwaitBehavior(expectFailure);
+    newInstance.setAssertionTimeout(assertionTimeout);
+    newInstance.setAssertionInterval(assertionInterval);
+    return newInstance;
+  }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/DevAwaitBehavior.java
@@ -93,8 +93,8 @@ public final class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
   }
 
   @Override
-  public void setAssertionTimeout(final Duration assertionTimeout) {
-    this.assertionTimeout = assertionTimeout;
+  public Duration getAssertionInterval() {
+    return assertionInterval;
   }
 
   @Override
@@ -103,7 +103,12 @@ public final class DevAwaitBehavior implements CamundaAssertAwaitBehavior {
   }
 
   @Override
-  public Duration getAssertionInterval() {
-    return assertionInterval;
+  public Duration getAssertionTimeout() {
+    return assertionTimeout;
+  }
+
+  @Override
+  public void setAssertionTimeout(final Duration assertionTimeout) {
+    this.assertionTimeout = assertionTimeout;
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/UserTaskBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/UserTaskBuilder.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.utils;
+
+import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.response.UserTask;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class UserTaskBuilder implements UserTask {
+
+  private static final OffsetDateTime CREATION_DATE = OffsetDateTime.parse("2025-03-20T13:23:00Z");
+
+  private Long userTaskKey;
+  private String name;
+  private UserTaskState state;
+  private String assignee;
+  private String elementId;
+  private Long elementInstanceKey;
+  private List<String> candidateGroups;
+  private List<String> candidateUsers;
+  private String bpmnProcessId;
+  private String processName;
+  private Long processDefinitionKey;
+  private Long processInstanceKey;
+  private Long rootProcessInstanceKey;
+  private Long formKey;
+  private OffsetDateTime creationDate;
+  private OffsetDateTime completionDate;
+  private OffsetDateTime followUpDate;
+  private OffsetDateTime dueDate;
+  private String tenantId;
+  private String externalFormReference;
+  private Integer processDefinitionVersion;
+  private Map<String, String> customHeaders;
+  private Integer priority;
+  private Set<String> tags;
+
+  @Override
+  public Long getUserTaskKey() {
+    return userTaskKey;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public UserTaskState getState() {
+    return state;
+  }
+
+  @Override
+  public String getAssignee() {
+    return assignee;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public Long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  @Override
+  public List<String> getCandidateGroups() {
+    return candidateGroups;
+  }
+
+  @Override
+  public List<String> getCandidateUsers() {
+    return candidateUsers;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public String getProcessName() {
+    return processName;
+  }
+
+  @Override
+  public Long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  @Override
+  public Long getFormKey() {
+    return formKey;
+  }
+
+  @Override
+  public OffsetDateTime getCreationDate() {
+    return creationDate;
+  }
+
+  @Override
+  public OffsetDateTime getCompletionDate() {
+    return completionDate;
+  }
+
+  @Override
+  public OffsetDateTime getFollowUpDate() {
+    return followUpDate;
+  }
+
+  @Override
+  public OffsetDateTime getDueDate() {
+    return dueDate;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public String getExternalFormReference() {
+    return externalFormReference;
+  }
+
+  @Override
+  public Integer getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  @Override
+  public Map<String, String> getCustomHeaders() {
+    return customHeaders;
+  }
+
+  @Override
+  public Integer getPriority() {
+    return priority;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return tags;
+  }
+
+  public UserTaskBuilder setTags(final Set<String> tags) {
+    this.tags = tags;
+    return this;
+  }
+
+  public UserTaskBuilder setPriority(final Integer priority) {
+    this.priority = priority;
+    return this;
+  }
+
+  public UserTaskBuilder setCustomHeaders(final Map<String, String> customHeaders) {
+    this.customHeaders = customHeaders;
+    return this;
+  }
+
+  public UserTaskBuilder setProcessDefinitionVersion(final Integer processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+    return this;
+  }
+
+  public UserTaskBuilder setExternalFormReference(final String externalFormReference) {
+    this.externalFormReference = externalFormReference;
+    return this;
+  }
+
+  public UserTaskBuilder setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  public UserTaskBuilder setDueDate(final OffsetDateTime dueDate) {
+    this.dueDate = dueDate;
+    return this;
+  }
+
+  public UserTaskBuilder setFollowUpDate(final OffsetDateTime followUpDate) {
+    this.followUpDate = followUpDate;
+    return this;
+  }
+
+  public UserTaskBuilder setCompletionDate(final OffsetDateTime completionDate) {
+    this.completionDate = completionDate;
+    return this;
+  }
+
+  public UserTaskBuilder setCreationDate(final OffsetDateTime creationDate) {
+    this.creationDate = creationDate;
+    return this;
+  }
+
+  public UserTaskBuilder setFormKey(final Long formKey) {
+    this.formKey = formKey;
+    return this;
+  }
+
+  public UserTaskBuilder setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
+  public UserTaskBuilder setProcessInstanceKey(final Long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
+  public UserTaskBuilder setProcessDefinitionKey(final Long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public UserTaskBuilder setProcessName(final String processName) {
+    this.processName = processName;
+    return this;
+  }
+
+  public UserTaskBuilder setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+    return this;
+  }
+
+  public UserTaskBuilder setCandidateUsers(final List<String> candidateUsers) {
+    this.candidateUsers = candidateUsers;
+    return this;
+  }
+
+  public UserTaskBuilder setCandidateGroups(final List<String> candidateGroups) {
+    this.candidateGroups = candidateGroups;
+    return this;
+  }
+
+  public UserTaskBuilder setElementInstanceKey(final Long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+    return this;
+  }
+
+  public UserTaskBuilder setElementId(final String elementId) {
+    this.elementId = elementId;
+    return this;
+  }
+
+  public UserTaskBuilder setAssignee(final String assignee) {
+    this.assignee = assignee;
+    return this;
+  }
+
+  public UserTaskBuilder setState(final UserTaskState state) {
+    this.state = state;
+    return this;
+  }
+
+  public UserTaskBuilder setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public UserTaskBuilder setUserTaskKey(final Long userTaskKey) {
+    this.userTaskKey = userTaskKey;
+    return this;
+  }
+
+  public UserTask build() {
+    return this;
+  }
+
+  public static UserTaskBuilder newCreatedUserTask(final long userTaskKey) {
+    return new UserTaskBuilder()
+        .setUserTaskKey(userTaskKey)
+        .setState(UserTaskState.CREATED)
+        .setCreationDate(CREATION_DATE);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
@@ -36,6 +36,9 @@ coverage.reportDirectory=custom/coverage-report
 coverage.excludedProcesses[0]=process1
 coverage.excludedProcesses[1]=process2
 
+assertion.timeout=PT5M
+assertion.interval=PT0.5S
+
 runtimeMode=remote
 
 client.restAddress=http://0.0.0.0:8090

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -24,6 +24,7 @@ import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.assertions.util.InstantProbeAwaitBehavior;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
+import io.camunda.process.test.impl.configuration.AssertionConfiguration;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
 import io.camunda.process.test.impl.configuration.CoverageReportConfiguration;
 import io.camunda.process.test.impl.containers.CamundaContainer.MultiTenancyConfiguration;
@@ -156,11 +157,10 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
             .excludeProcessDefinitionIds(coverageReportConfiguration.getExcludedProcesses())
             .build();
 
-    // initialize json mapper
+    // initializations
     initializeJsonMapper(jsonMapper, zeebeJsonMapper);
-
-    // initialize judge config
     initializeJudgeConfig(testContext, runtimeConfiguration);
+    initializeAssertions(runtimeConfiguration.getAssertion());
   }
 
   @Override
@@ -286,6 +286,11 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
     JudgeConfigResolver.resolve(
             testContext.getApplicationContext(), runtimeConfiguration.getJudge())
         .ifPresent(CamundaAssert::setJudgeConfig);
+  }
+
+  private void initializeAssertions(final AssertionConfiguration assertionConfiguration) {
+    assertionConfiguration.getTimeout().ifPresent(CamundaAssert::setAssertionTimeout);
+    assertionConfiguration.getInterval().ifPresent(CamundaAssert::setAssertionInterval);
   }
 
   private CamundaManagementClient createManagementClient(

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/AssertionConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/AssertionConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/** Configuration properties for assertions. */
+public class AssertionConfiguration {
+
+  /** The duration how long an assertion waits until the expected state is reached. */
+  private Duration timeout;
+
+  /** The duration between two assertion attempts until the expected state is reached. */
+  private Duration interval;
+
+  public Optional<Duration> getTimeout() {
+    return Optional.ofNullable(timeout);
+  }
+
+  public void setTimeout(final Duration timeout) {
+    this.timeout = timeout;
+  }
+
+  public Optional<Duration> getInterval() {
+    return Optional.ofNullable(interval);
+  }
+
+  public void setInterval(final Duration interval) {
+    this.interval = interval;
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -62,6 +62,9 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   @NestedConfigurationProperty private JudgeConfiguration judge = new JudgeConfiguration();
 
+  @NestedConfigurationProperty
+  private AssertionConfiguration assertion = new AssertionConfiguration();
+
   @Bean
   @Primary
   public CamundaProcessTestRuntimeConfiguration runtimeConfiguration(
@@ -242,5 +245,13 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   public void setJudge(final JudgeConfiguration judge) {
     this.judge = judge;
+  }
+
+  public AssertionConfiguration getAssertion() {
+    return assertion;
+  }
+
+  public void setAssertion(final AssertionConfiguration assertion) {
+    this.assertion = assertion;
   }
 }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
@@ -50,11 +50,13 @@ import io.camunda.zeebe.spring.client.event.ZeebeClientCreatedEvent;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -529,6 +531,67 @@ public class ExecutionListenerTest {
       cmcField.set(listener, camundaProcessTestResultCollector);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
+    }
+  }
+
+  @Nested
+  class AssertionConfigurationTest {
+
+    @AfterEach
+    void resetAssertion() {
+      CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
+      CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
+    }
+
+    @Test
+    void shouldSetAssertionTimeoutFromConfig() {
+      // given
+      final Duration assertionTimeout = Duration.ofMinutes(5);
+      final Duration assertionInterval = Duration.ofMillis(123);
+
+      final CamundaProcessTestRuntimeConfiguration configuration =
+          new CamundaProcessTestRuntimeConfiguration();
+      configuration.getAssertion().setTimeout(assertionTimeout);
+      configuration.getAssertion().setInterval(assertionInterval);
+
+      when(applicationContext.getBean(CamundaProcessTestRuntimeConfiguration.class))
+          .thenReturn(configuration);
+
+      final CamundaProcessTestExecutionListener listener =
+          new CamundaProcessTestExecutionListener(
+              camundaRuntimeBuilder, processCoverageBuilder, NOOP);
+
+      // when
+      listener.beforeTestClass(testContext);
+      listener.beforeTestMethod(testContext);
+
+      // then
+      final CamundaAssertAwaitBehavior awaitBehavior = CamundaAssert.getAwaitBehavior();
+      assertThat(awaitBehavior.getAssertionTimeout()).isEqualTo(assertionTimeout);
+      assertThat(awaitBehavior.getAssertionInterval()).isEqualTo(assertionInterval);
+    }
+
+    @Test
+    void shouldNotOverrideAssertionTimeoutIfNotSetInConfig() {
+      // given
+      final Duration assertionTimeout = Duration.ofMinutes(1);
+      final Duration assertionInterval = Duration.ofMillis(50);
+
+      CamundaAssert.setAssertionTimeout(assertionTimeout);
+      CamundaAssert.setAssertionInterval(assertionInterval);
+
+      final CamundaProcessTestExecutionListener listener =
+          new CamundaProcessTestExecutionListener(
+              camundaRuntimeBuilder, processCoverageBuilder, NOOP);
+
+      // when
+      listener.beforeTestClass(testContext);
+      listener.beforeTestMethod(testContext);
+
+      // then
+      final CamundaAssertAwaitBehavior awaitBehavior = CamundaAssert.getAwaitBehavior();
+      assertThat(awaitBehavior.getAssertionTimeout()).isEqualTo(assertionTimeout);
+      assertThat(awaitBehavior.getAssertionInterval()).isEqualTo(assertionInterval);
     }
   }
 }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/config/AssertionConfigurationTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/config/AssertionConfigurationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.process.test.impl.configuration.AssertionConfiguration;
+import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
+import io.camunda.process.test.impl.configuration.LegacyCamundaProcessTestRuntimeConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties({
+  CamundaProcessTestRuntimeConfiguration.class,
+  LegacyCamundaProcessTestRuntimeConfiguration.class
+})
+public class AssertionConfigurationTest {
+
+  @Nested
+  class DefaultConfig {
+
+    @Autowired private CamundaProcessTestRuntimeConfiguration configuration;
+
+    @Test
+    void shouldReturnEmpty() {
+      final AssertionConfiguration assertionConfiguration = configuration.getAssertion();
+
+      assertThat(assertionConfiguration).isNotNull();
+      assertThat(assertionConfiguration.getTimeout()).isEmpty();
+      assertThat(assertionConfiguration.getInterval()).isEmpty();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.process-test.assertion.timeout=PT1M",
+        "camunda.process-test.assertion.interval=PT0.5S"
+      })
+  class ConfigureAssertion {
+
+    @Autowired private CamundaProcessTestRuntimeConfiguration configuration;
+
+    @Test
+    void shouldReturnValues() {
+      final AssertionConfiguration assertionConfiguration = configuration.getAssertion();
+
+      assertThat(assertionConfiguration).isNotNull();
+      assertThat(assertionConfiguration.getTimeout()).hasValue(Duration.ofMinutes(1));
+      assertThat(assertionConfiguration.getInterval()).hasValue(Duration.ofMillis(500));
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #49145 to `stable/8.9`.

relates to camunda/camunda#48698