### PR TITLE
feat: Migrate stable/optimize-8.6 to minimus

### DIFF
--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -12,11 +12,12 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "ubuntu:noble",
+  "org.opencontainers.image.ref.name": $BASE_IMAGE,
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",
   "org.opencontainers.image.url": "https://camunda.com/platform/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.line": "21"
 }

--- a/.ci/docker/test/operate-docker-labels.golden.json
+++ b/.ci/docker/test/operate-docker-labels.golden.json
@@ -17,5 +17,6 @@
   "org.opencontainers.image.title": "Camunda Operate",
   "org.opencontainers.image.url": "https://camunda.com/platform/operate/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.line": "21"
 }

--- a/.ci/docker/test/tasklist-docker-labels.golden.json
+++ b/.ci/docker/test/tasklist-docker-labels.golden.json
@@ -17,5 +17,6 @@
   "org.opencontainers.image.title": "Camunda Tasklist",
   "org.opencontainers.image.url": "https://camunda.com/platform/tasklist/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.line": "21"
 }

--- a/.ci/docker/test/verify.sh
+++ b/.ci/docker/test/verify.sh
@@ -99,9 +99,19 @@ else
     exit 1
 fi
 
+# "Dumb" way to match if the base image already has a fully qualified name or not. If the prefix
+# before the slash contains a dot (indicating possibly a domain) or a colon (indicating a port),
+# followed by a slash, then we can assume it's fully qualified already.
+if [[ ! $BASE_IMAGE =~ ^(.+[\.\|:].+)?/.*$ ]]; then
+  # No registry prefix, so we add the default one
+  BASE_IMAGE="docker.io/library/${BASE_IMAGE}"
+fi
+
 # Extract the actual labels from the info - make sure to sort keys so we always have the same
 # ordering for maps to compare things properly
-actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels')
+# Exclude the minimus.images.version label, since it changes every time the image is patched, and
+# we can't really know in advance reliably what it will be.
+actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels | del(."io.minimus.images.version")')
 
 if [[ -z "${actualLabels}" || "${actualLabels}" == "null" || "${actualLabels}" == "[]" ]]; then
   echo >&2 "No labels found in the given image ${imageName}; raw inspect output to follow"
@@ -118,7 +128,7 @@ expectedLabels=$(
     --arg REVISION "${REVISION}" \
     --arg DATE "${DATE}" \
     --arg DIGEST "${DIGEST}" \
-    --arg BASE_IMAGE "docker.io/library/${BASE_IMAGE}" \
+    --arg BASE_IMAGE "${BASE_IMAGE}" \
     "$(cat "${labelsGoldenFile}")"
 )
 

--- a/.ci/docker/test/zeebe-docker-labels.golden.json
+++ b/.ci/docker/test/zeebe-docker-labels.golden.json
@@ -11,11 +11,12 @@
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/zeebe-deployment/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "ubuntu:noble",
+  "org.opencontainers.image.ref.name": $BASE_IMAGE,
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Zeebe",
   "org.opencontainers.image.url": "https://zeebe.io",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.line": "21"
 }

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -49,8 +49,39 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Detect branch type
+      id: branch-detect
+      shell: bash
+      env:
+        IS_MAIN_OR_STABLE_BRANCH: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}
+      run: |
+        echo is-main-or-stable-branch="$IS_MAIN_OR_STABLE_BRANCH" | tee -a $GITHUB_OUTPUT
+
+    - name: Check for Fork
+      uses: ./.github/actions/is-fork
+      id: is-fork
+
     - name: Set up multi-platform support
       uses: docker/setup-qemu-action@v3
+      with:
+        # only cache on persistent branches where reuse is likely
+        cache-image: ${{ steps.branch-detect.outputs.is-main-or-stable-branch == 'true' }}
+
+    - name: Set additional build args dynamically based on workflow run context
+      id: get-additional-build-args
+      shell: bash
+      run: |
+        # Check if current workflow run is related to a fork PR
+        if [[ "${{ steps.is-fork.outputs.is-fork }}" == "true" ]]; then
+          echo "The current workflow run is related to a fork PR."
+          echo "As a result, private Minimus hardened base images will be replaced with public images."
+
+          {
+            echo 'result<<EOF'
+            echo 'BASE=public'
+            echo 'EOF'
+          } | tee -a $GITHUB_OUTPUT
+        fi
 
     # Creating a context is required when installing buildx on self-hosted runners
     - name: Create context
