### PR TITLE
[Backport stable/8.9] perf: reduce redundant variable value writes to Elasticsearch

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/VariablesControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/VariablesControllerIT.java
@@ -212,4 +212,148 @@ public class VariablesControllerIT extends TasklistZeebeIntegrationTest {
         .hasInstanceId()
         .hasMessage("Variable with id %s not found.", variableId);
   }
+
+  @Test
+  public void getTaskVariableByIdWithTruncatedValue() throws Exception {
+    // given - create a large variable value that will be truncated
+    final var bpmnProcessId = "simpleTestProcess";
+    final var flowNodeBpmnId = "taskH_".concat(UUID.randomUUID().toString());
+    // Create a large string (> 8191 chars, the default variable size threshold)
+    final var largeValue = "\"" + "x".repeat(10000) + "\"";
+
+    final var variables =
+        tester
+            .createAndDeploySimpleProcess(bpmnProcessId, flowNodeBpmnId)
+            .then()
+            .processIsDeployed()
+            .and()
+            .startProcessInstance(bpmnProcessId, "{\"largeVar\": " + largeValue + "}")
+            .then()
+            .variablesExist("largeVar")
+            .and()
+            .taskIsCreated(flowNodeBpmnId)
+            .and()
+            .claimAndCompleteHumanTask(flowNodeBpmnId)
+            .then()
+            .getTaskVariables();
+
+    assertThat(variables).hasSize(1);
+    final var variableId = variables.get(0).getId();
+
+    // when
+    final var result =
+        mockMvcHelper.doRequest(
+            get(TasklistURIs.VARIABLES_URL_V1.concat("/{variableId}"), variableId));
+
+    // then
+    assertThat(result)
+        .hasOkHttpStatus()
+        .hasApplicationJsonContentType()
+        .extractingContent(objectMapper, VariableResponse.class)
+        .satisfies(
+            var -> {
+              assertThat(var.getId()).isEqualTo(variableId);
+              assertThat(var.getName()).isEqualTo("largeVar");
+              // Value should be the full value, not truncated
+              assertThat(var.getValue()).isNotNull();
+              assertThat(var.getValue()).isEqualTo(largeValue);
+              assertThat(var.getValue().length()).isGreaterThan(8191);
+            });
+  }
+
+  @Test
+  public void getCompletedTaskVariableWithTruncatedValue() throws Exception {
+    // given - complete a task with a large variable value
+    final var bpmnProcessId = "simpleTestProcess";
+    final var flowNodeBpmnId = "taskH_".concat(UUID.randomUUID().toString());
+    // Create a large string (> 8191 chars, the default variable size threshold)
+    final var largeValue = "\"" + "y".repeat(9000) + "\"";
+
+    final var taskTester =
+        tester
+            .createAndDeploySimpleProcess(bpmnProcessId, flowNodeBpmnId)
+            .then()
+            .processIsDeployed()
+            .and()
+            .startProcessInstance(bpmnProcessId)
+            .and()
+            .taskIsCreated(flowNodeBpmnId)
+            .and()
+            .claimHumanTask(flowNodeBpmnId);
+
+    final var taskId = taskTester.getTaskId();
+
+    // Complete task with large variable
+    taskTester.completeHumanTask(flowNodeBpmnId, "largeCompletionVar", largeValue);
+
+    final var variables = taskTester.then().getTaskVariables();
+    assertThat(variables).hasSize(1);
+    final var variableId = variables.get(0).getId();
+
+    // when
+    final var result =
+        mockMvcHelper.doRequest(
+            get(TasklistURIs.VARIABLES_URL_V1.concat("/{variableId}"), variableId));
+
+    // then - verify the v1 API returns the full value for truncated variables
+    assertThat(result)
+        .hasOkHttpStatus()
+        .hasApplicationJsonContentType()
+        .extractingContent(objectMapper, VariableResponse.class)
+        .satisfies(
+            var -> {
+              assertThat(var.getId()).isEqualTo(variableId);
+              assertThat(var.getName()).isEqualTo("largeCompletionVar");
+              // Value should be the full value, not null or truncated
+              assertThat(var.getValue()).isNotNull();
+              assertThat(var.getValue()).isEqualTo(largeValue);
+              assertThat(var.getValue().length()).isGreaterThan(8191);
+            });
+  }
+
+  @Test
+  public void getCompletedTaskVariableWithNonTruncatedValue() throws Exception {
+    // given - complete a task with a small variable value
+    final var bpmnProcessId = "simpleTestProcess";
+    final var flowNodeBpmnId = "taskH_".concat(UUID.randomUUID().toString());
+    final var smallValue = "\"small value\"";
+
+    final var taskTester =
+        tester
+            .createAndDeploySimpleProcess(bpmnProcessId, flowNodeBpmnId)
+            .then()
+            .processIsDeployed()
+            .and()
+            .startProcessInstance(bpmnProcessId)
+            .and()
+            .taskIsCreated(flowNodeBpmnId)
+            .and()
+            .claimHumanTask(flowNodeBpmnId);
+
+    // Complete task with small variable
+    taskTester.completeHumanTask(flowNodeBpmnId, "smallCompletionVar", smallValue);
+
+    final var variables = taskTester.then().getTaskVariables();
+    assertThat(variables).hasSize(1);
+    final var variableId = variables.get(0).getId();
+
+    // when
+    final var result =
+        mockMvcHelper.doRequest(
+            get(TasklistURIs.VARIABLES_URL_V1.concat("/{variableId}"), variableId));
+
+    // then - verify the v1 API returns the value correctly for non-truncated variables
+    assertThat(result)
+        .hasOkHttpStatus()
+        .hasApplicationJsonContentType()
+        .extractingContent(objectMapper, VariableResponse.class)
+        .satisfies(
+            var -> {
+              assertThat(var.getId()).isEqualTo(variableId);
+              assertThat(var.getName()).isEqualTo("smallCompletionVar");
+              // Value should be the actual value (not null)
+              assertThat(var.getValue()).isNotNull();
+              assertThat(var.getValue()).isEqualTo(smallValue);
+            });
+  }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableResponse.java
@@ -87,7 +87,7 @@ public class VariableResponse {
         .setId(variableEntity.getId())
         .setName(variableEntity.getName())
         .setValue(
-            variableEntity.getIsPreview()
+            variableEntity.getIsPreview() && variableEntity.getFullValue() != null
                 ? variableEntity.getFullValue()
                 : variableEntity.getValue())
         .setTenantId(variableEntity.getTenantId());
@@ -107,7 +107,7 @@ public class VariableResponse {
         .setId(variableEntity.getId())
         .setName(variableEntity.getName())
         .setValue(
-            variableEntity.getIsPreview()
+            variableEntity.getIsPreview() && variableEntity.getFullValue() != null
                 ? variableEntity.getFullValue()
                 : variableEntity.getValue())
         .setTenantId(variableEntity.getTenantId());

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableResponse.java
@@ -106,7 +106,10 @@ public class VariableResponse {
     return new VariableResponse()
         .setId(variableEntity.getId())
         .setName(variableEntity.getName())
-        .setValue(variableEntity.getFullValue())
+        .setValue(
+            variableEntity.getIsPreview()
+                ? variableEntity.getFullValue()
+                : variableEntity.getValue())
         .setTenantId(variableEntity.getTenantId());
   }
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableSearchResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableSearchResponse.java
@@ -140,7 +140,10 @@ public class VariableSearchResponse {
         .setName(variableEntity.getName())
         .setPreviewValue(variableEntity.getValue())
         .setIsValueTruncated(variableEntity.getIsPreview())
-        .setValue(variableEntity.getFullValue());
+        .setValue(
+            variableEntity.getIsPreview()
+                ? variableEntity.getFullValue()
+                : variableEntity.getValue());
   }
 
   @Override

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableSearchResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableSearchResponse.java
@@ -106,7 +106,7 @@ public class VariableSearchResponse {
         .setId(variableEntity.getId())
         .setName(variableEntity.getName())
         .setValue(
-            variableEntity.getIsPreview()
+            variableEntity.getIsPreview() && variableEntity.getFullValue() != null
                 ? variableEntity.getFullValue()
                 : variableEntity.getValue())
         .setIsValueTruncated(variableEntity.getIsPreview())
@@ -141,7 +141,7 @@ public class VariableSearchResponse {
         .setPreviewValue(variableEntity.getValue())
         .setIsValueTruncated(variableEntity.getIsPreview())
         .setValue(
-            variableEntity.getIsPreview()
+            variableEntity.getIsPreview() && variableEntity.getFullValue() != null
                 ? variableEntity.getFullValue()
                 : variableEntity.getValue());
   }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/VariableDTO.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/VariableDTO.java
@@ -72,7 +72,10 @@ public class VariableDTO {
     variableDTO
         .setPreviewValue(variableEntity.getValue())
         .setIsValueTruncated(variableEntity.getIsPreview())
-        .setValue(variableEntity.getFullValue());
+        .setValue(
+            variableEntity.getIsPreview()
+                ? variableEntity.getFullValue()
+                : variableEntity.getValue());
     return variableDTO;
   }
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/VariableDTO.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/VariableDTO.java
@@ -73,7 +73,7 @@ public class VariableDTO {
         .setPreviewValue(variableEntity.getValue())
         .setIsValueTruncated(variableEntity.getIsPreview())
         .setValue(
-            variableEntity.getIsPreview()
+            variableEntity.getIsPreview() && variableEntity.getFullValue() != null
                 ? variableEntity.getFullValue()
                 : variableEntity.getValue());
     return variableDTO;
@@ -86,7 +86,7 @@ public class VariableDTO {
         .setPreviewValue(variableEntity.getValue())
         .setIsValueTruncated(variableEntity.getIsPreview())
         .setValue(
-            variableEntity.getIsPreview()
+            variableEntity.getIsPreview() && variableEntity.getFullValue() != null
                 ? variableEntity.getFullValue()
                 : variableEntity.getValue());
     return variableDTO;

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableResponseTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableResponseTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.api.rest.v1.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.usertask.DraftTaskVariableEntity;
+import io.camunda.webapps.schema.entities.usertask.SnapshotTaskVariableEntity;
+import org.junit.jupiter.api.Test;
+
+class VariableResponseTest {
+
+  @Test
+  void shouldCreateFromVariableEntityWithTruncatedValue() {
+    // given - a variable with truncated value (isPreview = true)
+    final VariableEntity variableEntity = new VariableEntity();
+    variableEntity.setId("var-1");
+    variableEntity.setName("largeVariable");
+    variableEntity.setValue("truncated..."); // preview value
+    variableEntity.setFullValue("This is the full value that was truncated"); // full value
+    variableEntity.setIsPreview(true);
+    variableEntity.setTenantId("tenant-1");
+
+    // when
+    final VariableResponse response = VariableResponse.createFrom(variableEntity);
+
+    // then
+    assertThat(response.getId()).isEqualTo("var-1");
+    assertThat(response.getName()).isEqualTo("largeVariable");
+    assertThat(response.getValue()).isEqualTo("This is the full value that was truncated");
+    assertThat(response.getTenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldCreateFromVariableEntityWithNonTruncatedValue() {
+    // given - a variable with non-truncated value (isPreview = false)
+    final VariableEntity variableEntity = new VariableEntity();
+    variableEntity.setId("var-2");
+    variableEntity.setName("smallVariable");
+    variableEntity.setValue("small value");
+    variableEntity.setFullValue(null); // fullValue is null for non-truncated variables
+    variableEntity.setIsPreview(false);
+    variableEntity.setTenantId("tenant-1");
+
+    // when
+    final VariableResponse response = VariableResponse.createFrom(variableEntity);
+
+    // then
+    assertThat(response.getId()).isEqualTo("var-2");
+    assertThat(response.getName()).isEqualTo("smallVariable");
+    assertThat(response.getValue()).isEqualTo("small value");
+    assertThat(response.getTenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldCreateFromDraftTaskVariableEntity() {
+    // given
+    final DraftTaskVariableEntity draftVariable = new DraftTaskVariableEntity();
+    draftVariable.setId("draft-1");
+    draftVariable.setName("draftVariable");
+    draftVariable.setFullValue("draft value");
+    draftVariable.setTenantId("tenant-1");
+
+    // when
+    final VariableResponse response = VariableResponse.createFrom(draftVariable);
+
+    // then
+    assertThat(response.getId()).isEqualTo("draft-1");
+    assertThat(response.getName()).isEqualTo("draftVariable");
+    assertThat(response.getValue()).isNull();
+    assertThat(response.getDraft()).isNotNull();
+    assertThat(response.getDraft().getValue()).isEqualTo("draft value");
+    assertThat(response.getTenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldCreateFromSnapshotTaskVariableEntityWithTruncatedValue() {
+    // given - a snapshot variable with truncated value (isPreview = true)
+    final SnapshotTaskVariableEntity snapshotVariable = new SnapshotTaskVariableEntity();
+    snapshotVariable.setId("snapshot-1");
+    snapshotVariable.setName("largeSnapshotVariable");
+    snapshotVariable.setValue("truncated..."); // preview value
+    snapshotVariable.setFullValue("This is the full snapshot value that was truncated");
+    snapshotVariable.setIsPreview(true);
+    snapshotVariable.setTenantId("tenant-1");
+
+    // when
+    final VariableResponse response = VariableResponse.createFrom(snapshotVariable);
+
+    // then
+    assertThat(response.getId()).isEqualTo("snapshot-1");
+    assertThat(response.getName()).isEqualTo("largeSnapshotVariable");
+    assertThat(response.getValue())
+        .isEqualTo("This is the full snapshot value that was truncated");
+    assertThat(response.getTenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldCreateFromSnapshotTaskVariableEntityWithNonTruncatedValue() {
+    // given - a snapshot variable with non-truncated value (isPreview = false)
+    final SnapshotTaskVariableEntity snapshotVariable = new SnapshotTaskVariableEntity();
+    snapshotVariable.setId("snapshot-2");
+    snapshotVariable.setName("smallSnapshotVariable");
+    snapshotVariable.setValue("small snapshot value");
+    snapshotVariable.setFullValue(null); // fullValue is null for non-truncated variables
+    snapshotVariable.setIsPreview(false);
+    snapshotVariable.setTenantId("tenant-1");
+
+    // when
+    final VariableResponse response = VariableResponse.createFrom(snapshotVariable);
+
+    // then
+    assertThat(response.getId()).isEqualTo("snapshot-2");
+    assertThat(response.getName()).isEqualTo("smallSnapshotVariable");
+    assertThat(response.getValue()).isEqualTo("small snapshot value");
+    assertThat(response.getTenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldAddDraftToVariableResponse() {
+    // given
+    final VariableResponse response = new VariableResponse();
+    final DraftTaskVariableEntity draftVariable = new DraftTaskVariableEntity();
+    draftVariable.setFullValue("draft value");
+
+    // when
+    response.addDraft(draftVariable);
+
+    // then
+    assertThat(response.getDraft()).isNotNull();
+    assertThat(response.getDraft().getValue()).isEqualTo("draft value");
+  }
+}

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableResponseTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/entities/VariableResponseTest.java
@@ -96,8 +96,7 @@ class VariableResponseTest {
     // then
     assertThat(response.getId()).isEqualTo("snapshot-1");
     assertThat(response.getName()).isEqualTo("largeSnapshotVariable");
-    assertThat(response.getValue())
-        .isEqualTo("This is the full snapshot value that was truncated");
+    assertThat(response.getValue()).isEqualTo("This is the full snapshot value that was truncated");
     assertThat(response.getTenantId()).isEqualTo("tenant-1");
   }
 
@@ -119,6 +118,48 @@ class VariableResponseTest {
     assertThat(response.getId()).isEqualTo("snapshot-2");
     assertThat(response.getName()).isEqualTo("smallSnapshotVariable");
     assertThat(response.getValue()).isEqualTo("small snapshot value");
+    assertThat(response.getTenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldFallbackToPreviewValueWhenFullValueIsNullForVariableEntity() {
+    // given - a variable marked as preview but with no fullValue available
+    final VariableEntity variableEntity = new VariableEntity();
+    variableEntity.setId("var-preview-only");
+    variableEntity.setName("largeVariablePreviewOnly");
+    variableEntity.setValue("truncated...");
+    variableEntity.setFullValue(null);
+    variableEntity.setIsPreview(true);
+    variableEntity.setTenantId("tenant-1");
+
+    // when
+    final VariableResponse response = VariableResponse.createFrom(variableEntity);
+
+    // then
+    assertThat(response.getId()).isEqualTo("var-preview-only");
+    assertThat(response.getName()).isEqualTo("largeVariablePreviewOnly");
+    assertThat(response.getValue()).isEqualTo("truncated...");
+    assertThat(response.getTenantId()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  void shouldFallbackToPreviewValueWhenFullValueIsNullForSnapshotEntity() {
+    // given - a snapshot variable marked as preview but with no fullValue available
+    final SnapshotTaskVariableEntity snapshotVariable = new SnapshotTaskVariableEntity();
+    snapshotVariable.setId("snapshot-preview-only");
+    snapshotVariable.setName("largeSnapshotPreviewOnly");
+    snapshotVariable.setValue("truncated...");
+    snapshotVariable.setFullValue(null);
+    snapshotVariable.setIsPreview(true);
+    snapshotVariable.setTenantId("tenant-1");
+
+    // when
+    final VariableResponse response = VariableResponse.createFrom(snapshotVariable);
+
+    // then
+    assertThat(response.getId()).isEqualTo("snapshot-preview-only");
+    assertThat(response.getName()).isEqualTo("largeSnapshotPreviewOnly");
+    assertThat(response.getValue()).isEqualTo("truncated...");
     assertThat(response.getTenantId()).isEqualTo("tenant-1");
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/TaskTemplate.java
@@ -52,7 +52,13 @@ public class TaskTemplate extends AbstractTemplateDescriptor
   /* Variable Fields */
   public static final String VARIABLE_NAME = "name";
   public static final String VARIABLE_VALUE = "value";
-  public static final String VARIABLE_FULL_VALUE = "fullValue";
+
+  /**
+   * @deprecated fullValue is no longer written by the exporter. Kept in the index mapping for
+   *     backward compatibility with existing documents.
+   */
+  @Deprecated public static final String VARIABLE_FULL_VALUE = "fullValue";
+
   public static final String IS_TRUNCATED = "isTruncated";
   public static final String VARIABLE_SCOPE_KEY = "scopeKey";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskVariableEntity.java
@@ -32,6 +32,12 @@ public class TaskVariableEntity
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String value;
 
+  /**
+   * @deprecated fullValue is no longer written by the exporter. The field is kept in the index
+   *     mapping for backward compatibility with existing documents but will always be null for new
+   *     documents.
+   */
+  @Deprecated
   @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String fullValue;
@@ -121,10 +127,18 @@ public class TaskVariableEntity
     return this;
   }
 
+  /**
+   * @deprecated fullValue is no longer written by the exporter. Kept for backward compatibility.
+   */
+  @Deprecated
   public String getFullValue() {
     return fullValue;
   }
 
+  /**
+   * @deprecated fullValue is no longer written by the exporter. Kept for backward compatibility.
+   */
+  @Deprecated
   public TaskVariableEntity setFullValue(final String fullValue) {
     this.fullValue = fullValue;
     return this;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -247,7 +247,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new ListViewFlowNodeFromProcessInstanceHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewVariableFromVariableHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                configuration.getIndex().getVariableSizeThreshold()),
             new ClusterVariableCreatedUpdatedHandler(
                 indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
@@ -31,9 +31,12 @@ public class ListViewVariableFromVariableHandler
       LoggerFactory.getLogger(ListViewVariableFromVariableHandler.class);
 
   private final String indexName;
+  private final int variableSizeThreshold;
 
-  public ListViewVariableFromVariableHandler(final String indexName) {
+  public ListViewVariableFromVariableHandler(
+      final String indexName, final int variableSizeThreshold) {
     this.indexName = indexName;
+    this.variableSizeThreshold = variableSizeThreshold;
   }
 
   @Override
@@ -70,6 +73,10 @@ public class ListViewVariableFromVariableHandler
   public void updateEntity(
       final Record<VariableRecordValue> record, final VariableForListViewEntity entity) {
     final var recordValue = record.getValue();
+    final String value = recordValue.getValue();
+    final String truncatedValue =
+        value.length() > variableSizeThreshold ? value.substring(0, variableSizeThreshold) : value;
+
     entity
         .setId(VariableForListViewEntity.getIdBy(recordValue.getScopeKey(), recordValue.getName()))
         .setKey(record.getKey())
@@ -78,7 +85,7 @@ public class ListViewVariableFromVariableHandler
         .setScopeKey(recordValue.getScopeKey())
         .setProcessInstanceKey(recordValue.getProcessInstanceKey())
         .setVarName(recordValue.getName())
-        .setVarValue(recordValue.getValue())
+        .setVarValue(truncatedValue)
         .setTenantId(tenantOrDefault(recordValue.getTenantId()));
 
     // set parent

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -118,16 +118,16 @@ public class UserTaskCompletionVariableHandler
             .setName(e.getKey())
             .setTenantId(recordValue.getTenantId())
             .setProcessInstanceKey(recordValue.getProcessInstanceKey())
-            .setTaskId(String.valueOf(record.getValue().getUserTaskKey()))
-            .setFullValue(variableValueAsString);
+            .setTaskId(String.valueOf(record.getValue().getUserTaskKey()));
 
     if (variableValueAsString.length() > variableSizeThreshold) {
       // store preview
       snapshotVariableEntity
           .setValue(variableValueAsString.substring(0, variableSizeThreshold))
+          .setFullValue(variableValueAsString)
           .setIsPreview(true);
     } else {
-      snapshotVariableEntity.setValue(variableValueAsString).setIsPreview(false);
+      snapshotVariableEntity.setValue(variableValueAsString).setFullValue(null).setIsPreview(false);
     }
     final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
@@ -101,7 +101,6 @@ public class UserTaskVariableHandler
             v -> {
               final Map<String, Object> updateFields = new HashMap<>();
               updateFields.put(TaskTemplate.VARIABLE_VALUE, v.getValue());
-              updateFields.put(TaskTemplate.VARIABLE_FULL_VALUE, v.getFullValue());
               updateFields.put(TaskTemplate.IS_TRUNCATED, v.getIsTruncated());
               batchRequest.upsertWithRouting(
                   indexName, v.getId(), v, updateFields, String.valueOf(v.getProcessInstanceId()));
@@ -136,7 +135,7 @@ public class UserTaskVariableHandler
       final Record<VariableRecordValue> record, final TaskVariableEntity taskVariable) {
     if (record.getValue().getValue().length() > variableSizeThreshold) {
       taskVariable.setValue(record.getValue().getValue().substring(0, variableSizeThreshold));
-      taskVariable.setFullValue(record.getValue().getValue());
+      taskVariable.setFullValue(null);
       taskVariable.setIsTruncated(true);
     } else {
       taskVariable.setValue(record.getValue().getValue());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
@@ -34,8 +34,9 @@ public class ListViewVariableFromVariableHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-list-view";
+  private final int variableSizeThreshold = 100;
   private final ListViewVariableFromVariableHandler underTest =
-      new ListViewVariableFromVariableHandler(indexName);
+      new ListViewVariableFromVariableHandler(indexName, variableSizeThreshold);
 
   @Test
   public void testGetHandledValueType() {
@@ -178,5 +179,53 @@ public class ListViewVariableFromVariableHandlerTest {
 
     // then
     assertThat(entity.getRootProcessInstanceKey()).isNull();
+  }
+
+  @Test
+  void shouldTruncateVarValueWhenExceedsThreshold() {
+    // given
+    final String longValue = "v".repeat(variableSizeThreshold + 50);
+    final Record<VariableRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r ->
+                r.withIntent(VariableIntent.CREATED)
+                    .withValue(
+                        ImmutableVariableRecordValue.builder()
+                            .from(factory.generateObject(VariableRecordValue.class))
+                            .withValue(longValue)
+                            .build()));
+
+    // when
+    final VariableForListViewEntity entity = new VariableForListViewEntity();
+    underTest.updateEntity(variableRecord, entity);
+
+    // then
+    assertThat(entity.getVarValue()).hasSize(variableSizeThreshold);
+    assertThat(entity.getVarValue()).isEqualTo("v".repeat(variableSizeThreshold));
+  }
+
+  @Test
+  void shouldNotTruncateVarValueWhenBelowThreshold() {
+    // given
+    final String shortValue = "v".repeat(variableSizeThreshold - 10);
+    final Record<VariableRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r ->
+                r.withIntent(VariableIntent.CREATED)
+                    .withValue(
+                        ImmutableVariableRecordValue.builder()
+                            .from(factory.generateObject(VariableRecordValue.class))
+                            .withValue(shortValue)
+                            .build()));
+
+    // when
+    final VariableForListViewEntity entity = new VariableForListViewEntity();
+    underTest.updateEntity(variableRecord, entity);
+
+    // then
+    assertThat(entity.getVarValue()).hasSize(variableSizeThreshold - 10);
+    assertThat(entity.getVarValue()).isEqualTo(shortValue);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -169,7 +169,7 @@ public class UserTaskCompletionVariableHandlerTest {
     assertThat(variableEntity.getProcessInstanceKey())
         .isEqualTo(taskRecord.getValue().getProcessInstanceKey());
     assertThat(variableEntity.getIsPreview()).isFalse();
-    assertThat(variableEntity.getFullValue()).isEqualTo("\"val1\"");
+    assertThat(variableEntity.getFullValue()).isNull();
     assertThat(variableEntity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(taskRecord.getValue().getRootProcessInstanceKey());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
@@ -159,7 +159,6 @@ public class UserTaskVariableHandlerTest {
     final List<String> capturedRoutings = routingCaptor.getAllValues();
 
     final Map<String, Object> updateFieldsMap = new HashMap<>();
-    updateFieldsMap.put(TaskTemplate.VARIABLE_FULL_VALUE, null);
     updateFieldsMap.put(TaskTemplate.VARIABLE_VALUE, "value");
     updateFieldsMap.put(TaskTemplate.IS_TRUNCATED, false);
 
@@ -332,8 +331,7 @@ public class UserTaskVariableHandlerTest {
     assertThat(batch.getVariables()).hasSize(1);
     final var variableEntity = batch.getVariables().get(0);
     assertThat(variableEntity.getValue()).isEqualTo("v".repeat(underTest.variableSizeThreshold));
-    assertThat(variableEntity.getFullValue())
-        .isEqualTo("v".repeat(underTest.variableSizeThreshold + 1));
+    assertThat(variableEntity.getFullValue()).isNull();
     assertThat(variableEntity.getIsTruncated()).isTrue();
   }
 


### PR DESCRIPTION
# Description
Backport of #49099 to `stable/8.9`.

relates to camunda/camunda#49098