### PR TITLE
fix: fix Stackdriver not being able to output JSON for Optimize

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>log4j-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-layout-template-json</artifactId>
+    </dependency>
+
     <!-- this is necessary. Dependency:analyze error suppressed -->
     <dependency>
       <groupId>org.codehaus.janino</groupId>
@@ -686,6 +691,17 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core-test</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/optimize/backend/src/main/java/io/camunda/optimize/logging/OptimizeStackdriverResolver.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/logging/OptimizeStackdriverResolver.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.layout.template.json.resolver.EventResolver;
+import org.apache.logging.log4j.layout.template.json.resolver.TemplateResolverConfig;
+import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
+
+/** Custom resolver that emits Stackdriver-specific fields used by the JSON template layout. */
+public final class OptimizeStackdriverResolver implements EventResolver {
+
+  private static final String ERROR_TYPE =
+      "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent";
+
+  private static final EventResolver TYPE_RESOLVER =
+      new EventResolver() {
+        @Override
+        public boolean isResolvable(final LogEvent value) {
+          return value.getLevel().isMoreSpecificThan(Level.ERROR);
+        }
+
+        @Override
+        public void resolve(final LogEvent value, final JsonWriter jsonWriter) {
+          jsonWriter.writeString(ERROR_TYPE);
+        }
+      };
+
+  private static final EventResolver REPORT_LOCATION_RESOLVER =
+      new EventResolver() {
+        @Override
+        public boolean isResolvable(final LogEvent value) {
+          return value.getLevel().isMoreSpecificThan(Level.ERROR)
+              && value.getSource() != null
+              && value.getThrownProxy() == null;
+        }
+
+        @Override
+        public void resolve(final LogEvent value, final JsonWriter jsonWriter) {
+          final var stackTrace = value.getSource();
+          jsonWriter.writeObjectStart();
+          jsonWriter.writeObjectKey("filePath");
+          jsonWriter.writeString(stackTrace.getFileName());
+          jsonWriter.writeSeparator();
+          jsonWriter.writeObjectKey("functionName");
+          jsonWriter.writeString(stackTrace.getMethodName());
+          jsonWriter.writeSeparator();
+          jsonWriter.writeObjectKey("lineNumber");
+          jsonWriter.writeNumber(stackTrace.getLineNumber());
+          jsonWriter.writeObjectEnd();
+        }
+      };
+
+  private final EventResolver internalResolver;
+
+  public OptimizeStackdriverResolver(final TemplateResolverConfig config) {
+    internalResolver = createInternalResolver(config);
+  }
+
+  private static EventResolver createInternalResolver(final TemplateResolverConfig config) {
+    final String fieldName = config.getString("field");
+    return switch (fieldName) {
+      case "type" -> TYPE_RESOLVER;
+      case "reportLocation" -> REPORT_LOCATION_RESOLVER;
+      default -> throw new IllegalArgumentException("unknown field: " + config);
+    };
+  }
+
+  @Override
+  public boolean isResolvable(final LogEvent value) {
+    return internalResolver.isResolvable(value);
+  }
+
+  @Override
+  public void resolve(final LogEvent logEvent, final JsonWriter jsonWriter) {
+    internalResolver.resolve(logEvent, jsonWriter);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/logging/OptimizeStackdriverResolverFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/logging/OptimizeStackdriverResolverFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.logging;
+
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.layout.template.json.resolver.EventResolverContext;
+import org.apache.logging.log4j.layout.template.json.resolver.EventResolverFactory;
+import org.apache.logging.log4j.layout.template.json.resolver.TemplateResolverConfig;
+import org.apache.logging.log4j.layout.template.json.resolver.TemplateResolverFactory;
+
+@Plugin(name = "OptimizeResolverFactory", category = TemplateResolverFactory.CATEGORY)
+public final class OptimizeStackdriverResolverFactory implements EventResolverFactory {
+
+  private static final OptimizeStackdriverResolverFactory INSTANCE =
+      new OptimizeStackdriverResolverFactory();
+
+  private OptimizeStackdriverResolverFactory() {}
+
+  @PluginFactory
+  public static OptimizeStackdriverResolverFactory getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String getName() {
+    return "optimizeStackdriver";
+  }
+
+  @Override
+  public OptimizeStackdriverResolver create(
+      final EventResolverContext context, final TemplateResolverConfig config) {
+    return new OptimizeStackdriverResolver(config);
+  }
+}

--- a/optimize/backend/src/main/resources/log4j2.xml
+++ b/optimize/backend/src/main/resources/log4j2.xml
@@ -1,25 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" monitorInterval="30">
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-config-2.xsd"
+  status="WARN" monitorInterval="30">
   <Properties>
-    <Property name="LOG_PATTERN">%clr{%d{yyyy-MM-dd HH:mm:ss.SSS}}{faint} %clr{%5p} %clr{${sys:PID}}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n%xwEx</Property>
-    <Property name="log.stackdriver.serviceName">${env:OPTIMIZE_LOG_STACKDRIVER_SERVICENAME:-optimize}</Property>
-    <Property name="log.stackdriver.serviceVersion">${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-}</Property>
+    <Property name="LOG_PATTERN" value="%clr{%d{yyyy-MM-dd HH:mm:ss.SSS}}{faint} %clr{%5p} %clr{${sys:PID}}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n%xwEx" />
+    <Property name="log.stackdriver.serviceName" value="${env:OPTIMIZE_LOG_STACKDRIVER_SERVICENAME:-optimize}" />
+    <Property name="log.stackdriver.serviceVersion" value="${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-}" />
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">
       <PatternLayout pattern="${LOG_PATTERN}"/>
     </Console>
     <Console name="Stackdriver" target="SYSTEM_OUT" follow="true">
-      <StackdriverLayout serviceName="${log.stackdriver.serviceName}"
-        serviceVersion="${log.stackdriver.serviceVersion}" />
+      <JsonTemplateLayout charset="UTF-8"
+        eventTemplateUri="classpath:logging/OptimizeStackdriverLayout.json"
+        locationInfoEnabled="true"
+        stackTraceEnabled="true"/>
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-info}" />
-    <Logger name="io.camunda.optimize.upgrade" level="${env:UPGRADE_LOG_LEVEL:-info}" />
-    <Logger name="org.elasticsearch" level="${env:ES_LOG_LEVEL:-warn}" />
+    <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-INFO}" />
+    <Logger name="io.camunda.optimize.upgrade" level="${env:UPGRADE_LOG_LEVEL:-INFO}" />
+    <Logger name="org.elasticsearch" level="${env:ES_LOG_LEVEL:-WARN}" />
 