@@ -116,4 +147,5 @@ runs:
           DATE=${{ steps.get-date.outputs.result }}
           REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
           VERSION=${{ inputs.version != '' && inputs.version || steps.get-version.outputs.result }}
+          ${{ steps.get-additional-build-args.outputs.result }}
         target: app

--- a/.github/actions/compose/docker-compose.smoketest.yml
+++ b/.github/actions/compose/docker-compose.smoketest.yml
@@ -70,7 +70,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -q -f -I http://localhost:8090/api/readyz | grep -q '200 OK'",
+          "wget -q -S -O /dev/null http://localhost:8090/api/readyz 2>&1 | grep -q 'HTTP/1.1 200'",
         ]
       interval: 30s
       timeout: 5s
@@ -100,7 +100,7 @@ services:
       - elasticsearch
   keycloak:
     container_name: keycloak
-    image: bitnami/keycloak:25.0.6@sha256:f9c6583ae2b5079824b35f13ecef3ad96e90af185b8df7ae0b686e83c33e257b
+    image: bitnami/keycloak:26.3.3@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9
     ports:
       - "18080:8080"
     healthcheck:

--- a/.github/actions/is-fork/action.yml
+++ b/.github/actions/is-fork/action.yml
@@ -1,0 +1,20 @@
+# owner: @camunda/monorepo-devops-team
+name: Is Fork
+description: |
+  Checks if current job runs on code from a forked repository (via PR).
+  This information can be used to disable certain CI features that are not
+  available on forks (e.g. access to secrets).
+inputs: {}
+outputs:
+  is-fork:
+    description: Output whether the current job runs on code from a forked repository
+    value: ${{ steps.detect-fork.outputs.is-fork == 'true' }}
+runs:
+  using: composite
+  steps:
+  - id: detect-fork
+    env:
+      GH_EVENT_PR_FORK: ${{ github.event.pull_request.head.repo.fork }}
+    shell: bash
+    run: |
+      echo is-fork="$GH_EVENT_PR_FORK" | tee -a $GITHUB_OUTPUT

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -39,6 +39,12 @@ inputs:
     description: The path to Docker Hub secrets
     required: false
     default: "secret/data/products/zeebe/ci/zeebe"
+  minimus:
+    description: |
+      If enabled, logs into Minimus registry with a CI account.
+      Minimus login is automatically disabled for fork PRs.
+    required: false
+    default: "false"
 
 outputs: {}
 
@@ -73,6 +79,21 @@ runs:
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
           ${{ inputs.docker-secret-path }} REGISTRY_HUB_DOCKER_COM_USR;
           ${{ inputs.docker-secret-path }} ${{ inputs.docker-token }};
+          secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+
+    - name: Check for Fork
+      uses: ./.github/actions/is-fork
+      id: is-fork      
+    # Minimus login is disabled for fork PRs
+    - name: Logs on to Minimus    
+      if: >-      
+        steps.is-fork.outputs.is-fork != 'true' &&
+        inputs.minimus == 'true'    
+      uses: docker/login-action@v3    
+      with:
+        registry: reg.mini.dev
+        username: minimus
+        password: ${{ steps.secrets.outputs.minimus-token }}
     - uses: actions/setup-java@v4
       if: inputs.java == 'true'
       with:

--- a/.github/workflows/optimize-ci-build-reusable.yml
+++ b/.github/workflows/optimize-ci-build-reusable.yml
@@ -67,6 +67,32 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
 
       #########################################################################
+      # Setup Minimus if not fork
+      - name: Check for Fork
+        uses: ./.github/actions/is-fork
+        id: is-fork
+
+      - name: Import Minimus Secrets
+        id: minimus-secrets
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+
+      - name: Login to Minimus Registry
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.minimus-secrets.outputs.minimus-token }}
+
+      #########################################################################
       # Setup and configure Maven
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
@@ -94,5 +120,6 @@ jobs:
           build-args: |
             VERSION=${{ steps.pom-info.outputs.project_version }}
             REVISION=${{ env.GIT_COMMIT_HASH }}
+            ${{ steps.is-fork.outputs.is-fork == 'true' && 'BASE=public' || '' }}
           tags: ${{ env.IMAGE_TAG }}
           push: ${{ inputs.pushDocker }}

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -91,6 +91,30 @@ jobs:
       with:
         secrets: ${{ toJSON(secrets) }}
 
