### PR TITLE
fix: add missing BulkIndexRequest mixins for strict mapping on 8.8→8.9 upgrade

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -18,16 +18,21 @@ import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -55,29 +60,29 @@ final class BulkIndexRequest {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(DecisionRequirementsMetadataValue.class, IgnoreDeploymentKeyMixin.class)
+          .addMixIn(DecisionRequirementsRecordValue.class, IgnoreDeploymentKeyMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(IncidentRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(JobBatchRecordValue.class, JobBatchMixin.class)
           .addMixIn(
               JobRecordValue.class,
               IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
-          .addMixIn(
-              ProcessInstanceRecordValue.class,
-              IgnoreRootProcessInstanceKeyAndBusinessIdMixin.class)
+          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstanceMixin.class)
           .addMixIn(
               ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
           .addMixIn(
               ProcessInstanceModificationRecordValue.class, ProcessInstanceModificationMixin.class)
-          .addMixIn(
-              ProcessInstanceCreationRecordValue.class,
-              IgnoreRootProcessInstanceKeyAndBusinessIdMixin.class)
-          .addMixIn(
-              ProcessInstanceMigrationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationMixin.class)
+          .addMixIn(ProcessInstanceMigrationRecordValue.class, ProcessInstanceMigrationMixin.class)
           .addMixIn(
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
-          .addMixIn(UserTaskRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
-          .addMixIn(VariableRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(ProcessInstanceBatchRecordValue.class, IgnoreProcessDefinitionKeyMixin.class)
+          .addMixIn(ResourceDeletionRecordValue.class, ResourceDeletionMixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTaskMixin.class)
+          .addMixIn(VariableRecordValue.class, VariableMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -97,6 +102,19 @@ final class BulkIndexRequest {
   private static final String ROOT_PROCESS_INSTANCE_KEY_PROPERTY = "rootProcessInstanceKey";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
   private static final String JOB_TO_USER_TASK_MIGRATION_PROPERTY = "jobToUserTaskMigration";
+  private static final String ELEMENT_INSTANCE_KEY_PROPERTY = "elementInstanceKey";
+  private static final String TAGS_PROPERTY = "tags";
+  private static final String TENANT_FILTER_PROPERTY = "tenantFilter";
+  private static final String SOURCE_PROPERTY = "source";
+  private static final String LISTENERS_CONFIG_KEY_PROPERTY = "listenersConfigKey";
+  private static final String TENANT_ID_PROPERTY = "tenantId";
+  private static final String BPMN_PROCESS_ID_PROPERTY = "bpmnProcessId";
+  private static final String DEPLOYMENT_KEY_PROPERTY = "deploymentKey";
+  private static final String DELETE_HISTORY_PROPERTY = "deleteHistory";
+  private static final String BATCH_OPERATION_KEY_PROPERTY = "batchOperationKey";
+  private static final String BATCH_OPERATION_TYPE_PROPERTY = "batchOperationType";
+  private static final String RESOURCE_TYPE_PROPERTY = "resourceType";
+  private static final String RESOURCE_ID_PROPERTY = "resourceId";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -236,11 +254,65 @@ final class BulkIndexRequest {
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyMixin {}
 
-  @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, BUSINESS_ID_PROPERTY})
-  private static final class IgnoreRootProcessInstanceKeyAndBusinessIdMixin {}
-
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BUSINESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    TAGS_PROPERTY
+  })
+  private static final class ProcessInstanceMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BUSINESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    TAGS_PROPERTY
+  })
+  private static final class ProcessInstanceCreationMixin {}
+
+  @JsonIgnoreProperties({TENANT_FILTER_PROPERTY})
+  private static final class JobBatchMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    SOURCE_PROPERTY
+  })
+  private static final class VariableMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    LISTENERS_CONFIG_KEY_PROPERTY,
+    TAGS_PROPERTY
+  })
+  private static final class UserTaskMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY,
+    TENANT_ID_PROPERTY,
+    BPMN_PROCESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY
+  })
+  private static final class ProcessInstanceMigrationMixin {}
+
+  @JsonIgnoreProperties({DEPLOYMENT_KEY_PROPERTY})
+  private static final class IgnoreDeploymentKeyMixin {}
+
+  @JsonIgnoreProperties({MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY})
+  private static final class IgnoreProcessDefinitionKeyMixin {}
+
+  @JsonIgnoreProperties({
+    DELETE_HISTORY_PROPERTY,
+    BATCH_OPERATION_KEY_PROPERTY,
+    BATCH_OPERATION_TYPE_PROPERTY,
+    RESOURCE_TYPE_PROPERTY,
+    RESOURCE_ID_PROPERTY
+  })
+  private static final class ResourceDeletionMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -15,7 +15,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.BulkIndexRequest.IndexOperation;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -23,10 +25,12 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationMoveInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.util.VersionUtil;
@@ -35,6 +39,7 @@ import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -809,6 +814,471 @@ final class BulkIndexRequestTest {
           .describedAs(
               "Expect that job records are serialized with jobToUserTaskMigration on current version")
           .containsExactly(true);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithoutElementInstanceKeyOnPreviousVersion(final ValueType valueType) {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstanceKey"))
+          .describedAs("Expect that the records are serialized without elementInstanceKey")
+          .containsExactly(new Object[] {null});
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithElementInstanceKeyOnCurrentVersion(final ValueType valueType) {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstanceKey"))
+          .describedAs("Expect that the records are serialized with elementInstanceKey")
+          .doesNotContainNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithoutTagsOnPreviousVersion(final ValueType valueType) {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tags"))
+          .describedAs("Expect that the records are serialized without tags")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithoutTenantFilterOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobBatchRecord()
+                              .setType("test")
+                              .setTenantFilter(TenantFilter.ASSIGNED)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tenantFilter"))
+          .describedAs("Expect that the records are serialized without tenantFilter")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithTenantFilter() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobBatchRecord()
+                              .setType("test")
+                              .setTenantFilter(TenantFilter.ASSIGNED)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tenantFilter"))
+          .describedAs("Expect that the records are serialized with tenantFilter")
+          .containsExactly(TenantFilter.ASSIGNED.name());
+    }
+
+    @Test
+    void shouldIndexVariableRecordWithoutSourceOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.VARIABLE, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("source"))
+          .describedAs("Expect that the records are serialized without source")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexVariableRecordWithoutElementInstanceKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.VARIABLE, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstanceKey"))
+          .describedAs("Expect that the records are serialized without elementInstanceKey")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithoutListenersConfigKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new UserTaskRecord()
+                              .setUserTaskKey(1L)
+                              .setListenersConfigKey(42L)
+                              .setTags(Set.of("tag1"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("listenersConfigKey"))
+          .describedAs("Expect that the records are serialized without listenersConfigKey")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithoutTagsOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1", "tag2"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tags"))
+          .describedAs("Expect that the records are serialized without tags")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithTagsOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tags"))
+          .describedAs("Expect that the records are serialized with tags")
+          .doesNotContainNull();
+    }
+
+    @Test
+    void shouldIndexProcessInstanceMigrationWithoutNewFieldsOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_MIGRATION,
+              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .allSatisfy(
+              value -> {
+                final var valueMap = (Map<String, Object>) value;
+                assertThat(valueMap.get("processDefinitionKey"))
+                    .describedAs("processDefinitionKey should be absent")
+                    .isNull();
+                assertThat(valueMap.get("tenantId"))
+                    .describedAs("tenantId should be absent")
+                    .isNull();
+                assertThat(valueMap.get("bpmnProcessId"))
+                    .describedAs("bpmnProcessId should be absent")
+                    .isNull();
+                assertThat(valueMap.get("elementInstanceKey"))
+                    .describedAs("elementInstanceKey should be absent")
+                    .isNull();
+              });
+    }
+
+    @Test
+    void shouldIndexDecisionRequirementsRecordWithoutDeploymentKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new DecisionRequirementsRecord().setDeploymentKey(12345L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized without deploymentKey")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexDecisionRequirementsRecordWithDeploymentKey() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new DecisionRequirementsRecord().setDeploymentKey(12345L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(12345);
+    }
+
+    @Test
+    void shouldIndexProcessInstanceBatchRecordWithoutProcessDefinitionKeyOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_BATCH,
+              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs("Expect that the records are serialized without processDefinitionKey")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexProcessInstanceBatchRecordWithProcessDefinitionKey() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_BATCH, r -> r.withBrokerVersion(VersionUtil.getVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionKey"))
+          .describedAs("Expect that the records are serialized with processDefinitionKey")
+          .doesNotContainNull();
+    }
+
+    @Test
+    void shouldIndexResourceDeletionRecordWithoutNewFieldsOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.RESOURCE_DELETION,
+              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .allSatisfy(
+              value -> {
+                final var valueMap = (Map<String, Object>) value;
+                assertThat(valueMap.get("deleteHistory"))
+                    .describedAs("deleteHistory should be absent")
+                    .isNull();
+                assertThat(valueMap.get("batchOperationKey"))
+                    .describedAs("batchOperationKey should be absent")
+                    .isNull();
+                assertThat(valueMap.get("batchOperationType"))
+                    .describedAs("batchOperationType should be absent")
+                    .isNull();
+                assertThat(valueMap.get("resourceType"))
+                    .describedAs("resourceType should be absent")
+                    .isNull();
+                assertThat(valueMap.get("resourceId"))
+                    .describedAs("resourceId should be absent")
+                    .isNull();
+              });
+    }
+
+    @Test
+    void shouldIndexResourceDeletionRecordWithNewFieldsOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.RESOURCE_DELETION, r -> r.withBrokerVersion(VersionUtil.getVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .allSatisfy(
+              value -> {
+                final var valueMap = (Map<String, Object>) value;
+                assertThat(valueMap.get("deleteHistory"))
+                    .describedAs("deleteHistory should be present")
+                    .isNotNull();
+                assertThat(valueMap.get("batchOperationKey"))
+                    .describedAs("batchOperationKey should be present")
+                    .isNotNull();
+                assertThat(valueMap.get("batchOperationType"))
+                    .describedAs("batchOperationType should be present")
+                    .isNotNull();
+                assertThat(valueMap.get("resourceType"))
+                    .describedAs("resourceType should be present")
+                    .isNotNull();
+                assertThat(valueMap.get("resourceId"))
+                    .describedAs("resourceId should be present")
+                    .isNotNull();
+              });
     }
 
     private static long getRootProcessInstanceKey(final RecordValue recordValue) throws Exception {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -18,16 +18,21 @@ import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -62,29 +67,29 @@ final class BulkIndexRequest {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(DecisionRequirementsMetadataValue.class, IgnoreDeploymentKeyMixin.class)
+          .addMixIn(DecisionRequirementsRecordValue.class, IgnoreDeploymentKeyMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(IncidentRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(JobBatchRecordValue.class, JobBatchMixin.class)
           .addMixIn(
               JobRecordValue.class,
               IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
+          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstanceMixin.class)
           .addMixIn(
               ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
           .addMixIn(
-              ProcessInstanceRecordValue.class,
-              IgnoreRootProcessInstanceKeyAndBusinessIdMixin.class)
-          .addMixIn(
               ProcessInstanceModificationRecordValue.class, ProcessInstanceModificationMixin.class)
-          .addMixIn(
-              ProcessInstanceCreationRecordValue.class,
-              IgnoreRootProcessInstanceKeyAndBusinessIdMixin.class)
-          .addMixIn(
-              ProcessInstanceMigrationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationMixin.class)
+          .addMixIn(ProcessInstanceMigrationRecordValue.class, ProcessInstanceMigrationMixin.class)
           .addMixIn(
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
-          .addMixIn(UserTaskRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
-          .addMixIn(VariableRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(ProcessInstanceBatchRecordValue.class, IgnoreProcessDefinitionKeyMixin.class)
+          .addMixIn(ResourceDeletionRecordValue.class, ResourceDeletionMixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTaskMixin.class)
+          .addMixIn(VariableRecordValue.class, VariableMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -104,6 +109,19 @@ final class BulkIndexRequest {
   private static final String ROOT_PROCESS_INSTANCE_KEY_PROPERTY = "rootProcessInstanceKey";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
   private static final String JOB_TO_USER_TASK_MIGRATION_PROPERTY = "jobToUserTaskMigration";
+  private static final String ELEMENT_INSTANCE_KEY_PROPERTY = "elementInstanceKey";
+  private static final String TAGS_PROPERTY = "tags";
+  private static final String TENANT_FILTER_PROPERTY = "tenantFilter";
+  private static final String SOURCE_PROPERTY = "source";
+  private static final String LISTENERS_CONFIG_KEY_PROPERTY = "listenersConfigKey";
+  private static final String TENANT_ID_PROPERTY = "tenantId";
+  private static final String BPMN_PROCESS_ID_PROPERTY = "bpmnProcessId";
+  private static final String DEPLOYMENT_KEY_PROPERTY = "deploymentKey";
+  private static final String DELETE_HISTORY_PROPERTY = "deleteHistory";
+  private static final String BATCH_OPERATION_KEY_PROPERTY = "batchOperationKey";
+  private static final String BATCH_OPERATION_TYPE_PROPERTY = "batchOperationType";
+  private static final String RESOURCE_TYPE_PROPERTY = "resourceType";
+  private static final String RESOURCE_ID_PROPERTY = "resourceId";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -259,11 +277,65 @@ final class BulkIndexRequest {
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyMixin {}
 
-  @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, BUSINESS_ID_PROPERTY})
-  private static final class IgnoreRootProcessInstanceKeyAndBusinessIdMixin {}
-
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
   private static final class IgnoreRootProcessInstanceKeyAndJobToUserTaskMigrationMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BUSINESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    TAGS_PROPERTY
+  })
+  private static final class ProcessInstanceMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    BUSINESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    TAGS_PROPERTY
+  })
+  private static final class ProcessInstanceCreationMixin {}
+
+  @JsonIgnoreProperties({TENANT_FILTER_PROPERTY})
+  private static final class JobBatchMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY,
+    SOURCE_PROPERTY
+  })
+  private static final class VariableMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    LISTENERS_CONFIG_KEY_PROPERTY,
+    TAGS_PROPERTY
+  })
+  private static final class UserTaskMixin {}
+
+  @JsonIgnoreProperties({
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY,
+    MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY,
+    TENANT_ID_PROPERTY,
+    BPMN_PROCESS_ID_PROPERTY,
+    ELEMENT_INSTANCE_KEY_PROPERTY
+  })
+  private static final class ProcessInstanceMigrationMixin {}
+
+  @JsonIgnoreProperties({DEPLOYMENT_KEY_PROPERTY})
+  private static final class IgnoreDeploymentKeyMixin {}
+
+  @JsonIgnoreProperties({MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY})
+  private static final class IgnoreProcessDefinitionKeyMixin {}
+
+  @JsonIgnoreProperties({
+    DELETE_HISTORY_PROPERTY,
+    BATCH_OPERATION_KEY_PROPERTY,
+    BATCH_OPERATION_TYPE_PROPERTY,
+    RESOURCE_TYPE_PROPERTY,
+    RESOURCE_ID_PROPERTY
+  })
+  private static final class ResourceDeletionMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -13,7 +13,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -21,16 +23,19 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationMoveInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -817,6 +822,434 @@ final class BulkIndexRequestTest {
       assertThat(value.get("businessId"))
           .describedAs("Expect that the records are serialized with businessId")
           .isEqualTo(businessId);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithoutElementInstanceKeyOnPreviousVersion(final ValueType valueType)
+        throws Exception {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("elementInstanceKey"))
+          .describedAs("Expect that the records are serialized without elementInstanceKey")
+          .isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithElementInstanceKeyOnCurrentVersion(final ValueType valueType)
+        throws Exception {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("elementInstanceKey"))
+          .describedAs("Expect that the records are serialized with elementInstanceKey")
+          .isNotNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ValueType.class,
+        names = {
+          "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+        })
+    void shouldIndexWithoutTagsOnPreviousVersion(final ValueType valueType) throws Exception {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("tags"))
+          .describedAs("Expect that the records are serialized without tags")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithoutTenantFilterOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobBatchRecord()
+                              .setType("test")
+                              .setTenantFilter(TenantFilter.ASSIGNED)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("tenantFilter"))
+          .describedAs("Expect that the records are serialized without tenantFilter")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithTenantFilter() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobBatchRecord()
+                              .setType("test")
+                              .setTenantFilter(TenantFilter.ASSIGNED)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("tenantFilter"))
+          .describedAs("Expect that the records are serialized with tenantFilter")
+          .isEqualTo(TenantFilter.ASSIGNED.name());
+    }
+
+    @Test
+    void shouldIndexVariableRecordWithoutSourceOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.VARIABLE, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("source"))
+          .describedAs("Expect that the records are serialized without source")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexVariableRecordWithoutElementInstanceKeyOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.VARIABLE, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("elementInstanceKey"))
+          .describedAs("Expect that the records are serialized without elementInstanceKey")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithoutListenersConfigKeyOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new UserTaskRecord()
+                              .setUserTaskKey(1L)
+                              .setListenersConfigKey(42L)
+                              .setTags(Set.of("tag1"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("listenersConfigKey"))
+          .describedAs("Expect that the records are serialized without listenersConfigKey")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithoutTagsOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1", "tag2"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("tags"))
+          .describedAs("Expect that the records are serialized without tags")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithTagsOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("tags"))
+          .describedAs("Expect that the records are serialized with tags")
+          .isNotNull();
+    }
+
+    @Test
+    void shouldIndexProcessInstanceMigrationWithoutNewFieldsOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_MIGRATION,
+              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs("processDefinitionKey should be absent")
+          .isNull();
+      assertThat(value.get("tenantId")).describedAs("tenantId should be absent").isNull();
+      assertThat(value.get("bpmnProcessId")).describedAs("bpmnProcessId should be absent").isNull();
+      assertThat(value.get("elementInstanceKey"))
+          .describedAs("elementInstanceKey should be absent")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexDecisionRequirementsRecordWithoutDeploymentKeyOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new DecisionRequirementsRecord().setDeploymentKey(12345L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("deploymentKey"))
+          .describedAs("Expect that the records are serialized without deploymentKey")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexDecisionRequirementsRecordWithDeploymentKey() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new DecisionRequirementsRecord().setDeploymentKey(12345L)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .isEqualTo(12345);
+    }
+
+    @Test
+    void shouldIndexProcessInstanceBatchRecordWithoutProcessDefinitionKeyOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_BATCH,
+              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs("Expect that the records are serialized without processDefinitionKey")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexProcessInstanceBatchRecordWithProcessDefinitionKey() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_BATCH, r -> r.withBrokerVersion(VersionUtil.getVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processDefinitionKey"))
+          .describedAs("Expect that the records are serialized with processDefinitionKey")
+          .isNotNull();
+    }
+
+    @Test
+    void shouldIndexResourceDeletionRecordWithoutNewFieldsOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.RESOURCE_DELETION,
+              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("deleteHistory")).describedAs("deleteHistory should be absent").isNull();
+      assertThat(value.get("batchOperationKey"))
+          .describedAs("batchOperationKey should be absent")
+          .isNull();
+      assertThat(value.get("batchOperationType"))
+          .describedAs("batchOperationType should be absent")
+          .isNull();
+      assertThat(value.get("resourceType")).describedAs("resourceType should be absent").isNull();
+      assertThat(value.get("resourceId")).describedAs("resourceId should be absent").isNull();
+    }
+
+    @Test
+    void shouldIndexResourceDeletionRecordWithNewFieldsOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.RESOURCE_DELETION, r -> r.withBrokerVersion(VersionUtil.getVersion()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("deleteHistory"))
+          .describedAs("deleteHistory should be present")
+          .isNotNull();
+      assertThat(value.get("batchOperationKey"))
+          .describedAs("batchOperationKey should be present")
+          .isNotNull();
+      assertThat(value.get("batchOperationType"))
+          .describedAs("batchOperationType should be present")
+          .isNotNull();
+      assertThat(value.get("resourceType"))
+          .describedAs("resourceType should be present")
+          .isNotNull();
+      assertThat(value.get("resourceId")).describedAs("resourceId should be present").isNotNull();
     }
 
     private static String getBusinessId(final RecordValue recordValue) throws Exception {


### PR DESCRIPTION
## Summary
- Adds missing Jackson `@JsonIgnoreProperties` mixins to `PREVIOUS_VERSION_MAPPER` in both ES and OpenSearch exporter `BulkIndexRequest` classes
- Covers ~20 new fields across 10 record types that were causing `strict_dynamic_mapping_exception` when exporting old records to 8.8 index templates after upgrade
- New mixins: ProcessInstanceMixin (elementInstanceKey, tags), JobBatchMixin (tenantFilter), VariableMixin (elementInstanceKey, source), UserTaskMixin (listenersConfigKey, tags), ProcessInstanceMigrationMixin (processDefinitionKey, tenantId, bpmnProcessId, elementInstanceKey), IgnoreDeploymentKeyMixin, IgnoreProcessDefinitionKeyMixin, ResourceDeletionMixin (5 fields)

Complements existing fixes for `businessId` (#49174) and `jobToUserTaskMigration` (#49281).

## Test plan
- [x] BulkIndexRequestTest passes for ES exporter (65 tests, 0 failures)
- [x] BulkIndexRequestTest passes for OS exporter (65 tests, 0 failures)
- [ ] E2E migration test (8.8→8.9 with backlog) validates no more strict mapping exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)