### PR TITLE
[Backport stable/8.9] test: fix Operate modification locator and re-enable specs

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -200,7 +200,9 @@ class OperateProcessInstancePage {
         name: /process instance/i,
       });
     this.metadataModal = this.page.getByRole('dialog', {name: 'metadata'});
-    this.modifyInstanceButton = page.getByTestId('enter-modification-mode');
+    this.modifyInstanceButton = this.instanceHeader.getByRole('button', {
+      name: /modify instance/i,
+    });
     this.modifyDialog = this.page.getByLabel(
       'Process Instance Modification Mode',
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -16,22 +16,16 @@ import {
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
-import {defaultAssertionOptions} from 'utils/constants';
 
 type ProcessInstance = {processInstanceKey: number};
 
 let incidentProcessInstance: ProcessInstance;
 let embeddedSubprocessInstance: ProcessInstance;
 
-const startEventStartGlobal = 'StartGlobal';
 const activityNode = 'Node';
 const activityFirstSubprocess = 'FirstSubprocess';
-const eventStartFirstSubProcess = 'StartFirstSubProcess';
 const activityCollectMoney = 'CollectMoney';
-const activityFetchItems = 'FetchItems';
 const eventEndFirstSubProcess = 'EndFirstSubProcess';
-const eventOrderCancelled = 'OrderCanceled';
-const eventOrderCancelledEnd = 'OrderCancelledEnd';
 const activitySecondSubprocess = 'SecondSubprocess';
 const eventStartSecondSubProcess = 'StartSecondSubProcess';
 const activitySendItems = 'SendItems';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -102,8 +102,7 @@ test.describe('Process Instance Modifications', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // skipped due to bug 41143: https://github.com/camunda/camunda/issues/41143
-  test.skip('Should apply/remove edit variable modifications', async ({
+  test('Should apply/remove edit variable modifications', async ({
     operateProcessInstancePage,
     operateProcessInstanceViewModificationModePage,
   }) => {
@@ -224,13 +223,12 @@ test.describe('Process Instance Modifications', () => {
         operateProcessInstancePage.getVariableTestId('foo'),
       ).toBeVisible();
 
-      // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
-      // await expect(
-      //   operateProcessInstancePage.getEditVariableFieldSelector('test'),
-      // ).toHaveValue('123');
-      // await expect(
-      //   operateProcessInstancePage.getEditVariableFieldSelector('foo'),
-      // ).toHaveValue('1');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('test'),
+      ).toHaveValue('123');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('1');
     });
 
     await test.step('Undo again and verify all modifications removed', async () => {
@@ -296,7 +294,7 @@ test.describe('Process Instance Modifications', () => {
     });
   });
 
-  test.skip('Verify Variables functionality in Modification mode', async ({
+  test('Verify Variables functionality in Modification mode', async ({
     operateProcessInstancePage,
     page,
     operateProcessInstanceViewModificationModePage,
@@ -650,10 +648,7 @@ test.describe('Process Instance Modifications', () => {
     });
   });
 
-  // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
-  // !Note: assert the code after the bug is fixed as it was discoverd during the test implementation
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip('Should apply/remove add variable modifications', async ({
+  test('Should apply/remove add variable modifications', async ({
     page,
     operateProcessInstancePage,
     operateProcessInstanceViewModificationModePage,
@@ -803,10 +798,9 @@ test.describe('Process Instance Modifications', () => {
     await test.step('Undo again and verify new variable field removed', async () => {
       await operateProcessInstancePage.undoModification();
 
-      // here might be needed change from hidden to add token operation
       await expect(
         operateProcessInstancePage.lastAddedModificationText,
-      ).toBeHidden();
+      ).toBeVisible();
       await expect(
         operateProcessInstancePage.getVariableTestId('newVariables[0]'),
       ).toBeHidden();
@@ -822,7 +816,7 @@ test.describe('Process Instance Modifications', () => {
       const addedTokenInHistory = `${neverFailsHistoryItem}, this element instance is planned to be added`;
       await operateProcessInstancePage.clickTreeItem(addedTokenInHistory);
       await expect(
-        page.getByText(/The Flow Node has no Variables/i),
+        page.getByText(/The element has no Variables/i),
       ).toBeVisible();
 
       await operateProcessInstancePage.addNewVariableModificationMode(


### PR DESCRIPTION
# Description
Backport of #49221 to `stable/8.9`.

[Test run](https://github.com/camunda/camunda/actions/runs/23479506944)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later
relates to camunda/camunda#49095 camunda/camunda#49234