### PR TITLE
ci: set node-version for the two other instances of build-identity-fe jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1576,6 +1576,7 @@ jobs:
         with:
           directory: ./identity/client
           package-manager: "npm"
+          node-version: 24
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
       # not resolve-able by the Javadoc generator
@@ -1636,6 +1637,7 @@ jobs:
         with:
           directory: ./identity/client
           package-manager: "npm"
+          node-version: 24
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR applies the same pattern that other Identity build jobs have which is to set the node version, this worked previously so should also work in this instance too.

Its important to resolve this step and issue so we can begin pushing `8.8-SNAPSHOT` images again.
