### PR TITLE
ci: extract image build into reusable workflow

### DIFF
--- a/.github/workflows/camunda-build-load-test-images.yml
+++ b/.github/workflows/camunda-build-load-test-images.yml
@@ -1,0 +1,165 @@
+# description: Reusable workflow to build Camunda platform and load test Docker images.
+# This is called by camunda-load-test.yml and camunda-weekly-load-tests.yml
+# to avoid duplicating the build logic.
+# type: CI
+# owner: camunda/orchestration-cluster-team
+
+name: Build Load Test Images
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to checkout and build from'
+        type: string
+        default: 'main'
+        required: false
+      image-tag:
+        description: 'Docker image tag to use for all built images'
+        type: string
+        required: true
+      build-frontend:
+        description: 'Build frontend projects as part of the image build'
+        type: boolean
+        default: false
+        required: false
+      enable-optimize:
+        description: 'Include Optimize in the platform build and build the Optimize Docker image'
+        type: boolean
+        default: true
+        required: false
+      build-camunda-image:
+        description: 'Whether to build the Camunda platform and Optimize Docker images'
+        type: boolean
+        default: true
+        required: false
+      build-load-test-images:
+        description: 'Whether to build the Starter and Worker Docker images'
+        type: boolean
+        default: true
+        required: false
+
+env:
+  IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  build-camunda-image:
+    name: Build Camunda
+    if: ${{ inputs.build-camunda-image }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          harbor: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - uses: ./.github/actions/build-frontend
+        name: Build Operate Frontend
+        id: build-operate-fe
+        if: ${{ inputs.build-frontend }}
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Tasklist Frontend
+        id: build-tasklist-fe
+        if: ${{ inputs.build-frontend }}
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Identity Frontend
+        id: build-identity-fe
+        if: ${{ inputs.build-frontend }}
+        with:
+          directory: ./identity/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Optimize Frontend
+        id: build-optimize-fe
+        if: ${{ inputs.build-frontend && inputs.enable-optimize }}
+        with:
+          directory: ./optimize/client
+          package-manager: "yarn"
+      - uses: ./.github/actions/build-zeebe
+        name: Build Camunda Platform
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild ${{ inputs.enable-optimize && '-Pinclude-optimize' || '-P\!include-optimize' }}
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Camunda Docker Image
+        with:
+          repository: '${{ env.IMAGE_REPOSITORY }}/camunda'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ inputs.image-tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          dockerfile: 'camunda.Dockerfile'
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Optimize Docker Image
+        if: ${{ inputs.enable-optimize }}
+        with:
+          repository: '${{ env.IMAGE_REPOSITORY }}/optimize'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ inputs.image-tag }}
+          distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
+          dockerfile: 'optimize.Dockerfile'
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  build-load-test-images:
+    name: Build Starter and Worker
+    if: ${{ inputs.build-load-test-images }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          harbor: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl load-tests/load-tester -am install
+      - name: Build Starter Image
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ inputs.image-tag }}"
+      - name: Build Worker Image
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ inputs.image-tag }}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -297,138 +297,33 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  build-camunda-image:
-    name: Build Camunda
+  build-images:
+    name: Build Images
     needs: calculate-image-tag
