### PR TITLE
ci: add Optimize build support to weekly load tests

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -65,7 +65,7 @@ jobs:
     needs: test-data
     if: ${{ inputs.reuse-tag == '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -94,11 +94,16 @@ jobs:
         with:
           directory: ./identity/client
           package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Optimize Frontend
+        with:
+          directory: ./optimize/client
+          package-manager: "yarn"
       - uses: ./.github/actions/build-zeebe
         name: Build Camunda Platform
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -PskipFrontendBuild -Pinclude-optimize
       - uses: ./.github/actions/build-platform-docker
         name: Build and Push Camunda Docker Image
         with:
@@ -107,6 +112,14 @@ jobs:
           version: ${{ needs.test-data.outputs.image-tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           dockerfile: 'camunda.Dockerfile'
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Optimize Docker Image
+        with:
+          repository: '${{ env.IMAGE_REPOSITORY }}/optimize'
+          push: true
+          version: ${{ needs.test-data.outputs.image-tag }}
+          distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
+          dockerfile: 'optimize.Dockerfile'
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Adds Optimize frontend build step (yarn) to the weekly load test image build
- Switches Maven profile from `-P\!include-optimize` to `-Pinclude-optimize`
- Builds and pushes the Optimize Docker image alongside the Camunda image
- Increases build timeout from 30 to 45 minutes to accommodate the extra steps

The weekly workflow was missing Optimize in its build job, but the downstream deploy steps (via `camunda-load-test.yml`) default `enable-optimize: true`, expecting the Optimize images to exist.

## Test plan
- [x] Trigger weekly workflow via `workflow_dispatch` (without `reuse-tag`) to exercise the full build path
- [x] Verify Optimize frontend builds successfully
- [x] Verify Optimize Docker image is pushed to `registry.camunda.cloud/team-zeebe/optimize`
- [x] Verify at least one test scenario deploys successfully with Optimize enabled
- [ ] Backport to active maintenance branches after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)