+    - name: Check for Fork
+      uses: ./.github/actions/is-fork
+      id: is-fork
+
+    - name: Import Minimus Secrets
+      id: minimus-secrets
+      if: steps.is-fork.outputs.is-fork != 'true'
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: |
+          secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+
+    - name: Login to Minimus Registry
+      if: steps.is-fork.outputs.is-fork != 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: reg.mini.dev
+        username: minimus
+        password: ${{ steps.minimus-secrets.outputs.minimus-token }}
+
     - name: "Read Java / Version Info"
       id: "pom-info"
       uses: YunaBraska/java-info-action@main
@@ -171,6 +195,30 @@ jobs:
         uses: ./.github/actions/login-registry
         with:
           secrets: ${{ toJSON(secrets) }}
+
+      - name: Check for Fork
+        uses: ./.github/actions/is-fork
+        id: is-fork
+
+      - name: Import Minimus Secrets
+        id: minimus-secrets
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+
+      - name: Login to Minimus Registry
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.minimus-secrets.outputs.minimus-token }}
 
       - name: "Read Java / Version Info"
         id: "pom-info"
@@ -254,6 +302,30 @@ jobs:
         uses: ./.github/actions/login-registry
         with:
           secrets: ${{ toJSON(secrets) }}
+
+      - name: Check for Fork
+        uses: ./.github/actions/is-fork
+        id: is-fork
+
+      - name: Import Minimus Secrets
+        id: minimus-secrets
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+
+      - name: Login to Minimus Registry
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.minimus-secrets.outputs.minimus-token }}
 
       - name: "Read Java / Version Info"
         id: "pom-info"

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Log Input Variables
         run: |
@@ -89,6 +89,7 @@ jobs:
             secret/data/products/infra/ci/common CAMUNDA_NEXUS_PSW;
             secret/data/products/optimize/ci/camunda-optimize REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/optimize/ci/camunda-optimize REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
 
       - name: Git User Setup
         run: |
@@ -156,6 +157,16 @@ jobs:
             echo "TAG=${{ github.event.inputs.RELEASE_VERSION || '0.0.0' }}-optimize"
           } >> "$GITHUB_ENV"
 
+      - name: Check for Fork
+        uses: ./.github/actions/is-fork
+        id: is-fork
+      - name: Login to Minimus Registry
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }} 
       - name: Login to prod Harbor docker registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
@@ -171,21 +182,21 @@ jobs:
 
       - id: "auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           token_format: "access_token"
           workload_identity_provider: "projects/271764561088/locations/global/workloadIdentityPools/github/providers/camunda"
           service_account: "github-actions-camunda@team-infosec.iam.gserviceaccount.com"
 
       - name: Login to infosec registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: europe-west1-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Checkout release branch
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.BRANCH }}
           fetch-depth: 0
@@ -311,7 +322,7 @@ jobs:
           export VERSION="${RELEASE_VERSION}"
           export DATE="$(date +%FT%TZ)"
           export REVISION="${REVISION}"
-          export BASE_IMAGE=docker.io/library/alpine:3.23.0
+          export BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
 
           # if CI (GHA) export the variables for pushing in a later step
           if [ "${CI}" = "true" ]; then
@@ -324,6 +335,7 @@ jobs:
               --build-arg VERSION="${RELEASE_VERSION}" \
               --build-arg DATE="${DATE}" \
               --build-arg REVISION="${REVISION}" \
+              --build-arg BASE_IMAGE="${BASE_IMAGE}" \
               --provenance false \
               --load \
               -f optimize.Dockerfile \
@@ -357,7 +369,7 @@ jobs:
         if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: octokit/request-action@v2.3.1
+        uses: octokit/request-action@v2.4.0
         with:
           route: POST /repos/camunda/camunda/releases
           make_latest: "false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # see https://docs.docker.com/build/buildkit/#getting-started
 
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+ARG BASE_DIGEST="sha256:642e4a1ee31f95b307833477049aca67a3a4b094148691bc3768db2e072a8eca"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,91 +2,48 @@
 # This Dockerfile requires BuildKit to be enabled, by setting the environment variable
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
-# Both ubuntu and eclipse-temurin are pinned via digest and not by a strict version tag, as Renovate
-# has trouble with custom versioning schemes
-ARG BASE_IMAGE="ubuntu:noble"
-ARG BASE_DIGEST="sha256:99c35190e22d294cdace2783ac55effc69d32896daaa265f0bbedbcde4fbe3e5"
-ARG JDK_IMAGE="eclipse-temurin:21-jdk-noble"
-ARG JDK_DIGEST="sha256:397ce4722066bed7fa96f171e0c3c252bf509347da854ec4e9ca5664a00038c1"
+
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
+ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:c20c7d70c47fb9f09f19fae01d816c14108e10812a5a36ff7494710ada4216d3"
+ARG BASE="hardened"
 
 # set to "build" to build zeebe from scratch instead of using a distball
 ARG DIST="distball"
 
