### PR TITLE
[Backport stable/8.9] feat(testing): add byElementType, byElementInstanceKey, and byState selectors to ElementSelectors

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelectors.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 
@@ -39,6 +41,36 @@ public class ElementSelectors {
    */
   public static ElementSelector byName(final String elementName) {
     return new ElementNameSelector(elementName);
+  }
+
+  /**
+   * Select the BPMN element by its type.
+   *
+   * @param elementType the type of the BPMN element.
+   * @return the selector
+   */
+  public static ElementSelector byElementType(final ElementInstanceType elementType) {
+    return new ElementTypeSelector(elementType);
+  }
+
+  /**
+   * Select the BPMN element by its element instance key.
+   *
+   * @param elementInstanceKey the key of the element instance.
+   * @return the selector
+   */
+  public static ElementSelector byElementInstanceKey(final long elementInstanceKey) {
+    return new ElementInstanceKeySelector(elementInstanceKey);
+  }
+
+  /**
+   * Select the BPMN element by its state.
+   *
+   * @param state the state of the element instance.
+   * @return the selector
+   */
+  public static ElementSelector byState(final ElementInstanceState state) {
+    return new ElementStateSelector(state);
   }
 
   private static final class ElementIdSelector implements ElementSelector {
@@ -86,6 +118,78 @@ public class ElementSelectors {
     @Override
     public void applyFilter(final ElementInstanceFilter filter) {
       filter.elementName(elementName);
+    }
+  }
+
+  private static final class ElementTypeSelector implements ElementSelector {
+
+    private final ElementInstanceType elementType;
+
+    private ElementTypeSelector(final ElementInstanceType elementType) {
+      this.elementType = elementType;
+    }
+
+    @Override
+    public boolean test(final ElementInstance element) {
+      return elementType.equals(element.getType());
+    }
+
+    @Override
+    public String describe() {
+      return elementType.name();
+    }
+
+    @Override
+    public void applyFilter(final ElementInstanceFilter filter) {
+      filter.type(elementType);
+    }
+  }
+
+  private static final class ElementInstanceKeySelector implements ElementSelector {
+
+    private final long elementInstanceKey;
+
+    private ElementInstanceKeySelector(final long elementInstanceKey) {
+      this.elementInstanceKey = elementInstanceKey;
+    }
+
+    @Override
+    public boolean test(final ElementInstance element) {
+      return elementInstanceKey == element.getElementInstanceKey();
+    }
+
+    @Override
+    public String describe() {
+      return String.valueOf(elementInstanceKey);
+    }
+
+    @Override
+    public void applyFilter(final ElementInstanceFilter filter) {
+      filter.elementInstanceKey(elementInstanceKey);
+    }
+  }
+
+  private static final class ElementStateSelector implements ElementSelector {
+
+    private final ElementInstanceState state;
+
+    private ElementStateSelector(final ElementInstanceState state) {
+      this.state = state;
+    }
+
+    @Override
+    public boolean test(final ElementInstance element) {
+      return state.equals(element.getState());
+    }
+
+    @Override
+    public String describe() {
+      return state.name();
+    }
+
+    @Override
+    public void applyFilter(final ElementInstanceFilter filter) {
+      filter.state(state);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelectors.java
@@ -136,7 +136,7 @@ public class ElementSelectors {
 
     @Override
     public String describe() {
-      return elementType.name();
+      return "type: " + elementType.name();
     }
 
     @Override
@@ -160,7 +160,7 @@ public class ElementSelectors {
 
     @Override
     public String describe() {
-      return String.valueOf(elementInstanceKey);
+      return "element instance key: " + String.valueOf(elementInstanceKey);
     }
 
     @Override
@@ -184,7 +184,7 @@ public class ElementSelectors {
 
     @Override
     public String describe() {
-      return state.name();
+      return "state: " + state.name();
     }
 
     @Override

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.process.test.api.assertions.ElementSelector;
@@ -280,6 +281,77 @@ public class ElementAssertTest {
                   + "\t- 'element_C': completed\n"
                   + "\t- 'element_D': not activated",
               PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldUseByElementTypeSelector() {
+      // given
+      final ElementInstance elementInstanceA =
+          ElementInstanceBuilder.newActiveElementInstance("A", PROCESS_INSTANCE_KEY)
+              .setType(ElementInstanceType.SERVICE_TASK)
+              .build();
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstanceA));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasActiveElements(ElementSelectors.byElementType(ElementInstanceType.SERVICE_TASK));
+
+      verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
+
+      elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
+      verify(elementInstanceFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(elementInstanceFilter).type(ElementInstanceType.SERVICE_TASK);
+    }
+
+    @Test
+    void shouldUseByElementInstanceKeySelector() {
+      // given
+      final long elementInstanceKey = 42L;
+      final ElementInstance elementInstanceA =
+          ElementInstanceBuilder.newActiveElementInstance("A", PROCESS_INSTANCE_KEY)
+              .setElementInstanceKey(elementInstanceKey)
+              .build();
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstanceA));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasActiveElements(ElementSelectors.byElementInstanceKey(elementInstanceKey));
+
+      verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
+
+      elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
+      verify(elementInstanceFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(elementInstanceFilter).elementInstanceKey(elementInstanceKey);
+    }
+
+    @Test
+    void shouldUseByStateSelector() {
+      // given
+      final ElementInstance elementInstanceA =
+          ElementInstanceBuilder.newActiveElementInstance("A", PROCESS_INSTANCE_KEY).build();
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstanceA));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasActiveElements(ElementSelectors.byState(ElementInstanceState.ACTIVE));
+
+      verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
+
+      elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
+      verify(elementInstanceFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(elementInstanceFilter).state(ElementInstanceState.ACTIVE);
     }
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -95,6 +95,8 @@ public class ElementAssertTest {
 
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Arrays.asList(elementInstanceA, elementInstanceB, elementInstanceC));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
     }
 
     @AfterEach
@@ -104,15 +106,14 @@ public class ElementAssertTest {
 
     @Test
     public void canCombineSelectors() {
-      // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
-
-      // then
+      // given
       final ElementSelector combined =
           ElementSelectors.byName("element_A").and(ElementSelectors.byId("A"));
 
+      // when
       CamundaAssert.assertThatProcessInstance(processInstanceEvent).hasActiveElements(combined);
 
+      // then
       verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
 
       elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
@@ -123,13 +124,11 @@ public class ElementAssertTest {
     @Test
     @CamundaAssertExpectFailure
     public void combinedSelectorsRequireAllTestsToPass() {
-      // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
-
-      // then
+      // given
       final ElementSelector badCombination =
           ElementSelectors.byName("element_Foo").and(ElementSelectors.byId("A"));
 
+      // when/then
       Assertions.assertThatThrownBy(
               () ->
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
@@ -153,6 +152,8 @@ public class ElementAssertTest {
 
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Arrays.asList(elementInstanceA, elementInstanceB, elementInstanceC));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
     }
 
     @AfterEach
@@ -163,11 +164,9 @@ public class ElementAssertTest {
     @Test
     void shouldUseStringSelector() {
       // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
-
-      // then
       CamundaAssert.assertThatProcessInstance(processInstanceEvent).hasActiveElements("A");
 
+      // then
       verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
 
       elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
@@ -178,10 +177,7 @@ public class ElementAssertTest {
     @Test
     @CamundaAssertExpectFailure
     void shouldFailWithStringSelector() {
-      // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
-
-      // then
+      // when/then
       Assertions.assertThatThrownBy(
               () ->
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
@@ -199,22 +195,23 @@ public class ElementAssertTest {
       CamundaAssert.setElementSelector(ElementSelectors::byName);
 
       // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent).hasActiveElements("element_A");
 
       // then
-      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
-          .hasActiveElements("element_A", "element_B");
+      verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
+
+      elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
+      verify(elementInstanceFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(elementInstanceFilter).elementName("element_A");
     }
 
     @Test
     void shouldUseByIdSelector() {
       // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
-
-      // then
       CamundaAssert.assertThatProcessInstance(processInstanceEvent)
           .hasActiveElements(ElementSelectors.byId("A"));
 
+      // then
       verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
 
       elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
@@ -225,10 +222,7 @@ public class ElementAssertTest {
     @Test
     @CamundaAssertExpectFailure
     void shouldFailWithByIdSelector() {
-      // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
-
-      // then
+      // when/then
       Assertions.assertThatThrownBy(
               () ->
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
@@ -246,29 +240,26 @@ public class ElementAssertTest {
     @Test
     void shouldUseByNameSelector() {
       // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
-
-      // then
       CamundaAssert.assertThatProcessInstance(processInstanceEvent)
           .hasActiveElements(ElementSelectors.byName("element_A"));
 
+      // then
       verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
 
       elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
       verify(elementInstanceFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(elementInstanceFilter).elementName("element_A");
     }
 
     @Test
     @CamundaAssertExpectFailure
     void shouldFailWithByNameSelector() {
       // when
-      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
-
-      // then
       CamundaAssert.assertThatProcessInstance(processInstanceEvent)
           .hasActiveElements(
               ElementSelectors.byName("element_A"), ElementSelectors.byName("element_B"));
 
+      // then
       Assertions.assertThatThrownBy(
               () ->
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
@@ -293,13 +284,13 @@ public class ElementAssertTest {
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Collections.singletonList(elementInstanceA));
 
-      // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      // then
+      // when
       CamundaAssert.assertThatProcessInstance(processInstanceEvent)
           .hasActiveElements(ElementSelectors.byElementType(ElementInstanceType.SERVICE_TASK));
 
+      // then
       verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
 
       elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
@@ -318,13 +309,13 @@ public class ElementAssertTest {
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Collections.singletonList(elementInstanceA));
 
-      // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      // then
+      // when
       CamundaAssert.assertThatProcessInstance(processInstanceEvent)
           .hasActiveElements(ElementSelectors.byElementInstanceKey(elementInstanceKey));
 
+      // then
       verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
 
       elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);
@@ -340,13 +331,13 @@ public class ElementAssertTest {
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Collections.singletonList(elementInstanceA));
 
-      // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      // then
+      // when
       CamundaAssert.assertThatProcessInstance(processInstanceEvent)
           .hasActiveElements(ElementSelectors.byState(ElementInstanceState.ACTIVE));
 
+      // then
       verify(camundaDataSource).findElementInstances(elementInstanceFilterCapture.capture());
 
       elementInstanceFilterCapture.getValue().accept(elementInstanceFilter);


### PR DESCRIPTION
# Description
Backport of #49067 to `stable/8.9`.

relates to camunda/camunda#49021