### PR TITLE
[Backport stable/8.9] fix: support forward slashes in entity IDs from OIDC providers

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/group.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/group.ts
@@ -30,7 +30,7 @@ const getGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -51,7 +51,7 @@ const updateGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -60,7 +60,7 @@ const deleteGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -99,7 +99,7 @@ const queryUsersByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/search`;
 	},
 };
 
@@ -121,7 +121,7 @@ const queryClientsByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/search`;
 	},
 };
 
@@ -144,7 +144,7 @@ const queryRolesByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/roles/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/roles/search`;
 	},
 };
 
@@ -168,7 +168,7 @@ const queryMappingRulesByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/search`;
 	},
 };
 
@@ -177,7 +177,7 @@ const assignUserToGroup: Endpoint<Pick<Group, 'groupId'> & {username: string}> =
 	getUrl(params) {
 		const {groupId, username} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/${username}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -186,7 +186,7 @@ const unassignUserFromGroup: Endpoint<Pick<Group, 'groupId'> & {username: string
 	getUrl(params) {
 		const {groupId, username} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/${username}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -195,7 +195,7 @@ const assignClientToGroup: Endpoint<Pick<Group, 'groupId'> & {clientId: string}>
 	getUrl(params) {
 		const {groupId, clientId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/${clientId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -204,7 +204,7 @@ const unassignClientFromGroup: Endpoint<Pick<Group, 'groupId'> & {clientId: stri
 	getUrl(params) {
 		const {groupId, clientId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/${clientId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -213,7 +213,7 @@ const assignMappingToGroup: Endpoint<Pick<Group, 'groupId'> & Pick<MappingRule, 
 	getUrl(params) {
 		const {groupId, mappingId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/${mappingId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -222,7 +222,7 @@ const unassignMappingFromGroup: Endpoint<Pick<Group, 'groupId'> & Pick<MappingRu
 	getUrl(params) {
 		const {groupId, mappingId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/${mappingId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingId)}`;
 	},
 };
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/role.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/role.ts
@@ -104,7 +104,7 @@ const getRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -113,7 +113,7 @@ const updateRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -122,7 +122,7 @@ const deleteRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -138,7 +138,7 @@ const queryUsersByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/search`;
 	},
 };
 
@@ -147,7 +147,7 @@ const queryClientsByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/search`;
 	},
 };
 
@@ -156,7 +156,7 @@ const assignUserToRole: Endpoint<Pick<Role, 'roleId'> & {username: string}> = {
 	getUrl(params) {
 		const {roleId, username} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/${username}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -165,7 +165,7 @@ const unassignUserFromRole: Endpoint<Pick<Role, 'roleId'> & {username: string}> 
 	getUrl(params) {
 		const {roleId, username} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/${username}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -174,7 +174,7 @@ const assignClientToRole: Endpoint<Pick<Role, 'roleId'> & {clientId: string}> = 
 	getUrl(params) {
 		const {roleId, clientId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/${clientId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -183,7 +183,7 @@ const unassignClientFromRole: Endpoint<Pick<Role, 'roleId'> & {clientId: string}
 	getUrl(params) {
 		const {roleId, clientId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/${clientId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -192,7 +192,7 @@ const assignGroupToRole: Endpoint<Pick<Role, 'roleId'> & Pick<Group, 'groupId'>>
 	getUrl(params) {
 		const {roleId, groupId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/${groupId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -201,7 +201,7 @@ const unassignGroupFromRole: Endpoint<Pick<Role, 'roleId'> & Pick<Group, 'groupI
 	getUrl(params) {
 		const {roleId, groupId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/${groupId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -210,7 +210,7 @@ const queryGroupsByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/search`;
 	},
 };
 
@@ -219,7 +219,7 @@ const assignMappingToRole: Endpoint<Pick<Role, 'roleId'> & Pick<MappingRule, 'ma
 	getUrl(params) {
 		const {roleId, mappingId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mappings/${mappingId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mappings/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -228,7 +228,7 @@ const unassignMappingFromRole: Endpoint<Pick<Role, 'roleId'> & Pick<MappingRule,
 	getUrl(params) {
 		const {roleId, mappingId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mappings/${mappingId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mappings/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -237,7 +237,7 @@ const queryMappingRulesByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mapping-rules/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mapping-rules/search`;
 	},
 };
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/tenant.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/tenant.ts
@@ -110,17 +110,17 @@ const createTenant: Endpoint = {
 
 const getTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'GET',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const updateTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const deleteTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const queryTenants: Endpoint = {
@@ -130,77 +130,87 @@ const queryTenants: Endpoint = {
 
 const assignUserToTenant: Endpoint<Pick<Tenant, 'tenantId'> & {username: string}> = {
 	method: 'PUT',
-	getUrl: ({tenantId, username}) => `/${API_VERSION}/tenants/${tenantId}/users/${username}`,
+	getUrl: ({tenantId, username}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
 };
 
 const unassignUserFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & {username: string}> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, username}) => `/${API_VERSION}/tenants/${tenantId}/users/${username}`,
+	getUrl: ({tenantId, username}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
 };
 
 const queryUsersByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/users/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/search`,
 };
 
 const queryClientsByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/clients/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/search`,
 };
 
 const queryGroupsByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/groups/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/search`,
 };
 
 const queryRolesByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/roles/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/search`,
 };
 
 const assignClientToTenant: Endpoint<Pick<Tenant, 'tenantId'> & {clientId: string}> = {
 	method: 'PUT',
-	getUrl: ({tenantId, clientId}) => `/${API_VERSION}/tenants/${tenantId}/clients/${clientId}`,
+	getUrl: ({tenantId, clientId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
 };
 
 const unassignClientFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & {clientId: string}> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, clientId}) => `/${API_VERSION}/tenants/${tenantId}/clients/${clientId}`,
+	getUrl: ({tenantId, clientId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
 };
 
 const assignMappingRuleToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<MappingRule, 'mappingId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, mappingId}) => `/${API_VERSION}/tenants/${tenantId}/mappings/${mappingId}`,
+	getUrl: ({tenantId, mappingId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mappings/${encodeURIComponent(mappingId)}`,
 };
 
 const unassignMappingRuleFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<MappingRule, 'mappingId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, mappingId}) => `/${API_VERSION}/tenants/${tenantId}/mappings/${mappingId}`,
+	getUrl: ({tenantId, mappingId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mappings/${encodeURIComponent(mappingId)}`,
 };
 
 const queryMappingRulesByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/mappings/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mappings/search`,
 };
 
 const assignGroupToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Group, 'groupId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, groupId}) => `/${API_VERSION}/tenants/${tenantId}/groups/${groupId}`,
+	getUrl: ({tenantId, groupId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
 };
 
 const unassignGroupFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Group, 'groupId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, groupId}) => `/${API_VERSION}/tenants/${tenantId}/groups/${groupId}`,
+	getUrl: ({tenantId, groupId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
 };
 
 const assignRoleToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Role, 'roleId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, roleId}) => `/${API_VERSION}/tenants/${tenantId}/roles/${roleId}`,
+	getUrl: ({tenantId, roleId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
 };
 
 const unassignRoleFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Role, 'roleId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, roleId}) => `/${API_VERSION}/tenants/${tenantId}/roles/${roleId}`,
+	getUrl: ({tenantId, roleId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
 };
 
 export {

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/group.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/group.ts
@@ -40,7 +40,7 @@ const getGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -61,7 +61,7 @@ const updateGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -70,7 +70,7 @@ const deleteGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -109,7 +109,7 @@ const queryUsersByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/search`;
 	},
 };
 
@@ -131,7 +131,7 @@ const queryClientsByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/search`;
 	},
 };
 
@@ -154,7 +154,7 @@ const queryRolesByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/roles/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/roles/search`;
 	},
 };
 
@@ -178,7 +178,7 @@ const queryMappingRulesByGroup: Endpoint<Pick<Group, 'groupId'>> = {
 	getUrl(params) {
 		const {groupId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/search`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/search`;
 	},
 };
 
@@ -187,7 +187,7 @@ const assignUserToGroup: Endpoint<Pick<Group, 'groupId'> & {username: string}> =
 	getUrl(params) {
 		const {groupId, username} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/${username}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -196,7 +196,7 @@ const unassignUserFromGroup: Endpoint<Pick<Group, 'groupId'> & {username: string
 	getUrl(params) {
 		const {groupId, username} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/users/${username}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -205,7 +205,7 @@ const assignClientToGroup: Endpoint<Pick<Group, 'groupId'> & {clientId: string}>
 	getUrl(params) {
 		const {groupId, clientId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/${clientId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -214,7 +214,7 @@ const unassignClientFromGroup: Endpoint<Pick<Group, 'groupId'> & {clientId: stri
 	getUrl(params) {
 		const {groupId, clientId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/clients/${clientId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -223,7 +223,7 @@ const assignMappingToGroup: Endpoint<Pick<Group, 'groupId'> & Pick<MappingRule, 
 	getUrl(params) {
 		const {groupId, mappingId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/${mappingId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -232,7 +232,7 @@ const unassignMappingFromGroup: Endpoint<Pick<Group, 'groupId'> & Pick<MappingRu
 	getUrl(params) {
 		const {groupId, mappingId} = params;
 
-		return `/${API_VERSION}/groups/${groupId}/mapping-rules/${mappingId}`;
+		return `/${API_VERSION}/groups/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingId)}`;
 	},
 };
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/role.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/role.ts
@@ -113,7 +113,7 @@ const getRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -122,7 +122,7 @@ const updateRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -131,7 +131,7 @@ const deleteRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}`;
 	},
 };
 
@@ -147,7 +147,7 @@ const queryUsersByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/search`;
 	},
 };
 
@@ -156,7 +156,7 @@ const queryClientsByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/search`;
 	},
 };
 
@@ -165,7 +165,7 @@ const assignUserToRole: Endpoint<Pick<Role, 'roleId'> & {username: string}> = {
 	getUrl(params) {
 		const {roleId, username} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/${username}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -174,7 +174,7 @@ const unassignUserFromRole: Endpoint<Pick<Role, 'roleId'> & {username: string}> 
 	getUrl(params) {
 		const {roleId, username} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/users/${username}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`;
 	},
 };
 
@@ -183,7 +183,7 @@ const assignClientToRole: Endpoint<Pick<Role, 'roleId'> & {clientId: string}> = 
 	getUrl(params) {
 		const {roleId, clientId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/${clientId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -192,7 +192,7 @@ const unassignClientFromRole: Endpoint<Pick<Role, 'roleId'> & {clientId: string}
 	getUrl(params) {
 		const {roleId, clientId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/clients/${clientId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`;
 	},
 };
 
@@ -201,7 +201,7 @@ const assignGroupToRole: Endpoint<Pick<Role, 'roleId'> & Pick<Group, 'groupId'>>
 	getUrl(params) {
 		const {roleId, groupId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/${groupId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -210,7 +210,7 @@ const unassignGroupFromRole: Endpoint<Pick<Role, 'roleId'> & Pick<Group, 'groupI
 	getUrl(params) {
 		const {roleId, groupId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/${groupId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`;
 	},
 };
 
@@ -219,7 +219,7 @@ const queryGroupsByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/groups/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/groups/search`;
 	},
 };
 
@@ -228,7 +228,7 @@ const assignMappingToRole: Endpoint<Pick<Role, 'roleId'> & Pick<MappingRule, 'ma
 	getUrl(params) {
 		const {roleId, mappingId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mapping-rules/${mappingId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mapping-rules/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -237,7 +237,7 @@ const unassignMappingFromRole: Endpoint<Pick<Role, 'roleId'> & Pick<MappingRule,
 	getUrl(params) {
 		const {roleId, mappingId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mapping-rules/${mappingId}`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mapping-rules/${encodeURIComponent(mappingId)}`;
 	},
 };
 
@@ -246,7 +246,7 @@ const queryMappingRulesByRole: Endpoint<Pick<Role, 'roleId'>> = {
 	getUrl(params) {
 		const {roleId} = params;
 
-		return `/${API_VERSION}/roles/${roleId}/mapping-rules/search`;
+		return `/${API_VERSION}/roles/${encodeURIComponent(roleId)}/mapping-rules/search`;
 	},
 };
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/tenant.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/tenant.ts
@@ -122,17 +122,17 @@ const createTenant: Endpoint = {
 
 const getTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'GET',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const updateTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const deleteTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}`,
 };
 
 const queryTenants: Endpoint = {
@@ -142,77 +142,87 @@ const queryTenants: Endpoint = {
 
 const assignUserToTenant: Endpoint<Pick<Tenant, 'tenantId'> & {username: string}> = {
 	method: 'PUT',
-	getUrl: ({tenantId, username}) => `/${API_VERSION}/tenants/${tenantId}/users/${username}`,
+	getUrl: ({tenantId, username}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
 };
 
 const unassignUserFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & {username: string}> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, username}) => `/${API_VERSION}/tenants/${tenantId}/users/${username}`,
+	getUrl: ({tenantId, username}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
 };
 
 const queryUsersByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/users/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/users/search`,
 };
 
 const queryClientsByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/clients/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/search`,
 };
 
 const queryGroupsByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/groups/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/search`,
 };
 
 const queryRolesByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/roles/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/search`,
 };
 
 const assignClientToTenant: Endpoint<Pick<Tenant, 'tenantId'> & {clientId: string}> = {
 	method: 'PUT',
-	getUrl: ({tenantId, clientId}) => `/${API_VERSION}/tenants/${tenantId}/clients/${clientId}`,
+	getUrl: ({tenantId, clientId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
 };
 
 const unassignClientFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & {clientId: string}> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, clientId}) => `/${API_VERSION}/tenants/${tenantId}/clients/${clientId}`,
+	getUrl: ({tenantId, clientId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
 };
 
 const assignMappingRuleToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<MappingRule, 'mappingId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, mappingId}) => `/${API_VERSION}/tenants/${tenantId}/mapping-rules/${mappingId}`,
+	getUrl: ({tenantId, mappingId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mapping-rules/${encodeURIComponent(mappingId)}`,
 };
 
 const unassignMappingRuleFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<MappingRule, 'mappingId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, mappingId}) => `/${API_VERSION}/tenants/${tenantId}/mapping-rules/${mappingId}`,
+	getUrl: ({tenantId, mappingId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mapping-rules/${encodeURIComponent(mappingId)}`,
 };
 
 const queryMappingRulesByTenant: Endpoint<Pick<Tenant, 'tenantId'>> = {
 	method: 'POST',
-	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${tenantId}/mapping-rules/search`,
+	getUrl: ({tenantId}) => `/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/mapping-rules/search`,
 };
 
 const assignGroupToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Group, 'groupId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, groupId}) => `/${API_VERSION}/tenants/${tenantId}/groups/${groupId}`,
+	getUrl: ({tenantId, groupId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
 };
 
 const unassignGroupFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Group, 'groupId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, groupId}) => `/${API_VERSION}/tenants/${tenantId}/groups/${groupId}`,
+	getUrl: ({tenantId, groupId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
 };
 
 const assignRoleToTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Role, 'roleId'>> = {
 	method: 'PUT',
-	getUrl: ({tenantId, roleId}) => `/${API_VERSION}/tenants/${tenantId}/roles/${roleId}`,
+	getUrl: ({tenantId, roleId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
 };
 
 const unassignRoleFromTenant: Endpoint<Pick<Tenant, 'tenantId'> & Pick<Role, 'roleId'>> = {
 	method: 'DELETE',
-	getUrl: ({tenantId, roleId}) => `/${API_VERSION}/tenants/${tenantId}/roles/${roleId}`,
+	getUrl: ({tenantId, roleId}) =>
+		`/${API_VERSION}/tenants/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
 };
 
 export {

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -537,6 +537,17 @@
       </exclusions>
     </dependency>
 
+    <!-- Used by TomcatEncodedSlashConfig for encoded slash passthrough (#45215) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-tomcat</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-web-server</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jdbc</artifactId>

--- a/dist/src/main/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rest;
+
+import org.apache.tomcat.util.buf.EncodedSolidusHandling;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures Tomcat to pass encoded slashes ({@code %2F}) through to the application instead of
+ * rejecting them with a 400 error. This is required to support entity IDs that contain forward
+ * slashes (e.g., OIDC group IDs like {@code /myGroup} from Keycloak).
+ *
+ * <p>Spring Boot's {@code PathPatternParser} matches on raw/encoded URI segments and only decodes
+ * for {@code @PathVariable} binding, so {@code %2F} stays intact during route matching and is
+ * decoded to {@code /} when bound to the Java parameter.
+ *
+ * @see <a href="https://github.com/camunda/camunda/issues/45215">Issue #45215</a>
+ */
+@Configuration
+public class TomcatEncodedSlashConfig {
+
+  @Bean
+  public WebServerFactoryCustomizer<TomcatServletWebServerFactory> encodedSlashCustomizer() {
+    return factory ->
+        factory.addConnectorCustomizers(
+            connector ->
+                connector.setEncodedSolidusHandling(
+                    EncodedSolidusHandling.PASS_THROUGH.getValue()));
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfigTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfigTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.buf.EncodedSolidusHandling;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+
+class TomcatEncodedSlashConfigTest {
+
+  @Test
+  void shouldConfigurePassthroughForEncodedSlashes() {
+    // given
+    final var config = new TomcatEncodedSlashConfig();
+    final WebServerFactoryCustomizer<TomcatServletWebServerFactory> customizer =
+        config.encodedSlashCustomizer();
+    final var factory = mock(TomcatServletWebServerFactory.class);
+
+    // when
+    customizer.customize(factory);
+
+    // then
+    final var captor = ArgumentCaptor.forClass(TomcatConnectorCustomizer.class);
+    verify(factory).addConnectorCustomizers(captor.capture());
+
+    final var connector = mock(Connector.class);
+    captor.getValue().customize(connector);
+    verify(connector).setEncodedSolidusHandling(EncodedSolidusHandling.PASS_THROUGH.getValue());
+  }
+}

--- a/docs/adr/identity/0002-support-forward-slashes-in-entity-ids.md
+++ b/docs/adr/identity/0002-support-forward-slashes-in-entity-ids.md
@@ -1,0 +1,110 @@
+# ADR-0002: Support Forward Slashes in Entity IDs via URL Encoding
+
+## Status
+
+Proposed
+
+## Context
+
+Camunda's Identity REST API uses entity IDs (group, role, tenant, user, mapping rule) as path
+segments in URLs — for example, `PUT /v2/roles/{roleId}/groups/{groupId}`. When Camunda is
+configured with an OIDC provider such as Keycloak, entity IDs are sourced directly from the
+identity provider. Keycloak group IDs commonly contain forward slashes (e.g., `/myGroup`,
+`/org/team/engineering`).
+
+When the frontend constructs a URL with a literal `/` in an entity ID, the resulting path (e.g.,
+`PUT /v2/roles/admin/groups//myGroup`) contains extra path segments. Spring MVC finds no matching
+route and returns 400. This effectively prevents any OIDC-sourced entity with `/` in its ID from
+being managed through the REST API or the Identity UI.
+
+Two compounding issues cause this:
+
+1. **Validation allows `/`**: `SecurityConfiguration.DEFAULT_EXTERNAL_ID_REGEX` is `.*` when the
+   OIDC `groupsClaim` is configured, permitting any character in group IDs — including `/`.
+2. **Frontend does not encode**: URL paths are constructed via template literals without
+   `encodeURIComponent`, so special characters are inserted verbatim.
+
+See: https://github.com/camunda/camunda/issues/45215
+
+## Decision
+
+We will use standard URL encoding (`%2F`) on the client side and configure the embedded Tomcat
+server to pass encoded slashes through to Spring MVC. Entity IDs will not be normalized or
+transformed — they must match exactly what the identity provider returns.
+
+The solution has three layers:
+
+### 1. Frontend: Encode IDs with `encodeURIComponent`
+
+Every entity ID interpolated into a URL path is wrapped with `encodeURIComponent()`. This is
+standard HTTP behavior per RFC 3986 and is a no-op for alphanumeric strings, making it safe for
+all existing IDs.
+
+```typescript
+// Before
+apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+// After
+apiPut(`${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`);
+```
+
+### 2. Tomcat: PASSTHROUGH mode for encoded slashes
+
+Tomcat 11 rejects `%2F` in URL paths by default (`EncodedSolidusHandling.REJECT`). A
+`WebServerFactoryCustomizer` bean sets the handling mode to `PASSTHROUGH`, which forwards `%2F`
+as-is to the application without decoding or rejecting it.
+
+```java
+connector.setEncodedSolidusHandling("passthrough");
+```
+
+The `DECODE` mode was not chosen because it decodes `%2F` to `/` before Spring MVC sees the
+request, which would break route matching in the same way as the original unencoded slash.
+
+### 3. Spring MVC: PathPatternParser (no changes needed)
+
+Spring Boot's default `PathPatternParser` splits paths on literal `/` characters only. An encoded
+`%2F` is not a path separator, so `/v2/roles/admin/groups/%2FmyGroup` correctly matches
+`/v2/roles/{roleId}/groups/{groupId}`. Spring then decodes `%2F` to `/` when binding to the
+`@PathVariable` parameter. This is the default behavior — no configuration changes are required.
+
+## Alternatives Considered
+
+### Normalize IDs (strip or replace slashes)
+
+Rejected. Entity IDs must match the identity provider exactly. Normalizing would create a mismatch
+between Camunda's stored ID and the ID in OIDC tokens, breaking authorization checks.
+
+### Use request body instead of path variables
+
+Rejected. This would require changing the REST API contract, breaking backward compatibility for
+all API consumers. URL encoding is the standard HTTP mechanism for this problem.
+
+### Custom path matching or wildcard patterns
+
+Rejected. Using `**` patterns or custom `PathMatcher` configuration would be fragile, make routing
+ambiguous, and require changes across all controllers. Standard URL encoding solves the problem
+without any routing changes.
+
+## Consequences
+
+### Positive
+
+- Entity IDs from OIDC providers are supported as-is, regardless of special characters.
+- The solution follows HTTP standards (RFC 3986) — no custom encoding schemes.
+- Fully backward compatible: `encodeURIComponent` is a no-op on alphanumeric strings, and
+  `PASSTHROUGH` only affects requests that contain `%2F`.
+- No changes to controllers, service layer, or data model.
+
+### Negative
+
+- **Reverse proxies must forward raw URIs.** Proxies like nginx may reject or decode `%2F` by
+  default. Operators using reverse proxies must configure them to preserve encoded characters
+  (e.g., nginx: `proxy_pass` with `$request_uri`, or `merge_slashes off`).
+- **External API clients must encode IDs.** Any client calling the REST API directly must
+  URL-encode entity IDs containing special characters. This is standard HTTP behavior but must be
+  documented in the API reference.
+- **`PASSTHROUGH` applies to all connectors.** The Tomcat configuration affects all incoming
+  requests, not just identity endpoints. This is safe because `%2F` in a path segment is only
+  meaningful if the application interprets it — existing endpoints with alphanumeric IDs are
+  unaffected.
+

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -42,14 +42,14 @@ export const searchGroups: ApiDefinition<
 
 export const getGroupDetails: ApiDefinition<Group, Pick<Group, "groupId">> = ({
   groupId,
-}) => apiGet(`${GROUPS_ENDPOINT}/${groupId}`);
+}) => apiGet(`${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}`);
 
 export const createGroup: ApiDefinition<undefined, Group> = (params) =>
   apiPost(GROUPS_ENDPOINT, params);
 
 export const updateGroup: ApiDefinition<undefined, Group> = (group) => {
   const { groupId, name, description } = group;
-  return apiPut(`${GROUPS_ENDPOINT}/${groupId}`, {
+  return apiPut(`${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}`, {
     name,
     description,
   });
@@ -57,7 +57,7 @@ export const updateGroup: ApiDefinition<undefined, Group> = (group) => {
 
 export const deleteGroup: ApiDefinition<undefined, Pick<Group, "groupId">> = ({
   groupId,
-}) => apiDelete(`${GROUPS_ENDPOINT}/${groupId}`);
+}) => apiDelete(`${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}`);
 
 // ----------------- Roles within a Group -----------------
 
@@ -65,20 +65,27 @@ export const searchRolesByGroupId: ApiDefinition<
   QueryRolesByGroupResponseBody,
   QueryRolesByGroupRequestBody & Pick<Group, "groupId">
 > = ({ groupId, ...body }) =>
-  apiPost(`${GROUPS_ENDPOINT}/${groupId}/roles/search`, body);
+  apiPost(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/roles/search`,
+    body,
+  );
 
 export const assignGroupRole: ApiDefinition<
   undefined,
   Pick<Group, "groupId"> & Pick<Role, "roleId">
 > = ({ groupId, roleId }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 };
 
 export const unassignGroupRole: ApiDefinition<
   undefined,
   Pick<Group, "groupId"> & Pick<Role, "roleId">
 > = ({ groupId, roleId }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 
 // ----------------- Mapping rules within a Group -----------------
 
@@ -87,39 +94,53 @@ export const getMappingRulesByGroupId: ApiDefinition<
   QueryMappingRulesByGroupRequestBody & Pick<Group, "groupId">
 > = (params) => {
   const { groupId, ...body } = params;
-  return apiPost(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/search`, body);
+  return apiPost(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/mapping-rules/search`,
+    body,
+  );
 };
 
 export const assignGroupMappingRule: ApiDefinition<
   undefined,
   Pick<Group, "groupId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ groupId, mappingRuleId }) => {
-  return apiPut(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${mappingRuleId}`);
+  return apiPut(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 };
 
 export const unassignGroupMappingRule: ApiDefinition<
   undefined,
   Pick<Group, "groupId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ groupId, mappingRuleId }) =>
-  apiDelete(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${mappingRuleId}`);
+  apiDelete(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 
 export const getClientsByGroupId: ApiDefinition<
   QueryClientsByGroupResponseBody,
   QueryClientsByGroupRequestBody & Pick<Group, "groupId">
 > = (args) => {
   const { groupId, ...body } = args;
-  return apiPost(`${GROUPS_ENDPOINT}/${groupId}/clients/search`, body);
+  return apiPost(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/clients/search`,
+    body,
+  );
 };
 
 export const assignGroupClient: ApiDefinition<
   undefined,
   Pick<Group, "groupId"> & Pick<TenantClient, "clientId">
 > = ({ groupId, clientId }) => {
-  return apiPut(`${GROUPS_ENDPOINT}/${groupId}/clients/${clientId}`);
+  return apiPut(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`,
+  );
 };
 
 export const unassignGroupClient: ApiDefinition<
   undefined,
   Pick<Group, "groupId"> & Pick<TenantClient, "clientId">
 > = ({ groupId, clientId }) =>
-  apiDelete(`${GROUPS_ENDPOINT}/${groupId}/clients/${clientId}`);
+  apiDelete(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/clients/${encodeURIComponent(clientId)}`,
+  );

--- a/identity/client/src/utility/api/mapping-rules/index.ts
+++ b/identity/client/src/utility/api/mapping-rules/index.ts
@@ -34,7 +34,7 @@ export const updateMappingRule: ApiDefinition<
   undefined,
   UpdateMappingRuleRequestBody & Pick<MappingRule, "mappingRuleId">
 > = ({ mappingRuleId, claimName, claimValue, name }) =>
-  apiPut(`${MAPPING_RULES_ENDPOINT}/${mappingRuleId}`, {
+  apiPut(`${MAPPING_RULES_ENDPOINT}/${encodeURIComponent(mappingRuleId)}`, {
     name,
     claimName,
     claimValue,
@@ -44,4 +44,4 @@ export const deleteMappingRule: ApiDefinition<
   undefined,
   Pick<MappingRule, "mappingRuleId">
 > = ({ mappingRuleId }) =>
-  apiDelete(`${MAPPING_RULES_ENDPOINT}/${mappingRuleId}`);
+  apiDelete(`${MAPPING_RULES_ENDPOINT}/${encodeURIComponent(mappingRuleId)}`);

--- a/identity/client/src/utility/api/membership/index.ts
+++ b/identity/client/src/utility/api/membership/index.ts
@@ -27,54 +27,72 @@ export const searchMembersByGroup: ApiDefinition<
   QueryUsersByGroupResponseBody,
   QueryUsersByGroupRequestBody & Pick<Group, "groupId">
 > = ({ groupId, ...body }) =>
-  apiPost(`${GROUPS_ENDPOINT}/${groupId}/users/search`, body);
+  apiPost(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/users/search`,
+    body,
+  );
 
 export const getMembersByTenantId: ApiDefinition<
   QueryUsersByTenantResponseBody,
   QueryUsersByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
-  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/users/search`, body);
+  apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/users/search`,
+    body,
+  );
 
 export const getMembersByRole: ApiDefinition<
   QueryUsersByRoleResponseBody,
   QueryUsersByRoleRequestBody & Pick<Role, "roleId">
 > = ({ roleId, ...body }) =>
-  apiPost(`${ROLES_ENDPOINT}/${roleId}/users/search`, body);
+  apiPost(`${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/users/search`, body);
 
 export const assignGroupMember: ApiDefinition<
   undefined,
   Pick<Group, "groupId"> & Pick<User, "username">
 > = ({ groupId, username }) =>
-  apiPut(`${GROUPS_ENDPOINT}/${groupId}/users/${username}`);
+  apiPut(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`,
+  );
 
 export const unassignGroupMember: ApiDefinition<
   undefined,
   Pick<Group, "groupId"> & Pick<User, "username">
 > = ({ groupId, username }) =>
-  apiDelete(`${GROUPS_ENDPOINT}/${groupId}/users/${username}`);
+  apiDelete(
+    `${GROUPS_ENDPOINT}/${encodeURIComponent(groupId)}/users/${encodeURIComponent(username)}`,
+  );
 
 export const assignTenantMember: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & Pick<User, "username">
 > = ({ tenantId, username }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/users/${username}`);
+  return apiPut(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
+  );
 };
 
 export const unassignTenantMember: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & Pick<User, "username">
 > = ({ tenantId, username }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/users/${username}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(username)}`,
+  );
 
 export const assignRoleMember: ApiDefinition<
   undefined,
   Pick<Role, "roleId"> & Pick<User, "username">
 > = ({ roleId, username }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/users/${username}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`,
+  );
 };
 
 export const unassignRoleMember: ApiDefinition<
   undefined,
   Pick<Role, "roleId"> & Pick<User, "username">
 > = ({ roleId, username }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/users/${username}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/users/${encodeURIComponent(username)}`,
+  );

--- a/identity/client/src/utility/api/roles/index.ts
+++ b/identity/client/src/utility/api/roles/index.ts
@@ -37,14 +37,14 @@ export const searchRoles: ApiDefinition<
 
 export const getRoleDetails: ApiDefinition<Role, Pick<Role, "roleId">> = ({
   roleId,
-}) => apiGet(`${ROLES_ENDPOINT}/${roleId}`);
+}) => apiGet(`${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}`);
 
 export const createRole: ApiDefinition<undefined, Role> = (role) =>
   apiPost(ROLES_ENDPOINT, role);
 
 export const deleteRole: ApiDefinition<undefined, Pick<Role, "roleId">> = ({
   roleId,
-}) => apiDelete(`${ROLES_ENDPOINT}/${roleId}`);
+}) => apiDelete(`${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}`);
 
 // ----------------- Mapping rules within a Role -----------------
 
@@ -53,21 +53,28 @@ export const getMappingRulesByRoleId: ApiDefinition<
   QueryMappingRulesByRoleRequestBody & Pick<Role, "roleId">
 > = (params) => {
   const { roleId, ...body } = params;
-  return apiPost(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/search`, body);
+  return apiPost(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/mapping-rules/search`,
+    body,
+  );
 };
 
 export const assignRoleMappingRule: ApiDefinition<
   undefined,
   Pick<Role, "roleId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ roleId, mappingRuleId }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingRuleId}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 };
 
 export const unassignRoleMappingRule: ApiDefinition<
   undefined,
   Pick<Role, "roleId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ roleId, mappingRuleId }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingRuleId}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 
 // ----------------- Groups within a Role -----------------
 
@@ -75,20 +82,27 @@ export const getGroupsByRoleId: ApiDefinition<
   QueryGroupsByRoleResponseBody,
   Pick<Role, "roleId"> & QueryGroupsByRoleRequestBody
 > = ({ roleId, ...body }) =>
-  apiPost(`${ROLES_ENDPOINT}/${roleId}/groups/search`, body);
+  apiPost(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/search`,
+    body,
+  );
 
 export const assignRoleGroup: ApiDefinition<
   undefined,
   Pick<Role, "roleId"> & Pick<Group, "groupId">
 > = ({ roleId, groupId }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 };
 
 export const unassignRoleGroup: ApiDefinition<
   undefined,
   Pick<Role, "roleId"> & Pick<Group, "groupId">
 > = ({ roleId, groupId }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/groups/${groupId}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 
 // ----------------- Clients within a Role -----------------
 
@@ -97,18 +111,25 @@ export const getClientsByRoleId: ApiDefinition<
   QueryClientsByRoleRequestBody & Pick<Role, "roleId">
 > = (args) => {
   const { roleId, ...body } = args;
-  return apiPost(`${ROLES_ENDPOINT}/${roleId}/clients/search`, body);
+  return apiPost(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/clients/search`,
+    body,
+  );
 };
 
 export const assignRoleClient: ApiDefinition<
   undefined,
   Pick<Role, "roleId"> & Pick<TenantClient, "clientId">
 > = ({ roleId, clientId }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/clients/${clientId}`);
+  return apiPut(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`,
+  );
 };
 
 export const unassignRoleClient: ApiDefinition<
   undefined,
   Pick<Role, "roleId"> & Pick<TenantClient, "clientId">
 > = ({ roleId, clientId }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/clients/${clientId}`);
+  apiDelete(
+    `${ROLES_ENDPOINT}/${encodeURIComponent(roleId)}/clients/${encodeURIComponent(clientId)}`,
+  );

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -55,12 +55,16 @@ export const updateTenant: ApiDefinition<
   undefined,
   UpdateTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, name, description }) =>
-  apiPatch(`${TENANTS_ENDPOINT}/${tenantId}`, { name, description });
+  apiPatch(`${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}`, {
+    name,
+    description,
+  });
 
 export const deleteTenant: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId">
-> = ({ tenantId }) => apiDelete(`${TENANTS_ENDPOINT}/${tenantId}`);
+> = ({ tenantId }) =>
+  apiDelete(`${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}`);
 
 // ----------------- Groups within a Tenant -----------------
 
@@ -68,20 +72,27 @@ export const getGroupsByTenantId: ApiDefinition<
   QueryGroupsByTenantResponseBody,
   QueryGroupsByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
-  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/groups/search`, body);
+  apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/groups/search`,
+    body,
+  );
 
 export const assignTenantGroup: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & Pick<Group, "groupId">
 > = ({ tenantId, groupId }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupId}`);
+  return apiPut(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 };
 
 export const unassignTenantGroup: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & Pick<Group, "groupId">
 > = ({ tenantId, groupId }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupId}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/groups/${encodeURIComponent(groupId)}`,
+  );
 
 // ----------------- Roles within a Tenant -----------------
 
@@ -89,20 +100,27 @@ export const getRolesByTenantId: ApiDefinition<
   QueryRolesByTenantResponseBody,
   QueryRolesByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
-  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/roles/search`, body);
+  apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/roles/search`,
+    body,
+  );
 
 export const assignTenantRole: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & Pick<Role, "roleId">
 > = ({ tenantId, roleId }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/roles/${roleId}`);
+  return apiPut(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
+  );
 };
 
 export const unassignTenantRole: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & Pick<Role, "roleId">
 > = ({ tenantId, roleId }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/roles/${roleId}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/roles/${encodeURIComponent(roleId)}`,
+  );
 
 // ----------------- Mapping rules within a Tenant -----------------
 
@@ -111,7 +129,10 @@ export const getMappingRulesByTenantId: ApiDefinition<
   QueryMappingRulesByTenantRequestBody & Pick<Tenant, "tenantId">
 > = (params) => {
   const { tenantId, ...body } = params;
-  return apiPost(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/search`, body);
+  return apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/mapping-rules/search`,
+    body,
+  );
 };
 
 export const assignTenantMappingRule: ApiDefinition<
@@ -119,7 +140,7 @@ export const assignTenantMappingRule: ApiDefinition<
   Pick<Tenant, "tenantId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ tenantId, mappingRuleId }) => {
   return apiPut(
-    `${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${mappingRuleId}`,
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
   );
 };
 
@@ -127,23 +148,33 @@ export const unassignTenantMappingRule: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & Pick<MappingRule, "mappingRuleId">
 > = ({ tenantId, mappingRuleId }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${mappingRuleId}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+  );
 
 export const getClientsByTenantId: ApiDefinition<
   QueryClientsByTenantResponseBody,
   QueryClientsByTenantRequestBody & Pick<Tenant, "tenantId">
 > = ({ tenantId, ...body }) =>
-  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/clients/search`, body);
+  apiPost(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/clients/search`,
+    body,
+  );
 
 export const assignTenantClient: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & { clientId: string }
 > = ({ tenantId, clientId, ...body }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/clients/${clientId}`, body);
+  return apiPut(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
+    body,
+  );
 };
 
 export const unassignTenantClient: ApiDefinition<
   undefined,
   Pick<Tenant, "tenantId"> & { clientId: string }
 > = ({ tenantId, clientId }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/clients/${clientId}`);
+  apiDelete(
+    `${TENANTS_ENDPOINT}/${encodeURIComponent(tenantId)}/clients/${encodeURIComponent(clientId)}`,
+  );

--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -48,7 +48,7 @@ export const updateUser: ApiDefinition<
   UpdateUserRequestBody & Pick<User, "username">
 > = (user) => {
   const { name, email, username, password } = user;
-  return apiPut(`${USERS_ENDPOINT}/${username}`, {
+  return apiPut(`${USERS_ENDPOINT}/${encodeURIComponent(username)}`, {
     name,
     email,
     password,
@@ -57,4 +57,4 @@ export const updateUser: ApiDefinition<
 
 export const deleteUser: ApiDefinition<undefined, Pick<User, "username">> = ({
   username,
-}) => apiDelete(`${USERS_ENDPOINT}/${username}`);
+}) => apiDelete(`${USERS_ENDPOINT}/${encodeURIComponent(username)}`);


### PR DESCRIPTION
# Description
Backport of #48668 to `stable/8.9`.

relates to #45215