### PR TITLE
fix: make 8.8 API tests forward-compatible with 8.9 server

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -90,7 +90,13 @@
             "type": "number"
           }
         ],
-        "optional": []
+        "optional": [
+          {
+            "name": "clusterId",
+            "type": "string",
+            "nullable": true
+          }
+        ]
       }
     },
     {
@@ -145,7 +151,8 @@
           },
           {
             "name": "salesPlanType",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "tenants",
@@ -155,7 +162,8 @@
               "optional": [
                 {
                   "name": "description",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "name",
@@ -339,7 +347,8 @@
                       },
                       {
                         "name": "formKey",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "priority",
@@ -352,7 +361,13 @@
                         "nullable": true
                       }
                     ]
-                  }
+                  },
+                  "nullable": true
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -378,7 +393,8 @@
                 },
                 {
                   "name": "elementId",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "elementInstanceKey",
@@ -484,7 +500,8 @@
                 },
                 {
                   "name": "endTime",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "errorCode",
@@ -499,6 +516,21 @@
                 {
                   "name": "isDenied",
                   "type": "boolean",
+                  "nullable": true
+                },
+                {
+                  "name": "creationTime",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "lastUpdateTime",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
                   "nullable": true
                 }
               ]
@@ -517,7 +549,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -525,7 +558,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -543,7 +577,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
@@ -568,7 +603,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
@@ -593,7 +629,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
@@ -628,7 +665,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -636,7 +674,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -681,7 +720,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -689,7 +729,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -731,7 +772,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -739,7 +781,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -781,7 +824,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -789,7 +833,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -804,7 +849,8 @@
               "optional": [
                 {
                   "name": "description",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "name",
@@ -839,7 +885,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -847,7 +894,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -901,7 +949,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -909,7 +958,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -924,7 +974,8 @@
               "optional": [
                 {
                   "name": "description",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "name",
@@ -957,7 +1008,8 @@
         "optional": [
           {
             "name": "assignee",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "candidateGroups",
@@ -969,7 +1021,8 @@
           },
           {
             "name": "completionDate",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "creationDate",
@@ -981,7 +1034,8 @@
           },
           {
             "name": "dueDate",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "elementId",
@@ -993,19 +1047,23 @@
           },
           {
             "name": "externalFormReference",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "followUpDate",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "formKey",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "priority",
@@ -1029,7 +1087,8 @@
           },
           {
             "name": "processName",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "state",
@@ -1055,6 +1114,16 @@
             "underlyingPrimitive": "string",
             "rawRefName": "TenantId",
             "wrapper": true
+          },
+          {
+            "name": "rootProcessInstanceKey",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "tags",
+            "type": "array<string>",
+            "rawRefName": "tags"
           }
         ]
       }
@@ -1108,7 +1177,8 @@
               "optional": [
                 {
                   "name": "assignee",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "candidateGroups",
@@ -1120,7 +1190,8 @@
                 },
                 {
                   "name": "completionDate",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "creationDate",
@@ -1132,7 +1203,8 @@
                 },
                 {
                   "name": "dueDate",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "elementId",
@@ -1144,19 +1216,23 @@
                 },
                 {
                   "name": "externalFormReference",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "followUpDate",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "formKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "name",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "priority",
@@ -1180,7 +1256,8 @@
                 },
                 {
                   "name": "processName",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "state",
@@ -1206,6 +1283,16 @@
                   "underlyingPrimitive": "string",
                   "rawRefName": "TenantId",
                   "wrapper": true
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "tags",
+                  "type": "array<string>",
+                  "rawRefName": "tags"
                 }
               ]
             }
@@ -1223,7 +1310,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -1231,7 +1319,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -1280,7 +1369,13 @@
                   "type": "string"
                 }
               ],
-              "optional": []
+              "optional": [
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
+                }
+              ]
             }
           },
           {
@@ -1296,7 +1391,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -1304,7 +1400,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -1353,7 +1450,13 @@
                   "type": "string"
                 }
               ],
-              "optional": []
+              "optional": [
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
+                }
+              ]
             }
           },
           {
@@ -1369,7 +1472,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -1377,7 +1481,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -1417,7 +1522,13 @@
             "type": "string"
           }
         ],