-### Base image ###
-# All package installation, updates, etc., anything with APT should be done here in a single step
+### Base Application Image ###
 # hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
-WORKDIR /
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
 
-# Upgrade all outdated packages and install missing ones (e.g. locales, tini)
-# This breaks reproducibility of builds, but is acceptable to gain access to security patches faster
-# than the base image releases
-# FYI, installing packages via APT also updates the dpkg files, which are few MBs, but removing or
-# caching them could break stuff (like not knowing the package is present) or container scanners
-# hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    --mount=type=cache,target=/var/log/apt,sharing=locked \
-    apt-get -qq update && \
-    apt-get install -yqq --no-install-recommends tini ca-certificates && \
-    apt-get upgrade -yqq --no-install-recommends
-
-### Build custom JRE using the base JDK image
+### Base Public Application Image ###
 # hadolint ignore=DL3006
-FROM ${JDK_IMAGE}@${JDK_DIGEST} AS jre-build
-
-# Build a custom JRE which will strip down and compress modules to end up with a smaller Java \
-# distribution than the official JRE. This will also include useful debugging tools like
-# jcmd, jmod, jps, etc., which take little to no space. Anecdotally, compressing modules add around
-# 10ms to the start up time, which is negligible considering our application takes ~10s to start up.
-# See https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/
-# hadolint ignore=DL3018
-# required to compile a JRE on ARM64
-# see https://github.com/openzipkin/docker-java/issues/34
-ENV JAVA_TOOL_OPTIONS "-Djdk.lang.Process.launchMechanism=vfork"
-RUN jlink \
-     --add-modules ALL-MODULE-PATH \
-     --strip-debug \
-     --no-man-pages \
-     --no-header-files \
-     --compress=2 \
-     --output /jre && \
-   rm -rf /jre/lib/src.zip
-
-### Java base image
-FROM base AS java
-WORKDIR /
-
-# Inherit from previous build stage
-ARG JAVA_HOME=/opt/java/openjdk
-
-# Default to UTF-8 file encoding
-ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
-
-# Setup JAVA_HOME and binaries in the path
-ENV JAVA_HOME ${JAVA_HOME}
-ENV PATH $JAVA_HOME/bin:$PATH
-
-# Copy JRE from previous build stage
-COPY --from=jre-build /jre ${JAVA_HOME}
-
-# https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
-# https://openjdk.java.net/jeps/341
-# TL;DR generate some class data sharing for faster load time
-RUN java -Xshare:dump;
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
 
 ### Build zeebe from scratch ###
-FROM java AS build
+# hadolint ignore=DL3006
+FROM base-${BASE} AS build
+
+# hadolint ignore=DL3002
+USER root
 WORKDIR /zeebe
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
+ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 COPY --link . ./
 RUN --mount=type=cache,target=/root/.m2,rw \
     ./mvnw -B -am -pl dist package -T1C -D skipChecks -D skipTests && \
     mv dist/target/camunda-zeebe .
 
 ### Extract zeebe from distball ###
-# hadolint ignore=DL3006
-FROM base AS distball
+# hadolint ignore=DL3006,DL3007
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS distball
+
+# hadolint ignore=DL3002
+USER root
 WORKDIR /zeebe
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} zeebe.tar.gz
@@ -101,7 +58,7 @@ FROM ${DIST} AS dist
 ### Application Image ###
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # hadolint ignore=DL3006
-FROM java AS app
+FROM base-${BASE} AS app
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE
 ARG BASE_DIGEST
@@ -111,7 +68,7 @@ ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="zeebe@camunda.com"
 LABEL org.opencontainers.image.url="https://zeebe.io"
@@ -137,7 +94,7 @@ LABEL io.openshift.min-cpu="1"
 ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_STANDALONE_GATEWAY=false \
     ZEEBE_RESTORE=false
