### PR TITLE
POC configuration files deployment

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -62,4 +62,6 @@ public interface BpmnBehaviors {
   JobUpdateBehaviour jobUpdateBehaviour();
 
   BpmnAdHocSubProcessBehavior adHocSubProcessBehavior();
+
+  ExternalResourceBehavior externalResourceBehavior();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -280,7 +280,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState);
 
     externalResourceBehavior =
-        new ExternalResourceBehavior(stateBehavior, processingState.getResourceState());
+        new ExternalResourceBehavior(
+            stateBehavior,
+            processingState.getResourceState(),
+            expressionLanguage,
+            expressionProcessor);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -65,6 +65,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final BpmnConditionalBehavior conditionalBehavior;
   private final ExpressionBehavior expressionBehavior;
   private final ExpressionLanguage expressionLanguage;
+  private final ExternalResourceBehavior externalResourceBehavior;
 
   public BpmnBehaviorsImpl(
       final MutableProcessingState processingState,
@@ -277,6 +278,9 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             stateBehavior,
             variableBehavior,
             processingState);
+
+    externalResourceBehavior =
+        new ExternalResourceBehavior(stateBehavior, processingState.getResourceState());
   }
 
   @Override
@@ -392,6 +396,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public BpmnAdHocSubProcessBehavior adHocSubProcessBehavior() {
     return adHocSubProcessBehavior;
+  }
+
+  @Override
+  public ExternalResourceBehavior externalResourceBehavior() {
+    return externalResourceBehavior;
   }
 
   public ExpressionBehavior expressionBehavior() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/ExternalResourceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/ExternalResourceBehavior.java
