### PR TITLE
[Backport stable/8.9] fix: use oneOf for ScopeKey

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -315,6 +315,7 @@
             <!-- map complex String schemas to String -->
             <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
             <typeMapping>ResourceKey=String</typeMapping>
+            <typeMapping>ScopeKey=String</typeMapping>
             <!-- map specific filter properties to basic filter types -->
             <typeMapping>AuditLogEntityKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>AuditLogKeyFilterProperty=BasicStringFilterProperty</typeMapping>

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -90,6 +90,7 @@
                 <!-- map complex String schemas to String -->
                 <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
                 <typeMapping>ResourceKey=String</typeMapping>
+                <typeMapping>ScopeKey=String</typeMapping>
                 <typeMapping>ElementInstanceKey=String</typeMapping>
                 <!-- map specific filter properties to basic filter types -->
                 <typeMapping>AuditLogEntityKeyFilterProperty=BasicStringFilterProperty</typeMapping>
@@ -145,6 +146,7 @@
                 <!-- map complex String schemas to String -->
                 <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
                 <typeMapping>ResourceKey=String</typeMapping>
+                <typeMapping>ScopeKey=String</typeMapping>
                 <typeMapping>ElementInstanceKey=String</typeMapping>
                 <!-- map specific filter properties to String for equality behavior -->
                 <typeMapping>AuditLogEntityKeyFilterProperty=String</typeMapping>

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -66,6 +66,8 @@ components:
       description: |
         System-generated key for a scope. A scope can hold variables and represents either an
         element instance in a BPMN process or the process instance itself.
+      type: string
+      format: ScopeKey
       x-semantic-type: ScopeKey
       example: "2251799813683890"
       oneOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -66,10 +66,8 @@ components:
       description: |
         System-generated key for a scope. A scope can hold variables and represents either an
         element instance in a BPMN process or the process instance itself.
-      format: ScopeKey
       x-semantic-type: ScopeKey
       example: "2251799813683890"
-      type: string
       oneOf:
         - $ref: '#/components/schemas/ProcessInstanceKey'
         - $ref: '#/components/schemas/ElementInstanceKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -70,8 +70,9 @@ components:
       x-semantic-type: ScopeKey
       example: "2251799813683890"
       type: string
-      allOf:
-        - $ref: '#/components/schemas/LongKey'
+      oneOf:
+        - $ref: '#/components/schemas/ProcessInstanceKey'
+        - $ref: '#/components/schemas/ElementInstanceKey'
 
     IncidentKey:
       description: System-generated key for a incident.


### PR DESCRIPTION
# Description
Backport of #49000 to `stable/8.9`.

relates to camunda/orchestration-cluster-api-js#54