### PR TITLE
[Backport stable/8.8] fix: support forward slashes in entity IDs from OIDC providers

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/group.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/group.ts
@@ -22,7 +22,7 @@ const getGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -43,7 +43,7 @@ const updateGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -52,7 +52,7 @@ const deleteGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -91,7 +91,7 @@ const queryUsersByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/search`;
 	},
 };
 
@@ -113,7 +113,7 @@ const queryClientsByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/search`;
 	},
 };
 
@@ -136,7 +136,7 @@ const queryRolesByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/roles/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/roles/search`;
 	},
 };
 
@@ -160,7 +160,7 @@ const queryMappingRulesByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/search`;
 	},
 };
 
@@ -169,7 +169,7 @@ const assignUserToGroup: Endpoint<Pick<Group, 'groupId'> & {username: string}> =
 	getUrl(params) {
 		const {groupId, username} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/${username}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -178,7 +178,7 @@ const unassignUserFromGroup: Endpoint<Pick<Group, 'groupId'> & {username: string
 	getUrl(params) {
 		const {groupId, username} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/${username}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -187,7 +187,7 @@ const assignClientToGroup: Endpoint<Pick<Group, 'groupId'> & {clientId: string}>
 	getUrl(params) {
 		const {groupId, clientId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/${clientId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -196,7 +196,7 @@ const unassignClientFromGroup: Endpoint<Pick<Group, 'groupId'> & {clientId: stri
 	getUrl(params) {
 		const {groupId, clientId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/${clientId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -205,7 +205,7 @@ const assignMappingToGroup: Endpoint<Pick<Group, 'groupId'> & Pick<MappingRule, 
 	getUrl(params) {
 		const {groupId, mappingId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/${mappingId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -214,7 +214,7 @@ const unassignMappingFromGroup: Endpoint<Pick<Group, 'groupId'> & Pick<MappingRu
 	getUrl(params) {
 		const {groupId, mappingId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/${mappingId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingId)}`;
 	},
 };
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/role.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/role.ts
@@ -96,7 +96,7 @@ const getRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -105,7 +105,7 @@ const updateRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -114,7 +114,7 @@ const deleteRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -130,7 +130,7 @@ const queryUsersByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/search`;
 	},
 };
 
@@ -139,7 +139,7 @@ const queryClientsByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/search`;
 	},
 };
 
@@ -148,7 +148,7 @@ const assignUserToRole: Endpoint<Pick<Role, 'roleId'> & {username: string}> = {
 	getUrl(params) {
 		const {roleId, username} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/${username}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -157,7 +157,7 @@ const unassignUserFromRole: Endpoint<Pick<Role, 'roleId'> & {username: string}> 
 	getUrl(params) {
 		const {roleId, username} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/${username}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -166,7 +166,7 @@ const assignClientToRole: Endpoint<Pick<Role, 'roleId'> & {clientId: string}> = 
 	getUrl(params) {
 		const {roleId, clientId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/${clientId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -175,7 +175,7 @@ const unassignClientFromRole: Endpoint<Pick<Role, 'roleId'> & {clientId: string}
 	getUrl(params) {
 		const {roleId, clientId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/${clientId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -184,7 +184,7 @@ const assignGroupToRole: Endpoint<Pick<Role, 'roleId'> & Pick<Group, 'groupId'>>
 	getUrl(params) {
 		const {roleId, groupId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/${groupId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -193,7 +193,7 @@ const unassignGroupFromRole: Endpoint<Pick<Role, 'roleId'> & Pick<Group, 'groupI
 	getUrl(params) {
 		const {roleId, groupId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/${groupId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -202,7 +202,7 @@ const queryGroupsByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/search`;
 	},
 };
 
@@ -211,7 +211,7 @@ const assignMappingToRole: Endpoint<Pick<Role, 'roleId'> & Pick<MappingRule, 'ma
 	getUrl(params) {
 		const {roleId, mappingId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mappings/${mappingId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mappings/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -220,7 +220,7 @@ const unassignMappingFromRole: Endpoint<Pick<Role, 'roleId'> & Pick<MappingRule,
 	getUrl(params) {
 		const {roleId, mappingId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mappings/${mappingId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mappings/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -229,7 +229,7 @@ const queryMappingRulesByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mapping-rules/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mapping-rules/search`;
 	},
 };
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/tenant.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/tenant.ts
@@ -102,17 +102,17 @@ const createTenant: Endpoint = {
 
 const getTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'GET',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const updateTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const deleteTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const queryTenants: Endpoint = {
@@ -122,77 +122,87 @@ const queryTenants: Endpoint = {
 
 const assignUserToTenant: Endpoint<Pick<Tenant, 'tenantId'> & {username: string}> = {
 	method: 'PUT',
-	getUrl: ({tenantId, username}) => `/${API_VERSION}/tenants/${tenantId}/users/${username}`,
+	getUrl: ({tenantId, username}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
 };
 
 const unassignUserFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & {username: string}> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, username}) => `/${API_VERSION}/tenants/${tenantId}/users/${username}`,
+	getUrl: ({tenantId, username}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
 };
 
 const queryUsersByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/users/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/search`,
 };
 
 const queryClientsByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/clients/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/search`,
 };
 
 const queryGroupsByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/groups/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/search`,
 };
 
 const queryRolesByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/roles/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/search`,
 };
 
 const assignClientToTenant: Endpoint<Pick<Tenant, 'tenantId'> & {clientId: string}> = {
 	method: 'PUT',
-	getUrl: ({tenantId, clientId}) => `/${API_VERSION}/tenants/${tenantId}/clients/${clientId}`,
+	getUrl: ({tenantId, clientId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
 };
 
 const unassignClientFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & {clientId: string}> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, clientId}) => `/${API_VERSION}/tenants/${tenantId}/clients/${clientId}`,
+	getUrl: ({tenantId, clientId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
 };
 
 const assignMappingRuleToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<MappingRule, 'mappingId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, mappingId}) => `/${API_VERSION}/tenants/${tenantId}/mappings/${mappingId}`,
+	getUrl: ({tenantId, mappingId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mappings/${encodeURIComponent(mappingId)}`,
 };
 
 const unassignMappingRuleFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<MappingRule, 'mappingId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, mappingId}) => `/${API_VERSION}/tenants/${tenantId}/mappings/${mappingId}`,
+	getUrl: ({tenantId, mappingId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mappings/${encodeURIComponent(mappingId)}`,
 };
 
 const queryMappingRulesByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/mappings/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mappings/search`,
 };
 
 const assignGroupToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Group, 'groupId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, groupId}) => `/${API_VERSION}/tenants/${tenantId}/groups/${groupId}`,
+	getUrl: ({tenantId, groupId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
 };
 
 const unassignGroupFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Group, 'groupId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, groupId}) => `/${API_VERSION}/tenants/${tenantId}/groups/${groupId}`,
+	getUrl: ({tenantId, groupId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
 };
 
 const assignRoleToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Role, 'roleId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, roleId}) => `/${API_VERSION}/tenants/${tenantId}/roles/${roleId}`,
+	getUrl: ({tenantId, roleId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
 };
 
 const unassignRoleFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Role, 'roleId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, roleId}) => `/${API_VERSION}/tenants/${tenantId}/roles/${roleId}`,
+	getUrl: ({tenantId, roleId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
 };
 
 export {

--- a/dist/src/main/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rest;
+
+import org.apache.tomcat.util.buf.EncodedSolidusHandling;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures Tomcat to pass encoded slashes ({@code %2F}) through to the application instead of
+ * rejecting them with a 400 error. This is required to support entity IDs that contain forward
+ * slashes (e.g., OIDC group IDs like {@code /myGroup} from Keycloak).
+ *
+ * <p>Spring Boot's {@code PathPatternParser} matches on raw/encoded URI segments and only decodes
+ * for {@code @PathVariable} binding, so {@code %2F} stays intact during route matching and is
+ * decoded to {@code /} when bound to the Java parameter.
+ *
+ * @see <a href="https://github.com/camunda/camunda/issues/45215">Issue #45215</a>
+ */
+@Configuration
+public class TomcatEncodedSlashConfig {
+
+  @Bean
+  public WebServerFactoryCustomizer<TomcatServletWebServerFactory> encodedSlashCustomizer() {
+    return factory ->
+        factory.addConnectorCustomizers(
+            connector ->
+                connector.setEncodedSolidusHandling(
+                    EncodedSolidusHandling.PASS_THROUGH.getValue()));
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfigTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfigTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.buf.EncodedSolidusHandling;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+
+class TomcatEncodedSlashConfigTest {
+
+  @Test
+  void shouldConfigurePassthroughForEncodedSlashes() {
+    // given
+    final var config = new TomcatEncodedSlashConfig();
+    final WebServerFactoryCustomizer<TomcatServletWebServerFactory> customizer =
+        config.encodedSlashCustomizer();
+    final var factory = mock(TomcatServletWebServerFactory.class);
+
+    // when
+    customizer.customize(factory);
+
+    // then
+    final var captor = ArgumentCaptor.forClass(TomcatConnectorCustomizer.class);
+    verify(factory).addConnectorCustomizers(captor.capture());
+
+    final var connector = mock(Connector.class);
+    captor.getValue().customize(connector);
+    verify(connector).setEncodedSolidusHandling(EncodedSolidusHandling.PASS_THROUGH.getValue());
+  }
+}

--- a/docs/adr/identity/0002-support-forward-slashes-in-entity-ids.md
+++ b/docs/adr/identity/0002-support-forward-slashes-in-entity-ids.md
@@ -1,0 +1,110 @@
+# ADR-0002: Support Forward Slashes in Entity IDs via URL Encoding
+
+## Status
+
+Proposed
+
+## Context
+
+Camunda's Identity REST API uses entity IDs (group, role, tenant, user, mapping rule) as path
+segments in URLs — for example, `PUT /v2/roles/{roleId}/groups/{groupId}`. When Camunda is
+configured with an OIDC provider such as Keycloak, entity IDs are sourced directly from the
+identity provider. Keycloak group IDs commonly contain forward slashes (e.g., `/myGroup`,
+`/org/team/engineering`).
+
+When the frontend constructs a URL with a literal `/` in an entity ID, the resulting path (e.g.,
+`PUT /v2/roles/admin/groups//myGroup`) contains extra path segments. Spring MVC finds no matching
+route and returns 400. This effectively prevents any OIDC-sourced entity with `/` in its ID from
+being managed through the REST API or the Identity UI.
+
+Two compounding issues cause this:
+
+1. **Validation allows `/`**: `SecurityConfiguration.DEFAULT_EXTERNAL_ID_REGEX` is `.*` when the
+   OIDC `groupsClaim` is configured, permitting any character in group IDs — including `/`.
+2. **Frontend does not encode**: URL paths are constructed via template literals without
+   `encodeURIComponent`, so special characters are inserted verbatim.
+
+See: https://github.com/camunda/camunda/issues/45215
+
+## Decision
+
+We will use standard URL encoding (`%2F`) on the client side and configure the embedded Tomcat
+server to pass encoded slashes through to Spring MVC. Entity IDs will not be normalized or
+transformed — they must match exactly what the identity provider returns.
+
+The solution has three layers:
+
+### 1. Frontend: Encode IDs with `encodeURIComponent`
+
+Every entity ID interpolated into a URL path is wrapped with `encodeURIComponent()`. This is
+standard HTTP behavior per RFC 3986 and is a no-op for alphanumeric strings, making it safe for
+all existing IDs.
+
+```typescript
+// Before
+apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+// After
+apiPut(`${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`);
+```
+
+### 2. Tomcat: PASSTHROUGH mode for encoded slashes
+
+Tomcat 11 rejects `%2F` in URL paths by default (`EncodedSolidusHandling.REJECT`). A
+`WebServerFactoryCustomizer` bean sets the handling mode to `PASSTHROUGH`, which forwards `%2F`
+as-is to the application without decoding or rejecting it.
+
+```java
+connector.setEncodedSolidusHandling("passthrough");
+```
+
+The `DECODE` mode was not chosen because it decodes `%2F` to `/` before Spring MVC sees the
+request, which would break route matching in the same way as the original unencoded slash.
+
+### 3. Spring MVC: PathPatternParser (no changes needed)
+
+Spring Boot's default `PathPatternParser` splits paths on literal `/` characters only. An encoded
+`%2F` is not a path separator, so `/v2/roles/admin/groups/%2FmyGroup` correctly matches
+`/v2/roles/{roleId}/groups/{groupId}`. Spring then decodes `%2F` to `/` when binding to the
+`@PathVariable` parameter. This is the default behavior — no configuration changes are required.
+
+## Alternatives Considered
+
+### Normalize IDs (strip or replace slashes)
+
+Rejected. Entity IDs must match the identity provider exactly. Normalizing would create a mismatch
+between Camunda's stored ID and the ID in OIDC tokens, breaking authorization checks.
+
+### Use request body instead of path variables
+
+Rejected. This would require changing the REST API contract, breaking backward compatibility for
+all API consumers. URL encoding is the standard HTTP mechanism for this problem.
+
+### Custom path matching or wildcard patterns
+
+Rejected. Using `**` patterns or custom `PathMatcher` configuration would be fragile, make routing
+ambiguous, and require changes across all controllers. Standard URL encoding solves the problem
+without any routing changes.
+
+## Consequences
+
+### Positive
+
+- Entity IDs from OIDC providers are supported as-is, regardless of special characters.
+- The solution follows HTTP standards (RFC 3986) — no custom encoding schemes.
+- Fully backward compatible: `encodeURIComponent` is a no-op on alphanumeric strings, and
+  `PASSTHROUGH` only affects requests that contain `%2F`.
+- No changes to controllers, service layer, or data model.
+
+### Negative
+
+- **Reverse proxies must forward raw URIs.** Proxies like nginx may reject or decode `%2F` by
+  default. Operators using reverse proxies must configure them to preserve encoded characters
+  (e.g., nginx: `proxy_pass` with `$request_uri`, or `merge_slashes off`).
+- **External API clients must encode IDs.** Any client calling the REST API directly must
+  URL-encode entity IDs containing special characters. This is standard HTTP behavior but must be
+  documented in the API reference.
+- **`PASSTHROUGH` applies to all connectors.** The Tomcat configuration affects all incoming
+  requests, not just identity endpoints. This is safe because `%2F` in a path segment is only
+  meaningful if the application interprets it — existing endpoints with alphanumeric IDs are
+  unaffected.
+

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -47,14 +47,14 @@ export type GetGroupParams = {
 
 export const getGroupDetails: ApiDefinition<Group, GetGroupParams> = ({
   groupId,
-}) => apiGet(`${GROUPS_ENDPOINT}/${groupId}`);
+}) => apiGet(`${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}`);
 
 export const createGroup: ApiDefinition<undefined, Group> = (params) =>
   apiPost(GROUPS_ENDPOINT, params);
 
 export const updateGroup: ApiDefinition<undefined, Group> = (group) => {
   const { groupId, name, description } = group;
-  return apiPut(`${GROUPS_ENDPOINT}/${groupId}`, {
+  return apiPut(`${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}`, {
     name,
     description,
   });
@@ -64,7 +64,7 @@ type DeleteGroupParams = GetGroupParams;
 
 export const deleteGroup: ApiDefinition<undefined, DeleteGroupParams> = ({
   groupId,
-}) => apiDelete(`${GROUPS_ENDPOINT}/${groupId}`);
+}) => apiDelete(`${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}`);
 
 // ----------------- Roles within a Group -----------------
 
@@ -75,14 +75,19 @@ export const searchRolesByGroupId: ApiDefinition<
   SearchResponse<Role>,
   GetGroupRolesParams
 > = ({ groupId, ...body }) =>
-  apiPost(`${GROUPS_ENDPOINT}/${groupId}/roles/search`, body);
+  apiPost(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/roles/search`,
+    body,
+  );
 
 type AssignGroupRoleParams = GetGroupRolesParams & { roleId: string };
 export const assignGroupRole: ApiDefinition<
   undefined,
   AssignGroupRoleParams
 > = ({ groupId, roleId }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 };
 
 type UnassignGroupRoleParams = AssignGroupRoleParams;
@@ -90,7 +95,9 @@ export const unassignGroupRole: ApiDefinition<
   undefined,
   UnassignGroupRoleParams
 > = ({ groupId, roleId }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 
 // ----------------- Mapping rules within a Group -----------------
 
@@ -102,7 +109,10 @@ export const getMappingRulesByGroupId: ApiDefinition<
   GetGroupMappingRulesParams
 > = (params) => {
   const { groupId, ...body } = params;
-  return apiPost(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/search`, body);
+  return apiPost(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/mapping-rules/search`,
+    body,
+  );
 };
 
 type AssignGroupMappingRuleParams = GetGroupMappingRulesParams & {
@@ -112,7 +122,9 @@ export const assignGroupMappingRule: ApiDefinition<
   undefined,
   AssignGroupMappingRuleParams
 > = ({ groupId, mappingRuleId }) => {
-  return apiPut(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${mappingRuleId}`);
+  return apiPut(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 };
 
 type UnassignGroupMappingRuleParams = AssignGroupMappingRuleParams;
@@ -120,7 +132,9 @@ export const unassignGroupMappingRule: ApiDefinition<
   undefined,
   UnassignGroupMappingRuleParams
 > = ({ groupId, mappingRuleId }) =>
-  apiDelete(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${mappingRuleId}`);
+  apiDelete(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 
 type GetGroupClientsParams = {
   groupId: string;
@@ -135,7 +149,10 @@ export const getClientsByGroupId: ApiDefinition<
   GetGroupClientsParams
 > = (args) => {
   const { groupId, ...body } = args;
-  return apiPost(`${GROUPS_ENDPOINT}/${groupId}/clients/search`, body);
+  return apiPost(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/clients/search`,
+    body,
+  );
 };
 
 type AssignGroupClientParams = GetGroupClientsParams & Client;
@@ -143,7 +160,9 @@ export const assignGroupClient: ApiDefinition<
   undefined,
   AssignGroupClientParams
 > = ({ groupId, clientId }) => {
-  return apiPut(`${GROUPS_ENDPOINT}/${groupId}/clients/${clientId}`);
+  return apiPut(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`,
+  );
 };
 
 type UnassignGroupClientParams = AssignGroupClientParams;
@@ -151,4 +170,6 @@ export const unassignGroupClient: ApiDefinition<
   undefined,
   UnassignGroupClientParams
 > = ({ groupId, clientId }) =>
-  apiDelete(`${GROUPS_ENDPOINT}/${groupId}/clients/${clientId}`);
+  apiDelete(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`,
+  );

--- a/identity/client/src/utility/api/mapping-rules/index.ts
+++ b/identity/client/src/utility/api/mapping-rules/index.ts
@@ -52,7 +52,7 @@ export const updateMappingRule: ApiDefinition<
   undefined,
   UpdateMappingRuleParams
 > = ({ mappingRuleId, claimName, claimValue, name }) =>
-  apiPut(`${MAPPING_RULES_ENDPOINT}/${mappingRuleId}`, {
+  apiPut(`${MAPPING_RULES_ENDPOINT}/${encodeURIComponent(mappingRuleId)}`, {
     name,
     claimName,
     claimValue,
@@ -63,4 +63,4 @@ export const deleteMappingRule: ApiDefinition<
   undefined,
   { mappingRuleId: string }
 > = ({ mappingRuleId }) =>
-  apiDelete(`${MAPPING_RULES_ENDPOINT}/${mappingRuleId}`);
+  apiDelete(`${MAPPING_RULES_ENDPOINT}/${encodeURIComponent(mappingRuleId)}`);

--- a/identity/client/src/utility/api/membership/index.ts
+++ b/identity/client/src/utility/api/membership/index.ts
@@ -22,7 +22,10 @@ export const searchMembersByGroup: ApiDefinition<
   SearchResponse<MemberUser>,
   GetGroupMembersParams
 > = ({ groupId, ...body }) =>
-  apiPost(`${GROUPS_ENDPOINT}/${groupId}/users/search`, body);
+  apiPost(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/users/search`,
+    body,
+  );
 
 export type GetTenantMembersParams = {
   tenantId: string;
@@ -31,7 +34,10 @@ export const getMembersByTenantId: ApiDefinition<
   SearchResponse<MemberUser>,
   GetTenantMembersParams
 > = ({ tenantId, ...body }) =>
-  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/users/search`, body);
+  apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/users/search`,
+    body,
+  );
 
 export type GetRoleMembersParams = {
   roleId: string;
@@ -40,28 +46,34 @@ export const getMembersByRole: ApiDefinition<
   SearchResponse<MemberUser>,
   GetRoleMembersParams
 > = ({ roleId, ...body }) =>
-  apiPost(`${ROLES_ENDPOINT}/${roleId}/users/search`, body);
+  apiPost(`${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/users/search`, body);
 
 type AssignGroupMemberParams = GetGroupMembersParams & { username: string };
 export const assignGroupMember: ApiDefinition<
   undefined,
   AssignGroupMemberParams
 > = ({ groupId, username }) =>
-  apiPut(`${GROUPS_ENDPOINT}/${groupId}/users/${username}`);
+  apiPut(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`,
+  );
 
 type UnassignGroupMemberParams = AssignGroupMemberParams;
 export const unassignGroupMember: ApiDefinition<
   undefined,
   UnassignGroupMemberParams
 > = ({ groupId, username }) =>
-  apiDelete(`${GROUPS_ENDPOINT}/${groupId}/users/${username}`);
+  apiDelete(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`,
+  );
 
 type AssignTenantMemberParams = GetTenantMembersParams & { username: string };
 export const assignTenantMember: ApiDefinition<
   undefined,
   AssignTenantMemberParams
 > = ({ tenantId, username }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/users/${username}`);
+  return apiPut(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
+  );
 };
 
 type UnassignTenantMemberParams = AssignTenantMemberParams;
@@ -69,14 +81,18 @@ export const unassignTenantMember: ApiDefinition<
   undefined,
   UnassignTenantMemberParams
 > = ({ tenantId, username }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/users/${username}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
+  );
 
 type AssignRoleMemberParams = GetRoleMembersParams & { username: string };
 export const assignRoleMember: ApiDefinition<
   undefined,
   AssignRoleMemberParams
 > = ({ roleId, username }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/users/${username}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`,
+  );
 };
 
 type UnassignRoleMemberParams = AssignRoleMemberParams;
@@ -84,4 +100,6 @@ export const unassignRoleMember: ApiDefinition<
   undefined,
   UnassignRoleMemberParams
 > = ({ roleId, username }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/users/${username}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`,
+  );

--- a/identity/client/src/utility/api/roles/index.ts
+++ b/identity/client/src/utility/api/roles/index.ts
@@ -36,7 +36,7 @@ type GetRoleParams = {
 };
 export const getRoleDetails: ApiDefinition<Role, GetRoleParams> = ({
   roleId,
-}) => apiGet(`${ROLES_ENDPOINT}/${roleId}`);
+}) => apiGet(`${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}`);
 
 export const createRole: ApiDefinition<undefined, Role> = (role) =>
   apiPost(ROLES_ENDPOINT, role);
@@ -47,7 +47,7 @@ export type DeleteRoleParams = {
 };
 export const deleteRole: ApiDefinition<undefined, { roleId: string }> = ({
   roleId,
-}) => apiDelete(`${ROLES_ENDPOINT}/${roleId}`);
+}) => apiDelete(`${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}`);
 
 // ----------------- Mapping rules within a Role -----------------
 
@@ -59,7 +59,10 @@ export const getMappingRulesByRoleId: ApiDefinition<
   GetRoleMappingRulesParams
 > = (params) => {
   const { roleId, ...body } = params;
-  return apiPost(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/search`, body);
+  return apiPost(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/mapping-rules/search`,
+    body,
+  );
 };
 
 type AssignRoleMappingParams = GetRoleMappingRulesParams & {
@@ -69,7 +72,9 @@ export const assignRoleMappingRule: ApiDefinition<
   undefined,
   AssignRoleMappingParams
 > = ({ roleId, mappingRuleId }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingRuleId}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 };
 
 type UnassignRoleMappingParams = AssignRoleMappingParams;
@@ -77,7 +82,9 @@ export const unassignRoleMappingRule: ApiDefinition<
   undefined,
   UnassignRoleMappingParams
 > = ({ roleId, mappingRuleId }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingRuleId}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 
 // ----------------- Groups within a Role -----------------
 
@@ -89,14 +96,19 @@ export const getGroupsByRoleId: ApiDefinition<
   SearchResponse<Group>,
   GetRoleGroupsParams
 > = ({ roleId, ...body }) =>
-  apiPost(`${ROLES_ENDPOINT}/${roleId}/groups/search`, body);
+  apiPost(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/search`,
+    body,
+  );
 
 type AssignRoleGroupParams = GetRoleGroupsParams & Pick<Group, "groupId">;
 export const assignRoleGroup: ApiDefinition<
   undefined,
   AssignRoleGroupParams
 > = ({ roleId, groupId }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 };
 
 type UnassignRoleGroupParams = AssignRoleGroupParams;
@@ -104,7 +116,9 @@ export const unassignRoleGroup: ApiDefinition<
   undefined,
   UnassignRoleGroupParams
 > = ({ roleId, groupId }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 
 // ----------------- Clients within a Role -----------------
 
@@ -121,7 +135,10 @@ export const getClientsByRoleId: ApiDefinition<
   GetRoleClientsParams
 > = (args) => {
   const { roleId, ...body } = args;
-  return apiPost(`${ROLES_ENDPOINT}/${roleId}/clients/search`, body);
+  return apiPost(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/clients/search`,
+    body,
+  );
 };
 
 type AssignRoleClientParams = GetRoleClientsParams & Client;
@@ -129,7 +146,9 @@ export const assignRoleClient: ApiDefinition<
   undefined,
   AssignRoleClientParams
 > = ({ roleId, clientId }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/clients/${clientId}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`,
+  );
 };
 
 type UnassignRoleClientParams = AssignRoleClientParams;
@@ -137,4 +156,6 @@ export const unassignRoleClient: ApiDefinition<
   undefined,
   UnassignRoleClientParams
 > = ({ roleId, clientId }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/clients/${clientId}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`,
+  );

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -61,12 +61,16 @@ export const updateTenant: ApiDefinition<undefined, UpdateTenantParams> = ({
   tenantId,
   name,
   description,
-}) => apiPatch(`${TENANTS_ENDPOINT}/${tenantId}`, { name, description });
+}) =>
+  apiPatch(`${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}`, {
+    name,
+    description,
+  });
 
 export type DeleteTenantParams = UpdateTenantParams;
 export const deleteTenant: ApiDefinition<undefined, { tenantId: string }> = ({
   tenantId,
-}) => apiDelete(`${TENANTS_ENDPOINT}/${tenantId}`);
+}) => apiDelete(`${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}`);
 
 // ----------------- Groups within a Tenant -----------------
 
@@ -77,14 +81,19 @@ export const getGroupsByTenantId: ApiDefinition<
   SearchResponse<Group>,
   GetTenantGroupsParams
 > = ({ tenantId, ...body }) =>
-  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/groups/search`, body);
+  apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/groups/search`,
+    body,
+  );
 
 type AssignTenantGroupParams = GetTenantGroupsParams & { groupId: string };
 export const assignTenantGroup: ApiDefinition<
   undefined,
   AssignTenantGroupParams
 > = ({ tenantId, groupId }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupId}`);
+  return apiPut(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 };
 
 type UnassignTenantGroupParams = AssignTenantGroupParams;
@@ -92,7 +101,9 @@ export const unassignTenantGroup: ApiDefinition<
   undefined,
   UnassignTenantGroupParams
 > = ({ tenantId, groupId }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupId}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 
 // ----------------- Roles within a Tenant -----------------
 
@@ -103,14 +114,19 @@ export const getRolesByTenantId: ApiDefinition<
   SearchResponse<Role>,
   GetTenantRolesParams
 > = ({ tenantId, ...body }) =>
-  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/roles/search`, body);
+  apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/roles/search`,
+    body,
+  );
 
 type AssignTenantRoleParams = GetTenantRolesParams & { roleId: string };
 export const assignTenantRole: ApiDefinition<
   undefined,
   AssignTenantRoleParams
 > = ({ tenantId, roleId }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/roles/${roleId}`);
+  return apiPut(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
+  );
 };
 
 type UnassignTenantRoleParams = AssignTenantRoleParams;
@@ -118,7 +134,9 @@ export const unassignTenantRole: ApiDefinition<
   undefined,
   UnassignTenantRoleParams
 > = ({ tenantId, roleId }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/roles/${roleId}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
+  );
 
 // ----------------- Mapping rules within a Tenant -----------------
 
@@ -130,7 +148,10 @@ export const getMappingRulesByTenantId: ApiDefinition<
   GetTenantMappingRulesParams
 > = (params) => {
   const { tenantId, ...body } = params;
-  return apiPost(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/search`, body);
+  return apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/mapping-rules/search`,
+    body,
+  );
 };
 
 type AssignTenantMappingRuleParams = GetTenantMappingRulesParams & {
@@ -141,7 +162,7 @@ export const assignTenantMappingRule: ApiDefinition<
   AssignTenantMappingRuleParams
 > = ({ tenantId, mappingRuleId }) => {
   return apiPut(
-    `${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${mappingRuleId}`,
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
   );
 };
 
@@ -150,7 +171,9 @@ export const unassignTenantMappingRule: ApiDefinition<
   undefined,
   UnassignTenantMappingParams
 > = ({ tenantId, mappingRuleId }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${mappingRuleId}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 
 type GetTenantClientsParams = {
   tenantId: string;
@@ -164,14 +187,20 @@ export const getClientsByTenantId: ApiDefinition<
   SearchResponse<Client>,
   GetTenantClientsParams
 > = ({ tenantId, ...body }) =>
-  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/clients/search`, body);
+  apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/clients/search`,
+    body,
+  );
 
 type AssignTenantClientParams = GetTenantClientsParams & Client;
 export const assignTenantClient: ApiDefinition<
   undefined,
   AssignTenantClientParams
 > = ({ tenantId, clientId, ...body }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/clients/${clientId}`, body);
+  return apiPut(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
+    body,
+  );
 };
 
 type UnassignTenantClientParams = AssignTenantClientParams;
@@ -179,4 +208,6 @@ export const unassignTenantClient: ApiDefinition<
   undefined,
   UnassignTenantClientParams
 > = ({ tenantId, clientId }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/clients/${clientId}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
+  );

--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -58,7 +58,7 @@ export const updateUser: ApiDefinition<undefined, UpdateUserParams> = (
   user,
 ) => {
   const { name, email, username, password } = user;
-  return apiPut(`${USERS_ENDPOINT}/${username}`, {
+  return apiPut(`${USERS_ENDPOINT}/${encodeURIComponent(username)}`, {
     name,
     email,
     password: password ?? "",
@@ -71,4 +71,4 @@ type DeleteUserParams = {
 
 export const deleteUser: ApiDefinition<undefined, DeleteUserParams> = ({
   username,
-}) => apiDelete(`${USERS_ENDPOINT}/${username}`);
+}) => apiDelete(`${USERS_ENDPOINT}/${encodeURIComponent(username)}`);


### PR DESCRIPTION
# Description
Backport of #48668 to `stable/8.8`.

relates to #45215