-    <Root level="info">
+    <Root level="INFO">
       <AppenderRef ref="${env:OPTIMIZE_LOG_APPENDER:-Console}"/>
     </Root>
   </Loggers>

--- a/optimize/backend/src/main/resources/logging/OptimizeStackdriverLayout.json
+++ b/optimize/backend/src/main/resources/logging/OptimizeStackdriverLayout.json
@@ -59,8 +59,8 @@
     "field": "name"
   },
   "serviceContext": {
-    "service": "${log4j:configProperties:log.stackdriver.serviceName}",
-    "version": "${log4j:configProperties:log.stackdriver.serviceVersion}"
+    "service": "${log4j:configProperties:log.stackdriver.serviceName:-}",
+    "version": "${log4j:configProperties:log.stackdriver.serviceVersion:-}"
   },
   "@type": {
     "$resolver": "optimizeStackdriver",

--- a/optimize/backend/src/main/resources/logging/OptimizeStackdriverLayout.json
+++ b/optimize/backend/src/main/resources/logging/OptimizeStackdriverLayout.json
@@ -1,0 +1,80 @@
+{
+  "timestampSeconds": {
+    "$resolver": "timestamp",
+    "epoch": {
+      "unit": "secs",
+      "rounded": true
+    }
+  },
+  "timestampNanos": {
+    "$resolver": "timestamp",
+    "epoch": {
+      "unit": "secs.nanos"
+    }
+  },
+  "severity": {
+    "$resolver": "pattern",
+    "pattern": "%level{OFF=DEFAULT, ALL=DEFAULT, TRACE=DEBUG, DEBUG=DEBUG, INFO=INFO, WARN=WARNING, ERROR=ERROR, FATAL=CRITICAL}",
+    "stackTraceEnabled": false
+  },
+  "message": {
+    "$resolver": "pattern",
+    "pattern": "%m",
+    "stackTraceEnabled": false
+  },
+  "logging.googleapis.com/sourceLocation": {
+    "file": {
+      "$resolver": "source",
+      "field": "fileName"
+    },
+    "line": {
+      "$resolver": "source",
+      "field": "lineNumber"
+    },
+    "function": {
+      "$resolver": "pattern",
+      "pattern": "%replace{%C.%M}{^\\?\\.$}{}",
+      "stackTraceEnabled": false
+    }
+  },
+  "logging.googleapis.com/labels": {
+    "$resolver": "mdc"
+  },
+  "threadContext": {
+    "id": {
+      "$resolver": "thread",
+      "field": "id"
+    },
+    "name": {
+      "$resolver": "thread",
+      "field": "name"
+    },
+    "priority": {
+      "$resolver": "thread",
+      "field": "priority"
+    }
+  },
+  "loggerName": {
+    "$resolver": "logger",
+    "field": "name"
+  },
+  "serviceContext": {
+    "service": "${log4j:configProperties:log.stackdriver.serviceName}",
+    "version": "${log4j:configProperties:log.stackdriver.serviceVersion}"
+  },
+  "@type": {
+    "$resolver": "optimizeStackdriver",
+    "field": "type"
+  },
+  "exception": {
+    "$resolver": "exception",
+    "field": "stackTrace",
+    "stackTrace": {
+      "stringified": true
+    }
+  },
+  "reportLocation": {
+    "$resolver": "optimizeStackdriver",
+    "field": "reportLocation"
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/logging/OptimizeStackdriverLayoutTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/logging/OptimizeStackdriverLayoutTest.java
@@ -166,7 +166,7 @@ final class OptimizeStackdriverLayoutTest {
         "logging.googleapis.com/sourceLocation":{"file":"Foo.java","line":1,\
         "function":"Foo.Bar"},%s\
         "threadContext":{"id":%d,"name":"%s","priority":%d},\
-        "loggerName":"io.camunda.optimize.logging.StackdriverLayoutTest",\
+        "loggerName":"io.camunda.optimize.logging.OptimizeStackdriverLayoutTest",\
         "serviceContext":{"service":"","version":""}}""",
             message.getInstant().getEpochSecond(),
             message.getInstant().getNanoOfSecond(),
@@ -189,7 +189,7 @@ final class OptimizeStackdriverLayoutTest {
         "logging.googleapis.com/sourceLocation":{"file":"Foo.java","line":1,\
         "function":"Foo.Bar"},\
         "threadContext":{"id":%d,"name":"%s","priority":%d},\
-        "loggerName":"io.camunda.optimize.logging.StackdriverLayoutTest",\
+        "loggerName":"io.camunda.optimize.logging.OptimizeStackdriverLayoutTest",\
         "serviceContext":{"service":"","version":""},\
         "@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",\
         "reportLocation":{"filePath":"Foo.java","functionName":"Bar","lineNumber":1}}""",
@@ -211,14 +211,14 @@ final class OptimizeStackdriverLayoutTest {
             Pattern.quote(
                     // language=json
                     """
-        {"timestampSeconds":%d,"timestampNanos":%d,"severity":"ERROR","message":"Hello World!",\
-        "logging.googleapis.com/sourceLocation":{"file":"Foo.java","line":1,\
-        "function":"Foo.Bar"},\
-        "threadContext":{"id":%d,"name":"%s","priority":%d},\
-        "loggerName":"io.camunda.optimize.logging.StackdriverLayoutTest",\
-        "serviceContext":{"service":"","version":""},\
-        "@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",\
-        "exception":"""
+    {"timestampSeconds":%d,"timestampNanos":%d,"severity":"ERROR","message":"Hello World!",\
+    "logging.googleapis.com/sourceLocation":{"file":"Foo.java","line":1,\
+    "function":"Foo.Bar"},\
+    "threadContext":{"id":%d,"name":"%s","priority":%d},\
+    "loggerName":"io.camunda.optimize.logging.OptimizeStackdriverLayoutTest",\
+    "serviceContext":{"service":"","version":""},\
+    "@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",\
+    "exception":"""
                         .formatted(
                             message.getInstant().getEpochSecond(),
                             message.getInstant().getNanoOfSecond(),

--- a/optimize/backend/src/test/java/io/camunda/optimize/logging/OptimizeStackdriverLayoutTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/logging/OptimizeStackdriverLayoutTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.test.appender.EncodingListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.MDC;
+
+@SuppressWarnings("LoggingSimilarMessage")
+final class OptimizeStackdriverLayoutTest {
+
+  private static final StackTraceElement DUMMY_LOCATION =
+      new StackTraceElement("Foo", "Bar", "Foo.java", 1);
+  private static final String LOG_MESSAGE = "Hello World!";
+
+  private Logger logger;
+  private ListAppender appender;
+  private ListAppender encodingAppender;
+
+  @BeforeEach
+  void beforeEach() {
+    logger = (Logger) LogManager.getLogger();
+
+    final var configuration = logger.getContext().getConfiguration();
+    final var layout =
+        JsonTemplateLayout.newBuilder()
+            .setConfiguration(configuration)
+            .setEventTemplateUri("classpath:logging/OptimizeStackdriverLayout.json")
+            .setLocationInfoEnabled(true)
+            .setStackTraceEnabled(true)
+            .build();
+
+    appender = new ListAppender("event", null, null, true, false);
+    appender.start();
+    logger.addAppender(appender);
+
+    encodingAppender = new EncodingListAppender("json", null, layout, true, false);
+    encodingAppender.start();
+    logger.addAppender(encodingAppender);
+
+    logger.setLevel(Level.TRACE);
+  }
+
+  @AfterEach
+  void afterEach() {
+    if (encodingAppender != null) {
+      encodingAppender.stop();
+      if (logger != null) {
+        logger.removeAppender(encodingAppender);
+      }
+    }
+
+    if (appender != null) {
+      appender.stop();
+      if (logger != null) {
+        logger.removeAppender(appender);
+      }
+    }
+  }
+
+  @Test
+  void shouldLogReportLocationOnErrorWithoutException() {
+    // given
+
+    // when
+    logger.atError().withLocation(DUMMY_LOCATION).log(LOG_MESSAGE);
+
+    // then
+    assertMessageMatchesWithReportLocation();
+  }
+
+  @Test
+  void shouldLogException() {
+    // given
+    final var exception = new RuntimeException("Test Exception");
+
+    // when
+    logger.atError().withLocation(DUMMY_LOCATION).withThrowable(exception).log(LOG_MESSAGE);
+
+    // then
+    assertMessageMatchesWithException(exception);
+  }
+
+  @ParameterizedTest
+  @MethodSource("severityProvider")
+  void shouldMapSeverity(final String expectedSeverity, final Level actualLevel) {
+    // given
+
+    // when
+    logger.atLevel(actualLevel).withLocation(DUMMY_LOCATION).log(LOG_MESSAGE);
+
+    // then
+    assertMessageMatches(expectedSeverity);
+  }
+
+  @SuppressWarnings("unused")
+  @Test
+  void shouldLogContextMap() {
+    // given
+
+    // when
+    try (final var bar = MDC.putCloseable("foo", "bar");
+        final var baz = MDC.putCloseable("baz", "qux")) {
+      logger.atDebug().withLocation(DUMMY_LOCATION).log(LOG_MESSAGE);
+    }
+
+    // then - note that Log4j2 will print out the context map with keys alphabetically sorted
+    assertMessageMatchesWithContext(
+        "DEBUG",
+        """
+        "logging.googleapis.com/labels":{"baz":"qux","foo":"bar"}""");
+  }
+
+  @Test
+  void shouldLog() {
+    // given
+
+    // when
+    logger.atDebug().withLocation(DUMMY_LOCATION).log(LOG_MESSAGE);
+
+    // then
+    assertMessageMatches("DEBUG");
+  }
+
+  private static Stream<Arguments> severityProvider() {
+    return Stream.of(
+        Arguments.of("DEBUG", Level.TRACE),
+        Arguments.of("DEBUG", Level.DEBUG),
+        Arguments.of("INFO", Level.INFO),
+        Arguments.of("WARNING", Level.WARN));
+  }
+
+  private void assertMessageMatches(final String expectedSeverity) {
+    assertMessageMatchesWithContext(expectedSeverity, null);
+  }
+
+  private void assertMessageMatchesWithContext(
+      final String expectedSeverity, final String expectedContext) {
+    final var message = appender.getEvents().getFirst();
+    final var jsonMessage = encodingAppender.getMessages().getFirst();
+
+    assertThat(jsonMessage)
+        .isEqualTo(
+            // language=json
+            """
+        {"timestampSeconds":%d,"timestampNanos":%d,"severity":"%s","message":"Hello World!",\
+        "logging.googleapis.com/sourceLocation":{"file":"Foo.java","line":1,\
+        "function":"Foo.Bar"},%s\
+        "threadContext":{"id":%d,"name":"%s","priority":%d},\
+        "loggerName":"io.camunda.optimize.logging.StackdriverLayoutTest",\
+        "serviceContext":{"service":"","version":""}}""",
+            message.getInstant().getEpochSecond(),
+            message.getInstant().getNanoOfSecond(),
+            expectedSeverity,
+            expectedContext == null ? "" : expectedContext + ",",
+            message.getThreadId(),
+            message.getThreadName(),
+            message.getThreadPriority());
+  }
+
+  private void assertMessageMatchesWithReportLocation() {
+    final var message = appender.getEvents().getFirst();
+    final var jsonMessage = encodingAppender.getMessages().getFirst();
+
+    assertThat(jsonMessage)
+        .isEqualTo(
+            // language=json
+            """
+        {"timestampSeconds":%d,"timestampNanos":%d,"severity":"ERROR","message":"Hello World!",\
+        "logging.googleapis.com/sourceLocation":{"file":"Foo.java","line":1,\
+        "function":"Foo.Bar"},\
+        "threadContext":{"id":%d,"name":"%s","priority":%d},\
+        "loggerName":"io.camunda.optimize.logging.StackdriverLayoutTest",\
+        "serviceContext":{"service":"","version":""},\
+        "@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",\
+        "reportLocation":{"filePath":"Foo.java","functionName":"Bar","lineNumber":1}}""",
+            message.getInstant().getEpochSecond(),
+            message.getInstant().getNanoOfSecond(),
+            message.getThreadId(),
+            message.getThreadName(),
+            message.getThreadPriority());
+  }
+
+  private void assertMessageMatchesWithException(final RuntimeException exception) {
+    final var message = appender.getEvents().getFirst();
+    final var jsonMessage = encodingAppender.getMessages().getFirst();
+
+    // it's hard to generate the actual stack trace in the same format without breaking
+    // abstractions, so we just check that the exception message is present in the JSON
+    assertThat(jsonMessage)
+        .matches(
+            Pattern.quote(
+                    // language=json
+                    """
+        {"timestampSeconds":%d,"timestampNanos":%d,"severity":"ERROR","message":"Hello World!",\
+        "logging.googleapis.com/sourceLocation":{"file":"Foo.java","line":1,\
+        "function":"Foo.Bar"},\
+        "threadContext":{"id":%d,"name":"%s","priority":%d},\
+        "loggerName":"io.camunda.optimize.logging.StackdriverLayoutTest",\
+        "serviceContext":{"service":"","version":""},\
+        "@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",\
+        "exception":"""
+                        .formatted(
+                            message.getInstant().getEpochSecond(),
+                            message.getInstant().getNanoOfSecond(),
+                            message.getThreadId(),
+                            message.getThreadName(),
+                            message.getThreadPriority()))
+                + ".+\"}")
+        .contains(exception.getMessage());
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes the configuration for `log4j2` where Optimize could not output JSON given the configuration as described in https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/. There will need to be a follow-up task to clean up the `JSON_LOGGING` environment variable as that variable no longer exists.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45223
