### PR TITLE
fix: mark operation as completed with count 0

### DIFF
--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.test.tsx
@@ -136,7 +136,9 @@ describe('OperationEntryStatus', () => {
       />,
     );
 
-    expect(screen.getByText(/0 retries succeeded/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Completed — No incidents to retry/i),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/\d+\s(rejected)/i)).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.test.tsx
@@ -125,4 +125,18 @@ describe('OperationEntryStatus', () => {
     expect(screen.getByText(/4 retries succeeded/i)).toBeInTheDocument();
     expect(screen.getByText(/2 rejected/i)).toBeInTheDocument();
   });
+
+  it('should render success instance status count when all counts are 0', () => {
+    render(
+      <OperationEntryStatus
+        type="RESOLVE_INCIDENT"
+        failedCount={0}
+        completedCount={0}
+        state="COMPLETED"
+      />,
+    );
+
+    expect(screen.getByText(/0 retries succeeded/i)).toBeInTheDocument();
+    expect(screen.queryByText(/\d+\s(rejected)/i)).not.toBeInTheDocument();
+  });
 });

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
@@ -66,13 +66,15 @@ const OperationEntryStatus: React.FC<Props> = ({
   completedCount = 0,
   state,
 }) => {
+  const isEmptyCompletion =
+    state === 'COMPLETED' && completedCount === 0 && failedCount === 0;
+
   return (
     <Stack gap={3}>
       {state === 'PARTIALLY_COMPLETED' && <PartiallyCompleted />}
       {state === 'FAILED' && <Failed />}
       <StatusContainer>
-        {completedCount > 0 ||
-        (completedCount === 0 && failedCount === 0 && state === 'COMPLETED') ? (
+        {completedCount > 0 || isEmptyCompletion ? (
           <>
             <CheckmarkFilled />
             <Text>{getSuccessMessage(type, completedCount)}</Text>

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
@@ -64,7 +64,8 @@ const OperationEntryStatus: React.FC<Props> = ({
       {state === 'PARTIALLY_COMPLETED' && <PartiallyCompleted />}
       {state === 'FAILED' && <Failed />}
       <StatusContainer>
-        {completedCount > 0 ? (
+        {completedCount > 0 ||
+        (completedCount === 0 && failedCount === 0 && state === 'COMPLETED') ? (
           <>
             <CheckmarkFilled />
             <Text>{getSuccessMessage(type, completedCount)}</Text>

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
@@ -28,7 +28,14 @@ const getSuccessMessage = (
   completedCount: number,
 ): string => {
   if (type === 'RESOLVE_INCIDENT') {
-    return `${completedCount} ${completedCount === 1 ? 'retry' : 'retries'} succeeded`;
+    switch (completedCount) {
+      case 0:
+        return 'Completed — No incidents to retry';
+      case 1:
+        return '1 retry succeeded';
+      default:
+        return `${completedCount} retries succeeded`;
+    }
   }
 
   return `${pluralSuffix(completedCount, 'operation')} succeeded`;

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
@@ -201,6 +201,7 @@ describe('OperationsEntry', () => {
       <OperationsEntry
         operation={{
           ...OPERATIONS.CANCEL_PROCESS_INSTANCE,
+          state: 'ACTIVE',
           endDate: undefined,
           operationsTotalCount: 10,
           operationsCompletedCount: 0,
@@ -232,6 +233,7 @@ describe('OperationsEntry', () => {
       <OperationsEntry
         operation={{
           ...OPERATIONS.CANCEL_PROCESS_INSTANCE,
+          state: 'ACTIVE',
           endDate: undefined,
           operationsTotalCount: 10,
           operationsCompletedCount: 5,
@@ -266,6 +268,7 @@ describe('OperationsEntry', () => {
       <OperationsEntry
         operation={{
           ...OPERATIONS.CANCEL_PROCESS_INSTANCE,
+          state: 'ACTIVE',
           endDate: undefined,
           operationsTotalCount: 5,
           operationsCompletedCount: 0,
@@ -320,6 +323,24 @@ describe('OperationsEntry', () => {
           operationsTotalCount: 8,
           operationsCompletedCount: 8,
           operationsFailedCount: 2,
+        }}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('should not show progress bar when operation is completed with 0', () => {
+    render(
+      <OperationsEntry
+        {...mockProps}
+        operation={{
+          ...OPERATIONS.CANCEL_PROCESS_INSTANCE,
+          endDate: '2023-11-22T09:03:29.564+0100',
+          operationsTotalCount: 0,
+          operationsCompletedCount: 0,
+          operationsFailedCount: 0,
         }}
       />,
       {wrapper: createWrapper()},

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
@@ -49,10 +49,10 @@ const OperationsEntry: React.FC<Props> = ({operation}) => {
     state,
   } = operation;
 
-  const {fakeProgressPercentage, isComplete} = useLoadingProgress({
+  const {fakeProgressPercentage, isVisuallyCompleted} = useLoadingProgress({
     totalCount: operationsTotalCount,
     processedCount: operationsCompletedCount + operationsFailedCount,
-    isFinished: endDate !== undefined,
+    isCompleted: !['CREATED', 'ACTIVE'].includes(state),
   });
 
   const label = TYPE_LABELS[batchOperationType];
@@ -85,7 +85,9 @@ const OperationsEntry: React.FC<Props> = ({operation}) => {
       >
         {batchOperationKey}
       </Link>
-      {!isComplete && <ProgressBar label="" value={fakeProgressPercentage} />}
+      {!isVisuallyCompleted && (
+        <ProgressBar label="" value={fakeProgressPercentage} />
+      )}
       <Details>
         <OperationEntryStatus
           type={batchOperationType}
@@ -93,7 +95,7 @@ const OperationsEntry: React.FC<Props> = ({operation}) => {
           completedCount={operationsCompletedCount}
           state={state}
         />
-        {endDate !== undefined && isComplete && (
+        {endDate !== undefined && isVisuallyCompleted && (
           <div>{formatDate(endDate)}</div>
         )}
       </Details>

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
@@ -52,7 +52,7 @@ const OperationsEntry: React.FC<Props> = ({operation}) => {
   const {fakeProgressPercentage, isVisuallyCompleted} = useLoadingProgress({
     totalCount: operationsTotalCount,
     processedCount: operationsCompletedCount + operationsFailedCount,
-    isCompleted: !['CREATED', 'ACTIVE'].includes(state),
+    isCompleted: state !== 'CREATED' && state !== 'ACTIVE',
   });
 
   const label = TYPE_LABELS[batchOperationType];

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/useLoadingProgress.ts
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/useLoadingProgress.ts
@@ -9,24 +9,24 @@
 import {useState, useRef, useEffect} from 'react';
 
 /**
- * Returns a (faked) progress percentage and an isComplete indicator
- * based on totalCount, completedCount and isFinished parameters.
+ * Returns a (faked) progress percentage and an isVisuallyCompleted indicator
+ * based on totalCount, processedCount and isCompleted parameters.
  *
- * isFinished means the operation itself is finished
- * isComplete is true when the visual progress has finished
+ * isCompleted is true when the operation itself is completed
+ * isVisuallyCompleted is true when the visual progress is completed
  */
 const useLoadingProgress = ({
   totalCount,
   processedCount,
-  isFinished,
+  isCompleted,
 }: {
   totalCount: number;
   processedCount: number;
-  isFinished: boolean;
+  isCompleted: boolean;
 }) => {
   const [fakeProgressPercentage, setFakeProgressPercentage] = useState(0);
-  const [isComplete, setIsComplete] = useState(isFinished);
-  const initialCompleteRef = useRef(isFinished);
+  const [isVisuallyCompleted, setIsVisuallyCompleted] = useState(isCompleted);
+  const initialCompleteRef = useRef(isCompleted);
   const fakeTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
   const completedTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fakeStartPercentage = 10;
@@ -64,10 +64,10 @@ const useLoadingProgress = ({
   }, [fakeProgressPercentage, totalCount, processedCount]);
 
   useEffect(() => {
-    if (isFinished && !initialCompleteRef.current && !isComplete) {
+    if (isCompleted && !initialCompleteRef.current && !isVisuallyCompleted) {
       setFakeProgressPercentage(100);
       completedTimeoutId.current = setTimeout(() => {
-        setIsComplete(true);
+        setIsVisuallyCompleted(true);
       }, 2000);
     }
 
@@ -77,9 +77,9 @@ const useLoadingProgress = ({
         completedTimeoutId.current = null;
       }
     };
-  }, [isFinished, isComplete]);
+  }, [isCompleted, isVisuallyCompleted]);
 
-  return {fakeProgressPercentage, isComplete};
+  return {fakeProgressPercentage, isVisuallyCompleted};
 };
 
 export {useLoadingProgress};


### PR DESCRIPTION
## Description

Shows "0 retries succeeded" in case a batch operation did not contain any incidents. 

<img width="478" height="131" alt="image" src="https://github.com/user-attachments/assets/6e16298a-3f32-4fa9-8ba2-541157affec8" />



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #38518 
