### PR TITLE
[Backport stable/8.9] test(qa): stabilize Operate process instance key lookup

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -566,11 +566,23 @@ class OperateProcessInstancePage {
   }
 
   async getProcessInstanceKey(): Promise<string> {
-    const processInstanceKey = this.page
-      .getByTestId('instance-header')
-      .locator('table tbody tr td')
-      .nth(1);
-    return (await processInstanceKey.textContent()) ?? '';
+    const table = this.page.getByTestId('instance-header').locator('table');
+    const headers = await table.locator('thead tr th').allTextContents();
+    const keyColumnIndex = headers.findIndex((header) =>
+      /process\s+instance\s+key/i.test(header.trim()),
+    );
+
+    if (keyColumnIndex === -1) {
+      throw new Error('Could not find Process Instance Key column in header');
+    }
+
+    const keyCell = table
+      .locator('tbody tr')
+      .first()
+      .locator('td')
+      .nth(keyColumnIndex);
+    await expect(keyCell).toBeVisible();
+    return (await keyCell.textContent())?.trim() ?? '';
   }
 
   async gotoProcessInstancePage({id}: {id: string}): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -90,7 +90,7 @@ test.describe('Process Instance Variables', () => {
     });
   });
 
-  test.skip('Add variables', async ({
+  test('Add variables', async ({
     page,
     operateProcessInstancePage,
     operateHomePage,


### PR DESCRIPTION
# Description
Backport of #49218 to `stable/8.9`.


[Test run](https://github.com/camunda/camunda/actions/runs/23449644713)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later

relates to #49095