### PR TITLE
[Backport stable/8.9] feat: add azure-openai provider, timeout, temperature, and HTTP headers to judge providers

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/judge/ProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/judge/ProviderConfig.java
@@ -54,4 +54,14 @@ public interface ProviderConfig {
   default Duration getTimeout() {
     return null;
   }
+
+  /**
+   * Returns the temperature for LLM API calls, or {@code null} to use the provider's default
+   * temperature.
+   *
+   * @return the configured temperature, or {@code null} if not set
+   */
+  default Double getTemperature() {
+    return null;
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/judge/ProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/judge/ProviderConfig.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api.judge;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -43,5 +44,14 @@ public interface ProviderConfig {
    */
   default Map<String, String> getCustomProperties() {
     return Collections.emptyMap();
+  }
+
+  /**
+   * Returns the timeout for LLM API calls, or {@code null} to use the provider's default timeout.
+   *
+   * @return the configured timeout, or {@code null} if not set
+   */
+  default Duration getTimeout() {
+    return null;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/judge/ProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/judge/ProviderConfig.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.process.test.api.judge;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -44,24 +43,5 @@ public interface ProviderConfig {
    */
   default Map<String, String> getCustomProperties() {
     return Collections.emptyMap();
-  }
-
-  /**
-   * Returns the timeout for LLM API calls, or {@code null} to use the provider's default timeout.
-   *
-   * @return the configured timeout, or {@code null} if not set
-   */
-  default Duration getTimeout() {
-    return null;
-  }
-
-  /**
-   * Returns the temperature for LLM API calls, or {@code null} to use the provider's default
-   * temperature.
-   *
-   * @return the configured temperature, or {@code null} if not set
-   */
-  default Double getTemperature() {
-    return null;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/judge/BaseProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/judge/BaseProviderConfig.java
@@ -32,6 +32,7 @@ public abstract class BaseProviderConfig implements ProviderConfig {
   private final String provider;
   private final String model;
   private Duration timeout;
+  private Double temperature;
 
   protected BaseProviderConfig(final String provider, final String model) {
     this.provider = provider;
@@ -55,6 +56,15 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
   public void setTimeout(final Duration timeout) {
     this.timeout = timeout;
+  }
+
+  @Override
+  public Double getTemperature() {
+    return temperature;
+  }
+
+  public void setTemperature(final Double temperature) {
+    this.temperature = temperature;
   }
 
   /** Generic provider configuration for unknown or custom providers. */

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/judge/BaseProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/judge/BaseProviderConfig.java
@@ -161,11 +161,17 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     private final String baseUrl;
     private final String apiKey;
+    private final Map<String, String> headers;
 
-    public OpenAiCompatibleConfig(final String model, final String baseUrl, final String apiKey) {
+    public OpenAiCompatibleConfig(
+        final String model,
+        final String baseUrl,
+        final String apiKey,
+        final Map<String, String> headers) {
       super(PROVIDER_OPENAI_COMPATIBLE, model);
       this.baseUrl = baseUrl;
       this.apiKey = apiKey;
+      this.headers = headers;
     }
 
     public String getBaseUrl() {
@@ -174,6 +180,10 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     public String getApiKey() {
       return apiKey;
+    }
+
+    public Map<String, String> getHeaders() {
+      return headers;
     }
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/judge/BaseProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/judge/BaseProviderConfig.java
@@ -49,7 +49,6 @@ public abstract class BaseProviderConfig implements ProviderConfig {
     return model;
   }
 
-  @Override
   public Duration getTimeout() {
     return timeout;
   }
@@ -58,7 +57,6 @@ public abstract class BaseProviderConfig implements ProviderConfig {
     this.timeout = timeout;
   }
 
-  @Override
   public Double getTemperature() {
     return temperature;
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/judge/BaseProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/judge/BaseProviderConfig.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.judge;
 
 import io.camunda.process.test.api.judge.ProviderConfig;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -26,9 +27,11 @@ public abstract class BaseProviderConfig implements ProviderConfig {
   public static final String PROVIDER_ANTHROPIC = "anthropic";
   public static final String PROVIDER_AMAZON_BEDROCK = "amazon-bedrock";
   public static final String PROVIDER_OPENAI_COMPATIBLE = "openai-compatible";
+  public static final String PROVIDER_AZURE_OPENAI = "azure-openai";
 
   private final String provider;
   private final String model;
+  private Duration timeout;
 
   protected BaseProviderConfig(final String provider, final String model) {
     this.provider = provider;
@@ -43,6 +46,15 @@ public abstract class BaseProviderConfig implements ProviderConfig {
   @Override
   public String getModel() {
     return model;
+  }
+
+  @Override
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(final Duration timeout) {
+    this.timeout = timeout;
   }
 
   /** Generic provider configuration for unknown or custom providers. */
@@ -148,6 +160,27 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     public String getBaseUrl() {
       return baseUrl;
+    }
+
+    public String getApiKey() {
+      return apiKey;
+    }
+  }
+
+  /** Azure OpenAI provider configuration. */
+  public static final class AzureOpenAiConfig extends BaseProviderConfig {
+
+    private final String endpoint;
+    private final String apiKey;
+
+    public AzureOpenAiConfig(final String model, final String endpoint, final String apiKey) {
+      super(PROVIDER_AZURE_OPENAI, model);
+      this.endpoint = endpoint;
+      this.apiKey = apiKey;
+    }
+
+    public String getEndpoint() {
+      return endpoint;
     }
 
     public String getApiKey() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/JudgeProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/JudgeProperties.java
@@ -47,6 +47,7 @@ public class JudgeProperties {
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_CREDENTIALS_SECRET_KEY =
       "judge.chatModel.credentials.secretKey";
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_ENDPOINT = "judge.chatModel.endpoint";
+  public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_HEADERS = "judge.chatModel.headers";
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_TIMEOUT = "judge.chatModel.timeout";
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_TEMPERATURE =
       "judge.chatModel.temperature";
@@ -63,6 +64,7 @@ public class JudgeProperties {
   private final String chatModelBaseUrl;
   private final String chatModelRegion;
   private final String chatModelEndpoint;
+  private final Map<String, String> chatModelHeaders;
   private final Duration chatModelTimeout;
   private final Double chatModelTemperature;
   private final String chatModelCredentialsAccessKey;
@@ -86,6 +88,7 @@ public class JudgeProperties {
     chatModelBaseUrl = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_BASE_URL);
     chatModelRegion = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_REGION);
     chatModelEndpoint = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_ENDPOINT);
+    chatModelHeaders = getPropertyMapOrEmpty(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_HEADERS);
     chatModelTimeout = parseTimeout(properties);
     chatModelTemperature =
         getPropertyOrNull(
@@ -135,7 +138,7 @@ public class JudgeProperties {
       case PROVIDER_OPENAI_COMPATIBLE:
         config =
             new BaseProviderConfig.OpenAiCompatibleConfig(
-                chatModelModel, chatModelBaseUrl, chatModelApiKey);
+                chatModelModel, chatModelBaseUrl, chatModelApiKey, chatModelHeaders);
         break;
       case PROVIDER_AZURE_OPENAI:
         config =

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/JudgeProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/JudgeProperties.java
@@ -48,6 +48,8 @@ public class JudgeProperties {
       "judge.chatModel.credentials.secretKey";
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_ENDPOINT = "judge.chatModel.endpoint";
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_TIMEOUT = "judge.chatModel.timeout";
+  public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_TEMPERATURE =
+      "judge.chatModel.temperature";
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_CUSTOM_PROPERTIES_PREFIX =
       "judge.chatModel.customProperties";
 
@@ -62,6 +64,7 @@ public class JudgeProperties {
   private final String chatModelRegion;
   private final String chatModelEndpoint;
   private final Duration chatModelTimeout;
+  private final Double chatModelTemperature;
   private final String chatModelCredentialsAccessKey;
   private final String chatModelCredentialsSecretKey;
   private final Map<String, String> chatModelCustomProperties;
@@ -84,6 +87,9 @@ public class JudgeProperties {
     chatModelRegion = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_REGION);
     chatModelEndpoint = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_ENDPOINT);
     chatModelTimeout = parseTimeout(properties);
+    chatModelTemperature =
+        getPropertyOrNull(
+            properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_TEMPERATURE, Double::parseDouble);
     chatModelCredentialsAccessKey =
         getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_CREDENTIALS_ACCESS_KEY);
     chatModelCredentialsSecretKey =
@@ -144,6 +150,9 @@ public class JudgeProperties {
     }
     if (chatModelTimeout != null) {
       config.setTimeout(chatModelTimeout);
+    }
+    if (chatModelTemperature != null) {
+      config.setTemperature(chatModelTemperature);
     }
     return config;
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/JudgeProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/JudgeProperties.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.runtime.properties;
 
 import static io.camunda.process.test.impl.judge.BaseProviderConfig.PROVIDER_AMAZON_BEDROCK;
 import static io.camunda.process.test.impl.judge.BaseProviderConfig.PROVIDER_ANTHROPIC;
+import static io.camunda.process.test.impl.judge.BaseProviderConfig.PROVIDER_AZURE_OPENAI;
 import static io.camunda.process.test.impl.judge.BaseProviderConfig.PROVIDER_OPENAI;
 import static io.camunda.process.test.impl.judge.BaseProviderConfig.PROVIDER_OPENAI_COMPATIBLE;
 import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getPropertyMapOrEmpty;
@@ -27,6 +28,8 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.api.judge.ProviderConfig;
 import io.camunda.process.test.impl.judge.BaseProviderConfig;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -43,6 +46,8 @@ public class JudgeProperties {
       "judge.chatModel.credentials.accessKey";
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_CREDENTIALS_SECRET_KEY =
       "judge.chatModel.credentials.secretKey";
+  public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_ENDPOINT = "judge.chatModel.endpoint";
+  public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_TIMEOUT = "judge.chatModel.timeout";
   public static final String PROPERTY_NAME_JUDGE_CHAT_MODEL_CUSTOM_PROPERTIES_PREFIX =
       "judge.chatModel.customProperties";
 
@@ -55,6 +60,8 @@ public class JudgeProperties {
   private final String chatModelApiKey;
   private final String chatModelBaseUrl;
   private final String chatModelRegion;
+  private final String chatModelEndpoint;
+  private final Duration chatModelTimeout;
   private final String chatModelCredentialsAccessKey;
   private final String chatModelCredentialsSecretKey;
   private final Map<String, String> chatModelCustomProperties;
@@ -75,6 +82,8 @@ public class JudgeProperties {
     chatModelApiKey = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_API_KEY);
     chatModelBaseUrl = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_BASE_URL);
     chatModelRegion = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_REGION);
+    chatModelEndpoint = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_ENDPOINT);
+    chatModelTimeout = parseTimeout(properties);
     chatModelCredentialsAccessKey =
         getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_CREDENTIALS_ACCESS_KEY);
     chatModelCredentialsSecretKey =
@@ -100,24 +109,55 @@ public class JudgeProperties {
       return null;
     }
     final String normalized = chatModelProvider.trim().toLowerCase();
+    final BaseProviderConfig config;
     switch (normalized) {
       case PROVIDER_OPENAI:
-        return new BaseProviderConfig.OpenAiConfig(chatModelModel, chatModelApiKey);
+        config = new BaseProviderConfig.OpenAiConfig(chatModelModel, chatModelApiKey);
+        break;
       case PROVIDER_ANTHROPIC:
-        return new BaseProviderConfig.AnthropicConfig(chatModelModel, chatModelApiKey);
+        config = new BaseProviderConfig.AnthropicConfig(chatModelModel, chatModelApiKey);
+        break;
       case PROVIDER_AMAZON_BEDROCK:
-        return new BaseProviderConfig.AmazonBedrockConfig(
-            chatModelModel,
-            chatModelRegion,
-            chatModelApiKey,
-            chatModelCredentialsAccessKey,
-            chatModelCredentialsSecretKey);
+        config =
+            new BaseProviderConfig.AmazonBedrockConfig(
+                chatModelModel,
+                chatModelRegion,
+                chatModelApiKey,
+                chatModelCredentialsAccessKey,
+                chatModelCredentialsSecretKey);
+        break;
       case PROVIDER_OPENAI_COMPATIBLE:
-        return new BaseProviderConfig.OpenAiCompatibleConfig(
-            chatModelModel, chatModelBaseUrl, chatModelApiKey);
+        config =
+            new BaseProviderConfig.OpenAiCompatibleConfig(
+                chatModelModel, chatModelBaseUrl, chatModelApiKey);
+        break;
+      case PROVIDER_AZURE_OPENAI:
+        config =
+            new BaseProviderConfig.AzureOpenAiConfig(
+                chatModelModel, chatModelEndpoint, chatModelApiKey);
+        break;
       default:
-        return new BaseProviderConfig.GenericConfig(
-            normalized, chatModelModel, chatModelCustomProperties);
+        config =
+            new BaseProviderConfig.GenericConfig(
+                normalized, chatModelModel, chatModelCustomProperties);
+        break;
+    }
+    if (chatModelTimeout != null) {
+      config.setTimeout(chatModelTimeout);
+    }
+    return config;
+  }
+
+  private Duration parseTimeout(final Properties properties) {
+    final String raw = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_TIMEOUT);
+    if (raw == null) {
+      return null;
+    }
+    try {
+      return Duration.parse(raw);
+    } catch (final DateTimeParseException e) {
+      throw new IllegalArgumentException(
+          "judge.chatModel.timeout must be a valid ISO-8601 duration (e.g. PT30S), was: " + raw, e);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
@@ -312,8 +312,7 @@ public class JudgePropertiesTest {
 
     // when / then
     assertThatThrownBy(() -> new JudgeProperties(properties))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("judge.chatModel.temperature");
+        .isInstanceOf(NumberFormatException.class);
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.process.test.api.judge.ProviderConfig;
 import io.camunda.process.test.impl.judge.BaseProviderConfig;
+import java.time.Duration;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
@@ -155,6 +156,121 @@ public class JudgePropertiesTest {
 
     // then
     assertThat(config).isNull();
+  }
+
+  @Test
+  void shouldCreateAzureOpenAiProviderConfig() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "azure-openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.endpoint", "https://my-resource.openai.azure.com/");
+    properties.setProperty("judge.chatModel.apiKey", "test-key");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config).isInstanceOf(BaseProviderConfig.AzureOpenAiConfig.class);
+    assertThat(config.getProvider()).isEqualTo("azure-openai");
+    assertThat(config.getModel()).isEqualTo("gpt-4o");
+    final BaseProviderConfig.AzureOpenAiConfig azureConfig =
+        (BaseProviderConfig.AzureOpenAiConfig) config;
+    assertThat(azureConfig.getEndpoint()).isEqualTo("https://my-resource.openai.azure.com/");
+    assertThat(azureConfig.getApiKey()).isEqualTo("test-key");
+  }
+
+  @Test
+  void shouldCreateAzureOpenAiProviderConfigWithoutApiKey() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "azure-openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.endpoint", "https://my-resource.openai.azure.com/");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config).isInstanceOf(BaseProviderConfig.AzureOpenAiConfig.class);
+    final BaseProviderConfig.AzureOpenAiConfig azureConfig =
+        (BaseProviderConfig.AzureOpenAiConfig) config;
+    assertThat(azureConfig.getApiKey()).isNull();
+  }
+
+  @Test
+  void shouldParseTimeout() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.apiKey", "test-key");
+    properties.setProperty("judge.chatModel.timeout", "PT30S");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config.getTimeout()).isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void shouldParseTimeoutMinutes() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.apiKey", "test-key");
+    properties.setProperty("judge.chatModel.timeout", "PT2M");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config.getTimeout()).isEqualTo(Duration.ofMinutes(2));
+  }
+
+  @Test
+  void shouldReturnNullTimeoutWhenNotConfigured() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.apiKey", "test-key");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config.getTimeout()).isNull();
+  }
+
+  @Test
+  void shouldRejectInvalidTimeout() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.timeout", "not-a-duration");
+
+    // when / then
+    assertThatThrownBy(() -> new JudgeProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("judge.chatModel.timeout");
+  }
+
+  @Test
+  void shouldTreatPlaceholderTimeoutAsAbsent() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.apiKey", "test-key");
+    properties.setProperty("judge.chatModel.timeout", "${TIMEOUT}");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config.getTimeout()).isNull();
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.process.test.api.judge.ProviderConfig;
 import io.camunda.process.test.impl.judge.BaseProviderConfig;
+import io.camunda.process.test.impl.judge.BaseProviderConfig.AzureOpenAiConfig;
+import io.camunda.process.test.impl.judge.BaseProviderConfig.OpenAiCompatibleConfig;
 import java.time.Duration;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
@@ -171,11 +173,10 @@ public class JudgePropertiesTest {
     final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
 
     // then
-    assertThat(config).isInstanceOf(BaseProviderConfig.AzureOpenAiConfig.class);
+    assertThat(config).isInstanceOf(AzureOpenAiConfig.class);
     assertThat(config.getProvider()).isEqualTo("azure-openai");
     assertThat(config.getModel()).isEqualTo("gpt-4o");
-    final BaseProviderConfig.AzureOpenAiConfig azureConfig =
-        (BaseProviderConfig.AzureOpenAiConfig) config;
+    final AzureOpenAiConfig azureConfig = (AzureOpenAiConfig) config;
     assertThat(azureConfig.getEndpoint()).isEqualTo("https://my-resource.openai.azure.com/");
     assertThat(azureConfig.getApiKey()).isEqualTo("test-key");
   }
@@ -192,9 +193,8 @@ public class JudgePropertiesTest {
     final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
 
     // then
-    assertThat(config).isInstanceOf(BaseProviderConfig.AzureOpenAiConfig.class);
-    final BaseProviderConfig.AzureOpenAiConfig azureConfig =
-        (BaseProviderConfig.AzureOpenAiConfig) config;
+    assertThat(config).isInstanceOf(AzureOpenAiConfig.class);
+    final AzureOpenAiConfig azureConfig = (AzureOpenAiConfig) config;
     assertThat(azureConfig.getApiKey()).isNull();
   }
 
@@ -330,5 +330,29 @@ public class JudgePropertiesTest {
     assertThat(judgeProperties.getThreshold()).isEqualTo(0.5);
     assertThat(judgeProperties.getCustomPrompt()).isNull();
     assertThat(judgeProperties.hasProviderConfigured()).isFalse();
+  }
+
+  @Test
+  void shouldParseHeaders() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "openai-compatible");
+    properties.setProperty("judge.chatModel.model", "llama3");
+    properties.setProperty("judge.chatModel.baseUrl", "http://localhost:11434/v1");
+    properties.setProperty("judge.chatModel.headers.X-Test-Header1", "value1");
+    properties.setProperty("judge.chatModel.headers.X-Test-Header2", "value2");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config).isInstanceOf(OpenAiCompatibleConfig.class);
+    final OpenAiCompatibleConfig openAiCompatibleConfig = (OpenAiCompatibleConfig) config;
+
+    assertThat(openAiCompatibleConfig.getHeaders()).isNotNull();
+    assertThat(openAiCompatibleConfig.getHeaders())
+        .containsEntry("X-Test-Header1", "value1")
+        .containsEntry("X-Test-Header2", "value2")
+        .hasSize(2);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
@@ -208,7 +208,8 @@ public class JudgePropertiesTest {
     properties.setProperty("judge.chatModel.timeout", "PT30S");
 
     // when
-    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+    final BaseProviderConfig config =
+        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
 
     // then
     assertThat(config.getTimeout()).isEqualTo(Duration.ofSeconds(30));
@@ -224,7 +225,8 @@ public class JudgePropertiesTest {
     properties.setProperty("judge.chatModel.timeout", "PT2M");
 
     // when
-    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+    final BaseProviderConfig config =
+        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
 
     // then
     assertThat(config.getTimeout()).isEqualTo(Duration.ofMinutes(2));
@@ -239,7 +241,8 @@ public class JudgePropertiesTest {
     properties.setProperty("judge.chatModel.apiKey", "test-key");
 
     // when
-    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+    final BaseProviderConfig config =
+        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
 
     // then
     assertThat(config.getTimeout()).isNull();
@@ -267,7 +270,9 @@ public class JudgePropertiesTest {
     properties.setProperty("judge.chatModel.timeout", "${TIMEOUT}");
 
     // when
-    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+    // when
+    final BaseProviderConfig config =
+        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
 
     // then
     assertThat(config.getTimeout()).isNull();
@@ -283,8 +288,8 @@ public class JudgePropertiesTest {
     properties.setProperty("judge.chatModel.temperature", "0.7");
 
     // when
-    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
-
+    final BaseProviderConfig config =
+        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
     // then
     assertThat(config.getTemperature()).isEqualTo(0.7);
   }
@@ -298,7 +303,8 @@ public class JudgePropertiesTest {
     properties.setProperty("judge.chatModel.apiKey", "test-key");
 
     // when
-    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+    final BaseProviderConfig config =
+        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
 
     // then
     assertThat(config.getTemperature()).isNull();

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
@@ -274,6 +274,49 @@ public class JudgePropertiesTest {
   }
 
   @Test
+  void shouldParseTemperature() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.apiKey", "test-key");
+    properties.setProperty("judge.chatModel.temperature", "0.7");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config.getTemperature()).isEqualTo(0.7);
+  }
+
+  @Test
+  void shouldReturnNullTemperatureWhenNotConfigured() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.apiKey", "test-key");
+
+    // when
+    final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config.getTemperature()).isNull();
+  }
+
+  @Test
+  void shouldRejectInvalidTemperature() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.temperature", "not-a-number");
+
+    // when / then
+    assertThatThrownBy(() -> new JudgeProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("judge.chatModel.temperature");
+  }
+
+  @Test
   void shouldTreatPlaceholderAsAbsent() {
     // given
     final Properties properties = new Properties();

--- a/testing/camunda-process-test-langchain4j/pom.xml
+++ b/testing/camunda-process-test-langchain4j/pom.xml
@@ -57,6 +57,16 @@
     </dependency>
 
     <dependency>
+      <groupId>dev.langchain4j</groupId>
+      <artifactId>langchain4j-azure-open-ai</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/testing/camunda-process-test-langchain4j/pom.xml
+++ b/testing/camunda-process-test-langchain4j/pom.xml
@@ -67,6 +67,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilder.java
@@ -34,8 +34,15 @@ final class AnthropicChatModelBuilder {
     final String model = require(config.getModel(), "model", "anthropic");
     final String apiKey = require(config.getApiKey(), "apiKey", "anthropic");
 
-    final ChatModel chatModel =
-        AnthropicChatModel.builder().apiKey(apiKey).modelName(model).build();
+    final AnthropicChatModel.AnthropicChatModelBuilder builder =
+        AnthropicChatModel.builder().apiKey(apiKey).modelName(model);
+
+    if (config.getTimeout() != null) {
+      LOG.debug("Setting timeout to {}", config.getTimeout());
+      builder.timeout(config.getTimeout());
+    }
+
+    final ChatModel chatModel = builder.build();
     LOG.debug("Successfully built Anthropic chat model with model '{}'", model);
     return chatModel;
   }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilder.java
@@ -41,6 +41,10 @@ final class AnthropicChatModelBuilder {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       builder.timeout(config.getTimeout());
     }
+    if (config.getTemperature() != null) {
+      LOG.debug("Setting temperature to {}", config.getTemperature());
+      builder.temperature(config.getTemperature());
+    }
 
     final ChatModel chatModel = builder.build();
     LOG.debug("Successfully built Anthropic chat model with model '{}'", model);

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelAdapterProvider.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelAdapterProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.judge;
+
+import io.camunda.process.test.api.judge.ChatModelAdapter;
+import io.camunda.process.test.api.judge.ChatModelAdapterProvider;
+import io.camunda.process.test.api.judge.ProviderConfig;
+
+public class AzureOpenAiChatModelAdapterProvider implements ChatModelAdapterProvider {
+
+  @Override
+  public String getProviderName() {
+    return BaseProviderConfig.PROVIDER_AZURE_OPENAI;
+  }
+
+  @Override
+  public ChatModelAdapter create(final ProviderConfig config) {
+    return AzureOpenAiChatModelBuilder.build((BaseProviderConfig.AzureOpenAiConfig) config)::chat;
+  }
+}

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilder.java
@@ -53,6 +53,10 @@ final class AzureOpenAiChatModelBuilder {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       builder.timeout(config.getTimeout());
     }
+    if (config.getTemperature() != null) {
+      LOG.debug("Setting temperature to {}", config.getTemperature());
+      builder.temperature(config.getTemperature());
+    }
 
     final ChatModel chatModel = builder.build();
     LOG.debug(

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilder.java
@@ -18,31 +18,35 @@ package io.camunda.process.test.impl.judge;
 import static io.camunda.process.test.impl.judge.ModelBuilderSupport.hasText;
 import static io.camunda.process.test.impl.judge.ModelBuilderSupport.require;
 
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.openai.OpenAiChatModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class OpenAiCompatibleChatModelBuilder {
+final class AzureOpenAiChatModelBuilder {
 
-  private static final Logger LOG = LoggerFactory.getLogger(OpenAiCompatibleChatModelBuilder.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AzureOpenAiChatModelBuilder.class);
 
-  private OpenAiCompatibleChatModelBuilder() {}
+  private AzureOpenAiChatModelBuilder() {}
 
-  static ChatModel build(final BaseProviderConfig.OpenAiCompatibleConfig config) {
-    LOG.debug("Building OpenAI-compatible chat model");
+  static ChatModel build(final BaseProviderConfig.AzureOpenAiConfig config) {
+    LOG.debug("Building Azure OpenAI chat model");
 
-    final String model = require(config.getModel(), "model", "openai-compatible");
-    final String baseUrl = require(config.getBaseUrl(), "baseUrl", "openai-compatible");
+    final String model = require(config.getModel(), "model", "azure-openai");
+    final String endpoint = require(config.getEndpoint(), "endpoint", "azure-openai");
 
-    final OpenAiChatModel.OpenAiChatModelBuilder builder =
-        OpenAiChatModel.builder().baseUrl(baseUrl).modelName(model);
+    final AzureOpenAiChatModel.Builder builder =
+        AzureOpenAiChatModel.builder().endpoint(endpoint).deploymentName(model);
 
     if (hasText(config.getApiKey())) {
-      LOG.debug("Using configured API key");
+      LOG.debug("Using API key authentication");
       builder.apiKey(config.getApiKey().trim());
     } else {
-      LOG.debug("No API key configured, building without authentication");
+      LOG.debug(
+          "No API key configured, falling back to DefaultAzureCredential "
+              + "(environment, workload identity, managed identity, Azure CLI)");
+      builder.tokenCredential(new DefaultAzureCredentialBuilder().build());
     }
 
     if (config.getTimeout() != null) {
@@ -52,8 +56,8 @@ final class OpenAiCompatibleChatModelBuilder {
 
     final ChatModel chatModel = builder.build();
     LOG.debug(
-        "Successfully built OpenAI-compatible chat model with baseUrl '{}' and model '{}'",
-        baseUrl,
+        "Successfully built Azure OpenAI chat model with endpoint '{}' and deployment '{}'",
+        endpoint,
         model);
     return chatModel;
   }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
@@ -19,6 +19,7 @@ import static io.camunda.process.test.impl.judge.ModelBuilderSupport.hasText;
 import static io.camunda.process.test.impl.judge.ModelBuilderSupport.require;
 
 import dev.langchain4j.model.bedrock.BedrockChatModel;
+import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
 import java.util.List;
 import java.util.Map;
@@ -96,6 +97,12 @@ final class BedrockChatModelBuilder {
     if (config.getTimeout() != null) {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       bedrockBuilder.timeout(config.getTimeout());
+    }
+    if (config.getTemperature() != null) {
+      LOG.debug("Setting temperature to {}", config.getTemperature());
+      final BedrockChatRequestParameters requestParameters =
+          BedrockChatRequestParameters.builder().temperature(config.getTemperature()).build();
+      bedrockBuilder.defaultRequestParameters(requestParameters);
     }
 
     final ChatModel chatModel = bedrockBuilder.build();

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
@@ -90,8 +90,15 @@ final class BedrockChatModelBuilder {
       LOG.debug("No explicit credentials configured, falling back to AWS default credential chain");
     }
 
-    final ChatModel chatModel =
-        BedrockChatModel.builder().client(clientBuilder.build()).modelId(model).build();
+    final BedrockChatModel.Builder bedrockBuilder =
+        BedrockChatModel.builder().client(clientBuilder.build()).modelId(model);
+
+    if (config.getTimeout() != null) {
+      LOG.debug("Setting timeout to {}", config.getTimeout());
+      bedrockBuilder.timeout(config.getTimeout());
+    }
+
+    final ChatModel chatModel = bedrockBuilder.build();
     LOG.debug("Successfully built Amazon Bedrock chat model with modelId '{}'", model);
     return chatModel;
   }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilder.java
@@ -41,6 +41,10 @@ final class OpenAiChatModelBuilder {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       builder.timeout(config.getTimeout());
     }
+    if (config.getTemperature() != null) {
+      LOG.debug("Setting temperature to {}", config.getTemperature());
+      builder.temperature(config.getTemperature());
+    }
 
     final ChatModel chatModel = builder.build();
     LOG.debug("Successfully built OpenAI chat model with model '{}'", model);

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilder.java
@@ -34,7 +34,15 @@ final class OpenAiChatModelBuilder {
     final String model = require(config.getModel(), "model", "openai");
     final String apiKey = require(config.getApiKey(), "apiKey", "openai");
 
-    final ChatModel chatModel = OpenAiChatModel.builder().apiKey(apiKey).modelName(model).build();
+    final OpenAiChatModel.OpenAiChatModelBuilder builder =
+        OpenAiChatModel.builder().apiKey(apiKey).modelName(model);
+
+    if (config.getTimeout() != null) {
+      LOG.debug("Setting timeout to {}", config.getTimeout());
+      builder.timeout(config.getTimeout());
+    }
+
+    final ChatModel chatModel = builder.build();
     LOG.debug("Successfully built OpenAI chat model with model '{}'", model);
     return chatModel;
   }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
@@ -40,13 +40,14 @@ final class OpenAiCompatibleChatModelBuilder {
         OpenAiChatModel.builder().baseUrl(baseUrl).modelName(model);
 
     final Map<String, String> headers = config.getHeaders();
+    final boolean hasAuthorizationHeader =
+        headers != null && headers.keySet().stream().anyMatch("Authorization"::equalsIgnoreCase);
     if (hasText(config.getApiKey())) {
-      LOG.debug("Using configured API key");
-      builder.apiKey(config.getApiKey().trim());
-      if (headers != null
-          && headers.keySet().stream().anyMatch("Authorization"::equalsIgnoreCase)) {
+      if (hasAuthorizationHeader) {
         LOG.warn("Both API key and Authorization header are set. The API key will be ignored.");
-        builder.apiKey(null);
+      } else {
+        LOG.debug("Using configured API key");
+        builder.apiKey(config.getApiKey().trim());
       }
     }
 

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
@@ -49,6 +49,10 @@ final class OpenAiCompatibleChatModelBuilder {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       builder.timeout(config.getTimeout());
     }
+    if (config.getTemperature() != null) {
+      LOG.debug("Setting temperature to {}", config.getTemperature());
+      builder.temperature(config.getTemperature());
+    }
 
     final ChatModel chatModel = builder.build();
     LOG.debug(

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
@@ -20,6 +20,7 @@ import static io.camunda.process.test.impl.judge.ModelBuilderSupport.require;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,11 +39,19 @@ final class OpenAiCompatibleChatModelBuilder {
     final OpenAiChatModel.OpenAiChatModelBuilder builder =
         OpenAiChatModel.builder().baseUrl(baseUrl).modelName(model);
 
+    final Map<String, String> headers = config.getHeaders();
     if (hasText(config.getApiKey())) {
       LOG.debug("Using configured API key");
       builder.apiKey(config.getApiKey().trim());
-    } else {
-      LOG.debug("No API key configured, building without authentication");
+      if (headers != null
+          && headers.keySet().stream().anyMatch("Authorization"::equalsIgnoreCase)) {
+        LOG.warn("Both API key and Authorization header are set. The API key will be ignored.");
+        builder.apiKey(null);
+      }
+    }
+
+    if (headers != null && !headers.isEmpty()) {
+      builder.customHeaders(headers);
     }
 
     if (config.getTimeout() != null) {

--- a/testing/camunda-process-test-langchain4j/src/main/resources/META-INF/services/io.camunda.process.test.api.judge.ChatModelAdapterProvider
+++ b/testing/camunda-process-test-langchain4j/src/main/resources/META-INF/services/io.camunda.process.test.api.judge.ChatModelAdapterProvider
@@ -2,3 +2,4 @@ io.camunda.process.test.impl.judge.OpenAiChatModelAdapterProvider
 io.camunda.process.test.impl.judge.AnthropicChatModelAdapterProvider
 io.camunda.process.test.impl.judge.BedrockChatModelAdapterProvider
 io.camunda.process.test.impl.judge.OpenAiCompatibleChatModelAdapterProvider
+io.camunda.process.test.impl.judge.AzureOpenAiChatModelAdapterProvider

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilderTest.java
@@ -54,6 +54,20 @@ class AnthropicChatModelBuilderTest {
     assertThat(chatModel).isNotNull();
   }
 
+  @Test
+  void shouldBuildChatModelWithTemperature() {
+    // given
+    final BaseProviderConfig.AnthropicConfig config =
+        new BaseProviderConfig.AnthropicConfig("claude-3-5-sonnet-20241022", "test-api-key");
+    config.setTemperature(0.7);
+
+    // when
+    final ChatModel chatModel = AnthropicChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilderTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.model.chat.ChatModel;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -31,6 +32,20 @@ class AnthropicChatModelBuilderTest {
     // given
     final BaseProviderConfig.AnthropicConfig config =
         new BaseProviderConfig.AnthropicConfig("claude-3-5-sonnet-20241022", "test-api-key");
+
+    // when
+    final ChatModel chatModel = AnthropicChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
+  @Test
+  void shouldBuildChatModelWithTimeout() {
+    // given
+    final BaseProviderConfig.AnthropicConfig config =
+        new BaseProviderConfig.AnthropicConfig("claude-3-5-sonnet-20241022", "test-api-key");
+    config.setTimeout(Duration.ofSeconds(30));
 
     // when
     final ChatModel chatModel = AnthropicChatModelBuilder.build(config);

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilderTest.java
@@ -70,6 +70,21 @@ class AzureOpenAiChatModelBuilderTest {
     assertThat(chatModel).isNotNull();
   }
 
+  @Test
+  void shouldBuildChatModelWithTemperature() {
+    // given
+    final BaseProviderConfig.AzureOpenAiConfig config =
+        new BaseProviderConfig.AzureOpenAiConfig(
+            "gpt-4o", "https://my-resource.openai.azure.com/", "test-api-key");
+    config.setTemperature(0.7);
+
+    // when
+    final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.judge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.model.chat.ChatModel;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AzureOpenAiChatModelBuilderTest {
+
+  @Test
+  void shouldBuildChatModelWithApiKey() {
+    // given
+    final BaseProviderConfig.AzureOpenAiConfig config =
+        new BaseProviderConfig.AzureOpenAiConfig(
+            "gpt-4o", "https://my-resource.openai.azure.com/", "test-api-key");
+
+    // when
+    final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
+  @Test
+  void shouldBuildChatModelWithDefaultCredentials() {
+    // given — no API key, falls back to DefaultAzureCredential
+    final BaseProviderConfig.AzureOpenAiConfig config =
+        new BaseProviderConfig.AzureOpenAiConfig(
+            "gpt-4o", "https://my-resource.openai.azure.com/", null);
+
+    // when
+    final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
+  @Test
+  void shouldBuildChatModelWithTimeout() {
+    // given
+    final BaseProviderConfig.AzureOpenAiConfig config =
+        new BaseProviderConfig.AzureOpenAiConfig(
+            "gpt-4o", "https://my-resource.openai.azure.com/", "test-api-key");
+    config.setTimeout(Duration.ofSeconds(45));
+
+    // when
+    final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  "})
+  void shouldThrowWhenModelMissingOrBlank(final String model) {
+    // given
+    final BaseProviderConfig.AzureOpenAiConfig config =
+        new BaseProviderConfig.AzureOpenAiConfig(
+            model, "https://my-resource.openai.azure.com/", "test-api-key");
+
+    // when / then
+    assertThatThrownBy(() -> AzureOpenAiChatModelBuilder.build(config))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("model")
+        .hasMessageContaining("azure-openai");
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  "})
+  void shouldThrowWhenEndpointMissingOrBlank(final String endpoint) {
+    // given
+    final BaseProviderConfig.AzureOpenAiConfig config =
+        new BaseProviderConfig.AzureOpenAiConfig("gpt-4o", endpoint, "test-api-key");
+
+    // when / then
+    assertThatThrownBy(() -> AzureOpenAiChatModelBuilder.build(config))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("endpoint")
+        .hasMessageContaining("azure-openai");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "  "})
+  void shouldFallbackToDefaultCredentialsWhenApiKeyBlank(final String apiKey) {
+    // given — blank API key is treated as absent
+    final BaseProviderConfig.AzureOpenAiConfig config =
+        new BaseProviderConfig.AzureOpenAiConfig(
+            "gpt-4o", "https://my-resource.openai.azure.com/", apiKey);
+
+    // when
+    final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+}

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilderTest.java
@@ -94,6 +94,25 @@ class BedrockChatModelBuilderTest {
     assertThat(chatModel).isNotNull();
   }
 
+  @Test
+  void shouldBuildChatModelWithTemperature() {
+    // given
+    final BaseProviderConfig.AmazonBedrockConfig config =
+        new BaseProviderConfig.AmazonBedrockConfig(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "us-east-1",
+            null,
+            "test-access-key",
+            "test-secret-key");
+    config.setTemperature(0.7);
+
+    // when
+    final ChatModel chatModel = BedrockChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
   // -- Required field validation --
 
   @ParameterizedTest

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilderTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.model.chat.ChatModel;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -66,6 +67,25 @@ class BedrockChatModelBuilderTest {
     final BaseProviderConfig.AmazonBedrockConfig config =
         new BaseProviderConfig.AmazonBedrockConfig(
             "anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1", null, null, null);
+
+    // when
+    final ChatModel chatModel = BedrockChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
+  @Test
+  void shouldBuildChatModelWithTimeout() {
+    // given
+    final BaseProviderConfig.AmazonBedrockConfig config =
+        new BaseProviderConfig.AmazonBedrockConfig(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "us-east-1",
+            null,
+            "test-access-key",
+            "test-secret-key");
+    config.setTimeout(Duration.ofSeconds(60));
 
     // when
     final ChatModel chatModel = BedrockChatModelBuilder.build(config);

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/Langchain4jChatModelAdapterProviderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/Langchain4jChatModelAdapterProviderTest.java
@@ -63,6 +63,11 @@ public class Langchain4jChatModelAdapterProviderTest {
             "openai-compatible",
             new OpenAiCompatibleChatModelAdapterProvider(),
             new BaseProviderConfig.OpenAiCompatibleConfig(
-                "mistral-7b", "http://localhost:11434/v1", null)));
+                "mistral-7b", "http://localhost:11434/v1", null)),
+        Arguments.of(
+            "azure-openai",
+            new AzureOpenAiChatModelAdapterProvider(),
+            new BaseProviderConfig.AzureOpenAiConfig(
+                "gpt-4o", "https://my-resource.openai.azure.com/", "test-key")));
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/Langchain4jChatModelAdapterProviderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/Langchain4jChatModelAdapterProviderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.process.test.api.judge.ChatModelAdapter;
 import io.camunda.process.test.api.judge.ChatModelAdapterProvider;
 import io.camunda.process.test.api.judge.ProviderConfig;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -63,7 +64,10 @@ public class Langchain4jChatModelAdapterProviderTest {
             "openai-compatible",
             new OpenAiCompatibleChatModelAdapterProvider(),
             new BaseProviderConfig.OpenAiCompatibleConfig(
-                "mistral-7b", "http://localhost:11434/v1", null)),
+                "mistral-7b",
+                "http://localhost:11434/v1",
+                null,
+                Map.of("Authorization", "Bearer xyz"))),
         Arguments.of(
             "azure-openai",
             new AzureOpenAiChatModelAdapterProvider(),

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilderTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.model.chat.ChatModel;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -52,6 +53,20 @@ class OpenAiChatModelBuilderTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("apiKey")
         .hasMessageContaining("openai");
+  }
+
+  @Test
+  void shouldBuildChatModelWithTimeout() {
+    // given
+    final BaseProviderConfig.OpenAiConfig config =
+        new BaseProviderConfig.OpenAiConfig("gpt-4o", "test-api-key");
+    config.setTimeout(Duration.ofSeconds(30));
+
+    // when
+    final ChatModel chatModel = OpenAiChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
   }
 
   @ParameterizedTest

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilderTest.java
@@ -69,6 +69,20 @@ class OpenAiChatModelBuilderTest {
     assertThat(chatModel).isNotNull();
   }
 
+  @Test
+  void shouldBuildChatModelWithTemperature() {
+    // given
+    final BaseProviderConfig.OpenAiConfig config =
+        new BaseProviderConfig.OpenAiConfig("gpt-4o", "test-api-key");
+    config.setTemperature(0.7);
+
+    // when
+    final ChatModel chatModel = OpenAiChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
@@ -67,7 +67,7 @@ class OpenAiCompatibleChatModelBuilderTest {
             "llama3",
             "http://localhost:11434/v1",
             "test-api-key",
-            Map.of("X-Test-Header", "test-header-value"));
+            Map.of("Authorization", "Bearer test-token"));
 
     // when
     final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.model.chat.ChatModel;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -32,6 +33,21 @@ class OpenAiCompatibleChatModelBuilderTest {
     final BaseProviderConfig.OpenAiCompatibleConfig config =
         new BaseProviderConfig.OpenAiCompatibleConfig(
             "llama3", "http://localhost:11434/v1", "test-api-key");
+
+    // when
+    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
+  @Test
+  void shouldBuildChatModelWithTimeout() {
+    // given
+    final BaseProviderConfig.OpenAiCompatibleConfig config =
+        new BaseProviderConfig.OpenAiCompatibleConfig(
+            "llama3", "http://localhost:11434/v1", "test-api-key");
+    config.setTimeout(Duration.ofSeconds(30));
 
     // when
     final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
@@ -56,6 +56,21 @@ class OpenAiCompatibleChatModelBuilderTest {
     assertThat(chatModel).isNotNull();
   }
 
+  @Test
+  void shouldBuildChatModelWithTemperature() {
+    // given
+    final BaseProviderConfig.OpenAiCompatibleConfig config =
+        new BaseProviderConfig.OpenAiCompatibleConfig(
+            "llama3", "http://localhost:11434/v1", "test-api-key");
+    config.setTemperature(0.7);
+
+    // when
+    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.model.chat.ChatModel;
 import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -32,7 +33,41 @@ class OpenAiCompatibleChatModelBuilderTest {
     // given
     final BaseProviderConfig.OpenAiCompatibleConfig config =
         new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3", "http://localhost:11434/v1", "test-api-key");
+            "llama3", "http://localhost:11434/v1", "test-api-key", null);
+
+    // when
+    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
+  @Test
+  void shouldBuildChatModelWithHeaders() {
+    // given
+    final BaseProviderConfig.OpenAiCompatibleConfig config =
+        new BaseProviderConfig.OpenAiCompatibleConfig(
+            "llama3",
+            "http://localhost:11434/v1",
+            null,
+            Map.of("X-Test-Header", "test-header-value"));
+
+    // when
+    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
+
+    // then
+    assertThat(chatModel).isNotNull();
+  }
+
+  @Test
+  void shouldBuildChatModelWhenBothAuthorizationHeaderAndApiKeyPresent() {
+    // given
+    final BaseProviderConfig.OpenAiCompatibleConfig config =
+        new BaseProviderConfig.OpenAiCompatibleConfig(
+            "llama3",
+            "http://localhost:11434/v1",
+            "test-api-key",
+            Map.of("X-Test-Header", "test-header-value"));
 
     // when
     final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
@@ -46,7 +81,7 @@ class OpenAiCompatibleChatModelBuilderTest {
     // given
     final BaseProviderConfig.OpenAiCompatibleConfig config =
         new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3", "http://localhost:11434/v1", "test-api-key");
+            "llama3", "http://localhost:11434/v1", "test-api-key", null);
     config.setTimeout(Duration.ofSeconds(30));
 
     // when
@@ -61,7 +96,7 @@ class OpenAiCompatibleChatModelBuilderTest {
     // given
     final BaseProviderConfig.OpenAiCompatibleConfig config =
         new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3", "http://localhost:11434/v1", "test-api-key");
+            "llama3", "http://localhost:11434/v1", "test-api-key", null);
     config.setTemperature(0.7);
 
     // when
@@ -78,7 +113,7 @@ class OpenAiCompatibleChatModelBuilderTest {
     // given — null or blank apiKey is treated as absent
     final BaseProviderConfig.OpenAiCompatibleConfig config =
         new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3", "http://localhost:11434/v1", apiKey);
+            "llama3", "http://localhost:11434/v1", apiKey, null);
 
     // when
     final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
@@ -93,7 +128,7 @@ class OpenAiCompatibleChatModelBuilderTest {
   void shouldThrowWhenBaseUrlMissingOrBlank(final String baseUrl) {
     // given
     final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig("llama3", baseUrl, null);
+        new BaseProviderConfig.OpenAiCompatibleConfig("llama3", baseUrl, null, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiCompatibleChatModelBuilder.build(config))
@@ -108,7 +143,8 @@ class OpenAiCompatibleChatModelBuilderTest {
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
     final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig(model, "http://localhost:11434/v1", null);
+        new BaseProviderConfig.OpenAiCompatibleConfig(
+            model, "http://localhost:11434/v1", null, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiCompatibleChatModelBuilder.build(config))

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/JudgeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/JudgeConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.process.test.impl.configuration;
 import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.api.judge.ProviderConfig;
 import io.camunda.process.test.impl.judge.BaseProviderConfig;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -67,25 +68,44 @@ public class JudgeConfiguration {
   public ProviderConfig toProviderConfig() {
     final AwsCredentialsConfiguration credentials = chatModel.getCredentials();
     final String provider = chatModel.getProvider().trim().toLowerCase();
+    final BaseProviderConfig config;
     switch (provider) {
       case BaseProviderConfig.PROVIDER_OPENAI:
-        return new BaseProviderConfig.OpenAiConfig(chatModel.getModel(), chatModel.getApiKey());
+        config = new BaseProviderConfig.OpenAiConfig(chatModel.getModel(), chatModel.getApiKey());
+        break;
       case BaseProviderConfig.PROVIDER_ANTHROPIC:
-        return new BaseProviderConfig.AnthropicConfig(chatModel.getModel(), chatModel.getApiKey());
+        config =
+            new BaseProviderConfig.AnthropicConfig(chatModel.getModel(), chatModel.getApiKey());
+        break;
       case BaseProviderConfig.PROVIDER_AMAZON_BEDROCK:
-        return new BaseProviderConfig.AmazonBedrockConfig(
-            chatModel.getModel(),
-            chatModel.getRegion(),
-            chatModel.getApiKey(),
-            credentials != null ? credentials.getAccessKey() : null,
-            credentials != null ? credentials.getSecretKey() : null);
+        config =
+            new BaseProviderConfig.AmazonBedrockConfig(
+                chatModel.getModel(),
+                chatModel.getRegion(),
+                chatModel.getApiKey(),
+                credentials != null ? credentials.getAccessKey() : null,
+                credentials != null ? credentials.getSecretKey() : null);
+        break;
       case BaseProviderConfig.PROVIDER_OPENAI_COMPATIBLE:
-        return new BaseProviderConfig.OpenAiCompatibleConfig(
-            chatModel.getModel(), chatModel.getBaseUrl(), chatModel.getApiKey());
+        config =
+            new BaseProviderConfig.OpenAiCompatibleConfig(
+                chatModel.getModel(), chatModel.getBaseUrl(), chatModel.getApiKey());
+        break;
+      case BaseProviderConfig.PROVIDER_AZURE_OPENAI:
+        config =
+            new BaseProviderConfig.AzureOpenAiConfig(
+                chatModel.getModel(), chatModel.getEndpoint(), chatModel.getApiKey());
+        break;
       default:
-        return new BaseProviderConfig.GenericConfig(
-            provider, chatModel.getModel(), chatModel.getCustomProperties());
+        config =
+            new BaseProviderConfig.GenericConfig(
+                provider, chatModel.getModel(), chatModel.getCustomProperties());
+        break;
     }
+    if (chatModel.getTimeout() != null) {
+      config.setTimeout(chatModel.getTimeout());
+    }
+    return config;
   }
 
   public static class ChatModelConfiguration {
@@ -108,8 +128,17 @@ public class JudgeConfiguration {
     /** The base URL for the chat model API. Required for the 'openai-compatible' provider. */
     private String baseUrl;
 
+    /**
+     * The Azure OpenAI resource endpoint URL. Required for the 'azure-openai' provider (e.g.
+     * 'https://my-resource.openai.azure.com/').
+     */
+    private String endpoint;
+
     /** The AWS region for the Amazon Bedrock provider (e.g. 'us-east-1'). */
     private String region;
+
+    /** The timeout for LLM API calls as an ISO-8601 duration (e.g. 'PT30S', 'PT2M'). */
+    private Duration timeout;
 
     @NestedConfigurationProperty
     private AwsCredentialsConfiguration credentials = new AwsCredentialsConfiguration();
@@ -147,6 +176,22 @@ public class JudgeConfiguration {
 
     public void setBaseUrl(final String baseUrl) {
       this.baseUrl = baseUrl;
+    }
+
+    public String getEndpoint() {
+      return endpoint;
+    }
+
+    public void setEndpoint(final String endpoint) {
+      this.endpoint = endpoint;
+    }
+
+    public Duration getTimeout() {
+      return timeout;
+    }
+
+    public void setTimeout(final Duration timeout) {
+      this.timeout = timeout;
     }
 
     public String getRegion() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/JudgeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/JudgeConfiguration.java
@@ -105,6 +105,9 @@ public class JudgeConfiguration {
     if (chatModel.getTimeout() != null) {
       config.setTimeout(chatModel.getTimeout());
     }
+    if (chatModel.getTemperature() != null) {
+      config.setTemperature(chatModel.getTemperature());
+    }
     return config;
   }
 
@@ -139,6 +142,9 @@ public class JudgeConfiguration {
 
     /** The timeout for LLM API calls as an ISO-8601 duration (e.g. 'PT30S', 'PT2M'). */
     private Duration timeout;
+
+    /** The temperature for LLM API calls (e.g. 0.7). */
+    private Double temperature;
 
     @NestedConfigurationProperty
     private AwsCredentialsConfiguration credentials = new AwsCredentialsConfiguration();
@@ -192,6 +198,14 @@ public class JudgeConfiguration {
 
     public void setTimeout(final Duration timeout) {
       this.timeout = timeout;
+    }
+
+    public Double getTemperature() {
+      return temperature;
+    }
+
+    public void setTemperature(final Double temperature) {
+      this.temperature = temperature;
     }
 
     public String getRegion() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/JudgeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/JudgeConfiguration.java
@@ -118,7 +118,7 @@ public class JudgeConfiguration {
 
     /**
      * The LLM provider to use for the AI judge. Supported providers: openai, anthropic,
-     * amazon-bedrock, openai-compatible.
+     * amazon-bedrock, openai-compatible, azure-openai.
      */
     private String provider;
 

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/JudgeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/JudgeConfiguration.java
@@ -89,7 +89,10 @@ public class JudgeConfiguration {
       case BaseProviderConfig.PROVIDER_OPENAI_COMPATIBLE:
         config =
             new BaseProviderConfig.OpenAiCompatibleConfig(
-                chatModel.getModel(), chatModel.getBaseUrl(), chatModel.getApiKey());
+                chatModel.getModel(),
+                chatModel.getBaseUrl(),
+                chatModel.getApiKey(),
+                chatModel.getHeaders());
         break;
       case BaseProviderConfig.PROVIDER_AZURE_OPENAI:
         config =
@@ -139,6 +142,9 @@ public class JudgeConfiguration {
 
     /** The AWS region for the Amazon Bedrock provider (e.g. 'us-east-1'). */
     private String region;
+
+    /** Optional custom HTTP headers to include in chat model requests. */
+    private Map<String, String> headers;
 
     /** The timeout for LLM API calls as an ISO-8601 duration (e.g. 'PT30S', 'PT2M'). */
     private Duration timeout;
@@ -214,6 +220,14 @@ public class JudgeConfiguration {
 
     public void setRegion(final String region) {
       this.region = region;
+    }
+
+    public Map<String, String> getHeaders() {
+      return headers;
+    }
+
+    public void setHeaders(final Map<String, String> headers) {
+      this.headers = headers;
     }
 
     public AwsCredentialsConfiguration getCredentials() {

--- a/testing/camunda-process-test-spring/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/testing/camunda-process-test-spring/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -32,6 +32,10 @@
         {
           "value": "openai-compatible",
           "description": "Use an OpenAI-compatible API (requires base-url and model)."
+        },
+        {
+          "value": "azure-openai",
+          "description": "Use Azure OpenAI models (requires model and endpoint, and optionally api-key)."
         }
       ],
       "providers": [

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
@@ -277,7 +277,8 @@ public class JudgeConfigBootstrapIT {
       assertThat(config).isNotNull();
       assertThat(config.getChatModel()).isNotNull();
 
-      final ProviderConfig providerConfig = runtimeConfig.getJudge().toProviderConfig();
+      final BaseProviderConfig providerConfig =
+          (BaseProviderConfig) runtimeConfig.getJudge().toProviderConfig();
       assertThat(providerConfig.getTimeout()).isEqualTo(java.time.Duration.ofSeconds(45));
     }
   }
@@ -302,7 +303,8 @@ public class JudgeConfigBootstrapIT {
       assertThat(config).isNotNull();
       assertThat(config.getChatModel()).isNotNull();
 
-      final ProviderConfig providerConfig = runtimeConfig.getJudge().toProviderConfig();
+      final BaseProviderConfig providerConfig =
+          (BaseProviderConfig) runtimeConfig.getJudge().toProviderConfig();
       assertThat(providerConfig.getTemperature()).isEqualTo(0.7);
     }
   }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
@@ -169,6 +169,26 @@ public class JudgeConfigBootstrapIT {
   @SpringBootTest(
       classes = JudgeConfigBootstrapIT.class,
       properties = {
+        "camunda.process-test.judge.chatModel.provider=openai-compatible",
+        "camunda.process-test.judge.chatModel.model=llama3",
+        "camunda.process-test.judge.chatModel.baseUrl=http://localhost:11434/v1",
+        "camunda.process-test.judge.chat-model.headers.X-Test-Header=test-header-value"
+      })
+  @CamundaSpringProcessTest
+  class OpenAiCompatibleProviderWithHeaders {
+
+    @Test
+    void shouldBootstrapOpenAiCompatibleProvider() {
+      final JudgeConfig config = CamundaAssert.getJudgeConfig();
+      assertThat(config).isNotNull();
+      assertThat(config.getChatModel()).isNotNull();
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = JudgeConfigBootstrapIT.class,
+      properties = {
         "camunda.process-test.judge.chatModel.provider=openai",
         "camunda.process-test.judge.chatModel.model=gpt-4o",
         "camunda.process-test.judge.chatModel.apiKey=test-key",

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
@@ -24,7 +24,9 @@ import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.api.judge.ProviderConfig;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
 import io.camunda.process.test.impl.judge.BaseProviderConfig;
+import io.camunda.process.test.impl.judge.BaseProviderConfig.OpenAiCompatibleConfig;
 import io.camunda.process.test.impl.judge.OpenAiChatModelAdapterProvider;
+import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -172,16 +174,24 @@ public class JudgeConfigBootstrapIT {
         "camunda.process-test.judge.chatModel.provider=openai-compatible",
         "camunda.process-test.judge.chatModel.model=llama3",
         "camunda.process-test.judge.chatModel.baseUrl=http://localhost:11434/v1",
-        "camunda.process-test.judge.chat-model.headers.X-Test-Header=test-header-value"
+        "camunda.process-test.judge.chatModel.headers.X-Test-Header=test-header-value"
       })
   @CamundaSpringProcessTest
   class OpenAiCompatibleProviderWithHeaders {
+
+    @Autowired CamundaProcessTestRuntimeConfiguration runtimeConfig;
 
     @Test
     void shouldBootstrapOpenAiCompatibleProvider() {
       final JudgeConfig config = CamundaAssert.getJudgeConfig();
       assertThat(config).isNotNull();
       assertThat(config.getChatModel()).isNotNull();
+
+      final ProviderConfig providerConfig = runtimeConfig.getJudge().toProviderConfig();
+      assertThat(providerConfig).isInstanceOf(OpenAiCompatibleConfig.class);
+      final Map<String, String> headers = ((OpenAiCompatibleConfig) providerConfig).getHeaders();
+      assertThat(headers).isNotNull();
+      assertThat(headers).containsEntry("X-Test-Header", "test-header-value");
     }
   }
 

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
@@ -256,6 +256,31 @@ public class JudgeConfigBootstrapIT {
   @SpringBootTest(
       classes = JudgeConfigBootstrapIT.class,
       properties = {
+        "camunda.process-test.judge.chatModel.provider=openai",
+        "camunda.process-test.judge.chatModel.model=gpt-4o",
+        "camunda.process-test.judge.chatModel.apiKey=test-key",
+        "camunda.process-test.judge.chatModel.temperature=0.7"
+      })
+  @CamundaSpringProcessTest
+  class WithTemperature {
+
+    @Autowired CamundaProcessTestRuntimeConfiguration runtimeConfig;
+
+    @Test
+    void shouldBindTemperatureProperty() {
+      final JudgeConfig config = CamundaAssert.getJudgeConfig();
+      assertThat(config).isNotNull();
+      assertThat(config.getChatModel()).isNotNull();
+
+      final ProviderConfig providerConfig = runtimeConfig.getJudge().toProviderConfig();
+      assertThat(providerConfig.getTemperature()).isEqualTo(0.7);
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = JudgeConfigBootstrapIT.class,
+      properties = {
         "camunda.process-test.judge.chatModel.provider=openai-compatible",
         "camunda.process-test.judge.chatModel.model=llama3",
         "camunda.process-test.judge.chatModel.baseUrl=http://localhost:11434/v1"

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapIT.java
@@ -192,6 +192,70 @@ public class JudgeConfigBootstrapIT {
   @SpringBootTest(
       classes = JudgeConfigBootstrapIT.class,
       properties = {
+        "camunda.process-test.judge.chatModel.provider=azure-openai",
+        "camunda.process-test.judge.chatModel.model=gpt-4o",
+        "camunda.process-test.judge.chatModel.endpoint=https://my-resource.openai.azure.com/",
+        "camunda.process-test.judge.chatModel.apiKey=test-key"
+      })
+  @CamundaSpringProcessTest
+  class AzureOpenAiProvider {
+
+    @Test
+    void shouldBootstrapAzureOpenAiProvider() {
+      final JudgeConfig config = CamundaAssert.getJudgeConfig();
+      assertThat(config).isNotNull();
+      assertThat(config.getChatModel()).isNotNull();
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = JudgeConfigBootstrapIT.class,
+      properties = {
+        "camunda.process-test.judge.chatModel.provider=azure-openai",
+        "camunda.process-test.judge.chatModel.model=gpt-4o",
+        "camunda.process-test.judge.chatModel.endpoint=https://my-resource.openai.azure.com/"
+      })
+  @CamundaSpringProcessTest
+  class AzureOpenAiProviderWithoutApiKey {
+
+    @Test
+    void shouldBootstrapAzureOpenAiWithDefaultCredentials() {
+      final JudgeConfig config = CamundaAssert.getJudgeConfig();
+      assertThat(config).isNotNull();
+      assertThat(config.getChatModel()).isNotNull();
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = JudgeConfigBootstrapIT.class,
+      properties = {
+        "camunda.process-test.judge.chatModel.provider=openai",
+        "camunda.process-test.judge.chatModel.model=gpt-4o",
+        "camunda.process-test.judge.chatModel.apiKey=test-key",
+        "camunda.process-test.judge.chatModel.timeout=PT45S"
+      })
+  @CamundaSpringProcessTest
+  class WithTimeout {
+
+    @Autowired CamundaProcessTestRuntimeConfiguration runtimeConfig;
+
+    @Test
+    void shouldBindTimeoutProperty() {
+      final JudgeConfig config = CamundaAssert.getJudgeConfig();
+      assertThat(config).isNotNull();
+      assertThat(config.getChatModel()).isNotNull();
+
+      final ProviderConfig providerConfig = runtimeConfig.getJudge().toProviderConfig();
+      assertThat(providerConfig.getTimeout()).isEqualTo(java.time.Duration.ofSeconds(45));
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = JudgeConfigBootstrapIT.class,
+      properties = {
         "camunda.process-test.judge.chatModel.provider=openai-compatible",
         "camunda.process-test.judge.chatModel.model=llama3",
         "camunda.process-test.judge.chatModel.baseUrl=http://localhost:11434/v1"


### PR DESCRIPTION
# Description
Backport of #49219 to `stable/8.9`.

relates to 