### PR TITLE
fix: Attempt to fix job activation test flakiness

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
@@ -38,7 +38,7 @@ class ActivateJobsTest {
 
   @BeforeEach
   void initClientAndInstances() {
-    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofMillis(500)).build();
+    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
     resourcesHelper = new ZeebeResourcesHelper(client);
   }
 
@@ -64,7 +64,12 @@ class ActivateJobsTest {
   public void shouldReturnEmptyListOnRequestTimeout(final boolean useRest) {
     // when
     final var actual =
-        getCommand(client, useRest).jobType("notExisting").maxJobsToActivate(1).send().join();
+        getCommand(client, useRest)
+            .jobType("notExisting")
+            .maxJobsToActivate(1)
+            .requestTimeout(Duration.ofMillis(500))
+            .send()
+            .join();
 
     // then
     assertThat(actual.getJobs()).isEmpty();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
@@ -61,18 +61,21 @@ class ActivateJobsTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void shouldReturnEmptyListOnRequestTimeout(final boolean useRest) {
-    // when
-    final var actual =
-        getCommand(client, useRest)
-            .jobType("notExisting")
-            .maxJobsToActivate(1)
-            .requestTimeout(Duration.ofMillis(500))
-            .send()
-            .join();
+  public void shouldReturnEmptyListOnDefaultRequestTimeout(final boolean useRest) {
+    // given
+    try (final var clientWithShortTimeout =
+        ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofMillis(500)).build()) {
+      // when
+      final var actual =
+          getCommand(clientWithShortTimeout, useRest)
+              .jobType("notExisting")
+              .maxJobsToActivate(1)
+              .send()
+              .join();
 
-    // then
-    assertThat(actual.getJobs()).isEmpty();
+      // then
+      assertThat(actual.getJobs()).isEmpty();
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

See https://camunda.slack.com/archives/C071KP5BTHB/p1774333917870669

`ActivateJobsTest.shouldRespondActivatedJobsWhenJobsAreAvailable(boolean, TestInfo)[1] useRest = true` is flaky. I checked some CI jobs like [this](https://github.com/camunda/camunda/actions/runs/23455423295/job/68243281303#step:15:153) and it looks like the issue is in process deployment.

```
Error:  Tests run: 6, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 37.53 s <<< FAILURE! -- in io.camunda.zeebe.it.engine.client.command.ActivateJobsTest
Error:  io.camunda.zeebe.it.engine.client.command.ActivateJobsTest.shouldRespondActivatedJobsWhenJobsAreAvailable(boolean, TestInfo)[1] -- Time elapsed: 2.058 s <<< ERROR!
io.camunda.client.api.command.ClientStatusException: CallOptions deadline exceeded after 0.496202000s. Name resolution delay 0.000370850 seconds. [closed=[], open=[[connecting_and_lb_delay=6701601ns, remote_addr=0.0.0.0/127.0.0.1:1229]]]
	at io.camunda.client.impl.CamundaClientFutureImpl.transformExecutionException(CamundaClientFutureImpl.java:121)
	at io.camunda.client.impl.CamundaClientFutureImpl.join(CamundaClientFutureImpl.java:53)
	at io.camunda.zeebe.it.util.ZeebeResourcesHelper.deployProcess(ZeebeResourcesHelper.java:172)
```

Perhaps 500ms is not enough for a default client timeout when deploying processes. Other test classes seem to set a default timeout of seconds. Some examples:
* BroadcastSignalTest.java
* CreateProcessInstanceTest.java
* CorrelateMessageTest.java

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
