### PR TITLE
[Backport stable/8.8] fix: deduplicate user task variables by scope in API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -141,6 +141,7 @@ import io.camunda.client.api.search.request.ProcessInstanceSequenceFlowsRequest;
 import io.camunda.client.api.search.request.RolesByGroupSearchRequest;
 import io.camunda.client.api.search.request.RolesByTenantSearchRequest;
 import io.camunda.client.api.search.request.TenantsSearchRequest;
+import io.camunda.client.api.search.request.UserTaskEffectiveVariableSearchRequest;
 import io.camunda.client.api.search.request.UserTaskSearchRequest;
 import io.camunda.client.api.search.request.UserTaskVariableSearchRequest;
 import io.camunda.client.api.search.request.UsersByGroupSearchRequest;
@@ -1837,6 +1838,28 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the user task variable search request
    */
   UserTaskVariableSearchRequest newUserTaskVariableSearchRequest(long userTaskKey);
+
+  /**
+   * Executes a search request to query effective variables related to a user task. Returns
+   * deduplicated variables where the innermost scope wins when the same variable name exists at
+   * multiple scope levels.
+   *
+   * <pre>
+   *   long userTaskKey = ...;
+   *
+   *  camundaClient
+   *   .newUserTaskEffectiveVariableSearchRequest(userTaskKey)
+   *   .sort((s) -> s.value().asc())
+   *   .page((p) -> p.limit(100))
+   *   .withFullValues()
+   *   .send();
+   * </pre>
+   *
+   * @param userTaskKey the key of the user task
+   * @return a builder for the user task effective variable search request
+   */
+  UserTaskEffectiveVariableSearchRequest newUserTaskEffectiveVariableSearchRequest(
+      long userTaskKey);
 
   /**
    * <strong>Experimental: This method is under development. The respective API on compatible

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/UserTaskEffectiveVariableSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/UserTaskEffectiveVariableSearchRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.UserTaskVariableFilter;
+import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.api.search.sort.VariableSort;
+
+public interface UserTaskEffectiveVariableSearchRequest
+    extends TypedSearchRequest<
+            UserTaskVariableFilter, VariableSort, UserTaskEffectiveVariableSearchRequest>,
+        FinalSearchRequestStep<Variable> {
+
+  /**
+   * <pre>
+   * Sets {@code truncateValues=false} in the search request to return full variable values. By
+   * default, truncated values are returned.
+   *
+   * @return the builder for the search request
+   * </pre>
+   */
+  UserTaskEffectiveVariableSearchRequest withFullValues();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -152,6 +152,7 @@ import io.camunda.client.api.search.request.ProcessInstanceSequenceFlowsRequest;
 import io.camunda.client.api.search.request.RolesByGroupSearchRequest;
 import io.camunda.client.api.search.request.RolesByTenantSearchRequest;
 import io.camunda.client.api.search.request.TenantsSearchRequest;
+import io.camunda.client.api.search.request.UserTaskEffectiveVariableSearchRequest;
 import io.camunda.client.api.search.request.UserTaskSearchRequest;
 import io.camunda.client.api.search.request.UserTaskVariableSearchRequest;
 import io.camunda.client.api.search.request.UsersByGroupSearchRequest;
@@ -290,6 +291,7 @@ import io.camunda.client.impl.search.request.RolesByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.RolesByTenantSearchRequestImpl;
 import io.camunda.client.impl.search.request.RolesSearchRequestImpl;
 import io.camunda.client.impl.search.request.TenantsSearchRequestImpl;
+import io.camunda.client.impl.search.request.UserTaskEffectiveVariableSearchRequestImpl;
 import io.camunda.client.impl.search.request.UserTaskSearchRequestImpl;
 import io.camunda.client.impl.search.request.UserTaskVariableSearchRequestImpl;
 import io.camunda.client.impl.search.request.UsersByGroupSearchRequestImpl;
