### PR TITLE
fix: add processDefinitionId filtering to InstancesTable and update audit-log schema

### DIFF
--- a/client-components/package-lock.json
+++ b/client-components/package-lock.json
@@ -3965,7 +3965,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.53",
+			"version": "0.0.54",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.5.0",

--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.54
+
+### 🚀 Enhancements
+
+- Updated audit-log schema to support `processDefinitionId` filtering. ([#49391](https://github.com/camunda/camunda/issues/49391))
+
+### ❤️ Contributors
+
+- Daniel Kelemen ([@danielkelemen](https://github.com/danielkelemen))
+
 ## v0.0.53
 
 ### 🚀 Enhancements

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
@@ -115,6 +115,7 @@ const auditLogFilterSchema = z
 	.object({
 		auditLogKey: advancedStringFilterSchema.optional(),
 		processDefinitionKey: advancedStringFilterSchema.optional(),
+		processDefinitionId: advancedStringFilterSchema.optional(),
 		processInstanceKey: advancedStringFilterSchema.optional(),
 		elementInstanceKey: advancedStringFilterSchema.optional(),
 		operationType: getEnumFilterSchema(auditLogOperationTypeSchema).optional(),

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.53",
+	"version": "0.0.54",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.52",
+        "@camunda/camunda-api-zod-schemas": "0.0.54",
         "@camunda/camunda-composite-components": "0.22.5",
         "@carbon/elements": "11.85.0",
         "@carbon/react": "1.101.0",
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.52.tgz",
-      "integrity": "sha512-pknZawq9X+piz5T2iOhzRq/S+7VEiQN0kV2be0nEGKrw71dnwitZs710jArfDjFE7OtUCSInwfZ636J3AOVOsw==",
+      "version": "0.0.54",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.54.tgz",
+      "integrity": "sha512-adtpSoFLSXFhzdKh2y7W7BHxOAL3ibQShSw1SsTOSuXSvb8j/NqBC6LmYJt5+Kk7Ci+KeT3xyFo5accbkK/6jQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.52",
+    "@camunda/camunda-api-zod-schemas": "0.0.54",
     "@camunda/camunda-composite-components": "0.22.5",
     "@carbon/elements": "11.85.0",
     "@carbon/react": "1.101.0",

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -128,6 +128,12 @@ const InstancesTable: React.FC = observer(() => {
       filter: {
         category: {$neq: 'ADMIN'},
         processDefinitionKey: selectedProcessDefinition?.processDefinitionKey,
+        processDefinitionId:
+          filterValues.processDefinitionId &&
+          (!filterValues.processDefinitionVersion ||
+            filterValues.processDefinitionVersion === 'all')
+            ? filterValues.processDefinitionId
+            : undefined,
         processInstanceKey: filterValues.processInstanceKey,
         tenantId: selectedTenantId,
         operationType: filterValues.operationType


### PR DESCRIPTION
## Description

- Extended InstancesTable filtering logic to include processDefinitionId when processDefinitionVersion is 'all'.
- Updated audit-log schema to support processDefinitionId filtering.

## Related issues

closes https://github.com/camunda/camunda/issues/49391
