### PR TITLE
[Backport stable/8.9] fix: Fire timer start events immediately when cycle start date is in the past

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
@@ -76,12 +76,9 @@ public class Interval implements TemporalAmount {
 
   public long toEpochMilli(final long fromEpochMilli) {
     if (start.isPresent()) {
-      final long epochMilli = start.get().toInstant().toEpochMilli();
-      if (epochMilli < fromEpochMilli) {
-        // Start date is strictly in the past: the timer is already overdue, fire immediately.
-        return fromEpochMilli;
-      }
-      return epochMilli;
+      final long startEpochMilli = start.get().toInstant().toEpochMilli();
+      // If the start date is in the past the timer is already overdue, so fire immediately.
+      return Math.max(startEpochMilli, fromEpochMilli);
     }
 
     // No explicit start date: schedule relative to fromEpochMilli.

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
@@ -75,21 +75,24 @@ public class Interval implements TemporalAmount {
   }
 
   public long toEpochMilli(final long fromEpochMilli) {
-    final long epochMilli =
-        start.map(ZonedDateTime::toInstant).map(Instant::toEpochMilli).orElse(fromEpochMilli);
-
-    if (epochMilli <= fromEpochMilli) {
-      if (!isCalendarBased()) {
-        return fromEpochMilli + getDuration().toMillis();
+    if (start.isPresent()) {
+      final long epochMilli = start.get().toInstant().toEpochMilli();
+      if (epochMilli < fromEpochMilli) {
+        // Start date is strictly in the past: the timer is already overdue, fire immediately.
+        return fromEpochMilli;
       }
-
-      return ZonedDateTime.ofInstant(Instant.ofEpochMilli(fromEpochMilli), ZoneId.systemDefault())
-          .plus(this)
-          .toInstant()
-          .toEpochMilli();
+      return epochMilli;
     }
 
-    return epochMilli;
+    // No explicit start date: schedule relative to fromEpochMilli.
+    if (!isCalendarBased()) {
+      return fromEpochMilli + getDuration().toMillis();
+    }
+
+    return ZonedDateTime.ofInstant(Instant.ofEpochMilli(fromEpochMilli), ZoneId.systemDefault())
+        .plus(this)
+        .toInstant()
+        .toEpochMilli();
   }
 
   /**

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.Period;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
@@ -200,19 +201,71 @@ public class RepeatingIntervalTest {
   }
 
   @Test
-  public void shouldNotBeLessThanCurrentTime() {
+  public void shouldReturnFromEpochMilliWhenStartDateIsInThePast() {
     // given
-    final Interval interval = new Interval(Period.ZERO, Duration.ofSeconds(10));
     final Instant currentTime = Instant.now();
     final long fromEpochMilli = currentTime.toEpochMilli();
-
-    // set start time to be less than current time
-    final Instant start = currentTime.minus(Duration.ofDays(1));
+    final Instant pastStart = currentTime.minus(Duration.ofDays(1));
+    final Interval interval =
+        new Interval(
+            Optional.of(ZonedDateTime.ofInstant(pastStart, ZoneId.systemDefault())),
+            Period.ZERO,
+            Duration.ofSeconds(10));
 
     // when
-    final long dueDate = interval.withStart(start).toEpochMilli(fromEpochMilli);
+    final long dueDate = interval.toEpochMilli(fromEpochMilli);
 
-    // then
-    assertThat(dueDate).isEqualTo(currentTime.plusSeconds(10).toEpochMilli());
+    // then — start date is in the past, so fromEpochMilli is returned unchanged
+    assertThat(dueDate).isEqualTo(fromEpochMilli);
+  }
+
+  @Test
+  public void shouldReturnStartDateWhenStartDateIsInTheFuture() {
+    // given — start date is after fromEpochMilli
+    final Instant now = Instant.now();
+    final long fromEpochMilli = now.toEpochMilli();
+    final Instant futureStart = now.plus(Duration.ofHours(1));
+    final Interval interval =
+        new Interval(
+            Optional.of(ZonedDateTime.ofInstant(futureStart, ZoneId.systemDefault())),
+            Period.ZERO,
+            Duration.ofSeconds(10));
+
+    // when
+    final long dueDate = interval.toEpochMilli(fromEpochMilli);
+
+    // then — must return the future start date unchanged
+    assertThat(dueDate).isEqualTo(futureStart.toEpochMilli());
+  }
+
+  @Test
+  public void shouldReturnFromEpochMilliPlusDurationWhenNoStartDatePresent() {
+    // given — no start date, short duration
+    final Interval interval = new Interval(Period.ZERO, Duration.ofSeconds(30));
+    final long fromEpochMilli = Instant.now().toEpochMilli();
+
+    // when
+    final long dueDate = interval.toEpochMilli(fromEpochMilli);
+
+    // then — due date is exactly fromEpochMilli + duration
+    assertThat(dueDate).isEqualTo(fromEpochMilli + Duration.ofSeconds(30).toMillis());
+  }
+
+  @Test
+  public void shouldReturnCalendarAdjustedDateWhenNoStartDatePresent() {
+    // given — no start date, period-based interval
+    final Interval interval = new Interval(Period.ofMonths(1), Duration.ZERO);
+    final ZonedDateTime from = ZonedDateTime.of(2026, 1, 31, 0, 0, 0, 0, ZoneId.systemDefault());
+    final long fromEpochMilli = from.toInstant().toEpochMilli();
+
+    // when
+    final long dueDate = interval.toEpochMilli(fromEpochMilli);
+
+    // then — calendar arithmetic: Jan 31 + P1M = Feb 28, not Jan 31 + 31 days
+    final long expected =
+        ZonedDateTime.of(2026, 2, 28, 0, 0, 0, 0, ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli();
+    assertThat(dueDate).isEqualTo(expected);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -855,6 +855,145 @@ public final class TimerStartEventTest {
   }
 
   @Test
+  public void shouldTriggerImmediatelyAndSpaceCyclesCorrectlyWhenStartDateIsInThePast() {
+    // given — R3 cycle whose start date is far in the past
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .timerWithCycle("R3/2022-04-27T17:20:00Z/PT10M")
+            .endEvent("end")
+            .done();
+
+    // when
+    final var deployedProcess =
+        engine
+            .deployment()
+            .withXmlResource(model)
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0);
+    final long processDefinitionKey = deployedProcess.getProcessDefinitionKey();
+
+    final long now = engine.getClock().getCurrentTimeInMillis();
+
+    // then — 1st timer is due immediately (due date <= now at deployment time)
+    final TimerRecordValue createdTimer =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .getFirst()
+            .getValue();
+
+    assertThat(createdTimer.getDueDate()).isLessThanOrEqualTo(now);
+
+    // and — 1st process instance is triggered without advancing the clock
+    final long firstDueDate =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .getFirst()
+            .getValue()
+            .getDueDate();
+
+    Assertions.assertThat(
+            RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .getFirst()
+                .getValue())
+        .hasTargetElementId("start")
+        .hasElementInstanceKey(TimerInstance.NO_ELEMENT_INSTANCE)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementId("end")
+                .withProcessDefinitionKey(processDefinitionKey)
+                .exists())
+        .isTrue();
+
+    // when — advance enough for the 2nd firing
+    engine.increaseTime(Duration.ofMinutes(11));
+
+    // then — 2nd timer is spaced PT10M from the 1st due date, not from 2022
+    final long secondDueDate =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .skip(1)
+            .getFirst()
+            .getValue()
+            .getDueDate();
+
+    assertThat(secondDueDate).isEqualTo(firstDueDate + Duration.ofMinutes(10).toMillis());
+
+    // when — advance for the 3rd (and final) firing
+    engine.increaseTime(Duration.ofMinutes(10));
+
+    // then — 3rd timer is spaced PT10M from the 2nd; no 4th timer created (R3 exhausted)
+    final long thirdDueDate =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .skip(2)
+            .getFirst()
+            .getValue()
+            .getDueDate();
+
+    assertThat(thirdDueDate).isEqualTo(secondDueDate + Duration.ofMinutes(10).toMillis());
+
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CREATED)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .limit(3)
+                .count())
+        .isEqualTo(3);
+  }
+
+  @Test
+  public void shouldTriggerInfiniteCycleImmediatelyWhenStartDateIsInThePast() {
+    // given — infinite cycle (R/) whose start date is in the past
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .timerWithCycle("R/2022-04-27T17:20:00Z/PT5S")
+            .endEvent("end")
+            .done();
+
+    final var deployedProcess =
+        engine
+            .deployment()
+            .withXmlResource(model)
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0);
+    final long processDefinitionKey = deployedProcess.getProcessDefinitionKey();
+
+    final long now = engine.getClock().getCurrentTimeInMillis();
+
+    // then — 1st firing is immediate (due date <= now)
+    final long firstDueDate =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .getFirst()
+            .getValue()
+            .getDueDate();
+
+    assertThat(firstDueDate).isLessThanOrEqualTo(now);
+
+    // when — advance past 2nd interval
+    engine.increaseTime(Duration.ofSeconds(6));
+
+    // then — 2nd firing is spaced PT5S from the 1st due date
+    final long secondDueDate =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .skip(1)
+            .getFirst()
+            .getValue()
+            .getDueDate();
+
+    assertThat(secondDueDate).isEqualTo(firstDueDate + Duration.ofSeconds(5).toMillis());
+  }
+
+  @Test
   public void shouldTriggerOnlyTimerStartEvent() {
     // given
     final var deployedProcess =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -865,6 +865,7 @@ public final class TimerStartEventTest {
             .done();
 
     // when
+    final long now = engine.getClock().getCurrentTimeInMillis();
     final var deployedProcess =
         engine
             .deployment()
@@ -872,10 +873,8 @@ public final class TimerStartEventTest {
             .deploy()
             .getValue()
             .getProcessesMetadata()
-            .get(0);
+            .getFirst();
     final long processDefinitionKey = deployedProcess.getProcessDefinitionKey();
-
-    final long now = engine.getClock().getCurrentTimeInMillis();
 
     // then — 1st timer is due immediately (due date <= now at deployment time)
     final TimerRecordValue createdTimer =
@@ -884,31 +883,27 @@ public final class TimerStartEventTest {
             .getFirst()
             .getValue();
 
-    assertThat(createdTimer.getDueDate()).isLessThanOrEqualTo(now);
+    assertThat(createdTimer.getDueDate())
+        .describedAs(
+            "Expect timer with start date in the past to be scheduled 'now' (or shortly after)")
+        .isBetween(now, now + Duration.ofMinutes(1).toMillis());
 
     // and — 1st process instance is triggered without advancing the clock
-    final long firstDueDate =
+    final var firstTriggeredRecord =
         RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
             .withProcessDefinitionKey(processDefinitionKey)
-            .getFirst()
-            .getValue()
-            .getDueDate();
+            .getFirst();
 
-    Assertions.assertThat(
-            RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
-                .withProcessDefinitionKey(processDefinitionKey)
-                .getFirst()
-                .getValue())
-        .hasTargetElementId("start")
-        .hasElementInstanceKey(TimerInstance.NO_ELEMENT_INSTANCE)
-        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    final var firstTriggeredTimer = firstTriggeredRecord.getValue();
+    final long firstDueDate = firstTriggeredTimer.getDueDate();
 
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withElementId("end")
-                .withProcessDefinitionKey(processDefinitionKey)
-                .exists())
-        .isTrue();
+    assertThat(firstDueDate)
+        .describedAs("Expect triggered timer to still reflect the initial due date")
+        .isEqualTo(createdTimer.getDueDate());
+
+    assertThat(firstTriggeredRecord.getTimestamp())
+        .describedAs("Expect the triggered record timestamp to be 'now' (or shortly after)")
+        .isBetween(now, now + Duration.ofMinutes(1).toMillis());
 
     // when — advance enough for the 2nd firing
     engine.increaseTime(Duration.ofMinutes(11));
@@ -925,7 +920,7 @@ public final class TimerStartEventTest {
     assertThat(secondDueDate).isEqualTo(firstDueDate + Duration.ofMinutes(10).toMillis());
 
     // when — advance for the 3rd (and final) firing
-    engine.increaseTime(Duration.ofMinutes(10));
+    engine.increaseTime(Duration.ofMinutes(11));
 
     // then — 3rd timer is spaced PT10M from the 2nd; no 4th timer created (R3 exhausted)
     final long thirdDueDate =
@@ -938,12 +933,17 @@ public final class TimerStartEventTest {
 
     assertThat(thirdDueDate).isEqualTo(secondDueDate + Duration.ofMinutes(10).toMillis());
 
+    // when — advance past 3rd interval to check that no more timers are created
+    engine.increaseTime(Duration.ofMinutes(11));
     assertThat(
-            RecordingExporter.timerRecords(TimerIntent.CREATED)
-                .withProcessDefinitionKey(processDefinitionKey)
-                .limit(3)
-                .count())
-        .isEqualTo(3);
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.timerRecords(TimerIntent.CREATED)
+                        .withProcessDefinitionKey(processDefinitionKey)
+                        .skip(3)
+                        .exists()))
+        .describedAs("Expect no more timer events to be created after R3 cycle is exhausted")
+        .isFalse();
   }
 
   @Test
@@ -952,10 +952,12 @@ public final class TimerStartEventTest {
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess("process")
             .startEvent("start")
-            .timerWithCycle("R/2022-04-27T17:20:00Z/PT5S")
+            .timerWithCycle("R/2022-04-27T17:20:00Z/PT5M")
             .endEvent("end")
             .done();
 
+    // when
+    final long now = engine.getClock().getCurrentTimeInMillis();
     final var deployedProcess =
         engine
             .deployment()
@@ -963,23 +965,39 @@ public final class TimerStartEventTest {
             .deploy()
             .getValue()
             .getProcessesMetadata()
-            .get(0);
+            .getFirst();
     final long processDefinitionKey = deployedProcess.getProcessDefinitionKey();
 
-    final long now = engine.getClock().getCurrentTimeInMillis();
-
-    // then — 1st firing is immediate (due date <= now)
-    final long firstDueDate =
-        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+    // then - the 1st timer is due immediately (at deployment time)
+    final var createdTimer =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
             .withProcessDefinitionKey(processDefinitionKey)
             .getFirst()
-            .getValue()
-            .getDueDate();
+            .getValue();
 
-    assertThat(firstDueDate).isLessThanOrEqualTo(now);
+    assertThat(createdTimer.getDueDate())
+        .describedAs(
+            "Expect timer with start date in the past to be scheduled 'now' (or shortly after)")
+        .isBetween(now, now + Duration.ofMinutes(1).toMillis());
+
+    // and — 1st firing is immediate, without advancing the clock
+    final var firstTriggeredRecord =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .getFirst();
+
+    final long firstDueDate = firstTriggeredRecord.getValue().getDueDate();
+
+    assertThat(firstDueDate)
+        .describedAs("Expect triggered timer to still reflect the initial due date")
+        .isEqualTo(createdTimer.getDueDate());
+
+    assertThat(firstTriggeredRecord.getTimestamp())
+        .describedAs("Expect the triggered record timestamp to be 'now' (or shortly after)")
+        .isBetween(now, now + Duration.ofMinutes(1).toMillis());
 
     // when — advance past 2nd interval
-    engine.increaseTime(Duration.ofSeconds(6));
+    engine.increaseTime(Duration.ofMinutes(6));
 
     // then — 2nd firing is spaced PT5S from the 1st due date
     final long secondDueDate =
@@ -990,7 +1008,9 @@ public final class TimerStartEventTest {
             .getValue()
             .getDueDate();
 
-    assertThat(secondDueDate).isEqualTo(firstDueDate + Duration.ofSeconds(5).toMillis());
+    assertThat(secondDueDate)
+        .as("Expect the 2nd firing to be spaced 5M from the 1st due date")
+        .isEqualTo(firstDueDate + Duration.ofMinutes(5).toMillis());
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #49135 to `stable/8.9`.

relates to #38987