### PR TITLE
[Backport stable/8.9] feat: Remove ES7 & Fix ES8 Dependency

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -519,13 +519,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hdrhistogram</groupId>
-          <!-- Conflicts with histogram in elasticsearch exporter dependency -->
-          <artifactId>HdrHistogram</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -124,10 +124,6 @@
                   <dep>org.openjdk.jmh:jmh-generator-annprocess</dep>
                   <dep>org.postgresql:postgresql</dep>
                 </ignoredUnusedDeclaredDependencies>
-                <ignoredNonTestScopedDependencies>
-                  <dep>org.elasticsearch:elasticsearch-x-content</dep>
-                  <dep>org.apache.lucene:lucene-core</dep>
-                </ignoredNonTestScopedDependencies>
               </configuration>
             </execution>
           </executions>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -271,19 +271,6 @@
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
 
-    <!--Lucene dependencies-->
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
-      <version>${version.lucene}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
     <!--Test dependencies-->
     <dependency>
       <groupId>com.tdunning</groupId>

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdentitySearchResultResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdentitySearchResultResponseDto.java
@@ -7,31 +7,17 @@
  */
 package io.camunda.optimize.dto.optimize.query;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.IdentityWithMetadataResponseDto;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import org.apache.lucene.search.ScoreDoc;
 
 public class IdentitySearchResultResponseDto {
 
   private List<IdentityWithMetadataResponseDto> result = new ArrayList<>();
 
-  /**
-   * ScoreDoc holds a reference to the ScoreDoc of the last result the result list. Used to paginate
-   * through the searchableIdentityCache.
-   */
-  @JsonIgnore private ScoreDoc scoreDoc;
-
   public IdentitySearchResultResponseDto(final List<IdentityWithMetadataResponseDto> result) {
     this.result = result;
-  }
-
-  public IdentitySearchResultResponseDto(
-      final List<IdentityWithMetadataResponseDto> result, final ScoreDoc scoreDoc) {
-    this.result = result;
-    this.scoreDoc = scoreDoc;
   }
 
   public IdentitySearchResultResponseDto() {}
@@ -44,22 +30,13 @@ public class IdentitySearchResultResponseDto {
     this.result = result;
   }
 
-  public ScoreDoc getScoreDoc() {
-    return scoreDoc;
-  }
-
-  @JsonIgnore
-  public void setScoreDoc(final ScoreDoc scoreDoc) {
-    this.scoreDoc = scoreDoc;
-  }
-
   protected boolean canEqual(final Object other) {
     return other instanceof IdentitySearchResultResponseDto;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(result, scoreDoc);
+    return Objects.hash(result);
   }
 
   @Override
@@ -71,15 +48,11 @@ public class IdentitySearchResultResponseDto {
       return false;
     }
     final IdentitySearchResultResponseDto that = (IdentitySearchResultResponseDto) o;
-    return Objects.equals(result, that.result) && Objects.equals(scoreDoc, that.scoreDoc);
+    return Objects.equals(result, that.result);
   }
 
   @Override
   public String toString() {
-    return "IdentitySearchResultResponseDto(result="
-        + getResult()
-        + ", scoreDoc="
-        + getScoreDoc()
-        + ")";
+    return "IdentitySearchResultResponseDto(result=" + getResult() + ")";
   }
 }

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -59,8 +59,8 @@
 
     <!-- DATABASE -->
     <!-- Elasticsearch-->
-    <version.elasticsearch>8.16.6</version.elasticsearch>
     <version.elasticsearch-java-client>8.19.13</version.elasticsearch-java-client>
+    <version.elasticsearch>8.19.12</version.elasticsearch>
     <!-- The least supported elasticsearch version we should test against-->
     <elasticsearch.test.version>8.19.11</elasticsearch.test.version>
     <!-- The ElasticSearch version of the previous Optimize version -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -54,9 +54,9 @@
     <version.commons-text>1.15.0</version.commons-text>
     <version.cron-utils>9.2.1</version.cron-utils>
     <version.docker-java-api>3.7.0</version.docker-java-api>
-    <version.elasticsearch>8.16.6</version.elasticsearch>
     <version.elasticsearch-java-client>8.19.13</version.elasticsearch-java-client>
-    <version.error-prone>2.47.0</version.error-prone>
+    <version.elasticsearch>8.19.12</version.elasticsearch>
+    <version.error-prone>2.48.0</version.error-prone>
     <version.grpc>1.79.0</version.grpc>
     <version.gson>2.13.2</version.gson>
     <version.guava>33.5.0-jre</version.guava>
@@ -185,10 +185,14 @@
 
     <version.elasticsearch-test-container>2.0.3</version.elasticsearch-test-container>
     <version.postgres-test-container>2.0.3</version.postgres-test-container>
+<<<<<<< HEAD
     <version.elasticsearch7>8.19.13</version.elasticsearch7>
     <version.lz4>1.10.4</version.lz4>
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
     <version.lucene>8.11.4</version.lucene>
+=======
+    <version.lz4>1.10.4</version.lz4>
+>>>>>>> 79f29f6c58c (feat: Remove ES7 & Fix ES8 Dependency)
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
     <version.joda-time>2.14.1</version.joda-time>
     <version.commons-collections4>4.5.0</version.commons-collections4>