-        "optional": []
+        "optional": [
+          {
+            "name": "rootProcessInstanceKey",
+            "type": "string",
+            "nullable": true
+          }
+        ]
       }
     },
     {
@@ -1439,7 +1550,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -1447,7 +1559,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -1466,7 +1579,8 @@
                 },
                 {
                   "name": "name",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processDefinitionId",
@@ -1490,7 +1604,8 @@
                 },
                 {
                   "name": "versionTag",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -1511,7 +1626,8 @@
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "processDefinitionId",
@@ -1535,7 +1651,8 @@
           },
           {
             "name": "versionTag",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -1645,6 +1762,11 @@
             "name": "tags",
             "type": "array<string>",
             "rawRefName": "TagSet"
+          },
+          {
+            "name": "businessId",
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -1672,7 +1794,8 @@
           },
           {
             "name": "processDefinitionName",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "processDefinitionVersion",
@@ -1709,24 +1832,38 @@
         "optional": [
           {
             "name": "endDate",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "parentElementInstanceKey",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "parentProcessInstanceKey",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "processDefinitionVersionTag",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "tags",
             "type": "array<string>",
             "rawRefName": "TagSet"
+          },
+          {
+            "name": "businessId",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "rootProcessInstanceKey",
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -1770,6 +1907,11 @@
                   "underlyingPrimitive": "string",
                   "rawRefName": "TenantId",
                   "wrapper": true
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -1844,7 +1986,8 @@
                 },
                 {
                   "name": "processDefinitionName",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processDefinitionVersion",
@@ -1881,24 +2024,38 @@
               "optional": [
                 {
                   "name": "endDate",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "parentElementInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "parentProcessInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processDefinitionVersionTag",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "tags",
                   "type": "array<string>",
                   "rawRefName": "TagSet"
+                },
+                {
+                  "name": "businessId",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -1916,7 +2073,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -1924,7 +2082,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -1952,7 +2111,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -1960,7 +2120,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -2017,7 +2178,8 @@
                 },
                 {
                   "name": "jobKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processDefinitionId",
@@ -2044,6 +2206,11 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -2207,7 +2374,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -2215,7 +2383,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -2304,11 +2473,18 @@
               "optional": [
                 {
                   "name": "endDate",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "incidentKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -2399,11 +2575,18 @@
         "optional": [
           {
             "name": "endDate",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "incidentKey",
-            "type": "string"
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "rootProcessInstanceKey",
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -2427,7 +2610,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -2435,7 +2619,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -2474,6 +2659,14 @@
                 },
                 {
                   "name": "version",
+                  "type": "number"
+                },
+                {
+                  "name": "decisionRequirementsName",
+                  "type": "string"
+                },
+                {
+                  "name": "decisionRequirementsVersion",
                   "type": "number"
                 }
               ]
@@ -2516,6 +2709,14 @@
           {
             "name": "version",
             "type": "number"
+          },
+          {
+            "name": "decisionRequirementsName",
+            "type": "string"
+          },
+          {
+            "name": "decisionRequirementsVersion",
+            "type": "number"
           }
         ]
       }
@@ -2539,7 +2740,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -2547,7 +2749,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -2643,7 +2846,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -2651,7 +2855,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -2706,7 +2911,8 @@
                 },
                 {
                   "name": "elementInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "evaluationDate",
@@ -2714,15 +2920,18 @@
                 },
                 {
                   "name": "evaluationFailure",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processDefinitionKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "result",
@@ -2744,6 +2953,15 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "rootDecisionDefinitionKey",
+                  "type": "string"
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -2800,7 +3018,8 @@
           },
           {
             "name": "elementInstanceKey",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "evaluatedInputs",
@@ -2829,7 +3048,8 @@
           },
           {
             "name": "evaluationFailure",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "matchedRules",
@@ -2854,6 +3074,16 @@
                       {
                         "name": "outputValue",
                         "type": "string"
+                      },
+                      {
+                        "name": "ruleId",
+                        "type": "string",
+                        "nullable": true
+                      },
+                      {
+                        "name": "ruleIndex",
+                        "type": "number",
+                        "nullable": true
                       }
                     ]
                   }
@@ -2871,11 +3101,13 @@
           },
           {
             "name": "processDefinitionKey",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "processInstanceKey",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "result",
@@ -2897,6 +3129,15 @@
           {
             "name": "tenantId",
             "type": "string"
+          },
+          {
+            "name": "rootDecisionDefinitionKey",
+            "type": "string"
+          },
+          {
+            "name": "rootProcessInstanceKey",
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -3009,6 +3250,16 @@
                             {
                               "name": "outputValue",
                               "type": "string"
+                            },
+                            {
+                              "name": "ruleId",
+                              "type": "string",
+                              "nullable": true
+                            },
+                            {
+                              "name": "ruleIndex",
+                              "type": "number",
+                              "nullable": true
                             }
                           ]
                         }
@@ -3037,11 +3288,13 @@
           },
           {
             "name": "failedDecisionDefinitionId",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "failureMessage",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "output",
@@ -3110,11 +3363,17 @@
           },
           {
             "name": "resourceId",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "resourceType",
             "type": "string"
+          },
+          {
+            "name": "resourcePropertyName",
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -3138,7 +3397,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3146,7 +3406,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3188,11 +3449,17 @@
                 },
                 {
                   "name": "resourceId",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "resourceType",
                   "type": "string"
+                },
+                {
+                  "name": "resourcePropertyName",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3209,7 +3476,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
@@ -3231,7 +3499,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
@@ -3253,7 +3522,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
@@ -3285,7 +3555,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3293,7 +3564,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3338,7 +3610,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3346,7 +3619,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3388,7 +3662,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3396,7 +3671,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3411,7 +3687,8 @@
               "optional": [
                 {
                   "name": "description",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "name",
@@ -3446,7 +3723,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3454,7 +3732,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3496,7 +3775,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3504,7 +3784,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3548,7 +3829,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "groupId",
@@ -3570,7 +3852,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "groupId",
@@ -3592,7 +3875,8 @@
         "optional": [
           {
             "name": "description",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "groupId",
@@ -3624,7 +3908,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3632,7 +3917,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3677,7 +3963,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3685,7 +3972,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3739,7 +4027,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3747,7 +4036,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3762,7 +4052,8 @@
               "optional": [
                 {
                   "name": "description",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "name",
@@ -3797,7 +4088,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3805,7 +4097,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3847,7 +4140,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3855,7 +4149,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -3870,7 +4165,8 @@
               "optional": [
                 {
                   "name": "description",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "groupId",
@@ -3983,7 +4279,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -3991,7 +4288,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -4085,7 +4383,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -4093,7 +4392,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -4107,7 +4407,8 @@
               "required": [
                 {
                   "name": "correlationKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "correlationTime",
@@ -4149,11 +4450,17 @@
               "optional": [
                 {
                   "name": "elementInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processDefinitionKey",
                   "type": "string"
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -4180,7 +4487,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -4188,7 +4496,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -4203,7 +4512,8 @@
               "optional": [
                 {
                   "name": "correlationKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "elementId",
@@ -4211,7 +4521,8 @@
                 },
                 {
                   "name": "elementInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "lastUpdatedDate",
@@ -4244,11 +4555,13 @@
                 },
                 {
                   "name": "processDefinitionKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "tenantId",
@@ -4256,6 +4569,11 @@
                   "underlyingPrimitive": "string",
                   "rawRefName": "TenantId",
                   "wrapper": true
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -4279,7 +4597,8 @@
           },
           {
             "name": "contentHash",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "documentId",
@@ -4302,7 +4621,8 @@
                 },
                 {
                   "name": "expiresAt",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "fileName",
@@ -4310,11 +4630,13 @@
                 },
                 {
                   "name": "processDefinitionId",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "size",
@@ -4352,7 +4674,8 @@
                 },
                 {
                   "name": "contentHash",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "documentId",
@@ -4375,7 +4698,8 @@
                       },
                       {
                         "name": "expiresAt",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "fileName",
@@ -4383,11 +4707,13 @@
                       },
                       {
                         "name": "processDefinitionId",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "processInstanceKey",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "size",
@@ -4415,6 +4741,14 @@
                 },
                 {
                   "name": "fileName",
+                  "type": "string"
+                },
+                {
+                  "name": "status",
+                  "type": "number"
+                },
+                {
+                  "name": "title",
                   "type": "string"
                 }
               ]
@@ -4445,7 +4779,8 @@
                 },
                 {
                   "name": "contentHash",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "documentId",
@@ -4468,7 +4803,8 @@
                       },
                       {
                         "name": "expiresAt",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "fileName",
@@ -4476,11 +4812,13 @@
                       },
                       {
                         "name": "processDefinitionId",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "processInstanceKey",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                       },
                       {
                         "name": "size",
@@ -4508,6 +4846,14 @@
                 },
                 {
                   "name": "fileName",
+                  "type": "string"
+                },
+                {
+                  "name": "status",
+                  "type": "number"
+                },
+                {
+                  "name": "title",
                   "type": "string"
                 }
               ]
@@ -4543,11 +4889,13 @@
         "optional": [
           {
             "name": "email",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "username",
@@ -4573,11 +4921,13 @@
               "optional": [
                 {
                   "name": "email",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "name",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "username",
@@ -4602,7 +4952,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -4610,7 +4961,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -4628,11 +4980,13 @@
         "optional": [
           {
             "name": "email",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "username",
@@ -4653,11 +5007,13 @@
         "optional": [
           {
             "name": "email",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "username",
@@ -4678,11 +5034,13 @@
         "optional": [
           {
             "name": "email",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "username",
@@ -4713,7 +5071,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -4721,7 +5080,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -4778,7 +5138,8 @@
                 },
                 {
                   "name": "jobKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processDefinitionId",
@@ -4805,6 +5166,11 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -4863,7 +5229,8 @@
           },
           {
             "name": "jobKey",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "processDefinitionId",
@@ -4890,6 +5257,11 @@
           {
             "name": "tenantId",
             "type": "string"
+          },
+          {
+            "name": "rootProcessInstanceKey",
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -4976,7 +5348,8 @@
                         "type": "number"
                       }
                     ]
-                  }
+                  },
+                  "nullable": true
                 },
                 {
                   "name": "decisionRequirements",
@@ -5010,7 +5383,8 @@
                         "type": "number"
                       }
                     ]
-                  }
+                  },
+                  "nullable": true
                 },
                 {
                   "name": "form",
@@ -5043,7 +5417,8 @@
                         "type": "number"
                       }
                     ]
-                  }
+                  },
+                  "nullable": true
                 },
                 {
                   "name": "processDefinition",
@@ -5073,7 +5448,8 @@
                       }
                     ],
                     "optional": []
-                  }
+                  },
+                  "nullable": true
                 },
                 {
                   "name": "resource",
@@ -5106,7 +5482,8 @@
                         "type": "number"
                       }
                     ]
-                  }
+                  },
+                  "nullable": true
                 }
               ]
             }
