### PR TITLE
feat: display filtered incident count based on element selection

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
@@ -21,6 +21,8 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {createProcessInstance, searchResult} from 'modules/testUtils';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
+import {mockSearchIncidentsByElementInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByElementInstance';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {LocationLog} from 'modules/utils/LocationLog';
 
 const PROCESS_INSTANCE_ID = '123';
@@ -410,5 +412,101 @@ describe('<BottomPanelTabs />', () => {
     });
     expect(incidentsTab).toBeVisible();
     expect(await screen.findByText('5')).toBeVisible();
+  });
+
+  it('should display an incident count filtered to a selected element instance', async () => {
+    const elementInstanceKey = '456';
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: true,
+      }),
+    );
+    mockFetchElementInstance(':key').withSuccess({
+      elementInstanceKey,
+      processInstanceKey: PROCESS_INSTANCE_ID,
+      processDefinitionKey: '2223894723423800',
+      processDefinitionId: 'someKey',
+      startDate: '2024-01-01T00:00:00.000Z',
+      endDate: null,
+      state: 'ACTIVE',
+      incidentKey: null,
+      elementId: 'someElement',
+      elementName: null,
+      type: 'SERVICE_TASK',
+      tenantId: '<default>',
+      hasIncident: true,
+      rootProcessInstanceKey: null,
+    });
+    mockSearchIncidentsByElementInstance(':key').withSuccess(
+      searchResult([], 2),
+    );
+
+    const path = `${Paths.processInstance(PROCESS_INSTANCE_ID)}?elementId=someElement&elementInstanceKey=${elementInstanceKey}`;
+    render(<BottomPanelTabs />, {wrapper: getWrapper(path)});
+
+    expect(
+      await screen.findByRole('link', {name: /^Incidents$/i}),
+    ).toBeVisible();
+    expect(await screen.findByText('2')).toBeVisible();
+  });
+
+  it('should display an incident count filtered to selected element when no single instance is selected', async () => {
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: true,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(
+      searchResult(
+        [
+          {
+            elementInstanceKey: '1001',
+            processInstanceKey: PROCESS_INSTANCE_ID,
+            processDefinitionKey: '2223894723423800',
+            processDefinitionId: 'someKey',
+            startDate: '2024-01-01T00:00:00.000Z',
+            endDate: null,
+            state: 'ACTIVE',
+            incidentKey: null,
+            elementId: 'multiElement',
+            elementName: null,
+            type: 'SERVICE_TASK',
+            tenantId: '<default>',
+            hasIncident: true,
+            rootProcessInstanceKey: null,
+          },
+          {
+            elementInstanceKey: '1002',
+            processInstanceKey: PROCESS_INSTANCE_ID,
+            processDefinitionKey: '2223894723423800',
+            processDefinitionId: 'someKey',
+            startDate: '2024-01-01T00:00:00.000Z',
+            endDate: null,
+            state: 'ACTIVE',
+            incidentKey: null,
+            elementId: 'multiElement',
+            elementName: null,
+            type: 'SERVICE_TASK',
+            tenantId: '<default>',
+            hasIncident: true,
+            rootProcessInstanceKey: null,
+          },
+        ],
+        2,
+      ),
+    );
+    mockSearchIncidentsByProcessInstance(':key').withSuccess(
+      searchResult([], 3),
+    );
+
+    const selectedPath = `${Paths.processInstance(PROCESS_INSTANCE_ID)}?elementId=multiElement`;
+    render(<BottomPanelTabs />, {wrapper: getWrapper(selectedPath)});
+
+    expect(
+      await screen.findByRole('link', {name: /^Incidents$/i}),
+    ).toBeVisible();
+    expect(await screen.findByText('3')).toBeVisible();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -15,6 +15,37 @@ import {useCurrentPage} from 'modules/hooks/useCurrentPage';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/useProcessInstanceIncidentsCount';
+import {useElementInstanceIncidentsCount} from 'modules/queries/incidents/useElementInstanceIncidentsCount';
+
+function useSelectionAwareIncidentsCount(
+  processInstanceKey: string,
+  hasIncident: boolean,
+) {
+  const {resolvedElementInstance, isFetchingElement, selectedElementId} =
+    useProcessInstanceElementSelection();
+  const resolvedElementInstanceKey =
+    resolvedElementInstance?.elementInstanceKey;
+
+  const isElementInstanceSelected =
+    resolvedElementInstanceKey !== undefined &&
+    resolvedElementInstanceKey !== processInstanceKey;
+
+  const processIncidentsCount = useProcessInstanceIncidentsCount(
+    processInstanceKey ?? '',
+    {
+      enabled: hasIncident && !isElementInstanceSelected && !isFetchingElement,
+      filter: {elementId: selectedElementId ?? undefined},
+    },
+  );
+  const elementIncidentsCount = useElementInstanceIncidentsCount(
+    resolvedElementInstanceKey ?? '',
+    {enabled: hasIncident && isElementInstanceSelected},
+  );
+
+  return isElementInstanceSelected
+    ? elementIncidentsCount
+    : processIncidentsCount;
+}
 
 const BottomPanelTabs: React.FC = () => {
   const {hasSelection} = useProcessInstanceElementSelection();
@@ -22,10 +53,11 @@ const BottomPanelTabs: React.FC = () => {
   const {processInstanceId} = useProcessInstancePageParams();
   const {currentPage} = useCurrentPage();
   const hasIncident = processInstance?.hasIncident === true;
-  const incidentsCount = useProcessInstanceIncidentsCount(
+  const incidentsCount = useSelectionAwareIncidentsCount(
     processInstanceId ?? '',
-    {enabled: hasIncident},
+    hasIncident,
   );
+
   const tabItems = [
     {
       label: 'Incidents',

--- a/operate/client/src/modules/queries/incidents/useElementInstanceIncidentsCount.ts
+++ b/operate/client/src/modules/queries/incidents/useElementInstanceIncidentsCount.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {queryKeys} from '../queryKeys';
+import {searchIncidentsByElementInstance} from 'modules/api/v2/incidents/searchIncidentsByElementInstance';
+
+type CountQueryOptions = {
+  enabled?: boolean;
+};
+
+function useElementInstanceIncidentsCount(
+  elementInstanceKey: string,
+  options?: CountQueryOptions,
+): number {
+  const {data} = useQuery({
+    queryKey:
+      queryKeys.incidents.elementInstanceIncidentsCount(elementInstanceKey),
+    enabled: options?.enabled ?? !!elementInstanceKey,
+    refetchInterval: 5000,
+    staleTime: 5000,
+    queryFn: async () => {
+      const {response, error} = await searchIncidentsByElementInstance(
+        elementInstanceKey,
+        {page: {limit: 0}, filter: {state: 'ACTIVE'}},
+      );
+      if (response !== null) {
+        return response.page.totalItems;
+      }
+
+      throw error;
+    },
+  });
+
+  return data ?? 0;
+}
+
+export {useElementInstanceIncidentsCount};

--- a/operate/client/src/modules/queries/incidents/useProcessInstanceIncidentsCount.ts
+++ b/operate/client/src/modules/queries/incidents/useProcessInstanceIncidentsCount.ts
@@ -6,28 +6,37 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {QueryProcessInstanceIncidentsRequestBody} from '@camunda/camunda-api-zod-schemas/8.9';
 import {useQuery} from '@tanstack/react-query';
 import {queryKeys} from '../queryKeys';
 import {searchIncidentsByProcessInstance} from 'modules/api/v2/incidents/searchIncidentsByProcessInstance';
 
 type CountQueryOptions = {
   enabled?: boolean;
+  filter?: QueryProcessInstanceIncidentsRequestBody['filter'];
 };
 
 function useProcessInstanceIncidentsCount(
   processInstanceKey: string,
   options?: CountQueryOptions,
 ): number {
+  const filter: QueryProcessInstanceIncidentsRequestBody['filter'] = {
+    state: 'ACTIVE',
+    ...options?.filter,
+  };
+
   const {data} = useQuery({
-    queryKey:
-      queryKeys.incidents.processInstanceIncidentsCount(processInstanceKey),
+    queryKey: queryKeys.incidents.processInstanceIncidentsCount(
+      processInstanceKey,
+      filter,
+    ),
     enabled: options?.enabled ?? !!processInstanceKey,
     refetchInterval: 5000,
     staleTime: 5000,
     queryFn: async () => {
       const {response, error} = await searchIncidentsByProcessInstance(
         processInstanceKey,
-        {page: {limit: 0}, filter: {state: 'ACTIVE'}},
+        {page: {limit: 0}, filter},
       );
       if (response !== null) {
         return response.page.totalItems;

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -97,10 +97,19 @@ const queryKeys = {
   incidents: {
     get: (incidentKey: string) => ['incident', incidentKey],
     search: () => ['incidentsSearch'],
-    processInstanceIncidentsCount: (processInstanceKey: string) => [
+    processInstanceIncidentsCount: (
+      processInstanceKey: string,
+      filter?: QueryProcessInstanceIncidentsRequestBody['filter'],
+    ) => [
       queryKeys.incidents.search()[0],
       'processInstanceIncidentsCount',
       processInstanceKey,
+      filter,
+    ],
+    elementInstanceIncidentsCount: (elementInstanceKey: string) => [
+      queryKeys.incidents.search()[0],
+      'elementInstanceIncidentsCount',
+      elementInstanceKey,
     ],
     searchByProcessInstanceKeyPaginated: (
       processInstanceKey: string,


### PR DESCRIPTION
## Description

Updates the queries for the incident count on the bottom panel tab to be based on the current element selection. This aligns the count with the table result (before incident type filters are applied).

**Should this change be backported somewhere? "backport stable8/9" to get it into 8.9.1 or what is the correct approach?**

## Related issues

closes #49161
