### PR TITLE
[Backport stable/8.9] Tenant role api tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-role-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-role-api-tests.spec.ts
@@ -10,11 +10,9 @@ import {test, expect} from '@playwright/test';
 import {
   jsonHeaders,
   buildUrl,
-  assertRequiredFields,
   assertUnauthorizedRequest,
   assertNotFoundRequest,
   assertConflictRequest,
-  paginatedResponseFields,
   assertPaginatedRequest,
   assertStatusCode,
 } from '../../../../utils/http';
@@ -165,12 +163,12 @@ test.describe.parallel('Tenant Roles API Tests', () => {
 
         await assertStatusCode(res, 200);
         await validateResponse(
-            {
-                path: '/tenants/{tenantId}/roles/search',
-                method: 'POST',
-                status: '200',
-            },
-            res,
+          {
+            path: '/tenants/{tenantId}/roles/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
         );
         const json = await res.json();
         expect(json.page.totalItems).toBe(0);
@@ -297,7 +295,9 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  test('Search Tenant Roles Tenant - Not Found (empty response)', async ({request}) => {
+  test('Search Tenant Roles Tenant - Not Found (empty response)', async ({
+    request,
+  }) => {
     const p = {tenantId: 'invalid-tenant-id'};
     const res = await request.post(
       buildUrl('/tenants/{tenantId}/roles/search', p),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-role-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-role-api-tests.spec.ts
@@ -27,7 +27,7 @@ import {
   roleIdValueUsingKey,
 } from '@requestHelpers';
 import {ROLES_EXPECTED_BODY} from '../../../../utils/beans/requestBeans';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Tenant Roles API Tests', () => {
@@ -42,7 +42,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     await assignRolesToTenant(request, 3, 'tenantId3', state);
   });
 
-  test('Assign Role To Tenant', async ({request}) => {
+  test('Assign Role To Tenant - Success', async ({request}) => {
     const roleBody = await createRole(request);
     const p = {
       roleId: roleBody.roleId as string,
@@ -60,7 +60,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Assign Role To Tenant Non Existent Role Not Found', async ({
+  test('Assign Role To Tenant Non Existent Role - Not Found', async ({
     request,
   }) => {
     const stateParams: Record<string, string> = {
@@ -80,7 +80,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     );
   });
 
-  test('Assign Role To Tenant Non Existent Tenant Not Found', async ({
+  test('Assign Role To Tenant Non Existent Tenant - Not Found', async ({
     request,
   }) => {
     const stateParams: Record<string, string> = {
@@ -100,7 +100,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     );
   });
 
-  test('Assign Role To Tenant Unauthorized', async ({request}) => {
+  test('Assign Role To Tenant - Unauthorized', async ({request}) => {
     const stateParams: Record<string, string> = {
       roleId: roleIdValueUsingKey('tenantId1', state) as string,
       tenantId: state['tenantId1'] as string,
@@ -117,7 +117,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Assign Already Added Role To Tenant Conflict', async ({request}) => {
+  test('Assign Already Added Role To Tenant - Conflict', async ({request}) => {
     const stateParams: Record<string, string> = {
       roleId: roleIdValueUsingKey('tenantId1', state) as string,
       tenantId: state['tenantId1'] as string,
@@ -135,11 +135,12 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Unassign Role From Tenant', async ({request}) => {
+  test('Unassign Role From Tenant - Success', async ({request}) => {
     const p = {
       roleId: roleIdValueUsingKey('tenantId2', state) as string,
       tenantId: state['tenantId2'] as string,
     };
+
     await test.step('Unassign Role From Tenant', async () => {
       await expect(async () => {
         const res = await request.delete(
@@ -152,28 +153,32 @@ test.describe.parallel('Tenant Roles API Tests', () => {
       }).toPass(defaultAssertionOptions);
     });
 
-    await test.step(
-      'Search Tenant Roles After Deletion',
-      async () => {
-        await expect(async () => {
-          const res = await request.post(
-            buildUrl('/tenants/{tenantId}/roles/search', p),
-            {
-              headers: jsonHeaders(),
-              data: {},
-            },
-          );
+    await test.step('Search Tenant Roles After Deletion', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/tenants/{tenantId}/roles/search', p),
+          {
+            headers: jsonHeaders(),
+            data: {},
+          },
+        );
 
-          await assertStatusCode(res, 200);
-          const json = await res.json();
-          assertRequiredFields(json, paginatedResponseFields);
-          expect(json.page.totalItems).toBe(0);
-        }).toPass(defaultAssertionOptions);
-      },
-    );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+            {
+                path: '/tenants/{tenantId}/roles/search',
+                method: 'POST',
+                status: '200',
+            },
+            res,
+        );
+        const json = await res.json();
+        expect(json.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
   });
 
-  test('Unassign Role From Tenant Unauthorized', async ({request}) => {
+  test('Unassign Role From Tenant - Unauthorized', async ({request}) => {
     const p = {
       roleId: roleIdValueUsingKey('tenantId2', state) as string,
       tenantId: state['tenantId2'] as string,
@@ -187,7 +192,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  test('Unassign Role From Tenant Non Existent Role Not Found', async ({
+  test('Unassign Role From Tenant Non Existent Role - Not Found', async ({
     request,
   }) => {
     const p = {
@@ -206,7 +211,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     );
   });
 
-  test('Unassign Role From Tenant Non Existent Tenant Not Found', async ({
+  test('Unassign Role From Tenant Non Existent Tenant - Not Found', async ({
     request,
   }) => {
     const p = {
@@ -242,14 +247,14 @@ test.describe.parallel('Tenant Roles API Tests', () => {
       });
       const json = await res.json();
       await assertStatusCode(res, 200);
-    await validateResponse(
+      await validateResponse(
         {
-            path: '/tenants/{tenantId}/roles/search',
-            method: 'POST',
-            status: '200',
+          path: '/tenants/{tenantId}/roles/search',
+          method: 'POST',
+          status: '200',
         },
         res,
-    );
+      );
       assertRolesInResponse(json, ROLES_EXPECTED_BODY(role1), role1);
       assertRolesInResponse(json, ROLES_EXPECTED_BODY(role2), role2);
       assertRolesInResponse(json, ROLES_EXPECTED_BODY(role3), role3);
@@ -268,14 +273,14 @@ test.describe.parallel('Tenant Roles API Tests', () => {
         {headers: jsonHeaders(), data: {}},
       );
       await assertStatusCode(res, 200);
-    await validateResponse(
+      await validateResponse(
         {
-            path: '/tenants/{tenantId}/roles/search',
-            method: 'POST',
-            status: '200',
+          path: '/tenants/{tenantId}/roles/search',
+          method: 'POST',
+          status: '200',
         },
         res,
-    );
+      );
       await assertPaginatedRequest(res, {
         itemsLengthEqualTo: 0,
         totalItemsEqualTo: 0,
@@ -283,7 +288,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Tenant Roles Unauthorized', async ({request}) => {
+  test('Search Tenant Roles - Unauthorized', async ({request}) => {
     const p = {tenantId: state['tenantId3'] as string};
     const res = await request.post(
       buildUrl('/tenants/{tenantId}/roles/search', p),
@@ -292,7 +297,7 @@ test.describe.parallel('Tenant Roles API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  test('Search Tenant Roles Tenant Not Found', async ({request}) => {
+  test('Search Tenant Roles Tenant - Not Found (empty response)', async ({request}) => {
     const p = {tenantId: 'invalid-tenant-id'};
     const res = await request.post(
       buildUrl('/tenants/{tenantId}/roles/search', p),
@@ -301,12 +306,12 @@ test.describe.parallel('Tenant Roles API Tests', () => {
 
     await assertStatusCode(res, 200);
     await validateResponse(
-        {
-            path: '/tenants/{tenantId}/roles/search',
-            method: 'POST',
-            status: '200',
-        },
-        res,
+      {
+        path: '/tenants/{tenantId}/roles/search',
+        method: 'POST',
+        status: '200',
+      },
+      res,
     );
     await assertPaginatedRequest(res, {
       itemsLengthEqualTo: 0,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-role-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-role-api-tests.spec.ts
@@ -1,0 +1,316 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  paginatedResponseFields,
+  assertPaginatedRequest,
+  assertStatusCode,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assertRolesInResponse,
+  assignRolesToTenant,
+  createRole,
+  createTenant,
+  roleIdValueUsingKey,
+} from '@requestHelpers';
+import {ROLES_EXPECTED_BODY} from '../../../../utils/beans/requestBeans';
+import { validateResponse } from 'json-body-assertions';
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel('Tenant Roles API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createTenant(request, state, '1');
+    await createTenant(request, state, '2');
+    await createTenant(request, state, '3');
+    await assignRolesToTenant(request, 2, 'tenantId1', state);
+    await assignRolesToTenant(request, 1, 'tenantId2', state);
+    await assignRolesToTenant(request, 3, 'tenantId3', state);
+  });
+
+  test('Assign Role To Tenant', async ({request}) => {
+    const roleBody = await createRole(request);
+    const p = {
+      roleId: roleBody.roleId as string,
+      tenantId: state['tenantId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/roles/{roleId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(res, 204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Role To Tenant Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      roleId: 'invalidRoleId',
+      tenantId: state['tenantId1'] as string,
+    };
+
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/roles/{roleId}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To Tenant Non Existent Tenant Not Found', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      roleId: roleIdValueUsingKey('tenantId1', state) as string,
+      tenantId: 'invalidTenantId',
+    };
+
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/roles/{roleId}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To Tenant Unauthorized', async ({request}) => {
+    const stateParams: Record<string, string> = {
+      roleId: roleIdValueUsingKey('tenantId1', state) as string,
+      tenantId: state['tenantId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/roles/{roleId}', stateParams),
+        {
+          headers: {},
+        },
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Role To Tenant Conflict', async ({request}) => {
+    const stateParams: Record<string, string> = {
+      roleId: roleIdValueUsingKey('tenantId1', state) as string,
+      tenantId: state['tenantId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/roles/{roleId}', stateParams),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Unassign Role From Tenant', async ({request}) => {
+    const p = {
+      roleId: roleIdValueUsingKey('tenantId2', state) as string,
+      tenantId: state['tenantId2'] as string,
+    };
+    await test.step('Unassign Role From Tenant', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/tenants/{tenantId}/roles/{roleId}', p),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(res, 204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step(
+      'Search Tenant Roles After Deletion',
+      async () => {
+        await expect(async () => {
+          const res = await request.post(
+            buildUrl('/tenants/{tenantId}/roles/search', p),
+            {
+              headers: jsonHeaders(),
+              data: {},
+            },
+          );
+
+          await assertStatusCode(res, 200);
+          const json = await res.json();
+          assertRequiredFields(json, paginatedResponseFields);
+          expect(json.page.totalItems).toBe(0);
+        }).toPass(defaultAssertionOptions);
+      },
+    );
+  });
+
+  test('Unassign Role From Tenant Unauthorized', async ({request}) => {
+    const p = {
+      roleId: roleIdValueUsingKey('tenantId2', state) as string,
+      tenantId: state['tenantId2'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/roles/{roleId}', p),
+      {
+        headers: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From Tenant Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: 'invalidRoleId',
+      tenantId: state['tenantId2'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/roles/{roleId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From Tenant Non Existent Tenant Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: roleIdValueUsingKey('tenantId2', state) as string,
+      tenantId: 'invalidTenantId',
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/roles/{roleId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Search Tenant Roles', async ({request}) => {
+    const p = {tenantId: state['tenantId3'] as string};
+    const role1 = roleIdValueUsingKey('tenantId3', state, 1);
+    const role2 = roleIdValueUsingKey('tenantId3', state, 2);
+    const role3 = roleIdValueUsingKey('tenantId3', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/tenants/{tenantId}/roles/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 3,
+        totalItemsEqualTo: 3,
+      });
+      const json = await res.json();
+      await assertStatusCode(res, 200);
+    await validateResponse(
+        {
+            path: '/tenants/{tenantId}/roles/search',
+            method: 'POST',
+            status: '200',
+        },
+        res,
+    );
+      assertRolesInResponse(json, ROLES_EXPECTED_BODY(role1), role1);
+      assertRolesInResponse(json, ROLES_EXPECTED_BODY(role2), role2);
+      assertRolesInResponse(json, ROLES_EXPECTED_BODY(role3), role3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenant Roles Tenant With No Assignments Returns Empty', async ({
+    request,
+  }) => {
+    const tenant = await createTenant(request);
+    const p = {tenantId: tenant.tenantId as string};
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/tenants/{tenantId}/roles/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertStatusCode(res, 200);
+    await validateResponse(
+        {
+            path: '/tenants/{tenantId}/roles/search',
+            method: 'POST',
+            status: '200',
+        },
+        res,
+    );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenant Roles Unauthorized', async ({request}) => {
+    const p = {tenantId: state['tenantId3'] as string};
+    const res = await request.post(
+      buildUrl('/tenants/{tenantId}/roles/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Tenant Roles Tenant Not Found', async ({request}) => {
+    const p = {tenantId: 'invalid-tenant-id'};
+    const res = await request.post(
+      buildUrl('/tenants/{tenantId}/roles/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+
+    await assertStatusCode(res, 200);
+    await validateResponse(
+        {
+            path: '/tenants/{tenantId}/roles/search',
+            method: 'POST',
+            status: '200',
+        },
+        res,
+    );
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -653,6 +653,12 @@ export function GROUPS_EXPECTED_BODY(groupId: string) {
   };
 }
 
+export function ROLES_EXPECTED_BODY(roleId: string) {
+  return {
+    roleId: roleId,
+  };
+}
+
 export function CREATE_COMPONENT_AUTHORIZATION(
   ownerType: 'ROLE' | 'USER' | 'GROUP',
   ownerId: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -18,6 +18,8 @@ export {assignRolesToMappingRules} from './role-requestHelpers';
 export {createMappingRule} from './role-requestHelpers';
 export {createTenantAndStoreResponseFields} from './tenant-requestHelpers';
 export {assignGroupsToTenant} from './tenant-requestHelpers';
+export {assignRolesToTenant} from './tenant-requestHelpers';
+export {assertRolesInResponse} from './tenant-requestHelpers';
 export {createTenant} from './tenant-requestHelpers';
 export {assignClientsToTenant} from './tenant-requestHelpers';
 export {assignUsersToTenant} from './tenant-requestHelpers';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
@@ -7,7 +7,10 @@
  */
 
 import type {APIRequestContext} from 'playwright-core';
-import {groupIdFromState} from './get-value-from-state-requestHelpers';
+import {
+  groupIdFromState,
+  roleIdValueUsingKey,
+} from './get-value-from-state-requestHelpers';
 import {
   assertEqualsForKeys,
   assertRequiredFields,
@@ -17,11 +20,18 @@ import {
 } from '../http';
 import {expect} from '@playwright/test';
 import {generateUniqueId} from '../constants';
-import {CREATE_NEW_TENANT, tenantRequiredFields} from '../beans/requestBeans';
+import {
+  CREATE_NEW_TENANT,
+  roleRequiredFields,
+  tenantRequiredFields,
+} from '../beans/requestBeans';
 import {Serializable} from 'playwright-core/types/structs';
-import {createGroupAndStoreResponseFields} from './group-requestHelpers';
-import {createUser} from './user-requestHelpers';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
+import {
+  createUser,
+  createRole,
+  createGroupAndStoreResponseFields,
+} from '@requestHelpers'
 
 export async function assignUsersToTenant(
   request: APIRequestContext,
@@ -132,6 +142,42 @@ export async function assignGroupsToTenant(
     await assertStatusCode(res, 204);
   }
 }
+export async function assignRolesToTenant(
+  request: APIRequestContext,
+  numberOfRoles: number,
+  tenantIdKey: string,
+  state: Record<string, unknown>,
+) {
+  const tenantId = state[tenantIdKey] as string;
+  for (let i = 1; i <= numberOfRoles; i++) {
+    await createRole(request, state, `${tenantId}${i}`);
+    const p = {
+      roleId: roleIdValueUsingKey(tenantIdKey, state, i) as string,
+      tenantId: tenantId as string,
+    };
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/roles/{roleId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertStatusCode(res, 204);
+  }
+}
+
+export function assertRolesInResponse(
+  json: Serializable,
+  expectedBody: Serializable,
+  roleId: string,
+) {
+  const matchingItem = json.items.find(
+    (it: {roleId: string}) => it.roleId === roleId,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, roleRequiredFields);
+  assertEqualsForKeys(matchingItem, expectedBody, ['roleId']);
+}
+
 export function assertTenantInResponse(
   json: Serializable,
   expectedBody: Serializable,


### PR DESCRIPTION
## Description
Backport of #48794 to `stable/8.9`.

## related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/62)
## On demand workflow
[Was all green on API](https://github.com/camunda/camunda/actions/runs/23482252963)