### PR TITLE
[Backport stable/8.8] ci: add missing checkout step in calculate-scenario-config

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -242,6 +242,9 @@ jobs:
       load-test-load: ${{ steps.config.outputs.load-test-load }}
       platform-additional-config: ${{ steps.config.outputs.platform-additional-config }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
       - name: Calculate configuration based on scenario
         id: config
         run: |


### PR DESCRIPTION
# Description
Backport of #49276 to `stable/8.8`.

relates to 