-    if: ${{ inputs.reuse-tag == '' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref }}
-      - uses: ./.github/actions/setup-build
-        with:
-          dockerhub-readonly: true
-          harbor: true
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          minimus: true
-      - uses: ./.github/actions/build-frontend
-        name: Build Operate Frontend
-        id: build-operate-fe
-        if: ${{ inputs.build-frontend }}
-        with:
-          directory: ./operate/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Tasklist Frontend
-        id: build-tasklist-fe
-        if: ${{ inputs.build-frontend }}
-        with:
-          directory: ./tasklist/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Identity Frontend
-        id: build-identity-fe
-        if: ${{ inputs.build-frontend }}
-        with:
-          directory: ./identity/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Optimize Frontend
-        id: build-optimize-fe
-        if: ${{ inputs.build-frontend && inputs.enable-optimize }}
-        with:
-          directory: ./optimize/client
-          package-manager: "yarn"
-      - uses: ./.github/actions/build-zeebe
-        name: Build Camunda Platform
-        id: build-camunda
-        with:
-          maven-extra-args: -PskipFrontendBuild ${{ inputs.enable-optimize && '-Pinclude-optimize' || '-P\!include-optimize' }}
-      - uses: ./.github/actions/build-platform-docker
-        name: Build Camunda Docker Image
-        with:
-          repository: '${{ env.IMAGE_REPOSITORY }}/camunda'
-          revision: ${{ inputs.ref }}
-          push: true
-          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
-          dockerfile: 'camunda.Dockerfile'
-      - uses: ./.github/actions/build-platform-docker
-        name: Build Optimize Docker Image
-        if: ${{ inputs.enable-optimize }}
-        with:
-          repository: '${{ env.IMAGE_REPOSITORY }}/optimize'
-          revision: ${{ inputs.ref }}
-          push: true
-          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
-          distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
-          dockerfile: 'optimize.Dockerfile'
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
-  build-load-test-images:
-    name: Build Starter and Worker
     if: ${{ inputs.reuse-tag == '' || inputs.use-official-docker-images == true }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: calculate-image-tag
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref }}
-      - uses: ./.github/actions/setup-build
-        with:
-          dockerhub-readonly: true
-          harbor: true
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl load-tests/load-tester -am install
-      - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
-      - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+    uses: ./.github/workflows/camunda-build-load-test-images.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+      image-tag: ${{ needs.calculate-image-tag.outputs.image-tag }}
+      build-frontend: ${{ inputs.build-frontend }}
+      enable-optimize: ${{ inputs.enable-optimize }}
+      build-camunda-image: ${{ inputs.reuse-tag == '' }}
+      build-load-test-images: ${{ inputs.reuse-tag == '' || inputs.use-official-docker-images == true }}
 
   deploy-cluster-under-test:
     name: Deploy cluster under test
     needs:
       - calculate-image-tag
       - calculate-scenario-config
-      - build-camunda-image
-      - build-load-test-images
+      - build-images
     # To have the possibility to re-deploy the tests without rebuilding the images,
     # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
       needs.calculate-image-tag.result == 'success' &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+      needs.calculate-scenario-config.result == 'success' &&
