### PR TITLE
[Backport stable/8.8] fix: prevent NPE in deployment parse errors while preserving cause-based messages

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -99,13 +99,19 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
       final var failureMessage =
           String.format(
               "Failed to parse form JSON. '%s': %s",
-              resource.getResourceName(), e.getCause().getMessage());
+              resource.getResourceName(), getFailureExceptionMessage(e));
       return Either.left(new Failure(failureMessage));
     } catch (final IOException e) {
       final var failureMessage =
-          String.format("'%s': %s", resource.getResourceName(), e.getCause().getMessage());
+          String.format("'%s': %s", resource.getResourceName(), getFailureExceptionMessage(e));
       return Either.left(new Failure(failureMessage));
     }
+  }
+
+  private static String getFailureExceptionMessage(final Exception exception) {
+    return Optional.ofNullable(exception.getCause())
+        .map(Throwable::getMessage)
+        .orElse(exception.getMessage());
   }
 
   private Either<Failure, ?> checkForDuplicateFormId(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/RpaTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/RpaTransformer.java
@@ -154,13 +154,19 @@ public class RpaTransformer implements DeploymentResourceTransformer {
       final var failureMessage =
           String.format(
               "Failed to parse resource JSON. '%s': %s",
-              resource.getResourceName(), e.getCause().getMessage());
+              resource.getResourceName(), getFailureExceptionMessage(e));
       return Either.left(new Failure(failureMessage));
     } catch (final IOException e) {
       final var failureMessage =
-          String.format("'%s': %s", resource.getResourceName(), e.getCause().getMessage());
+          String.format("'%s': %s", resource.getResourceName(), getFailureExceptionMessage(e));
       return Either.left(new Failure(failureMessage));
     }
+  }
+
+  private static String getFailureExceptionMessage(final Exception exception) {
+    return Optional.ofNullable(exception.getCause())
+        .map(Throwable::getMessage)
+        .orElse(exception.getMessage());
   }
 
   private Either<Failure, Resource> validateResource(final Resource res) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/FormDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/FormDeploymentTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.junit.Rule;
@@ -365,6 +366,29 @@ public class FormDeploymentTest {
     assertThat(formMetadata2.getChecksum())
         .describedAs("Expect the MD5 checksum of the DMN resource")
         .isEqualTo(getChecksum(TEST_FORM_2));
+  }
+
+  @Test
+  public void shouldRejectWhenFormJsonIsMalformed() {
+    // given
+    final byte[] malformedJson = "{not valid json".getBytes(StandardCharsets.UTF_8);
+
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withJsonResource(malformedJson, "malformed.form")
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains("Failed to parse form JSON. 'malformed.form':");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.Resource;
 import io.camunda.zeebe.protocol.record.value.deployment.ResourceMetadataValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.junit.Rule;
@@ -132,6 +133,29 @@ public class ResourceDeploymentTest {
 
     assertThat(deploymentEvent.getRejectionReason())
         .contains(String.format("Expected the resource id to be filled, but it is blank"));
+  }
+
+  @Test
+  public void shouldRejectWhenResourceJsonIsMalformed() {
+    // given
+    final byte[] malformedJson = "{not valid json".getBytes(StandardCharsets.UTF_8);
+
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withJsonResource(malformedJson, "malformed.rpa")
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains("Failed to parse resource JSON. 'malformed.rpa':");
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #48916 to `stable/8.8`.

relates to #26640 camunda/camunda#26640