### PR TITLE
test: start pi after snapshot

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -203,6 +203,9 @@ public interface BackupCompatibilityAcceptance {
         .atMost(Duration.ofSeconds(60))
         .until(() -> partitionsActuator.query().get(1).snapshotId(), Objects::nonNull);
 
+    // Initiate additional processing to progress logstream so that backup doesn't fail
+    createProcessInstanceWithJob(broker);
+
     // Use the 8.8 actuator path (/actuator/backups) rather than the current
     // /actuator/backupRuntime
     final var backupActuator =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Create an additional PI after taking the snapshot to avoid the previous version error:

```
Cannot find a snapshot that can be included in the backup %d. All available snapshots (%s) 
have processedPosition or lastFollowupEventPosition > checkpointPosition %d
```

when everything is consumed from the first snapshot. 

P.S: The backwards compat version for main is still 8.8.0, since we don't have a stable 8.9 image, this issue is possibly resolved on 8.9 as the implementation is changed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