+      (needs.build-images.result == 'success' || needs.build-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -65,7 +65,7 @@ jobs:
     needs: test-data
     if: ${{ inputs.reuse-tag == '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -94,11 +94,16 @@ jobs:
         with:
           directory: ./identity/client
           package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Optimize Frontend
+        with:
+          directory: ./optimize/client
+          package-manager: "yarn"
       - uses: ./.github/actions/build-zeebe
         name: Build Camunda Platform
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -PskipFrontendBuild -Pinclude-optimize
       - uses: ./.github/actions/build-platform-docker
         name: Build and Push Camunda Docker Image
         with:
@@ -107,6 +112,14 @@ jobs:
           version: ${{ needs.test-data.outputs.image-tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           dockerfile: 'camunda.Dockerfile'
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Optimize Docker Image
+        with:
+          repository: '${{ env.IMAGE_REPOSITORY }}/optimize'
+          push: true
+          version: ${{ needs.test-data.outputs.image-tag }}
+          distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
+          dockerfile: 'optimize.Dockerfile'
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -60,120 +60,26 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  build-camunda-image:
-    name: Build Camunda Image
+  build-images:
+    name: Build Images
     needs: test-data
     if: ${{ inputs.reuse-tag == '' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-build
-        with:
-          dockerhub-readonly: true
-          harbor: true
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          minimus: true
-      - uses: ./.github/actions/build-frontend
-        name: Build Operate Frontend
-        with:
-          directory: ./operate/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Tasklist Frontend
-        with:
-          directory: ./tasklist/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Identity Frontend
-        with:
-          directory: ./identity/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        name: Build Optimize Frontend
-        with:
-          directory: ./optimize/client
-          package-manager: "yarn"
-      - uses: ./.github/actions/build-zeebe
-        name: Build Camunda Platform
-        id: build-camunda
-        with:
-          maven-extra-args: -PskipFrontendBuild -Pinclude-optimize
-      - uses: ./.github/actions/build-platform-docker
-        name: Build and Push Camunda Docker Image
-        with:
-          repository: '${{ env.IMAGE_REPOSITORY }}/camunda'
-          push: true
-          version: ${{ needs.test-data.outputs.image-tag }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
-          dockerfile: 'camunda.Dockerfile'
-      - uses: ./.github/actions/build-platform-docker
-        name: Build Optimize Docker Image
-        with:
-          repository: '${{ env.IMAGE_REPOSITORY }}/optimize'
-          push: true
-          version: ${{ needs.test-data.outputs.image-tag }}
-          distball: 'optimize-distro/target/camunda-optimize-*.tar.gz'
-          dockerfile: 'optimize.Dockerfile'
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
-  build-load-test-images:
-    name: Build Starter and Worker
-    needs: test-data
-    if: ${{ inputs.reuse-tag == '' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-build
-        with:
-          dockerhub-readonly: true
-          harbor: true
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - run: ./mvnw -B -DskipTests -DskipChecks -P\!include-optimize -pl load-tests/load-tester -am install
-      - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.test-data.outputs.image-tag }}"
-      - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.test-data.outputs.image-tag }}"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+    uses: ./.github/workflows/camunda-build-load-test-images.yml
+    secrets: inherit
+    with:
+      image-tag: ${{ needs.test-data.outputs.image-tag }}
+      build-frontend: true
+      enable-optimize: true
 
   setup-typical-load-test:
     name: Typical load test
     needs:
       - test-data
-      - build-camunda-image
-      - build-load-test-images
+      - build-images
     if: |
       always() &&
       needs.test-data.result == 'success' &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+      (needs.build-images.result == 'success' || needs.build-images.result == 'skipped')
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
@@ -186,13 +92,11 @@ jobs:
     name: Postgres realistic load test
     needs:
       - test-data
-      - build-camunda-image
-      - build-load-test-images
+      - build-images
     if: |
       always() &&
       needs.test-data.result == 'success' &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+      (needs.build-images.result == 'success' || needs.build-images.result == 'skipped')
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
@@ -208,13 +112,11 @@ jobs:
     secrets: inherit
     needs:
       - test-data
-      - build-camunda-image
-      - build-load-test-images
+      - build-images
     if: |
       always() &&
       needs.test-data.result == 'success' &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+      (needs.build-images.result == 'success' || needs.build-images.result == 'skipped')
     with:
       name: ${{ needs.test-data.outputs.image-tag }}-realistic
       ttl: ${{ fromJSON(inputs.ttl || '28') }}
@@ -227,13 +129,11 @@ jobs:
     secrets: inherit
     needs:
       - test-data
-      - build-camunda-image
-      - build-load-test-images
+      - build-images
     if: |
       always() &&
       needs.test-data.result == 'success' &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+      (needs.build-images.result == 'success' || needs.build-images.result == 'skipped')
     with:
       name: ${{ needs.test-data.outputs.image-tag }}-latency
       ttl: ${{ fromJSON(inputs.ttl || '28') }}
@@ -243,7 +143,7 @@ jobs:
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ build-camunda-image, build-load-test-images, setup-typical-load-test, setup-rdbms-realistic-load-test, setup-realistic-test, setup-latency-test ]
+    needs: [ build-images, setup-typical-load-test, setup-rdbms-realistic-load-test, setup-realistic-test, setup-latency-test ]
     if: failure()
     timeout-minutes: 5
     permissions: { }


### PR DESCRIPTION
## Summary
- Creates `camunda-build-load-test-images.yml` as a shared reusable workflow containing the Camunda platform, Optimize, and load test image build jobs
- Both `camunda-load-test.yml` and `camunda-weekly-load-tests.yml` now call this workflow instead of duplicating build logic
- This also adds Optimize build support to the weekly load tests (which was previously missing)
- The weekly "build once, deploy many" pattern is preserved — images are built once via the reusable workflow, then all 4 test scenarios reuse them via `reuse-tag`

## Test plan
- [ ] Trigger weekly workflow via `workflow_dispatch` (without `reuse-tag`) to exercise the full build path
- [ ] Trigger `camunda-load-test.yml` via `workflow_dispatch` (without `reuse-tag`) to exercise the ad-hoc build path
- [ ] Trigger `camunda-load-test.yml` with `reuse-tag` + `use-official-docker-images: true` to verify the edge case where only load test images are built
- [ ] Verify Optimize Docker images are built and pushed in both weekly and ad-hoc cases
- [ ] Verify at least one test scenario deploys successfully with Optimize enabled
- [ ] Backport to active maintenance branches after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)