### PR TITLE
[Backport stable/8.9] Fix: update process instance history and process Instance Incidents tests to match new UI updates

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -26,7 +26,8 @@ class OperateProcessInstancePage {
   readonly incidentsTable: Locator;
   readonly incidentsTableOperationSpinner: Locator;
   readonly incidentsTableRows: Locator;
-  readonly incidentsBanner: Locator;
+  readonly incidentsTab: Locator;
+  readonly incidentsViewHeader: Locator;
   readonly variablePanelEmptyText: Locator;
   readonly addVariableButton: Locator;
   readonly saveVariableButton: Locator;
@@ -38,6 +39,8 @@ class OperateProcessInstancePage {
   readonly executionCountToggleOn: Locator;
   readonly executionCountToggleOff: Locator;
   readonly listenersTabButton: Locator;
+  readonly detailsTabButton: Locator;
+  readonly variablesTabButton: Locator;
   readonly operationsLogTabButton: Locator;
   readonly operationsLogTable: Locator;
   readonly operationsLogTableRow: Locator;
@@ -65,12 +68,11 @@ class OperateProcessInstancePage {
   readonly stateOverlayActive: Locator;
   readonly stateOverlayCompletedEndEvents: Locator;
   readonly cancelInstanceButton: (instanceId: string) => Locator;
-  readonly incidentBannerButton: (count: number) => Locator;
   readonly incidentTypeFilter: Locator;
+  readonly cancellationScheduledToast: Locator;
   readonly executionCountToggle: Locator;
   readonly executionCountToggleLabel: Locator;
   readonly endDateField: Locator;
-  readonly incidentsViewHeader: Locator;
   readonly modificationModeText: Locator;
   readonly lastAddedModificationText: Locator;
   readonly undoModificationButton: Locator;
@@ -139,7 +141,9 @@ class OperateProcessInstancePage {
     this.incidentsTableOperationSpinner =
       this.incidentsTable.getByTestId('operation-spinner');
     this.incidentsTableRows = this.incidentsTable.getByRole('row');
-    this.incidentsBanner = page.getByTestId('incidents-banner');
+    this.incidentsTab = page
+      .getByLabel('Process Instance Bottom Panel Tabs')
+      .getByRole('link', {name: /^Incidents$/i});
     this.incidentIconsInHistory = this.instanceHistory
       .getByRole('treeitem')
       .getByTestId('INCIDENT-icon');
@@ -162,6 +166,12 @@ class OperateProcessInstancePage {
     this.listenersTabButton = page
       .getByLabel('Process Instance Bottom Panel Tabs')
       .getByRole('link', {name: /^Listeners$/i});
+    this.detailsTabButton = page
+      .getByLabel('Process Instance Bottom Panel Tabs')
+      .getByRole('link', {name: /^Details$/i});
+    this.variablesTabButton = page
+      .getByLabel('Process Instance Bottom Panel Tabs')
+      .getByRole('link', {name: /^Variables$/i});
     this.operationsLogTabButton = page.getByRole('link', {
       name: /^Operations Log$/i,
     });
@@ -235,15 +245,16 @@ class OperateProcessInstancePage {
     );
     this.cancelInstanceButton = (instanceId: string) =>
       page.getByRole('button', {name: `Cancel Instance ${instanceId}`});
-    this.incidentBannerButton = (count: number) =>
-      page.getByRole('button', {
-        name: new RegExp(`view ${count} incidents in instance`, 'i'),
-      });
+    this.incidentsViewHeader = page.getByRole('heading', {
+      name: /^\d+\s+results?$/i,
+    });
     this.incidentTypeFilter = page.getByRole('combobox', {
       name: /filter by incident type/i,
     });
+    this.cancellationScheduledToast = page
+      .getByRole('status')
+      .getByText('Instance is scheduled for cancellation');
     this.endDateField = this.instanceHeader.getByTestId('end-date');
-    this.incidentsViewHeader = page.getByText(/incidents\s+-\s+/i);
     this.modificationModeText = page.getByText(
       'Process Instance Modification Mode',
     );
@@ -346,14 +357,6 @@ class OperateProcessInstancePage {
     await expect(errorMessage!).toHaveText(message);
   }
 
-  async connectorResultVariableName(name: string): Promise<Locator> {
-    return this.page.getByTestId(name);
-  }
-
-  async connectorResultVariableValue(variableName: string): Promise<Locator> {
-    return this.page.getByTestId(variableName).locator('td').last();
-  }
-
   private async waitForIconWithRetry(
     icon: Locator,
     iconName: string,
@@ -428,10 +431,6 @@ class OperateProcessInstancePage {
 
   async clickReviewModifications() {
     await this.reviewModificationsButton.click();
-  }
-
-  async clickAddVariable() {
-    await this.addVariableModificationButton.click();
   }
 
   async clickDeleteVariableModification() {
@@ -529,16 +528,6 @@ class OperateProcessInstancePage {
     await this.page.keyboard.press('Tab');
   }
 
-  async navigateToProcessInstance(id: string) {
-    await this.page.goto(`operate/processes/${id}`);
-  }
-
-  async getNthTreeNodeTestId(n: number) {
-    return this.page
-      .getByTestId(/^tree-node-/)
-      .nth(n)
-      .getAttribute('data-testid');
-  }
   async clickEditVariableButton(variableName: string): Promise<void> {
     const editVariableButton = 'Edit variable ' + variableName;
     await this.page.getByLabel(editVariableButton).click();
@@ -571,22 +560,31 @@ class OperateProcessInstancePage {
 
   async getProcessInstanceKey(): Promise<string> {
     const table = this.page.getByTestId('instance-header').locator('table');
+    const firstRow = table.locator('tbody tr').first();
+    await expect(firstRow).toBeVisible();
+
     const headers = await table.locator('thead tr th').allTextContents();
     const keyColumnIndex = headers.findIndex((header) =>
       /process\s+instance\s+key/i.test(header.trim()),
     );
 
-    if (keyColumnIndex === -1) {
-      throw new Error('Could not find Process Instance Key column in header');
+    if (keyColumnIndex !== -1) {
+      const keyCell = firstRow.locator('td').nth(keyColumnIndex);
+      await expect(keyCell).toBeVisible();
+      return (await keyCell.textContent())?.trim() ?? '';
     }
 
-    const keyCell = table
-      .locator('tbody tr')
-      .first()
-      .locator('td')
-      .nth(keyColumnIndex);
-    await expect(keyCell).toBeVisible();
-    return (await keyCell.textContent())?.trim() ?? '';
+    const firstCell = firstRow.locator('td').first();
+    await expect(firstCell).toBeVisible();
+    const fallbackKey = (await firstCell.textContent())?.trim() ?? '';
+
+    if (fallbackKey) {
+      return fallbackKey;
+    }
+
+    throw new Error(
+      'Could not extract Process Instance Key from instance header table',
+    );
   }
 
   async gotoProcessInstancePage({id}: {id: string}): Promise<void> {
@@ -662,6 +660,14 @@ class OperateProcessInstancePage {
 
   async openListenersTab(): Promise<void> {
     await this.listenersTabButton.click();
+  }
+
+  async clickVariablesTab(): Promise<void> {
+    await this.variablesTabButton.click();
+  }
+
+  async clickDetailsTab(): Promise<void> {
+    await this.detailsTabButton.click();
   }
 
   async verifyListenersTabVisible(): Promise<void> {
@@ -746,10 +752,6 @@ class OperateProcessInstancePage {
     await this.applyButton.click();
   }
 
-  async clickIncidentBanner(count: number): Promise<void> {
-    await this.incidentBannerButton(count).click();
-  }
-
   async toggleExecutionCount(): Promise<void> {
     await this.executionCountToggle.waitFor({state: 'visible'});
     if (
@@ -771,8 +773,8 @@ class OperateProcessInstancePage {
     await this.getDiagramElement(elementId).click();
   }
 
-  async getDiagramElementBadge(elementId: string) {
-    return this.page.$(`[data-element-id="${elementId}"] .badge`);
+  async getDiagramElementBadge(elementId: string): Promise<Locator> {
+    return this.getDiagramElement(elementId).locator('.badge');
   }
 
   async verifyExecutionCountBadgesNotVisible(
@@ -780,7 +782,7 @@ class OperateProcessInstancePage {
   ): Promise<void> {
     for (const elementId of elementIds) {
       const badge = await this.getDiagramElementBadge(elementId);
-      expect(badge).toBeNull();
+      await expect(badge).toHaveCount(0);
     }
   }
 
@@ -801,27 +803,41 @@ class OperateProcessInstancePage {
   async clickViewParentInstance(): Promise<void> {
     await this.viewParentInstanceLink.click();
   }
-  async getAllIncidentIconsAmountInHistory(): Promise<number> {
-    return await this.incidentIconsInHistory.count();
+
+  async clickIncidentsTab(): Promise<void> {
+    await this.incidentsTab.click();
   }
 
-  async clickIncidentsBanner(): Promise<void> {
-    await this.incidentsBanner.click();
-  }
+  async getIncidentRowByErrorType(errorType: string) {
+    const parentRows = this.incidentsTable.locator(
+      'tr[data-parent-row="true"]',
+    );
 
-  async getIncidentRowByErrorMessage(errorMessage: string) {
-    return this.incidentsTable.getByRole('row').filter({
+    const exactParentRow = parentRows.filter({
       has: this.page
-        .getByTestId('cell-errorMessage')
-        .filter({hasText: errorMessage}),
+        .getByTestId('cell-errorType')
+        .filter({hasText: new RegExp(`^${errorType}$`, 'i')}),
+    });
+
+    if ((await exactParentRow.count()) > 0) {
+      return exactParentRow.first();
+    }
+
+    const partialParentRow = parentRows.filter({
+      has: this.page.getByTestId('cell-errorType').filter({hasText: errorType}),
+    });
+
+    if ((await partialParentRow.count()) > 0) {
+      return partialParentRow.first();
+    }
+
+    return this.incidentsTable.getByRole('row').filter({
+      has: this.page.getByTestId('cell-errorType').filter({hasText: errorType}),
     });
   }
 
-  async retryIncidentByErrorMessage(errorMessage: string) {
-    const incidentRow = await this.getIncidentRowByErrorMessage(errorMessage);
-    console.log(
-      await incidentRow.getByTestId('cell-flowNodeName').allInnerTexts(),
-    );
+  async retryIncidentByErrorType(errorType: string) {
+    const incidentRow = await this.getIncidentRowByErrorType(errorType);
     const retryButton = incidentRow.getByTestId('retry-operation');
     await retryButton.click();
   }
@@ -832,13 +848,6 @@ class OperateProcessInstancePage {
 
   async clickModifyDialogContinueButton(): Promise<void> {
     await this.modifyDialogContinueButton.click();
-  }
-
-  async getAllInstanceHistoryNodeDetails(): Promise<Locator[]> {
-    return this.instanceHistory
-      .getByRole('treeitem')
-      .getByTestId(/^node-details-/)
-      .all();
   }
 
   async checkIfPresentExpandeingElementsInMainProcess(
@@ -943,12 +952,40 @@ class OperateProcessInstancePage {
     }
   }
 
+  async clickOnElementInDiagram(elementId: string): Promise<void> {
+    await this.clickDiagramElement(elementId);
+  }
+
+  getCalledProcessLink(processName: string): Locator {
+    return this.page.getByRole('link', {name: processName});
+  }
+
+  async clickCalledProcessLink(processName: string): Promise<void> {
+    await this.getCalledProcessLink(processName).click();
+  }
+
   getOperationsLogTableRowCount(): Promise<number> {
     return this.operationsLogTableRow.count();
   }
 
   getOperationsLogTableProcessInstanceCellCount(): Promise<number> {
     return this.operationsLogTableProcessInstanceCell.count();
+  }
+
+  async getIncidentCount(): Promise<number> {
+    await expect(this.incidentsViewHeader).toBeVisible();
+    const headingText = await this.incidentsViewHeader.innerText();
+    if (!headingText) {
+      return 0;
+    }
+
+    const match = headingText.match(/(\d+)\s+results?/i);
+    return match ? parseInt(match[1], 10) : 0;
+  }
+
+  async verifyIncidentCount(expectedCount: number): Promise<void> {
+    const actualCount = await this.getIncidentCount();
+    expect(actualCount).toBe(expectedCount);
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/callProcess_with Incident.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/callProcess_with Incident.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:ns1="modeler" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:ns0="xmlns" id="bpmn_copilot_Definition_id" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="a8d7898" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0" ns0:modeler="http://camunda.org/schema/modeler/1.0" ns1:executionPlatform="Camunda Cloud" ns1:executionPlatformVersion="8.6">
+  <bpmn:process id="call-level-1-process" name="Call Activity Level 1 Process" processType="None" isClosed="false" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Level1" name="Start Level 1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=if required_variable != null then required_variable else error(&#34;Input variable &#39;required_variable&#39; is mandatory and was not provided.&#34;)" target="required_variable" />
+          <zeebe:output source="=test" target="OutputVariable_2r18fea" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_to_preprocess_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_preprocess_1" sourceRef="StartEvent_Level1" targetRef="Task_PreProcessing_Level1" />
+    <bpmn:sequenceFlow id="Flow_to_call_2" sourceRef="Task_PreProcessing_Level1" targetRef="EndEvent_Level1" />
+    <bpmn:endEvent id="EndEvent_Level1" name="End Level 1">
+      <bpmn:incoming>Flow_to_call_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Task_PreProcessing_Level1" name="Level 1 Pre-Processing">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=1" target="test" />
+        </zeebe:ioMapping>
+        <zeebe:calledElement processId="Not" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_preprocess_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_call_2</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_call-level-1-process">
+    <bpmndi:BPMNPlane id="BPMNPlane_call-level-1-process" bpmnElement="call-level-1-process">
+      <bpmndi:BPMNShape id="StartEvent_Level1_di" bpmnElement="StartEvent_Level1">
+        <dc:Bounds x="57" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Level1_di" bpmnElement="EndEvent_Level1">
+        <dc:Bounds x="357" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jnllr1_di" bpmnElement="Task_PreProcessing_Level1">
+        <dc:Bounds x="175" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_preprocess_1_di" bpmnElement="Flow_to_preprocess_1">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_call_2_di" bpmnElement="Flow_to_call_2">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="357" y="70" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decision_to_test-incident.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decision_to_test-incident.dmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_decision_chain_a" name="Decision Chain A=>B=>C" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+
+  <!-- Decision C: Root cause - always fails with assertion error -->
+  <decision id="decision-c" name="Decision C (Root Cause)">
+    <literalExpression id="LiteralExpression_C">
+      <text>assert(false, "Decision C assertion failed - this is the root cause")</text>
+    </literalExpression>
+  </decision>
+
+  <!-- Decision B: Depends on Decision C -->
+  <decision id="decision-b" name="Decision B">
+    <informationRequirement id="InformationRequirement_B_requires_C">
+      <requiredDecision href="#decision-c" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_B">
+      <input id="Input_B" label="Result from C">
+        <inputExpression id="InputExpression_B" typeRef="string">
+          <text>decision-c</text>
+        </inputExpression>
+      </input>
+      <output id="Output_B" name="resultB" typeRef="string" />
+      <rule id="Rule_B_1">
+        <inputEntry id="InputEntry_B_1">
+          <text>"success"</text>
+        </inputEntry>
+        <outputEntry id="OutputEntry_B_1">
+          <text>"B processed successfully"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+
+  <!-- Decision A: Top-level decision, depends on Decision B -->
+  <decision id="decision-a" name="Decision A">
+    <informationRequirement id="InformationRequirement_A_requires_B">
+      <requiredDecision href="#decision-b"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_A">
+      <input id="Input_A" label="Result from B">
+        <inputExpression id="InputExpression_A" typeRef="string">
+          <text>resultB</text>
+        </inputExpression>
+      </input>
+      <output id="Output_A" name="finalResult" typeRef="string"/>
+      <rule id="Rule_A_1">
+        <inputEntry id="InputEntry_A_1">
+          <text>"B processed successfully"</text>
+        </inputEntry>
+        <outputEntry id="OutputEntry_A_1">
+          <text>"All decisions passed"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="decision-c">
+        <dc:Bounds height="80" width="180" x="160" y="200" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape dmnElementRef="decision-b">
+        <dc:Bounds height="80" width="180" x="390" y="200" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape dmnElementRef="decision-a">
+        <dc:Bounds height="80" width="180" x="620" y="200" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_B_requires_C">
+        <di:waypoint x="340" y="240" />
+        <di:waypoint x="390" y="240" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_A_requires_B">
+        <di:waypoint x="570" y="240" />
+        <di:waypoint x="620" y="240" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/process_to_test_incidents.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/process_to_test_incidents.bpmn
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:ns1="http://camunda.org/schema/modeler/1.0" id="Definitions_root_cause" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1" ns1:executionPlatform="Camunda Cloud" ns1:executionPlatformVersion="8.8.0">
+  <bpmn:process id="root-cause-test" name="Process-Incident" isExecutable="true">
+    <bpmn:startEvent id="Start" name="Start">
+      <bpmn:outgoing>Flow_Start</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_Start" sourceRef="Start" targetRef="Gateway_Split" />
+    <bpmn:parallelGateway id="Gateway_Split">
+      <bpmn:incoming>Flow_Start</bpmn:incoming>
+      <bpmn:outgoing>Flow_A</bpmn:outgoing>
+      <bpmn:outgoing>Flow_B</bpmn:outgoing>
+      <bpmn:outgoing>Flow_D</bpmn:outgoing>
+      <bpmn:outgoing>Flow_E</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_A" sourceRef="Gateway_Split" targetRef="Task_Decision" />
+    <bpmn:businessRuleTask id="Task_Decision" name="A: Decision Chain">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="decision-a" resultVariable="test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_A</bpmn:incoming>
+      <bpmn:outgoing>Flow_A_Merge</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="Flow_A_Merge" sourceRef="Task_Decision" targetRef="Gateway_Merge" />
+    <bpmn:sequenceFlow id="Flow_B" sourceRef="Gateway_Split" targetRef="Task_CallActivity" />
+    <bpmn:callActivity id="Task_CallActivity" name="B: Call Activity Level 1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="call-level-1-process" propagateAllChildVariables="true" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="demoFail" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_B</bpmn:incoming>
+      <bpmn:outgoing>Flow_B_Merge</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_B_Merge" sourceRef="Task_CallActivity" targetRef="Gateway_Merge" />
+    <bpmn:sequenceFlow id="Flow_D" sourceRef="Gateway_Split" targetRef="Task_IOMapping" />
+    <bpmn:serviceTask id="Task_IOMapping" name="D: IO Mapping Failure">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="rootCauseIOMapping" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=assert(false, &#34;IO mapping failed&#34;)" target="result" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_D</bpmn:incoming>
+      <bpmn:outgoing>Flow_D_Merge</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_D_Merge" sourceRef="Task_IOMapping" targetRef="Gateway_Merge" />
+    <bpmn:sequenceFlow id="Flow_E" sourceRef="Gateway_Split" targetRef="Gateway_Expression" />
+    <bpmn:exclusiveGateway id="Gateway_Expression" name="E: Expression Test" default="Flow_E_Default">
+      <bpmn:incoming>Flow_E</bpmn:incoming>
+      <bpmn:outgoing>Flow_E_Condition</bpmn:outgoing>
+      <bpmn:outgoing>Flow_E_Default</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_E_Condition" name="Bad Expression" sourceRef="Gateway_Expression" targetRef="Task_E_Bad">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assert(false, "Expression evaluation failed")</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_E_Default" sourceRef="Gateway_Expression" targetRef="Task_E_Good" />
+    <bpmn:serviceTask id="Task_E_Bad" name="Bad Path">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="rootCauseBadPath" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_E_Condition</bpmn:incoming>
+      <bpmn:outgoing>Flow_E_Bad_Merge</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_E_Good" name="Default Path">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="rootCauseGoodPath" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_E_Default</bpmn:incoming>
+      <bpmn:outgoing>Flow_E_Good_Merge</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_E_Bad_Merge" sourceRef="Task_E_Bad" targetRef="Gateway_E_Join" />
+    <bpmn:sequenceFlow id="Flow_E_Good_Merge" sourceRef="Task_E_Good" targetRef="Gateway_E_Join" />
+    <bpmn:exclusiveGateway id="Gateway_E_Join">
+      <bpmn:incoming>Flow_E_Bad_Merge</bpmn:incoming>
+      <bpmn:incoming>Flow_E_Good_Merge</bpmn:incoming>
+      <bpmn:outgoing>Flow_E_Merge</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_E_Merge" sourceRef="Gateway_E_Join" targetRef="Gateway_Merge" />
+    <bpmn:parallelGateway id="Gateway_Merge">
+      <bpmn:incoming>Flow_A_Merge</bpmn:incoming>
+      <bpmn:incoming>Flow_B_Merge</bpmn:incoming>
+      <bpmn:incoming>Flow_D_Merge</bpmn:incoming>
+      <bpmn:incoming>Flow_E_Merge</bpmn:incoming>
+      <bpmn:outgoing>Flow_End</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_End" sourceRef="Gateway_Merge" targetRef="End" />
+    <bpmn:endEvent id="End" name="End">
+      <bpmn:incoming>Flow_End</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="root-cause-test">
+      <bpmndi:BPMNShape id="Shape_Start" bpmnElement="Start">
+        <dc:Bounds x="152" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="325" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Split" bpmnElement="Gateway_Split">
+        <dc:Bounds x="245" y="275" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Decision" bpmnElement="Task_Decision">
+        <dc:Bounds x="410" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Call" bpmnElement="Task_CallActivity">
+        <dc:Bounds x="410" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_IO" bpmnElement="Task_IOMapping">
+        <dc:Bounds x="410" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Gateway_E" bpmnElement="Gateway_Expression" isMarkerVisible="true">
+        <dc:Bounds x="305" y="385" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="246" y="356" width="68" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_E_Bad" bpmnElement="Task_E_Bad">
+        <dc:Bounds x="400" y="370" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_E_Good" bpmnElement="Task_E_Good">
+        <dc:Bounds x="400" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_E_Join" bpmnElement="Gateway_E_Join" isMarkerVisible="true">
+        <dc:Bounds x="565" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Merge" bpmnElement="Gateway_Merge">
+        <dc:Bounds x="565" y="275" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_End" bpmnElement="End">
+        <dc:Bounds x="672" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="680" y="325" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Edge_Start" bpmnElement="Flow_Start">
+        <di:waypoint x="188" y="300" />
+        <di:waypoint x="245" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_A" bpmnElement="Flow_A">
+        <di:waypoint x="270" y="275" />
+        <di:waypoint x="270" y="210" />
+        <di:waypoint x="410" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_A_Merge" bpmnElement="Flow_A_Merge">
+        <di:waypoint x="510" y="210" />
+        <di:waypoint x="590" y="210" />
+        <di:waypoint x="590" y="275" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_B" bpmnElement="Flow_B">
+        <di:waypoint x="270" y="275" />
+        <di:waypoint x="270" y="120" />
+        <di:waypoint x="410" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_B_Merge" bpmnElement="Flow_B_Merge">
+        <di:waypoint x="510" y="120" />
+        <di:waypoint x="590" y="120" />
+        <di:waypoint x="590" y="275" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_D" bpmnElement="Flow_D">
+        <di:waypoint x="295" y="300" />
+        <di:waypoint x="410" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_D_Merge" bpmnElement="Flow_D_Merge">
+        <di:waypoint x="510" y="300" />
+        <di:waypoint x="565" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E" bpmnElement="Flow_E">
+        <di:waypoint x="270" y="325" />
+        <di:waypoint x="270" y="410" />
+        <di:waypoint x="305" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Condition" bpmnElement="Flow_E_Condition">
+        <di:waypoint x="355" y="410" />
+        <di:waypoint x="400" y="410" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="231" y="413" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Default" bpmnElement="Flow_E_Default">
+        <di:waypoint x="330" y="435" />
+        <di:waypoint x="330" y="500" />
+        <di:waypoint x="400" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Bad_Merge" bpmnElement="Flow_E_Bad_Merge">
+        <di:waypoint x="500" y="410" />
+        <di:waypoint x="565" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Good_Merge" bpmnElement="Flow_E_Good_Merge">
+        <di:waypoint x="500" y="500" />
+        <di:waypoint x="590" y="500" />
+        <di:waypoint x="590" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Merge" bpmnElement="Flow_E_Merge">
+        <di:waypoint x="590" y="385" />
+        <di:waypoint x="590" y="325" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_End" bpmnElement="Flow_End">
+        <di:waypoint x="615" y="300" />
+        <di:waypoint x="672" y="300" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -127,15 +127,15 @@ test.describe('Multi Instance Flow Node Selection', () => {
     });
 
     await test.step('Verify incidents banner shows 25 incidents', async () => {
-      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
-      await expect(operateProcessInstancePage.incidentsBanner).toContainText(
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+      await expect(operateProcessInstancePage.incidentsTab).toContainText(
         '25 Incidents occurred',
       );
     });
 
     await test.step('Click incidents banner to open incidents table', async () => {
       await operateProcessInstancePage.navigateToRootScope();
-      await operateProcessInstancePage.incidentsBanner.click();
+      await operateProcessInstancePage.incidentsTab.click();
       await expect(
         operateProcessInstancePage.incidentsViewHeader,
       ).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -8,7 +8,7 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {DATE_REGEX} from 'utils/constants';
@@ -68,10 +68,7 @@ test.describe('Process Instance', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test.skip('Resolve an incident', async ({
-    page,
-    operateProcessInstancePage,
-  }) => {
+  test('Resolve an incident', async ({page, operateProcessInstancePage}) => {
     await test.step('Navigate to process instance with incident', async () => {
       await operateProcessInstancePage.gotoProcessInstancePage({
         id: instanceWithIncidentToResolve.processInstanceKey,
@@ -79,18 +76,18 @@ test.describe('Process Instance', () => {
       await sleep(1000);
     });
 
-    await test.step('Verify incident banner is visible', async () => {
-      await expect(
-        operateProcessInstancePage.incidentBannerButton(2),
-      ).toBeVisible();
+    await test.step('Verify incidents tab is visible', async () => {
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
     });
 
-    await test.step('Click and expand incident bar', async () => {
-      await operateProcessInstancePage.clickIncidentBanner(2);
+    await test.step('Open incidents tab', async () => {
+      await operateProcessInstancePage.clickIncidentsTab();
       await expect(operateProcessInstancePage.incidentTypeFilter).toBeVisible();
+      await operateProcessInstancePage.verifyIncidentCount(2);
     });
 
     await test.step('Edit goUp variable', async () => {
+      await operateProcessInstancePage.clickVariablesTab();
       await operateProcessInstancePage.editVariableButtonInList.click();
 
       await operateProcessInstancePage.editVariableValueField.clear();
@@ -104,12 +101,18 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Retry one incident to resolve it', async () => {
-      await operateProcessInstancePage.retryIncident(/Condition error/i);
+      await operateProcessInstancePage.clickIncidentsTab();
+      const firstErrorType = 'Condition error.';
+      const remainingErrorType = 'Extract value error.';
+
+      await operateProcessInstancePage.retryIncidentByErrorType(firstErrorType);
 
       await expect(
-        operateProcessInstancePage.getIncidentRowOperationSpinner(
-          /Condition error/i,
-        ),
+        (
+          await operateProcessInstancePage.getIncidentRowByErrorType(
+            firstErrorType,
+          )
+        ).getByTestId('operation-spinner'),
       ).toBeVisible();
       await waitForAssertion({
         assertion: async () => {
@@ -127,18 +130,23 @@ test.describe('Process Instance', () => {
       });
 
       await expect
-        .poll(() => operateProcessInstancePage.incidentsTableRows.count())
+        .poll(async () => await operateProcessInstancePage.getIncidentCount())
         .toBe(1);
 
       await expect(
-        operateProcessInstancePage.incidentsTable.getByText(/is cool\?/i),
-      ).toBeVisible();
+        await operateProcessInstancePage.getIncidentRowByErrorType(
+          firstErrorType,
+        ),
+      ).toHaveCount(0);
       await expect(
-        operateProcessInstancePage.incidentsTable.getByText(/where to go\?/i),
-      ).toBeHidden();
+        await operateProcessInstancePage.getIncidentRowByErrorType(
+          remainingErrorType,
+        ),
+      ).toBeVisible();
     });
 
     await test.step('Add variable isCool', async () => {
+      await operateProcessInstancePage.clickVariablesTab();
       await operateProcessInstancePage.addVariableButton.click();
 
       await operateProcessInstancePage.newVariableNameField.type('isCool');
@@ -152,19 +160,25 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Retry second incident to resolve it', async () => {
-      await operateProcessInstancePage.retryIncident(/Extract value error/i);
+      await operateProcessInstancePage.clickIncidentsTab();
+      const secondErrorType = 'Extract value error.';
+      await operateProcessInstancePage.retryIncidentByErrorType(
+        secondErrorType,
+      );
 
       await expect(
-        operateProcessInstancePage.getIncidentRowOperationSpinner(
-          /Extract value error/i,
-        ),
+        (
+          await operateProcessInstancePage.getIncidentRowByErrorType(
+            secondErrorType,
+          )
+        ).getByTestId('operation-spinner'),
       ).toBeVisible();
     });
 
     await test.step('Expect all incidents resolved', async () => {
       await waitForAssertion({
         assertion: async () => {
-          await expect(operateProcessInstancePage.incidentsBanner).toBeHidden();
+          await expect(operateProcessInstancePage.incidentsTab).toBeHidden();
         },
         onFailure: async () => {
           await page.reload();
@@ -176,10 +190,7 @@ test.describe('Process Instance', () => {
     });
   });
 
-  test.skip('Cancel an instance', async ({
-    operateProcessInstancePage,
-    page,
-  }) => {
+  test('Cancel an instance', async ({operateProcessInstancePage, page}) => {
     const instanceId = instanceWithIncidentToCancel.processInstanceKey;
 
     await test.step('Navigate to process instance with incident', async () => {
@@ -189,25 +200,25 @@ test.describe('Process Instance', () => {
       await sleep(1000);
     });
 
-    await test.step('Verify incident banner is visible', async () => {
-      await expect(
-        operateProcessInstancePage.incidentBannerButton(3),
-      ).toBeVisible();
+    await test.step('Verify incidents tab is visible', async () => {
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+      await operateProcessInstancePage.clickIncidentsTab();
+      await expect(operateProcessInstancePage.incidentTypeFilter).toBeVisible();
+      await operateProcessInstancePage.verifyIncidentCount(3);
     });
 
     await test.step('Cancel the instance', async () => {
       await operateProcessInstancePage.cancelInstance(instanceId);
 
-      await expect(operateProcessInstancePage.operationSpinner).toBeVisible();
-      await expect(operateProcessInstancePage.operationSpinner).toBeHidden();
+      await expect(
+        operateProcessInstancePage.cancellationScheduledToast,
+      ).toBeVisible();
     });
 
     await test.step('Verify instance is canceled', async () => {
       await waitForAssertion({
         assertion: async () => {
-          await expect(
-            operateProcessInstancePage.incidentBannerButton(3),
-          ).toBeHidden();
+          await expect(operateProcessInstancePage.incidentsTab).toBeHidden();
         },
         onFailure: async () => {
           await page.reload();
@@ -223,10 +234,9 @@ test.describe('Process Instance', () => {
     });
   });
 
-  test.skip('Should render collapsed sub process and navigate between planes', async ({
+  test('Should render collapsed sub process and navigate between planes', async ({
     page,
     operateProcessInstancePage,
-    operateDiagramPage,
   }) => {
     const {diagramHelper} = operateProcessInstancePage;
 
@@ -239,6 +249,7 @@ test.describe('Process Instance', () => {
 
     await test.step('Click on startEvent in instance history', async () => {
       await operateProcessInstancePage.clickTreeItem('startEvent');
+      await operateProcessInstancePage.clickDetailsTab();
       await expect(page.getByText(/execution duration/i)).toBeVisible();
     });
 
@@ -254,20 +265,6 @@ test.describe('Process Instance', () => {
       await page.keyboard.press('ArrowRight');
       await operateProcessInstancePage.clickTreeItem(/fill form/i);
       await expect(diagramHelper.getFlowNode('fill form')).toBeVisible();
-      await operateProcessInstancePage.clickTreeItem(/fill form/i);
-
-      await waitForAssertion({
-        assertion: async () => {
-          await operateDiagramPage.popover.waitFor({
-            state: 'visible',
-          });
-        },
-        onFailure: async () => {
-          await operateProcessInstancePage.clickTreeItem(/fill form/i);
-        },
-      });
-
-      await expect(page.getByText(/retries left/i)).toBeVisible();
     });
 
     await test.step('Click on collapsed sub process', async () => {
@@ -340,6 +337,93 @@ test.describe('Process Instance', () => {
       await operateProcessInstancePage.verifyExecutionCountBadgesNotVisible(
         elementIds,
       );
+    });
+  });
+});
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/decision_to_test-incident.dmn',
+    './resources/process_to_test_incidents.bpmn',
+    './resources/callProcess_with Incident.bpmn',
+  ]);
+  await createInstances('root-cause-test', 1, 1);
+  await createInstances('call-level-1-process', 1, 1, {shouldFail: true});
+
+  await sleep(5000);
+});
+
+test.describe('Process Instance Incident', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Verify Incident root cause instance', async ({
+    operateProcessInstancePage,
+    operateHomePage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName('Process-Incident');
+      await operateProcessesPage.clickProcessInstanceLink();
+    });
+
+    await test.step('Verify error indicators on all affected elements', async () => {
+      await expect(operateProcessInstancePage.diagram).toBeVisible();
+      await expect(operateProcessInstancePage.diagramSpinner).toBeHidden({
+        timeout: 30000,
+      });
+
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+      await operateProcessInstancePage.clickIncidentsTab();
+
+      await operateProcessInstancePage.verifyIncidentCount(4);
+
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+    });
+
+    await test.step('Click IO mapping Error and verify Error Type', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram(
+        'Task_IOMapping',
+      );
+
+      await expect(
+        operateProcessInstancePage.getSelectedIncidentRow(
+          /IO mapping error\./i,
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Click ExclusiveGatewayError and verify Error Type', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram(
+        'Gateway_Expression',
+      );
+
+      await expect(
+        operateProcessInstancePage.getSelectedIncidentRow(
+          /Extract value error\./i,
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Click Call Activity and verify the error type', async () => {
+      await operateProcessInstancePage
+        .getDiagramElement('Task_CallActivity')
+        .dblclick();
+
+      await expect(
+        operateProcessInstancePage.getIncidentRow(/Called element error\./i),
+      ).toBeVisible();
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -59,7 +59,7 @@ test.beforeAll(async () => {
   };
 });
 
-test.describe.skip('Process Instance History', () => {
+test.describe('Process Instance History', () => {
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
@@ -148,9 +148,7 @@ test.describe.skip('Process Instance History', () => {
       await expect(operateProcessInstancePage.instanceHistory).toBeVisible();
       await waitForAssertion({
         assertion: async () => {
-          await expect(
-            operateProcessInstancePage.incidentsBanner,
-          ).toBeVisible();
+          await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();
@@ -171,6 +169,7 @@ test.describe.skip('Process Instance History', () => {
     });
 
     await test.step('Add variable to the process', async () => {
+      await operateProcessInstancePage.clickVariablesTab();
       await operateProcessInstancePage.clickAddVariableButton();
       await operateProcessInstancePage.fillNewVariable('goUp', '6');
       await operateProcessInstancePage.clickSaveVariableButton();
@@ -178,18 +177,16 @@ test.describe.skip('Process Instance History', () => {
     });
 
     await test.step('Retry incident', async () => {
-      await operateProcessInstancePage.clickIncidentsBanner();
-      const errorMessage = "Expected result of the expression 'goUp < 0'";
-      await operateProcessInstancePage.retryIncidentByErrorMessage(
-        errorMessage,
-      );
+      await operateProcessInstancePage.clickIncidentsTab();
+      const errorType = 'Extract value error.';
+      await operateProcessInstancePage.retryIncidentByErrorType(errorType);
     });
 
     await test.step('Verify incident is resolved in Instance History', async () => {
       await page.waitForTimeout(12000);
       await waitForAssertion({
         assertion: async () => {
-          await expect(operateProcessInstancePage.incidentsBanner).toBeHidden();
+          await expect(operateProcessInstancePage.incidentsTab).toBeHidden();
         },
         onFailure: async () => {
           await page.reload();


### PR DESCRIPTION
# Description
Backport of #49282 to `stable/8.9`.

[Test run](https://github.com/camunda/camunda/actions/runs/23481046906)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later

relates to #49230 #49231