### PR TITLE
[Backport stable/8.6] ci: add missing checkout step in calculate-scenario-config

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -195,6 +195,9 @@ jobs:
     outputs:
       load-test-load: ${{ steps.config.outputs.load-test-load }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
       - name: Calculate configuration based on scenario
         id: config
         run: |


### PR DESCRIPTION
# Description
Backport of #49276 to `stable/8.6`.

relates to 