### PR TITLE
fix: avoid re-run fail when dry-run-release-XY fail

### DIFF
--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -32,6 +32,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || 'main' }}
+      - name: Create fake dry-run tags
+        run: |
+          for tag in 0.0.0-dryrun-minor 0.0.0-dryrun-alpha; do
+            git tag -f "$tag"
+            git push origin --force "refs/tags/${tag}"
+            echo "Prepared fake dry-run tag: ${tag}"
+          done
       - name: Resolve release branch
         id: resolve-branch
         run: |
@@ -88,6 +95,12 @@ jobs:
       - uses: actions/checkout@v6
       - name: Delete temporary release branch
         run: git push origin --delete "${{ needs.setup.outputs.branch }}" 2>/dev/null || true
+      - name: Delete fake dry-run tags
+        if: ${{ needs.dry-run-release.result == 'success' }}
+        run: |
+          for tag in 0.0.0-dryrun-minor 0.0.0-dryrun-alpha; do
+            git push origin --delete "refs/tags/${tag}" 2>/dev/null || true
+          done
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -215,7 +215,6 @@ jobs:
           # Assign the amount of seconds that the plugin will wait for a deployment
           # state. Can not be less than Constants.WAIT_MAX_TIME_DEFAULT_VALUE.
           CENTRAL_WAIT_MAX_TIME: "3600"
-          MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
         run: |
           # Perform a maven release
           # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
@@ -236,18 +235,15 @@ jobs:
             ARGUMENTS_PROFILE="-P!include-optimize"
           fi
 
-          GPG_PASSPHRASE_FOR_ARGS=${MAVEN_GPG_PASSPHRASE//\\/\\\\}
-          GPG_PASSPHRASE_FOR_ARGS=${GPG_PASSPHRASE_FOR_ARGS//\"/\\\"}
-
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \
             -DreleaseVersion="${RELEASE_VERSION}" \
-            -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}" \
+            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout="${{ inputs.dryRun }}" \
             -DskipQaBuild=true \
             -P-autoFormat \
             ${PROFILE_FLAGS} \
-            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${GPG_PASSPHRASE_FOR_ARGS}\""
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -215,6 +215,7 @@ jobs:
           # Assign the amount of seconds that the plugin will wait for a deployment
           # state. Can not be less than Constants.WAIT_MAX_TIME_DEFAULT_VALUE.
           CENTRAL_WAIT_MAX_TIME: "3600"
+          MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
         run: |
           # Perform a maven release
           # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
@@ -235,15 +236,18 @@ jobs:
             ARGUMENTS_PROFILE="-P!include-optimize"
           fi
 
+          GPG_PASSPHRASE_FOR_ARGS=${MAVEN_GPG_PASSPHRASE//\\/\\\\}
+          GPG_PASSPHRASE_FOR_ARGS=${GPG_PASSPHRASE_FOR_ARGS//\"/\\\"}
+
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \
             -DreleaseVersion="${RELEASE_VERSION}" \
-            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
+            -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}" \
             -DlocalCheckout="${{ inputs.dryRun }}" \
             -DskipQaBuild=true \
             -P-autoFormat \
             ${PROFILE_FLAGS} \
-            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${GPG_PASSPHRASE_FOR_ARGS}\""
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -64,7 +64,7 @@ jobs:
   dry-run-release-89:
     name: "Release from stable/8.9"
     needs: create-dry-run-branches
-    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@fix-release-fail-lifecycle-unknown-stable
+    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.9
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -44,6 +44,22 @@ jobs:
             git push origin "${branch_name}"
             echo "Created ${branch_name} from stable/${version}"
           done
+      - name: Create fake dry-run tags
+        run: |
+          declare -A tags=(
+            [8.6]=0.0.0-dryrun-86
+            [8.7]=0.0.0-dryrun-87
+            [8.8]=0.0.0-dryrun-88
+            [8.9]=0.0.0-dryrun-89
+          )
+
+          for version in 8.6 8.7 8.8 8.9; do
+            tag_name="${tags[$version]}"
+            git checkout "origin/stable/${version}"
+            git tag -f "${tag_name}"
+            git push origin --force "refs/tags/${tag_name}"
+            echo "Prepared ${tag_name} from stable/${version}"
+          done
 
   dry-run-release-89:
     name: "Release from stable/8.9"
@@ -102,7 +118,7 @@ jobs:
       isLatest: true
       dryRun: true
 
-  # Always run cleanup. Delete branches for successful dry runs and keep failed
+  # Always run cleanup. Delete refs for successful dry runs and keep failed
   # ones available for targeted reruns.
   cleanup-dry-run-branches:
     name: Delete temporary dry-run branches
@@ -127,26 +143,30 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ steps.github-token.outputs.token }}
-      - name: Delete stable/8.9 branch
+      - name: Delete temporary dryrun 8.9 branch and tag
         if: ${{ needs.dry-run-release-89.result == 'success' }}
         run: |
           branch_name="tmp-dryrun-8.9-${{ github.run_id }}"
           git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
-      - name: Delete stable/8.8 branch
+          git push origin --delete "refs/tags/0.0.0-dryrun-89" 2>/dev/null || echo "::warning::Failed to delete 0.0.0-dryrun-89, it may have already been deleted"
+      - name: Delete temporary dryrun 8.8 branch and tag
         if: ${{ needs.dry-run-release-88.result == 'success' }}
         run: |
           branch_name="tmp-dryrun-8.8-${{ github.run_id }}"
           git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
