### PR TITLE
ci: disable qa team notification on failures

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -231,8 +231,7 @@ jobs:
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
-          INCLUDE_SLACK_REPORTER: "true"
-          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          INCLUDE_SLACK_REPORTER: "false"
           VERSION: "Forward Compat - Server: ${{ matrix.server_branch }} / Tests: ${{ matrix.test_branch }}"
           API_TESTS_ONLY: "true"
           DATABASE: "Elasticsearch"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

disable qa team notification on failures for forward compatibility tests