-ENV PATH "${ZB_HOME}/bin:${PATH}"
+ENV PATH="${ZB_HOME}/bin:${PATH}"
 # Disable RocksDB runtime check for musl, which launches `ldd` as a shell process
 # We know there's no need to check for musl on this image
 ENV ROCKSDB_MUSL_LIBC=false
@@ -148,8 +105,10 @@ VOLUME /tmp
 VOLUME ${ZB_HOME}/data
 VOLUME ${ZB_HOME}/logs
 
-RUN groupadd --gid 1001 camunda && \
-    useradd --system --gid 1001 --uid 1001 --home ${ZB_HOME} camunda && \
+# Switch to root to allow setting up our own user
+USER root
+RUN addgroup --gid 1001 camunda && \
+    adduser -S -G camunda -u 1001 -h ${ZB_HOME} -s /sbin/nologin camunda && \
     chmod g=u /etc/passwd && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -2,91 +2,47 @@
 # This Dockerfile requires BuildKit to be enabled, by setting the environment variable
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
-# Both ubuntu and eclipse-temurin are pinned via digest and not by a strict version tag, as Renovate
-# has trouble with custom versioning schemes
-ARG BASE_IMAGE="ubuntu:noble"
-ARG BASE_DIGEST="sha256:99c35190e22d294cdace2783ac55effc69d32896daaa265f0bbedbcde4fbe3e5"
-ARG JDK_IMAGE="eclipse-temurin:21-jdk-noble"
-ARG JDK_DIGEST="sha256:397ce4722066bed7fa96f171e0c3c252bf509347da854ec4e9ca5664a00038c1"
+
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
+ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:c20c7d70c47fb9f09f19fae01d816c14108e10812a5a36ff7494710ada4216d3"
+ARG BASE="hardened"
 
 # set to "build" to build camunda from scratch instead of using a distball
 ARG DIST="distball"
 
-### Base image ###
-# All package installation, updates, etc., anything with APT should be done here in a single step
+### Base Application Image ###
 # hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
-WORKDIR /
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
 
-# Upgrade all outdated packages and install missing ones (e.g. locales, tini)
-# This breaks reproducibility of builds, but is acceptable to gain access to security patches faster
-# than the base image releases
-# FYI, installing packages via APT also updates the dpkg files, which are few MBs, but removing or
-# caching them could break stuff (like not knowing the package is present) or container scanners
-# hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    --mount=type=cache,target=/var/log/apt,sharing=locked \
-    apt-get -qq update && \
-    apt-get install -yqq --no-install-recommends tini ca-certificates && \
-    apt-get upgrade -yqq --no-install-recommends
-
-### Build custom JRE using the base JDK image
+### Base Public Application Image ###
 # hadolint ignore=DL3006
-FROM ${JDK_IMAGE}@${JDK_DIGEST} AS jre-build
-
-# Build a custom JRE which will strip down and compress modules to end up with a smaller Java \
-# distribution than the official JRE. This will also include useful debugging tools like
-# jcmd, jmod, jps, etc., which take little to no space. Anecdotally, compressing modules add around
-# 10ms to the start up time, which is negligible considering our application takes ~10s to start up.
-# See https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/
-# hadolint ignore=DL3018
-# required to compile a JRE on ARM64
-# see https://github.com/openzipkin/docker-java/issues/34
-ENV JAVA_TOOL_OPTIONS "-Djdk.lang.Process.launchMechanism=vfork"
-RUN jlink \
-     --add-modules ALL-MODULE-PATH \
-     --strip-debug \
-     --no-man-pages \
-     --no-header-files \
-     --compress=2 \
-     --output /jre && \
-   rm -rf /jre/lib/src.zip
-
-### Java base image
-FROM base AS java
-WORKDIR /
-
-# Inherit from previous build stage
-ARG JAVA_HOME=/opt/java/openjdk
-
-# Default to UTF-8 file encoding
-ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
-
-# Setup JAVA_HOME and binaries in the path
-ENV JAVA_HOME ${JAVA_HOME}
-ENV PATH $JAVA_HOME/bin:$PATH
-
-# Copy JRE from previous build stage
-COPY --from=jre-build /jre ${JAVA_HOME}
-
-# https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
-# https://openjdk.java.net/jeps/341
-# TL;DR generate some class data sharing for faster load time
-RUN java -Xshare:dump;
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
 
 ### Build camunda from scratch ###
