### PR TITLE
[Backport stable/8.8] 48200 archive bulk get batches

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -314,6 +314,7 @@ public final class BackgroundTaskManagerFactory {
 
     return buildReschedulingArchiverTask(
         new ProcessInstanceArchiverJob(
+            config.getHistory(),
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
             dependantTemplates,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -21,8 +21,8 @@ import io.camunda.exporter.tasks.archiver.ArchiverRepository;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
 import io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
+import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
-import io.camunda.exporter.tasks.archiver.ProcessInstancesArchiverJob;
 import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricsArchiverJob;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
@@ -313,7 +313,7 @@ public final class BackgroundTaskManagerFactory {
         .forEach(dependantTemplates::add);
 
     return buildReschedulingArchiverTask(
-        new ProcessInstancesArchiverJob(
+        new ProcessInstanceArchiverJob(
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
             dependantTemplates,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -12,6 +12,10 @@ import java.util.List;
 
 public record ArchiveBatch(String finishDate, List<String> ids) {
   public List<ArchiveBatch> chunk(final int chunkSize) {
+    if (ids.isEmpty()) {
+      return List.of(this);
+    }
+
     final var chunks = new ArrayList<ArchiveBatch>();
 
     List<String> currentIds = new ArrayList<>();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -12,11 +12,11 @@ import java.util.List;
 
 public record ArchiveBatch(String finishDate, List<String> ids) {
   public List<ArchiveBatch> chunk(final int chunkSize) {
-    if (ids.isEmpty()) {
-      return List.of(this);
-    }
-
     final var chunks = new ArrayList<ArchiveBatch>();
+    if (ids.isEmpty()) {
+      chunks.add(this);
+      return chunks;
+    }
 
     List<String> currentIds = new ArrayList<>();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -7,6 +7,27 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public record ArchiveBatch(String finishDate, List<String> ids) {}
+public record ArchiveBatch(String finishDate, List<String> ids) {
+  public List<ArchiveBatch> chunk(final int chunkSize) {
+    final var chunks = new ArrayList<ArchiveBatch>();
+
+    List<String> currentIds = new ArrayList<>();
+
+    for (final var id : ids()) {
+      if (currentIds.size() >= chunkSize) {
+        chunks.add(new ArchiveBatch(finishDate, currentIds));
+        currentIds = new ArrayList<>();
+      }
+      currentIds.add(id);
+    }
+
+    if (!currentIds.isEmpty()) {
+      chunks.add(new ArchiveBatch(finishDate, currentIds));
+    }
+
+    return chunks;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -27,7 +27,7 @@ public interface ArchiverRepository extends AutoCloseable {
           UsageMetricTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName,
           UsageMetricTUTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName);
 
-  CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch();
+  CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(final int size);
 
   CompletableFuture<ArchiveBatch> getBatchOperationsNextBatch();
 
@@ -83,7 +83,7 @@ public interface ArchiverRepository extends AutoCloseable {
   class NoopArchiverRepository implements ArchiverRepository {
 
     @Override
-    public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+    public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(final int size) {
       return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -132,7 +132,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(final int size) {
     return withArchivingStatus()
         .thenComposeAsync(
             status -> {
@@ -140,7 +140,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                 logger.debug("Archiving is currently blocked.");
                 return CompletableFuture.completedFuture(new ArchiveBatch(null, List.of()));
               }
-              final var searchRequest = createFinishedInstancesSearchRequest();
+              final var searchRequest = createFinishedInstancesSearchRequest(size);
 
               final var timer = Timer.start();
               return client
@@ -384,10 +384,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenApplyAsync(response -> new ArrayList<>(response.result().keySet()), executor);
   }
 
-  private SearchRequest createFinishedInstancesSearchRequest() {
+  private SearchRequest createFinishedInstancesSearchRequest(final int size) {
     return createSearchRequest(
         listViewTemplateDescriptor.getFullQualifiedName(),
         finishedProcessInstancesQuery(config.getArchivingTimePoint(), partitionId),
+        size,
         ListViewTemplate.END_DATE);
   }
 
@@ -530,6 +531,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
   private SearchRequest createSearchRequest(
       final String indexName, final Query filterQuery, final String sortField) {
+    return createSearchRequest(indexName, filterQuery, config.getRolloverBatchSize(), sortField);
+  }
+
+  private SearchRequest createSearchRequest(
+      final String indexName, final Query filterQuery, final int size, final String sortField) {
     logger.trace(
         "Create search request against index '{}', with filter '{}' and sortField '{}'",
         indexName,
@@ -545,7 +551,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .fields(fields -> fields.field(sortField).format(config.getElsRolloverDateFormat()))
         .query(query -> query.bool(q -> q.filter(filterQuery)))
         .sort(sort -> sort.field(field -> field.field(sortField).order(SortOrder.Asc)))
-        .size(config.getRolloverBatchSize())
+        .size(size)
         .build();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -138,7 +138,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(final int size) {
     try {
       return withArchivingStatus()
           .thenComposeAsync(
@@ -147,7 +147,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
                   logger.debug("Archiving is currently blocked.");
                   return CompletableFuture.completedFuture(new ArchiveBatch(null, List.of()));
                 }
-                final var request = createFinishedInstancesSearchRequest();
+                final var request = createFinishedInstancesSearchRequest(size);
 
                 final var timer = Timer.start();
                 return sendRequestAsync(() -> client.search(request, Object.class))
@@ -508,10 +508,11 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     return CompletableFuture.completedFuture(null);
   }
 
-  private SearchRequest createFinishedInstancesSearchRequest() {
+  private SearchRequest createFinishedInstancesSearchRequest(final int size) {
     return createSearchRequest(
         listViewTemplateDescriptor.getFullQualifiedName(),
         finishedProcessInstancesQuery(config.getArchivingTimePoint(), partitionId),
+        size,
         ListViewTemplate.END_DATE);
   }
 
@@ -636,6 +637,11 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
   private SearchRequest createSearchRequest(
       final String indexName, final Query filterQuery, final String sortField) {
+    return createSearchRequest(indexName, filterQuery, config.getRolloverBatchSize(), sortField);
+  }
+
+  private SearchRequest createSearchRequest(
+      final String indexName, final Query filterQuery, final int size, final String sortField) {
     logger.trace(
         "Create search request against index '{}', with filter '{}' and sortField '{}'",
         indexName,
@@ -651,7 +657,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .fields(fields -> fields.field(sortField).format(config.getElsRolloverDateFormat()))
         .query(query -> query.bool(q -> q.filter(filterQuery)))
         .sort(sort -> sort.field(field -> field.field(sortField).order(SortOrder.Asc)))
-        .size(config.getRolloverBatchSize())
+        .size(size)
         .build();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -78,10 +78,13 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
         .getProcessInstancesNextBatch(largeBatchSize())
         .thenApply(
             batch -> {
-              final var chunks = batch.chunk(config.getRolloverBatchSize());
-              final var first = chunks.removeFirst();
-              pendingBatches.addAll(chunks);
-              return first;
+              if (batch != null) {
+                final var chunks = batch.chunk(config.getRolloverBatchSize());
+                final var first = chunks.removeFirst();
+                pendingBatches.addAll(chunks);
+                return first;
+              }
+              return batch;
             });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -20,6 +21,7 @@ import org.slf4j.Logger;
 
 public class ProcessInstanceArchiverJob implements ArchiverJob {
 
+  private final HistoryConfiguration config;
   private final ArchiverRepository repository;
   private final ListViewTemplate template;
   private final List<ProcessInstanceDependant> dependants;
@@ -28,12 +30,14 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
   private final Executor executor;
 
   public ProcessInstanceArchiverJob(
+      final HistoryConfiguration config,
       final ArchiverRepository repository,
       final ListViewTemplate template,
       final List<ProcessInstanceDependant> dependants,
       final CamundaExporterMetrics metrics,
       final Logger logger,
       final Executor executor) {
+    this.config = config;
     this.repository = repository;
     this.template = template;
     this.dependants = dependants;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -131,8 +131,11 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
   }
 
   private int largeBatchSize() {
-    return Math.min(
-        MAX_LARGE_BATCH_SIZE, SUB_BATCHES_PER_LARGE_BATCH * config.getRolloverBatchSize());
+    final int rolloverBatchSize = config.getRolloverBatchSize();
+    final int largeBatchSize =
+        Math.min(MAX_LARGE_BATCH_SIZE, SUB_BATCHES_PER_LARGE_BATCH * rolloverBatchSize);
+    // just in case rollover batch size is configured very high
+    return Math.max(largeBatchSize, rolloverBatchSize);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -50,7 +50,7 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
   public CompletionStage<Integer> archiveNextBatch() {
     final var timer = Timer.start();
     return repository
-        .getProcessInstancesNextBatch()
+        .getProcessInstancesNextBatch(config.getRolloverBatchSize())
         .thenComposeAsync(this::archiveBatch, executor)
         // we schedule us after the archiveBatch future - to correctly measure
         // the time it takes all in all, including searching, reindexing, deletion

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
-public class ProcessInstancesArchiverJob implements ArchiverJob {
+public class ProcessInstanceArchiverJob implements ArchiverJob {
 
   private final ArchiverRepository repository;
   private final ListViewTemplate template;
@@ -27,7 +27,7 @@ public class ProcessInstancesArchiverJob implements ArchiverJob {
   private final Logger logger;
   private final Executor executor;
 
-  public ProcessInstancesArchiverJob(
+  public ProcessInstanceArchiverJob(
       final ArchiverRepository repository,
       final ListViewTemplate template,
       final List<ProcessInstanceDependant> dependants,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -12,14 +12,18 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.zeebe.util.FunctionUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.Timer;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
 public class ProcessInstanceArchiverJob implements ArchiverJob {
+  private static final int MAX_LARGE_BATCH_SIZE = 5_000;
+  private static final int SUB_BATCHES_PER_LARGE_BATCH = 10;
 
   private final HistoryConfiguration config;
   private final ArchiverRepository repository;
@@ -28,6 +32,8 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
   private final CamundaExporterMetrics metrics;
   private final Logger logger;
   private final Executor executor;
+  private final Queue<ArchiveBatch> pendingBatches =
+      new java.util.concurrent.ConcurrentLinkedQueue<>();
 
   public ProcessInstanceArchiverJob(
       final HistoryConfiguration config,
@@ -49,8 +55,7 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
   @Override
   public CompletionStage<Integer> archiveNextBatch() {
     final var timer = Timer.start();
-    return repository
-        .getProcessInstancesNextBatch(config.getRolloverBatchSize())
+    return getNextBatch()
         .thenComposeAsync(this::archiveBatch, executor)
         // we schedule us after the archiveBatch future - to correctly measure
         // the time it takes all in all, including searching, reindexing, deletion
@@ -62,6 +67,22 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
               return CompletableFuture.completedFuture(count);
             },
             executor);
+  }
+
+  @VisibleForTesting
+  CompletableFuture<ArchiveBatch> getNextBatch() {
+    if (!pendingBatches.isEmpty()) {
+      return CompletableFuture.completedFuture(pendingBatches.poll());
+    }
+    return repository
+        .getProcessInstancesNextBatch(largeBatchSize())
+        .thenApply(
+            batch -> {
+              final var chunks = batch.chunk(config.getRolloverBatchSize());
+              final var first = chunks.removeFirst();
+              pendingBatches.addAll(chunks);
+              return first;
+            });
   }
 
   private CompletionStage<Integer> archiveBatch(final ArchiveBatch batch) {
@@ -107,6 +128,11 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
             processInstanceKeys,
             executor)
         .thenApplyAsync(ok -> processInstanceKeys.size(), executor);
+  }
+
+  private int largeBatchSize() {
+    return Math.min(
+        MAX_LARGE_BATCH_SIZE, SUB_BATCHES_PER_LARGE_BATCH * config.getRolloverBatchSize());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
@@ -16,8 +16,8 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
+import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
-import io.camunda.exporter.tasks.archiver.ProcessInstancesArchiverJob;
 import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricsArchiverJob;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
@@ -217,7 +217,7 @@ class BackgroundTaskManagerFactoryTest {
   }
 
   private boolean isProcessInstanceArchiverTask(final RunnableTask task) {
-    return isTaskOfType(task, ProcessInstancesArchiverJob.class);
+    return isTaskOfType(task, ProcessInstanceArchiverJob.class);
   }
 
   private boolean isProcessInstanceToBeArchivedCountTask(final RunnableTask task) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
@@ -58,7 +58,9 @@ abstract class AbstractArchiverRepositoryTest {
   static Stream<Named<Function<ArchiverRepository, CompletableFuture<ArchiveBatch>>>>
       archiveBatchSuppliers() {
     return Stream.of(
-        Named.of("getProcessInstancesNextBatch", ArchiverRepository::getProcessInstancesNextBatch),
+        Named.of(
+            "getProcessInstancesNextBatch",
+            archiverRepository -> archiverRepository.getProcessInstancesNextBatch(100)),
         Named.of("getBatchOperationsNextBatch", ArchiverRepository::getBatchOperationsNextBatch),
         Named.of("getUsageMetricTUNextBatch", ArchiverRepository::getUsageMetricTUNextBatch),
         Named.of("getUsageMetricNextBatch", ArchiverRepository::getUsageMetricNextBatch),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ArchiveBatchTest {
+
+  @ParameterizedTest
+  @MethodSource("shouldChunkProcessInstanceBatchArguments")
+  void shouldChunkProcessInstanceBatch(final int chunkSize, final List<ArchiveBatch> expected) {
+    final var batch = new ArchiveBatch("finished-date", List.of("1", "2", "3"));
+
+    assertThat(batch.chunk(chunkSize)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> shouldChunkProcessInstanceBatchArguments() {
+    return Stream.of(
+        Arguments.of(5, List.of(new ArchiveBatch("finished-date", List.of("1", "2", "3")))),
+        Arguments.of(3, List.of(new ArchiveBatch("finished-date", List.of("1", "2", "3")))),
+        Arguments.of(
+            2,
+            List.of(
+                new ArchiveBatch("finished-date", List.of("1", "2")),
+                new ArchiveBatch("finished-date", List.of("3")))),
+        Arguments.of(
+            1,
+            List.of(
+                new ArchiveBatch("finished-date", List.of("1")),
+                new ArchiveBatch("finished-date", List.of("2")),
+                new ArchiveBatch("finished-date", List.of("3")))));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
@@ -8,15 +8,22 @@
 package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ArchiveBatchTest {
+
+  @Test
+  void shouldChunkEmptyProcessInstanceBatch() {
+    final var batch = new ArchiveBatch("finished-date", List.of());
+
+    assertThat(batch.chunk(10)).isEqualTo(List.of(new ArchiveBatch("finished-date", List.of())));
+  }
 
   @ParameterizedTest
   @MethodSource("shouldChunkProcessInstanceBatchArguments")

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.LongStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpHost;
 import org.awaitility.Awaitility;
@@ -413,7 +414,7 @@ final class ElasticsearchArchiverRepositoryIT {
     config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getProcessInstancesNextBatch();
+    final var result = repository.getProcessInstancesNextBatch(100);
 
     // then - we expect only the first document created two hours ago to be returned
     final var dateFormatter =
@@ -422,6 +423,42 @@ final class ElasticsearchArchiverRepositoryIT {
     final var batch = result.join();
     assertThat(batch.ids()).containsExactly("1");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+  }
+
+  @Test
+  void shouldLimitGetProcessInstancesNextBatch() throws IOException {
+    // given - multiple finished PIs
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        LongStream.rangeClosed(1, 10)
+            .mapToObj(
+                id ->
+                    new TestProcessInstance(
+                        String.valueOf(id),
+                        twoHoursAgo,
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION,
+                        1))
+            .toList();
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when
+    final var resultLimit20 = repository.getProcessInstancesNextBatch(20);
+    final var resultLimit5 = repository.getProcessInstancesNextBatch(5);
+
+    // then - the size used should limit the number of returned documents
+    assertThat(resultLimit20).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(resultLimit5).succeedsWithin(Duration.ofSeconds(30));
+    final var batch20 = resultLimit20.join();
+    assertThat(batch20.ids()).hasSize(10);
+    final var batch5 = resultLimit5.join();
+    assertThat(batch5.ids()).hasSize(5);
   }
 
   @Test
@@ -454,7 +491,7 @@ final class ElasticsearchArchiverRepositoryIT {
                     .index(archiverBlockedIndex)
                     .meta(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY, JsonData.of(true)));
     // when
-    final var result = repository.getProcessInstancesNextBatch();
+    final var result = repository.getProcessInstancesNextBatch(100);
 
     // then - we expect only the first document created two hours ago to be returned
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1152,7 +1189,7 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when
     // ensure PI batch is processed first to assert that both dates are maintained separately
-    final var piBatch = repository.getProcessInstancesNextBatch().join();
+    final var piBatch = repository.getProcessInstancesNextBatch(100).join();
     final var batchOperationBatch = repository.getBatchOperationsNextBatch().join();
 
     // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.LongStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpHost;
 import org.awaitility.Awaitility;
@@ -399,7 +400,7 @@ final class OpenSearchArchiverRepositoryIT {
     config.setRolloverBatchSize(3);
 
     // when
-    final var result = repository.getProcessInstancesNextBatch();
+    final var result = repository.getProcessInstancesNextBatch(100);
 
     // then - we expect only the first document created two hours ago to be returned
     final var dateFormatter =
@@ -408,6 +409,42 @@ final class OpenSearchArchiverRepositoryIT {
     final var batch = result.join();
     assertThat(batch.ids()).containsExactly("1");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+  }
+
+  @Test
+  void shouldLimitGetProcessInstancesNextBatch() throws IOException {
+    // given - multiple finished PIs
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        LongStream.rangeClosed(1, 10)
+            .mapToObj(
+                id ->
+                    new TestProcessInstance(
+                        String.valueOf(id),
+                        twoHoursAgo,
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION,
+                        1))
+            .toList();
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when
+    final var resultLimit20 = repository.getProcessInstancesNextBatch(20);
+    final var resultLimit5 = repository.getProcessInstancesNextBatch(5);
+
+    // then - the size used should limit the number of returned documents
+    assertThat(resultLimit20).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(resultLimit5).succeedsWithin(Duration.ofSeconds(30));
+    final var batch20 = resultLimit20.join();
+    assertThat(batch20.ids()).hasSize(10);
+    final var batch5 = resultLimit5.join();
+    assertThat(batch5.ids()).hasSize(5);
   }
 
   @Test
@@ -440,7 +477,7 @@ final class OpenSearchArchiverRepositoryIT {
                     .index(archiverBlockedIndex)
                     .meta(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY, JsonData.of(true)));
     // when
-    final var result = repository.getProcessInstancesNextBatch();
+    final var result = repository.getProcessInstancesNextBatch(100);
 
     // then - we expect only the first document created two hours ago to be returned
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1031,7 +1068,7 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when
     // ensure PI batch is processed first to assert that both dates are maintained separately
-    final var piBatch = repository.getProcessInstancesNextBatch().join();
+    final var piBatch = repository.getProcessInstancesNextBatch(100).join();
     final var batchOperationBatch = repository.getBatchOperationsNextBatch().join();
 
     // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -8,6 +8,9 @@
 package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
@@ -20,6 +23,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +34,7 @@ final class ProcessInstanceArchiverJobTest {
 
   private final Executor executor = Runnable::run;
   private final HistoryConfiguration historyConfiguration = new HistoryConfiguration();
-  private final TestRepository repository = new TestRepository();
+  private final TestRepository repository = spy(new TestRepository());
   private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
   private final DecisionInstanceTemplate decisionInstanceTemplate =
       new DecisionInstanceTemplate("", true);
@@ -183,6 +187,86 @@ final class ProcessInstanceArchiverJobTest {
                 .count())
         .isEqualTo(6)
         .isEqualTo(count);
+  }
+
+  @Test
+  void shouldRequestLargeBatchesWhenArchiving() {
+    // given
+    repository.batch =
+        new ArchiveBatch(
+            "2024-01-01", LongStream.rangeClosed(1L, 125L).mapToObj(String::valueOf).toList());
+
+    // when
+    final var count1 = job.archiveNextBatch().toCompletableFuture().join();
+    final var count2 = job.archiveNextBatch().toCompletableFuture().join();
+
+    // then
+    assertThat(count1).isEqualTo(100);
+    assertThat(count2).isEqualTo(25);
+
+    // two batches processed, but only one request made to get the batches
+    verify(repository).getProcessInstancesNextBatch(1_000);
+  }
+
+  @Test
+  void shouldRequestLargeBatchAndChunkIt() {
+    // given
+    repository.batch =
+        new ArchiveBatch(
+            "2024-01-01", LongStream.rangeClosed(1L, 300L).mapToObj(String::valueOf).toList());
+
+    // when
+    final var first = job.getNextBatch().toCompletableFuture().join();
+    final var second = job.getNextBatch().toCompletableFuture().join();
+    final var third = job.getNextBatch().toCompletableFuture().join();
+
+    // then
+    assertThat(first)
+        .isEqualTo(
+            new ArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(1L, 100L).mapToObj(String::valueOf).toList()));
+    assertThat(second)
+        .isEqualTo(
+            new ArchiveBatch(
+                "2024-01-01",
+                LongStream.rangeClosed(101L, 200L).mapToObj(String::valueOf).toList()));
+    assertThat(third)
+        .isEqualTo(
+            new ArchiveBatch(
+                "2024-01-01",
+                LongStream.rangeClosed(201L, 300L).mapToObj(String::valueOf).toList()));
+
+    verify(repository).getProcessInstancesNextBatch(1_000);
+  }
+
+  @Test
+  void shouldRequestAgainWhenChunksExhausted() {
+    // given
+    repository.batch =
+        new ArchiveBatch(
+            "2024-01-01", LongStream.rangeClosed(1L, 200L).mapToObj(String::valueOf).toList());
+
+    // when
+    final var first = job.getNextBatch().toCompletableFuture().join();
+    final var second = job.getNextBatch().toCompletableFuture().join();
+    final var third = job.getNextBatch().toCompletableFuture().join();
+
+    // then
+    assertThat(first)
+        .isEqualTo(
+            new ArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(1L, 100L).mapToObj(String::valueOf).toList()));
+    assertThat(second)
+        .isEqualTo(
+            new ArchiveBatch(
+                "2024-01-01",
+                LongStream.rangeClosed(101L, 200L).mapToObj(String::valueOf).toList()));
+    assertThat(third)
+        .isEqualTo(
+            new ArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(1L, 100L).mapToObj(String::valueOf).toList()));
+
+    verify(repository, times(2)).getProcessInstancesNextBatch(1_000);
   }
 
   private static final class WeirdlyNamedDependant implements ProcessInstanceDependant {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
@@ -28,6 +29,7 @@ final class ProcessInstanceArchiverJobTest {
       LoggerFactory.getLogger(ProcessInstanceArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
+  private final HistoryConfiguration historyConfiguration = new HistoryConfiguration();
   private final TestRepository repository = new TestRepository();
   private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
   private final DecisionInstanceTemplate decisionInstanceTemplate =
@@ -37,6 +39,7 @@ final class ProcessInstanceArchiverJobTest {
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
   private final ProcessInstanceArchiverJob job =
       new ProcessInstanceArchiverJob(
+          historyConfiguration,
           repository,
           processInstanceTemplate,
           List.of(sequenceFlowTemplate, decisionInstanceTemplate),
@@ -99,7 +102,13 @@ final class ProcessInstanceArchiverJobTest {
     final var dependant = new WeirdlyNamedDependant();
     final var job =
         new ProcessInstanceArchiverJob(
-            repository, processInstanceTemplate, List.of(dependant), metrics, LOGGER, executor);
+            historyConfiguration,
+            repository,
+            processInstanceTemplate,
+            List.of(dependant),
+            metrics,
+            LOGGER,
+            executor);
     repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class ProcessInstancesArchiverJobTest {
+final class ProcessInstanceArchiverJobTest {
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(ProcessInstancesArchiverJobTest.class);
+      LoggerFactory.getLogger(ProcessInstanceArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
   private final TestRepository repository = new TestRepository();
@@ -35,8 +35,8 @@ final class ProcessInstancesArchiverJobTest {
   private final SequenceFlowTemplate sequenceFlowTemplate = new SequenceFlowTemplate("", true);
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
-  private final ProcessInstancesArchiverJob job =
-      new ProcessInstancesArchiverJob(
+  private final ProcessInstanceArchiverJob job =
+      new ProcessInstanceArchiverJob(
           repository,
           processInstanceTemplate,
           List.of(sequenceFlowTemplate, decisionInstanceTemplate),
@@ -98,7 +98,7 @@ final class ProcessInstancesArchiverJobTest {
     // given
     final var dependant = new WeirdlyNamedDependant();
     final var job =
-        new ProcessInstancesArchiverJob(
+        new ProcessInstanceArchiverJob(
             repository, processInstanceTemplate, List.of(dependant), metrics, LOGGER, executor);
     repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -18,7 +18,7 @@ final class TestRepository extends NoopArchiverRepository {
   ArchiveBatch batch;
 
   @Override
-  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(final int size) {
     return CompletableFuture.completedFuture(batch);
   }
 


### PR DESCRIPTION
# Description
Backport of #49073 to `stable/8.8`.

relates to #48200

This did involve a fair bit of manual work in the end and does also include the fix from https://github.com/camunda/camunda/pull/49411