### PR TITLE
[Backport stable/8.9] fix: ignore jobToUserTaskMigration for old index templates <8.9

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -57,7 +57,9 @@ final class BulkIndexRequest {
           .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(IncidentRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
-          .addMixIn(JobRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(
+              JobRecordValue.class,
+              IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(
               ProcessInstanceRecordValue.class,
@@ -92,9 +94,9 @@ final class BulkIndexRequest {
       "processDefinitionKey";
   private static final String PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY =
       "moveInstructions";
-  private static final String TERMINATE_INSTRUCTIONS_ELEMENT_ID_PROPERTY = "elementId";
   private static final String ROOT_PROCESS_INSTANCE_KEY_PROPERTY = "rootProcessInstanceKey";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
+  private static final String JOB_TO_USER_TASK_MIGRATION_PROPERTY = "jobToUserTaskMigration";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -236,6 +238,9 @@ final class BulkIndexRequest {
 
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, BUSINESS_ID_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyAndBusinessIdMixin {}
+
+  @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
+  private static final class IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.exporter.BulkIndexRequest.IndexOperation;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
@@ -756,6 +757,58 @@ final class BulkIndexRequestTest {
           .extracting(source -> ((Map<String, Object>) source).get("rootProcessInstanceKey"))
           .describedAs("Expect that the records are serialized with rootProcessInstanceKey")
           .containsExactly(rootProcessInstanceKey);
+    }
+
+    @Test
+    void shouldIndexJobRecordWithoutJobToUserTaskMigrationOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobRecord().setType("test-job").setIsJobToUserTaskMigration(true)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobToUserTaskMigration"))
+          .describedAs(
+              "Expect that job records are serialized without jobToUserTaskMigration on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithJobToUserTaskMigration() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobRecord().setType("test-job").setIsJobToUserTaskMigration(true)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobToUserTaskMigration"))
+          .describedAs(
+              "Expect that job records are serialized with jobToUserTaskMigration on current version")
+          .containsExactly(true);
     }
 
     private static long getRootProcessInstanceKey(final RecordValue recordValue) throws Exception {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -64,7 +64,9 @@ final class BulkIndexRequest {
           .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(IncidentRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
-          .addMixIn(JobRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(
+              JobRecordValue.class,
+              IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(
               ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
@@ -101,6 +103,7 @@ final class BulkIndexRequest {
       "moveInstructions";
   private static final String ROOT_PROCESS_INSTANCE_KEY_PROPERTY = "rootProcessInstanceKey";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
+  private static final String JOB_TO_USER_TASK_MIGRATION_PROPERTY = "jobToUserTaskMigration";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -258,6 +261,9 @@ final class BulkIndexRequest {
 
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, BUSINESS_ID_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyAndBusinessIdMixin {}
+
+  @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
+  private static final class IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
@@ -700,6 +701,56 @@ final class BulkIndexRequestTest {
       assertThat(value.get("rootProcessInstanceKey"))
           .describedAs("Expect that the records are serialized with rootProcessInstanceKey")
           .isEqualTo(rootProcessInstanceKey);
+    }
+
+    @Test
+    void shouldIndexJobRecordWithoutJobToUserTaskMigrationOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobRecord().setType("test-job").setIsJobToUserTaskMigration(true)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("jobToUserTaskMigration"))
+          .describedAs(
+              "Expect that job records are serialized without jobToUserTaskMigration on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexJobRecordWithJobToUserTaskMigration() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobRecord().setType("test-job").setIsJobToUserTaskMigration(true)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("jobToUserTaskMigration"))
+          .describedAs(
+              "Expect that job records are serialized with jobToUserTaskMigration on current version")
+          .isEqualTo(true);
     }
 
     private static long getRootProcessInstanceKey(final RecordValue recordValue) throws Exception {


### PR DESCRIPTION
# Description
Backport of #49281 to `stable/8.9`.

relates to 