-FROM java AS build
+# hadolint ignore=DL3006
+FROM base-${BASE} AS build
+
+# hadolint ignore=DL3002
+USER root
 WORKDIR /camunda
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
+ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 COPY --link . ./
 RUN --mount=type=cache,target=/root/.m2,rw \
     ./mvnw -B -am -pl dist package -T1C -D skipChecks -D skipTests -D skipOptimize && \
     mv dist/target/camunda-zeebe .
 
-### Extract camunda from distball ###
-# hadolint ignore=DL3006
-FROM base AS distball
+# hadolint ignore=DL3006,DL3007
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS distball
+
+# hadolint ignore=DL3002
+USER root
 WORKDIR /camunda
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} camunda.tar.gz
@@ -101,7 +57,7 @@ FROM ${DIST} AS dist
 ### Application Image ###
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # hadolint ignore=DL3006
-FROM java AS app
+FROM base-${BASE} AS app
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE
 ARG BASE_DIGEST
@@ -111,7 +67,7 @@ ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="community@camunda.com"
 LABEL org.opencontainers.image.url="https://camunda.com/platform/"
@@ -137,6 +93,7 @@ LABEL io.openshift.wants="elasticsearch"
 
 ENV CAMUNDA_HOME=/usr/local/camunda
 ENV PATH "${CAMUNDA_HOME}/bin:${PATH}"
+ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 # Disable RocksDB runtime check for musl, which launches `ldd` as a shell process
 # We know there's no need to check for musl on this image
 ENV ROCKSDB_MUSL_LIBC=false
@@ -147,8 +104,10 @@ VOLUME /tmp
 VOLUME ${CAMUNDA_HOME}/data
 VOLUME ${CAMUNDA_HOME}/logs
 
-RUN groupadd --gid 1001 camunda && \
-    useradd --system --gid 1001 --uid 1001 --home ${CAMUNDA_HOME} camunda && \
+# Switch to root to allow setting up our own user
+USER root
+RUN addgroup --gid 1001 camunda && \
+    adduser -S -G camunda -u 1001 -h ${CAMUNDA_HOME} camunda && \
     chmod g=u /etc/passwd && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+ARG BASE_DIGEST="sha256:642e4a1ee31f95b307833477049aca67a3a4b094148691bc3768db2e072a8eca"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -1,9 +1,24 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="alpine:3.23.0"
-ARG BASE_DIGEST="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
+ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with Alpine.
+ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
+ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE="hardened"
+
+### Base Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
+
+### Base Public Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
 
 # Prepare Operate Distribution
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS prepare
+FROM base-${BASE} AS prepare
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 WORKDIR /tmp/operate
 
@@ -14,19 +29,15 @@ RUN tar xzvf operate.tar.gz --strip 1 && \
 COPY docker-notice.txt notice.txt
 RUN sed -i '/^exec /i cat /usr/local/operate/notice.txt' bin/operate
 
-### Base image ###
-# hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
 
-# Install Tini
-RUN apk update && apk add --no-cache tini
 
 ### Application Image ###
 # TARGETARCH is provided by buildkit
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # hadolint ignore=DL3006
 
-FROM base AS app
+FROM base-${BASE} AS app
+
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE
 ARG BASE_DIGEST
@@ -35,7 +46,7 @@ ARG DATE=""
 ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="operate@camunda.com"
@@ -59,17 +70,15 @@ LABEL io.k8s.description="Tool for process observability and troubleshooting pro
 
 EXPOSE 8080
 
-RUN apk update && apk upgrade
-RUN apk add --no-cache bash openjdk21-jre tzdata
-
 ENV OPE_HOME=/usr/local/operate
 
 WORKDIR ${OPE_HOME}
 VOLUME /tmp
 VOLUME ${OPE_HOME}/logs
 
+USER root
 RUN addgroup --gid 1001 camunda && \
