### PR TITLE
[Backport stable/8.9] Enable call activities test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -277,11 +277,12 @@ class OperateProcessInstancePage {
     });
     this.instanceHeaderSkeleton = page.getByTestId('instance-header-skeleton');
     this.viewAllCalledInstancesLink = page.getByRole('link', {
-      name: /view all called instances/i,
+      name: /View Called Process instance \d+/i,
     });
-    this.viewParentInstanceLink = page.getByRole('link', {
-      name: /view parent instance/i,
-    });
+    this.viewParentInstanceLink = page
+      .getByLabel('Breadcrumb')
+      .locator('.cds--breadcrumb-item:not(.cds--breadcrumb-item--current)')
+      .getByRole('link');
     this.executionCountToggle = this.page.locator('#toggle-execution-count');
     this.executionCountToggleLabel = this.page.locator(
       '#toggle-execution-count_label',
@@ -296,9 +297,6 @@ class OperateProcessInstancePage {
         .getByTestId(`variable-${name}`)
         .getByRole('cell')
         .nth(2);
-    this.incidentIconsInHistory = this.instanceHistory
-      .getByRole('treeitem')
-      .getByTestId('INCIDENT-icon');
 
     this.existingVariableByName = (name: string) => ({
       name: this.variablesList
@@ -797,6 +795,7 @@ class OperateProcessInstancePage {
   }
 
   async clickViewAllCalledInstances(): Promise<void> {
+    await this.clickDetailsTab();
     await this.viewAllCalledInstancesLink.click();
   }
 
@@ -932,9 +931,8 @@ class OperateProcessInstancePage {
   }
 
   /**
-   *
-   * @param itemName
-   * @param expectedStatus array of icons in expected order in history, can be 'COMPLETED', 'ACTIVE', 'TERMINATED', 'INCIDENT'
+   * @param itemName - The name of the history item to verify
+   * @param expectedStatus - Array of icons in expected order in history, can be 'COMPLETED', 'ACTIVE', 'TERMINATED', 'INCIDENT'
    */
   async verifyHistoryItemsStatus(
     itemName: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -48,9 +48,8 @@ test.describe('Call Activities', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test.skip('Navigate to called and parent process instances', async ({
+  test('Navigate to called and parent process instances', async ({
     operateProcessInstancePage,
-    operateProcessesPage,
     operateDiagramPage,
   }) => {
     test.slow();
@@ -66,37 +65,9 @@ test.describe('Call Activities', () => {
       ).toBeHidden();
       await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
       await expect(
-        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
-      ).toBeVisible();
-      await expect(
-        operateProcessInstancePage.instanceHeader.getByText(
-          'Call Activity Process',
-        ),
-      ).toBeVisible();
-    });
-
-    await test.step('View all called instances', async () => {
-      await operateProcessInstancePage.clickViewAllCalledInstances();
-
-      await expect(operateProcessesPage.processInstancesTable).toHaveCount(1);
-      await expect(
-        operateProcessesPage.processInstancesTable.getByText('Called Process'),
-      ).toBeVisible();
-    });
-
-    let calledProcessInstanceId: string;
-
-    await test.step('Get called process instance ID', async () => {
-      calledProcessInstanceId = await operateProcessesPage
-        .calledInstanceCell()
-        .innerText();
-    });
-
-    await test.step('Navigate back to parent instance from list', async () => {
-      await operateProcessesPage.clickViewParentInstanceFromList();
-
-      await expect(
-        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
+        operateProcessInstancePage.instanceHeader
+          .getByText(processInstanceKey)
+          .first(),
       ).toBeVisible();
       await expect(
         operateProcessInstancePage.instanceHeader.getByText(
@@ -131,23 +102,13 @@ test.describe('Call Activities', () => {
     });
 
     await test.step('Navigate to called process instance via diagram', async () => {
-      await operateDiagramPage.clickFlowNode('Activity_13otele');
-
-      await expect(
-        operateDiagramPage.getPopoverText(/Called Process Instance/),
-      ).toBeVisible();
-
-      await operateDiagramPage.clickPopoverLink(
-        /view called process instance/i,
+      await operateProcessInstancePage.diagramHelper.clickFlowNode(
+        'Call Activity',
       );
+      await operateProcessInstancePage.clickViewAllCalledInstances();
     });
 
-    await test.step('Verify called process instance header and history', async () => {
-      await expect(
-        operateProcessInstancePage.instanceHeader.getByText(
-          calledProcessInstanceId,
-        ),
-      ).toBeVisible();
+    await test.step('Verify called process instance page', async () => {
       await expect(
         operateProcessInstancePage.instanceHeader.getByText('Called Process', {
           exact: true,
@@ -167,17 +128,13 @@ test.describe('Call Activities', () => {
       ).toBeVisible();
     });
 
-    await test.step('Verify called process diagram', async () => {
-      await expect(
-        operateDiagramPage.getFlowNode('StartEvent_1'),
-      ).toBeVisible();
-    });
-
     await test.step('Navigate back to parent instance from header', async () => {
       await operateProcessInstancePage.clickViewParentInstance();
 
       await expect(
-        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
+        operateProcessInstancePage.instanceHeader
+          .getByText(processInstanceKey)
+          .first(),
       ).toBeVisible();
       await expect(
         operateProcessInstancePage.instanceHeader.getByText(


### PR DESCRIPTION
# Description
Backport of #49406 to `stable/8.9`.

[Test run](https://github.com/camunda/camunda/actions/runs/23498243383)
❗ re-enabled test passed, failures are not related to my changes and will be investigated later

relates to camunda/camunda#49226