@@ -2079,62 +2083,6 @@
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna-platform</artifactId>
         <version>${version.jna-platform}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.elasticsearch.client</groupId>
-        <artifactId>elasticsearch-rest-high-level-client</artifactId>
-        <version>${version.elasticsearch7}</version>
-      </dependency>
-
-      <!-- START have to define this to override wrong version coming from spring-boot-dependencies BOM -->
-      <dependency>
-        <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch-x-content</artifactId>
-        <version>${version.elasticsearch7}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch</artifactId>
-        <version>${version.elasticsearch7}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <!-- Override the transitive dependency from org.elasticsearch:elasticsearch,
-      replacing the discontinued org.lz4:lz4-java with the maintained fork at.yawk.lz4:lz4-java.
-      This override will remain necessary unless Elasticsearch itself adopts the maintained fork. -->
-      <dependency>
-        <groupId>at.yawk.lz4</groupId>
-        <artifactId>lz4-java</artifactId>
-        <version>${version.lz4}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch-core</artifactId>
-        <version>${version.elasticsearch7}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>parent-join-client</artifactId>
-        <version>${version.elasticsearch7}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-core</artifactId>
-        <version>${version.lucene}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-join</artifactId>
-        <version>${version.lucene}</version>
       </dependency>
 
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -185,14 +185,7 @@
 
     <version.elasticsearch-test-container>2.0.3</version.elasticsearch-test-container>
     <version.postgres-test-container>2.0.3</version.postgres-test-container>
-<<<<<<< HEAD
-    <version.elasticsearch7>8.19.13</version.elasticsearch7>
     <version.lz4>1.10.4</version.lz4>
-    <!-- the lucene version must be coupled with version.elasticsearch7 -->
-    <version.lucene>8.11.4</version.lucene>
-=======
-    <version.lz4>1.10.4</version.lz4>
->>>>>>> 79f29f6c58c (feat: Remove ES7 & Fix ES8 Dependency)
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
     <version.joda-time>2.14.1</version.joda-time>
     <version.commons-collections4>4.5.0</version.commons-collections4>

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -117,11 +117,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
@@ -175,8 +170,6 @@
             <dep>io.camunda:zeebe-build-tools</dep>
             <dep>org.apache.logging.log4j:log4j-core</dep>
             <dep>org.apache.logging.log4j:log4j-slf4j2-impl</dep>
-            <dep>org.apache.lucene:lucene-core</dep>
-            <dep>org.elasticsearch:elasticsearch-x-content</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
@@ -43,7 +43,6 @@ import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.resilience.annotation.EnableResilientMethods;
 import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Component;
@@ -153,14 +152,14 @@ public class TasklistAPICaller {
 
   @Bean
   public ObjectMapper objectMapper() {
-    return Jackson2ObjectMapperBuilder.json()
-        .featuresToDisable(
-            SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
-            DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE,
-            DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-            DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-        .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS)
-        .build();
+    final ObjectMapper mapper = new ObjectMapper();
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    mapper.disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+    mapper.disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+    mapper.enable(JsonParser.Feature.ALLOW_COMMENTS);
+    return mapper;
   }
 
   @Retryable(

--- a/tasklist/qa/util/pom.xml
+++ b/tasklist/qa/util/pom.xml
@@ -102,6 +102,11 @@
     </dependency>
 
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/rest/StatefulRestTemplate.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/rest/StatefulRestTemplate.java
@@ -25,6 +25,8 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.*;
 import org.springframework.http.client.support.BasicAuthenticationInterceptor;
+import org.springframework.http.converter.HttpMessageConverters;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RequestCallback;
@@ -50,7 +52,19 @@ public class StatefulRestTemplate extends RestTemplate {
   private final String contextPath;
 
   public StatefulRestTemplate(final String host, final Integer port, final String contextPath) {
-    super();
+    super(
+        HttpMessageConverters.forClient()
+            .registerDefaults()
+            .withJsonConverter(
+                new JacksonJsonHttpMessageConverter(
+                    tools.jackson.databind.json.JsonMapper.builder()
+                        .disable(
+                            tools.jackson.databind.DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                        .disable(
+                            tools.jackson.databind.DeserializationFeature
+                                .FAIL_ON_UNKNOWN_PROPERTIES)
+                        .build()))
+            .build());
     this.host = host;
     this.port = port;
     this.contextPath = contextPath;

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -277,11 +277,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
@@ -401,7 +396,6 @@
             <dep>jakarta.servlet:jakarta.servlet-api</dep>
             <dep>jakarta.annotation:jakarta.annotation-api</dep>
             <dep>org.springframework:spring-aspects</dep>
-            <dep>org.elasticsearch:elasticsearch</dep>
           </ignoredUnusedDeclaredDependencies>
           <ignoredNonTestScopedDependencies>
             <dependency>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</dependency>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backport of https://github.com/camunda/camunda/pull/48180 in stable/8.9.

I'm making this PR manually because the one that was generated automatically by the backport label seems to have conflicts, but also they are in the wrong place (some things were not present in the generated PR): https://github.com/camunda/camunda/pull/49387

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