-    adduser -D -h ${OPE_HOME} -G camunda -u 1001 camunda && \
+    adduser -D -G camunda -u 1001 -h ${OPE_HOME} camunda && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.
     mkdir ${OPE_HOME}/logs && \

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+ARG BASE_DIGEST="sha256:642e4a1ee31f95b307833477049aca67a3a4b094148691bc3768db2e072a8eca"
 ARG WAITFORIT_CHECKSUM="b7a04f38de1e51e7455ecf63151c8c7e405bd2d45a2d4e16f6419db737a125d6"
 
 # If you don't have access to Minimus hardened base images, you can use public

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,7 +1,38 @@
-ARG BASE_IMAGE="alpine:3.23.2"
-ARG BASE_DIGEST="sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62"
+# hadolint global ignore=DL3006
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
+ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+ARG WAITFORIT_CHECKSUM="b7a04f38de1e51e7455ecf63151c8c7e405bd2d45a2d4e16f6419db737a125d6"
 
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with Alpine.
+ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
+ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE="hardened"
+
+### Download wait-for-it.sh ###
+# hadolint ignore=DL3006,DL3007
+FROM alpine AS tools
+ARG WAITFORIT_CHECKSUM
+
+# hadolint ignore=DL4006,DL3018
+RUN --mount=type=cache,target=/root/.tools,rw \
+    apk add -q --no-cache curl 2>/dev/null && \
+    # Download wait-for-it.sh \
+    curl -sL "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" -o /wait-for-it.sh && \
+    echo "${WAITFORIT_CHECKSUM} /wait-for-it.sh" | sha256sum -c && \
+    chmod +x /wait-for-it.sh
+
+### Base Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
+
+### Base Public Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
+
+# Prepare Optimize Distribution
+FROM base-${BASE} AS prepare
 WORKDIR /
 
 ARG VERSION=""
@@ -23,18 +54,17 @@ COPY ./optimize/docker/bin/optimize.sh ${BUILD_DIR}/optimize.sh
 RUN rm ${BUILD_DIR}/config/environment-config.yaml
 
 ##### FINAL IMAGE #####
-FROM base AS app
-
+# hadolint ignore=DL3006
+FROM base-${BASE} AS app
+# leave unset to use the default value at the top of the file
 ARG VERSION=""
 ARG DATE=""
 ARG REVISION=""
-
-# leave the values below unset to use the default value at the top of the file
 ARG BASE_IMAGE
 ARG BASE_DIGEST
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="optimize@camunda.com"
@@ -65,14 +95,13 @@ EXPOSE 8090 8091
 
 VOLUME /tmp
 
-RUN apk add --no-cache bash curl tini openjdk21-jre tzdata && \
-    apk -U upgrade && \
-    curl "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" --output /usr/local/bin/wait-for-it.sh && \
-    chmod +x /usr/local/bin/wait-for-it.sh && \
-    addgroup -S -g 1001 camunda && \
-    adduser -S -g 1001 -u 1001 camunda && \
+USER root
+RUN addgroup -S -g 1001 camunda && \
+    adduser -S -G camunda -u 1001 camunda && \
     mkdir -p /optimize && \
     chown 1001:1001 /optimize
+
+COPY --from=tools --chown=1001:1001 /wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
 WORKDIR /optimize
 USER 1001:1001
@@ -80,4 +109,4 @@ USER 1001:1001
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["./optimize.sh"]
 
-COPY --chown=1001:1001 --from=base /tmp/build .
+COPY --chown=1001:1001 --from=prepare /tmp/build .

--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.wants": "zeebe,elasticsearch,identity,keycloak",
   "io.openshift.tags": "bpmn,optimization,camunda",
   "org.opencontainers.image.authors": "optimize@camunda.com",
-  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.23.2",
+  "org.opencontainers.image.base.name": $BASE_IMAGE,
   "org.opencontainers.image.base.digest": $BASEDIGEST,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Provides business activity monitoring for workflows and uses BPMN-based analysis to uncover process bottlenecks",
@@ -17,5 +17,6 @@
   "org.opencontainers.image.title": "Camunda Optimize",
   "org.opencontainers.image.url": "https://docs.camunda.io/docs/components/optimize/what-is-optimize/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.line": "21"
 }

--- a/optimize/docker/test/verify.sh
+++ b/optimize/docker/test/verify.sh
@@ -60,7 +60,7 @@ SCRIPT_DIR=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
 DOCKERFILE_PATH="${SCRIPT_DIR}/../../../optimize.Dockerfile"
 
 echo "[INFO] Looking for digest in Dockerfile: ${DOCKERFILE_PATH}"
-DIGEST=$(cat "$DOCKERFILE_PATH" | grep -o 'sha256:[a-f0-9]\{64\}' | head -n 1)
+DIGEST=$(cat "$DOCKERFILE_PATH" | grep 'BASE_DIGEST=' | head -1 | grep -o 'sha256:[a-f0-9]\{64\}')
 if [[ -z "$DIGEST" ]]; then
     echo >&2 "Docker image digest can not be found in the Dockerfile (with name $DOCKERFILE_PATH)"
     exit 1
