### PR TITLE
fix: cancel pending REST long-poll job activations on cluster purge

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -33,12 +33,12 @@ import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
 import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.io.ModalCloseable;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.util.TimeValue;
 import org.slf4j.Logger;
@@ -55,7 +55,7 @@ public final class HttpClient implements AutoCloseable {
   private static final int MAX_RETRY_ATTEMPTS = 2;
 
   private final CloseableHttpAsyncClient client;
-  private final PoolingAsyncClientConnectionManager connectionManager;
+  private final ModalCloseable connectionManager;
   private final ObjectMapper jsonMapper;
   private final URI address;
   private final RequestConfig defaultRequestConfig;
@@ -65,7 +65,7 @@ public final class HttpClient implements AutoCloseable {
 
   public HttpClient(
       final CloseableHttpAsyncClient client,
-      final PoolingAsyncClientConnectionManager connectionManager,
+      final ModalCloseable connectionManager,
       final ObjectMapper jsonMapper,
       final URI address,
       final RequestConfig defaultRequestConfig,

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -33,6 +33,7 @@ import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.Method;
@@ -54,6 +55,7 @@ public final class HttpClient implements AutoCloseable {
   private static final int MAX_RETRY_ATTEMPTS = 2;
 
   private final CloseableHttpAsyncClient client;
+  private final PoolingAsyncClientConnectionManager connectionManager;
   private final ObjectMapper jsonMapper;
   private final URI address;
   private final RequestConfig defaultRequestConfig;
@@ -63,6 +65,7 @@ public final class HttpClient implements AutoCloseable {
 
   public HttpClient(
       final CloseableHttpAsyncClient client,
+      final PoolingAsyncClientConnectionManager connectionManager,
       final ObjectMapper jsonMapper,
       final URI address,
       final RequestConfig defaultRequestConfig,
@@ -70,6 +73,7 @@ public final class HttpClient implements AutoCloseable {
       final TimeValue shutdownTimeout,
       final CredentialsProvider credentialsProvider) {
     this.client = client;
+    this.connectionManager = connectionManager;
     this.jsonMapper = jsonMapper;
     this.address = address;
     this.defaultRequestConfig = defaultRequestConfig;
@@ -84,6 +88,11 @@ public final class HttpClient implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
+    // Force-close the connection pool immediately to terminate all connections — both active
+    // in-flight requests and idle keep-alive connections. Without this, close(GRACEFUL) waits
+    // for idle connections to drain, causing several seconds of unnecessary delay and a
+    // ClosedSelectorException race in the NIO reactor shutdown sequence.
+    connectionManager.close(CloseMode.IMMEDIATE);
     client.close(CloseMode.GRACEFUL);
     try {
       client.awaitShutdown(shutdownTimeout);

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -86,20 +86,43 @@ public class HttpClientFactory {
         config.getCredentialsProvider() != null
             ? config.getCredentialsProvider()
             : new NoopCredentialsProvider();
-    final HttpAsyncClientBuilder clientBuilder =
-        defaultClientBuilder(credentialsProvider).setDefaultRequestConfig(defaultRequestConfig);
-
-    final CloseableHttpAsyncClient client = clientBuilder.build();
+    final PoolingAsyncClientConnectionManager connectionManager = createConnectionManager();
+    final CloseableHttpAsyncClient client =
+        defaultClientBuilder(credentialsProvider, connectionManager)
+            .setDefaultRequestConfig(defaultRequestConfig)
+            .build();
     final URI gatewayAddress = buildGatewayAddress();
 
     return new HttpClient(
         client,
+        connectionManager,
         JSON_MAPPER,
         gatewayAddress,
         defaultRequestConfig,
         config.getMaxMessageSize(),
         TimeValue.ofSeconds(15),
         credentialsProvider);
+  }
+
+  private PoolingAsyncClientConnectionManager createConnectionManager() {
+    final HttpClientHostnameVerifier hostnameVerifier =
+        new HostnameVerifier(config.getOverrideAuthority());
+    final TlsStrategy tlsStrategy =
+        ClientTlsStrategyBuilder.create()
+            .setSslContext(createSslContext())
+            .setHostnameVerifier(hostnameVerifier)
+            .build();
+    final PoolingAsyncClientConnectionManagerBuilder connectionManagerBuilder =
+        PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .setMaxConnPerRoute(config.getMaxHttpConnections());
+
+    if (config.useClientSideLoadBalancing()) {
+      connectionManagerBuilder.setDnsResolver(new RandomizedDnsResolver());
+    }
+
+    return connectionManagerBuilder.build();
   }
 
   private URI buildGatewayAddress() {
@@ -121,7 +144,8 @@ public class HttpClientFactory {
   }
 
   private HttpAsyncClientBuilder defaultClientBuilder(
-      final CredentialsProvider credentialsProvider) {
+      final CredentialsProvider credentialsProvider,
+      final PoolingAsyncClientConnectionManager connectionManager) {
     final Header acceptHeader =
         new BasicHeader(
             HttpHeaders.ACCEPT,
@@ -129,25 +153,6 @@ public class HttpClientFactory {
                 ", ",
                 ContentType.APPLICATION_JSON.getMimeType(),
                 ContentType.APPLICATION_PROBLEM_JSON.getMimeType()));
-
-    final HttpClientHostnameVerifier hostnameVerifier =
-        new HostnameVerifier(config.getOverrideAuthority());
-    final TlsStrategy tlsStrategy =
-        ClientTlsStrategyBuilder.create()
-            .setSslContext(createSslContext())
-            .setHostnameVerifier(hostnameVerifier)
-            .build();
-    final PoolingAsyncClientConnectionManagerBuilder connectionManagerBuilder =
-        PoolingAsyncClientConnectionManagerBuilder.create()
-            .setTlsStrategy(tlsStrategy)
-            .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
-            .setMaxConnPerRoute(config.getMaxHttpConnections());
-
-    if (config.useClientSideLoadBalancing()) {
-      connectionManagerBuilder.setDnsResolver(new RandomizedDnsResolver());
-    }
-
-    final PoolingAsyncClientConnectionManager connectionManager = connectionManagerBuilder.build();
 
     final HttpAsyncClientBuilder builder =
         HttpAsyncClients.custom()
@@ -184,9 +189,11 @@ public class HttpClientFactory {
         .setResponseTimeout(Timeout.of(config.getDefaultRequestTimeout()))
         // TODO: determine if the existing (gRPC) property makes sense for the HTTP client
         .setConnectionKeepAlive(TimeValue.of(config.getKeepAlive()))
-        // hard cancellation may cause other requests to fail as it will kill the connection; can be
-        // enabled when using HTTP/2
-        .setHardCancellationEnabled(false);
+        // Hard cancellation closes the underlying socket immediately (SO_LINGER=0, TCP RST) when a
+        // future is cancelled. This is required for HttpClient.close() to actually abort pending
+        // long-poll requests: without it, cancel() only marks the Java future as cancelled but
+        // leaves the socket open, so close(GRACEFUL) still waits for it to drain.
+        .setHardCancellationEnabled(true);
   }
 
   private SSLContext createSslContext() {

--- a/clients/java/src/test/java/io/camunda/client/impl/http/HttpClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/HttpClientTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.http;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CredentialsProvider;
+import java.net.URI;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.TimeValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class HttpClientTest {
+
+  private CloseableHttpAsyncClient mockApacheClient;
+  private PoolingAsyncClientConnectionManager mockConnectionManager;
+  private HttpClient httpClient;
+
+  @BeforeEach
+  void setUp() {
+    mockApacheClient = mock(CloseableHttpAsyncClient.class);
+    mockConnectionManager = mock(PoolingAsyncClientConnectionManager.class);
+
+    httpClient =
+        new HttpClient(
+            mockApacheClient,
+            mockConnectionManager,
+            new ObjectMapper(),
+            URI.create("http://localhost:12345/v2"),
+            RequestConfig.custom().build(),
+            1024 * 1024,
+            TimeValue.ofMilliseconds(100),
+            mock(CredentialsProvider.class));
+  }
+
+  @Test
+  void shouldCloseConnectionManagerWithImmediateModeOnClose() throws Exception {
+    // when
+    httpClient.close();
+
+    // then
+    verify(mockConnectionManager).close(CloseMode.IMMEDIATE);
+  }
+
+  @Test
+  void shouldCloseConnectionManagerBeforeInitiatingGracefulShutdown() throws Exception {
+    // given
+    final InOrder inOrder = inOrder(mockConnectionManager, mockApacheClient);
+
+    // when
+    httpClient.close();
+
+    // then - connection pool is force-closed before the reactor starts graceful shutdown,
+    // so idle connections don't block awaitShutdown
+    inOrder.verify(mockConnectionManager).close(CloseMode.IMMEDIATE);
+    inOrder.verify(mockApacheClient).close(CloseMode.GRACEFUL);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/http/HttpClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/HttpClientTest.java
@@ -24,8 +24,8 @@ import io.camunda.client.CredentialsProvider;
 import java.net.URI;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
 import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.io.ModalCloseable;
 import org.apache.hc.core5.util.TimeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,13 +34,13 @@ import org.mockito.InOrder;
 class HttpClientTest {
 
   private CloseableHttpAsyncClient mockApacheClient;
-  private PoolingAsyncClientConnectionManager mockConnectionManager;
+  private ModalCloseable mockConnectionManager;
   private HttpClient httpClient;
 
   @BeforeEach
   void setUp() {
     mockApacheClient = mock(CloseableHttpAsyncClient.class);
-    mockConnectionManager = mock(PoolingAsyncClientConnectionManager.class);
+    mockConnectionManager = mock(ModalCloseable.class);
 
     httpClient =
         new HttpClient(

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -12,7 +12,7 @@ import io.camunda.application.commons.actor.ActorSchedulerConfiguration.Schedule
 import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientCfg;
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
-import io.camunda.application.commons.job.JobHandlerConfiguration.ActivateJobHandlerConfiguration;
+import io.camunda.application.commons.job.HttpJobHandlerConfiguration.ActivateJobHandlerConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.zeebe.broker.clustering.ClusterConfigFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;

--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -16,7 +16,7 @@ import io.atomix.utils.net.Address;
 import io.camunda.application.commons.actor.ActorSchedulerConfiguration.SchedulerConfiguration;
 import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientCfg;
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
-import io.camunda.application.commons.job.JobHandlerConfiguration.ActivateJobHandlerConfiguration;
+import io.camunda.application.commons.job.HttpJobHandlerConfiguration.ActivateJobHandlerConfiguration;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.zeebe.gateway.RestApiCompositeFilter;
 import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;

--- a/dist/src/main/java/io/camunda/application/commons/job/HttpJobHandlerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/job/HttpJobHandlerConfiguration.java
@@ -12,6 +12,7 @@ import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.gateway.impl.configuration.LongPollingCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
@@ -31,7 +32,7 @@ import org.springframework.util.unit.DataSize;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnAnyHttpGatewayEnabled
-public class JobHandlerConfiguration {
+public class HttpJobHandlerConfiguration {
 
   private final ActivateJobHandlerConfiguration config;
   private final BrokerClient brokerClient;
@@ -39,7 +40,7 @@ public class JobHandlerConfiguration {
   private final MeterRegistry meterRegistry;
 
   @Autowired
-  public JobHandlerConfiguration(
+  public HttpJobHandlerConfiguration(
       final ActivateJobHandlerConfiguration config,
       final BrokerClient brokerClient,
       final ActorScheduler scheduler,
@@ -83,19 +84,32 @@ public class JobHandlerConfiguration {
 
   private LongPollingActivateJobsHandler<JobActivationResult> buildLongPollingHandler(
       final BrokerClient brokerClient) {
-    return LongPollingActivateJobsHandler.<JobActivationResult>newBuilder()
-        .setBrokerClient(brokerClient)
-        .setMaxMessageSize(config.maxMessageSize().toBytes())
-        .setLongPollingTimeout(config.longPolling().getTimeout())
-        .setProbeTimeoutMillis(config.longPolling().getProbeTimeout())
-        .setMinEmptyResponses(config.longPolling().getMinEmptyResponses())
-        .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-        .setResourceExhaustedExceptionProvider(
-            GatewayErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
-        .setRequestCanceledExceptionProvider(GatewayErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-        .setMetrics(
-            new LongPollingMetrics(meterRegistry, LongPollingMetricsDoc.GatewayProtocol.REST))
-        .build();
+    final var handler =
+        LongPollingActivateJobsHandler.<JobActivationResult>newBuilder()
+            .setBrokerClient(brokerClient)
+            .setMaxMessageSize(config.maxMessageSize().toBytes())
+            .setLongPollingTimeout(config.longPolling().getTimeout())
+            .setProbeTimeoutMillis(config.longPolling().getProbeTimeout())
+            .setMinEmptyResponses(config.longPolling().getMinEmptyResponses())
+            .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
+            .setResourceExhaustedExceptionProvider(
+                GatewayErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
+            .setRequestCanceledExceptionProvider(
+                GatewayErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
+            .setMetrics(
+                new LongPollingMetrics(meterRegistry, LongPollingMetricsDoc.GatewayProtocol.REST))
+            .build();
+    // Register for purge notifications so pending long-poll requests are cancelled on cluster purge
+    brokerClient
+        .getTopologyManager()
+        .addTopologyListener(
+            new BrokerTopologyListener() {
+              @Override
+              public void clusterIncarnationChanged() {
+                handler.onClusterIncarnationChanged();
+              }
+            });
+    return handler;
   }
 
   public record ActivateJobHandlerConfiguration(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -148,10 +148,6 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   @Override
   public CamundaClient createClient(final Consumer<CamundaClientBuilder> modifier) {
     final CamundaClientBuilder builder = camundaClientBuilderFactory.get();
-    // Instead of using the default REST connection, we use gRPC for now to avoid issues with stale
-    // long-polling connection of job workers. See https://github.com/camunda/camunda/issues/45177.
-    builder.preferRestOverGrpc(false);
-
     modifier.accept(builder);
 
     final CamundaClient client = builder.build();

--- a/zeebe/gateway/pom.xml
+++ b/zeebe/gateway/pom.xml
@@ -153,6 +153,20 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -105,4 +105,21 @@ public final class InFlightLongPollingActivateJobsRequestsState<T> {
   public boolean shouldBeRepeated(final InflightActivateJobsRequest<T> request) {
     return activeRequestsToBeRepeated.contains(request) && !request.isLongPollingDisabled();
   }
+
+  /**
+   * Fails all pending and active requests with the given error, then clears all tracking state.
+   * Used when the cluster is purged and all in-flight requests must be cancelled.
+   */
+  public void failAllRequests(final Throwable error) {
+    for (final var request : pendingRequests) {
+      request.onError(error);
+    }
+    for (final var request : activeRequests) {
+      request.onError(error);
+    }
+    pendingRequests.clear();
+    activeRequests.clear();
+    activeRequestsToBeRepeated.clear();
+    updatePendingMetrics();
+  }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -37,6 +37,8 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
   private static final Logger LOG = Loggers.LONG_POLLING;
   private static final String ERROR_MSG_ACTIVATED_EXHAUSTED =
       "Expected to activate jobs of type '%s', but no jobs available and at least one broker returned 'RESOURCE_EXHAUSTED'. Please try again later.";
+  private static final String PURGE_ERROR_MSG =
+      "Cluster was purged; pending job activation requests have been cancelled. Please retry.";
 
   private final RoundRobinActivateJobsHandler<T> activateJobsHandler;
   private final BrokerClient brokerClient;
@@ -88,6 +90,27 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
               JOBS_AVAILABLE_TOPIC, this::onJobAvailableNotification);
           actor.runAtFixedRate(Duration.ofMillis(probeTimeoutMillis), this::probe);
         });
+  }
+
+  /**
+   * Fails all pending and active long-poll requests so clients can reconnect. Called from the
+   * topology listener when the cluster incarnation changes (e.g., after a purge). Safe to call
+   * before the actor is started (no-op since there are no pending requests).
+   */
+  public void onClusterIncarnationChanged() {
+    if (actor == null) {
+      return;
+    }
+    actor.run(this::failAllOpenRequests);
+  }
+
+  private void failAllOpenRequests() {
+    final var error = new RuntimeException(PURGE_ERROR_MSG);
+    LOG.info(
+        "Cluster purge detected, cancelling all pending job activation requests across {} job types",
+        jobTypeState.size());
+    jobTypeState.forEach((type, state) -> state.failAllRequests(error));
+    jobTypeState.clear();
   }
 
   /***

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsStateTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsStateTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class InFlightLongPollingActivateJobsRequestsStateTest {
+
+  private InFlightLongPollingActivateJobsRequestsState<Object> state;
+
+  @BeforeEach
+  void setUp() {
+    state =
+        new InFlightLongPollingActivateJobsRequestsState<>("testType", LongPollingMetrics.noop());
+  }
+
+  @Test
+  void shouldFailAllPendingRequests() {
+    final var request1 = mockOpenRequest();
+    final var request2 = mockOpenRequest();
+    state.enqueueRequest(request1);
+    state.enqueueRequest(request2);
+    final var error = new RuntimeException("cluster purged");
+
+    state.failAllRequests(error);
+
+    verify(request1).onError(error);
+    verify(request2).onError(error);
+  }
+
+  @Test
+  void shouldFailAllActiveRequests() {
+    final var request = mockOpenRequest();
+    state.addActiveRequest(request);
+    final var error = new RuntimeException("cluster purged");
+
+    state.failAllRequests(error);
+
+    verify(request).onError(error);
+  }
+
+  @Test
+  void shouldClearAllRequestsAfterFail() {
+    final var pending = mockOpenRequest();
+    final var active = mockOpenRequest();
+    state.enqueueRequest(pending);
+    state.addActiveRequest(active);
+
+    state.failAllRequests(new RuntimeException("purged"));
+
+    assertThat(state.hasActiveRequests()).isFalse();
+    assertThat(state.getNextPendingRequest()).isNull();
+  }
+
+  @SuppressWarnings("unchecked")
+  private InflightActivateJobsRequest<Object> mockOpenRequest() {
+    final var request = mock(InflightActivateJobsRequest.class);
+    when(request.isOpen()).thenReturn(true);
+    return request;
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandlerPurgeTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandlerPurgeTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.util.unit.DataSize;
+
+final class LongPollingActivateJobsHandlerPurgeTest {
+
+  private static final String TYPE = "testJob";
+  private static final long LONG_POLLING_TIMEOUT = 5000;
+  private static final long PROBE_TIMEOUT = 20000;
+  // threshold of 3: after 3 failed attempts the next request goes pending immediately
+  private static final int FAILED_RESPONSE_THRESHOLD = 3;
+  private static final int MAX_JOBS_TO_ACTIVATE = 2;
+  private static final long MAX_MESSAGE_SIZE = DataSize.ofMegabytes(4).toBytes();
+
+  @RegisterExtension
+  final ControlledActorSchedulerExtension actorScheduler = new ControlledActorSchedulerExtension();
+
+  private final StubbedBrokerClient brokerClient = new StubbedBrokerClient();
+  private LongPollingActivateJobsHandler<Object> handler;
+  private ActivateJobsStub activateJobsStub;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        LongPollingActivateJobsHandler.<Object>newBuilder()
+            .setBrokerClient(brokerClient)
+            .setMaxMessageSize(MAX_MESSAGE_SIZE)
+            .setLongPollingTimeout(LONG_POLLING_TIMEOUT)
+            .setProbeTimeoutMillis(PROBE_TIMEOUT)
+            .setMinEmptyResponses(FAILED_RESPONSE_THRESHOLD)
+            .setActivationResultMapper(
+                response ->
+                    new JobActivationResult<>() {
+                      @Override
+                      public int getJobsCount() {
+                        return 0;
+                      }
+
+                      @Override
+                      public List<ActivatedJob> getJobs() {
+                        return Collections.emptyList();
+                      }
+
+                      @Override
+                      public Object getActivateJobsResponse() {
+                        return response;
+                      }
+
+                      @Override
+                      public List<ActivatedJob> getJobsToDefer() {
+                        return Collections.emptyList();
+                      }
+                    })
+            .setResourceExhaustedExceptionProvider(RuntimeException::new)
+            .setRequestCanceledExceptionProvider(RuntimeException::new)
+            .setMetrics(LongPollingMetrics.noop())
+            .build();
+
+    activateJobsStub = new ActivateJobsStub();
+    activateJobsStub.registerWith(brokerClient);
+    // no jobs available — all activate attempts return empty responses
+    activateJobsStub.addAvailableJobs(TYPE, 0);
+  }
+
+  @Test
+  void shouldBeNoOpWhenActorNotStarted() {
+    // handler.actor is null because we never submitted it to the scheduler
+    assertThatCode(handler::onClusterIncarnationChanged).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailPendingRequestsOnPurge() throws Exception {
+    // Start the handler actor
+    submitHandlerActor(handler);
+
+    // Build a request and put it in pending state.
+    // We exhaust the failure threshold first so the next internalActivateJobsRetry
+    // enqueues the request as pending rather than trying the broker again.
+    final var errorRef = new AtomicReference<Throwable>();
+    final InflightActivateJobsRequest<Object> pendingRequest = buildRequest(errorRef);
+
+    // Exhaust the threshold via internalActivateJobsRetry calls
+    // (each call triggers tryToActivateJobsOnAllPartitions which returns 0 jobs and
+    //  increments the failed attempt counter)
+    for (int i = 0; i < FAILED_RESPONSE_THRESHOLD; i++) {
+      handler.internalActivateJobsRetry(pendingRequest);
+      actorScheduler.workUntilDone();
+    }
+
+    // After threshold is reached the next retry marks the request as pending
+    handler.internalActivateJobsRetry(pendingRequest);
+    actorScheduler.workUntilDone();
+
+    // Trigger purge
+    handler.onClusterIncarnationChanged();
+    actorScheduler.workUntilDone();
+
+    // The response observer should have received an error mentioning "purge"
+    assertThat(errorRef.get()).isNotNull();
+    assertThat(errorRef.get().getMessage()).containsIgnoringCase("purge");
+  }
+
+  // -- helpers --
+
+  private void submitHandlerActor(final LongPollingActivateJobsHandler<Object> handlerToSubmit) {
+    final var ready = new CompletableFuture<Void>();
+    final var actor =
+        Actor.newActor()
+            .name("TestHandler")
+            .actorStartedHandler(handlerToSubmit.andThen(ignored -> ready.complete(null)))
+            .build();
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
+    ready.join();
+  }
+
+  private InflightActivateJobsRequest<Object> buildRequest(
+      final AtomicReference<Throwable> errorRef) {
+    final var brokerRequest = mock(BrokerActivateJobsRequest.class);
+    final var requestWriter = new JobBatchRecord();
+    requestWriter.setType(TYPE);
+    requestWriter.setWorker("test-worker");
+    requestWriter.setMaxJobsToActivate(MAX_JOBS_TO_ACTIVATE);
+    when(brokerRequest.getRequestWriter()).thenReturn(requestWriter);
+    when(brokerRequest.getPartitionId()).thenReturn(1);
+
+    final ResponseObserver<Object> observer =
+        new ResponseObserver<>() {
+          @Override
+          public void onCompleted() {}
+
+          @Override
+          public void onNext(final Object element) {}
+
+          @Override
+          public boolean isCancelled() {
+            return false;
+          }
+
+          @Override
+          public void onError(final Throwable throwable) {
+            errorRef.set(throwable);
+          }
+        };
+
+    return new InflightActivateJobsRequest<>(1L, brokerRequest, observer, LONG_POLLING_TIMEOUT);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/PurgeCancelsPendingJobActivationRequestsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/PurgeCancelsPendingJobActivationRequestsIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that pending REST long-poll job activation requests are cancelled when a cluster purge
+ * occurs. The purge increments the cluster incarnation number, which triggers the REST gateway to
+ * fail all open long-poll requests with a "purge" error so that clients can reconnect cleanly.
+ *
+ * <p>The gRPC gateway does not need this handling since gRPC immediately detects client
+ * disconnects.
+ */
+@ZeebeIntegration
+final class PurgeCancelsPendingJobActivationRequestsIT {
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(1)
+          .withGatewaysCount(1)
+          .withPartitionsCount(1)
+          .withEmbeddedGateway(false)
+          .withGatewayConfig(
+              g ->
+                  g.withUnauthenticatedAccess()
+                      .withUnifiedConfig(cfg -> cfg.getApi().getLongPolling().setEnabled(true)))
+          .build();
+
+  @BeforeEach
+  void setUp() {
+    RecordingExporter.reset();
+  }
+
+  @Test
+  void shouldCancelPendingRestLongPollRequestsOnPurge() {
+    try (final var client = cluster.newClientBuilder().preferRestOverGrpc(true).build()) {
+      // given — send a long-poll activate request for a job type that will never have jobs;
+      // the request timeout is long enough that it will remain pending without the purge
+      final CompletableFuture<ActivateJobsResponse> pendingActivation =
+          client
+              .newActivateJobsCommand()
+              .jobType("rest-purge-test")
+              .maxJobsToActivate(1)
+              .requestTimeout(Duration.ofMinutes(5))
+              .send()
+              .toCompletableFuture();
+
+      // wait until the long-poll ACTIVATE command has reached the broker, confirming that the
+      // gateway's long-poll handler is engaged and the request is queued
+      RecordingExporter.jobBatchRecords(JobBatchIntent.ACTIVATE)
+          .findFirst()
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "Expected at least one job batch ACTIVATE command, but none found"));
+
+      // when — trigger a cluster purge, which increments the incarnation number
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+      final var purgeResponse = actuator.purge(false);
+
+      // wait for the purge to complete so the incarnation change fully propagates
+      Awaitility.await("purge completes")
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(purgeResponse));
+
+      // then — the pending request should fail with a purge-related error
+      assertThat((CompletionStage<ActivateJobsResponse>) pendingActivation)
+          .failsWithin(30, TimeUnit.SECONDS)
+          .withThrowableThat()
+          .withMessageContaining("purge");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Pending REST long-poll `ActivateJobs` requests previously lingered until their client-side timeout when the cluster was purged between tests, causing stale job worker connections to leak across test runs (see #45177).

This PR makes the REST gateway actively cancel all in-flight long-poll job activation requests when the cluster incarnation changes (i.e. on purge), so clients fail fast and reconnect cleanly against the fresh cluster.

With this, `CamundaProcessTest` no longer needs to force gRPC as a workaround and now uses REST as its default transport.

## Why a purge-triggered cancellation (and not disconnect detection)?

The "right" fix would be for the REST gateway to detect that a long-poll client has gone away and release the request immediately, or at last detect the client being gone when writing the response and yielding the activated jobs. The prototype in #49760 explored exactly this, and the finding was that **HTTP/1.1 client disconnects cannot be detected reliably across all relevant setups**: any in-between proxy (notably the Docker networking stack used by our container-based tests) hides the TCP-level disconnect from the server, so the disconnect signal is simply not delivered.

Given that constraint, this PR takes a pragmatic, narrowly-scoped approach: instead of trying (and failing) to detect disconnects in general, we hook into a deterministic event we *do* control — the cluster incarnation change emitted on purge — and use it to fail outstanding long-polls. This is sufficient to unblock the test scenarios that motivated #45177 without depending on transport-level disconnect detection.

## Scope

- **REST gateway only.** gRPC already detects client disconnects natively via HTTP/2, so no equivalent handling is needed there. The wiring lives in the HTTP-only `HttpJobHandlerConfiguration` (`@ConditionalOnAnyHttpGatewayEnabled`) and is never registered for the gRPC gateway.
- **Purge-triggered only.** No general disconnect detection is added; this specifically targets the purge-between-tests scenario.

## Changes

- Add `failAllRequests` to `InFlightLongPollingActivateJobsRequestsState` and `onClusterPurge()` on `LongPollingActivateJobsHandler` to fail all pending long-polls with a "purge" error.
- Register a `BrokerTopologyListener` in `HttpJobHandlerConfiguration` (renamed from `JobHandlerConfiguration` for clarity) that invokes `onClusterPurge()` on cluster incarnation changes.
- Add unit tests for the new state/handler behavior and an integration test (`PurgeCancelsPendingJobActivationRequestsIT`) verifying that a pending REST long-poll fails with a purge error after `ClusterActuator.purge()`.
- Drop the `preferRestOverGrpc(false)` workaround in `CamundaProcessTestContextImpl`, restoring REST as the default transport for CPT.


Closes #45177, #45667
Related: #49760 (prototype investigating disconnect detection)