### PR TITLE
[Backport stable/8.9] fix: also truncate the job error message in update and merge-updates

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.JobEntity.ListenerEventType;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,15 +115,9 @@ public class JobDbModel implements Copyable<JobDbModel> {
   }
 
   public JobDbModel truncateErrorMessage(final int sizeLimit, final Integer byteLimit) {
-    if (errorMessage == null) {
+    final var truncatedValue = doTruncateErrorMessage(jobKey, errorMessage, sizeLimit, byteLimit);
+    if (Objects.equals(truncatedValue, errorMessage)) {
       return this;
-    }
-
-    final var truncatedValue = TruncateUtil.truncateValue(errorMessage, sizeLimit, byteLimit);
-
-    if (truncatedValue.length() < errorMessage.length()) {
-      LOG.warn(
-          "Truncated error message for job {}, original message was: {}", jobKey, errorMessage);
     }
 
     return new JobDbModel(
@@ -151,6 +146,19 @@ public class JobDbModel implements Copyable<JobDbModel> {
         partitionId,
         creationTime,
         lastUpdateTime);
+  }
+
+  private static String doTruncateErrorMessage(
+      final Long jobKey, final String errorMessage, final int sizeLimit, final Integer byteLimit) {
+    if (errorMessage == null) {
+      return null;
+    }
+    final var truncatedValue = TruncateUtil.truncateValue(errorMessage, sizeLimit, byteLimit);
+    if (truncatedValue.length() < errorMessage.length()) {
+      LOG.warn(
+          "Truncated error message for job {}, original message was: {}", jobKey, errorMessage);
+    }
+    return truncatedValue;
   }
 
   public Long jobKey() {
@@ -472,6 +480,11 @@ public class JobDbModel implements Copyable<JobDbModel> {
 
     public Builder errorMessage(final String errorMessage) {
       this.errorMessage = errorMessage;
+      return this;
+    }
+
+    public Builder truncateErrorMessage(final int sizeLimit, final Integer byteLimit) {
+      errorMessage = doTruncateErrorMessage(jobKey, errorMessage, sizeLimit, byteLimit);
       return this;
     }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -75,6 +75,9 @@ public class JobWriter extends ProcessInstanceDependant implements RdbmsWriter {
                     .hasFailedWithRetriesLeft(job.hasFailedWithRetriesLeft())
                     .errorCode(job.errorCode())
                     .errorMessage(job.errorMessage())
+                    .truncateErrorMessage(
+                        vendorDatabaseProperties.errorMessageSize(),
+                        vendorDatabaseProperties.charColumnMaxBytes())
                     .customHeaders(job.customHeaders())
                     .deadline(job.deadline())
                     .endTime(job.endTime())
@@ -96,7 +99,9 @@ public class JobWriter extends ProcessInstanceDependant implements RdbmsWriter {
               WriteStatementType.UPDATE,
               job.jobKey(),
               "io.camunda.db.rdbms.sql.JobMapper.update",
-              job));
+              job.truncateErrorMessage(
+                  vendorDatabaseProperties.errorMessageSize(),
+                  vendorDatabaseProperties.charColumnMaxBytes())));
     }
   }
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/JobWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/JobWriterTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -23,8 +24,10 @@ import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.QueueItemMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class JobWriterTest {
 
@@ -53,6 +56,7 @@ class JobWriterTest {
 
     writer.create(model);
 
+    verify(model).truncateErrorMessage(anyInt(), anyInt());
     verify(executionQueue)
         .executeInQueue(
             eq(
@@ -84,13 +88,21 @@ class JobWriterTest {
 
   @Test
   void shouldUpdateJobWhenNotMerged() {
+    // given
+    when(vendorDatabaseProperties.errorMessageSize()).thenReturn(5000);
+    when(vendorDatabaseProperties.charColumnMaxBytes()).thenReturn(20000);
     when(executionQueue.tryMergeWithExistingQueueItem(any())).thenReturn(false);
 
     final var model = mock(JobDbModel.class);
+    final var truncatedModel = mock(JobDbModel.class);
+    when(model.truncateErrorMessage(anyInt(), anyInt())).thenReturn(truncatedModel);
     when(model.jobKey()).thenReturn(123L);
 
+    // when
     writer.update(model);
 
+    // then
+    verify(model).truncateErrorMessage(anyInt(), anyInt());
     verify(executionQueue)
         .executeInQueue(
             eq(
@@ -99,7 +111,41 @@ class JobWriterTest {
                     WriteStatementType.UPDATE,
                     123L,
                     "io.camunda.db.rdbms.sql.JobMapper.update",
-                    model)));
+                    truncatedModel)));
+  }
+
+  @Test
+  void shouldTruncateErrorMessageInBuilderWhenMergingUpdate() {
+    // given
+    when(vendorDatabaseProperties.errorMessageSize()).thenReturn(5);
+    when(vendorDatabaseProperties.charColumnMaxBytes()).thenReturn(null);
+    when(executionQueue.tryMergeWithExistingQueueItem(any())).thenReturn(true);
+
+    final var longErrorMessage = "this message is way too long";
+    final var job = new JobDbModel.Builder().jobKey(123L).errorMessage(longErrorMessage).build();
+
+    // when
+    writer.update(job);
+
+    // then — capture the merger and apply it to a queue item to verify builder-based truncation
+    final var mergerCaptor = ArgumentCaptor.forClass(QueueItemMerger.class);
+    verify(executionQueue).tryMergeWithExistingQueueItem(mergerCaptor.capture());
+
+    final var existingJob = new JobDbModel.Builder().jobKey(123L).build();
+    final var existingQueueItem =
+        new QueueItem(
+            ContextType.JOB,
+            WriteStatementType.INSERT,
+            -1L,
+            "io.camunda.db.rdbms.sql.JobMapper.insert",
+            new BatchInsertDto<>(existingJob));
+
+    final var mergedItem = mergerCaptor.getValue().merge(existingQueueItem);
+
+    @SuppressWarnings("unchecked")
+    final var mergedJob =
+        ((BatchInsertDto<JobDbModel>) mergedItem.parameter()).dbModels().getFirst();
+    assertThat(mergedJob.errorMessage()).isEqualTo("this ");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
@@ -78,6 +78,27 @@ public class JobIT {
   }
 
   @TestTemplate
+  public void shouldSaveUpdateAndFindJobWithLargeErrorMessageByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final JobDbReader jobReader = rdbmsService.getJobReader();
+
+    final var errorMessage = "x".repeat(9000);
+
+    final var original = JobFixtures.createRandomized(b -> b);
+    createAndSaveJob(rdbmsWriters, original);
+    final var update = original.copy(b -> ((JobDbModel.Builder) b).errorMessage(errorMessage));
+    rdbmsWriters.getJobWriter().update(update);
+    rdbmsWriters.flush();
+
+    final var instance = jobReader.findOne(original.jobKey()).orElse(null);
+
+    assertThat(instance).isNotNull();
+    assertThat(instance.errorMessage().length()).isLessThan(errorMessage.length());
+  }
+
+  @TestTemplate
   public void shouldFindJobByProcessDefinitionId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();


### PR DESCRIPTION
# Description
Backport of #49255 to `stable/8.9`.

relates to #49254