@@ -80,7 +80,9 @@ for imageName in "$@"; do
 
   # Extract the actual labels from the info - make sure to sort keys so we always have the same
   # ordering for maps to compare things properly
-  actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels')
+  # Exclude the minimus.images.version label, since it changes every time the image is patched, and
+  # we can't really know in advance reliably what it will be.
+  actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels | del(."io.minimus.images.version")')
 
   if [[ -z "${actualLabels}" || "${actualLabels}" == "null" || "${actualLabels}" == "[]" ]]; then
     echo >&2 "No labels found in the given image ${imageName}; raw inspect output to follow"

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -1,10 +1,24 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="alpine:3.23.0"
-ARG BASE_DIGEST="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
+ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
 
-# Prepare tasklist Distribution
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS prepare
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with Alpine.
+ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
+ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE="hardened"
 
+### Base Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
+
+### Base Public Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
+
+# Prepare Tasklist Distribution
+FROM base-${BASE} AS prepare
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 WORKDIR /tmp/tasklist
 
@@ -13,17 +27,10 @@ COPY ${DISTBALL} tasklist.tar.gz
 RUN tar xzvf tasklist.tar.gz --strip 1 && \
     rm tasklist.tar.gz
 
-### Base image ###
-# hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
-
-# Install Tini
-RUN apk update && apk add --no-cache tini
-
 ### Application Image ###
 # hadolint ignore=DL3006
+FROM base-${BASE} AS app
 
-FROM base AS app
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE
 ARG BASE_DIGEST
@@ -32,7 +39,7 @@ ARG DATE=""
 ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="hto@camunda.com"
@@ -56,17 +63,15 @@ LABEL io.k8s.description="Tasklist is a ready-to-use application to rapidly impl
 
 EXPOSE 8080
 
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash openjdk21-jre tzdata
-
 ENV TASKLIST_HOME=/usr/local/tasklist
 
 WORKDIR ${TASKLIST_HOME}
 VOLUME /tmp
 VOLUME ${TASKLIST_HOME}/logs
 
+USER root
 RUN addgroup --gid 1001 camunda && \
-    adduser -D -h ${TASKLIST_HOME} -G camunda -u 1001 camunda && \
+    adduser -D -G camunda -u 1001 -h ${TASKLIST_HOME} camunda && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.
     mkdir ${TASKLIST_HOME}/logs && \

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+ARG BASE_DIGEST="sha256:642e4a1ee31f95b307833477049aca67a3a4b094148691bc3768db2e072a8eca"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.


### PR DESCRIPTION
## Description
This PR is related to https://github.com/camunda/camunda/issues/42830 regarding updating the docker images, CI workflows and configurations to use the hardened minimus base image in stable/optimize-8.6 

### Investigation

The package contents are compared based on what packages are contained, what are not.

Ubuntu noble vs minimus:
https://docs.google.com/spreadsheets/d/1Mh7A-8tKjaus_KsmpoKcsYtNUmsBk44VoGCDqdKjOkM/edit?gid=1418593616#gid=1418593616

Alpine vs minimus:
https://docs.google.com/spreadsheets/d/1SWNEBiGuM0s_pt8n91SEvEWwbwTmLsPq0lwBJ6ZAQEQ/edit?gid=793461536#gid=793461536

### Resolution

- Updated all Dockerfiles to use `reg.mini.dev/1212/openjre-base-compat:21-dev`
- Updated Docker label verification to handle minimus-specific labels
- Updated GHA workflows to properly handle the new base image

## Changes Made
- [x] All Dockerfiles updated to new base image
- [x] CI pipeline workflows updated  
- [x] Golden files updated for Docker label validation
- [x] Verification script updated to exclude dynamic base image labels
- [x] Full test suite validation in progress

## Tests
### Successful release dry-run test
[Workflow run](https://github.com/camunda/camunda/actions/runs/23838892329)

### Camunda Load Test
As per the discussion with @pranjalg13 Load testing is not possible in this scenario

### Trivy
<img width="1121" height="141" alt="image" src="https://github.com/user-attachments/assets/d0dff72d-608b-4cef-aae3-d7a8520fda7f" />



## Related issues
https://github.com/camunda/camunda/issues/40856