@@ -5148,7 +5525,8 @@
           },
           {
             "name": "versionTag",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -5211,7 +5589,8 @@
           },
           {
             "name": "endDate",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "errors",
@@ -5252,7 +5631,8 @@
           },
           {
             "name": "startDate",
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "state",
@@ -5266,6 +5646,16 @@
               "PARTIALLY_COMPLETED",
               "SUSPENDED"
             ]
+          },
+          {
+            "name": "actorId",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "actorType",
+            "type": "string",
+            "nullable": true
           }
         ]
       }
@@ -5289,7 +5679,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -5297,7 +5688,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -5334,7 +5726,8 @@
                 },
                 {
                   "name": "endDate",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "errors",
@@ -5375,7 +5768,8 @@
                 },
                 {
                   "name": "startDate",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "state",
@@ -5389,6 +5783,16 @@
                     "PARTIALLY_COMPLETED",
                     "SUSPENDED"
                   ]
+                },
+                {
+                  "name": "actorId",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "actorType",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -5415,7 +5819,8 @@
               "optional": [
                 {
                   "name": "endCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "hasMoreTotalItems",
@@ -5423,7 +5828,8 @@
                 },
                 {
                   "name": "startCursor",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }
@@ -5442,7 +5848,8 @@
                 },
                 {
                   "name": "errorMessage",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "itemKey",
@@ -5468,7 +5875,8 @@
                 },
                 {
                   "name": "processedDate",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "processInstanceKey",
@@ -5484,6 +5892,11 @@
                     "CANCELED",
                     "FAILED"
                   ]
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
                 }
               ]
             }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -168,6 +168,45 @@ export async function assertInvalidArgument(
   expect(json.detail).toContain(detail);
 }
 
