### PR TITLE
fix: re-enable process instance audit log tests after UI updates

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -173,7 +173,7 @@ class OperateProcessInstancePage {
     this.variablesTabButton = page
       .getByLabel('Process Instance Bottom Panel Tabs')
       .getByRole('link', {name: /^Variables$/i});
-    this.operationsLogTabButton = page.getByRole('tab', {
+    this.operationsLogTabButton = page.getByRole('link', {
       name: /^Operations Log$/i,
     });
     this.operationsLogTable = page

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceAuditLog.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceAuditLog.spec.ts
@@ -35,7 +35,7 @@ test.beforeAll(async ({request}) => {
   await waitForProcessInstances(request, [instance.processInstanceKey], 1);
 });
 
-test.describe.skip('Process Instance Audit Log', () => {
+test.describe('Process Instance Audit Log', () => {
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Fix Operations Log tab locator from role='tab' to role='link' in OperateProcessInstancePage
- Re-enable processInstanceAuditLog test suite by removing .skip
- Updates locators to match new UI structure after recent changes


[Test run](https://github.com/camunda/camunda/actions/runs/23481988190)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Closes #49229

