### PR TITLE
[Backport stable/8.9] test: stabilize operate listeners assertions for new UI

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -159,7 +159,9 @@ class OperateProcessInstancePage {
     this.executionCountToggleOff = this.instanceHistory.getByLabel(
       'hide execution count',
     );
-    this.listenersTabButton = page.getByTestId('listeners-tab-button');
+    this.listenersTabButton = page
+      .getByLabel('Process Instance Bottom Panel Tabs')
+      .getByRole('link', {name: /^Listeners$/i});
     this.operationsLogTabButton = page.getByRole('tab', {
       name: /^Operations Log$/i,
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -202,7 +202,9 @@ class OperateProcessInstancePage {
         name: /process instance/i,
       });
     this.metadataModal = this.page.getByRole('dialog', {name: 'metadata'});
-    this.modifyInstanceButton = page.getByTestId('enter-modification-mode');
+    this.modifyInstanceButton = this.instanceHeader.getByRole('button', {
+      name: /modify instance/i,
+    });
     this.modifyDialog = this.page.getByLabel(
       'Process Instance Modification Mode',
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -54,7 +54,7 @@ test.beforeAll(async () => {
   await sleep(3000);
 });
 
-test.describe.skip('Process Instance Listeners', () => {
+test.describe('Process Instance Listeners', () => {
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
@@ -221,10 +221,20 @@ test.describe.skip('Process Instance Listeners', () => {
       const completeRes = await completeUserTask(request, userTaskKey);
       expect(completeRes.status()).toBe(204);
 
-      await expect(operateProcessInstancePage.stateOverlayActive).toBeHidden();
-      await expect(
-        operateProcessInstancePage.stateOverlayCompletedEndEvents,
-      ).toBeVisible();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.stateOverlayActive,
+          ).toBeHidden();
+          await expect(
+            operateProcessInstancePage.stateOverlayCompletedEndEvents,
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
       await sleep(1000);
       await operateProcessInstancePage.clickInstanceHistoryElement(
         'Service Task B',


### PR DESCRIPTION
# Description
Backport of #49256 to `stable/8.9`.

[Test run](https://github.com/camunda/camunda/actions/runs/23479740876)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later

relates to #49232