### PR TITLE
fix: prevent NPE when BoundaryEvent attachedTo is null

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/ActivityImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/ActivityImpl.java
@@ -197,7 +197,7 @@ public abstract class ActivityImpl extends FlowNodeImpl implements Activity {
   public Query<BoundaryEvent> getBoundaryEvents() {
     final Collection<BoundaryEvent> queryElements =
         getParentElement().getChildElementsByType(BoundaryEvent.class).stream()
-            .filter(event -> event.getAttachedTo().equals(this))
+            .filter(event -> this.equals(event.getAttachedTo()))
             .collect(Collectors.toSet());
 
     return new QueryImpl<>(queryElements);

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
@@ -15,11 +15,14 @@
  */
 package io.camunda.zeebe.model.bpmn.validation;
 
+import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ATTRIBUTE_ATTACHED_TO_REF;
 import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
 import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractBpmnModelElementBuilder;
+import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import org.junit.runners.Parameterized.Parameters;
 
 public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTest {
@@ -89,7 +92,27 @@ public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTes
             .endEvent("end")
             .done(),
         singletonList(expect("boundary", "Cannot have incoming sequence flows"))
+      },
+      {
+        createBoundaryEventWithNonExistingAttachedTo(),
+        singletonList(expect("boundary", "Must be attached to an activity"))
       }
     };
+  }
+
+  private static BpmnModelInstance createBoundaryEventWithNonExistingAttachedTo() {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", b -> b.zeebeJobType("type"))
+            .boundaryEvent("boundary")
+            .timerWithDuration("PT1S")
+            .endEvent("end")
+            .done();
+
+    final BoundaryEvent boundary = model.getModelElementById("boundary");
+    boundary.setAttributeValue(BPMN_ATTRIBUTE_ATTACHED_TO_REF, "no_such_activity", false);
+
+    return model;
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR is copy/pasted from an external contribution https://github.com/camunda/camunda/pull/46054. The reason that we created it manually instead of back porting is that we need to make the fix to `8.9` release. Given the timeline of CI fixes will go beyond `8.9` freeze, we decided to create a dedicated PR to merge into `stable/8.9`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/42907
