### PR TITLE
[Backport stable/8.9] fix: re-enable process instance audit log tests after UI updates

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -162,7 +162,7 @@ class OperateProcessInstancePage {
     this.listenersTabButton = page
       .getByLabel('Process Instance Bottom Panel Tabs')
       .getByRole('link', {name: /^Listeners$/i});
-    this.operationsLogTabButton = page.getByRole('tab', {
+    this.operationsLogTabButton = page.getByRole('link', {
       name: /^Operations Log$/i,
     });
     this.operationsLogTable = page

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceAuditLog.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceAuditLog.spec.ts
@@ -35,7 +35,7 @@ test.beforeAll(async ({request}) => {
   await waitForProcessInstances(request, [instance.processInstanceKey], 1);
 });
 
-test.describe.skip('Process Instance Audit Log', () => {
+test.describe('Process Instance Audit Log', () => {
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');


### PR DESCRIPTION
# Description
Backport of #49373 to `stable/8.9`.

[Test run](https://github.com/camunda/camunda/actions/runs/23484542956)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later

relates to #49229