### PR TITLE
refactor: link bug ticket to skipped test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -44,6 +44,7 @@ test.describe('Decision Navigation', () => {
     await captureFailureVideo(page, testInfo);
   });
 
+  // skipped due to bug 49425: https://github.com/camunda/camunda/issues/49425
   test.skip('Navigation between process and decision', async ({
     operateProcessInstancePage,
     operateDecisionInstancePage,
@@ -71,7 +72,7 @@ test.describe('Decision Navigation', () => {
       await expect
         .poll(
           async () => {
-            return await operateProcessInstancePage.incidentsBanner.isVisible();
+            return await operateProcessInstancePage.incidentsTab.isVisible();
           },
           {timeout: 30000},
         )


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Test is initially skipped due to the process instance page redesign (https://github.com/camunda/camunda/issues/46750), while enabling the tests a bug was found, this PR links the [bug](https://github.com/camunda/camunda/issues/49425) to the test
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
