### PR TITLE
[Backport stable/8.9] fix: use anonymous auth for decision instance existence check to return 403 instead of 404

### DIFF
--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -103,7 +103,11 @@ public final class DecisionInstanceServices
       final Long operationReference,
       final CamundaAuthentication authentication) {
 
-    // make sure decision instance exists before deletion, otherwise return not found
+    // Check if the decision instance exists using anonymous authentication.
+    // This bypasses authorization checks to distinguish between:
+    // - 404 NOT_FOUND: instance doesn't exist
+    // - 403 FORBIDDEN: instance exists but user lacks DELETE permission (checked in broker request)
+    // This matches the pattern used in ProcessInstanceServices.deleteProcessInstance().
     final var searchResult =
         search(
             decisionInstanceSearchQuery(

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -108,7 +108,7 @@ public final class DecisionInstanceServices
         search(
             decisionInstanceSearchQuery(
                 q -> q.filter(f -> f.decisionInstanceKeys(decisionEvaluationKey))),
-            authentication);
+            CamundaAuthentication.anonymous());
 
     if (searchResult.items().isEmpty()) {
       throw ErrorMapper.mapSearchError(

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -109,10 +109,15 @@ public final class DecisionInstanceServices
     // - 403 FORBIDDEN: instance exists but user lacks DELETE permission (checked in broker request)
     // This matches the pattern used in ProcessInstanceServices.deleteProcessInstance().
     final var searchResult =
-        search(
-            decisionInstanceSearchQuery(
-                q -> q.filter(f -> f.decisionInstanceKeys(decisionEvaluationKey))),
-            CamundaAuthentication.anonymous());
+        executeSearchRequest(
+            () ->
+                decisionInstanceSearchClient
+                    .withSecurityContext(
+                        securityContextProvider.provideSecurityContext(
+                            CamundaAuthentication.anonymous()))
+                    .searchDecisionInstances(
+                        decisionInstanceSearchQuery(
+                            q -> q.filter(f -> f.decisionInstanceKeys(decisionEvaluationKey)))));
 
     if (searchResult.items().isEmpty()) {
       throw ErrorMapper.mapSearchError(

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -60,6 +60,7 @@ class DecisionInstanceServiceTest {
   private DecisionInstanceServices services;
   private DecisionInstanceSearchClient client;
   private BrokerClient brokerClient;
+  private SecurityContextProvider securityContextProvider;
   private final CamundaAuthentication authentication = CamundaAuthentication.none();
 
   @BeforeEach
@@ -67,12 +68,13 @@ class DecisionInstanceServiceTest {
     final ApiServicesExecutorProvider executorProvider = mock(ApiServicesExecutorProvider.class);
     client = mock(DecisionInstanceSearchClient.class);
     brokerClient = mock(BrokerClient.class);
+    securityContextProvider = mock(SecurityContextProvider.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     services =
         new DecisionInstanceServices(
             brokerClient,
-            mock(SecurityContextProvider.class),
+            securityContextProvider,
             client,
             executorProvider,
             mock(BrokerRequestAuthorizationConverter.class));
@@ -264,11 +266,14 @@ class DecisionInstanceServiceTest {
     // when
     services.deleteDecisionInstance(decisionInstanceKey, null, authentication).join();
 
-    // then - verify that search was called (existence check happens with anonymous auth internally)
+    // then - verify that anonymous authentication was used for the existence check
+    final var authCaptor = ArgumentCaptor.forClass(CamundaAuthentication.class);
+    verify(securityContextProvider).provideSecurityContext(authCaptor.capture());
+    assertThat(authCaptor.getValue().isAnonymous()).isTrue();
+
+    // Also verify the query was for the correct decision instance key
     final var queryCaptor = ArgumentCaptor.forClass(DecisionInstanceQuery.class);
     verify(client).searchDecisionInstances(queryCaptor.capture());
-
-    // Verify the query was for the correct decision instance key
     final var capturedQuery = queryCaptor.getValue();
     assertThat(capturedQuery.filter().decisionInstanceKeys()).containsExactly(decisionInstanceKey);
   }

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -207,6 +207,22 @@ class DecisionInstanceServiceTest {
   }
 
   @Test
+  void shouldReturn404WhenDecisionInstanceDoesNotExist() {
+    // given
+    final var result = mock(SearchQueryResult.class);
+    when(result.items()).thenReturn(List.of());
+    when(client.searchDecisionInstances(any(DecisionInstanceQuery.class))).thenReturn(result);
+
+    // when/then
+    assertThatThrownBy(
+            () -> services.deleteDecisionInstance(NON_EXISTENT_KEY, null, authentication).join())
+        .isInstanceOf(ServiceException.class)
+        .hasMessage("Decision Instance with key '" + NON_EXISTENT_KEY + "' not found")
+        .extracting(e -> ((ServiceException) e).getStatus())
+        .isEqualTo(Status.NOT_FOUND);
+  }
+
+  @Test
   void shouldNotDeleteDecisionInstance() {
     // given
     when(client.searchDecisionInstances(any(DecisionInstanceQuery.class)))
@@ -220,6 +236,41 @@ class DecisionInstanceServiceTest {
             () -> services.deleteDecisionInstance(NON_EXISTENT_KEY, null, authentication).join())
         .isInstanceOf(ServiceException.class)
         .hasMessage("Decision Instance with key '" + NON_EXISTENT_KEY + "' not found");
+  }
+
+  @Test
+  void shouldUseAnonymousAuthenticationForExistenceCheckWhenDeleting() {
+    // given
+    final var decisionInstanceKey = 123L;
+    final var tenantId = "tenantId";
+
+    final var entity = mock(DecisionInstanceEntity.class);
+    when(entity.decisionDefinitionId()).thenReturn(DECISION_DEFINITION_ID);
+    when(entity.tenantId()).thenReturn(tenantId);
+
+    final var result = mock(SearchQueryResult.class);
+    when(result.items()).thenReturn(List.of(entity));
+    when(client.searchDecisionInstances(any(DecisionInstanceQuery.class))).thenReturn(result);
+
+    final var record =
+        new HistoryDeletionRecord()
+            .setResourceKey(decisionInstanceKey)
+            .setResourceType(HistoryDeletionType.DECISION_INSTANCE)
+            .setDecisionDefinitionId(DECISION_DEFINITION_ID)
+            .setTenantId(tenantId);
+    when(brokerClient.sendRequest(any(BrokerDeleteHistoryRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
+
+    // when
+    services.deleteDecisionInstance(decisionInstanceKey, null, authentication).join();
+
+    // then - verify that search was called (existence check happens with anonymous auth internally)
+    final var queryCaptor = ArgumentCaptor.forClass(DecisionInstanceQuery.class);
+    verify(client).searchDecisionInstances(queryCaptor.capture());
+
+    // Verify the query was for the correct decision instance key
+    final var capturedQuery = queryCaptor.getValue();
+    assertThat(capturedQuery.filter().decisionInstanceKeys()).containsExactly(decisionInstanceKey);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #49293 to `stable/8.9`.

relates to camunda/camunda#49280