### PR TITLE
[Backport stable/8.9] fix: add processDefinitionId filtering to InstancesTable and update audit-log schema

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.52",
+        "@camunda/camunda-api-zod-schemas": "0.0.54",
         "@camunda/camunda-composite-components": "0.22.5",
         "@carbon/elements": "11.84.0",
         "@carbon/react": "1.100.0",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.52.tgz",
-      "integrity": "sha512-pknZawq9X+piz5T2iOhzRq/S+7VEiQN0kV2be0nEGKrw71dnwitZs710jArfDjFE7OtUCSInwfZ636J3AOVOsw==",
+      "version": "0.0.54",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.54.tgz",
+      "integrity": "sha512-adtpSoFLSXFhzdKh2y7W7BHxOAL3ibQShSw1SsTOSuXSvb8j/NqBC6LmYJt5+Kk7Ci+KeT3xyFo5accbkK/6jQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.52",
+    "@camunda/camunda-api-zod-schemas": "0.0.54",
     "@camunda/camunda-composite-components": "0.22.5",
     "@carbon/elements": "11.84.0",
     "@carbon/react": "1.100.0",

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -128,6 +128,12 @@ const InstancesTable: React.FC = observer(() => {
       filter: {
         category: {$neq: 'ADMIN'},
         processDefinitionKey: selectedProcessDefinition?.processDefinitionKey,
+        processDefinitionId:
+          filterValues.processDefinitionId &&
+          (!filterValues.processDefinitionVersion ||
+            filterValues.processDefinitionVersion === 'all')
+            ? filterValues.processDefinitionId
+            : undefined,
         processInstanceKey: filterValues.processInstanceKey,
         tenantId: selectedTenantId,
         operationType: filterValues.operationType


### PR DESCRIPTION
# Description
Backport of #49408 to `stable/8.9`.

relates to camunda/camunda#49391