### PR TITLE
[Backport stable/8.8] test: relax assertion on processed positions

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/system/BrokerAdminServiceWithOutExporterTest.java
@@ -35,9 +35,9 @@ public class BrokerAdminServiceWithOutExporterTest {
     // then
     final var partitionStatus = leaderAdminService.getPartitionStatus().get(1);
     assertThat(partitionStatus.role()).isEqualTo(Role.LEADER);
-    assertThat(partitionStatus.processedPosition()).isPositive();
+    assertThat(partitionStatus.processedPosition()).isNotNegative();
     assertThat(partitionStatus.snapshotId()).isNotNull();
-    assertThat(partitionStatus.processedPositionInSnapshot()).isPositive();
+    assertThat(partitionStatus.processedPositionInSnapshot()).isNotNegative();
     assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);
     assertThat(partitionStatus.exporterPhase()).isEqualTo(ExporterPhase.EXPORTING);
     assertThat(partitionStatus.exportedPosition()).isEqualTo(-1);


### PR DESCRIPTION
# Description
Backport of #49363 to `stable/8.8`.

relates to 