### PR TITLE
feat: updated renovate test

### DIFF
--- a/cmd/renovate/README.md
+++ b/cmd/renovate/README.md
@@ -8,6 +8,7 @@ You can make use of the script [renovate-local.sh](./renovate-local.sh) to do so
 > [!IMPORTANT]
 > - [GitHub CLI](https://github.com/cli/cli/blob/trunk/docs/install_linux.md) — required
 > - [Docker](https://docs.docker.com/get-docker/) — required (runs the Renovate container)
+> - [jq](https://jqlang.github.io/jq/download/) — required (JSON processing for secrets)
 > - [HashiCorp Vault CLI](https://developer.hashicorp.com/vault/install) — recommended for proper testing with real registry credentials
 
 ### Installing Vault CLI

--- a/cmd/renovate/README.md
+++ b/cmd/renovate/README.md
@@ -3,12 +3,48 @@
 If you want to tweak the [renovate config](../../.github/renovate.json), it's a good idea to test this locally.
 You can make use of the script [renovate-local.sh](./renovate-local.sh) to do so.
 
+## Prerequisites
+
 > [!IMPORTANT]
-> Make sure you've installed [GitHub CLI](https://github.com/cli/cli/blob/trunk/docs/install_linux.md) locally.
+> - [GitHub CLI](https://github.com/cli/cli/blob/trunk/docs/install_linux.md) — required
+> - [Docker](https://docs.docker.com/get-docker/) — required (runs the Renovate container)
+> - [HashiCorp Vault CLI](https://developer.hashicorp.com/vault/install) — recommended for proper testing with real registry credentials
+
+### Installing Vault CLI
+
+```shell
+# macOS
+brew tap hashicorp/tap
+brew install hashicorp/tap/vault
+
+# Linux (Ubuntu/Debian)
+wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install vault
+```
+
+For other Linux distributions, see the [official Vault install guide](https://developer.hashicorp.com/vault/install).
+
+### Authenticating with Vault
+
+```shell
+export VAULT_ADDR="https://vault.int.camunda.com"
+vault login -method=oidc
+```
+
+This opens a browser window for SSO authentication. The session token is cached locally and reused by the script.
 
 ## Usage in this repo
 
-You can just execute `./cmd/renovate/renovate-local.sh`.
+For proper testing with real registry credentials (recommended):
+
+```shell
+export VAULT_ADDR="https://vault.int.camunda.com"
+vault login -method=oidc
+./cmd/renovate/renovate-local.sh
+```
+
+Without Vault, the script still runs but uses dummy placeholder values for secrets. This means registry lookups requiring authentication (e.g. `reg.mini.dev`) will fail, which may abort the Renovate run early depending on which managers are enabled.
 
 ## Usage in other repos
 
@@ -19,6 +55,11 @@ If you want to use this script in other repositories, you can simply execute the
 curl https://raw.githubusercontent.com/camunda/camunda/refs/heads/main/cmd/renovate/renovate-local.sh | bash
 ```
 
+## Secrets
+
+The Renovate config references secrets (e.g. `{{ secrets.INFRA_MINIMUS_REGISTRY_TOKEN }}`).
+When Vault is authenticated, the script automatically fetches real values. The mapping from Renovate secret names to Vault fields is defined in `vault_field_for_secret()` inside the script. To add a new secret, add a `case` entry there.
+
 ## Options
 
 The script itself will automatically login to Github.
@@ -27,3 +68,4 @@ This is why you need to be located in the repositories root with your terminal s
 You can however set the following environment variables to override default behavior:
 - `LOCAL_RENOVATE_CONFIG` - filename (with full path) of the local renovate config to use
 - `REPO_NAME` - Github repository name (e.g. `camunda/camunda`)
+- `RENOVATE_ENABLED_MANAGERS` - JSON array of Renovate managers to enable (e.g. `'["maven","npm"]'`). Useful to skip slow managers like `docker` during testing.

--- a/cmd/renovate/renovate-local.sh
+++ b/cmd/renovate/renovate-local.sh
@@ -43,6 +43,58 @@ fi
 mkdir -p "${LOCAL_CACHE_DIR}"
 mkdir -p "${LOCAL_BASE_DIR}"
 
+# Vault path and field mapping for Renovate secrets.
+# Add entries to vault_field_for_secret() when new {{ secrets.XYZ }} refs are
+# added to the Renovate config.
+VAULT_MOUNT="secret"
+VAULT_SECRET_PATH="products/camunda/ci/github-actions"
+
+vault_field_for_secret() {
+  case "$1" in
+    INFRA_MINIMUS_REGISTRY_TOKEN) echo "REGISTRY_MINIMUS_PSW" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Resolve secrets referenced in the config: fetch from Vault when authenticated,
+# otherwise fall back to dummy values so the dry-run can still proceed.
+RENOVATE_SECRETS="{}"
+secret_names=$(grep -oE '\{\{\s*secrets\.[A-Z_a-z0-9]+\s*\}\}' "$LOCAL_RENOVATE_CONFIG" \
+  | sed 's/.*secrets\.\([A-Za-z0-9_]*\).*/\1/' | sort -u)
+if [ -n "$secret_names" ]; then
+  vault_ok=false
+  if command -v vault >/dev/null 2>&1 && vault token lookup >/dev/null 2>&1; then
+    vault_ok=true
+    echo "Vault authenticated — will fetch real secret values"
+  else
+    echo "Vault not available — using dummy secret values (run 'vault login -method=oidc' for real values)"
+  fi
+
+  json="{"
+  first=true
+  for name in $secret_names; do
+    if [ "$first" = true ]; then first=false; else json+=","; fi
+    value="dummy-local-value"
+    vault_field=$(vault_field_for_secret "$name")
+
+    if [ "$vault_ok" = true ] && [ -n "$vault_field" ]; then
+      fetched=$(vault kv get -mount="$VAULT_MOUNT" -field="$vault_field" "$VAULT_SECRET_PATH" 2>/dev/null) || true
+      if [ -n "$fetched" ]; then
+        value="$fetched"
+        echo "  ✓ $name (Vault field: $vault_field)"
+      else
+        echo "  ✗ $name: Vault fetch failed for field '$vault_field', using dummy value"
+      fi
+    elif [ "$vault_ok" = true ]; then
+      echo "  ? $name: no Vault mapping defined, using dummy value"
+    fi
+
+    json+="\"$name\":\"$value\""
+  done
+  json+="}"
+  RENOVATE_SECRETS="$json"
+fi
+
 echo "Processing repository: ${REPO_NAME}"
 echo "Using local renovate configuration from: ${LOCAL_RENOVATE_CONFIG}"
 echo "Using local Renovate cache at: ${LOCAL_CACHE_DIR}"
@@ -60,6 +112,8 @@ docker run --rm \
   -e RENOVATE_TOKEN="${GITHUB_TOKEN}" \
   -e RENOVATE_REPOSITORIES="${REPO_NAME}" \
   -e RENOVATE_REQUIRE_CONFIG="ignored" \
+  -e RENOVATE_SECRETS="${RENOVATE_SECRETS}" \
+  ${RENOVATE_ENABLED_MANAGERS:+-e RENOVATE_ENABLED_MANAGERS="${RENOVATE_ENABLED_MANAGERS}"} \
   -e RENOVATE_CONFIG_FILE="/usr/src/app/mounted-renovate-config.json" \
   -v "${LOCAL_RENOVATE_CONFIG}:/usr/src/app/mounted-renovate-config.json:ro" \
   -e RENOVATE_BASE_DIR="/tmp/renovate" \

--- a/cmd/renovate/renovate-local.sh
+++ b/cmd/renovate/renovate-local.sh
@@ -8,6 +8,12 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
+# Ensure jq is installed (used for safe JSON construction of secrets)
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is not installed. Please install it (e.g. 'brew install jq' or 'apt install jq')."
+  exit 1
+fi
+
 # Login to GitHub CLI if not already authenticated
 if [ ! "$(gh auth status)" ]; then
   gh auth login -p https -h github.com -w
@@ -60,7 +66,7 @@ vault_field_for_secret() {
 # otherwise fall back to dummy values so the dry-run can still proceed.
 RENOVATE_SECRETS="{}"
 secret_names=$(grep -oE '\{\{\s*secrets\.[A-Z_a-z0-9]+\s*\}\}' "$LOCAL_RENOVATE_CONFIG" \
-  | sed 's/.*secrets\.\([A-Za-z0-9_]*\).*/\1/' | sort -u)
+  | sed 's/.*secrets\.\([A-Za-z0-9_]*\).*/\1/' | sort -u || true)
 if [ -n "$secret_names" ]; then
   vault_ok=false
   if command -v vault >/dev/null 2>&1 && vault token lookup >/dev/null 2>&1; then
@@ -70,10 +76,8 @@ if [ -n "$secret_names" ]; then
     echo "Vault not available — using dummy secret values (run 'vault login -method=oidc' for real values)"
   fi
 
-  json="{"
-  first=true
+  RENOVATE_SECRETS="{}"
   for name in $secret_names; do
-    if [ "$first" = true ]; then first=false; else json+=","; fi
     value="dummy-local-value"
     vault_field=$(vault_field_for_secret "$name")
 
@@ -89,10 +93,8 @@ if [ -n "$secret_names" ]; then
       echo "  ? $name: no Vault mapping defined, using dummy value"
     fi
 
-    json+="\"$name\":\"$value\""
+    RENOVATE_SECRETS=$(echo "$RENOVATE_SECRETS" | jq --arg k "$name" --arg v "$value" '. + {($k): $v}')
   done
-  json+="}"
-  RENOVATE_SECRETS="$json"
 fi
 
 echo "Processing repository: ${REPO_NAME}"


### PR DESCRIPTION
## Description:

Improves the local Renovate dry-run script ([renovate-local.sh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to automatically resolve secrets from HashiCorp Vault and updates the README with proper setup documentation.

## Why
The Renovate config references {{ secrets.INFRA_MINIMUS_REGISTRY_TOKEN }} for the reg.mini.dev Docker registry. Previously, the local test script had no way to provide real secret values, causing registry lookups to fail and potentially aborting the entire dry-run. Users had to manually extract and inject secrets.

## Changes
#### Script renovate-local.sh
- Vault secret resolution: Automatically detects {{ secrets.* }} references in the Renovate config and fetches real values from Vault (secret/products/camunda/ci/github-actions) when authenticated. Falls back to dummy placeholder values when Vault is unavailable.
- Extensible mapping: New vault_field_for_secret() function maps Renovate secret names to Vault field names (currently: INFRA_MINIMUS_REGISTRY_TOKEN → REGISTRY_MINIMUS_PSW). Adding new secrets requires only a new case entry.
- RENOVATE_SECRETS passthrough: Passes the resolved secrets JSON to the Docker container via -e RENOVATE_SECRETS.
- RENOVATE_ENABLED_MANAGERS support: Conditionally forwards this env var to the container, allowing users to limit which managers run (e.g. '["maven","npm"]' to skip Docker manager during testing).

#### Documentation README.md
- Added Prerequisites section listing GitHub CLI, Docker, and Vault CLI with importance levels.
- Added Installing Vault CLI instructions for macOS and Ubuntu/Debian, with a link to the official guide for other distros.
- Added Authenticating with Vault section with VAULT_ADDR and vault login -method=oidc.
- Updated Usage section to lead with the Vault-authenticated flow.
- Added Secrets section explaining the auto-resolution mechanism.
- Documented RENOVATE_ENABLED_MANAGERS in the Options section.

Testing
Tested locally with an active Vault session — the script successfully fetched the real REGISTRY_MINIMUS_PSW value and injected it as INFRA_MINIMUS_REGISTRY_TOKEN into the Renovate container.