-      - name: Delete stable/8.7 branch
+          git push origin --delete "refs/tags/0.0.0-dryrun-88" 2>/dev/null || echo "::warning::Failed to delete 0.0.0-dryrun-88, it may have already been deleted"
+      - name: Delete temporary dryrun 8.7 branch and tag
         if: ${{ needs.dry-run-release-87.result == 'success' }}
         run: |
           branch_name="tmp-dryrun-8.7-${{ github.run_id }}"
           git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
-      - name: Delete stable/8.6 branch
+          git push origin --delete "refs/tags/0.0.0-dryrun-87" 2>/dev/null || echo "::warning::Failed to delete 0.0.0-dryrun-87, it may have already been deleted"
+      - name: Delete temporary dryrun 8.6 branch and tag
         if: ${{ needs.dry-run-release-86.result == 'success' }}
         run: |
           branch_name="tmp-dryrun-8.6-${{ github.run_id }}"
           git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
+          git push origin --delete "refs/tags/0.0.0-dryrun-86" 2>/dev/null || echo "::warning::Failed to delete 0.0.0-dryrun-86, it may have already been deleted"
 
   notify-camunda:
     name: Send Slack notification for 8.6+

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -64,7 +64,7 @@ jobs:
   dry-run-release-89:
     name: "Release from stable/8.9"
     needs: create-dry-run-branches
-    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.9
+    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@fix-release-fail-lifecycle-unknown-stable
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -102,7 +102,8 @@ jobs:
       isLatest: true
       dryRun: true
 
-  # Always clean up the temporary branches, regardless of success or failure
+  # Always run cleanup. Delete branches for successful dry runs and keep failed
+  # ones available for targeted reruns.
   cleanup-dry-run-branches:
     name: Delete temporary dry-run branches
     runs-on: ubuntu-slim
@@ -126,12 +127,26 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ steps.github-token.outputs.token }}
-      - name: Delete branches
+      - name: Delete stable/8.9 branch
+        if: ${{ needs.dry-run-release-89.result == 'success' }}
         run: |
-          for version in 8.6 8.7 8.8 8.9; do
-            branch_name="tmp-dryrun-${version}-${{ github.run_id }}"
-            git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
-          done
+          branch_name="tmp-dryrun-8.9-${{ github.run_id }}"
+          git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
+      - name: Delete stable/8.8 branch
+        if: ${{ needs.dry-run-release-88.result == 'success' }}
+        run: |
+          branch_name="tmp-dryrun-8.8-${{ github.run_id }}"
+          git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
+      - name: Delete stable/8.7 branch
+        if: ${{ needs.dry-run-release-87.result == 'success' }}
+        run: |
+          branch_name="tmp-dryrun-8.7-${{ github.run_id }}"
+          git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
+      - name: Delete stable/8.6 branch
+        if: ${{ needs.dry-run-release-86.result == 'success' }}
+        run: |
+          branch_name="tmp-dryrun-8.6-${{ github.run_id }}"
+          git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
 
   notify-camunda:
     name: Send Slack notification for 8.6+


### PR DESCRIPTION
## Description

This pull request updates the workflow logic in `.github/workflows/zeebe-release-stable-dry-run.yml` to make the deletion of temporary dry-run branches more robust. The key change ensures that the deletion step only runs if all preceding dry-run release jobs succeed, rather than always running regardless of their outcome.

Examples:

- [Attempt #1:](https://github.com/camunda/camunda/actions/runs/23419763152/attempts/1) fatal: unable to access 'https://github.com/camunda/camunda/': The requested URL returned error: 403
- [Attempt #2 (re-run failed job)](https://github.com/camunda/camunda/actions/runs/23419763152) (re-run failed):  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/tmp-dryrun-8.9-23419763152*:refs/remotes/origin/tmp-dryrun-8.9-23419763152* +refs/tags/tmp-dryrun-8.9-23419763152*:refs/tags/tmp-dryrun-8.9-23419763152* The process '/usr/bin/git' failed with exit code 1
- [Attempt #1:](https://github.com/camunda/camunda/actions/runs/23453783722/attempts/1) fatal: Remote branch 0.0.0-dryrun-89 not found in upstream origin + /home/runner/_work/_temp/5bcf8210-0e7a-482d-9b44-e220c523b226.sh: line 24: unexpected EOF while looking for matching `''
- [Attempt #2 (re-run failed job):](https://github.com/camunda/camunda/actions/runs/23453783722/attempts/2)  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/tmp-dryrun-8.9-23453783722*:refs/remotes/origin/tmp-dryrun-8.9-23453783722* +refs/tags/tmp-dryrun-8.9-23453783722*:refs/tags/tmp-dryrun-8.9-23453783722* The process '/usr/bin/git' failed with exit code 1
- [Attempt #3 (re-run all)](https://github.com/camunda/camunda/actions/runs/23453783722/job/68249393332): fatal: Remote branch 0.0.0-dryrun-89 not found in upstream origin + /home/runner/_work/_temp/5bcf8210-0e7a-482d-9b44-e220c523b226.sh: line 24: unexpected EOF while looking for matching `''

Test:

https://github.com/camunda/camunda/actions/runs/23461756634
2nd attempt (re-run failed job): https://github.com/camunda/camunda/actions/runs/23461756634/job/68267833879, same issue as before \o/

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