@@ -1080,6 +1082,12 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public UserTaskVariableSearchRequest newUserTaskVariableSearchRequest(final long userTaskKey) {
     return new UserTaskVariableSearchRequestImpl(httpClient, jsonMapper, userTaskKey);
+  }
+
+  @Override
+  public UserTaskEffectiveVariableSearchRequest newUserTaskEffectiveVariableSearchRequest(
+      final long userTaskKey) {
+    return new UserTaskEffectiveVariableSearchRequestImpl(httpClient, jsonMapper, userTaskKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UserTaskEffectiveVariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UserTaskEffectiveVariableSearchRequestImpl.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.userTaskVariableFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.variableSort;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.UserTaskVariableFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.request.UserTaskEffectiveVariableSearchRequest;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.api.search.sort.VariableSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.UserTaskEffectiveVariableSearchQueryRequest;
+import io.camunda.client.protocol.rest.VariableSearchQueryResult;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UserTaskEffectiveVariableSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<UserTaskEffectiveVariableSearchQueryRequest>
+    implements UserTaskEffectiveVariableSearchRequest {
+
+  private final UserTaskEffectiveVariableSearchQueryRequest request;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final JsonMapper jsonMapper;
+  private final long userTaskKey;
+  private boolean withFullValues = false;
+
+  public UserTaskEffectiveVariableSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final long userTaskKey) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.userTaskKey = userTaskKey;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new UserTaskEffectiveVariableSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Variable> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Variable>> send() {
+    final HttpCamundaFuture<SearchResponse<Variable>> result = new HttpCamundaFuture<>();
+
+    final Map<String, String> queryParams = new HashMap<>();
+    if (withFullValues) {
+      queryParams.put("truncateValues", String.valueOf(false));
+    }
+    httpClient.post(
+        String.format("/user-tasks/%d/effective-variables/search", userTaskKey),
+        queryParams,
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        VariableSearchQueryResult.class,
+        SearchResponseMapper::toVariableSearchResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public UserTaskEffectiveVariableSearchRequest filter(final UserTaskVariableFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public UserTaskEffectiveVariableSearchRequest filter(final Consumer<UserTaskVariableFilter> fn) {
+    return filter(userTaskVariableFilter(fn));
+  }
+
+  @Override
+  public UserTaskEffectiveVariableSearchRequest sort(final VariableSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toUserTaskVariableSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public UserTaskEffectiveVariableSearchRequest sort(final Consumer<VariableSort> fn) {
+    return sort(variableSort(fn));
+  }
+
+  @Override
+  public UserTaskEffectiveVariableSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public UserTaskEffectiveVariableSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public UserTaskEffectiveVariableSearchRequest withFullValues() {
+    withFullValues = true;
+    return this;
+  }
+
+  @Override
+  protected UserTaskEffectiveVariableSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskEffectiveVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskEffectiveVariableTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.usertask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.protocol.rest.UserTaskEffectiveVariableSearchQueryRequest;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+
+public final class SearchUserTaskEffectiveVariableTest extends ClientRestTest {
+
+  @Test
+  void shouldSearchEffectiveVariables() {
+    final long userTaskKey = 1L;
+
+    // when
+    client.newUserTaskEffectiveVariableSearchRequest(userTaskKey).send().join();
+
+    // then
+    final UserTaskEffectiveVariableSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskEffectiveVariableSearchQueryRequest.class);
+    assertThat(request.getFilter()).isNull();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 class UserTaskSearchTest {
   private static Long userTaskKeyTaskAssigned;
   private static Long userTaskSubprocessKey;
+  private static Long userTaskOverlapKey;
   private static final String LARGE_VAR_NAME = "largeVariable";
   private static final String LARGE_VALUE = "b".repeat(DEFAULT_VARIABLE_SIZE_THRESHOLD + 10);
 
@@ -56,6 +57,9 @@ class UserTaskSearchTest {
     deployProcessFromResourcePath("/process/bpm_variable_test.bpmn", "bpm_variable_test.bpmn");
     deployProcessFromResourcePath(
         "/process/bpmn_subprocess_case.bpmn", "bpmn_subprocess_case.bpmn");
+    deployProcessFromResourcePath(
+        "/process/process_with_overlapping_variables.bpmn",
+        "process_with_overlapping_variables.bpmn");
 
     deployResource(camundaClient, "form/form.form");
     deployProcessFromResourcePath("/process/process_with_form.bpmn", "process_with_form.bpmn");
@@ -66,6 +70,7 @@ class UserTaskSearchTest {
     startProcessInstance(camundaClient, "process");
     startProcessInstance(camundaClient, "process-3");
     startProcessInstance(camundaClient, "bpmProcessVariable");
+    startProcessInstance(camundaClient, "processWithOverlappingVars");
     startProcessInstance(camundaClient, "processWithForm");
     startProcessInstance(
         camundaClient, "processWithSubProcess", Map.of(LARGE_VAR_NAME, LARGE_VALUE));
@@ -79,6 +84,14 @@ class UserTaskSearchTest {
     final var userTaskList =
         camundaClient.newUserTaskSearchRequest().filter(f -> f.elementId("TaskSub")).send().join();
     userTaskSubprocessKey = userTaskList.items().stream().findFirst().get().getUserTaskKey();
+
+    final var overlapUserTaskList =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.elementId("TaskOverlap"))
+            .send()
+            .join();
+    userTaskOverlapKey = overlapUserTaskList.items().stream().findFirst().get().getUserTaskKey();
   }
 
   @Test
@@ -363,7 +376,7 @@ class UserTaskSearchTest {
   @Test
   public void shouldRetrieveAllTasks() {
     final var result = camundaClient.newUserTaskSearchRequest().send().join();
-    assertThat(result.items()).hasSize(8);
+    assertThat(result.items()).hasSize(9);
   }
 
   @Test
@@ -429,7 +442,7 @@ class UserTaskSearchTest {
             .filter(f -> f.state(UserTaskState.CREATED))
             .send()
             .join();
-    assertThat(resultCreated.items()).hasSize(7);
+    assertThat(resultCreated.items()).hasSize(8);
     resultCreated
         .items()
         .forEach(item -> assertThat(item.getState()).isEqualTo(UserTaskState.CREATED));
@@ -541,7 +554,7 @@ class UserTaskSearchTest {
             .send()
             .join();
 
-    assertThat(resultAfter.items()).hasSize(7);
+    assertThat(resultAfter.items()).hasSize(8);
     // apply searchBefore
     final var resultBefore =
         camundaClient
@@ -558,7 +571,7 @@ class UserTaskSearchTest {
     final var result =
         camundaClient.newUserTaskSearchRequest().sort(s -> s.creationDate().asc()).send().join();
 
-    assertThat(result.items()).hasSize(8);
+    assertThat(result.items()).hasSize(9);
 
     // Assert that the creation date of item 0 is before item 1, and item 1 is before item 2
     final UserTask firstItem = result.items().get(0);
@@ -572,7 +585,7 @@ class UserTaskSearchTest {
     final var result =
         camundaClient.newUserTaskSearchRequest().sort(s -> s.creationDate().desc()).send().join();
 
-    assertThat(result.items()).hasSize(8);
+    assertThat(result.items()).hasSize(9);
 
     assertThat(result.items().get(0).getCreationDate())
         .isAfterOrEqualTo(result.items().get(1).getCreationDate());
@@ -596,7 +609,7 @@ class UserTaskSearchTest {
   public void shouldRetrieveTaskByTenantId() {
     final var resultDefaultTenant =
         camundaClient.newUserTaskSearchRequest().filter(f -> f.tenantId("<default>")).send().join();
-    assertThat(resultDefaultTenant.items()).hasSize(8);
+    assertThat(resultDefaultTenant.items()).hasSize(9);
     resultDefaultTenant
         .items()
         .forEach(item -> assertThat(item.getTenantId()).isEqualTo("<default>"));
@@ -809,6 +822,27 @@ class UserTaskSearchTest {
   }
 
   @Test
+  void shouldReturnEffectiveVariablesDeduplicatedByScope() {
+    // given - the process has sharedVar at both process and subprocess scope
+    // when - effective-variables endpoint should deduplicate, keeping innermost scope
+    final var result =
+        camundaClient
+            .newUserTaskEffectiveVariableSearchRequest(userTaskOverlapKey)
+            .sort(s -> s.name().asc())
+            .send()
+            .join();
+
+    // then - 3 effective variables (sharedVar appears once with subprocess value)
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().stream().map(Variable::getName))
+        .containsExactly("processOnly", "sharedVar", "subOnly");
+    // sharedVar should have the subprocess (innermost) value, not the process value
+    final var sharedVar =
+        result.items().stream().filter(v -> v.getName().equals("sharedVar")).findFirst().get();
+    assertThat(sharedVar.getValue()).isEqualTo("\"subprocess\"");
+  }
+
+  @Test
   void shouldReturnUserTaskByCreationDateExists() {
     // when
     final var result =
@@ -819,7 +853,7 @@ class UserTaskSearchTest {
             .join();
 
     // then
-    assertThat(result.items()).hasSize(8);
+    assertThat(result.items()).hasSize(9);
   }
 
   @Test
@@ -1429,7 +1463,7 @@ class UserTaskSearchTest {
         .untilAsserted(
             () -> {
               final var result = camundaClient.newUserTaskSearchRequest().send().join();
-              assertThat(result.items()).hasSize(8);
+              assertThat(result.items()).hasSize(9);
               userTaskKeyTaskAssigned = result.items().getFirst().getUserTaskKey();
             });
 

--- a/qa/acceptance-tests/src/test/resources/process/process_with_overlapping_variables.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_overlapping_variables.bpmn
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="processWithOverlappingVars" isExecutable="true">
+    <bpmn:startEvent id="StartEvent">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=&#34;fromProcess&#34;" target="processOnly" />
+          <zeebe:output source="=&#34;process&#34;" target="sharedVar" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="SubProcess">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=&#34;fromSub&#34;" target="subOnly" />
+          <zeebe:input source="=&#34;subprocess&#34;" target="sharedVar" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow1</bpmn:incoming>
+      <bpmn:outgoing>Flow2</bpmn:outgoing>
+      <bpmn:startEvent id="SubStart">
+        <bpmn:outgoing>Flow3</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:userTask id="TaskOverlap" name="TaskOverlap">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow3</bpmn:incoming>
+        <bpmn:outgoing>Flow4</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:endEvent id="SubEnd">
+        <bpmn:incoming>Flow4</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow3" sourceRef="SubStart" targetRef="TaskOverlap" />
+      <bpmn:sequenceFlow id="Flow4" sourceRef="TaskOverlap" targetRef="SubEnd" />
+    </bpmn:subProcess>
+    <bpmn:endEvent id="EndEvent">
+      <bpmn:incoming>Flow2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow1" sourceRef="StartEvent" targetRef="SubProcess" />
+    <bpmn:sequenceFlow id="Flow2" sourceRef="SubProcess" targetRef="EndEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithOverlappingVars">
+      <bpmndi:BPMNShape id="StartEvent_di" bpmnElement="StartEvent">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="265" y="77" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubStart_di" bpmnElement="SubStart">
+        <dc:Bounds x="302" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TaskOverlap_di" bpmnElement="TaskOverlap">
+        <dc:Bounds x="390" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubEnd_di" bpmnElement="SubEnd">
+        <dc:Bounds x="542" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow3_di" bpmnElement="Flow3">
+        <di:waypoint x="338" y="170" />
+        <di:waypoint x="390" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow4_di" bpmnElement="Flow4">
+        <di:waypoint x="490" y="170" />
+        <di:waypoint x="542" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_di" bpmnElement="EndEvent">
+        <dc:Bounds x="672" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow1_di" bpmnElement="Flow1">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="265" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow2_di" bpmnElement="Flow2">
+        <di:waypoint x="615" y="177" />
+        <di:waypoint x="672" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.UserTaskQuery.Builder;
@@ -34,8 +35,11 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserTaskCompletionRequ
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserTaskUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -239,6 +243,105 @@ public final class UserTaskServices
             variableServices
                 .withAuthentication(CamundaAuthentication.anonymous())
                 .search(variableQueryWithTreePathFilter));
+  }
+
+  public SearchQueryResult<VariableEntity> searchUserTaskEffectiveVariables(
+      final long userTaskKey, final VariableQuery variableQuery) {
+
+    final var userTask = getByKey(userTaskKey);
+
+    final String treePath = fetchFlowNodeTreePath(userTask.elementInstanceKey());
+
+    final List<Long> treePathList =
+        treePath != null
+            ? Arrays.stream(treePath.split("/")).map(Long::valueOf).toList()
+            : Collections.emptyList();
+
+    // Early exit: if there is no tree path or it only contains the user task itself,
+    // there is no hierarchy and no deduplication is needed. Delegate to the standard
+    // searchUserTaskVariables, but strip cursors since this endpoint does not support
+    // cursor-based pagination (in the general case, we perform in-memory deduplication).
+    if (treePathList.size() <= 1) {
+      final var result = searchUserTaskVariables(userTaskKey, variableQuery);
+      return new SearchQueryResult<>(
+          result.total(), result.hasMoreTotalItems(), result.items(), null, null);
+    }
+
+    final var unlimitedQuery =
+        variableSearchQuery(
+            q ->
+                q.filter(f -> f.copyFrom(variableQuery.filter()).scopeKeys(treePathList))
+                    .sort(variableQuery.sort())
+                    .unlimited());
+
+    final var allVariables =
+        executeSearchRequest(
+            () ->
+                variableServices
+                    .withAuthentication(CamundaAuthentication.anonymous())
+                    .search(unlimitedQuery));
+
+    // Deduplicate variables by name, keeping the one from the innermost scope.
+    // Since this is a sorted result set by the user's criteria, we iterate through
+    // it in order and use a LinkedHashMap to preserve that order while deduplicating.
+    final List<VariableEntity> dedupedVariables =
+        deduplicateVariablesByScope(allVariables.items(), treePathList);
+
+    // Apply offset-based pagination to the deduplicated and sorted result.
+    // Cursor-based pagination (after/before) is not supported for this endpoint because
+    // deduplication and sorting are performed in-memory after fetching from the search backend.
+    final var page = variableQuery.page();
+    final int size = page.size() != null ? page.size() : SearchQueryPage.DEFAULT_SIZE;
+    final int total = dedupedVariables.size();
+    final int from = page.from() != null ? page.from() : 0;
+    final int end = Math.min(from + size, total);
+    final List<VariableEntity> pageItems =
+        from < total ? new ArrayList<>(dedupedVariables.subList(from, end)) : List.of();
+
+    return new SearchQueryResult<>(total, false, pageItems, null, null);
+  }
+
+  /**
+   * Deduplicates variables by name, keeping the variable from the innermost scope (closest to the
+   * user task). The variables list is already sorted according to the user's criteria. We iterate
+   * through them in order, and for each variable name, we keep the one from the closest scope. If a
+   * variable from a closer scope is encountered later, we replace the previous one and move it to
+   * the end of the LinkedHashMap, preserving the relative order while ensuring innermost scope
+   * wins.
+   */
+  private List<VariableEntity> deduplicateVariablesByScope(
+      final List<VariableEntity> variables, final List<Long> treePathList) {
+
+    // Create a map from scope key to its depth (distance from root).
+    // Higher depth = closer to innermost (user task).
+    final Map<Long, Integer> scopeDepth = new HashMap<>();
+    for (int i = 0; i < treePathList.size(); i++) {
+      scopeDepth.put(treePathList.get(i), i);
+    }
+
+    // Iterate through sorted variables and deduplicate by name,
+    // keeping the one from the closest scope (highest depth).
+    final var dedupedMap = new LinkedHashMap<String, VariableEntity>();
+
+    for (final VariableEntity variable : variables) {
+      final var currentDepth = scopeDepth.get(variable.scopeKey());
+      final var existing = dedupedMap.get(variable.name());
+
+      if (existing == null) {
+        // First time seeing this variable name, add it
+        dedupedMap.put(variable.name(), variable);
+      } else {
+        final var existingDepth = scopeDepth.get(existing.scopeKey());
+        if (currentDepth > existingDepth) {
+          // This variable is from a closer scope, replace the existing one and put it to the end of
+          // the LinkedHashMap.
+          dedupedMap.putLast(variable.name(), variable);
+        }
+        // else: existing variable is from a closer or equal scope, keep it
+      }
+    }
+
+    return new ArrayList<>(dedupedMap.values());
   }
 
   private String fetchFlowNodeTreePath(final long flowNodeInstanceKey) {

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -11,6 +11,7 @@ import static io.camunda.search.query.SearchQueryBuilders.variableSearchQuery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -27,6 +28,8 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableQuery;
+import io.camunda.search.sort.SortOptionBuilders;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.cache.ProcessCache;
@@ -36,6 +39,7 @@ import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -133,6 +137,296 @@ public class UserTaskServiceTest {
 
       // then
       assertThat(searchQueryResult.items()).containsOnly(variable);
+    }
+  }
+
+  @Nested
+  class SearchUserTaskEffectiveVariables {
+
+    @Test
+    public void shouldDeduplicateVariablesByScope() {
+      // given — same variable "city" at root scope (1) and inner scope (3)
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1/2/3")
+              .create();
+      final var outerVar =
+          new VariableEntity(100L, "city", "Munich", "Munich", false, 1L, 1L, "proc", "t1");
+      final var innerVar =
+          new VariableEntity(101L, "city", "Berlin", "Berlin", false, 3L, 1L, "proc", "t1");
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(elementInstanceServices.getByKey(eq(flowNodeInstanceEntity.flowNodeInstanceKey())))
+          .thenReturn(flowNodeInstanceEntity);
+      when(variableServices.search(any())).thenReturn(SearchQueryResult.of(outerVar, innerVar));
+
+      // when
+      final SearchQueryResult<VariableEntity> result =
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(), variableSearchQuery().build());
+
+      // then — innermost scope (3) wins, only one "city" returned
+      assertThat(result.total()).isEqualTo(1);
+      assertThat(result.items()).containsExactly(innerVar);
+    }
+
+    @Test
+    public void shouldKeepInnermostScopeVariable() {
+      // given — variable "x" at three scopes: root (1), middle (2), leaf (3)
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1/2/3")
+              .create();
+      final var rootVar =
+          new VariableEntity(100L, "x", "root", "root", false, 1L, 1L, "proc", "t1");
+      final var midVar = new VariableEntity(101L, "x", "mid", "mid", false, 2L, 1L, "proc", "t1");
+      final var leafVar =
+          new VariableEntity(102L, "x", "leaf", "leaf", false, 3L, 1L, "proc", "t1");
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(elementInstanceServices.getByKey(eq(flowNodeInstanceEntity.flowNodeInstanceKey())))
+          .thenReturn(flowNodeInstanceEntity);
+      when(variableServices.search(any()))
+          .thenReturn(SearchQueryResult.of(rootVar, midVar, leafVar));
+
+      // when
+      final SearchQueryResult<VariableEntity> result =
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(), variableSearchQuery().build());
+
+      // then — leaf (innermost) wins
+      assertThat(result.total()).isEqualTo(1);
+      assertThat(result.items()).containsExactly(leafVar);
+      assertThat(result.items().getFirst().value()).isEqualTo("leaf");
+    }
+
+    @Test
+    public void shouldReturnCorrectTotalAfterDedup() {
+      // given — 3 unique names across scopes, but 5 total variable documents
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1/2/3")
+              .create();
+      final var vars =
+          List.of(
+              new VariableEntity(1L, "a", "v1", "v1", false, 1L, 1L, "p", "t"),
+              new VariableEntity(2L, "a", "v2", "v2", false, 3L, 1L, "p", "t"),
+              new VariableEntity(3L, "b", "v3", "v3", false, 1L, 1L, "p", "t"),
+              new VariableEntity(4L, "b", "v4", "v4", false, 2L, 1L, "p", "t"),
+              new VariableEntity(5L, "c", "v5", "v5", false, 1L, 1L, "p", "t"));
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(elementInstanceServices.getByKey(eq(flowNodeInstanceEntity.flowNodeInstanceKey())))
+          .thenReturn(flowNodeInstanceEntity);
+      when(variableServices.search(any()))
+          .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
+
+      // when
+      final SearchQueryResult<VariableEntity> result =
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(), variableSearchQuery().build());
+
+      // then — 3 unique names after dedup, total reflects deduplicated count
+      assertThat(result.total()).isEqualTo(3);
+      assertThat(result.items()).hasSize(3);
+      assertThat(result.items())
+          .extracting(VariableEntity::name, VariableEntity::value)
+          .containsExactlyInAnyOrder(tuple("a", "v2"), tuple("b", "v4"), tuple("c", "v5"));
+    }
+
+    @Test
+    public void shouldSortDeduplicatedVariablesByNameAsc() {
+      // given
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1/2")
+              .create();
+      final var vars =
+          List.of(
+              // apple only at scope 2
+              new VariableEntity(3L, "apple", "a", "a", false, 2L, 1L, "p", "t"),
+              // mango only at scope 1
+              new VariableEntity(4L, "mango", "m", "m", false, 1L, 1L, "p", "t"),
+              // zebra at scope 1 (outer) and scope 2 (inner) — inner wins after dedup
+              new VariableEntity(1L, "zebra", "z-outer", "z-outer", false, 1L, 1L, "p", "t"),
+              new VariableEntity(2L, "zebra", "z-inner", "z-inner", false, 2L, 1L, "p", "t"));
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(elementInstanceServices.getByKey(eq(flowNodeInstanceEntity.flowNodeInstanceKey())))
+          .thenReturn(flowNodeInstanceEntity);
+      // Mock returns variables sorted by name ASC (like data layer would)
+      when(variableServices.search(any()))
+          .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
+
+      // when — sort by name ASC after deduplication
+      final var query =
+          VariableQuery.of(q -> q.sort(SortOptionBuilders.variable(s -> s.name().asc())));
+      final SearchQueryResult<VariableEntity> result =
+          services.searchUserTaskEffectiveVariables(entity.userTaskKey(), query);
+
+      // then — 3 unique variables after dedup, sorted by name ASC
+      assertThat(result.total()).isEqualTo(3);
+      assertThat(result.items())
+          .extracting(VariableEntity::name, VariableEntity::value)
+          .containsExactly(tuple("apple", "a"), tuple("mango", "m"), tuple("zebra", "z-inner"));
+    }
+
+    @Test
+    public void shouldSortDeduplicatedVariablesByValueDesc() {
+      // given
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1/2")
+              .create();
+      final var vars =
+          List.of(
+              // Sorted by value DESC: zebra > charlie > bravo > alpha
+              new VariableEntity(2L, "a", "zebra", "zebra", false, 2L, 1L, "p", "t"),
+              new VariableEntity(3L, "b", "charlie", "charlie", false, 1L, 1L, "p", "t"),
+              new VariableEntity(4L, "c", "bravo", "bravo", false, 2L, 1L, "p", "t"),
+              // Variable "a" at outer scope (comes after inner scope version in DESC sort)
+              new VariableEntity(1L, "a", "alpha", "alpha", false, 1L, 1L, "p", "t"));
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(elementInstanceServices.getByKey(eq(flowNodeInstanceEntity.flowNodeInstanceKey())))
+          .thenReturn(flowNodeInstanceEntity);
+      // Mock returns variables sorted by value DESC (like data layer would)
+      when(variableServices.search(any()))
+          .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
+
+      // when — sort by value DESC after deduplication
+      final var query =
+          VariableQuery.of(q -> q.sort(SortOptionBuilders.variable(s -> s.value().desc())));
+      final SearchQueryResult<VariableEntity> result =
+          services.searchUserTaskEffectiveVariables(entity.userTaskKey(), query);
+
+      // then — 3 unique variables, sorted by value DESC (zebra > charlie > bravo)
+      assertThat(result.total()).isEqualTo(3);
+      assertThat(result.items())
+          .extracting(VariableEntity::name, VariableEntity::value)
+          .containsExactly(tuple("a", "zebra"), tuple("b", "charlie"), tuple("c", "bravo"));
+    }
+
+    @Test
+    public void shouldApplyPaginationAfterDedup() {
+      // given — 6 variable documents across 2 scopes, 4 unique names after dedup
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1/2")
+              .create();
+      final var vars =
+          List.of(
+              // Sorted by name ASC: a, a, b, b, c, d
+              new VariableEntity(1L, "a", "1-outer", "1-outer", false, 1L, 1L, "p", "t"),
+              new VariableEntity(2L, "a", "1-inner", "1-inner", false, 2L, 1L, "p", "t"),
+              new VariableEntity(3L, "b", "2-outer", "2-outer", false, 1L, 1L, "p", "t"),
+              new VariableEntity(4L, "b", "2-inner", "2-inner", false, 2L, 1L, "p", "t"),
+              new VariableEntity(5L, "c", "3", "3", false, 2L, 1L, "p", "t"),
+              new VariableEntity(6L, "d", "4", "4", false, 2L, 1L, "p", "t"));
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(elementInstanceServices.getByKey(eq(flowNodeInstanceEntity.flowNodeInstanceKey())))
+          .thenReturn(flowNodeInstanceEntity);
+      // Mock returns variables sorted by name ASC (like data layer would)
+      when(variableServices.search(any()))
+          .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
+
+      // when — sort by name ASC, then paginate from=1, size=2
+      final var query =
+          VariableQuery.of(
+              q ->
+                  q.sort(SortOptionBuilders.variable(s -> s.name().asc()))
+                      .page(p -> p.from(1).size(2)));
+      final SearchQueryResult<VariableEntity> result =
+          services.searchUserTaskEffectiveVariables(entity.userTaskKey(), query);
+
+      // then — 4 unique after dedup, page returns items at index 1 and 2 (b-inner, c)
+      assertThat(result.total()).isEqualTo(4);
+      assertThat(result.items()).hasSize(2);
+      assertThat(result.items())
+          .extracting(VariableEntity::name, VariableEntity::value)
+          .containsExactly(tuple("b", "2-inner"), tuple("c", "3"));
+    }
+
+    @Test
+    public void shouldStripCursorsInEarlyExitCase() {
+      // given — when treePathList.size() <= 1, the service takes an early exit and delegates
+      // to searchUserTaskVariables. However, cursors must still be stripped because the
+      // effective variables endpoint does not support cursor-based pagination.
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1") // Only 1 scope = early exit
+              .create();
+      final var vars =
+          List.of(
+              new VariableEntity(10L, "alpha", "a", "a", false, 1L, 1L, "p", "t"),
+              new VariableEntity(20L, "bravo", "b", "b", false, 1L, 1L, "p", "t"));
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(elementInstanceServices.getByKey(eq(flowNodeInstanceEntity.flowNodeInstanceKey())))
+          .thenReturn(flowNodeInstanceEntity);
+      // The search backend returns cursors, but the early-exit must strip them
+      when(variableServices.search(any()))
+          .thenReturn(new SearchQueryResult<>(2, false, vars, "start-cursor", "end-cursor"));
+
+      // when
+      final SearchQueryResult<VariableEntity> result =
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(), variableSearchQuery().build());
+
+      // then — items are returned but cursors are stripped (null)
+      assertThat(result.total()).isEqualTo(2);
+      assertThat(result.items()).hasSize(2);
+      assertThat(result.startCursor()).isNull();
+      assertThat(result.endCursor()).isNull();
+    }
+
+    @Test
+    public void shouldReturnNullCursors() {
+      // given — cursors are not supported for this endpoint because deduplication and sorting
+      // are performed in-memory.
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1/2")
+              .create();
+      final var vars =
+          List.of(
+              new VariableEntity(10L, "alpha", "a", "a", false, 1L, 1L, "p", "t"),
+              new VariableEntity(20L, "bravo", "b", "b", false, 2L, 1L, "p", "t"));
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(elementInstanceServices.getByKey(eq(flowNodeInstanceEntity.flowNodeInstanceKey())))
+          .thenReturn(flowNodeInstanceEntity);
+      // The search backend returns cursors, but the service should strip them
+      when(variableServices.search(any()))
+          .thenReturn(new SearchQueryResult<>(2, false, vars, "start-cursor", "end-cursor"));
+
+      // when
+      final SearchQueryResult<VariableEntity> result =
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(), variableSearchQuery().build());
+
+      // then — items are returned but cursors are always null
+      assertThat(result.total()).isEqualTo(2);
+      assertThat(result.items()).hasSize(2);
+      assertThat(result.startCursor()).isNull();
+      assertThat(result.endCursor()).isNull();
     }
   }
 

--- a/tasklist/client/e2e/fixtures/v2-visual.ts
+++ b/tasklist/client/e2e/fixtures/v2-visual.ts
@@ -173,7 +173,7 @@ const test = base.extend<PlaywrightFixtures>({
   mockQueryVariablesByUserTaskRequest: async ({page}, use) => {
     await use(async ({variables = [], userTaskKey}) => {
       await page.route(
-        `**/v2/user-tasks/${userTaskKey}/variables/search**`,
+        `**/v2/user-tasks/${userTaskKey}/effective-variables/search**`,
         (route) =>
           route.fulfill({
             status: 200,

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.16.0",
         "@bpmn-io/form-js-viewer": "1.16.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.52",
+        "@camunda/camunda-api-zod-schemas": "0.0.53",
         "@camunda/camunda-composite-components": "0.22.5",
         "@carbon/elements": "11.78.0",
         "@carbon/react": "1.94.2",
@@ -591,9 +591,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.52.tgz",
-      "integrity": "sha512-pknZawq9X+piz5T2iOhzRq/S+7VEiQN0kV2be0nEGKrw71dnwitZs710jArfDjFE7OtUCSInwfZ636J3AOVOsw==",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.53.tgz",
+      "integrity": "sha512-zAZHY95dK4sz2BfOVi+g1vwDK1E3jZth1dzOTz0FH25ExW0v98CpuHtUgbNBCxDqeG4GZuIGipu898dEsWVB0w==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.16.0",
     "@bpmn-io/form-js-viewer": "1.16.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.52",
+    "@camunda/camunda-api-zod-schemas": "0.0.53",
     "@camunda/camunda-composite-components": "0.22.5",
     "@carbon/elements": "11.78.0",
     "@carbon/react": "1.94.2",

--- a/tasklist/client/src/v2/TaskDetails/FormJS/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetails/FormJS/index.test.tsx
@@ -80,7 +80,7 @@ describe('<FormJS />', () => {
   it('should render form for unassigned task', async () => {
     nodeMockServer.use(
       http.post<never, QueryVariablesByUserTaskRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (
             hasRequestedVariables(await request.json(), REQUESTED_VARIABLES)
@@ -139,7 +139,7 @@ describe('<FormJS />', () => {
   it('should render form for assigned task', async () => {
     nodeMockServer.use(
       http.post<never, QueryVariablesByUserTaskRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (
             hasRequestedVariables(await request.json(), REQUESTED_VARIABLES)
@@ -197,7 +197,7 @@ describe('<FormJS />', () => {
   it('should render a prefilled form', async () => {
     nodeMockServer.use(
       http.post<never, QueryVariablesByUserTaskRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (
             hasRequestedVariables(await request.json(), REQUESTED_VARIABLES)
@@ -252,7 +252,7 @@ describe('<FormJS />', () => {
   it('should submit prefilled form', async () => {
     nodeMockServer.use(
       http.post<never, QueryVariablesByUserTaskRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (
             hasRequestedVariables(await request.json(), REQUESTED_VARIABLES)
@@ -319,7 +319,7 @@ describe('<FormJS />', () => {
   it('should submit edited form', async () => {
     nodeMockServer.use(
       http.post<never, QueryVariablesByUserTaskRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (
             hasRequestedVariables(await request.json(), REQUESTED_VARIABLES)
@@ -389,7 +389,7 @@ describe('<FormJS />', () => {
         return HttpResponse.json(formMocks.dynamicForm);
       }),
       http.post<never, QueryVariablesByUserTaskRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (
             hasRequestedVariables(
@@ -445,11 +445,14 @@ describe('<FormJS />', () => {
 
   it("should show an error message if variables can't be loaded", async () => {
     nodeMockServer.use(
-      http.post('/v2/user-tasks/:userTaskKey/variables/search', () => {
-        return HttpResponse.json(null, {
-          status: 404,
-        });
-      }),
+      http.post(
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
+        () => {
+          return HttpResponse.json(null, {
+            status: 404,
+          });
+        },
+      ),
     );
     render(
       <FormJS
@@ -485,7 +488,7 @@ describe('<FormJS />', () => {
         },
       ),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json([]);
         },
@@ -521,7 +524,7 @@ describe('<FormJS />', () => {
   it("should make sure fetched variables don't truncate", async () => {
     nodeMockServer.use(
       http.post<never, QueryVariablesByUserTaskRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           const url = new URL(request.url);
 

--- a/tasklist/client/src/v2/TaskDetails/Variables/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetails/Variables/index.test.tsx
@@ -65,9 +65,12 @@ describe('<Variables />', () => {
 
   it("should show an error message if variables can't be loaded", async () => {
     nodeMockServer.use(
-      http.post('/v2/user-tasks/:userTaskKey/variables/search', () => {
-        return HttpResponse.json(null, {status: 404});
-      }),
+      http.post(
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
+        () => {
+          return HttpResponse.json(null, {status: 404});
+        },
+      ),
     );
 
     render(
@@ -94,7 +97,7 @@ describe('<Variables />', () => {
   it('should show existing variables for unassigned tasks', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -139,7 +142,7 @@ describe('<Variables />', () => {
   it('should show a message when the tasks has no variables', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(getQueryVariablesResponseMock([]));
@@ -181,7 +184,7 @@ describe('<Variables />', () => {
   it('should edit variable', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -234,7 +237,7 @@ describe('<Variables />', () => {
   it('should add two variables and remove one', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -299,7 +302,7 @@ describe('<Variables />', () => {
   it('should add variable on task without variables', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -345,7 +348,7 @@ describe('<Variables />', () => {
   it('should validate an empty variable name', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -398,7 +401,7 @@ describe('<Variables />', () => {
   it('should validate an invalid variable name', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -474,7 +477,7 @@ describe('<Variables />', () => {
   it('should validate an empty variable value', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -524,7 +527,7 @@ describe('<Variables />', () => {
   it('should validate an invalid variable value', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -581,7 +584,7 @@ describe('<Variables />', () => {
   it('should not validate valid variables', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -645,7 +648,7 @@ describe('<Variables />', () => {
   it('should handle submission', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -666,7 +669,7 @@ describe('<Variables />', () => {
         },
       ),
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -771,7 +774,7 @@ describe('<Variables />', () => {
   it('should change variable and complete task', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -827,7 +830,7 @@ describe('<Variables />', () => {
   it('should add new variable and complete task', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -895,7 +898,7 @@ describe('<Variables />', () => {
   it('should hide add variable button on completed tasks', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -938,7 +941,7 @@ describe('<Variables />', () => {
   it('should disable submit button on form errors for existing variables', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -988,7 +991,7 @@ describe('<Variables />', () => {
   it('should disable submit button on form errors for new variables', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -1042,7 +1045,7 @@ describe('<Variables />', () => {
   it('should disable completion button', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -1085,7 +1088,7 @@ describe('<Variables />', () => {
   it('should hide completion button on completed tasks', async () => {
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -1136,7 +1139,7 @@ describe('<Variables />', () => {
         {once: true},
       ),
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -1216,7 +1219,7 @@ describe('<Variables />', () => {
         {once: true},
       ),
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -1293,7 +1296,7 @@ describe('<Variables />', () => {
         {once: true},
       ),
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -1318,7 +1321,7 @@ describe('<Variables />', () => {
         {once: true},
       ),
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(
@@ -1369,7 +1372,7 @@ describe('<Variables />', () => {
     it('should display error if name is the same with one of the existing variables', async () => {
       nodeMockServer.use(
         http.post<never, VariableSearchRequestBody>(
-          '/v2/user-tasks/:userTaskKey/variables/search',
+          '/v2/user-tasks/:userTaskKey/effective-variables/search',
           async ({request}) => {
             if (isRequestingAllVariables(await request.json())) {
               return HttpResponse.json(
@@ -1418,7 +1421,7 @@ describe('<Variables />', () => {
     it('should display duplicate name error on last edited variable', async () => {
       nodeMockServer.use(
         http.post(
-          '/v2/user-tasks/:userTaskKey/variables/search',
+          '/v2/user-tasks/:userTaskKey/effective-variables/search',
           () => {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
@@ -1484,7 +1487,7 @@ describe('<Variables />', () => {
     it('should display error if duplicate name is used and immediately started typing on to the value field', async () => {
       nodeMockServer.use(
         http.post<never, VariableSearchRequestBody>(
-          '/v2/user-tasks/:userTaskKey/variables/search',
+          '/v2/user-tasks/:userTaskKey/effective-variables/search',
           async ({request}) => {
             if (isRequestingAllVariables(await request.json())) {
               return HttpResponse.json(
@@ -1548,7 +1551,7 @@ describe('<Variables />', () => {
     it('should continue to display existing duplicate name error', async () => {
       nodeMockServer.use(
         http.post<never, VariableSearchRequestBody>(
-          '/v2/user-tasks/:userTaskKey/variables/search',
+          '/v2/user-tasks/:userTaskKey/effective-variables/search',
           async ({request}) => {
             if (isRequestingAllVariables(await request.json())) {
               return HttpResponse.json(
@@ -1639,7 +1642,7 @@ describe('<Variables />', () => {
 
     nodeMockServer.use(
       http.post<never, VariableSearchRequestBody>(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
           if (isRequestingAllVariables(await request.json())) {
             return HttpResponse.json(

--- a/tasklist/client/src/v2/TaskDetails/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetails/index.test.tsx
@@ -96,7 +96,7 @@ describe('<Task />', () => {
         {once: true},
       ),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json(
             getQueryVariablesResponseMock(variableMocks.variables),
@@ -148,7 +148,7 @@ describe('<Task />', () => {
         {once: true},
       ),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json(
             getQueryVariablesResponseMock(variableMocks.variables),
@@ -209,7 +209,7 @@ describe('<Task />', () => {
         {once: true},
       ),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json(
             getQueryVariablesResponseMock(variableMocks.variables),
@@ -277,7 +277,7 @@ describe('<Task />', () => {
         );
       }),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json(getQueryVariablesResponseMock([]));
         },
@@ -355,7 +355,7 @@ describe('<Task />', () => {
         {once: true},
       ),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json(
             getQueryVariablesResponseMock(variableMocks.variables),
@@ -423,7 +423,7 @@ describe('<Task />', () => {
         {once: true},
       ),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json(
             getQueryVariablesResponseMock(variableMocks.variables),
@@ -504,7 +504,7 @@ describe('<Task />', () => {
         );
       }),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json(
             getQueryVariablesResponseMock(variableMocks.variables),
@@ -556,9 +556,12 @@ describe('<Task />', () => {
         },
         {once: true},
       ),
-      http.post('/v2/user-tasks/:userTaskKey/variables/search', () => {
-        return HttpResponse.json([]);
-      }),
+      http.post(
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
+        () => {
+          return HttpResponse.json([]);
+        },
+      ),
       http.delete('/v2/user-tasks/:userTaskKey/assignee', () => {
         return HttpResponse.json();
       }),
@@ -649,7 +652,7 @@ describe('<Task />', () => {
         {once: true},
       ),
       http.post(
-        '/v2/user-tasks/:userTaskKey/variables/search',
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
           return HttpResponse.json(
             getQueryVariablesResponseMock(variableMocks.variables),

--- a/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
@@ -1417,6 +1417,51 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /user-tasks/{userTaskKey}/effective-variables/search:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - User task
+      operationId: searchUserTaskEffectiveVariables
+      summary: Search user task effective variables
+      description: |
+        Search for the effective variables of a user task. This endpoint returns deduplicated
+        variables where each variable name appears at most once. When the same variable name exists
+        at multiple scope levels in the scope hierarchy, the value from the innermost scope (closest
+        to the user task) takes precedence. This is useful for retrieving the actual runtime state
+        of variables as seen by the user task. By default, long variable values in the response are
+        truncated.
+      parameters:
+        - name: userTaskKey
+          in: path
+          required: true
+          description: The key of the user task.
+          schema:
+            type: string
+        - name: truncateValues
+          in: query
+          required: false
+          description: When true (default), long variable values in the response are truncated. When false, full variable values are returned.
+          schema:
+            type: boolean
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserTaskEffectiveVariableSearchQueryRequest'
+      responses:
+        "200":
+          description: The user task effective variable search result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VariableSearchQueryResult'
+        "400":
+          $ref: '#/components/responses/InvalidData'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
   /variables/search:
     post:
       tags:
@@ -5706,6 +5751,23 @@ components:
           description: The user task variable search filters.
           allOf:
             - $ref: "#/components/schemas/UserTaskVariableFilter"
+    UserTaskEffectiveVariableSearchQueryRequest:
+      allOf:
+        - $ref: '#/components/schemas/SearchQueryRequest'
+      description: >
+        User task effective variable search query request. Uses offset-based pagination only.
+      additionalProperties: false
+      type: object
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: '#/components/schemas/UserTaskVariableSearchQuerySortRequest'
+        filter:
+          allOf:
+            - $ref: '#/components/schemas/UserTaskVariableFilter'
+          description: The user task variable search filters.
     UserTaskSearchQueryResult:
       description: User task search query response.
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1431,7 +1431,13 @@ paths:
       operationId: searchUserTaskVariables
       summary: Search user task variables
       description: |
-        Search for user task variables based on given criteria. By default, long variable values in the response are truncated.
+        Search for user task variables based on given criteria. This endpoint returns all variable
+        documents visible from the user task's scope, including variables from parent scopes in the
+        scope hierarchy. If the same variable name exists at multiple scope levels, each scope's
+        variable is returned as a separate result. Use the
+        `/user-tasks/{userTaskKey}/effective-variables/search` endpoint to get deduplicated variables
+        where the innermost scope takes precedence. By default, long variable values in the response
+        are truncated.
       parameters:
         - name: userTaskKey
           in: path
@@ -1463,6 +1469,50 @@ paths:
           $ref: "#/components/responses/InvalidData"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /user-tasks/{userTaskKey}/effective-variables/search:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - User task
+      operationId: searchUserTaskEffectiveVariables
+      summary: Search user task effective variables
+      description: |
+        Search for the effective variables of a user task. This endpoint returns deduplicated
+        variables where each variable name appears at most once. When the same variable name exists
+        at multiple scope levels in the scope hierarchy, the value from the innermost scope (closest
+        to the user task) takes precedence. This is useful for retrieving the actual runtime state
+        of variables as seen by the user task. By default, long variable values in the response are
+        truncated.
+      parameters:
+        - name: userTaskKey
+          in: path
+          required: true
+          description: The key of the user task.
+          schema:
+            $ref: '#/components/schemas/UserTaskKey'
+        - name: truncateValues
+          in: query
+          required: false
+          description: When true (default), long variable values in the response are truncated. When false, full variable values are returned.
+          schema:
+            type: boolean
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserTaskEffectiveVariableSearchQueryRequest'
+      responses:
+        "200":
+          description: The user task effective variable search result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VariableSearchQueryResult'
+        "400":
+          $ref: '#/components/responses/InvalidData'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
   /variables/search:
     post:
       tags:
@@ -6012,6 +6062,25 @@ components:
           description: The user task variable search filters.
           allOf:
             - $ref: "#/components/schemas/UserTaskVariableFilter"
+    UserTaskEffectiveVariableSearchQueryRequest:
+      description: >
+        User task effective variable search query request. Uses offset-based pagination only.
+      additionalProperties: false
+      type: object
+      properties:
+        page:
+          description: Pagination parameters.
+          allOf:
+            - $ref: '#/components/schemas/OffsetPagination'
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: '#/components/schemas/UserTaskVariableSearchQuerySortRequest'
+        filter:
+          allOf:
+            - $ref: '#/components/schemas/UserTaskVariableFilter'
+          description: The user task variable search filters.
     UserTaskSearchQueryResult:
       description: User task search query response.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -16,6 +16,7 @@ import io.camunda.service.UserTaskServices;
 import io.camunda.zeebe.gateway.protocol.rest.FormResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskEffectiveVariableSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryResult;
@@ -143,6 +144,22 @@ public class UserTaskController {
             query -> searchUserTaskVariableQuery(userTaskKey, query, truncateValues));
   }
 
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/{userTaskKey}/effective-variables/search")
+  public ResponseEntity<VariableSearchQueryResult> searchEffectiveVariables(
+      @PathVariable("userTaskKey") final long userTaskKey,
+      @RequestBody(required = false)
+          final UserTaskEffectiveVariableSearchQueryRequest
+              userTaskEffectiveVariablesSearchQueryRequest,
+      @RequestParam(name = "truncateValues", required = false, defaultValue = "true")
+          final boolean truncateValues) {
+    return SearchQueryRequestMapper.toUserTaskEffectiveVariableQuery(
+            userTaskEffectiveVariablesSearchQueryRequest)
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            query -> searchUserTaskEffectiveVariableQuery(userTaskKey, query, truncateValues));
+  }
+
   private ResponseEntity<UserTaskSearchQueryResult> search(final UserTaskQuery query) {
     try {
       final var result =
@@ -163,6 +180,20 @@ public class UserTaskController {
           userTaskServices
               .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .searchUserTaskVariables(userTaskKey, query);
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private ResponseEntity<VariableSearchQueryResult> searchUserTaskEffectiveVariableQuery(
+      final long userTaskKey, final VariableQuery query, final boolean truncateValues) {
+    try {
+      final var result =
+          userTaskServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .searchUserTaskEffectiveVariables(userTaskKey, query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
@@ -447,6 +447,24 @@ public final class SearchQueryRequestMapper {
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::variableSearchQuery);
   }
 
+  public static Either<ProblemDetail, VariableQuery> toUserTaskEffectiveVariableQuery(
+      final UserTaskEffectiveVariableSearchQueryRequest request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.variableSearchQuery().build());
+    }
+
+    final var filter = SearchQueryFilterMapper.toUserTaskVariableFilter(request.getFilter());
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        SearchQuerySortRequestMapper.toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromUserTaskVariableSearchQuerySortRequest(
+                request.getSort()),
+            SortOptionBuilders::variable,
+            SearchQuerySortRequestMapper::applyUserTaskVariableSortField);
+
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::variableSearchQuery);
+  }
+
   public static Either<ProblemDetail, VariableQuery> toVariableQuery(
       final VariableSearchQuery request) {
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -155,6 +155,36 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
       }
       """;
 
+  private static final String EXPECTED_EFFECTIVE_VARIABLE_RESULT_JSON =
+      """
+      {
+        "items": [
+          {
+              "variableKey":"0",
+              "name":"name",
+              "value":"value",
+              "scopeKey":"1",
+              "processInstanceKey":"2",
+              "tenantId":"<default>",
+              "isTruncated":false
+          },
+          {
+              "variableKey":"1",
+              "name":"name2",
+              "value":"value",
+              "scopeKey":"1",
+              "processInstanceKey":"2",
+              "tenantId":"<default>",
+              "isTruncated":true
+          }
+        ],
+        "page": {
+          "totalItems": 2,
+          "hasMoreTotalItems": false
+        }
+      }
+      """;
+
   private static final String USER_TASK_ITEM_JSON =
       """
           {
@@ -239,6 +269,16 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                       1L, "name2", "value", "valueLong", true, 1L, 2L, "bpid", "<default>")))
           .startCursor("0")
           .endCursor("1")
+          .build();
+
+  private static final SearchQueryResult<VariableEntity> SEARCH_EFFECTIVE_VAR_QUERY_RESULT =
+      new Builder<VariableEntity>()
+          .total(2L)
+          .items(
+              List.of(
+                  new VariableEntity(0L, "name", "value", null, false, 1L, 2L, "bpid", "<default>"),
+                  new VariableEntity(
+                      1L, "name2", "value", "valueLong", true, 1L, 2L, "bpid", "<default>")))
           .build();
 
   @MockitoBean UserTaskServices userTaskServices;
@@ -896,6 +936,41 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
 
     verify(userTaskServices)
         .searchUserTaskVariables(
+            VALID_USER_TASK_KEY,
+            variableSearchQuery().filter(f -> f.nameOperations(Operation.eq("varName"))).build());
+  }
+
+  @Test
+  public void shouldReturnEffectiveVariableForValidUserTaskKey() {
+    final var request =
+        """
+                {
+                    "filter":
+                        {
+                            "name": "varName"
+                        }
+
+                }""";
+
+    when(userTaskServices.searchUserTaskEffectiveVariables(
+            VALID_USER_TASK_KEY,
+            variableSearchQuery().filter(f -> f.nameOperations(Operation.eq("varName"))).build()))
+        .thenReturn(SEARCH_EFFECTIVE_VAR_QUERY_RESULT);
+    // when and then
+    webClient
+        .post()
+        .uri("/v2/user-tasks/" + VALID_USER_TASK_KEY + "/effective-variables/search")
+        .accept(APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(EXPECTED_EFFECTIVE_VARIABLE_RESULT_JSON, JsonCompareMode.STRICT);
+
+    verify(userTaskServices)
+        .searchUserTaskEffectiveVariables(
             VALID_USER_TASK_KEY,
             variableSearchQuery().filter(f -> f.nameOperations(Operation.eq("varName"))).build());
   }


### PR DESCRIPTION
# Description
Backport of #49162 to `stable/8.8`.

relates to #46967