+// ---------------------------------------------------------------------------
+// Forward-compatibility: when AJB_ALLOW_EXTRA_FIELDS=true, tolerate
+//   1. extra keys in actual nested objects (newer server added fields)
+//   2. null ≈ '' for scalar values (newer server returns null instead of '')
+// ---------------------------------------------------------------------------
+const _forwardCompat = process.env.AJB_ALLOW_EXTRA_FIELDS === 'true';
+
+/**
+ * Recursively strips keys from `actual` that are not present in `expected`.
+ * This ensures that `JSON.stringify` comparisons are not broken by new fields
+ * added in a newer server version.
+ */
+function _stripExtraKeys(actual: unknown, expected: unknown): unknown {
+  if (
+    actual === null ||
+    expected === null ||
+    typeof actual !== 'object' ||
+    typeof expected !== 'object'
+  ) {
+    return actual;
+  }
+
+  if (Array.isArray(actual) && Array.isArray(expected)) {
+    return actual.map((item, i) =>
+      i < expected.length ? _stripExtraKeys(item, expected[i]) : item,
+    );
+  }
+
+  const rec = actual as Record<string, unknown>;
+  const exp = expected as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(exp)) {
+    if (Object.prototype.hasOwnProperty.call(rec, key)) {
+      result[key] = _stripExtraKeys(rec[key], exp[key]);
+    }
+  }
+  return result;
+}
+
 export function assertEqualsForKeys(
   obj: unknown,
   expected: Record<string, unknown>,
@@ -195,7 +234,7 @@ export function assertEqualsForKeys(
       throw new Error(`Missing key '${k}' in expected values`);
     }
 
-    const actual = rec[k];
+    let actual = rec[k];
     const exp = expected[k];
 
     const bothObjects =
@@ -204,9 +243,24 @@ export function assertEqualsForKeys(
       exp !== null &&
       typeof exp === 'object';
 
-    const equal = bothObjects
-      ? fmt(actual) === fmt(exp)
-      : Object.is(actual, exp);
+    let equal: boolean;
+    if (bothObjects) {
+      // In forward-compat mode, strip extra keys from actual before comparison
+      // so that new fields added by a newer server don't break JSON.stringify.
+      const comparable = _forwardCompat
+        ? _stripExtraKeys(actual, exp)
+        : actual;
+      equal = fmt(comparable) === fmt(exp);
+    } else if (_forwardCompat) {
+      // In forward-compat mode, treat null ≈ '' (newer server may return null
+      // where the older version returned an empty string, or vice-versa).
+      equal =
+        Object.is(actual, exp) ||
+        (actual === null && exp === '') ||
+        (actual === '' && exp === null);
+    } else {
+      equal = Object.is(actual, exp);
+    }
 
     if (!equal) {
       throw new Error(


### PR DESCRIPTION
## Description

The [C8 REST API Forward Compatibility Tests](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml) nightly workflow (Server: `stable/8.9` / Tests: `stable/8.8`) is failing because the 8.9 server introduces API response changes that the 8.8 test suite doesn't tolerate.

### Root causes

1. **`[TYPE]` errors** — The 8.9 server returns `null` for fields like `failedDecisionDefinitionId` and `failureMessage` where 8.8 returns `""`. The schema in `responses.json` didn't mark these as nullable.
2. **`[EXTRA]` errors** — The 8.9 server returns ~48 new fields (e.g. `rootProcessInstanceKey`, `businessId`, `tags`, `clusterId`, `ruleId`, `ruleIndex`, etc.) not declared in the 8.8 schema. While the `AJB_ALLOW_EXTRA_FIELDS=true` env var suppresses these in `validateResponse`, the `assertEqualsForKeys` helper does strict `JSON.stringify` comparison on nested objects, which still fails on extra keys.
3. **Scalar null vs `''` mismatches** — `assertEqualsForKeys` uses `Object.is()` for scalar comparison, so `Object.is("", null)` → `false`.

### Changes

#### `responses.json` (schema — backward-compatible)
- Add `"nullable": true` to ~215 string fields that 8.9 may return as `null`
- Add ~48 new optional fields introduced by the 8.9 API

These changes only make schema validation **more permissive** — same-version 8.8 runs are unaffected.

#### `http.ts` (`assertEqualsForKeys` — gated behind env var)
- Add forward-compat mode activated only when `AJB_ALLOW_EXTRA_FIELDS=true`
- **Nested objects**: strip extra keys from the actual response before `JSON.stringify` comparison, so new fields from a newer server don't break equality
- **Scalars**: treat `null ≈ ''` as equivalent, so nullability changes don't cause false failures
- **Default behavior (env var unset)**: identical to before — strict `Object.is` for scalars, exact `JSON.stringify` for objects

### Workflows affected

| Workflow | Impact |
|---|---|
| `c8-orchestration-cluster-forward-compatibility-tests.yml` | ✅ **Fixed** — sets `AJB_ALLOW_EXTRA_FIELDS=true` |
| `c8-orchestration-cluster-e2e-tests-nightly.yml` (api-tests) | ✅ **Not affected** — env var not set, strict mode preserved |

### Related

- Failed run: https://github.com/camunda/camunda/actions/runs/23471042254/job/68293617065