### PR TITLE
ci: fix pagination in case of many jobs with errors

### DIFF
--- a/.github/actions/post-ci-failure-reasons/action.yml
+++ b/.github/actions/post-ci-failure-reasons/action.yml
@@ -57,9 +57,11 @@ runs:
 
         # Get all jobs from the current workflow run
         JOBS_JSON=$(gh api \
+          --paginate \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100")
+          "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
+          | jq -s '{jobs: map(.jobs) | add}')
 
         # Filter unsuccessful jobs (failure, cancelled)
         UNSUCCESSFUL_JOBS=$(echo "$JOBS_JSON" | jq -r '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .id')
@@ -89,9 +91,11 @@ runs:
 
           # Get annotations for this job
           ANNOTATIONS=$(gh api \
+            --paginate \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${{ github.repository }}/check-runs/$JOB_ID/annotations?per_page=100")
+            "/repos/${{ github.repository }}/check-runs/$JOB_ID/annotations?per_page=100" \
+            | jq -s 'add')
 
           HAS_PRIORITY_CANCELLATION=$(echo "$ANNOTATIONS" | jq -sR '
             try (


### PR DESCRIPTION
## Description

I discovered in https://github.com/camunda/camunda/pull/49323 that without this fix not all annotations where displayed. Since only the first 100 checks of each run got analyzed, depending on the order some failing jobs could be missed -> not all annotations displayed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
