### PR TITLE
fix: exclude new 8.9 properties from 8.8 templates

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -200,6 +200,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-value</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -16,18 +16,26 @@ import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.RuntimeInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -55,29 +63,37 @@ final class BulkIndexRequest {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(DecisionRequirementsRecordValue.class, DeploymentKeyMixin.class)
+          .addMixIn(DecisionRequirementsMetadataValue.class, DeploymentKeyMixin.class)
+          .addMixIn(DeploymentRecordValue.class, DeploymentMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(IncidentRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(JobBatchRecordValue.class, JobBatchMixin.class)
           .addMixIn(
               JobRecordValue.class,
               IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin.class)
+          .addMixIn(MessageCorrelationRecordValue.class, ProcessDefinitionKeyMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(
               ProcessInstanceRecordValue.class,
-              IgnoreRootProcessInstanceKeyAndBusinessIdMixin.class)
+              IgnoreRootProcessInstanceKeyAndBusinessIdAndElementInstanceKeyMixin.class)
+          .addMixIn(ProcessInstanceBatchRecordValue.class, ProcessDefinitionKeyMixin.class)
           .addMixIn(
               ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
           .addMixIn(
               ProcessInstanceModificationRecordValue.class, ProcessInstanceModificationMixin.class)
           .addMixIn(
               ProcessInstanceCreationRecordValue.class,
-              IgnoreRootProcessInstanceKeyAndBusinessIdMixin.class)
-          .addMixIn(
-              ProcessInstanceMigrationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+              IgnoreRootProcessInstanceKeyAndBusinessIdAndElementInstanceKeyMixin.class)
+          .addMixIn(ProcessInstanceMigrationRecordValue.class, ProcessInstanceMigrationMixin.class)
           .addMixIn(
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
-          .addMixIn(UserTaskRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
-          .addMixIn(VariableRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(ResourceDeletionRecordValue.class, ResourceDeletionMixin.class)
+          .addMixIn(RuntimeInstructionRecordValue.class, ProcessDefinitionKeyMixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTaskMixin.class)
+          .addMixIn(
+              VariableRecordValue.class, IgnoreRootProcessInstanceKeyAndAuditFieldsMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -90,13 +106,25 @@ final class BulkIndexRequest {
   private static final String CHECKPOINT_TIMESTAMP_PROPERTY = "checkpointTimestamp";
   private static final String CHECKPOINT_TYPE_PROPERTY = "checkpointType";
   private static final String CHECKPOINT_FIRST_LOG_POSITION_PROPERTY = "firstLogPosition";
-  private static final String MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY =
-      "processDefinitionKey";
+  private static final String DEFINITION_KEY_PROPERTY = "processDefinitionKey";
   private static final String PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY =
       "moveInstructions";
   private static final String ROOT_PROCESS_INSTANCE_KEY_PROPERTY = "rootProcessInstanceKey";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
   private static final String JOB_TO_USER_TASK_MIGRATION_PROPERTY = "jobToUserTaskMigration";
+  private static final String BPMN_PROCESS_ID_PROPERTY = "bpmnProcessId";
+  private static final String ELEMENT_INSTANCE_KEY_PROPERTY = "elementInstanceKey";
+  private static final String VARIABLE_SOURCE_PROPERTY = "source";
+  private static final String TENANT_FILTER_PROPERTY = "tenantFilter";
+  private static final String TAGS_PROPERTY = "tags";
+  private static final String LISTENERS_CONFIG_KEY_PROPERTY = "listenersConfigKey";
+  private static final String DEPLOYMENT_KEY_PROPERTY = "deploymentKey";
+  private static final String DELETE_HISTORY_PROPERTY = "deleteHistory";
+  private static final String BATCH_OPERATION_KEY_PROPERTY = "batchOperationKey";
+  private static final String BATCH_OPERATION_TYPE_PROPERTY = "batchOperationType";
+  private static final String RESOURCE_TYPE_PROPERTY = "resourceType";
+  private static final String RESOURCE_ID_PROPERTY = "resourceId";
+  private static final String TENANT_ID_PROPERTY = "tenantId";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -218,29 +246,77 @@ final class BulkIndexRequest {
   })
   private static final class CheckpointRecordMixin {}
 
-  @JsonIgnoreProperties({MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY})
+  @JsonIgnoreProperties({DEFINITION_KEY_PROPERTY})
   private static final class MessageSubscriptionMixin {}
 
-  @JsonIgnoreProperties({
-    MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY,
-    ROOT_PROCESS_INSTANCE_KEY_PROPERTY
-  })
+  @JsonIgnoreProperties({DEFINITION_KEY_PROPERTY, ROOT_PROCESS_INSTANCE_KEY_PROPERTY})
   private static final class ProcessMessageSubscriptionMixin {}
 
   @JsonIgnoreProperties({
     PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY,
-    ROOT_PROCESS_INSTANCE_KEY_PROPERTY
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BPMN_PROCESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    DEFINITION_KEY_PROPERTY
   })
   private static final class ProcessInstanceModificationMixin {}
 
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyMixin {}
 
-  @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, BUSINESS_ID_PROPERTY})
-  private static final class IgnoreRootProcessInstanceKeyAndBusinessIdMixin {}
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BUSINESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY
+  })
+  private static final class IgnoreRootProcessInstanceKeyAndBusinessIdAndElementInstanceKeyMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BPMN_PROCESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    DEFINITION_KEY_PROPERTY,
+    TENANT_ID_PROPERTY
+  })
+  private static final class ProcessInstanceMigrationMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    VARIABLE_SOURCE_PROPERTY
+  })
+  private static final class IgnoreRootProcessInstanceKeyAndAuditFieldsMixin {}
 
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin {}
+
+  @JsonIgnoreProperties({TENANT_FILTER_PROPERTY})
+  private static final class JobBatchMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    TAGS_PROPERTY,
+    LISTENERS_CONFIG_KEY_PROPERTY
+  })
+  private static final class UserTaskMixin {}
+
+  @JsonIgnoreProperties({DEPLOYMENT_KEY_PROPERTY})
+  private static final class DeploymentKeyMixin {}
+
+  @JsonIgnoreProperties({DEPLOYMENT_KEY_PROPERTY})
+  private static final class DeploymentMixin {}
+
+  @JsonIgnoreProperties({
+    DELETE_HISTORY_PROPERTY,
+    BATCH_OPERATION_KEY_PROPERTY,
+    BATCH_OPERATION_TYPE_PROPERTY,
+    RESOURCE_TYPE_PROPERTY,
+    RESOURCE_ID_PROPERTY
+  })
+  private static final class ResourceDeletionMixin {}
+
+  @JsonIgnoreProperties({DEFINITION_KEY_PROPERTY})
+  private static final class ProcessDefinitionKeyMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -15,26 +15,42 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.BulkIndexRequest.IndexOperation;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationMoveInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -343,7 +359,6 @@ final class BulkIndexRequestTest {
     @Test
     void shouldIndexCheckpointRecordWithType() {
       // given
-      final var timestamp = Instant.now();
       final var record =
           recordFactory.generateRecord(
               r ->
@@ -811,6 +826,261 @@ final class BulkIndexRequestTest {
           .containsExactly(true);
     }
 
+    @Test
+    void
+        shouldIndexProcessInstanceMigrationWithoutBpmnProcessIdAndElementInstanceKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceMigrationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setTargetProcessDefinitionKey(99L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .doesNotContainKey("bpmnProcessId")
+                      .doesNotContainKey("elementInstanceKey")
+                      .doesNotContainKey("rootProcessInstanceKey"));
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceMigrationWithBpmnProcessIdAndElementInstanceKeyOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceMigrationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setTargetProcessDefinitionKey(99L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("bpmnProcessId"))
+          .describedAs(
+              "Expect that migration records are serialized with bpmnProcessId on current version")
+          .containsExactly("my-process");
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceModificationWithoutBpmnProcessIdAndElementInstanceKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceModificationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .doesNotContainKey("bpmnProcessId")
+                      .doesNotContainKey("elementInstanceKey")
+                      .doesNotContainKey("rootProcessInstanceKey")
+                      .doesNotContainKey("moveInstructions"));
+    }
+
+    @Test
+    void shouldIndexProcessInstanceModificationWithBpmnProcessIdOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceModificationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("bpmnProcessId"))
+          .describedAs(
+              "Expect that modification records are serialized with bpmnProcessId on current version")
+          .containsExactly("my-process");
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithoutElementInstanceKeyOnPreviousVersion(final ValueType valueType) {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstanceKey"))
+          .describedAs(
+              "Expect that records are serialized without elementInstanceKey on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithElementInstanceKeyOnCurrentVersion(final ValueType valueType) {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstanceKey"))
+          .describedAs(
+              "Expect that records are serialized with elementInstanceKey on current version")
+          .doesNotContainNull();
+    }
+
+    @Test
+    void shouldIndexVariableRecordWithoutElementInstanceKeyAndSourceOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.VARIABLE,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new VariableRecord()
+                              .setName(BufferUtil.wrapString("varName"))
+                              .setValue(BufferUtil.wrapString("\"varValue\""))
+                              .setScopeKey(1L)
+                              .setProcessInstanceKey(2L)
+                              .setProcessDefinitionKey(3L)
+                              .setRootProcessInstanceKey(100L)
+                              .setSource(VariableSourceRecord.api())));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .doesNotContainKey("elementInstanceKey")
+                      .doesNotContainKey("source")
+                      .doesNotContainKey("rootProcessInstanceKey"));
+    }
+
+    @Test
+    void shouldIndexVariableRecordWithElementInstanceKeyAndSourceOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.VARIABLE,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new VariableRecord()
+                              .setName(BufferUtil.wrapString("varName"))
+                              .setValue(BufferUtil.wrapString("\"varValue\""))
+                              .setScopeKey(1L)
+                              .setProcessInstanceKey(2L)
+                              .setProcessDefinitionKey(3L)
+                              .setRootProcessInstanceKey(100L)
+                              .setSource(VariableSourceRecord.api())));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .containsKey("source")
+                      .containsKey("rootProcessInstanceKey"));
+    }
+
     private static long getRootProcessInstanceKey(final RecordValue recordValue) throws Exception {
       final var field = recordValue.getClass().getDeclaredField("rootProcessInstanceKey");
       field.setAccessible(true);
@@ -824,6 +1094,924 @@ final class BulkIndexRequestTest {
         throw new UncheckedIOException(
             String.format("Failed to deserialize operation [%s] source", operation.metadata()), e);
       }
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithoutTenantFilterOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobBatchRecord()
+                              .setType("test-type")
+                              .setTenantFilter(TenantFilter.PROVIDED)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tenantFilter"))
+          .describedAs(
+              "Expect that job batch records are serialized without tenantFilter on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithTenantFilterOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobBatchRecord()
+                              .setType("test-type")
+                              .setTenantFilter(TenantFilter.PROVIDED)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tenantFilter"))
+          .describedAs(
+              "Expect that job batch records are serialized with tenantFilter on current version")
+          .containsExactly(TenantFilter.PROVIDED.name());
+    }
+
+    @Test
+    void
+        shouldIndexJobBatchRecordWithoutRootProcessInstanceKeyAndJobToUserTaskMigrationInNestedJobsOnPreviousVersion() {
+      // given - the JobRecordValue mixin should also suppress rootProcessInstanceKey and
+      // jobToUserTaskMigration inside the nested jobs list of a JobBatchRecord
+      final var jobBatchRecord = new JobBatchRecord().setType("test-type");
+      jobBatchRecord
+          .jobs()
+          .add()
+          .setType("test-job")
+          .setRootProcessInstanceKey(42L)
+          .setIsJobToUserTaskMigration(true);
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()).withValue(jobBatchRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values -> {
+                final var value = (Map<String, Object>) values.getFirst();
+                final var jobs = (List<Map<String, Object>>) value.get("jobs");
+                assertThat(jobs).isNotEmpty();
+                assertThat(jobs.getFirst())
+                    .doesNotContainKey("rootProcessInstanceKey")
+                    .doesNotContainKey("jobToUserTaskMigration");
+              });
+    }
+
+    @Test
+    void
+        shouldIndexJobBatchRecordWithRootProcessInstanceKeyAndJobToUserTaskMigrationInNestedJobsOnCurrentVersion() {
+      // given
+      final var jobBatchRecord = new JobBatchRecord().setType("test-type");
+      jobBatchRecord
+          .jobs()
+          .add()
+          .setType("test-job")
+          .setRootProcessInstanceKey(42L)
+          .setIsJobToUserTaskMigration(true);
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValue(jobBatchRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values -> {
+                final var value = (Map<String, Object>) values.getFirst();
+                final var jobs = (List<Map<String, Object>>) value.get("jobs");
+                assertThat(jobs).isNotEmpty();
+                assertThat(jobs.getFirst())
+                    .containsEntry("rootProcessInstanceKey", 42)
+                    .containsEntry("jobToUserTaskMigration", true);
+              });
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithoutTagsAndListenersConfigKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.USER_TASK,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .doesNotContainKey("tags")
+                      .doesNotContainKey("listenersConfigKey")
+                      .doesNotContainKey("rootProcessInstanceKey"));
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithTagsOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.USER_TASK,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tags"))
+          .describedAs("Expect that user task records are serialized with tags on current version")
+          .doesNotContainNull();
+    }
+
+    @Test
+    void shouldIndexDecisionRequirementsRecordWithoutDeploymentKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DECISION_REQUIREMENTS,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new DecisionRequirementsRecord()
+                              .setDecisionRequirementsId("drg-1")
+                              .setDeploymentKey(99L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs(
+              "Expect that decision requirements records are serialized without deploymentKey on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexDecisionRequirementsRecordWithDeploymentKeyOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DECISION_REQUIREMENTS,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new DecisionRequirementsRecord()
+                              .setDecisionRequirementsId("drg-1")
+                              .setDeploymentKey(99L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs(
+              "Expect that decision requirements records are serialized with deploymentKey on current version")
+          .containsExactly(99);
+    }
+
+    @Test
+    void
+        shouldIndexDeploymentRecordWithoutDeploymentKeyInDecisionRequirementsMetadataOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DEPLOYMENT,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new DeploymentRecord().setDeploymentKey(42L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs(
+              "Expect that deployment records are serialized without deploymentKey on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordWithDeploymentKeyOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DEPLOYMENT,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new DeploymentRecord().setDeploymentKey(42L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs(
+              "Expect that deployment records are serialized with deploymentKey on current version")
+          .containsExactly(42);
+    }
+
+    @Test
+    void shouldIndexResourceDeletionRecordWithoutNewFieldsOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ResourceDeletionRecord()
+                              .setResourceKey(1L)
+                              .setDeleteHistory(true)
+                              .setBatchOperationKey(100L)
+                              .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
+                              .setResourceType(ResourceType.PROCESS_DEFINITION)
+                              .setResourceId("my-process")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .doesNotContainKey("deleteHistory")
+                      .doesNotContainKey("batchOperationKey")
+                      .doesNotContainKey("batchOperationType")
+                      .doesNotContainKey("resourceType")
+                      .doesNotContainKey("resourceId"));
+    }
+
+    @Test
+    void shouldIndexResourceDeletionRecordWithNewFieldsOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ResourceDeletionRecord()
+                              .setResourceKey(1L)
+                              .setDeleteHistory(true)
+                              .setBatchOperationKey(100L)
+                              .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
+                              .setResourceType(ResourceType.PROCESS_DEFINITION)
+                              .setResourceId("my-process")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .containsKey("deleteHistory")
+                      .containsKey("batchOperationKey")
+                      .containsKey("batchOperationType")
+                      .containsKey("resourceType")
+                      .containsKey("resourceId"));
+    }
+
+    @Test
+    void shouldIndexMessageCorrelationRecordWithoutProcessDefinitionKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new MessageCorrelationRecord()
+                              .setName("msg")
+                              .setCorrelationKey("key")
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(99L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs(
+              "Expect that message correlation records are serialized without processDefinitionKey on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexMessageCorrelationRecordWithProcessDefinitionKeyOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new MessageCorrelationRecord()
+                              .setName("msg")
+                              .setCorrelationKey("key")
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(99L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs(
+              "Expect that message correlation records are serialized with processDefinitionKey on current version")
+          .containsExactly(99);
+    }
+
+    @Test
+    void shouldIndexProcessInstanceBatchRecordWithoutProcessDefinitionKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceBatchRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(88L)
+                              .setBatchElementInstanceKey(5L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs(
+              "Expect that process instance batch records are serialized without processDefinitionKey on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexProcessInstanceBatchRecordWithProcessDefinitionKeyOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceBatchRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(88L)
+                              .setBatchElementInstanceKey(5L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs(
+              "Expect that process instance batch records are serialized with processDefinitionKey on current version")
+          .containsExactly(88);
+    }
+
+    @Test
+    void shouldIndexRuntimeInstructionRecordWithoutProcessDefinitionKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new RuntimeInstructionRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(77L)
+                              .setElementId("task-1")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs(
+              "Expect that runtime instruction records are serialized without processDefinitionKey on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexRuntimeInstructionRecordWithProcessDefinitionKeyOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new RuntimeInstructionRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(77L)
+                              .setElementId("task-1")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs(
+              "Expect that runtime instruction records are serialized with processDefinitionKey on current version")
+          .containsExactly(77);
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceMigrationRecordWithoutProcessDefinitionKeyAndTenantIdOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceMigrationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setTargetProcessDefinitionKey(99L)
+                              .setProcessDefinitionKey(55L)
+                              .setTenantId("my-tenant")
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .doesNotContainKey("processDefinitionKey")
+                      .doesNotContainKey("tenantId")
+                      .doesNotContainKey("bpmnProcessId")
+                      .doesNotContainKey("rootProcessInstanceKey"));
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceMigrationRecordWithProcessDefinitionKeyAndTenantIdOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceMigrationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setTargetProcessDefinitionKey(99L)
+                              .setProcessDefinitionKey(55L)
+                              .setTenantId("my-tenant")
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .containsEntry("processDefinitionKey", 55)
+                      .containsEntry("tenantId", "my-tenant"));
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceModificationRecordWithoutProcessDefinitionKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceModificationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(66L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .doesNotContainKey("processDefinitionKey")
+                      .doesNotContainKey("bpmnProcessId")
+                      .doesNotContainKey("rootProcessInstanceKey"));
+    }
+
+    @Test
+    void shouldIndexProcessInstanceModificationRecordWithProcessDefinitionKeyOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceModificationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(66L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs(
+              "Expect that modification records are serialized with processDefinitionKey on current version")
+          .containsExactly(66);
+    }
+
+    @Test
+    void
+        shouldIndexDecisionEvaluationRecordWithoutDecisionEvaluationInstanceKeyOnPreviousVersion() {
+      // given - EvaluatedDecisionMixin suppresses decisionEvaluationInstanceKey in nested objects;
+      // we must construct a record with evaluatedDecisions populated
+      final var decisionEvaluationRecord = new DecisionEvaluationRecord();
+      decisionEvaluationRecord
+          .evaluatedDecisions()
+          .add()
+          .setDecisionId("decision-1")
+          .setDecisionName("Decision 1")
+          .setDecisionKey(1L)
+          .setDecisionVersion(1)
+          .setDecisionType("DECISION_TABLE")
+          .setDecisionOutput(BufferUtil.wrapString("\"output\""))
+          .setDecisionEvaluationInstanceKey("eval-key-1");
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DECISION_EVALUATION,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(decisionEvaluationRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("evaluatedDecisions"))
+          .extracting(source -> ((List<Object>) source).getFirst())
+          .extracting(source -> ((Map<String, Object>) source).get("decisionEvaluationInstanceKey"))
+          .describedAs(
+              "Expect that evaluatedDecisions are serialized without decisionEvaluationInstanceKey on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexDecisionEvaluationRecordWithDecisionEvaluationInstanceKeyOnCurrentVersion() {
+      // given - decisionEvaluationInstanceKey is @JsonIgnore on the impl class, so it will
+      // always be null in the serialized output regardless of version. The EvaluatedDecisionMixin
+      // on the previous-version mapper is for immutable values (generated via ProtocolFactory).
+      final var decisionEvaluationRecord = new DecisionEvaluationRecord();
+      decisionEvaluationRecord
+          .evaluatedDecisions()
+          .add()
+          .setDecisionId("decision-1")
+          .setDecisionName("Decision 1")
+          .setDecisionKey(1L)
+          .setDecisionVersion(1)
+          .setDecisionType("DECISION_TABLE")
+          .setDecisionOutput(BufferUtil.wrapString("\"output\""))
+          .setDecisionEvaluationInstanceKey("eval-key-1");
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DECISION_EVALUATION,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(decisionEvaluationRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then - decisionEvaluationInstanceKey is always null because it has @JsonIgnore on the impl
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("evaluatedDecisions"))
+          .extracting(source -> ((List<Object>) source).getFirst())
+          .extracting(source -> ((Map<String, Object>) source).get("decisionEvaluationInstanceKey"))
+          .describedAs(
+              "Expect that decisionEvaluationInstanceKey is suppressed via @JsonIgnore on the impl class")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexCheckpointRecordWithoutFirstLogPositionOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new CheckpointRecord()
+                              .setCheckpointType(CheckpointType.SCHEDULED_BACKUP)
+                              .setCheckpointId(100)
+                              .setCheckpointPosition(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .doesNotContainKey("checkpointType")
+                      .doesNotContainKey("checkpointTimestamp")
+                      .doesNotContainKey("firstLogPosition"));
+    }
+
+    @Test
+    void shouldIndexCheckpointRecordWithFirstLogPositionOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new CheckpointRecord()
+                              .setCheckpointType(CheckpointType.SCHEDULED_BACKUP)
+                              .setCheckpointId(100)
+                              .setCheckpointPosition(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values ->
+                  assertThat((Map<String, Object>) values.getFirst())
+                      .containsKey("checkpointType")
+                      .containsKey("firstLogPosition"));
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithListenersConfigKeyOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.USER_TASK,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new UserTaskRecord().setUserTaskKey(1L).setListenersConfigKey(42L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("listenersConfigKey"))
+          .describedAs(
+              "Expect that user task records are serialized with listenersConfigKey on current version")
+          .containsExactly(42);
+    }
+
+    @Test
+    void
+        shouldIndexDeploymentRecordWithoutDeploymentKeyInNestedDecisionRequirementsMetadataOnPreviousVersion() {
+      // given - deploymentKey must also be suppressed in nested DecisionRequirementsMetadataValue
+      final var deploymentRecord = new DeploymentRecord().setDeploymentKey(42L);
+      deploymentRecord
+          .decisionRequirementsMetadata()
+          .add()
+          .setDecisionRequirementsId("drg-1")
+          .setDeploymentKey(42L);
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DEPLOYMENT,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(deploymentRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values -> {
+                final var value = (Map<String, Object>) values.getFirst();
+                assertThat(value).doesNotContainKey("deploymentKey");
+                final var metadata =
+                    (List<Map<String, Object>>) value.get("decisionRequirementsMetadata");
+                assertThat(metadata).isNotNull().isNotEmpty();
+                assertThat(metadata.getFirst()).doesNotContainKey("deploymentKey");
+              });
+    }
+
+    @Test
+    void
+        shouldIndexDeploymentRecordWithDeploymentKeyInNestedDecisionRequirementsMetadataOnCurrentVersion() {
+      // given
+      final var deploymentRecord = new DeploymentRecord().setDeploymentKey(42L);
+      deploymentRecord
+          .decisionRequirementsMetadata()
+          .add()
+          .setDecisionRequirementsId("drg-1")
+          .setDeploymentKey(42L);
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DEPLOYMENT,
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValue(deploymentRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .satisfies(
+              values -> {
+                final var value = (Map<String, Object>) values.getFirst();
+                assertThat(value).containsEntry("deploymentKey", 42);
+                final var metadata =
+                    (List<Map<String, Object>>) value.get("decisionRequirementsMetadata");
+                assertThat(metadata).isNotNull().isNotEmpty();
+                assertThat(metadata.getFirst()).containsEntry("deploymentKey", 42);
+              });
     }
   }
 }

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -226,6 +226,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-value</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-auth-spi</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -16,18 +16,26 @@ import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.RuntimeInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -62,29 +70,37 @@ final class BulkIndexRequest {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(DecisionRequirementsRecordValue.class, DeploymentKeyMixin.class)
+          .addMixIn(DecisionRequirementsMetadataValue.class, DeploymentKeyMixin.class)
+          .addMixIn(DeploymentRecordValue.class, DeploymentMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(IncidentRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(JobBatchRecordValue.class, JobBatchMixin.class)
           .addMixIn(
               JobRecordValue.class,
               IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin.class)
+          .addMixIn(MessageCorrelationRecordValue.class, ProcessDefinitionKeyMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(
-              ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
-          .addMixIn(
               ProcessInstanceRecordValue.class,
-              IgnoreRootProcessInstanceKeyAndBusinessIdMixin.class)
+              IgnoreRootProcessInstanceKeyAndBusinessIdAndElementInstanceKeyMixin.class)
+          .addMixIn(ProcessInstanceBatchRecordValue.class, ProcessDefinitionKeyMixin.class)
+          .addMixIn(
+              ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
           .addMixIn(
               ProcessInstanceModificationRecordValue.class, ProcessInstanceModificationMixin.class)
           .addMixIn(
               ProcessInstanceCreationRecordValue.class,
-              IgnoreRootProcessInstanceKeyAndBusinessIdMixin.class)
-          .addMixIn(
-              ProcessInstanceMigrationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+              IgnoreRootProcessInstanceKeyAndBusinessIdAndElementInstanceKeyMixin.class)
+          .addMixIn(ProcessInstanceMigrationRecordValue.class, ProcessInstanceMigrationMixin.class)
           .addMixIn(
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
-          .addMixIn(UserTaskRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
-          .addMixIn(VariableRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(ResourceDeletionRecordValue.class, ResourceDeletionMixin.class)
+          .addMixIn(RuntimeInstructionRecordValue.class, ProcessDefinitionKeyMixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTaskMixin.class)
+          .addMixIn(
+              VariableRecordValue.class, IgnoreRootProcessInstanceKeyAndAuditFieldsMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -97,13 +113,25 @@ final class BulkIndexRequest {
   private static final String CHECKPOINT_TIMESTAMP_PROPERTY = "checkpointTimestamp";
   private static final String CHECKPOINT_TYPE_PROPERTY = "checkpointType";
   private static final String CHECKPOINT_FIRST_LOG_POSITION_PROPERTY = "firstLogPosition";
-  private static final String MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY =
-      "processDefinitionKey";
+  private static final String DEFINITION_KEY_PROPERTY = "processDefinitionKey";
   private static final String PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY =
       "moveInstructions";
   private static final String ROOT_PROCESS_INSTANCE_KEY_PROPERTY = "rootProcessInstanceKey";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
   private static final String JOB_TO_USER_TASK_MIGRATION_PROPERTY = "jobToUserTaskMigration";
+  private static final String BPMN_PROCESS_ID_PROPERTY = "bpmnProcessId";
+  private static final String ELEMENT_INSTANCE_KEY_PROPERTY = "elementInstanceKey";
+  private static final String VARIABLE_SOURCE_PROPERTY = "source";
+  private static final String TENANT_FILTER_PROPERTY = "tenantFilter";
+  private static final String TAGS_PROPERTY = "tags";
+  private static final String LISTENERS_CONFIG_KEY_PROPERTY = "listenersConfigKey";
+  private static final String DEPLOYMENT_KEY_PROPERTY = "deploymentKey";
+  private static final String DELETE_HISTORY_PROPERTY = "deleteHistory";
+  private static final String BATCH_OPERATION_KEY_PROPERTY = "batchOperationKey";
+  private static final String BATCH_OPERATION_TYPE_PROPERTY = "batchOperationType";
+  private static final String RESOURCE_TYPE_PROPERTY = "resourceType";
+  private static final String RESOURCE_ID_PROPERTY = "resourceId";
+  private static final String TENANT_ID_PROPERTY = "tenantId";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -241,29 +269,77 @@ final class BulkIndexRequest {
   })
   private static final class CheckpointRecordMixin {}
 
-  @JsonIgnoreProperties({MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY})
+  @JsonIgnoreProperties({DEFINITION_KEY_PROPERTY})
   private static final class MessageSubscriptionMixin {}
 
-  @JsonIgnoreProperties({
-    MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY,
-    ROOT_PROCESS_INSTANCE_KEY_PROPERTY
-  })
+  @JsonIgnoreProperties({DEFINITION_KEY_PROPERTY, ROOT_PROCESS_INSTANCE_KEY_PROPERTY})
   private static final class ProcessMessageSubscriptionMixin {}
 
   @JsonIgnoreProperties({
     PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY,
-    ROOT_PROCESS_INSTANCE_KEY_PROPERTY
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BPMN_PROCESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    DEFINITION_KEY_PROPERTY
   })
   private static final class ProcessInstanceModificationMixin {}
 
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyMixin {}
 
-  @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, BUSINESS_ID_PROPERTY})
-  private static final class IgnoreRootProcessInstanceKeyAndBusinessIdMixin {}
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BUSINESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY
+  })
+  private static final class IgnoreRootProcessInstanceKeyAndBusinessIdAndElementInstanceKeyMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BPMN_PROCESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    DEFINITION_KEY_PROPERTY,
+    TENANT_ID_PROPERTY
+  })
+  private static final class ProcessInstanceMigrationMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    VARIABLE_SOURCE_PROPERTY
+  })
+  private static final class IgnoreRootProcessInstanceKeyAndAuditFieldsMixin {}
 
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin {}
+
+  @JsonIgnoreProperties({TENANT_FILTER_PROPERTY})
+  private static final class JobBatchMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    TAGS_PROPERTY,
+    LISTENERS_CONFIG_KEY_PROPERTY
+  })
+  private static final class UserTaskMixin {}
+
+  @JsonIgnoreProperties({DEPLOYMENT_KEY_PROPERTY})
+  private static final class DeploymentKeyMixin {}
+
+  @JsonIgnoreProperties({DEPLOYMENT_KEY_PROPERTY})
+  private static final class DeploymentMixin {}
+
+  @JsonIgnoreProperties({
+    DELETE_HISTORY_PROPERTY,
+    BATCH_OPERATION_KEY_PROPERTY,
+    BATCH_OPERATION_TYPE_PROPERTY,
+    RESOURCE_TYPE_PROPERTY,
+    RESOURCE_ID_PROPERTY
+  })
+  private static final class ResourceDeletionMixin {}
+
+  @JsonIgnoreProperties({DEFINITION_KEY_PROPERTY})
+  private static final class ProcessDefinitionKeyMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -13,24 +13,41 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationMoveInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -835,6 +852,1091 @@ final class BulkIndexRequestTest {
         throws IOException {
       final Map<String, Object> doc = getDocumentAsMap(request.bulkOperations().getFirst());
       return (Map<String, Object>) doc.get("value");
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceMigrationWithoutBpmnProcessIdAndElementInstanceKeyOnPreviousVersion()
+            throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceMigrationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setTargetProcessDefinitionKey(99L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .doesNotContainKey("bpmnProcessId")
+          .doesNotContainKey("elementInstanceKey")
+          .doesNotContainKey("rootProcessInstanceKey");
+    }
+
+    @Test
+    void shouldIndexProcessInstanceMigrationWithBpmnProcessIdAndElementInstanceKeyOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceMigrationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setTargetProcessDefinitionKey(99L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("bpmnProcessId"))
+          .describedAs(
+              "Expect that migration records are serialized with bpmnProcessId on current version")
+          .isEqualTo("my-process");
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceModificationWithoutBpmnProcessIdAndElementInstanceKeyOnPreviousVersion()
+            throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceModificationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .doesNotContainKey("bpmnProcessId")
+          .doesNotContainKey("elementInstanceKey")
+          .doesNotContainKey("rootProcessInstanceKey")
+          .doesNotContainKey("moveInstructions");
+    }
+
+    @Test
+    void shouldIndexProcessInstanceModificationWithBpmnProcessIdOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceModificationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("bpmnProcessId"))
+          .describedAs(
+              "Expect that modification records are serialized with bpmnProcessId on current version")
+          .isEqualTo("my-process");
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithoutElementInstanceKeyOnPreviousVersion(final ValueType valueType)
+        throws Exception {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("elementInstanceKey"))
+          .describedAs(
+              "Expect that records are serialized without elementInstanceKey on previous version")
+          .isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithElementInstanceKeyOnCurrentVersion(final ValueType valueType)
+        throws Exception {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("elementInstanceKey"))
+          .describedAs(
+              "Expect that records are serialized with elementInstanceKey on current version")
+          .isNotNull();
+    }
+
+    @Test
+    void shouldIndexVariableRecordWithoutElementInstanceKeyAndSourceOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.VARIABLE,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new VariableRecord()
+                              .setName(BufferUtil.wrapString("varName"))
+                              .setValue(BufferUtil.wrapString("\"varValue\""))
+                              .setScopeKey(1L)
+                              .setProcessInstanceKey(2L)
+                              .setProcessDefinitionKey(3L)
+                              .setRootProcessInstanceKey(100L)
+                              .setSource(VariableSourceRecord.api())));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .doesNotContainKey("elementInstanceKey")
+          .doesNotContainKey("source")
+          .doesNotContainKey("rootProcessInstanceKey");
+    }
+
+    @Test
+    void shouldIndexVariableRecordWithElementInstanceKeyAndSourceOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.VARIABLE,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new VariableRecord()
+                              .setName(BufferUtil.wrapString("varName"))
+                              .setValue(BufferUtil.wrapString("\"varValue\""))
+                              .setScopeKey(1L)
+                              .setProcessInstanceKey(2L)
+                              .setProcessDefinitionKey(3L)
+                              .setRootProcessInstanceKey(100L)
+                              .setSource(VariableSourceRecord.api())));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value).containsKey("source").containsKey("rootProcessInstanceKey");
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithoutTenantFilterOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobBatchRecord()
+                              .setType("test-type")
+                              .setTenantFilter(TenantFilter.PROVIDED)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("tenantFilter"))
+          .describedAs(
+              "Expect that job batch records are serialized without tenantFilter on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithTenantFilterOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobBatchRecord()
+                              .setType("test-type")
+                              .setTenantFilter(TenantFilter.PROVIDED)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("tenantFilter"))
+          .describedAs(
+              "Expect that job batch records are serialized with tenantFilter on current version")
+          .isEqualTo(TenantFilter.PROVIDED.name());
+    }
+
+    @Test
+    void
+        shouldIndexJobBatchRecordWithoutRootProcessInstanceKeyAndJobToUserTaskMigrationInNestedJobsOnPreviousVersion()
+            throws IOException {
+      // given - the JobRecordValue mixin should also suppress rootProcessInstanceKey and
+      // jobToUserTaskMigration inside the nested jobs list of a JobBatchRecord
+      final var jobBatchRecord = new JobBatchRecord().setType("test-type");
+      jobBatchRecord
+          .jobs()
+          .add()
+          .setType("test-job")
+          .setRootProcessInstanceKey(42L)
+          .setIsJobToUserTaskMigration(true);
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()).withValue(jobBatchRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      final var jobs = (List<Map<String, Object>>) value.get("jobs");
+      assertThat(jobs).isNotNull().isNotEmpty();
+      assertThat(jobs.getFirst())
+          .doesNotContainKey("rootProcessInstanceKey")
+          .doesNotContainKey("jobToUserTaskMigration");
+    }
+
+    @Test
+    void
+        shouldIndexJobBatchRecordWithRootProcessInstanceKeyAndJobToUserTaskMigrationInNestedJobsOnCurrentVersion()
+            throws IOException {
+      // given
+      final var jobBatchRecord = new JobBatchRecord().setType("test-type");
+      jobBatchRecord
+          .jobs()
+          .add()
+          .setType("test-job")
+          .setRootProcessInstanceKey(42L)
+          .setIsJobToUserTaskMigration(true);
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValue(jobBatchRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      final var jobs = (List<Map<String, Object>>) value.get("jobs");
+      assertThat(jobs).isNotNull().isNotEmpty();
+      assertThat(jobs.getFirst())
+          .containsEntry("rootProcessInstanceKey", 42)
+          .containsEntry("jobToUserTaskMigration", true);
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithoutTagsAndListenersConfigKeyOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.USER_TASK,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .doesNotContainKey("tags")
+          .doesNotContainKey("listenersConfigKey")
+          .doesNotContainKey("rootProcessInstanceKey");
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithTagsOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.USER_TASK,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("tags"))
+          .describedAs("Expect that user task records are serialized with tags on current version")
+          .isNotNull();
+    }
+
+    @Test
+    void shouldIndexDecisionRequirementsRecordWithoutDeploymentKeyOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DECISION_REQUIREMENTS,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new DecisionRequirementsRecord()
+                              .setDecisionRequirementsId("drg-1")
+                              .setDeploymentKey(99L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("deploymentKey"))
+          .describedAs(
+              "Expect that decision requirements records are serialized without deploymentKey on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexDecisionRequirementsRecordWithDeploymentKeyOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DECISION_REQUIREMENTS,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new DecisionRequirementsRecord()
+                              .setDecisionRequirementsId("drg-1")
+                              .setDeploymentKey(99L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("deploymentKey"))
+          .describedAs(
+              "Expect that decision requirements records are serialized with deploymentKey on current version")
+          .isEqualTo(99);
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordWithoutDeploymentKeyOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DEPLOYMENT,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new DeploymentRecord().setDeploymentKey(42L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("deploymentKey"))
+          .describedAs(
+              "Expect that deployment records are serialized without deploymentKey on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordWithDeploymentKeyOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DEPLOYMENT,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new DeploymentRecord().setDeploymentKey(42L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("deploymentKey"))
+          .describedAs(
+              "Expect that deployment records are serialized with deploymentKey on current version")
+          .isEqualTo(42);
+    }
+
+    @Test
+    void shouldIndexResourceDeletionRecordWithoutNewFieldsOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ResourceDeletionRecord()
+                              .setResourceKey(1L)
+                              .setDeleteHistory(true)
+                              .setBatchOperationKey(100L)
+                              .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
+                              .setResourceType(ResourceType.PROCESS_DEFINITION)
+                              .setResourceId("my-process")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .doesNotContainKey("deleteHistory")
+          .doesNotContainKey("batchOperationKey")
+          .doesNotContainKey("batchOperationType")
+          .doesNotContainKey("resourceType")
+          .doesNotContainKey("resourceId");
+    }
+
+    @Test
+    void shouldIndexResourceDeletionRecordWithNewFieldsOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ResourceDeletionRecord()
+                              .setResourceKey(1L)
+                              .setDeleteHistory(true)
+                              .setBatchOperationKey(100L)
+                              .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
+                              .setResourceType(ResourceType.PROCESS_DEFINITION)
+                              .setResourceId("my-process")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .containsKey("deleteHistory")
+          .containsKey("batchOperationKey")
+          .containsKey("batchOperationType")
+          .containsKey("resourceType")
+          .containsKey("resourceId");
+    }
+
+    @Test
+    void shouldIndexMessageCorrelationRecordWithoutProcessDefinitionKeyOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new MessageCorrelationRecord()
+                              .setName("msg")
+                              .setCorrelationKey("key")
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(99L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs(
+              "Expect that message correlation records are serialized without processDefinitionKey on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexMessageCorrelationRecordWithProcessDefinitionKeyOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new MessageCorrelationRecord()
+                              .setName("msg")
+                              .setCorrelationKey("key")
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(99L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs(
+              "Expect that message correlation records are serialized with processDefinitionKey on current version")
+          .isEqualTo(99);
+    }
+
+    @Test
+    void shouldIndexProcessInstanceBatchRecordWithoutProcessDefinitionKeyOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceBatchRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(88L)
+                              .setBatchElementInstanceKey(5L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs(
+              "Expect that process instance batch records are serialized without processDefinitionKey on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexProcessInstanceBatchRecordWithProcessDefinitionKeyOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceBatchRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(88L)
+                              .setBatchElementInstanceKey(5L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs(
+              "Expect that process instance batch records are serialized with processDefinitionKey on current version")
+          .isEqualTo(88);
+    }
+
+    @Test
+    void shouldIndexRuntimeInstructionRecordWithoutProcessDefinitionKeyOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new RuntimeInstructionRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(77L)
+                              .setElementId("task-1")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs(
+              "Expect that runtime instruction records are serialized without processDefinitionKey on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexRuntimeInstructionRecordWithProcessDefinitionKeyOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new RuntimeInstructionRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(77L)
+                              .setElementId("task-1")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs(
+              "Expect that runtime instruction records are serialized with processDefinitionKey on current version")
+          .isEqualTo(77);
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceMigrationRecordWithoutProcessDefinitionKeyAndTenantIdOnPreviousVersion()
+            throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceMigrationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setTargetProcessDefinitionKey(99L)
+                              .setProcessDefinitionKey(55L)
+                              .setTenantId("my-tenant")
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .doesNotContainKey("processDefinitionKey")
+          .doesNotContainKey("tenantId")
+          .doesNotContainKey("bpmnProcessId")
+          .doesNotContainKey("rootProcessInstanceKey");
+    }
+
+    @Test
+    void
+        shouldIndexProcessInstanceMigrationRecordWithProcessDefinitionKeyAndTenantIdOnCurrentVersion()
+            throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceMigrationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setTargetProcessDefinitionKey(99L)
+                              .setProcessDefinitionKey(55L)
+                              .setTenantId("my-tenant")
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .containsEntry("processDefinitionKey", 55)
+          .containsEntry("tenantId", "my-tenant");
+    }
+
+    @Test
+    void shouldIndexProcessInstanceModificationRecordWithoutProcessDefinitionKeyOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new ProcessInstanceModificationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(66L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .doesNotContainKey("processDefinitionKey")
+          .doesNotContainKey("bpmnProcessId")
+          .doesNotContainKey("rootProcessInstanceKey");
+    }
+
+    @Test
+    void shouldIndexProcessInstanceModificationRecordWithProcessDefinitionKeyOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new ProcessInstanceModificationRecord()
+                              .setProcessInstanceKey(1L)
+                              .setProcessDefinitionKey(66L)
+                              .setBpmnProcessId("my-process")
+                              .setRootProcessInstanceKey(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs(
+              "Expect that modification records are serialized with processDefinitionKey on current version")
+          .isEqualTo(66);
+    }
+
+    @Test
+    void shouldIndexDecisionEvaluationRecordWithoutDecisionEvaluationInstanceKeyOnPreviousVersion()
+        throws IOException {
+      // given - EvaluatedDecisionMixin suppresses decisionEvaluationInstanceKey in nested objects;
+      // we must construct a record with evaluatedDecisions populated
+      final var decisionEvaluationRecord = new DecisionEvaluationRecord();
+      decisionEvaluationRecord
+          .evaluatedDecisions()
+          .add()
+          .setDecisionId("decision-1")
+          .setDecisionName("Decision 1")
+          .setDecisionKey(1L)
+          .setDecisionVersion(1)
+          .setDecisionType("DECISION_TABLE")
+          .setDecisionOutput(BufferUtil.wrapString("\"output\""))
+          .setDecisionEvaluationInstanceKey("eval-key-1");
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DECISION_EVALUATION,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(decisionEvaluationRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      final var evaluatedDecisions = (List<Map<String, Object>>) value.get("evaluatedDecisions");
+      assertThat(evaluatedDecisions).isNotNull().isNotEmpty();
+      assertThat(evaluatedDecisions.getFirst())
+          .describedAs(
+              "Expect that evaluatedDecisions are serialized without decisionEvaluationInstanceKey on previous version")
+          .doesNotContainKey("decisionEvaluationInstanceKey");
+    }
+
+    @Test
+    void shouldIndexDecisionEvaluationRecordWithDecisionEvaluationInstanceKeyOnCurrentVersion()
+        throws IOException {
+      // given - decisionEvaluationInstanceKey is @JsonIgnore on the impl class, so it will
+      // always be null in the serialized output regardless of version. The EvaluatedDecisionMixin
+      // on the previous-version mapper is for immutable values (generated via ProtocolFactory).
+      final var decisionEvaluationRecord = new DecisionEvaluationRecord();
+      decisionEvaluationRecord
+          .evaluatedDecisions()
+          .add()
+          .setDecisionId("decision-1")
+          .setDecisionName("Decision 1")
+          .setDecisionKey(1L)
+          .setDecisionVersion(1)
+          .setDecisionType("DECISION_TABLE")
+          .setDecisionOutput(BufferUtil.wrapString("\"output\""))
+          .setDecisionEvaluationInstanceKey("eval-key-1");
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DECISION_EVALUATION,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(decisionEvaluationRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then - decisionEvaluationInstanceKey is always null because it has @JsonIgnore on the impl
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      final var evaluatedDecisions = (List<Map<String, Object>>) value.get("evaluatedDecisions");
+      assertThat(evaluatedDecisions).isNotNull().isNotEmpty();
+      assertThat(evaluatedDecisions.getFirst().get("decisionEvaluationInstanceKey"))
+          .describedAs(
+              "Expect that decisionEvaluationInstanceKey is suppressed via @JsonIgnore on the impl class")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexCheckpointRecordWithoutFirstLogPositionOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new CheckpointRecord()
+                              .setCheckpointType(CheckpointType.SCHEDULED_BACKUP)
+                              .setCheckpointId(100)
+                              .setCheckpointPosition(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value)
+          .doesNotContainKey("checkpointType")
+          .doesNotContainKey("checkpointTimestamp")
+          .doesNotContainKey("firstLogPosition");
+    }
+
+    @Test
+    void shouldIndexCheckpointRecordWithFirstLogPositionOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new CheckpointRecord()
+                              .setCheckpointType(CheckpointType.SCHEDULED_BACKUP)
+                              .setCheckpointId(100)
+                              .setCheckpointPosition(100L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value).containsKey("checkpointType").containsKey("firstLogPosition");
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithListenersConfigKeyOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.USER_TASK,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new UserTaskRecord().setUserTaskKey(1L).setListenersConfigKey(42L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("listenersConfigKey"))
+          .describedAs(
+              "Expect that user task records are serialized with listenersConfigKey on current version")
+          .isEqualTo(42);
+    }
+
+    @Test
+    void
+        shouldIndexDeploymentRecordWithoutDeploymentKeyInNestedDecisionRequirementsMetadataOnPreviousVersion()
+            throws IOException {
+      // given - DecisionRequirementsMixin must suppress deploymentKey both at the top level
+      // and inside the nested decisionRequirementsMetadata list
+      final var deploymentRecord = new DeploymentRecord().setDeploymentKey(42L);
+      deploymentRecord
+          .decisionRequirementsMetadata()
+          .add()
+          .setDecisionRequirementsId("drg-1")
+          .setDeploymentKey(42L);
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DEPLOYMENT,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(deploymentRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value).doesNotContainKey("deploymentKey");
+      final var metadata = (List<Map<String, Object>>) value.get("decisionRequirementsMetadata");
+      assertThat(metadata).isNotNull().isNotEmpty();
+      assertThat(metadata.getFirst()).doesNotContainKey("deploymentKey");
+    }
+
+    @Test
+    void
+        shouldIndexDeploymentRecordWithDeploymentKeyInNestedDecisionRequirementsMetadataOnCurrentVersion()
+            throws IOException {
+      // given
+      final var deploymentRecord = new DeploymentRecord().setDeploymentKey(42L);
+      deploymentRecord
+          .decisionRequirementsMetadata()
+          .add()
+          .setDecisionRequirementsId("drg-1")
+          .setDeploymentKey(42L);
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.DEPLOYMENT,
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValue(deploymentRecord));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value).containsEntry("deploymentKey", 42);
+      final var metadata = (List<Map<String, Object>>) value.get("decisionRequirementsMetadata");
+      assertThat(metadata).isNotNull().isNotEmpty();
+      assertThat(metadata.getFirst()).containsEntry("deploymentKey", 42);
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Excludes some new properties in 8.9 that did not have explicit MixIns for exclusion from 8.8 templates.

Context in Slack thread: https://camunda.slack.com/archives/C0AMU9WAVRT/p1774292114852979

### MixIn Coverage

| Record Type | Suppressed Property | MixIn | Added in this PR? | Tested (prev ✗ / curr ✓) |
| :--- | :--- | :--- | :--- | :--- |
| **ProcessInstanceRecordValue** | rootProcessInstanceKey | `IgnoreRootProcessInstanceKey…Mixin` | No (pre-existing) | ✅ / ✅ |
| | businessId | `IgnoreRootProcessInstanceKey…Mixin` | No (pre-existing) | ✅ / ✅ |
| | elementInstanceKey | `IgnoreRootProcessInstanceKeyAndBusinessIdAndElementInstanceKeyMixin` | Yes — expanded mixin | ✅ / ✅ |
| **ProcessInstanceCreationRecordValue** | rootProcessInstanceKey | `IgnoreRootProcessInstanceKey…Mixin` | No (pre-existing) | ✅ / ✅ |
| | businessId | `IgnoreRootProcessInstanceKey…Mixin` | No (pre-existing) | ✅ / ✅ |
| | elementInstanceKey | `IgnoreRootProcessInstanceKeyAndBusinessIdAndElementInstanceKeyMixin` | Yes — expanded mixin | ✅ / ✅ |
| **JobRecordValue** | rootProcessInstanceKey | `IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin` | No (pre-existing) | ✅ / ✅ |
| | jobToUserTaskMigration | `IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin` | No (pre-existing) | ✅ / ✅ |
| **JobBatchRecordValue** | tenantFilter | `JobBatchMixin` | Yes — new mixin + registration | ✅ / ✅ |
| | jobs.rootProcessInstanceKey | `IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin` | No (covered by existing) | Yes — new test |
| | jobs.jobToUserTaskMigration | `IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin` | No (covered by existing) | Yes — new test |
| **IncidentRecordValue** | rootProcessInstanceKey | `IgnoreRootProcessInstanceKeyMixin` | No (pre-existing) | ✅ / ✅ |
| **VariableRecordValue** | rootProcessInstanceKey | `IgnoreRootProcessInstanceKeyAndAuditFieldsMixin` | No (was IgnoreRoot...) | ✅ / ✅ |
| | elementInstanceKey | `IgnoreRootProcessInstanceKeyAndAuditFieldsMixin` | Yes — expanded mixin | ✅ / ✅ |
| | source | `IgnoreRootProcessInstanceKeyAndAuditFieldsMixin` | Yes — expanded mixin | ✅ / ✅ |
| **UserTaskRecordValue** | rootProcessInstanceKey | `UserTaskMixin` | No (was IgnoreRoot...) | ✅ / ✅ |
| | listenersConfigKey | `UserTaskMixin` | Yes — new mixin replacing old | ✅ / ✅ |
| | tags | `UserTaskMixin` | Yes — new mixin replacing old | ✅ / ✅ |
| **DeploymentRecordValue** | deploymentKey | `DeploymentMixin` | Yes — new mixin + registration | ✅ / ✅ |
| | decisionRequirementsMetadata[].deploymentKey | `DeploymentKeyMixin` | Yes — new mixin + registration | ✅ / ✅ |
| **DecisionEvaluationRecordValue** | rootProcessInstanceKey | `IgnoreRootProcessInstanceKeyMixin` | No (pre-existing) | ✅ / ✅ |
| **EvaluatedDecisionValue** | decisionEvaluationInstanceKey | `EvaluatedDecisionMixin` | No (pre-existing) | Yes — new test |
| **DecisionRequirementsRecordValue** | deploymentKey | `DeploymentKeyMixin` | Yes — new mixin + registration | ✅ / ✅ |
| **MessageCorrelationRecordValue** | processDefinitionKey | `ProcessDefinitionKeyMixin` | Yes — new mixin + registration | ✅ / ✅ |
| **MessageSubscriptionRecordValue** | processDefinitionKey | `MessageSubscriptionMixin` | No (pre-existing) | ✅ / ✅ |
| **ProcessMessageSubscriptionRecordValue** | processDefinitionKey | `ProcessMessageSubscriptionMixin` | No (pre-existing) | ✅ / ✅ |
| | rootProcessInstanceKey | `ProcessMessageSubscriptionMixin` | No (pre-existing) | ✅ / ✅ |
| **ProcessInstanceBatchRecordValue** | processDefinitionKey | `ProcessDefinitionKeyMixin` | Yes — new mixin + registration | ✅ / ✅ |
| **ProcessInstanceMigrationRecordValue** | rootProcessInstanceKey | `ProcessInstanceMigrationMixin` | No (was IgnoreRoot...) | ✅ / ✅ |
| | processDefinitionKey | `ProcessInstanceMigrationMixin` | Yes — expanded mixin | ✅ / ✅ |
| | tenantId | `ProcessInstanceMigrationMixin` | Yes — expanded mixin | ✅ / ✅ |
| | bpmnProcessId | `ProcessInstanceMigrationMixin` | Yes — expanded mixin | ✅ / ✅ |
| | elementInstanceKey | `ProcessInstanceMigrationMixin` | Yes — expanded mixin | ✅ / ✅ |
| **ProcessInstanceModificationRecordValue** | moveInstructions | `ProcessInstanceModificationMixin` | No (pre-existing) | ✅ / ✅ |
| | rootProcessInstanceKey | `ProcessInstanceModificationMixin` | No (pre-existing) | ✅ / ✅ |
| | processDefinitionKey | `ProcessInstanceModificationMixin` | Yes — expanded mixin | ✅ / ✅ |
| | bpmnProcessId | `ProcessInstanceModificationMixin` | Yes — expanded mixin | ✅ / ✅ |
| | elementInstanceKey | `ProcessInstanceModificationMixin` | Yes — expanded mixin | ✅ / ✅ |
| **ResourceDeletionRecordValue** | deleteHistory | `ResourceDeletionMixin` | Yes — new mixin + registration | ✅ / ✅ |
| | batchOperationKey | `ResourceDeletionMixin` | Yes — new mixin + registration | ✅ / ✅ |
| | batchOperationType | `ResourceDeletionMixin` | Yes — new mixin + registration | ✅ / ✅ |
| | resourceType | `ResourceDeletionMixin` | Yes — new mixin + registration | ✅ / ✅ |
| | resourceId | `ResourceDeletionMixin` | Yes — new mixin + registration | ✅ / ✅ |
| **RuntimeInstructionRecordValue** | processDefinitionKey | `ProcessDefinitionKeyMixin` | Yes — new mixin + registration | ✅ / ✅ |
| **CheckpointRecordValue** | checkpointType | `CheckpointRecordMixin` | No (pre-existing) | ✅ / ✅ |
| | firstLogPosition | `CheckpointRecordMixin` | No (pre-existing) | ✅ / ✅ |


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