@@ -10,26 +10,35 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior.LinkedResourceProps;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 
 public class ExternalResourceBehavior {
   // TODO We can do this object mapping on deploy time. Then we don't have to parse the resource for
-  //  every service task. We can store the variable names and values in state and fetch them here.
+  //  every service task. We can store the variable names and values (expressions) in state and
+  // fetch them here.
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   private final BpmnStateBehavior stateBehavior;
   private final ResourceState resourceState;
+  private final ExpressionLanguage expressionLanguage;
+  private final ExpressionProcessor expressionProcessor;
 
   public ExternalResourceBehavior(
-      final BpmnStateBehavior stateBehavior, final ResourceState resourceState) {
+      final BpmnStateBehavior stateBehavior,
+      final ResourceState resourceState,
+      final ExpressionLanguage expressionLanguage,
+      final ExpressionProcessor expressionProcessor) {
     this.stateBehavior = stateBehavior;
     this.resourceState = resourceState;
+    this.expressionLanguage = expressionLanguage;
+    this.expressionProcessor = expressionProcessor;
   }
 
   public Either<Failure, Void> createExternalResourceVariables(
@@ -66,20 +75,24 @@ public class ExternalResourceBehavior {
 
   private Either<Failure, Void> createVariables(
       final BpmnElementContext context, final ConfigValues configValues) {
-    // TODO FEEL expressions
-    configValues
-        .configValues()
-        .forEach(
-            configValue ->
-                stateBehavior.setLocalVariable(
-                    context,
-                    BufferUtil.wrapString(configValue.id()),
-                    BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(configValue.value()))));
+    for (final ConfigValue configValue : configValues.configValues()) {
+      final var expression = expressionLanguage.parseExpression(configValue.value());
+      final var evaluatedValue =
+          expressionProcessor.evaluateAnyExpressionToBuffer(
+              expression, context.getElementInstanceKey(), context.getTenantId());
+
+      if (evaluatedValue.isLeft()) {
+        return Either.left(evaluatedValue.getLeft());
+      }
+
+      stateBehavior.setLocalVariable(
+          context, BufferUtil.wrapString(configValue.id()), evaluatedValue.get());
+    }
     return Either.right(null);
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   private record ConfigValues(List<ConfigValue> configValues) {}
 
-  private record ConfigValue(String id, Object value) {}
+  private record ConfigValue(String id, String value) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/ExternalResourceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/ExternalResourceBehavior.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior.LinkedResourceProps;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.state.immutable.ResourceState;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+
+public class ExternalResourceBehavior {
+  // TODO We can do this object mapping on deploy time. Then we don't have to parse the resource for
+  //  every service task. We can store the variable names and values in state and fetch them here.
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private final BpmnStateBehavior stateBehavior;
+  private final ResourceState resourceState;
+
+  public ExternalResourceBehavior(
+      final BpmnStateBehavior stateBehavior, final ResourceState resourceState) {
+    this.stateBehavior = stateBehavior;
+    this.resourceState = resourceState;
+  }
+
+  public Either<Failure, Void> createExternalResourceVariables(
+      final BpmnElementContext context, final List<LinkedResourceProps> resourceProps) {
+    resourceProps.stream()
+        .map(LinkedResourceProps::getResourceKey)
+        .map(Long::parseLong)
+        .forEach(
+            resourceKey -> {
+              parseResource(context, resourceKey);
+            });
+
+    return Either.right(null);
+  }
+
+  private Either<Failure, Void> parseResource(
+      final BpmnElementContext context, final Long resourceKey) {
+    final var resourceOptional =
+        resourceState.findResourceByKey(resourceKey, context.getTenantId());
+    if (resourceOptional.isEmpty()) {
+      return Either.left(
+          new Failure(
+              "Expected to find a resource with key '%d', but no resource was found."
+                  .formatted(resourceKey)));
+    }
+    final var resource = resourceOptional.get();
+    try {
+      final var configValues = JSON_MAPPER.readValue(resource.getResource(), ConfigValues.class);
+      return createVariables(context, configValues);
+    } catch (final JsonProcessingException e) {
+      return Either.left(new Failure(e.getMessage()));
+    }
+  }
+
+  private Either<Failure, Void> createVariables(
+      final BpmnElementContext context, final ConfigValues configValues) {
+    // TODO FEEL expressions
+    configValues
+        .configValues()
+        .forEach(
+            configValue ->
+                stateBehavior.setLocalVariable(
+                    context,
+                    BufferUtil.wrapString(configValue.id()),
+                    BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(configValue.value()))));
+    return Either.right(null);
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private record ConfigValues(List<ConfigValue> configValues) {}
+
+  private record ConfigValue(String id, Object value) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.ExternalResourceBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
 import io.camunda.zeebe.util.Either;
@@ -34,6 +35,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
   private final BpmnJobBehavior jobBehavior;
   private final BpmnStateBehavior stateBehavior;
   private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
+  private final ExternalResourceBehavior externalResourceBehavior;
 
   public JobWorkerTaskProcessor(
       final BpmnBehaviors behaviors, final BpmnStateTransitionBehavior stateTransitionBehavior) {
@@ -44,6 +46,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
     jobBehavior = behaviors.jobBehavior();
     stateBehavior = behaviors.stateBehavior();
     compensationSubscriptionBehaviour = behaviors.compensationSubscriptionBehaviour();
+    externalResourceBehavior = behaviors.externalResourceBehavior();
   }
 
   @Override
@@ -60,8 +63,17 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
   @Override
   public Either<Failure, ?> finalizeActivation(
       final ExecutableJobWorkerTask element, final BpmnElementContext context) {
+    // TODO we should add a new behavior. The behavior gets the resource and parses the JSON. Then
+    //  it will create the variables, using FEEL where necessary.
+    //  Also consider placing this straight after the input mappings. That way execution listener
+    //  can use these variables if they so desire.
     return jobBehavior
         .evaluateJobExpressions(element.getJobWorkerProperties(), context)
+        .flatMap(
+            j ->
+                externalResourceBehavior
+                    .createExternalResourceVariables(context, j.getLinkedResources())
+                    .map(ok -> j))
         .flatMap(j -> eventSubscriptionBehavior.subscribeToEvents(element, context).map(ok -> j))
         .thenDo(
             jobProperties -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -88,7 +88,12 @@ public final class DeploymentTransformer {
             entry(".xml", bpmnResourceTransformer),
             entry(".dmn", dmnResourceTransformer),
             entry(".form", formResourceTransformer),
-            entry(".rpa", resourceTransformer));
+            entry(".rpa", resourceTransformer),
+            // TODO this should get its own transformer, not the RpaTransformer. But it works for
+            //  PoC purposes.
+            //  It also considers every .json file a configuration file right now. We must make this
+            //  smarter if we want to support generic resource deployment.
+            entry(".json", resourceTransformer));
   }
 
   public DirectBuffer getChecksum(final byte[] resource) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/ExternalConfigurationResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/ExternalConfigurationResourceTransformer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.immutable.ResourceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+
+public class ExternalConfigurationResourceTransformer implements DeploymentResourceTransformer {
+
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final ChecksumGenerator checksumGenerator;
+  private final ResourceState resourceState;
+
+  public ExternalConfigurationResourceTransformer(
+      final KeyGenerator keyGenerator,
+      final StateWriter stateWriter,
+      final ChecksumGenerator checksumGenerator,
+      final ResourceState resourceState) {
+    this.keyGenerator = keyGenerator;
+    this.stateWriter = stateWriter;
+    this.checksumGenerator = checksumGenerator;
+    this.resourceState = resourceState;
+  }
+
+  @Override
+  public Either<Failure, Void> createMetadata(
+      final DeploymentResource resource,
+      final DeploymentRecord deployment,
+      final DeploymentResourceContext context) {
+    return null;
+  }
+
+  @Override
+  public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {}
+}


### PR DESCRIPTION
## POC DO NOT MERGE

This POC allows deployments of configuration files. These files can be linked to tasks (in this case only a job worker task). The configuration file gets parsed and variables defined within are created on the scope of the task (similar to input mappings).

In the POC the config variables are created after the input mappings. As a result input mappings are available to the config, but not the other way around.

**Things of note:**
1. We now parse the config file for every job worker. This can be done at deploy time so we only have to do it once.
2. This implementation assumes that a config value is always a `String`.
3. Files with extension type `.json` are now considered to be configuration files. This works fine for the POC, but when generic resource deployment gets implemented we can have clashes here. This is a problem that exists regardless with `xml` files always being considered BPMN resources.
4. I had to add an `id` field to the config file. This is so we know what id the resource should get. It's the identifier that should be used upon linking the resource to a task.

```json
{
  "id": "configPoc",
  "configurationType": "aws-connection",
  "configValues": [
    {
      "id": "authentication.type",
      "value": "credentials"
    },
    {
      "id": "authentication.accessKey",
      "value": "{{secrets.AWS_ACCESS_KEY}}"
    },
    {
      "id": "authentication.secretKey",
      "value": "{{secrets.AWS_SECRET_KEY}}"
    },
    {
      "id": "configuration.region",
      "value": "=camunda.env.awsRegion"
    }
  ]
}
```