### PR TITLE
refactor: align embedding model providers with those of judge

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/JudgeProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/JudgeProperties.java
@@ -29,7 +29,6 @@ import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.api.judge.ProviderConfig;
 import io.camunda.process.test.impl.judge.BaseProviderConfig;
 import java.time.Duration;
-import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -89,7 +88,8 @@ public class JudgeProperties {
     chatModelRegion = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_REGION);
     chatModelEndpoint = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_ENDPOINT);
     chatModelHeaders = getPropertyMapOrEmpty(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_HEADERS);
-    chatModelTimeout = parseTimeout(properties);
+    chatModelTimeout =
+        getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_TIMEOUT, Duration::parse);
     chatModelTemperature =
         getPropertyOrNull(
             properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_TEMPERATURE, Double::parseDouble);
@@ -158,18 +158,5 @@ public class JudgeProperties {
       config.setTemperature(chatModelTemperature);
     }
     return config;
-  }
-
-  private Duration parseTimeout(final Properties properties) {
-    final String raw = getPropertyOrNull(properties, PROPERTY_NAME_JUDGE_CHAT_MODEL_TIMEOUT);
-    if (raw == null) {
-      return null;
-    }
-    try {
-      return Duration.parse(raw);
-    } catch (final DateTimeParseException e) {
-      throw new IllegalArgumentException(
-          "judge.chatModel.timeout must be a valid ISO-8601 duration (e.g. PT30S), was: " + raw, e);
-    }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityProperties.java
@@ -172,6 +172,7 @@ public class SemanticSimilarityProperties {
         return new BaseProviderConfig.AmazonBedrockConfig(
             embeddingModelModel,
             embeddingModelRegion,
+            embeddingModelApiKey,
             embeddingModelCredentialsAccessKey,
             embeddingModelCredentialsSecretKey,
             embeddingModelNormalize,

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityProperties.java
@@ -150,10 +150,7 @@ public class SemanticSimilarityProperties {
     switch (normalized) {
       case PROVIDER_OPENAI:
         return new BaseProviderConfig.OpenAiConfig(
-            embeddingModelModel,
-            embeddingModelApiKey,
-            embeddingModelDimensions,
-            embeddingModelHeaders);
+            embeddingModelModel, embeddingModelApiKey, embeddingModelDimensions);
       case PROVIDER_OPENAI_COMPATIBLE:
         return new BaseProviderConfig.OpenAiCompatibleConfig(
             embeddingModelModel,
@@ -166,8 +163,7 @@ public class SemanticSimilarityProperties {
             embeddingModelModel,
             embeddingModelEndpoint,
             embeddingModelApiKey,
-            embeddingModelDimensions,
-            embeddingModelHeaders);
+            embeddingModelDimensions);
       case PROVIDER_AMAZON_BEDROCK:
         return new BaseProviderConfig.AmazonBedrockConfig(
             embeddingModelModel,

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityProperties.java
@@ -151,9 +151,7 @@ public class SemanticSimilarityProperties {
     final BaseProviderConfig config;
     switch (normalized) {
       case PROVIDER_OPENAI:
-        config =
-            new BaseProviderConfig.OpenAiConfig(
-                embeddingModelModel, embeddingModelApiKey, embeddingModelDimensions);
+        config = new BaseProviderConfig.OpenAiConfig(embeddingModelModel, embeddingModelApiKey);
         break;
       case PROVIDER_OPENAI_COMPATIBLE:
         config =
@@ -161,16 +159,12 @@ public class SemanticSimilarityProperties {
                 embeddingModelModel,
                 embeddingModelBaseUrl,
                 embeddingModelApiKey,
-                embeddingModelDimensions,
                 embeddingModelHeaders);
         break;
       case PROVIDER_AZURE_OPENAI:
         config =
             new BaseProviderConfig.AzureOpenAiConfig(
-                embeddingModelModel,
-                embeddingModelEndpoint,
-                embeddingModelApiKey,
-                embeddingModelDimensions);
+                embeddingModelModel, embeddingModelEndpoint, embeddingModelApiKey);
         break;
       case PROVIDER_AMAZON_BEDROCK:
         config =
@@ -180,14 +174,16 @@ public class SemanticSimilarityProperties {
                 embeddingModelApiKey,
                 embeddingModelCredentialsAccessKey,
                 embeddingModelCredentialsSecretKey,
-                embeddingModelNormalize,
-                embeddingModelDimensions);
+                embeddingModelNormalize);
         break;
       default:
         config =
             new BaseProviderConfig.GenericConfig(
                 normalized, embeddingModelModel, embeddingModelCustomProperties);
         break;
+    }
+    if (embeddingModelDimensions != null) {
+      config.setDimensions(embeddingModelDimensions);
     }
     if (embeddingModelTimeout != null) {
       config.setTimeout(embeddingModelTimeout);

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityProperties.java
@@ -27,6 +27,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import io.camunda.process.test.api.similarity.ProviderConfig;
 import io.camunda.process.test.api.similarity.SemanticSimilarityConfig;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 
@@ -57,6 +58,8 @@ public class SemanticSimilarityProperties {
       "similarity.preprocessors.defaults-enabled";
   public static final String PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_NORMALIZE =
       "similarity.embeddingModel.normalize";
+  public static final String PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_TIMEOUT =
+      "similarity.embeddingModel.timeout";
   public static final String PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_CUSTOM_PROPERTIES_PREFIX =
       "similarity.embeddingModel.customProperties";
 
@@ -75,6 +78,7 @@ public class SemanticSimilarityProperties {
   private final Map<String, String> embeddingModelHeaders;
   private final boolean defaultPreprocessorsEnabled;
   private final Boolean embeddingModelNormalize;
+  private final Duration embeddingModelTimeout;
   private final Map<String, String> embeddingModelCustomProperties;
 
   public SemanticSimilarityProperties(final Properties properties) {
@@ -106,11 +110,8 @@ public class SemanticSimilarityProperties {
     embeddingModelEndpoint =
         getPropertyOrNull(properties, PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_ENDPOINT);
     embeddingModelDimensions =
-        getPropertyOrDefault(
-            properties,
-            PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_DIMENSIONS,
-            Integer::parseInt,
-            null);
+        getPropertyOrNull(
+            properties, PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_DIMENSIONS, Integer::parseInt);
     embeddingModelHeaders =
         getPropertyMapOrEmpty(properties, PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_HEADERS);
     defaultPreprocessorsEnabled =
@@ -120,11 +121,11 @@ public class SemanticSimilarityProperties {
             Boolean::parseBoolean,
             true);
     embeddingModelNormalize =
-        getPropertyOrDefault(
-            properties,
-            PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_NORMALIZE,
-            Boolean::parseBoolean,
-            null);
+        getPropertyOrNull(
+            properties, PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_NORMALIZE, Boolean::parseBoolean);
+    embeddingModelTimeout =
+        getPropertyOrNull(
+            properties, PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_TIMEOUT, Duration::parse);
     embeddingModelCustomProperties =
         getPropertyMapOrEmpty(
             properties, PROPERTY_NAME_SIMILARITY_EMBEDDING_MODEL_CUSTOM_PROPERTIES_PREFIX);
@@ -147,35 +148,50 @@ public class SemanticSimilarityProperties {
       return null;
     }
     final String normalized = embeddingModelProvider.trim().toLowerCase();
+    final BaseProviderConfig config;
     switch (normalized) {
       case PROVIDER_OPENAI:
-        return new BaseProviderConfig.OpenAiConfig(
-            embeddingModelModel, embeddingModelApiKey, embeddingModelDimensions);
+        config =
+            new BaseProviderConfig.OpenAiConfig(
+                embeddingModelModel, embeddingModelApiKey, embeddingModelDimensions);
+        break;
       case PROVIDER_OPENAI_COMPATIBLE:
-        return new BaseProviderConfig.OpenAiCompatibleConfig(
-            embeddingModelModel,
-            embeddingModelBaseUrl,
-            embeddingModelApiKey,
-            embeddingModelDimensions,
-            embeddingModelHeaders);
+        config =
+            new BaseProviderConfig.OpenAiCompatibleConfig(
+                embeddingModelModel,
+                embeddingModelBaseUrl,
+                embeddingModelApiKey,
+                embeddingModelDimensions,
+                embeddingModelHeaders);
+        break;
       case PROVIDER_AZURE_OPENAI:
-        return new BaseProviderConfig.AzureOpenAiConfig(
-            embeddingModelModel,
-            embeddingModelEndpoint,
-            embeddingModelApiKey,
-            embeddingModelDimensions);
+        config =
+            new BaseProviderConfig.AzureOpenAiConfig(
+                embeddingModelModel,
+                embeddingModelEndpoint,
+                embeddingModelApiKey,
+                embeddingModelDimensions);
+        break;
       case PROVIDER_AMAZON_BEDROCK:
-        return new BaseProviderConfig.AmazonBedrockConfig(
-            embeddingModelModel,
-            embeddingModelRegion,
-            embeddingModelApiKey,
-            embeddingModelCredentialsAccessKey,
-            embeddingModelCredentialsSecretKey,
-            embeddingModelNormalize,
-            embeddingModelDimensions);
+        config =
+            new BaseProviderConfig.AmazonBedrockConfig(
+                embeddingModelModel,
+                embeddingModelRegion,
+                embeddingModelApiKey,
+                embeddingModelCredentialsAccessKey,
+                embeddingModelCredentialsSecretKey,
+                embeddingModelNormalize,
+                embeddingModelDimensions);
+        break;
       default:
-        return new BaseProviderConfig.GenericConfig(
-            normalized, embeddingModelModel, embeddingModelCustomProperties);
+        config =
+            new BaseProviderConfig.GenericConfig(
+                normalized, embeddingModelModel, embeddingModelCustomProperties);
+        break;
     }
+    if (embeddingModelTimeout != null) {
+      config.setTimeout(embeddingModelTimeout);
+    }
+    return config;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/similarity/BaseProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/similarity/BaseProviderConfig.java
@@ -30,6 +30,8 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
   private final String provider;
   private final String model;
+
+  private Integer dimensions;
   private Duration timeout;
 
   protected BaseProviderConfig(final String provider, final String model) {
@@ -45,6 +47,14 @@ public abstract class BaseProviderConfig implements ProviderConfig {
   @Override
   public String getModel() {
     return model;
+  }
+
+  public Integer getDimensions() {
+    return dimensions;
+  }
+
+  public void setDimensions(final Integer dimensions) {
+    this.dimensions = dimensions;
   }
 
   public Duration getTimeout() {
@@ -80,20 +90,14 @@ public abstract class BaseProviderConfig implements ProviderConfig {
   public static final class OpenAiConfig extends BaseProviderConfig {
 
     private final String apiKey;
-    private final Integer dimensions;
 
-    public OpenAiConfig(final String model, final String apiKey, final Integer dimensions) {
+    public OpenAiConfig(final String model, final String apiKey) {
       super(PROVIDER_OPENAI, model);
       this.apiKey = apiKey;
-      this.dimensions = dimensions;
     }
 
     public String getApiKey() {
       return apiKey;
-    }
-
-    public Integer getDimensions() {
-      return dimensions;
     }
   }
 
@@ -102,19 +106,16 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     private final String baseUrl;
     private final String apiKey;
-    private final Integer dimensions;
     private final Map<String, String> headers;
 
     public OpenAiCompatibleConfig(
         final String model,
         final String baseUrl,
         final String apiKey,
-        final Integer dimensions,
         final Map<String, String> headers) {
       super(PROVIDER_OPENAI_COMPATIBLE, model);
       this.baseUrl = baseUrl;
       this.apiKey = apiKey;
-      this.dimensions = dimensions;
       this.headers = headers;
     }
 
@@ -124,10 +125,6 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     public String getApiKey() {
       return apiKey;
-    }
-
-    public Integer getDimensions() {
-      return dimensions;
     }
 
     public Map<String, String> getHeaders() {
@@ -140,14 +137,11 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     private final String endpoint;
     private final String apiKey;
-    private final Integer dimensions;
 
-    public AzureOpenAiConfig(
-        final String model, final String endpoint, final String apiKey, final Integer dimensions) {
+    public AzureOpenAiConfig(final String model, final String endpoint, final String apiKey) {
       super(PROVIDER_AZURE_OPENAI, model);
       this.endpoint = endpoint;
       this.apiKey = apiKey;
-      this.dimensions = dimensions;
     }
 
     public String getEndpoint() {
@@ -156,10 +150,6 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     public String getApiKey() {
       return apiKey;
-    }
-
-    public Integer getDimensions() {
-      return dimensions;
     }
   }
 
@@ -171,7 +161,6 @@ public abstract class BaseProviderConfig implements ProviderConfig {
     private final String credentialsAccessKey;
     private final String credentialsSecretKey;
     private final Boolean normalize;
-    private final Integer dimensions;
 
     public AmazonBedrockConfig(
         final String model,
@@ -179,15 +168,13 @@ public abstract class BaseProviderConfig implements ProviderConfig {
         final String apiKey,
         final String credentialsAccessKey,
         final String credentialsSecretKey,
-        final Boolean normalize,
-        final Integer dimensions) {
+        final Boolean normalize) {
       super(PROVIDER_AMAZON_BEDROCK, model);
       this.region = region;
       this.apiKey = apiKey;
       this.credentialsAccessKey = credentialsAccessKey;
       this.credentialsSecretKey = credentialsSecretKey;
       this.normalize = normalize;
-      this.dimensions = dimensions;
     }
 
     public String getRegion() {
@@ -213,10 +200,6 @@ public abstract class BaseProviderConfig implements ProviderConfig {
      */
     public Boolean getNormalize() {
       return normalize;
-    }
-
-    public Integer getDimensions() {
-      return dimensions;
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/similarity/BaseProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/similarity/BaseProviderConfig.java
@@ -71,17 +71,11 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     private final String apiKey;
     private final Integer dimensions;
-    private final Map<String, String> headers;
 
-    public OpenAiConfig(
-        final String model,
-        final String apiKey,
-        final Integer dimensions,
-        final Map<String, String> headers) {
+    public OpenAiConfig(final String model, final String apiKey, final Integer dimensions) {
       super(PROVIDER_OPENAI, model);
       this.apiKey = apiKey;
       this.dimensions = dimensions;
-      this.headers = headers;
     }
 
     public String getApiKey() {
@@ -90,10 +84,6 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     public Integer getDimensions() {
       return dimensions;
-    }
-
-    public Map<String, String> getHeaders() {
-      return headers;
     }
   }
 
@@ -141,19 +131,13 @@ public abstract class BaseProviderConfig implements ProviderConfig {
     private final String endpoint;
     private final String apiKey;
     private final Integer dimensions;
-    private final Map<String, String> headers;
 
     public AzureOpenAiConfig(
-        final String model,
-        final String endpoint,
-        final String apiKey,
-        final Integer dimensions,
-        final Map<String, String> headers) {
+        final String model, final String endpoint, final String apiKey, final Integer dimensions) {
       super(PROVIDER_AZURE_OPENAI, model);
       this.endpoint = endpoint;
       this.apiKey = apiKey;
       this.dimensions = dimensions;
-      this.headers = headers;
     }
 
     public String getEndpoint() {
@@ -166,10 +150,6 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     public Integer getDimensions() {
       return dimensions;
-    }
-
-    public Map<String, String> getHeaders() {
-      return headers;
     }
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/similarity/BaseProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/similarity/BaseProviderConfig.java
@@ -177,6 +177,7 @@ public abstract class BaseProviderConfig implements ProviderConfig {
   public static final class AmazonBedrockConfig extends BaseProviderConfig {
 
     private final String region;
+    private final String apiKey;
     private final String credentialsAccessKey;
     private final String credentialsSecretKey;
     private final Boolean normalize;
@@ -185,12 +186,14 @@ public abstract class BaseProviderConfig implements ProviderConfig {
     public AmazonBedrockConfig(
         final String model,
         final String region,
+        final String apiKey,
         final String credentialsAccessKey,
         final String credentialsSecretKey,
         final Boolean normalize,
         final Integer dimensions) {
       super(PROVIDER_AMAZON_BEDROCK, model);
       this.region = region;
+      this.apiKey = apiKey;
       this.credentialsAccessKey = credentialsAccessKey;
       this.credentialsSecretKey = credentialsSecretKey;
       this.normalize = normalize;
@@ -199,6 +202,10 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
     public String getRegion() {
       return region;
+    }
+
+    public String getApiKey() {
+      return apiKey;
     }
 
     public String getCredentialsAccessKey() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/similarity/BaseProviderConfig.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/similarity/BaseProviderConfig.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.similarity;
 
 import io.camunda.process.test.api.similarity.ProviderConfig;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ public abstract class BaseProviderConfig implements ProviderConfig {
 
   private final String provider;
   private final String model;
+  private Duration timeout;
 
   protected BaseProviderConfig(final String provider, final String model) {
     this.provider = provider;
@@ -43,6 +45,14 @@ public abstract class BaseProviderConfig implements ProviderConfig {
   @Override
   public String getModel() {
     return model;
+  }
+
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(final Duration timeout) {
+    this.timeout = timeout;
   }
 
   /** Generic provider configuration for unknown or custom providers. */

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/JudgePropertiesTest.java
@@ -23,6 +23,7 @@ import io.camunda.process.test.impl.judge.BaseProviderConfig;
 import io.camunda.process.test.impl.judge.BaseProviderConfig.AzureOpenAiConfig;
 import io.camunda.process.test.impl.judge.BaseProviderConfig.OpenAiCompatibleConfig;
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
@@ -101,6 +102,7 @@ public class JudgePropertiesTest {
     properties.setProperty("judge.chatModel.provider", "openai");
     properties.setProperty("judge.chatModel.model", "gpt-4o");
     properties.setProperty("judge.chatModel.apiKey", "test-key");
+    properties.setProperty("judge.chatModel.timeout", "PT30S");
 
     // when
     final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
@@ -109,6 +111,8 @@ public class JudgePropertiesTest {
     assertThat(config).isInstanceOf(BaseProviderConfig.OpenAiConfig.class);
     assertThat(config.getProvider()).isEqualTo("openai");
     assertThat(config.getModel()).isEqualTo("gpt-4o");
+    assertThat(((BaseProviderConfig.OpenAiConfig) config).getTimeout())
+        .isEqualTo(Duration.ofSeconds(30));
   }
 
   @Test
@@ -168,6 +172,7 @@ public class JudgePropertiesTest {
     properties.setProperty("judge.chatModel.model", "gpt-4o");
     properties.setProperty("judge.chatModel.endpoint", "https://my-resource.openai.azure.com/");
     properties.setProperty("judge.chatModel.apiKey", "test-key");
+    properties.setProperty("judge.chatModel.timeout", "PT30S");
 
     // when
     final ProviderConfig config = new JudgeProperties(properties).toProviderConfig();
@@ -179,6 +184,7 @@ public class JudgePropertiesTest {
     final AzureOpenAiConfig azureConfig = (AzureOpenAiConfig) config;
     assertThat(azureConfig.getEndpoint()).isEqualTo("https://my-resource.openai.azure.com/");
     assertThat(azureConfig.getApiKey()).isEqualTo("test-key");
+    assertThat(azureConfig.getTimeout()).isEqualTo(Duration.ofSeconds(30));
   }
 
   @Test
@@ -196,86 +202,6 @@ public class JudgePropertiesTest {
     assertThat(config).isInstanceOf(AzureOpenAiConfig.class);
     final AzureOpenAiConfig azureConfig = (AzureOpenAiConfig) config;
     assertThat(azureConfig.getApiKey()).isNull();
-  }
-
-  @Test
-  void shouldParseTimeout() {
-    // given
-    final Properties properties = new Properties();
-    properties.setProperty("judge.chatModel.provider", "openai");
-    properties.setProperty("judge.chatModel.model", "gpt-4o");
-    properties.setProperty("judge.chatModel.apiKey", "test-key");
-    properties.setProperty("judge.chatModel.timeout", "PT30S");
-
-    // when
-    final BaseProviderConfig config =
-        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
-
-    // then
-    assertThat(config.getTimeout()).isEqualTo(Duration.ofSeconds(30));
-  }
-
-  @Test
-  void shouldParseTimeoutMinutes() {
-    // given
-    final Properties properties = new Properties();
-    properties.setProperty("judge.chatModel.provider", "openai");
-    properties.setProperty("judge.chatModel.model", "gpt-4o");
-    properties.setProperty("judge.chatModel.apiKey", "test-key");
-    properties.setProperty("judge.chatModel.timeout", "PT2M");
-
-    // when
-    final BaseProviderConfig config =
-        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
-
-    // then
-    assertThat(config.getTimeout()).isEqualTo(Duration.ofMinutes(2));
-  }
-
-  @Test
-  void shouldReturnNullTimeoutWhenNotConfigured() {
-    // given
-    final Properties properties = new Properties();
-    properties.setProperty("judge.chatModel.provider", "openai");
-    properties.setProperty("judge.chatModel.model", "gpt-4o");
-    properties.setProperty("judge.chatModel.apiKey", "test-key");
-
-    // when
-    final BaseProviderConfig config =
-        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
-
-    // then
-    assertThat(config.getTimeout()).isNull();
-  }
-
-  @Test
-  void shouldRejectInvalidTimeout() {
-    // given
-    final Properties properties = new Properties();
-    properties.setProperty("judge.chatModel.timeout", "not-a-duration");
-
-    // when / then
-    assertThatThrownBy(() -> new JudgeProperties(properties))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("judge.chatModel.timeout");
-  }
-
-  @Test
-  void shouldTreatPlaceholderTimeoutAsAbsent() {
-    // given
-    final Properties properties = new Properties();
-    properties.setProperty("judge.chatModel.provider", "openai");
-    properties.setProperty("judge.chatModel.model", "gpt-4o");
-    properties.setProperty("judge.chatModel.apiKey", "test-key");
-    properties.setProperty("judge.chatModel.timeout", "${TIMEOUT}");
-
-    // when
-    // when
-    final BaseProviderConfig config =
-        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
-
-    // then
-    assertThat(config.getTimeout()).isNull();
   }
 
   @Test
@@ -319,6 +245,33 @@ public class JudgePropertiesTest {
     // when / then
     assertThatThrownBy(() -> new JudgeProperties(properties))
         .isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  void shouldReturnNullTimeoutWhenNotConfigured() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.provider", "openai");
+    properties.setProperty("judge.chatModel.model", "gpt-4o");
+    properties.setProperty("judge.chatModel.apiKey", "test-key");
+
+    // when
+    final BaseProviderConfig config =
+        (BaseProviderConfig) new JudgeProperties(properties).toProviderConfig();
+
+    // then
+    assertThat(config.getTimeout()).isNull();
+  }
+
+  @Test
+  void shouldRejectInvalidTimeout() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("judge.chatModel.timeout", "1ms");
+
+    // when/then
+    assertThatThrownBy(() -> new JudgeProperties(properties))
+        .isInstanceOf(DateTimeParseException.class);
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityPropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityPropertiesTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.process.test.api.similarity.ProviderConfig;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
@@ -100,6 +102,7 @@ public class SemanticSimilarityPropertiesTest {
     properties.setProperty("similarity.embeddingModel.model", "text-embedding-3-small");
     properties.setProperty("similarity.embeddingModel.apiKey", "sk-test");
     properties.setProperty("similarity.embeddingModel.dimensions", "512");
+    properties.setProperty("similarity.embeddingModel.timeout", "PT30S");
 
     // when
     final ProviderConfig config = new SemanticSimilarityProperties(properties).toProviderConfig();
@@ -111,6 +114,7 @@ public class SemanticSimilarityPropertiesTest {
     assertThat(openAiConfig.getModel()).isEqualTo("text-embedding-3-small");
     assertThat(openAiConfig.getApiKey()).isEqualTo("sk-test");
     assertThat(openAiConfig.getDimensions()).isEqualTo(512);
+    assertThat(openAiConfig.getTimeout()).isEqualTo(Duration.ofSeconds(30));
   }
 
   @Test
@@ -122,6 +126,7 @@ public class SemanticSimilarityPropertiesTest {
     properties.setProperty("similarity.embeddingModel.baseUrl", "http://localhost:11434/v1");
     properties.setProperty("similarity.embeddingModel.apiKey", "ollama");
     properties.setProperty("similarity.embeddingModel.dimensions", "768");
+    properties.setProperty("similarity.embeddingModel.timeout", "PT1M");
 
     // when
     final ProviderConfig config = new SemanticSimilarityProperties(properties).toProviderConfig();
@@ -135,6 +140,7 @@ public class SemanticSimilarityPropertiesTest {
     assertThat(compatConfig.getBaseUrl()).isEqualTo("http://localhost:11434/v1");
     assertThat(compatConfig.getApiKey()).isEqualTo("ollama");
     assertThat(compatConfig.getDimensions()).isEqualTo(768);
+    assertThat(compatConfig.getTimeout()).isEqualTo(Duration.ofMinutes(1));
   }
 
   @Test
@@ -147,6 +153,7 @@ public class SemanticSimilarityPropertiesTest {
         "similarity.embeddingModel.endpoint", "https://my-resource.openai.azure.com/");
     properties.setProperty("similarity.embeddingModel.apiKey", "azure-key");
     properties.setProperty("similarity.embeddingModel.dimensions", "1024");
+    properties.setProperty("similarity.embeddingModel.timeout", "PT30S");
 
     // when
     final ProviderConfig config = new SemanticSimilarityProperties(properties).toProviderConfig();
@@ -160,6 +167,7 @@ public class SemanticSimilarityPropertiesTest {
     assertThat(azureConfig.getEndpoint()).isEqualTo("https://my-resource.openai.azure.com/");
     assertThat(azureConfig.getApiKey()).isEqualTo("azure-key");
     assertThat(azureConfig.getDimensions()).isEqualTo(1024);
+    assertThat(azureConfig.getTimeout()).isEqualTo(Duration.ofSeconds(30));
   }
 
   @Test
@@ -211,6 +219,7 @@ public class SemanticSimilarityPropertiesTest {
     properties.setProperty("similarity.embeddingModel.region", "eu-west-1");
     properties.setProperty("similarity.embeddingModel.credentials.accessKey", "ak");
     properties.setProperty("similarity.embeddingModel.credentials.secretKey", "sk");
+    properties.setProperty("similarity.embeddingModel.timeout", "PT30S");
 
     // when
     final SemanticSimilarityProperties similarityProperties =
@@ -225,6 +234,7 @@ public class SemanticSimilarityPropertiesTest {
     assertThat(bedrockConfig.getRegion()).isEqualTo("eu-west-1");
     assertThat(bedrockConfig.getCredentialsAccessKey()).isEqualTo("ak");
     assertThat(bedrockConfig.getCredentialsSecretKey()).isEqualTo("sk");
+    assertThat(bedrockConfig.getTimeout()).isEqualTo(Duration.ofSeconds(30));
     assertThat(similarityProperties.getThreshold()).isEqualTo(0.7);
   }
 
@@ -254,5 +264,16 @@ public class SemanticSimilarityPropertiesTest {
     // then
     assertThat(similarityProperties.getThreshold()).isEqualTo(0.5);
     assertThat(similarityProperties.hasProviderConfigured()).isFalse();
+  }
+
+  @Test
+  void shouldRejectInvalidTimeout() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("similarity.embeddingModel.timeout", "1ms");
+
+    // when/then
+    assertThatThrownBy(() -> new SemanticSimilarityProperties(properties))
+        .isInstanceOf(DateTimeParseException.class);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityPropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/SemanticSimilarityPropertiesTest.java
@@ -100,7 +100,6 @@ public class SemanticSimilarityPropertiesTest {
     properties.setProperty("similarity.embeddingModel.model", "text-embedding-3-small");
     properties.setProperty("similarity.embeddingModel.apiKey", "sk-test");
     properties.setProperty("similarity.embeddingModel.dimensions", "512");
-    properties.setProperty("similarity.embeddingModel.headers.X-Custom", "value");
 
     // when
     final ProviderConfig config = new SemanticSimilarityProperties(properties).toProviderConfig();
@@ -112,7 +111,6 @@ public class SemanticSimilarityPropertiesTest {
     assertThat(openAiConfig.getModel()).isEqualTo("text-embedding-3-small");
     assertThat(openAiConfig.getApiKey()).isEqualTo("sk-test");
     assertThat(openAiConfig.getDimensions()).isEqualTo(512);
-    assertThat(openAiConfig.getHeaders()).containsEntry("X-Custom", "value");
   }
 
   @Test

--- a/testing/camunda-process-test-langchain4j/README.md
+++ b/testing/camunda-process-test-langchain4j/README.md
@@ -137,7 +137,6 @@ similarity.embeddingModel.provider=openai
 similarity.embeddingModel.apiKey=<your api key>
 similarity.embeddingModel.model=text-embedding-3-small
 similarity.embeddingModel.dimensions=512                                     # optional
-similarity.embeddingModel.headers.<header-name>=<header-value>               # optional, can have multiple custom headers
 ```
 
 ### Azure OpenAI
@@ -148,7 +147,6 @@ similarity.embeddingModel.endpoint=https://my-resource.openai.azure.com/
 similarity.embeddingModel.apiKey=<your api key>
 similarity.embeddingModel.model=text-embedding-3-large
 similarity.embeddingModel.dimensions=1024                                    # optional
-similarity.embeddingModel.headers.<header-name>=<header-value>               # optional, can have multiple custom headers
 ```
 
 ### Amazon Bedrock

--- a/testing/camunda-process-test-langchain4j/README.md
+++ b/testing/camunda-process-test-langchain4j/README.md
@@ -159,6 +159,7 @@ similarity.embeddingModel.region=eu-central-1                               # op
 similarity.embeddingModel.model=amazon.titan-embed-text-v2:0
 similarity.embeddingModel.credentials.accessKey=<your access key>           # optional; uses default credentials chain if absent
 similarity.embeddingModel.credentials.secretKey=<your secret key>           # optional
+similarity.embeddingModel.apiKey=<your api key>                             # optional, instead of accessKey and secretKey
 similarity.embeddingModel.credentials.normalize=true                        # optional, defaults to no normalization
 ```
 

--- a/testing/camunda-process-test-langchain4j/README.md
+++ b/testing/camunda-process-test-langchain4j/README.md
@@ -153,12 +153,12 @@ similarity.embeddingModel.dimensions=1024                                    # o
 
 ```properties
 similarity.embeddingModel.provider=amazon-bedrock
-similarity.embeddingModel.region=eu-central-1                               # optional, defaults to us-east-1
+similarity.embeddingModel.region=eu-central-1                               # optional
 similarity.embeddingModel.model=amazon.titan-embed-text-v2:0
 similarity.embeddingModel.credentials.accessKey=<your access key>           # optional; uses default credentials chain if absent
 similarity.embeddingModel.credentials.secretKey=<your secret key>           # optional
 similarity.embeddingModel.apiKey=<your api key>                             # optional, instead of accessKey and secretKey
-similarity.embeddingModel.credentials.normalize=true                        # optional, defaults to no normalization
+similarity.embeddingModel.normalize=true                                    # optional, defaults to no normalization
 ```
 
 ### OpenAI-compatible

--- a/testing/camunda-process-test-langchain4j/pom.xml
+++ b/testing/camunda-process-test-langchain4j/pom.xml
@@ -76,6 +76,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+    </dependency>
+
     <!--  test scope  -->
 
     <dependency>

--- a/testing/camunda-process-test-langchain4j/pom.xml
+++ b/testing/camunda-process-test-langchain4j/pom.xml
@@ -76,11 +76,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-identity</artifactId>
-    </dependency>
-
     <!--  test scope  -->
 
     <dependency>

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/BedrockRuntimeClientFactory.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/BedrockRuntimeClientFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl;
+
+import static io.camunda.process.test.impl.ModelBuilderSupport.hasText;
+
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClientBuilder;
+
+/** Factory for creating a configured {@link BedrockRuntimeClient} from Amazon Bedrock config. */
+public final class BedrockRuntimeClientFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BedrockRuntimeClientFactory.class);
+
+  private BedrockRuntimeClientFactory() {}
+
+  public static BedrockRuntimeClient build(
+      final String region,
+      final String apiKey,
+      final String credentialsAccessKey,
+      final String credentialsSecretKey) {
+    final boolean hasAccessKey = hasText(credentialsAccessKey);
+    final boolean hasSecretKey = hasText(credentialsSecretKey);
+    final boolean hasKeyPairAuth = hasAccessKey && hasSecretKey;
+    final boolean hasPartialKeyPair = hasAccessKey != hasSecretKey;
+    final boolean hasApiKeyAuth = hasText(apiKey);
+
+    if (hasPartialKeyPair) {
+      throw new IllegalStateException(
+          "Incomplete key-pair authentication for the 'amazon-bedrock' provider: "
+              + "both 'accessKey' and 'secretKey' must be set together.");
+    }
+
+    if (hasKeyPairAuth && hasApiKeyAuth) {
+      throw new IllegalStateException(
+          "Ambiguous authentication for the 'amazon-bedrock' provider: "
+              + "both accessKey/secretKey and apiKey are set. Use only one authentication method.");
+    }
+
+    final BedrockRuntimeClientBuilder clientBuilder = BedrockRuntimeClient.builder();
+
+    if (hasText(region)) {
+      LOG.debug("Using configured region '{}'", region.trim());
+      clientBuilder.region(Region.of(region.trim()));
+    } else {
+      LOG.debug("No region configured, falling back to the default region");
+    }
+
+    if (hasKeyPairAuth) {
+      LOG.debug("Using access key / secret key authentication");
+      clientBuilder.credentialsProvider(
+          StaticCredentialsProvider.create(
+              AwsBasicCredentials.create(
+                  credentialsAccessKey.trim(), credentialsSecretKey.trim())));
+    } else if (hasApiKeyAuth) {
+      LOG.debug("Using API key (Bearer token) authentication");
+      clientBuilder
+          .credentialsProvider(AnonymousCredentialsProvider.create())
+          .putAuthScheme(NoAuthAuthScheme.create());
+      clientBuilder.overrideConfiguration(
+          cfg -> cfg.headers(Map.of("Authorization", List.of("Bearer " + apiKey.trim()))));
+    } else {
+      LOG.debug("No explicit credentials configured, falling back to AWS default credential chain");
+    }
+
+    return clientBuilder.build();
+  }
+}

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/BedrockRuntimeClientFactory.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/BedrockRuntimeClientFactory.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl;
 
 import static io.camunda.process.test.impl.ModelBuilderSupport.hasText;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -32,6 +33,9 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClientBuilde
 /** Factory for creating a configured {@link BedrockRuntimeClient} from Amazon Bedrock config. */
 public final class BedrockRuntimeClientFactory {
 
+  // reflects the default timeout used by BedrockChatModel
+  public static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
+
   private static final Logger LOG = LoggerFactory.getLogger(BedrockRuntimeClientFactory.class);
 
   private BedrockRuntimeClientFactory() {}
@@ -40,12 +44,14 @@ public final class BedrockRuntimeClientFactory {
       final String region,
       final String apiKey,
       final String credentialsAccessKey,
-      final String credentialsSecretKey) {
+      final String credentialsSecretKey,
+      final Duration timeout) {
     final boolean hasAccessKey = hasText(credentialsAccessKey);
     final boolean hasSecretKey = hasText(credentialsSecretKey);
     final boolean hasKeyPairAuth = hasAccessKey && hasSecretKey;
     final boolean hasPartialKeyPair = hasAccessKey != hasSecretKey;
     final boolean hasApiKeyAuth = hasText(apiKey);
+    final Duration effectiveTimeout = timeout != null ? timeout : DEFAULT_TIMEOUT;
 
     if (hasPartialKeyPair) {
       throw new IllegalStateException(
@@ -79,11 +85,16 @@ public final class BedrockRuntimeClientFactory {
       clientBuilder
           .credentialsProvider(AnonymousCredentialsProvider.create())
           .putAuthScheme(NoAuthAuthScheme.create());
-      clientBuilder.overrideConfiguration(
-          cfg -> cfg.headers(Map.of("Authorization", List.of("Bearer " + apiKey.trim()))));
-    } else {
-      LOG.debug("No explicit credentials configured, falling back to AWS default credential chain");
     }
+
+    LOG.debug("Setting timeout to {}", effectiveTimeout);
+    clientBuilder.overrideConfiguration(
+        cfg -> {
+          if (hasApiKeyAuth) {
+            cfg.headers(Map.of("Authorization", List.of("Bearer " + apiKey.trim())));
+          }
+          cfg.apiCallTimeout(effectiveTimeout);
+        });
 
     return clientBuilder.build();
   }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilder.java
@@ -24,19 +24,24 @@ import org.slf4j.LoggerFactory;
 
 final class AnthropicChatModelBuilder {
 
+  public static final String ANTHROPIC = "anthropic";
   private static final Logger LOG = LoggerFactory.getLogger(AnthropicChatModelBuilder.class);
 
   private AnthropicChatModelBuilder() {}
 
   static ChatModel build(final BaseProviderConfig.AnthropicConfig config) {
     LOG.debug("Building Anthropic chat model");
+    final ChatModel chatModel = build(config, AnthropicChatModel.builder());
+    LOG.debug("Successfully built Anthropic chat model with model '{}'", config.getModel());
+    return chatModel;
+  }
 
-    final String model = require(config.getModel(), "model", "anthropic");
-    final String apiKey = require(config.getApiKey(), "apiKey", "anthropic");
-
-    final AnthropicChatModel.AnthropicChatModelBuilder builder =
-        AnthropicChatModel.builder().apiKey(apiKey).modelName(model);
-
+  // visible for testing
+  static ChatModel build(
+      final BaseProviderConfig.AnthropicConfig config,
+      final AnthropicChatModel.AnthropicChatModelBuilder builder) {
+    builder.apiKey(require(config.getApiKey(), "apiKey", ANTHROPIC));
+    builder.modelName(require(config.getModel(), "model", ANTHROPIC));
     if (config.getTimeout() != null) {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       builder.timeout(config.getTimeout());
@@ -45,9 +50,6 @@ final class AnthropicChatModelBuilder {
       LOG.debug("Setting temperature to {}", config.getTemperature());
       builder.temperature(config.getTemperature());
     }
-
-    final ChatModel chatModel = builder.build();
-    LOG.debug("Successfully built Anthropic chat model with model '{}'", model);
-    return chatModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilder.java
@@ -36,7 +36,6 @@ final class AnthropicChatModelBuilder {
     return chatModel;
   }
 
-  // visible for testing
   static ChatModel build(
       final BaseProviderConfig.AnthropicConfig config,
       final AnthropicChatModel.AnthropicChatModelBuilder builder) {

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilder.java
@@ -26,19 +26,27 @@ import org.slf4j.LoggerFactory;
 
 final class AzureOpenAiChatModelBuilder {
 
+  public static final String AZURE_OPENAI = "azure-openai";
   private static final Logger LOG = LoggerFactory.getLogger(AzureOpenAiChatModelBuilder.class);
 
   private AzureOpenAiChatModelBuilder() {}
 
   static ChatModel build(final BaseProviderConfig.AzureOpenAiConfig config) {
     LOG.debug("Building Azure OpenAI chat model");
+    final ChatModel chatModel = build(config, AzureOpenAiChatModel.builder());
+    LOG.debug(
+        "Successfully built Azure OpenAI chat model with endpoint '{}' and deployment '{}'",
+        config.getEndpoint(),
+        config.getModel());
+    return chatModel;
+  }
 
-    final String model = require(config.getModel(), "model", "azure-openai");
-    final String endpoint = require(config.getEndpoint(), "endpoint", "azure-openai");
-
-    final AzureOpenAiChatModel.Builder builder =
-        AzureOpenAiChatModel.builder().endpoint(endpoint).deploymentName(model);
-
+  // visible for testing
+  static ChatModel build(
+      final BaseProviderConfig.AzureOpenAiConfig config,
+      final AzureOpenAiChatModel.Builder builder) {
+    builder.endpoint(require(config.getEndpoint(), "endpoint", AZURE_OPENAI));
+    builder.deploymentName(require(config.getModel(), "model", AZURE_OPENAI));
     if (hasText(config.getApiKey())) {
       LOG.debug("Using API key authentication");
       builder.apiKey(config.getApiKey().trim());
@@ -48,7 +56,6 @@ final class AzureOpenAiChatModelBuilder {
               + "(environment, workload identity, managed identity, Azure CLI)");
       builder.tokenCredential(new DefaultAzureCredentialBuilder().build());
     }
-
     if (config.getTimeout() != null) {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       builder.timeout(config.getTimeout());
@@ -57,12 +64,6 @@ final class AzureOpenAiChatModelBuilder {
       LOG.debug("Setting temperature to {}", config.getTemperature());
       builder.temperature(config.getTemperature());
     }
-
-    final ChatModel chatModel = builder.build();
-    LOG.debug(
-        "Successfully built Azure OpenAI chat model with endpoint '{}' and deployment '{}'",
-        endpoint,
-        model);
-    return chatModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilder.java
@@ -41,7 +41,6 @@ final class AzureOpenAiChatModelBuilder {
     return chatModel;
   }
 
-  // visible for testing
   static ChatModel build(
       final BaseProviderConfig.AzureOpenAiConfig config,
       final AzureOpenAiChatModel.Builder builder) {

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
@@ -39,7 +39,6 @@ final class BedrockChatModelBuilder {
     return chatModel;
   }
 
-  // visible for testing
   static ChatModel build(
       final BaseProviderConfig.AmazonBedrockConfig config, final BedrockChatModel.Builder builder) {
     final String model = require(config.getModel(), "model", AMAZON_BEDROCK);

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
@@ -48,13 +48,10 @@ final class BedrockChatModelBuilder {
             config.getRegion(),
             config.getApiKey(),
             config.getCredentialsAccessKey(),
-            config.getCredentialsSecretKey());
+            config.getCredentialsSecretKey(),
+            config.getTimeout());
     builder.client(client);
     builder.modelId(model);
-    if (config.getTimeout() != null) {
-      LOG.debug("Setting timeout to {}", config.getTimeout());
-      builder.timeout(config.getTimeout());
-    }
     if (config.getTemperature() != null) {
       LOG.debug("Setting temperature to {}", config.getTemperature());
       final BedrockChatRequestParameters requestParameters =

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
@@ -15,23 +15,15 @@
  */
 package io.camunda.process.test.impl.judge;
 
-import static io.camunda.process.test.impl.ModelBuilderSupport.hasText;
 import static io.camunda.process.test.impl.ModelBuilderSupport.require;
 
 import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
-import java.util.List;
-import java.util.Map;
+import io.camunda.process.test.impl.BedrockRuntimeClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
-import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClientBuilder;
 
 final class BedrockChatModelBuilder {
 
@@ -44,55 +36,15 @@ final class BedrockChatModelBuilder {
 
     final String model = require(config.getModel(), "model", "amazon-bedrock");
 
-    final boolean hasAccessKey = hasText(config.getCredentialsAccessKey());
-    final boolean hasSecretKey = hasText(config.getCredentialsSecretKey());
-    final boolean hasKeyPairAuth = hasAccessKey && hasSecretKey;
-    final boolean hasPartialKeyPair = hasAccessKey != hasSecretKey;
-    final boolean hasApiKeyAuth = hasText(config.getApiKey());
-
-    if (hasPartialKeyPair) {
-      throw new IllegalStateException(
-          "Incomplete key-pair authentication for the 'amazon-bedrock' provider: "
-              + "both 'accessKey' and 'secretKey' must be set together.");
-    }
-
-    if (hasKeyPairAuth && hasApiKeyAuth) {
-      throw new IllegalStateException(
-          "Ambiguous authentication for the 'amazon-bedrock' provider: "
-              + "both accessKey/secretKey and apiKey are set. Use only one authentication method.");
-    }
-
-    final BedrockRuntimeClientBuilder clientBuilder = BedrockRuntimeClient.builder();
-
-    if (hasText(config.getRegion())) {
-      LOG.debug("Using configured region '{}'", config.getRegion().trim());
-      clientBuilder.region(Region.of(config.getRegion().trim()));
-    } else {
-      LOG.debug("No region configured, falling back to AWS default region resolution");
-    }
-
-    if (hasKeyPairAuth) {
-      LOG.debug("Using access key / secret key authentication");
-      clientBuilder.credentialsProvider(
-          StaticCredentialsProvider.create(
-              AwsBasicCredentials.create(
-                  config.getCredentialsAccessKey().trim(),
-                  config.getCredentialsSecretKey().trim())));
-    } else if (hasApiKeyAuth) {
-      LOG.debug("Using API key (Bearer token) authentication");
-      clientBuilder
-          .credentialsProvider(AnonymousCredentialsProvider.create())
-          .putAuthScheme(NoAuthAuthScheme.create());
-
-      clientBuilder.overrideConfiguration(
-          cfg ->
-              cfg.headers(Map.of("Authorization", List.of("Bearer " + config.getApiKey().trim()))));
-    } else {
-      LOG.debug("No explicit credentials configured, falling back to AWS default credential chain");
-    }
+    final BedrockRuntimeClient client =
+        BedrockRuntimeClientFactory.build(
+            config.getRegion(),
+            config.getApiKey(),
+            config.getCredentialsAccessKey(),
+            config.getCredentialsSecretKey());
 
     final BedrockChatModel.Builder bedrockBuilder =
-        BedrockChatModel.builder().client(clientBuilder.build()).modelId(model);
+        BedrockChatModel.builder().client(client).modelId(model);
 
     if (config.getTimeout() != null) {
       LOG.debug("Setting timeout to {}", config.getTimeout());

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilder.java
@@ -27,38 +27,40 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 final class BedrockChatModelBuilder {
 
+  public static final String AMAZON_BEDROCK = "amazon-bedrock";
   private static final Logger LOG = LoggerFactory.getLogger(BedrockChatModelBuilder.class);
 
   private BedrockChatModelBuilder() {}
 
   static ChatModel build(final BaseProviderConfig.AmazonBedrockConfig config) {
     LOG.debug("Building Amazon Bedrock chat model");
+    final ChatModel chatModel = build(config, BedrockChatModel.builder());
+    LOG.debug("Successfully built Amazon Bedrock chat model with modelId '{}'", config.getModel());
+    return chatModel;
+  }
 
-    final String model = require(config.getModel(), "model", "amazon-bedrock");
-
+  // visible for testing
+  static ChatModel build(
+      final BaseProviderConfig.AmazonBedrockConfig config, final BedrockChatModel.Builder builder) {
+    final String model = require(config.getModel(), "model", AMAZON_BEDROCK);
     final BedrockRuntimeClient client =
         BedrockRuntimeClientFactory.build(
             config.getRegion(),
             config.getApiKey(),
             config.getCredentialsAccessKey(),
             config.getCredentialsSecretKey());
-
-    final BedrockChatModel.Builder bedrockBuilder =
-        BedrockChatModel.builder().client(client).modelId(model);
-
+    builder.client(client);
+    builder.modelId(model);
     if (config.getTimeout() != null) {
       LOG.debug("Setting timeout to {}", config.getTimeout());
-      bedrockBuilder.timeout(config.getTimeout());
+      builder.timeout(config.getTimeout());
     }
     if (config.getTemperature() != null) {
       LOG.debug("Setting temperature to {}", config.getTemperature());
       final BedrockChatRequestParameters requestParameters =
           BedrockChatRequestParameters.builder().temperature(config.getTemperature()).build();
-      bedrockBuilder.defaultRequestParameters(requestParameters);
+      builder.defaultRequestParameters(requestParameters);
     }
-
-    final ChatModel chatModel = bedrockBuilder.build();
-    LOG.debug("Successfully built Amazon Bedrock chat model with modelId '{}'", model);
-    return chatModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilder.java
@@ -24,19 +24,24 @@ import org.slf4j.LoggerFactory;
 
 final class OpenAiChatModelBuilder {
 
+  public static final String OPENAI = "openai";
   private static final Logger LOG = LoggerFactory.getLogger(OpenAiChatModelBuilder.class);
 
   private OpenAiChatModelBuilder() {}
 
   static ChatModel build(final BaseProviderConfig.OpenAiConfig config) {
     LOG.debug("Building OpenAI chat model");
+    final ChatModel chatModel = build(config, OpenAiChatModel.builder());
+    LOG.debug("Successfully built OpenAI chat model with model '{}'", config.getModel());
+    return chatModel;
+  }
 
-    final String model = require(config.getModel(), "model", "openai");
-    final String apiKey = require(config.getApiKey(), "apiKey", "openai");
-
-    final OpenAiChatModel.OpenAiChatModelBuilder builder =
-        OpenAiChatModel.builder().apiKey(apiKey).modelName(model);
-
+  // visible for testing
+  static ChatModel build(
+      final BaseProviderConfig.OpenAiConfig config,
+      final OpenAiChatModel.OpenAiChatModelBuilder builder) {
+    builder.apiKey(require(config.getApiKey(), "apiKey", OPENAI));
+    builder.modelName(require(config.getModel(), "model", OPENAI));
     if (config.getTimeout() != null) {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       builder.timeout(config.getTimeout());
@@ -45,9 +50,6 @@ final class OpenAiChatModelBuilder {
       LOG.debug("Setting temperature to {}", config.getTemperature());
       builder.temperature(config.getTemperature());
     }
-
-    final ChatModel chatModel = builder.build();
-    LOG.debug("Successfully built OpenAI chat model with model '{}'", model);
-    return chatModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilder.java
@@ -36,7 +36,6 @@ final class OpenAiChatModelBuilder {
     return chatModel;
   }
 
-  // visible for testing
   static ChatModel build(
       final BaseProviderConfig.OpenAiConfig config,
       final OpenAiChatModel.OpenAiChatModelBuilder builder) {

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
@@ -41,7 +41,6 @@ final class OpenAiCompatibleChatModelBuilder {
     return chatModel;
   }
 
-  // visible for testing
   static ChatModel build(
       final BaseProviderConfig.OpenAiCompatibleConfig config,
       final OpenAiChatModel.OpenAiChatModelBuilder builder) {

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilder.java
@@ -26,19 +26,27 @@ import org.slf4j.LoggerFactory;
 
 final class OpenAiCompatibleChatModelBuilder {
 
+  public static final String OPENAI_COMPATIBLE = "openai-compatible";
   private static final Logger LOG = LoggerFactory.getLogger(OpenAiCompatibleChatModelBuilder.class);
 
   private OpenAiCompatibleChatModelBuilder() {}
 
   static ChatModel build(final BaseProviderConfig.OpenAiCompatibleConfig config) {
     LOG.debug("Building OpenAI-compatible chat model");
+    final ChatModel chatModel = build(config, OpenAiChatModel.builder());
+    LOG.debug(
+        "Successfully built OpenAI-compatible chat model with baseUrl '{}' and model '{}'",
+        config.getBaseUrl(),
+        config.getModel());
+    return chatModel;
+  }
 
-    final String model = require(config.getModel(), "model", "openai-compatible");
-    final String baseUrl = require(config.getBaseUrl(), "baseUrl", "openai-compatible");
-
-    final OpenAiChatModel.OpenAiChatModelBuilder builder =
-        OpenAiChatModel.builder().baseUrl(baseUrl).modelName(model);
-
+  // visible for testing
+  static ChatModel build(
+      final BaseProviderConfig.OpenAiCompatibleConfig config,
+      final OpenAiChatModel.OpenAiChatModelBuilder builder) {
+    builder.baseUrl(require(config.getBaseUrl(), "baseUrl", OPENAI_COMPATIBLE));
+    builder.modelName(require(config.getModel(), "model", OPENAI_COMPATIBLE));
     final Map<String, String> headers = config.getHeaders();
     final boolean hasAuthorizationHeader =
         headers != null && headers.keySet().stream().anyMatch("Authorization"::equalsIgnoreCase);
@@ -50,11 +58,9 @@ final class OpenAiCompatibleChatModelBuilder {
         builder.apiKey(config.getApiKey().trim());
       }
     }
-
     if (headers != null && !headers.isEmpty()) {
       builder.customHeaders(headers);
     }
-
     if (config.getTimeout() != null) {
       LOG.debug("Setting timeout to {}", config.getTimeout());
       builder.timeout(config.getTimeout());
@@ -63,12 +69,6 @@ final class OpenAiCompatibleChatModelBuilder {
       LOG.debug("Setting temperature to {}", config.getTemperature());
       builder.temperature(config.getTemperature());
     }
-
-    final ChatModel chatModel = builder.build();
-    LOG.debug(
-        "Successfully built OpenAI-compatible chat model with baseUrl '{}' and model '{}'",
-        baseUrl,
-        model);
-    return chatModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
@@ -15,8 +15,10 @@
  */
 package io.camunda.process.test.impl.similarity;
 
+import static io.camunda.process.test.impl.ModelBuilderSupport.hasText;
 import static io.camunda.process.test.impl.ModelBuilderSupport.require;
 
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import dev.langchain4j.model.azure.AzureOpenAiEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.AzureOpenAiConfig;
@@ -35,14 +37,20 @@ final class AzureOpenAiEmbeddingModelBuilder {
     LOG.debug("Building Azure OpenAI embedding model");
 
     final String endpoint = require(config.getEndpoint(), "endpoint", AZURE_OPENAI);
-    final String apiKey = require(config.getApiKey(), "apiKey", AZURE_OPENAI);
     final String deploymentName = require(config.getModel(), "model", AZURE_OPENAI);
 
     final AzureOpenAiEmbeddingModel.Builder builder =
-        AzureOpenAiEmbeddingModel.builder()
-            .endpoint(endpoint)
-            .apiKey(apiKey)
-            .deploymentName(deploymentName);
+        AzureOpenAiEmbeddingModel.builder().endpoint(endpoint).deploymentName(deploymentName);
+
+    if (hasText(config.getApiKey())) {
+      LOG.debug("Using API key authentication");
+      builder.apiKey(config.getApiKey().trim());
+    } else {
+      LOG.debug(
+          "No API key configured, falling back to DefaultAzureCredential "
+              + "(environment, workload identity, managed identity, Azure CLI)");
+      builder.tokenCredential(new DefaultAzureCredentialBuilder().build());
+    }
 
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
@@ -42,7 +42,6 @@ final class AzureOpenAiEmbeddingModelBuilder {
     return embeddingModel;
   }
 
-  // visible for testing
   static EmbeddingModel build(
       final AzureOpenAiConfig config, final AzureOpenAiEmbeddingModel.Builder builder) {
     builder.endpoint(require(config.getEndpoint(), "endpoint", AZURE_OPENAI));

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
@@ -22,7 +22,6 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import dev.langchain4j.model.azure.AzureOpenAiEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.AzureOpenAiConfig;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,11 +53,6 @@ final class AzureOpenAiEmbeddingModelBuilder {
 
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());
-    }
-
-    final Map<String, String> headers = config.getHeaders();
-    if (headers != null && !headers.isEmpty()) {
-      builder.customHeaders(headers);
     }
 
     final EmbeddingModel embeddingModel = builder.build();

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
@@ -36,7 +36,8 @@ final class AzureOpenAiEmbeddingModelBuilder {
     LOG.debug("Building Azure OpenAI embedding model");
     final EmbeddingModel embeddingModel = build(config, AzureOpenAiEmbeddingModel.builder());
     LOG.debug(
-        "Successfully built Azure OpenAI embedding model with deploymentName '{}'",
+        "Successfully built Azure OpenAI embedding model with endpoint '{}' and deployment '{}'",
+        config.getEndpoint(),
         config.getModel());
     return embeddingModel;
   }
@@ -55,7 +56,12 @@ final class AzureOpenAiEmbeddingModelBuilder {
               + "(environment, workload identity, managed identity, Azure CLI)");
       builder.tokenCredential(new DefaultAzureCredentialBuilder().build());
     }
+    if (config.getTimeout() != null) {
+      LOG.debug("Setting timeout to {}", config.getTimeout());
+      builder.timeout(config.getTimeout());
+    }
     if (config.getDimensions() != null) {
+      LOG.debug("Setting dimensions to {}", config.getDimensions());
       builder.dimensions(config.getDimensions());
     }
     return builder.build();

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilder.java
@@ -34,13 +34,18 @@ final class AzureOpenAiEmbeddingModelBuilder {
 
   static EmbeddingModel build(final AzureOpenAiConfig config) {
     LOG.debug("Building Azure OpenAI embedding model");
+    final EmbeddingModel embeddingModel = build(config, AzureOpenAiEmbeddingModel.builder());
+    LOG.debug(
+        "Successfully built Azure OpenAI embedding model with deploymentName '{}'",
+        config.getModel());
+    return embeddingModel;
+  }
 
-    final String endpoint = require(config.getEndpoint(), "endpoint", AZURE_OPENAI);
-    final String deploymentName = require(config.getModel(), "model", AZURE_OPENAI);
-
-    final AzureOpenAiEmbeddingModel.Builder builder =
-        AzureOpenAiEmbeddingModel.builder().endpoint(endpoint).deploymentName(deploymentName);
-
+  // visible for testing
+  static EmbeddingModel build(
+      final AzureOpenAiConfig config, final AzureOpenAiEmbeddingModel.Builder builder) {
+    builder.endpoint(require(config.getEndpoint(), "endpoint", AZURE_OPENAI));
+    builder.deploymentName(require(config.getModel(), "model", AZURE_OPENAI));
     if (hasText(config.getApiKey())) {
       LOG.debug("Using API key authentication");
       builder.apiKey(config.getApiKey().trim());
@@ -50,14 +55,9 @@ final class AzureOpenAiEmbeddingModelBuilder {
               + "(environment, workload identity, managed identity, Azure CLI)");
       builder.tokenCredential(new DefaultAzureCredentialBuilder().build());
     }
-
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());
     }
-
-    final EmbeddingModel embeddingModel = builder.build();
-    LOG.debug(
-        "Successfully built Azure OpenAI embedding model with deploymentName '{}'", deploymentName);
-    return embeddingModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilder.java
@@ -15,18 +15,16 @@
  */
 package io.camunda.process.test.impl.similarity;
 
-import static io.camunda.process.test.impl.ModelBuilderSupport.hasText;
 import static io.camunda.process.test.impl.ModelBuilderSupport.require;
 
 import dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel;
 import dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import io.camunda.process.test.impl.BedrockRuntimeClientFactory;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.AmazonBedrockConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 final class BedrockEmbeddingModelBuilder {
 
@@ -40,37 +38,15 @@ final class BedrockEmbeddingModelBuilder {
 
     final String model = require(config.getModel(), "model", AMAZON_BEDROCK);
 
-    final boolean hasAccessKey = hasText(config.getCredentialsAccessKey());
-    final boolean hasSecretKey = hasText(config.getCredentialsSecretKey());
-    final boolean hasKeyPairAuth = hasAccessKey && hasSecretKey;
-    final boolean hasPartialKeyPair = hasAccessKey != hasSecretKey;
-
-    if (hasPartialKeyPair) {
-      throw new IllegalStateException(
-          "Incomplete key-pair authentication for the 'amazon-bedrock' provider: "
-              + "both 'credentialsAccessKey' and 'credentialsSecretKey' must be set together.");
-    }
+    final BedrockRuntimeClient client =
+        BedrockRuntimeClientFactory.build(
+            config.getRegion(),
+            config.getApiKey(),
+            config.getCredentialsAccessKey(),
+            config.getCredentialsSecretKey());
 
     final BedrockTitanEmbeddingModelBuilder builder =
-        BedrockTitanEmbeddingModel.builder().model(model);
-
-    if (hasText(config.getRegion())) {
-      LOG.debug("Using configured region '{}'", config.getRegion().trim());
-      builder.region(Region.of(config.getRegion().trim()));
-    } else {
-      LOG.debug("No region configured, falling back to AWS default region resolution");
-    }
-
-    if (hasKeyPairAuth) {
-      LOG.debug("Using access key / secret key authentication");
-      builder.credentialsProvider(
-          StaticCredentialsProvider.create(
-              AwsBasicCredentials.create(
-                  config.getCredentialsAccessKey().trim(),
-                  config.getCredentialsSecretKey().trim())));
-    } else {
-      LOG.debug("No explicit credentials configured, falling back to AWS default credential chain");
-    }
+        BedrockTitanEmbeddingModel.builder().client(client).model(model);
 
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilder.java
@@ -50,13 +50,16 @@ final class BedrockEmbeddingModelBuilder {
             config.getRegion(),
             config.getApiKey(),
             config.getCredentialsAccessKey(),
-            config.getCredentialsSecretKey());
+            config.getCredentialsSecretKey(),
+            config.getTimeout());
     builder.client(client);
     builder.model(model);
     if (config.getDimensions() != null) {
+      LOG.debug("Setting dimensions to {}", config.getDimensions());
       builder.dimensions(config.getDimensions());
     }
     if (config.getNormalize() != null) {
+      LOG.debug("Setting normalize to {}", config.getNormalize());
       builder.normalize(config.getNormalize());
     }
     return builder.build();

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilder.java
@@ -41,7 +41,6 @@ final class BedrockEmbeddingModelBuilder {
     return embeddingModel;
   }
 
-  // visible for testing
   static EmbeddingModel build(
       final AmazonBedrockConfig config, final BedrockTitanEmbeddingModelBuilder builder) {
     final String model = require(config.getModel(), "model", AMAZON_BEDROCK);

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilder.java
@@ -35,29 +35,30 @@ final class BedrockEmbeddingModelBuilder {
 
   static EmbeddingModel build(final AmazonBedrockConfig config) {
     LOG.debug("Building Amazon Bedrock embedding model");
+    final EmbeddingModel embeddingModel = build(config, BedrockTitanEmbeddingModel.builder());
+    LOG.debug(
+        "Successfully built Amazon Bedrock embedding model with modelId '{}'", config.getModel());
+    return embeddingModel;
+  }
 
+  // visible for testing
+  static EmbeddingModel build(
+      final AmazonBedrockConfig config, final BedrockTitanEmbeddingModelBuilder builder) {
     final String model = require(config.getModel(), "model", AMAZON_BEDROCK);
-
     final BedrockRuntimeClient client =
         BedrockRuntimeClientFactory.build(
             config.getRegion(),
             config.getApiKey(),
             config.getCredentialsAccessKey(),
             config.getCredentialsSecretKey());
-
-    final BedrockTitanEmbeddingModelBuilder builder =
-        BedrockTitanEmbeddingModel.builder().client(client).model(model);
-
+    builder.client(client);
+    builder.model(model);
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());
     }
-
     if (config.getNormalize() != null) {
       builder.normalize(config.getNormalize());
     }
-
-    final EmbeddingModel embeddingModel = builder.build();
-    LOG.debug("Successfully built Amazon Bedrock embedding model with modelId '{}'", model);
-    return embeddingModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilder.java
@@ -43,7 +43,6 @@ final class OpenAiCompatibleEmbeddingModelBuilder {
     return embeddingModel;
   }
 
-  // visible for testing
   static EmbeddingModel build(
       final OpenAiCompatibleConfig config,
       final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder) {

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilder.java
@@ -35,13 +35,20 @@ final class OpenAiCompatibleEmbeddingModelBuilder {
 
   static EmbeddingModel build(final OpenAiCompatibleConfig config) {
     LOG.debug("Building OpenAI-compatible embedding model");
+    final EmbeddingModel embeddingModel = build(config, OpenAiEmbeddingModel.builder());
+    LOG.debug(
+        "Successfully built OpenAI-compatible embedding model with baseUrl '{}' and model '{}'",
+        config.getBaseUrl(),
+        config.getModel());
+    return embeddingModel;
+  }
 
-    final String model = require(config.getModel(), "model", OPENAI_COMPATIBLE);
-    final String baseUrl = require(config.getBaseUrl(), "baseUrl", OPENAI_COMPATIBLE);
-
-    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder =
-        OpenAiEmbeddingModel.builder().baseUrl(baseUrl).modelName(model);
-
+  // visible for testing
+  static EmbeddingModel build(
+      final OpenAiCompatibleConfig config,
+      final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder) {
+    builder.baseUrl(require(config.getBaseUrl(), "baseUrl", OPENAI_COMPATIBLE));
+    builder.modelName(require(config.getModel(), "model", OPENAI_COMPATIBLE));
     final Map<String, String> headers = config.getHeaders();
     final boolean hasAuthorizationHeader =
         headers != null && headers.keySet().stream().anyMatch("Authorization"::equalsIgnoreCase);
@@ -53,20 +60,12 @@ final class OpenAiCompatibleEmbeddingModelBuilder {
         builder.apiKey(config.getApiKey().trim());
       }
     }
-
     if (headers != null && !headers.isEmpty()) {
       builder.customHeaders(headers);
     }
-
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());
     }
-
-    final EmbeddingModel embeddingModel = builder.build();
-    LOG.debug(
-        "Successfully built OpenAI-compatible embedding model with baseUrl '{}' and model '{}'",
-        baseUrl,
-        model);
-    return embeddingModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilder.java
@@ -63,7 +63,12 @@ final class OpenAiCompatibleEmbeddingModelBuilder {
     if (headers != null && !headers.isEmpty()) {
       builder.customHeaders(headers);
     }
+    if (config.getTimeout() != null) {
+      LOG.debug("Setting timeout to {}", config.getTimeout());
+      builder.timeout(config.getTimeout());
+    }
     if (config.getDimensions() != null) {
+      LOG.debug("Setting dimensions to {}", config.getDimensions());
       builder.dimensions(config.getDimensions());
     }
     return builder.build();

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilder.java
@@ -42,20 +42,24 @@ final class OpenAiCompatibleEmbeddingModelBuilder {
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder =
         OpenAiEmbeddingModel.builder().baseUrl(baseUrl).modelName(model);
 
+    final Map<String, String> headers = config.getHeaders();
+    final boolean hasAuthorizationHeader =
+        headers != null && headers.keySet().stream().anyMatch("Authorization"::equalsIgnoreCase);
     if (hasText(config.getApiKey())) {
-      LOG.debug("Using configured API key");
-      builder.apiKey(config.getApiKey().trim());
-    } else {
-      LOG.debug("No API key configured, building without authentication");
+      if (hasAuthorizationHeader) {
+        LOG.warn("Both API key and Authorization header are set. The API key will be ignored.");
+      } else {
+        LOG.debug("Using configured API key");
+        builder.apiKey(config.getApiKey().trim());
+      }
+    }
+
+    if (headers != null && !headers.isEmpty()) {
+      builder.customHeaders(headers);
     }
 
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());
-    }
-
-    final Map<String, String> headers = config.getHeaders();
-    if (headers != null && !headers.isEmpty()) {
-      builder.customHeaders(headers);
     }
 
     final EmbeddingModel embeddingModel = builder.build();

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilder.java
@@ -32,19 +32,19 @@ final class OpenAiEmbeddingModelBuilder {
 
   static EmbeddingModel build(final OpenAiConfig config) {
     LOG.debug("Building OpenAI embedding model");
+    final EmbeddingModel embeddingModel = build(config, OpenAiEmbeddingModel.builder());
+    LOG.debug("Successfully built OpenAI embedding model with model '{}'", config.getModel());
+    return embeddingModel;
+  }
 
-    final String model = require(config.getModel(), "model", OPENAI);
-    final String apiKey = require(config.getApiKey(), "apiKey", OPENAI);
-
-    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder =
-        OpenAiEmbeddingModel.builder().apiKey(apiKey).modelName(model);
-
+  // visible for testing
+  static EmbeddingModel build(
+      final OpenAiConfig config, final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder) {
+    builder.apiKey(require(config.getApiKey(), "apiKey", OPENAI));
+    builder.modelName(require(config.getModel(), "model", OPENAI));
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());
     }
-
-    final EmbeddingModel embeddingModel = builder.build();
-    LOG.debug("Successfully built OpenAI embedding model with model '{}'", model);
-    return embeddingModel;
+    return builder.build();
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilder.java
@@ -20,7 +20,6 @@ import static io.camunda.process.test.impl.ModelBuilderSupport.require;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.OpenAiConfig;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,11 +41,6 @@ final class OpenAiEmbeddingModelBuilder {
 
     if (config.getDimensions() != null) {
       builder.dimensions(config.getDimensions());
-    }
-
-    final Map<String, String> headers = config.getHeaders();
-    if (headers != null && !headers.isEmpty()) {
-      builder.customHeaders(headers);
     }
 
     final EmbeddingModel embeddingModel = builder.build();

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilder.java
@@ -37,7 +37,6 @@ final class OpenAiEmbeddingModelBuilder {
     return embeddingModel;
   }
 
-  // visible for testing
   static EmbeddingModel build(
       final OpenAiConfig config, final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder) {
     builder.apiKey(require(config.getApiKey(), "apiKey", OPENAI));

--- a/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilder.java
+++ b/testing/camunda-process-test-langchain4j/src/main/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilder.java
@@ -42,7 +42,12 @@ final class OpenAiEmbeddingModelBuilder {
       final OpenAiConfig config, final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder) {
     builder.apiKey(require(config.getApiKey(), "apiKey", OPENAI));
     builder.modelName(require(config.getModel(), "model", OPENAI));
+    if (config.getTimeout() != null) {
+      LOG.debug("Setting timeout to {}", config.getTimeout());
+      builder.timeout(config.getTimeout());
+    }
     if (config.getDimensions() != null) {
+      LOG.debug("Setting dimensions to {}", config.getDimensions());
       builder.dimensions(config.getDimensions());
     }
     return builder.build();

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/BedrockRuntimeClientFactoryTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/BedrockRuntimeClientFactoryTest.java
@@ -164,7 +164,7 @@ class BedrockRuntimeClientFactoryTest {
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
   void shouldThrowWhenOnlyAccessKeyProvided(final String secretKey) {
-    assertThatThrownBy(() -> BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, null))
+    assertThatThrownBy(() -> BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, secretKey))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("accessKey")
         .hasMessageContaining("secretKey");
@@ -174,7 +174,7 @@ class BedrockRuntimeClientFactoryTest {
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
   void shouldThrowWhenOnlySecretKeyProvided(final String accessKey) {
-    assertThatThrownBy(() -> BedrockRuntimeClientFactory.build(REGION, null, null, SECRET_KEY))
+    assertThatThrownBy(() -> BedrockRuntimeClientFactory.build(REGION, null, accessKey, SECRET_KEY))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("accessKey")
         .hasMessageContaining("secretKey");

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/BedrockRuntimeClientFactoryTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/BedrockRuntimeClientFactoryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
@@ -70,7 +71,7 @@ class BedrockRuntimeClientFactoryTest {
   @Test
   void shouldConfigureRegionOnClientBuilder() {
     // when
-    BedrockRuntimeClientFactory.build(REGION, null, null, null);
+    BedrockRuntimeClientFactory.build(REGION, null, null, null, null);
 
     // then
     verify(mockClientBuilder).region(Region.of(REGION));
@@ -81,7 +82,7 @@ class BedrockRuntimeClientFactoryTest {
   @ValueSource(strings = {"  "})
   void shouldNotConfigureRegionWhenAbsent(final String region) {
     // when
-    BedrockRuntimeClientFactory.build(region, null, null, null);
+    BedrockRuntimeClientFactory.build(region, null, null, null, null);
 
     // then
     verify(mockClientBuilder, never()).region(any());
@@ -92,7 +93,7 @@ class BedrockRuntimeClientFactoryTest {
   @Test
   void shouldConfigureAccessKeyCredentialsOnClientBuilder() {
     // when
-    BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, SECRET_KEY);
+    BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, SECRET_KEY, null);
 
     // then
     final ArgumentCaptor<AwsCredentialsProvider> credentialsCaptor =
@@ -109,7 +110,7 @@ class BedrockRuntimeClientFactoryTest {
   @Test
   void shouldConfigureApiKeyAuthOnClientBuilder() {
     // when
-    BedrockRuntimeClientFactory.build(REGION, API_KEY, null, null);
+    BedrockRuntimeClientFactory.build(REGION, API_KEY, null, null, null);
 
     // then
     verify(mockClientBuilder).credentialsProvider(any(AnonymousCredentialsProvider.class));
@@ -130,7 +131,7 @@ class BedrockRuntimeClientFactoryTest {
   @Test
   void shouldTrimApiKeyInAuthorizationHeader() {
     // when
-    BedrockRuntimeClientFactory.build(REGION, "  " + API_KEY + "  ", null, null);
+    BedrockRuntimeClientFactory.build(REGION, "  " + API_KEY + "  ", null, null, null);
 
     // then
     @SuppressWarnings("unchecked")
@@ -145,17 +146,53 @@ class BedrockRuntimeClientFactoryTest {
         .containsEntry("Authorization", List.of("Bearer " + API_KEY));
   }
 
+  // -- Timeout configuration --
+
+  @Test
+  void shouldConfigureTimeoutWhenSet() {
+    // when
+    BedrockRuntimeClientFactory.build(REGION, null, null, null, Duration.ofSeconds(30));
+
+    // then
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Consumer<ClientOverrideConfiguration.Builder>> overrideCaptor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(mockClientBuilder).overrideConfiguration(overrideCaptor.capture());
+
+    final ClientOverrideConfiguration.Builder overrideBuilder =
+        ClientOverrideConfiguration.builder();
+    overrideCaptor.getValue().accept(overrideBuilder);
+    assertThat(overrideBuilder.build().apiCallTimeout()).hasValue(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void shouldUseDefaultTimeoutWhenNull() {
+    // when
+    BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, SECRET_KEY, null);
+
+    // then
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Consumer<ClientOverrideConfiguration.Builder>> overrideCaptor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(mockClientBuilder).overrideConfiguration(overrideCaptor.capture());
+
+    final ClientOverrideConfiguration.Builder overrideBuilder =
+        ClientOverrideConfiguration.builder();
+    overrideCaptor.getValue().accept(overrideBuilder);
+    assertThat(overrideBuilder.build().apiCallTimeout())
+        .hasValue(BedrockRuntimeClientFactory.DEFAULT_TIMEOUT);
+  }
+
   // -- Default credential chain --
 
   @Test
   void shouldNotConfigureCredentialsWhenNoneProvided() {
     // when
-    BedrockRuntimeClientFactory.build(null, null, null, null);
+    BedrockRuntimeClientFactory.build(null, null, null, null, null);
 
     // then
     verify(mockClientBuilder, never()).credentialsProvider(any());
     verify(mockClientBuilder, never()).putAuthScheme(any());
-    verify(mockClientBuilder, never()).overrideConfiguration(any(Consumer.class));
   }
 
   // -- Error cases --
@@ -164,7 +201,8 @@ class BedrockRuntimeClientFactoryTest {
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
   void shouldThrowWhenOnlyAccessKeyProvided(final String secretKey) {
-    assertThatThrownBy(() -> BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, secretKey))
+    assertThatThrownBy(
+            () -> BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, secretKey, null))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("accessKey")
         .hasMessageContaining("secretKey");
@@ -174,7 +212,8 @@ class BedrockRuntimeClientFactoryTest {
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
   void shouldThrowWhenOnlySecretKeyProvided(final String accessKey) {
-    assertThatThrownBy(() -> BedrockRuntimeClientFactory.build(REGION, null, accessKey, SECRET_KEY))
+    assertThatThrownBy(
+            () -> BedrockRuntimeClientFactory.build(REGION, null, accessKey, SECRET_KEY, null))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("accessKey")
         .hasMessageContaining("secretKey");
@@ -183,7 +222,7 @@ class BedrockRuntimeClientFactoryTest {
   @Test
   void shouldThrowWhenBothAuthMethodsProvided() {
     assertThatThrownBy(
-            () -> BedrockRuntimeClientFactory.build(REGION, API_KEY, ACCESS_KEY, SECRET_KEY))
+            () -> BedrockRuntimeClientFactory.build(REGION, API_KEY, ACCESS_KEY, SECRET_KEY, null))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("amazon-bedrock");
   }

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/BedrockRuntimeClientFactoryTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/BedrockRuntimeClientFactoryTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.auth.scheme.NoAuthAuthScheme;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClientBuilder;
+
+class BedrockRuntimeClientFactoryTest {
+
+  private static final String REGION = "us-east-1";
+  private static final String API_KEY = "test-api-key";
+  private static final String ACCESS_KEY = "test-access-key";
+  private static final String SECRET_KEY = "test-secret-key";
+
+  private BedrockRuntimeClientBuilder mockClientBuilder;
+  private MockedStatic<BedrockRuntimeClient> staticBedrockRuntimeClient;
+
+  @BeforeEach
+  void setUp() {
+    mockClientBuilder = mock(BedrockRuntimeClientBuilder.class, Mockito.RETURNS_SELF);
+    staticBedrockRuntimeClient = mockStatic(BedrockRuntimeClient.class);
+    staticBedrockRuntimeClient.when(BedrockRuntimeClient::builder).thenReturn(mockClientBuilder);
+  }
+
+  @AfterEach
+  void tearDown() {
+    staticBedrockRuntimeClient.close();
+  }
+
+  // -- Region configuration --
+
+  @Test
+  void shouldConfigureRegionOnClientBuilder() {
+    // when
+    BedrockRuntimeClientFactory.build(REGION, null, null, null);
+
+    // then
+    verify(mockClientBuilder).region(Region.of(REGION));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  "})
+  void shouldNotConfigureRegionWhenAbsent(final String region) {
+    // when
+    BedrockRuntimeClientFactory.build(region, null, null, null);
+
+    // then
+    verify(mockClientBuilder, never()).region(any());
+  }
+
+  // -- Access/secret key authentication --
+
+  @Test
+  void shouldConfigureAccessKeyCredentialsOnClientBuilder() {
+    // when
+    BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, SECRET_KEY);
+
+    // then
+    final ArgumentCaptor<AwsCredentialsProvider> credentialsCaptor =
+        ArgumentCaptor.forClass(AwsCredentialsProvider.class);
+    verify(mockClientBuilder).credentialsProvider(credentialsCaptor.capture());
+
+    final AwsCredentials credentials = credentialsCaptor.getValue().resolveCredentials();
+    assertThat(credentials.accessKeyId()).isEqualTo(ACCESS_KEY);
+    assertThat(credentials.secretAccessKey()).isEqualTo(SECRET_KEY);
+  }
+
+  // -- API key (Bearer token) authentication --
+
+  @Test
+  void shouldConfigureApiKeyAuthOnClientBuilder() {
+    // when
+    BedrockRuntimeClientFactory.build(REGION, API_KEY, null, null);
+
+    // then
+    verify(mockClientBuilder).credentialsProvider(any(AnonymousCredentialsProvider.class));
+    verify(mockClientBuilder).putAuthScheme(any(NoAuthAuthScheme.class));
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Consumer<ClientOverrideConfiguration.Builder>> overrideCaptor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(mockClientBuilder).overrideConfiguration(overrideCaptor.capture());
+
+    final ClientOverrideConfiguration.Builder overrideBuilder =
+        ClientOverrideConfiguration.builder();
+    overrideCaptor.getValue().accept(overrideBuilder);
+    assertThat(overrideBuilder.build().headers())
+        .containsEntry("Authorization", List.of("Bearer " + API_KEY));
+  }
+
+  @Test
+  void shouldTrimApiKeyInAuthorizationHeader() {
+    // when
+    BedrockRuntimeClientFactory.build(REGION, "  " + API_KEY + "  ", null, null);
+
+    // then
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Consumer<ClientOverrideConfiguration.Builder>> overrideCaptor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(mockClientBuilder).overrideConfiguration(overrideCaptor.capture());
+
+    final ClientOverrideConfiguration.Builder overrideBuilder =
+        ClientOverrideConfiguration.builder();
+    overrideCaptor.getValue().accept(overrideBuilder);
+    assertThat(overrideBuilder.build().headers())
+        .containsEntry("Authorization", List.of("Bearer " + API_KEY));
+  }
+
+  // -- Default credential chain --
+
+  @Test
+  void shouldNotConfigureCredentialsWhenNoneProvided() {
+    // when
+    BedrockRuntimeClientFactory.build(null, null, null, null);
+
+    // then
+    verify(mockClientBuilder, never()).credentialsProvider(any());
+    verify(mockClientBuilder, never()).putAuthScheme(any());
+    verify(mockClientBuilder, never()).overrideConfiguration(any(Consumer.class));
+  }
+
+  // -- Error cases --
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  "})
+  void shouldThrowWhenOnlyAccessKeyProvided(final String secretKey) {
+    assertThatThrownBy(() -> BedrockRuntimeClientFactory.build(REGION, null, ACCESS_KEY, null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("accessKey")
+        .hasMessageContaining("secretKey");
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  "})
+  void shouldThrowWhenOnlySecretKeyProvided(final String accessKey) {
+    assertThatThrownBy(() -> BedrockRuntimeClientFactory.build(REGION, null, null, SECRET_KEY))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("accessKey")
+        .hasMessageContaining("secretKey");
+  }
+
+  @Test
+  void shouldThrowWhenBothAuthMethodsProvided() {
+    assertThatThrownBy(
+            () -> BedrockRuntimeClientFactory.build(REGION, API_KEY, ACCESS_KEY, SECRET_KEY))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("amazon-bedrock");
+  }
+}

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AnthropicChatModelBuilderTest.java
@@ -17,8 +17,14 @@ package io.camunda.process.test.impl.judge;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.chat.ChatModel;
+import io.camunda.process.test.impl.judge.BaseProviderConfig.AnthropicConfig;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,11 +33,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class AnthropicChatModelBuilderTest {
 
+  private static final String MODEL = "claude-3-5-sonnet-20241022";
+  private static final String API_KEY = "test-api-key";
+
   @Test
   void shouldBuildChatModel() {
     // given
-    final BaseProviderConfig.AnthropicConfig config =
-        new BaseProviderConfig.AnthropicConfig("claude-3-5-sonnet-20241022", "test-api-key");
+    final AnthropicConfig config = new AnthropicConfig(MODEL, API_KEY);
 
     // when
     final ChatModel chatModel = AnthropicChatModelBuilder.build(config);
@@ -41,31 +49,50 @@ class AnthropicChatModelBuilderTest {
   }
 
   @Test
-  void shouldBuildChatModelWithTimeout() {
+  void shouldSetRequiredFieldsOnBuilder() {
     // given
-    final BaseProviderConfig.AnthropicConfig config =
-        new BaseProviderConfig.AnthropicConfig("claude-3-5-sonnet-20241022", "test-api-key");
+    final AnthropicConfig config = new AnthropicConfig(MODEL, API_KEY);
+    final AnthropicChatModel.AnthropicChatModelBuilder mockBuilder =
+        mock(AnthropicChatModel.AnthropicChatModelBuilder.class);
+
+    // when
+    AnthropicChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).apiKey(API_KEY);
+    verify(mockBuilder).modelName(MODEL);
+  }
+
+  @Test
+  void shouldApplyTimeoutToBuilder() {
+    // given
+    final AnthropicConfig config = new AnthropicConfig(MODEL, API_KEY);
     config.setTimeout(Duration.ofSeconds(30));
+    final AnthropicChatModel.AnthropicChatModelBuilder mockBuilder =
+        mock(AnthropicChatModel.AnthropicChatModelBuilder.class);
 
     // when
-    final ChatModel chatModel = AnthropicChatModelBuilder.build(config);
+    AnthropicChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder).timeout(Duration.ofSeconds(30));
+    verify(mockBuilder, never()).temperature(any());
   }
 
   @Test
-  void shouldBuildChatModelWithTemperature() {
+  void shouldApplyTemperatureToBuilder() {
     // given
-    final BaseProviderConfig.AnthropicConfig config =
-        new BaseProviderConfig.AnthropicConfig("claude-3-5-sonnet-20241022", "test-api-key");
+    final AnthropicConfig config = new AnthropicConfig(MODEL, API_KEY);
     config.setTemperature(0.7);
+    final AnthropicChatModel.AnthropicChatModelBuilder mockBuilder =
+        mock(AnthropicChatModel.AnthropicChatModelBuilder.class);
 
     // when
-    final ChatModel chatModel = AnthropicChatModelBuilder.build(config);
+    AnthropicChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder, never()).timeout(any());
+    verify(mockBuilder).temperature(0.7);
   }
 
   @ParameterizedTest
@@ -73,8 +100,7 @@ class AnthropicChatModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenApiKeyMissingOrBlank(final String apiKey) {
     // given
-    final BaseProviderConfig.AnthropicConfig config =
-        new BaseProviderConfig.AnthropicConfig("claude-3-5-sonnet-20241022", apiKey);
+    final AnthropicConfig config = new AnthropicConfig(MODEL, apiKey);
 
     // when / then
     assertThatThrownBy(() -> AnthropicChatModelBuilder.build(config))
@@ -88,8 +114,7 @@ class AnthropicChatModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final BaseProviderConfig.AnthropicConfig config =
-        new BaseProviderConfig.AnthropicConfig(model, "test-api-key");
+    final AnthropicConfig config = new AnthropicConfig(model, API_KEY);
 
     // when / then
     assertThatThrownBy(() -> AnthropicChatModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/AzureOpenAiChatModelBuilderTest.java
@@ -17,8 +17,15 @@ package io.camunda.process.test.impl.judge;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.azure.core.credential.TokenCredential;
+import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import dev.langchain4j.model.chat.ChatModel;
+import io.camunda.process.test.impl.judge.BaseProviderConfig.AzureOpenAiConfig;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,12 +34,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class AzureOpenAiChatModelBuilderTest {
 
+  private static final String MODEL = "gpt-4o";
+  private static final String ENDPOINT = "https://my-resource.openai.azure.com/";
+  private static final String API_KEY = "test-api-key";
+
   @Test
   void shouldBuildChatModelWithApiKey() {
     // given
-    final BaseProviderConfig.AzureOpenAiConfig config =
-        new BaseProviderConfig.AzureOpenAiConfig(
-            "gpt-4o", "https://my-resource.openai.azure.com/", "test-api-key");
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
 
     // when
     final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
@@ -42,47 +51,77 @@ class AzureOpenAiChatModelBuilderTest {
   }
 
   @Test
-  void shouldBuildChatModelWithDefaultCredentials() {
-    // given — no API key, falls back to DefaultAzureCredential
-    final BaseProviderConfig.AzureOpenAiConfig config =
-        new BaseProviderConfig.AzureOpenAiConfig(
-            "gpt-4o", "https://my-resource.openai.azure.com/", null);
-
-    // when
-    final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
-
-    // then
-    assertThat(chatModel).isNotNull();
-  }
-
-  @Test
-  void shouldBuildChatModelWithTimeout() {
+  void shouldSetRequiredFieldsOnBuilder() {
     // given
-    final BaseProviderConfig.AzureOpenAiConfig config =
-        new BaseProviderConfig.AzureOpenAiConfig(
-            "gpt-4o", "https://my-resource.openai.azure.com/", "test-api-key");
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
+    final AzureOpenAiChatModel.Builder mockBuilder = mock(AzureOpenAiChatModel.Builder.class);
+
+    // when
+    AzureOpenAiChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).endpoint(ENDPOINT);
+    verify(mockBuilder).deploymentName(MODEL);
+  }
+
+  @Test
+  void shouldApplyApiKeyToBuilder() {
+    // given
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
+    final AzureOpenAiChatModel.Builder mockBuilder = mock(AzureOpenAiChatModel.Builder.class);
+
+    // when
+    AzureOpenAiChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).apiKey(API_KEY);
+    verify(mockBuilder, never()).tokenCredential(any());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  "})
+  void shouldApplyDefaultCredentialsToBuilderWhenNoApiKey(final String apiKey) {
+    // given
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, apiKey);
+    final AzureOpenAiChatModel.Builder mockBuilder = mock(AzureOpenAiChatModel.Builder.class);
+
+    // when
+    AzureOpenAiChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).tokenCredential(any(TokenCredential.class));
+    verify(mockBuilder, never()).apiKey(any());
+  }
+
+  @Test
+  void shouldApplyTimeoutToBuilder() {
+    // given
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
     config.setTimeout(Duration.ofSeconds(45));
+    final AzureOpenAiChatModel.Builder mockBuilder = mock(AzureOpenAiChatModel.Builder.class);
 
     // when
-    final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
+    AzureOpenAiChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder).timeout(Duration.ofSeconds(45));
+    verify(mockBuilder, never()).temperature(any());
   }
 
   @Test
-  void shouldBuildChatModelWithTemperature() {
+  void shouldApplyTemperatureToBuilder() {
     // given
-    final BaseProviderConfig.AzureOpenAiConfig config =
-        new BaseProviderConfig.AzureOpenAiConfig(
-            "gpt-4o", "https://my-resource.openai.azure.com/", "test-api-key");
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
     config.setTemperature(0.7);
+    final AzureOpenAiChatModel.Builder mockBuilder = mock(AzureOpenAiChatModel.Builder.class);
 
     // when
-    final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);
+    AzureOpenAiChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder, never()).timeout(any());
+    verify(mockBuilder).temperature(0.7);
   }
 
   @ParameterizedTest
@@ -90,9 +129,7 @@ class AzureOpenAiChatModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final BaseProviderConfig.AzureOpenAiConfig config =
-        new BaseProviderConfig.AzureOpenAiConfig(
-            model, "https://my-resource.openai.azure.com/", "test-api-key");
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(model, ENDPOINT, API_KEY);
 
     // when / then
     assertThatThrownBy(() -> AzureOpenAiChatModelBuilder.build(config))
@@ -106,8 +143,7 @@ class AzureOpenAiChatModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenEndpointMissingOrBlank(final String endpoint) {
     // given
-    final BaseProviderConfig.AzureOpenAiConfig config =
-        new BaseProviderConfig.AzureOpenAiConfig("gpt-4o", endpoint, "test-api-key");
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, endpoint, API_KEY);
 
     // when / then
     assertThatThrownBy(() -> AzureOpenAiChatModelBuilder.build(config))
@@ -120,9 +156,7 @@ class AzureOpenAiChatModelBuilderTest {
   @ValueSource(strings = {"", "  "})
   void shouldFallbackToDefaultCredentialsWhenApiKeyBlank(final String apiKey) {
     // given — blank API key is treated as absent
-    final BaseProviderConfig.AzureOpenAiConfig config =
-        new BaseProviderConfig.AzureOpenAiConfig(
-            "gpt-4o", "https://my-resource.openai.azure.com/", apiKey);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, apiKey);
 
     // when
     final ChatModel chatModel = AzureOpenAiChatModelBuilder.build(config);

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilderTest.java
@@ -17,28 +17,42 @@ package io.camunda.process.test.impl.judge;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import dev.langchain4j.model.bedrock.BedrockChatModel;
+import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
+import io.camunda.process.test.impl.BedrockRuntimeClientFactory;
+import io.camunda.process.test.impl.judge.BaseProviderConfig.AmazonBedrockConfig;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 class BedrockChatModelBuilderTest {
+
+  private static final String MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+  private static final String REGION = "us-east-1";
+  private static final String ACCESS_KEY = "test-access-key";
+  private static final String SECRET_KEY = "test-secret-key";
+  private static final String API_KEY = "test-api-key";
 
   // -- Happy paths --
 
   @Test
-  void shouldBuildChatModelWithAccessKeyCredentials() {
+  void shouldBuildChatModel() {
     // given
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "us-east-1",
-            null,
-            "test-access-key",
-            "test-secret-key");
+    final AmazonBedrockConfig config =
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY);
 
     // when
     final ChatModel chatModel = BedrockChatModelBuilder.build(config);
@@ -48,69 +62,76 @@ class BedrockChatModelBuilderTest {
   }
 
   @Test
-  void shouldBuildChatModelWithApiKey() {
+  void shouldSetRequiredFieldsOnBuilder() {
     // given
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1", "test-api-key", null, null);
+    final AmazonBedrockConfig config = new AmazonBedrockConfig(MODEL, REGION, null, null, null);
+    final BedrockChatModel.Builder mockBuilder = mock(BedrockChatModel.Builder.class);
 
     // when
-    final ChatModel chatModel = BedrockChatModelBuilder.build(config);
+    BedrockChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder).modelId(MODEL);
+    verify(mockBuilder).client(any());
   }
 
   @Test
-  void shouldBuildChatModelWithDefaultCredentialChain() {
-    // given — no explicit authentication, uses AWS default credential chain
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1", null, null, null);
-
-    // when
-    final ChatModel chatModel = BedrockChatModelBuilder.build(config);
-
-    // then
-    assertThat(chatModel).isNotNull();
-  }
-
-  @Test
-  void shouldBuildChatModelWithTimeout() {
+  void shouldApplyTimeoutToBuilder() {
     // given
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "us-east-1",
-            null,
-            "test-access-key",
-            "test-secret-key");
+    final AmazonBedrockConfig config =
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY);
     config.setTimeout(Duration.ofSeconds(60));
+    final BedrockChatModel.Builder mockBuilder = mock(BedrockChatModel.Builder.class);
 
     // when
-    final ChatModel chatModel = BedrockChatModelBuilder.build(config);
+    BedrockChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder).timeout(Duration.ofSeconds(60));
+    verify(mockBuilder, never()).defaultRequestParameters(any());
   }
 
   @Test
-  void shouldBuildChatModelWithTemperature() {
+  void shouldApplyTemperatureToBuilder() {
     // given
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "us-east-1",
-            null,
-            "test-access-key",
-            "test-secret-key");
+    final AmazonBedrockConfig config =
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY);
     config.setTemperature(0.7);
+    final BedrockChatModel.Builder mockBuilder = mock(BedrockChatModel.Builder.class);
+    final ArgumentCaptor<BedrockChatRequestParameters> captor =
+        ArgumentCaptor.forClass(BedrockChatRequestParameters.class);
 
     // when
-    final ChatModel chatModel = BedrockChatModelBuilder.build(config);
+    BedrockChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder, never()).timeout(any());
+    verify(mockBuilder).defaultRequestParameters(captor.capture());
+    assertThat(captor.getValue().temperature()).isEqualTo(0.7);
+  }
+
+  @Test
+  void shouldForwardConfigToClientFactory() {
+    // given
+    final AmazonBedrockConfig config =
+        new AmazonBedrockConfig(MODEL, REGION, API_KEY, ACCESS_KEY, SECRET_KEY);
+    final BedrockChatModel.Builder mockBuilder = mock(BedrockChatModel.Builder.class);
+
+    try (final MockedStatic<BedrockRuntimeClientFactory> mockFactory =
+        mockStatic(BedrockRuntimeClientFactory.class)) {
+      mockFactory
+          .when(() -> BedrockRuntimeClientFactory.build(any(), any(), any(), any()))
+          .thenReturn(mock(BedrockRuntimeClient.class));
+
+      // when
+      BedrockChatModelBuilder.build(config, mockBuilder);
+
+      // then
+      mockFactory.verify(
+          () ->
+              BedrockRuntimeClientFactory.build(
+                  eq(REGION), eq(API_KEY), eq(ACCESS_KEY), eq(SECRET_KEY)));
+    }
   }
 
   // -- Required field validation --
@@ -120,133 +141,13 @@ class BedrockChatModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            model, "us-east-1", null, "test-access-key", "test-secret-key");
+    final AmazonBedrockConfig config =
+        new AmazonBedrockConfig(model, REGION, null, ACCESS_KEY, SECRET_KEY);
 
     // when / then
     assertThatThrownBy(() -> BedrockChatModelBuilder.build(config))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("model")
         .hasMessageContaining("amazon-bedrock");
-  }
-
-  // -- Blank optional fields treated as absent --
-
-  @ParameterizedTest
-  @ValueSource(strings = {"", "  "})
-  void shouldFallbackToDefaultCredentialChainWhenApiKeyBlank(final String apiKey) {
-    // given — blank apiKey is treated as absent
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1", apiKey, null, null);
-
-    // when
-    final ChatModel chatModel = BedrockChatModelBuilder.build(config);
-
-    // then
-    assertThat(chatModel).isNotNull();
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"", "  "})
-  void shouldFallbackToDefaultCredentialChainWhenBothKeysBlank(final String blankValue) {
-    // given — both blank credentials are treated as absent
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1", null, blankValue, blankValue);
-
-    // when
-    final ChatModel chatModel = BedrockChatModelBuilder.build(config);
-
-    // then
-    assertThat(chatModel).isNotNull();
-  }
-
-  // -- Authentication edge cases --
-
-  @Test
-  void shouldThrowWhenBothAuthMethodsProvided() {
-    // given — both accessKey/secretKey and apiKey are set
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "us-east-1",
-            "test-api-key",
-            "test-access-key",
-            "test-secret-key");
-
-    // when / then
-    assertThatThrownBy(() -> BedrockChatModelBuilder.build(config))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("amazon-bedrock");
-  }
-
-  @Test
-  void shouldThrowWhenOnlyAccessKeyProvided() {
-    // given — only accessKey without secretKey
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "us-east-1",
-            null,
-            "test-access-key",
-            null);
-
-    // when / then
-    assertThatThrownBy(() -> BedrockChatModelBuilder.build(config))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("accessKey")
-        .hasMessageContaining("secretKey");
-  }
-
-  @Test
-  void shouldThrowWhenOnlySecretKeyProvided() {
-    // given — only secretKey without accessKey
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "us-east-1",
-            null,
-            null,
-            "test-secret-key");
-
-    // when / then
-    assertThatThrownBy(() -> BedrockChatModelBuilder.build(config))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("accessKey")
-        .hasMessageContaining("secretKey");
-  }
-
-  @Test
-  void shouldThrowWhenAccessKeyBlankAndSecretKeySet() {
-    // given — blank accessKey treated as absent, creating a partial key-pair
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "us-east-1",
-            null,
-            "  ",
-            "test-secret-key");
-
-    // when / then
-    assertThatThrownBy(() -> BedrockChatModelBuilder.build(config))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("accessKey")
-        .hasMessageContaining("secretKey");
-  }
-
-  @Test
-  void shouldThrowWhenSecretKeyBlankAndAccessKeySet() {
-    // given — blank secretKey treated as absent, creating a partial key-pair
-    final BaseProviderConfig.AmazonBedrockConfig config =
-        new BaseProviderConfig.AmazonBedrockConfig(
-            "anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1", null, "test-access-key", "");
-
-    // when / then
-    assertThatThrownBy(() -> BedrockChatModelBuilder.build(config))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("accessKey")
-        .hasMessageContaining("secretKey");
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/BedrockChatModelBuilderTest.java
@@ -76,22 +76,6 @@ class BedrockChatModelBuilderTest {
   }
 
   @Test
-  void shouldApplyTimeoutToBuilder() {
-    // given
-    final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY);
-    config.setTimeout(Duration.ofSeconds(60));
-    final BedrockChatModel.Builder mockBuilder = mock(BedrockChatModel.Builder.class);
-
-    // when
-    BedrockChatModelBuilder.build(config, mockBuilder);
-
-    // then
-    verify(mockBuilder).timeout(Duration.ofSeconds(60));
-    verify(mockBuilder, never()).defaultRequestParameters(any());
-  }
-
-  @Test
   void shouldApplyTemperatureToBuilder() {
     // given
     final AmazonBedrockConfig config =
@@ -115,12 +99,13 @@ class BedrockChatModelBuilderTest {
     // given
     final AmazonBedrockConfig config =
         new AmazonBedrockConfig(MODEL, REGION, API_KEY, ACCESS_KEY, SECRET_KEY);
+    config.setTimeout(Duration.ofSeconds(60));
     final BedrockChatModel.Builder mockBuilder = mock(BedrockChatModel.Builder.class);
 
     try (final MockedStatic<BedrockRuntimeClientFactory> mockFactory =
         mockStatic(BedrockRuntimeClientFactory.class)) {
       mockFactory
-          .when(() -> BedrockRuntimeClientFactory.build(any(), any(), any(), any()))
+          .when(() -> BedrockRuntimeClientFactory.build(any(), any(), any(), any(), any()))
           .thenReturn(mock(BedrockRuntimeClient.class));
 
       // when
@@ -130,7 +115,11 @@ class BedrockChatModelBuilderTest {
       mockFactory.verify(
           () ->
               BedrockRuntimeClientFactory.build(
-                  eq(REGION), eq(API_KEY), eq(ACCESS_KEY), eq(SECRET_KEY)));
+                  eq(REGION),
+                  eq(API_KEY),
+                  eq(ACCESS_KEY),
+                  eq(SECRET_KEY),
+                  eq(Duration.ofSeconds(60))));
     }
   }
 

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiChatModelBuilderTest.java
@@ -17,8 +17,14 @@ package io.camunda.process.test.impl.judge;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.camunda.process.test.impl.judge.BaseProviderConfig.OpenAiConfig;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,11 +33,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class OpenAiChatModelBuilderTest {
 
+  private static final String MODEL = "gpt-4o";
+  private static final String API_KEY = "test-api-key";
+
   @Test
   void shouldBuildChatModel() {
     // given
-    final BaseProviderConfig.OpenAiConfig config =
-        new BaseProviderConfig.OpenAiConfig("gpt-4o", "test-api-key");
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY);
 
     // when
     final ChatModel chatModel = OpenAiChatModelBuilder.build(config);
@@ -40,13 +48,59 @@ class OpenAiChatModelBuilderTest {
     assertThat(chatModel).isNotNull();
   }
 
+  @Test
+  void shouldSetRequiredFieldsOnBuilder() {
+    // given
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY);
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+
+    // when
+    OpenAiChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).apiKey(API_KEY);
+    verify(mockBuilder).modelName(MODEL);
+  }
+
+  @Test
+  void shouldApplyTimeoutToBuilder() {
+    // given
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY);
+    config.setTimeout(Duration.ofSeconds(30));
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+
+    // when
+    OpenAiChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).timeout(Duration.ofSeconds(30));
+    verify(mockBuilder, never()).temperature(any());
+  }
+
+  @Test
+  void shouldApplyTemperatureToBuilder() {
+    // given
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY);
+    config.setTemperature(0.7);
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+
+    // when
+    OpenAiChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder, never()).timeout(any());
+    verify(mockBuilder).temperature(0.7);
+  }
+
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
   void shouldThrowWhenApiKeyMissingOrBlank(final String apiKey) {
     // given
-    final BaseProviderConfig.OpenAiConfig config =
-        new BaseProviderConfig.OpenAiConfig("gpt-4o", apiKey);
+    final OpenAiConfig config = new OpenAiConfig(MODEL, apiKey);
 
     // when / then
     assertThatThrownBy(() -> OpenAiChatModelBuilder.build(config))
@@ -55,41 +109,12 @@ class OpenAiChatModelBuilderTest {
         .hasMessageContaining("openai");
   }
 
-  @Test
-  void shouldBuildChatModelWithTimeout() {
-    // given
-    final BaseProviderConfig.OpenAiConfig config =
-        new BaseProviderConfig.OpenAiConfig("gpt-4o", "test-api-key");
-    config.setTimeout(Duration.ofSeconds(30));
-
-    // when
-    final ChatModel chatModel = OpenAiChatModelBuilder.build(config);
-
-    // then
-    assertThat(chatModel).isNotNull();
-  }
-
-  @Test
-  void shouldBuildChatModelWithTemperature() {
-    // given
-    final BaseProviderConfig.OpenAiConfig config =
-        new BaseProviderConfig.OpenAiConfig("gpt-4o", "test-api-key");
-    config.setTemperature(0.7);
-
-    // when
-    final ChatModel chatModel = OpenAiChatModelBuilder.build(config);
-
-    // then
-    assertThat(chatModel).isNotNull();
-  }
-
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final BaseProviderConfig.OpenAiConfig config =
-        new BaseProviderConfig.OpenAiConfig(model, "test-api-key");
+    final OpenAiConfig config = new OpenAiConfig(model, API_KEY);
 
     // when / then
     assertThatThrownBy(() -> OpenAiChatModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/judge/OpenAiCompatibleChatModelBuilderTest.java
@@ -17,8 +17,15 @@ package io.camunda.process.test.impl.judge;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.camunda.process.test.impl.judge.BaseProviderConfig.OpenAiCompatibleConfig;
 import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -28,12 +35,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class OpenAiCompatibleChatModelBuilderTest {
 
+  private static final String MODEL = "llama3";
+  private static final String BASE_URL = "http://localhost:11434/v1";
+  private static final String API_KEY = "test-api-key";
+
   @Test
-  void shouldBuildChatModelWithApiKey() {
+  void shouldBuildChatModel() {
     // given
-    final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3", "http://localhost:11434/v1", "test-api-key", null);
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null);
 
     // when
     final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
@@ -43,83 +53,118 @@ class OpenAiCompatibleChatModelBuilderTest {
   }
 
   @Test
-  void shouldBuildChatModelWithHeaders() {
+  void shouldSetRequiredFieldsOnBuilder() {
     // given
-    final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3",
-            "http://localhost:11434/v1",
-            null,
-            Map.of("X-Test-Header", "test-header-value"));
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null);
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
 
     // when
-    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
+    OpenAiCompatibleChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder).baseUrl(BASE_URL);
+    verify(mockBuilder).modelName(MODEL);
+    verify(mockBuilder, never()).apiKey(any());
+    verify(mockBuilder, never()).customHeaders(anyMap());
   }
 
   @Test
-  void shouldBuildChatModelWhenBothAuthorizationHeaderAndApiKeyPresent() {
+  void shouldApplyApiKeyToBuilderWhenNoAuthorizationHeader() {
     // given
-    final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3",
-            "http://localhost:11434/v1",
-            "test-api-key",
-            Map.of("Authorization", "Bearer test-token"));
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null);
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
 
     // when
-    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
+    OpenAiCompatibleChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder).apiKey(API_KEY);
   }
 
   @Test
-  void shouldBuildChatModelWithTimeout() {
+  void shouldNotApplyApiKeyWhenAuthorizationHeaderPresent() {
     // given
-    final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3", "http://localhost:11434/v1", "test-api-key", null);
-    config.setTimeout(Duration.ofSeconds(30));
+    final Map<String, String> headers = Map.of("Authorization", "Bearer test-token");
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, headers);
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
 
     // when
-    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
+    OpenAiCompatibleChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
-  }
-
-  @Test
-  void shouldBuildChatModelWithTemperature() {
-    // given
-    final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3", "http://localhost:11434/v1", "test-api-key", null);
-    config.setTemperature(0.7);
-
-    // when
-    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
-
-    // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder, never()).apiKey(any());
+    verify(mockBuilder).customHeaders(headers);
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
-  void shouldBuildChatModelWithoutApiKey(final String apiKey) {
-    // given — null or blank apiKey is treated as absent
-    final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig(
-            "llama3", "http://localhost:11434/v1", apiKey, null);
+  void shouldNotApplyApiKeyToBuilderWhenNullOrBlank(final String apiKey) {
+    // given
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(MODEL, BASE_URL, apiKey, null);
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
 
     // when
-    final ChatModel chatModel = OpenAiCompatibleChatModelBuilder.build(config);
+    OpenAiCompatibleChatModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(chatModel).isNotNull();
+    verify(mockBuilder, never()).apiKey(any());
+  }
+
+  @Test
+  void shouldApplyHeadersToBuilder() {
+    // given
+    final Map<String, String> headers = Map.of("X-Test-Header", "test-header-value");
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, headers);
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+
+    // when
+    OpenAiCompatibleChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).customHeaders(headers);
+  }
+
+  @Test
+  void shouldApplyTimeoutToBuilder() {
+    // given
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null);
+    config.setTimeout(Duration.ofSeconds(30));
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+
+    // when
+    OpenAiCompatibleChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).timeout(Duration.ofSeconds(30));
+    verify(mockBuilder, never()).temperature(any());
+  }
+
+  @Test
+  void shouldApplyTemperatureToBuilder() {
+    // given
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null);
+    config.setTemperature(0.7);
+    final OpenAiChatModel.OpenAiChatModelBuilder mockBuilder =
+        mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+
+    // when
+    OpenAiCompatibleChatModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder, never()).timeout(any());
+    verify(mockBuilder).temperature(0.7);
   }
 
   @ParameterizedTest
@@ -127,8 +172,7 @@ class OpenAiCompatibleChatModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenBaseUrlMissingOrBlank(final String baseUrl) {
     // given
-    final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig("llama3", baseUrl, null, null);
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(MODEL, baseUrl, null, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiCompatibleChatModelBuilder.build(config))
@@ -142,9 +186,7 @@ class OpenAiCompatibleChatModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final BaseProviderConfig.OpenAiCompatibleConfig config =
-        new BaseProviderConfig.OpenAiCompatibleConfig(
-            model, "http://localhost:11434/v1", null, null);
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(model, BASE_URL, null, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiCompatibleChatModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class AzureOpenAiEmbeddingModelBuilderTest {
 
   @Test
-  void shouldBuildEmbeddingModel() {
+  void shouldBuildEmbeddingModelWithApiKey() {
     // given
     final AzureOpenAiConfig config =
         new AzureOpenAiConfig(
@@ -38,6 +38,22 @@ class AzureOpenAiEmbeddingModelBuilderTest {
             "test-api-key",
             null,
             null);
+
+    // when
+    final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
+
+    // then
+    assertThat(embeddingModel).isNotNull();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  "})
+  void shouldFallbackToDefaultCredentialsWhenApiKeyNullOrBlank(final String apiKey) {
+    // given — no API key, falls back to DefaultAzureCredential
+    final AzureOpenAiConfig config =
+        new AzureOpenAiConfig(
+            "text-embedding-3-small", "https://my-resource.openai.azure.com/", apiKey, null, null);
 
     // when
     final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
@@ -94,22 +110,6 @@ class AzureOpenAiEmbeddingModelBuilderTest {
     assertThatThrownBy(() -> AzureOpenAiEmbeddingModelBuilder.build(config))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("endpoint")
-        .hasMessageContaining(AzureOpenAiEmbeddingModelBuilder.AZURE_OPENAI);
-  }
-
-  @ParameterizedTest
-  @NullAndEmptySource
-  @ValueSource(strings = {"  "})
-  void shouldThrowWhenApiKeyMissingOrBlank(final String apiKey) {
-    // given
-    final AzureOpenAiConfig config =
-        new AzureOpenAiConfig(
-            "text-embedding-3-small", "https://my-resource.openai.azure.com/", apiKey, null, null);
-
-    // when / then
-    assertThatThrownBy(() -> AzureOpenAiEmbeddingModelBuilder.build(config))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("apiKey")
         .hasMessageContaining(AzureOpenAiEmbeddingModelBuilder.AZURE_OPENAI);
   }
 

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
@@ -17,7 +17,13 @@ package io.camunda.process.test.impl.similarity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.azure.core.credential.TokenCredential;
+import dev.langchain4j.model.azure.AzureOpenAiEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.AzureOpenAiConfig;
 import org.junit.jupiter.api.Test;
@@ -27,51 +33,82 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class AzureOpenAiEmbeddingModelBuilderTest {
 
+  private static final String MODEL = "text-embedding-3-small";
+  private static final String ENDPOINT = "https://my-resource.openai.azure.com/";
+  private static final String API_KEY = "test-api-key";
+
   @Test
-  void shouldBuildEmbeddingModelWithApiKey() {
+  void shouldBuildEmbeddingModel() {
     // given
-    final AzureOpenAiConfig config =
-        new AzureOpenAiConfig(
-            "text-embedding-3-small",
-            "https://my-resource.openai.azure.com/",
-            "test-api-key",
-            null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, null);
 
     // when
     final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
 
     // then
     assertThat(embeddingModel).isNotNull();
+  }
+
+  @Test
+  void shouldSetRequiredFieldsOnBuilder() {
+    // given
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, null);
+    final AzureOpenAiEmbeddingModel.Builder mockBuilder =
+        mock(AzureOpenAiEmbeddingModel.Builder.class);
+
+    // when
+    AzureOpenAiEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).endpoint(ENDPOINT);
+    verify(mockBuilder).deploymentName(MODEL);
+    verify(mockBuilder, never()).dimensions(any());
+  }
+
+  @Test
+  void shouldApplyApiKeyToBuilder() {
+    // given
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, null);
+    final AzureOpenAiEmbeddingModel.Builder mockBuilder =
+        mock(AzureOpenAiEmbeddingModel.Builder.class);
+
+    // when
+    AzureOpenAiEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).apiKey(API_KEY);
+    verify(mockBuilder, never()).tokenCredential(any());
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
-  void shouldFallbackToDefaultCredentialsWhenApiKeyNullOrBlank(final String apiKey) {
-    // given — no API key, falls back to DefaultAzureCredential
-    final AzureOpenAiConfig config =
-        new AzureOpenAiConfig(
-            "text-embedding-3-small", "https://my-resource.openai.azure.com/", apiKey, null);
+  void shouldApplyDefaultCredentialsToBuilderWhenNoApiKey(final String apiKey) {
+    // given
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, apiKey, null);
+    final AzureOpenAiEmbeddingModel.Builder mockBuilder =
+        mock(AzureOpenAiEmbeddingModel.Builder.class);
 
     // when
-    final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
+    AzureOpenAiEmbeddingModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(embeddingModel).isNotNull();
+    verify(mockBuilder).tokenCredential(any(TokenCredential.class));
+    verify(mockBuilder, never()).apiKey(any());
   }
 
   @Test
-  void shouldBuildEmbeddingModelWithDimensions() {
+  void shouldApplyDimensionsToBuilder() {
     // given
-    final AzureOpenAiConfig config =
-        new AzureOpenAiConfig(
-            "text-embedding-3-small", "https://my-resource.openai.azure.com/", "test-api-key", 512);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, 512);
+    final AzureOpenAiEmbeddingModel.Builder mockBuilder =
+        mock(AzureOpenAiEmbeddingModel.Builder.class);
 
     // when
-    final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
+    AzureOpenAiEmbeddingModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(embeddingModel).isNotNull();
+    verify(mockBuilder).dimensions(512);
   }
 
   @ParameterizedTest
@@ -79,8 +116,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenEndpointMissingOrBlank(final String endpoint) {
     // given
-    final AzureOpenAiConfig config =
-        new AzureOpenAiConfig("text-embedding-3-small", endpoint, "test-api-key", null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, endpoint, API_KEY, null);
 
     // when / then
     assertThatThrownBy(() -> AzureOpenAiEmbeddingModelBuilder.build(config))
@@ -94,8 +130,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final AzureOpenAiConfig config =
-        new AzureOpenAiConfig(model, "https://my-resource.openai.azure.com/", "test-api-key", null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(model, ENDPOINT, API_KEY, null);
 
     // when / then
     assertThatThrownBy(() -> AzureOpenAiEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
@@ -41,7 +41,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldBuildEmbeddingModel() {
     // given
-    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
 
     // when
     final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
@@ -53,7 +53,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldSetRequiredFieldsOnBuilder() {
     // given
-    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
     final AzureOpenAiEmbeddingModel.Builder mockBuilder =
         mock(AzureOpenAiEmbeddingModel.Builder.class);
 
@@ -70,7 +70,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldApplyTimeoutToBuilder() {
     // given
-    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
     config.setTimeout(Duration.ofSeconds(45));
     final AzureOpenAiEmbeddingModel.Builder mockBuilder =
         mock(AzureOpenAiEmbeddingModel.Builder.class);
@@ -85,7 +85,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldApplyApiKeyToBuilder() {
     // given
-    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
     final AzureOpenAiEmbeddingModel.Builder mockBuilder =
         mock(AzureOpenAiEmbeddingModel.Builder.class);
 
@@ -102,7 +102,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldApplyDefaultCredentialsToBuilderWhenNoApiKey(final String apiKey) {
     // given
-    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, apiKey, null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, apiKey);
     final AzureOpenAiEmbeddingModel.Builder mockBuilder =
         mock(AzureOpenAiEmbeddingModel.Builder.class);
 
@@ -117,7 +117,8 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldApplyDimensionsToBuilder() {
     // given
-    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, 512);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY);
+    config.setDimensions(512);
     final AzureOpenAiEmbeddingModel.Builder mockBuilder =
         mock(AzureOpenAiEmbeddingModel.Builder.class);
 
@@ -133,7 +134,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenEndpointMissingOrBlank(final String endpoint) {
     // given
-    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, endpoint, API_KEY, null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, endpoint, API_KEY);
 
     // when / then
     assertThatThrownBy(() -> AzureOpenAiEmbeddingModelBuilder.build(config))
@@ -147,7 +148,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final AzureOpenAiConfig config = new AzureOpenAiConfig(model, ENDPOINT, API_KEY, null);
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(model, ENDPOINT, API_KEY);
 
     // when / then
     assertThatThrownBy(() -> AzureOpenAiEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.AzureOpenAiConfig;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -36,7 +35,6 @@ class AzureOpenAiEmbeddingModelBuilderTest {
             "text-embedding-3-small",
             "https://my-resource.openai.azure.com/",
             "test-api-key",
-            null,
             null);
 
     // when
@@ -53,7 +51,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
     // given — no API key, falls back to DefaultAzureCredential
     final AzureOpenAiConfig config =
         new AzureOpenAiConfig(
-            "text-embedding-3-small", "https://my-resource.openai.azure.com/", apiKey, null, null);
+            "text-embedding-3-small", "https://my-resource.openai.azure.com/", apiKey, null);
 
     // when
     final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
@@ -67,29 +65,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
     // given
     final AzureOpenAiConfig config =
         new AzureOpenAiConfig(
-            "text-embedding-3-small",
-            "https://my-resource.openai.azure.com/",
-            "test-api-key",
-            512,
-            null);
-
-    // when
-    final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
-
-    // then
-    assertThat(embeddingModel).isNotNull();
-  }
-
-  @Test
-  void shouldBuildEmbeddingModelWithCustomHeaders() {
-    // given
-    final AzureOpenAiConfig config =
-        new AzureOpenAiConfig(
-            "text-embedding-3-small",
-            "https://my-resource.openai.azure.com/",
-            "test-api-key",
-            null,
-            Map.of("X-Custom-Header", "value"));
+            "text-embedding-3-small", "https://my-resource.openai.azure.com/", "test-api-key", 512);
 
     // when
     final EmbeddingModel embeddingModel = AzureOpenAiEmbeddingModelBuilder.build(config);
@@ -104,7 +80,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   void shouldThrowWhenEndpointMissingOrBlank(final String endpoint) {
     // given
     final AzureOpenAiConfig config =
-        new AzureOpenAiConfig("text-embedding-3-small", endpoint, "test-api-key", null, null);
+        new AzureOpenAiConfig("text-embedding-3-small", endpoint, "test-api-key", null);
 
     // when / then
     assertThatThrownBy(() -> AzureOpenAiEmbeddingModelBuilder.build(config))
@@ -119,8 +95,7 @@ class AzureOpenAiEmbeddingModelBuilderTest {
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
     final AzureOpenAiConfig config =
-        new AzureOpenAiConfig(
-            model, "https://my-resource.openai.azure.com/", "test-api-key", null, null);
+        new AzureOpenAiConfig(model, "https://my-resource.openai.azure.com/", "test-api-key", null);
 
     // when / then
     assertThatThrownBy(() -> AzureOpenAiEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/AzureOpenAiEmbeddingModelBuilderTest.java
@@ -26,6 +26,7 @@ import com.azure.core.credential.TokenCredential;
 import dev.langchain4j.model.azure.AzureOpenAiEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.AzureOpenAiConfig;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -63,6 +64,22 @@ class AzureOpenAiEmbeddingModelBuilderTest {
     verify(mockBuilder).endpoint(ENDPOINT);
     verify(mockBuilder).deploymentName(MODEL);
     verify(mockBuilder, never()).dimensions(any());
+    verify(mockBuilder, never()).timeout(any());
+  }
+
+  @Test
+  void shouldApplyTimeoutToBuilder() {
+    // given
+    final AzureOpenAiConfig config = new AzureOpenAiConfig(MODEL, ENDPOINT, API_KEY, null);
+    config.setTimeout(Duration.ofSeconds(45));
+    final AzureOpenAiEmbeddingModel.Builder mockBuilder =
+        mock(AzureOpenAiEmbeddingModel.Builder.class);
+
+    // when
+    AzureOpenAiEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).timeout(Duration.ofSeconds(45));
   }
 
   @Test

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilderTest.java
@@ -28,16 +28,31 @@ import org.junit.jupiter.params.provider.ValueSource;
 class BedrockEmbeddingModelBuilderTest {
 
   @Test
-  void shouldBuildEmbeddingModel() {
+  void shouldBuildEmbeddingModelWithAccessKeyCredentials() {
     // given
     final AmazonBedrockConfig config =
         new AmazonBedrockConfig(
             "amazon.titan-embed-text-v2:0",
             "us-east-1",
+            null,
             "test-access-key",
             "test-secret-key",
             null,
             null);
+
+    // when
+    final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
+
+    // then
+    assertThat(embeddingModel).isNotNull();
+  }
+
+  @Test
+  void shouldBuildEmbeddingModelWithApiKey() {
+    // given
+    final AmazonBedrockConfig config =
+        new AmazonBedrockConfig(
+            "amazon.titan-embed-text-v2:0", "us-east-1", "text-api-key", null, null, null, null);
 
     // when
     final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
@@ -53,7 +68,13 @@ class BedrockEmbeddingModelBuilderTest {
     // given — no credentials; AWS SDK resolves them from the default credential chain
     final AmazonBedrockConfig config =
         new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0", "us-east-1", nullOrEmpty, nullOrEmpty, null, null);
+            "amazon.titan-embed-text-v2:0",
+            "us-east-1",
+            nullOrEmpty,
+            nullOrEmpty,
+            nullOrEmpty,
+            null,
+            null);
 
     // when
     final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
@@ -69,6 +90,7 @@ class BedrockEmbeddingModelBuilderTest {
         new AmazonBedrockConfig(
             "amazon.titan-embed-text-v2:0",
             "us-east-1",
+            null,
             "test-access-key",
             "test-secret-key",
             null,
@@ -88,6 +110,7 @@ class BedrockEmbeddingModelBuilderTest {
         new AmazonBedrockConfig(
             "amazon.titan-embed-text-v2:0",
             "us-east-1",
+            null,
             "test-access-key",
             "test-secret-key",
             true,
@@ -107,7 +130,7 @@ class BedrockEmbeddingModelBuilderTest {
     // given
     final AmazonBedrockConfig config =
         new AmazonBedrockConfig(
-            model, "us-east-1", "test-access-key", "test-secret-key", null, null);
+            model, "us-east-1", null, "test-access-key", "test-secret-key", null, null);
 
     // when / then
     assertThatThrownBy(() -> BedrockEmbeddingModelBuilder.build(config))
@@ -121,13 +144,13 @@ class BedrockEmbeddingModelBuilderTest {
     // given — partial key pair should fail
     final AmazonBedrockConfig config =
         new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0", "us-east-1", "test-access-key", null, null, null);
+            "amazon.titan-embed-text-v2:0", "us-east-1", null, "test-access-key", null, null, null);
 
     // when / then
     assertThatThrownBy(() -> BedrockEmbeddingModelBuilder.build(config))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("credentialsAccessKey")
-        .hasMessageContaining("credentialsSecretKey");
+        .hasMessageContaining("accessKey")
+        .hasMessageContaining("secretKey");
   }
 
   @Test
@@ -135,12 +158,12 @@ class BedrockEmbeddingModelBuilderTest {
     // given — partial key pair should fail
     final AmazonBedrockConfig config =
         new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0", "us-east-1", null, "test-secret-key", null, null);
+            "amazon.titan-embed-text-v2:0", "us-east-1", null, null, "test-secret-key", null, null);
 
     // when / then
     assertThatThrownBy(() -> BedrockEmbeddingModelBuilder.build(config))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("credentialsAccessKey")
-        .hasMessageContaining("credentialsSecretKey");
+        .hasMessageContaining("accessKey")
+        .hasMessageContaining("secretKey");
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilderTest.java
@@ -28,6 +28,7 @@ import dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.camunda.process.test.impl.BedrockRuntimeClientFactory;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.AmazonBedrockConfig;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -77,13 +78,14 @@ class BedrockEmbeddingModelBuilderTest {
     // given
     final AmazonBedrockConfig config =
         new AmazonBedrockConfig(MODEL, REGION, API_KEY, ACCESS_KEY, SECRET_KEY, null, null);
+    config.setTimeout(Duration.ofSeconds(60));
     final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
         mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
 
     try (final MockedStatic<BedrockRuntimeClientFactory> mockFactory =
         mockStatic(BedrockRuntimeClientFactory.class)) {
       mockFactory
-          .when(() -> BedrockRuntimeClientFactory.build(any(), any(), any(), any()))
+          .when(() -> BedrockRuntimeClientFactory.build(any(), any(), any(), any(), any()))
           .thenReturn(mock(BedrockRuntimeClient.class));
 
       // when
@@ -93,7 +95,11 @@ class BedrockEmbeddingModelBuilderTest {
       mockFactory.verify(
           () ->
               BedrockRuntimeClientFactory.build(
-                  eq(REGION), eq(API_KEY), eq(ACCESS_KEY), eq(SECRET_KEY)));
+                  eq(REGION),
+                  eq(API_KEY),
+                  eq(ACCESS_KEY),
+                  eq(SECRET_KEY),
+                  eq(Duration.ofSeconds(60))));
     }
   }
 

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilderTest.java
@@ -48,7 +48,7 @@ class BedrockEmbeddingModelBuilderTest {
   void shouldBuildEmbeddingModel() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, null, null);
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, null);
 
     // when
     final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
@@ -61,7 +61,7 @@ class BedrockEmbeddingModelBuilderTest {
   void shouldSetRequiredFieldsOnBuilder() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(MODEL, REGION, null, null, null, null, null);
+        new AmazonBedrockConfig(MODEL, REGION, null, null, null, null);
     final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
         mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
 
@@ -77,7 +77,7 @@ class BedrockEmbeddingModelBuilderTest {
   void shouldForwardConfigToClientFactory() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(MODEL, REGION, API_KEY, ACCESS_KEY, SECRET_KEY, null, null);
+        new AmazonBedrockConfig(MODEL, REGION, API_KEY, ACCESS_KEY, SECRET_KEY, null);
     config.setTimeout(Duration.ofSeconds(60));
     final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
         mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
@@ -107,7 +107,8 @@ class BedrockEmbeddingModelBuilderTest {
   void shouldApplyDimensionsToBuilder() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, null, 256);
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, null);
+    config.setDimensions(256);
     final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
         mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
 
@@ -123,7 +124,7 @@ class BedrockEmbeddingModelBuilderTest {
   void shouldApplyNormalizeToBuilder() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, true, null);
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, true);
     final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
         mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
 
@@ -141,7 +142,7 @@ class BedrockEmbeddingModelBuilderTest {
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(model, REGION, null, ACCESS_KEY, SECRET_KEY, null, null);
+        new AmazonBedrockConfig(model, REGION, null, ACCESS_KEY, SECRET_KEY, null);
 
     // when / then
     assertThatThrownBy(() -> BedrockEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/BedrockEmbeddingModelBuilderTest.java
@@ -17,28 +17,37 @@ package io.camunda.process.test.impl.similarity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import io.camunda.process.test.impl.BedrockRuntimeClientFactory;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.AmazonBedrockConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 class BedrockEmbeddingModelBuilderTest {
 
+  private static final String MODEL = "amazon.titan-embed-text-v2:0";
+  private static final String REGION = "us-east-1";
+  private static final String ACCESS_KEY = "test-access-key";
+  private static final String SECRET_KEY = "test-secret-key";
+  private static final String API_KEY = "test-api-key";
+
   @Test
-  void shouldBuildEmbeddingModelWithAccessKeyCredentials() {
+  void shouldBuildEmbeddingModel() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0",
-            "us-east-1",
-            null,
-            "test-access-key",
-            "test-secret-key",
-            null,
-            null);
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, null, null);
 
     // when
     final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
@@ -48,79 +57,76 @@ class BedrockEmbeddingModelBuilderTest {
   }
 
   @Test
-  void shouldBuildEmbeddingModelWithApiKey() {
+  void shouldSetRequiredFieldsOnBuilder() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0", "us-east-1", "text-api-key", null, null, null, null);
+        new AmazonBedrockConfig(MODEL, REGION, null, null, null, null, null);
+    final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
+        mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
 
     // when
-    final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
+    BedrockEmbeddingModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(embeddingModel).isNotNull();
-  }
-
-  @ParameterizedTest
-  @NullAndEmptySource
-  @ValueSource(strings = {"  "})
-  void shouldBuildEmbeddingModelWithoutCredentials(final String nullOrEmpty) {
-    // given — no credentials; AWS SDK resolves them from the default credential chain
-    final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0",
-            "us-east-1",
-            nullOrEmpty,
-            nullOrEmpty,
-            nullOrEmpty,
-            null,
-            null);
-
-    // when
-    final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
-
-    // then
-    assertThat(embeddingModel).isNotNull();
+    verify(mockBuilder).model(MODEL);
+    verify(mockBuilder).client(any());
   }
 
   @Test
-  void shouldBuildEmbeddingModelWithDimensions() {
+  void shouldForwardConfigToClientFactory() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0",
-            "us-east-1",
-            null,
-            "test-access-key",
-            "test-secret-key",
-            null,
-            256);
+        new AmazonBedrockConfig(MODEL, REGION, API_KEY, ACCESS_KEY, SECRET_KEY, null, null);
+    final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
+        mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
 
-    // when
-    final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
+    try (final MockedStatic<BedrockRuntimeClientFactory> mockFactory =
+        mockStatic(BedrockRuntimeClientFactory.class)) {
+      mockFactory
+          .when(() -> BedrockRuntimeClientFactory.build(any(), any(), any(), any()))
+          .thenReturn(mock(BedrockRuntimeClient.class));
 
-    // then
-    assertThat(embeddingModel).isNotNull();
+      // when
+      BedrockEmbeddingModelBuilder.build(config, mockBuilder);
+
+      // then
+      mockFactory.verify(
+          () ->
+              BedrockRuntimeClientFactory.build(
+                  eq(REGION), eq(API_KEY), eq(ACCESS_KEY), eq(SECRET_KEY)));
+    }
   }
 
   @Test
-  void shouldBuildEmbeddingModelWithNormalize() {
+  void shouldApplyDimensionsToBuilder() {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0",
-            "us-east-1",
-            null,
-            "test-access-key",
-            "test-secret-key",
-            true,
-            null);
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, null, 256);
+    final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
+        mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
 
     // when
-    final EmbeddingModel embeddingModel = BedrockEmbeddingModelBuilder.build(config);
+    BedrockEmbeddingModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(embeddingModel).isNotNull();
+    verify(mockBuilder).dimensions(256);
+    verify(mockBuilder, never()).normalize(any());
+  }
+
+  @Test
+  void shouldApplyNormalizeToBuilder() {
+    // given
+    final AmazonBedrockConfig config =
+        new AmazonBedrockConfig(MODEL, REGION, null, ACCESS_KEY, SECRET_KEY, true, null);
+    final BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder mockBuilder =
+        mock(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
+
+    // when
+    BedrockEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder, never()).dimensions(any());
+    verify(mockBuilder).normalize(true);
   }
 
   @ParameterizedTest
@@ -129,41 +135,12 @@ class BedrockEmbeddingModelBuilderTest {
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
     final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(
-            model, "us-east-1", null, "test-access-key", "test-secret-key", null, null);
+        new AmazonBedrockConfig(model, REGION, null, ACCESS_KEY, SECRET_KEY, null, null);
 
     // when / then
     assertThatThrownBy(() -> BedrockEmbeddingModelBuilder.build(config))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("model")
         .hasMessageContaining(BedrockEmbeddingModelBuilder.AMAZON_BEDROCK);
-  }
-
-  @Test
-  void shouldThrowWhenOnlyAccessKeySet() {
-    // given — partial key pair should fail
-    final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0", "us-east-1", null, "test-access-key", null, null, null);
-
-    // when / then
-    assertThatThrownBy(() -> BedrockEmbeddingModelBuilder.build(config))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("accessKey")
-        .hasMessageContaining("secretKey");
-  }
-
-  @Test
-  void shouldThrowWhenOnlySecretKeySet() {
-    // given — partial key pair should fail
-    final AmazonBedrockConfig config =
-        new AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0", "us-east-1", null, null, "test-secret-key", null, null);
-
-    // when / then
-    assertThatThrownBy(() -> BedrockEmbeddingModelBuilder.build(config))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("accessKey")
-        .hasMessageContaining("secretKey");
   }
 }

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/Langchain4jEmbeddingModelAdapterProviderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/Langchain4jEmbeddingModelAdapterProviderTest.java
@@ -60,7 +60,13 @@ public class Langchain4jEmbeddingModelAdapterProviderTest {
   void shouldResolveBedrockProvider() {
     final var config =
         new BaseProviderConfig.AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0", "us-east-1", "access-key", "secret-key", null, null);
+            "amazon.titan-embed-text-v2:0",
+            "us-east-1",
+            null,
+            "access-key",
+            "secret-key",
+            null,
+            null);
     final Optional<EmbeddingModelAdapter> adapter = EmbeddingModelAdapterResolver.resolve(config);
     assertThat(adapter).isPresent();
   }

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/Langchain4jEmbeddingModelAdapterProviderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/Langchain4jEmbeddingModelAdapterProviderTest.java
@@ -51,7 +51,7 @@ public class Langchain4jEmbeddingModelAdapterProviderTest {
   @Test
   void shouldResolveOpenAiProvider() {
     final var config =
-        new BaseProviderConfig.OpenAiConfig("text-embedding-3-small", "test-key", null, null);
+        new BaseProviderConfig.OpenAiConfig("text-embedding-3-small", "test-key", null);
     final Optional<EmbeddingModelAdapter> adapter = EmbeddingModelAdapterResolver.resolve(config);
     assertThat(adapter).isPresent();
   }
@@ -84,11 +84,7 @@ public class Langchain4jEmbeddingModelAdapterProviderTest {
   void shouldResolveAzureOpenAiProvider() {
     final var config =
         new BaseProviderConfig.AzureOpenAiConfig(
-            "text-embedding-3-small",
-            "https://my-resource.openai.azure.com/",
-            "test-key",
-            null,
-            null);
+            "text-embedding-3-small", "https://my-resource.openai.azure.com/", "test-key", null);
     final Optional<EmbeddingModelAdapter> adapter = EmbeddingModelAdapterResolver.resolve(config);
     assertThat(adapter).isPresent();
   }

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/Langchain4jEmbeddingModelAdapterProviderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/Langchain4jEmbeddingModelAdapterProviderTest.java
@@ -50,8 +50,7 @@ public class Langchain4jEmbeddingModelAdapterProviderTest {
 
   @Test
   void shouldResolveOpenAiProvider() {
-    final var config =
-        new BaseProviderConfig.OpenAiConfig("text-embedding-3-small", "test-key", null);
+    final var config = new BaseProviderConfig.OpenAiConfig("text-embedding-3-small", "test-key");
     final Optional<EmbeddingModelAdapter> adapter = EmbeddingModelAdapterResolver.resolve(config);
     assertThat(adapter).isPresent();
   }
@@ -60,13 +59,7 @@ public class Langchain4jEmbeddingModelAdapterProviderTest {
   void shouldResolveBedrockProvider() {
     final var config =
         new BaseProviderConfig.AmazonBedrockConfig(
-            "amazon.titan-embed-text-v2:0",
-            "us-east-1",
-            null,
-            "access-key",
-            "secret-key",
-            null,
-            null);
+            "amazon.titan-embed-text-v2:0", "us-east-1", null, "access-key", "secret-key", null);
     final Optional<EmbeddingModelAdapter> adapter = EmbeddingModelAdapterResolver.resolve(config);
     assertThat(adapter).isPresent();
   }
@@ -75,7 +68,7 @@ public class Langchain4jEmbeddingModelAdapterProviderTest {
   void shouldResolveOpenAiCompatibleProvider() {
     final var config =
         new BaseProviderConfig.OpenAiCompatibleConfig(
-            "nomic-embed-text", "http://localhost:11434/v1", null, null, null);
+            "nomic-embed-text", "http://localhost:11434/v1", null, null);
     final Optional<EmbeddingModelAdapter> adapter = EmbeddingModelAdapterResolver.resolve(config);
     assertThat(adapter).isPresent();
   }
@@ -84,7 +77,7 @@ public class Langchain4jEmbeddingModelAdapterProviderTest {
   void shouldResolveAzureOpenAiProvider() {
     final var config =
         new BaseProviderConfig.AzureOpenAiConfig(
-            "text-embedding-3-small", "https://my-resource.openai.azure.com/", "test-key", null);
+            "text-embedding-3-small", "https://my-resource.openai.azure.com/", "test-key");
     final Optional<EmbeddingModelAdapter> adapter = EmbeddingModelAdapterResolver.resolve(config);
     assertThat(adapter).isPresent();
   }

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilderTest.java
@@ -43,7 +43,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   void shouldBuildEmbeddingModel() {
     // given
     final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null, null);
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null);
 
     // when
     final EmbeddingModel embeddingModel = OpenAiCompatibleEmbeddingModelBuilder.build(config);
@@ -55,8 +55,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   @Test
   void shouldSetRequiredFieldsOnBuilder() {
     // given
-    final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null, null);
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null);
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
@@ -75,8 +74,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   @Test
   void shouldApplyTimeoutToBuilder() {
     // given
-    final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null, null);
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null);
     config.setTimeout(Duration.ofSeconds(30));
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
@@ -92,7 +90,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   void shouldApplyApiKeyToBuilderWhenNoAuthorizationHeader() {
     // given
     final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null, null);
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null);
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
@@ -108,7 +106,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
     // given
     final Map<String, String> headers = Map.of("Authorization", "Bearer test-token");
     final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null, headers);
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, headers);
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
@@ -125,8 +123,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldNotApplyApiKeyToBuilderWhenNullOrBlank(final String apiKey) {
     // given
-    final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, BASE_URL, apiKey, null, null);
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(MODEL, BASE_URL, apiKey, null);
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
@@ -142,7 +139,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
     // given
     final Map<String, String> headers = Map.of("X-Custom-Header", "value");
     final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null, headers);
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, headers);
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
@@ -156,8 +153,8 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   @Test
   void shouldApplyDimensionsToBuilder() {
     // given
-    final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, 768, null);
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null);
+    config.setDimensions(768);
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
@@ -173,8 +170,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(model, BASE_URL, null, null, null);
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(model, BASE_URL, null, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiCompatibleEmbeddingModelBuilder.build(config))
@@ -188,8 +184,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenBaseUrlMissingOrBlank(final String baseUrl) {
     // given
-    final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(MODEL, baseUrl, null, null, null);
+    final OpenAiCompatibleConfig config = new OpenAiCompatibleConfig(MODEL, baseUrl, null, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiCompatibleEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilderTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.OpenAiCompatibleConfig;
+import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -68,6 +69,23 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
     verify(mockBuilder, never()).apiKey(any());
     verify(mockBuilder, never()).customHeaders(anyMap());
     verify(mockBuilder, never()).dimensions(any());
+    verify(mockBuilder, never()).timeout(any());
+  }
+
+  @Test
+  void shouldApplyTimeoutToBuilder() {
+    // given
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null, null);
+    config.setTimeout(Duration.ofSeconds(30));
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiCompatibleEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).timeout(Duration.ofSeconds(30));
   }
 
   @Test

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiCompatibleEmbeddingModelBuilderTest.java
@@ -17,8 +17,14 @@ package io.camunda.process.test.impl.similarity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.OpenAiCompatibleConfig;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -28,14 +34,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class OpenAiCompatibleEmbeddingModelBuilderTest {
 
-  @ParameterizedTest
-  @NullAndEmptySource
-  @ValueSource(strings = {"  "})
-  void shouldBuildEmbeddingModelWithoutApiKey(final String apiKey) {
-    // given — null or blank apiKey is treated as absent
+  private static final String MODEL = "nomic-embed-text";
+  private static final String BASE_URL = "http://localhost:11434/v1";
+  private static final String API_KEY = "test-api-key";
+
+  @Test
+  void shouldBuildEmbeddingModel() {
+    // given
     final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(
-            "nomic-embed-text", "http://localhost:11434/v1", apiKey, null, null);
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null, null);
 
     // when
     final EmbeddingModel embeddingModel = OpenAiCompatibleEmbeddingModelBuilder.build(config);
@@ -45,21 +52,102 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   }
 
   @Test
-  void shouldBuildEmbeddingModelWithOptionalFields() {
+  void shouldSetRequiredFieldsOnBuilder() {
     // given
     final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(
-            "nomic-embed-text",
-            "http://localhost:11434/v1",
-            "optional-key",
-            768,
-            Map.of("X-Custom-Header", "value"));
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null, null);
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
     // when
-    final EmbeddingModel embeddingModel = OpenAiCompatibleEmbeddingModelBuilder.build(config);
+    OpenAiCompatibleEmbeddingModelBuilder.build(config, mockBuilder);
 
     // then
-    assertThat(embeddingModel).isNotNull();
+    verify(mockBuilder).baseUrl(BASE_URL);
+    verify(mockBuilder).modelName(MODEL);
+    verify(mockBuilder, never()).apiKey(any());
+    verify(mockBuilder, never()).customHeaders(anyMap());
+    verify(mockBuilder, never()).dimensions(any());
+  }
+
+  @Test
+  void shouldApplyApiKeyToBuilderWhenNoAuthorizationHeader() {
+    // given
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null, null);
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiCompatibleEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).apiKey(API_KEY);
+  }
+
+  @Test
+  void shouldNotApplyApiKeyWhenAuthorizationHeaderPresent() {
+    // given
+    final Map<String, String> headers = Map.of("Authorization", "Bearer test-token");
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, API_KEY, null, headers);
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiCompatibleEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder, never()).apiKey(any());
+    verify(mockBuilder).customHeaders(headers);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  "})
+  void shouldNotApplyApiKeyToBuilderWhenNullOrBlank(final String apiKey) {
+    // given
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, apiKey, null, null);
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiCompatibleEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder, never()).apiKey(any());
+  }
+
+  @Test
+  void shouldApplyHeadersToBuilder() {
+    // given
+    final Map<String, String> headers = Map.of("X-Custom-Header", "value");
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, null, headers);
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiCompatibleEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).customHeaders(headers);
+  }
+
+  @Test
+  void shouldApplyDimensionsToBuilder() {
+    // given
+    final OpenAiCompatibleConfig config =
+        new OpenAiCompatibleConfig(MODEL, BASE_URL, null, 768, null);
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiCompatibleEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).dimensions(768);
   }
 
   @ParameterizedTest
@@ -68,7 +156,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
     final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig(model, "http://localhost:11434/v1", null, null, null);
+        new OpenAiCompatibleConfig(model, BASE_URL, null, null, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiCompatibleEmbeddingModelBuilder.build(config))
@@ -83,7 +171,7 @@ class OpenAiCompatibleEmbeddingModelBuilderTest {
   void shouldThrowWhenBaseUrlMissingOrBlank(final String baseUrl) {
     // given
     final OpenAiCompatibleConfig config =
-        new OpenAiCompatibleConfig("nomic-embed-text", baseUrl, null, null, null);
+        new OpenAiCompatibleConfig(MODEL, baseUrl, null, null, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiCompatibleEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilderTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.OpenAiConfig;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -31,22 +30,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldBuildEmbeddingModel() {
     // given
-    final OpenAiConfig config =
-        new OpenAiConfig("text-embedding-3-small", "test-api-key", null, null);
-
-    // when
-    final EmbeddingModel embeddingModel = OpenAiEmbeddingModelBuilder.build(config);
-
-    // then
-    assertThat(embeddingModel).isNotNull();
-  }
-
-  @Test
-  void shouldBuildEmbeddingModelWithDimensionsAndHeaders() {
-    // given
-    final OpenAiConfig config =
-        new OpenAiConfig(
-            "text-embedding-3-small", "test-api-key", 512, Map.of("Custom-Header", "HeaderValue"));
+    final OpenAiConfig config = new OpenAiConfig("text-embedding-3-small", "test-api-key", null);
 
     // when
     final EmbeddingModel embeddingModel = OpenAiEmbeddingModelBuilder.build(config);
@@ -60,7 +44,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenApiKeyMissingOrBlank(final String apiKey) {
     // given
-    final OpenAiConfig config = new OpenAiConfig("text-embedding-3-small", apiKey, null, null);
+    final OpenAiConfig config = new OpenAiConfig("text-embedding-3-small", apiKey, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiEmbeddingModelBuilder.build(config))
@@ -74,7 +58,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final OpenAiConfig config = new OpenAiConfig(model, "test-api-key", null, null);
+    final OpenAiConfig config = new OpenAiConfig(model, "test-api-key", null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilderTest.java
@@ -17,8 +17,13 @@ package io.camunda.process.test.impl.similarity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.OpenAiConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,10 +32,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class OpenAiEmbeddingModelBuilderTest {
 
+  private static final String MODEL = "text-embedding-3-small";
+  private static final String API_KEY = "test-api-key";
+
   @Test
   void shouldBuildEmbeddingModel() {
     // given
-    final OpenAiConfig config = new OpenAiConfig("text-embedding-3-small", "test-api-key", null);
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY, null);
 
     // when
     final EmbeddingModel embeddingModel = OpenAiEmbeddingModelBuilder.build(config);
@@ -39,12 +47,42 @@ class OpenAiEmbeddingModelBuilderTest {
     assertThat(embeddingModel).isNotNull();
   }
 
+  @Test
+  void shouldSetRequiredFieldsOnBuilder() {
+    // given
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY, null);
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).apiKey(API_KEY);
+    verify(mockBuilder).modelName(MODEL);
+    verify(mockBuilder, never()).dimensions(any());
+  }
+
+  @Test
+  void shouldApplyDimensionsToBuilder() {
+    // given
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY, 512);
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).dimensions(512);
+  }
+
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"  "})
   void shouldThrowWhenApiKeyMissingOrBlank(final String apiKey) {
     // given
-    final OpenAiConfig config = new OpenAiConfig("text-embedding-3-small", apiKey, null);
+    final OpenAiConfig config = new OpenAiConfig(MODEL, apiKey, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiEmbeddingModelBuilder.build(config))
@@ -58,7 +96,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final OpenAiConfig config = new OpenAiConfig(model, "test-api-key", null);
+    final OpenAiConfig config = new OpenAiConfig(model, API_KEY, null);
 
     // when / then
     assertThatThrownBy(() -> OpenAiEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilderTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig.OpenAiConfig;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -61,6 +62,22 @@ class OpenAiEmbeddingModelBuilderTest {
     verify(mockBuilder).apiKey(API_KEY);
     verify(mockBuilder).modelName(MODEL);
     verify(mockBuilder, never()).dimensions(any());
+    verify(mockBuilder, never()).timeout(any());
+  }
+
+  @Test
+  void shouldApplyTimeoutToBuilder() {
+    // given
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY, null);
+    config.setTimeout(Duration.ofSeconds(30));
+    final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
+        mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+
+    // when
+    OpenAiEmbeddingModelBuilder.build(config, mockBuilder);
+
+    // then
+    verify(mockBuilder).timeout(Duration.ofSeconds(30));
   }
 
   @Test

--- a/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilderTest.java
+++ b/testing/camunda-process-test-langchain4j/src/test/java/io/camunda/process/test/impl/similarity/OpenAiEmbeddingModelBuilderTest.java
@@ -39,7 +39,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldBuildEmbeddingModel() {
     // given
-    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY, null);
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY);
 
     // when
     final EmbeddingModel embeddingModel = OpenAiEmbeddingModelBuilder.build(config);
@@ -51,7 +51,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldSetRequiredFieldsOnBuilder() {
     // given
-    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY, null);
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY);
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
@@ -68,7 +68,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldApplyTimeoutToBuilder() {
     // given
-    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY, null);
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY);
     config.setTimeout(Duration.ofSeconds(30));
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
@@ -83,7 +83,8 @@ class OpenAiEmbeddingModelBuilderTest {
   @Test
   void shouldApplyDimensionsToBuilder() {
     // given
-    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY, 512);
+    final OpenAiConfig config = new OpenAiConfig(MODEL, API_KEY);
+    config.setDimensions(512);
     final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder mockBuilder =
         mock(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
 
@@ -99,7 +100,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenApiKeyMissingOrBlank(final String apiKey) {
     // given
-    final OpenAiConfig config = new OpenAiConfig(MODEL, apiKey, null);
+    final OpenAiConfig config = new OpenAiConfig(MODEL, apiKey);
 
     // when / then
     assertThatThrownBy(() -> OpenAiEmbeddingModelBuilder.build(config))
@@ -113,7 +114,7 @@ class OpenAiEmbeddingModelBuilderTest {
   @ValueSource(strings = {"  "})
   void shouldThrowWhenModelMissingOrBlank(final String model) {
     // given
-    final OpenAiConfig config = new OpenAiConfig(model, API_KEY, null);
+    final OpenAiConfig config = new OpenAiConfig(model, API_KEY);
 
     // when / then
     assertThatThrownBy(() -> OpenAiEmbeddingModelBuilder.build(config))

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/SemanticSimilarityConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/SemanticSimilarityConfiguration.java
@@ -73,9 +73,7 @@ public class SemanticSimilarityConfiguration {
       case BaseProviderConfig.PROVIDER_OPENAI:
         config =
             new BaseProviderConfig.OpenAiConfig(
-                embeddingModel.getModel(),
-                embeddingModel.getApiKey(),
-                embeddingModel.getDimensions());
+                embeddingModel.getModel(), embeddingModel.getApiKey());
         break;
       case BaseProviderConfig.PROVIDER_OPENAI_COMPATIBLE:
         config =
@@ -83,7 +81,6 @@ public class SemanticSimilarityConfiguration {
                 embeddingModel.getModel(),
                 embeddingModel.getBaseUrl(),
                 embeddingModel.getApiKey(),
-                embeddingModel.getDimensions(),
                 embeddingModel.getHeaders());
         break;
       case BaseProviderConfig.PROVIDER_AZURE_OPENAI:
@@ -91,8 +88,7 @@ public class SemanticSimilarityConfiguration {
             new BaseProviderConfig.AzureOpenAiConfig(
                 embeddingModel.getModel(),
                 embeddingModel.getEndpoint(),
-                embeddingModel.getApiKey(),
-                embeddingModel.getDimensions());
+                embeddingModel.getApiKey());
         break;
       case BaseProviderConfig.PROVIDER_AMAZON_BEDROCK:
         config =
@@ -102,14 +98,16 @@ public class SemanticSimilarityConfiguration {
                 embeddingModel.getApiKey(),
                 credentials != null ? credentials.getAccessKey() : null,
                 credentials != null ? credentials.getSecretKey() : null,
-                embeddingModel.getNormalize(),
-                embeddingModel.getDimensions());
+                embeddingModel.getNormalize());
         break;
       default:
         config =
             new BaseProviderConfig.GenericConfig(
                 provider, embeddingModel.getModel(), embeddingModel.customProperties);
         break;
+    }
+    if (embeddingModel.getDimensions() != null) {
+      config.setDimensions(embeddingModel.getDimensions());
     }
     if (embeddingModel.getTimeout() != null) {
       config.setTimeout(embeddingModel.getTimeout());

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/SemanticSimilarityConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/SemanticSimilarityConfiguration.java
@@ -92,6 +92,7 @@ public class SemanticSimilarityConfiguration {
         return new BaseProviderConfig.AmazonBedrockConfig(
             embeddingModel.getModel(),
             embeddingModel.getRegion(),
+            embeddingModel.getApiKey(),
             credentials != null ? credentials.getAccessKey() : null,
             credentials != null ? credentials.getSecretKey() : null,
             embeddingModel.getNormalize(),

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/SemanticSimilarityConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/SemanticSimilarityConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.process.test.impl.configuration;
 import io.camunda.process.test.api.similarity.ProviderConfig;
 import io.camunda.process.test.api.similarity.SemanticSimilarityConfig;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -67,36 +68,53 @@ public class SemanticSimilarityConfiguration {
   public ProviderConfig toProviderConfig() {
     final AwsCredentialsConfiguration credentials = embeddingModel.getCredentials();
     final String provider = embeddingModel.getProvider().trim().toLowerCase();
+    final BaseProviderConfig config;
     switch (provider) {
       case BaseProviderConfig.PROVIDER_OPENAI:
-        return new BaseProviderConfig.OpenAiConfig(
-            embeddingModel.getModel(), embeddingModel.getApiKey(), embeddingModel.getDimensions());
+        config =
+            new BaseProviderConfig.OpenAiConfig(
+                embeddingModel.getModel(),
+                embeddingModel.getApiKey(),
+                embeddingModel.getDimensions());
+        break;
       case BaseProviderConfig.PROVIDER_OPENAI_COMPATIBLE:
-        return new BaseProviderConfig.OpenAiCompatibleConfig(
-            embeddingModel.getModel(),
-            embeddingModel.getBaseUrl(),
-            embeddingModel.getApiKey(),
-            embeddingModel.getDimensions(),
-            embeddingModel.getHeaders());
+        config =
+            new BaseProviderConfig.OpenAiCompatibleConfig(
+                embeddingModel.getModel(),
+                embeddingModel.getBaseUrl(),
+                embeddingModel.getApiKey(),
+                embeddingModel.getDimensions(),
+                embeddingModel.getHeaders());
+        break;
       case BaseProviderConfig.PROVIDER_AZURE_OPENAI:
-        return new BaseProviderConfig.AzureOpenAiConfig(
-            embeddingModel.getModel(),
-            embeddingModel.getEndpoint(),
-            embeddingModel.getApiKey(),
-            embeddingModel.getDimensions());
+        config =
+            new BaseProviderConfig.AzureOpenAiConfig(
+                embeddingModel.getModel(),
+                embeddingModel.getEndpoint(),
+                embeddingModel.getApiKey(),
+                embeddingModel.getDimensions());
+        break;
       case BaseProviderConfig.PROVIDER_AMAZON_BEDROCK:
-        return new BaseProviderConfig.AmazonBedrockConfig(
-            embeddingModel.getModel(),
-            embeddingModel.getRegion(),
-            embeddingModel.getApiKey(),
-            credentials != null ? credentials.getAccessKey() : null,
-            credentials != null ? credentials.getSecretKey() : null,
-            embeddingModel.getNormalize(),
-            embeddingModel.getDimensions());
+        config =
+            new BaseProviderConfig.AmazonBedrockConfig(
+                embeddingModel.getModel(),
+                embeddingModel.getRegion(),
+                embeddingModel.getApiKey(),
+                credentials != null ? credentials.getAccessKey() : null,
+                credentials != null ? credentials.getSecretKey() : null,
+                embeddingModel.getNormalize(),
+                embeddingModel.getDimensions());
+        break;
       default:
-        return new BaseProviderConfig.GenericConfig(
-            provider, embeddingModel.getModel(), embeddingModel.customProperties);
+        config =
+            new BaseProviderConfig.GenericConfig(
+                provider, embeddingModel.getModel(), embeddingModel.customProperties);
+        break;
     }
+    if (embeddingModel.getTimeout() != null) {
+      config.setTimeout(embeddingModel.getTimeout());
+    }
+    return config;
   }
 
   public static class EmbeddingModelConfiguration {
@@ -130,6 +148,9 @@ public class SemanticSimilarityConfiguration {
 
     /** Optional custom HTTP headers to include in embedding model requests. */
     private Map<String, String> headers;
+
+    /** The timeout for embedding model API calls as an ISO-8601 duration (e.g. 'PT30S', 'PT2M'). */
+    private Duration timeout;
 
     @NestedConfigurationProperty
     private AwsCredentialsConfiguration credentials = new AwsCredentialsConfiguration();
@@ -207,6 +228,14 @@ public class SemanticSimilarityConfiguration {
 
     public void setHeaders(final Map<String, String> headers) {
       this.headers = headers;
+    }
+
+    public Duration getTimeout() {
+      return timeout;
+    }
+
+    public void setTimeout(final Duration timeout) {
+      this.timeout = timeout;
     }
 
     public AwsCredentialsConfiguration getCredentials() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/SemanticSimilarityConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/SemanticSimilarityConfiguration.java
@@ -70,10 +70,7 @@ public class SemanticSimilarityConfiguration {
     switch (provider) {
       case BaseProviderConfig.PROVIDER_OPENAI:
         return new BaseProviderConfig.OpenAiConfig(
-            embeddingModel.getModel(),
-            embeddingModel.getApiKey(),
-            embeddingModel.getDimensions(),
-            embeddingModel.getHeaders());
+            embeddingModel.getModel(), embeddingModel.getApiKey(), embeddingModel.getDimensions());
       case BaseProviderConfig.PROVIDER_OPENAI_COMPATIBLE:
         return new BaseProviderConfig.OpenAiCompatibleConfig(
             embeddingModel.getModel(),
@@ -86,8 +83,7 @@ public class SemanticSimilarityConfiguration {
             embeddingModel.getModel(),
             embeddingModel.getEndpoint(),
             embeddingModel.getApiKey(),
-            embeddingModel.getDimensions(),
-            embeddingModel.getHeaders());
+            embeddingModel.getDimensions());
       case BaseProviderConfig.PROVIDER_AMAZON_BEDROCK:
         return new BaseProviderConfig.AmazonBedrockConfig(
             embeddingModel.getModel(),

--- a/testing/camunda-process-test-spring/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/testing/camunda-process-test-spring/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -39,7 +39,7 @@
         },
         {
           "value": "amazon-bedrock",
-          "description": "Use Amazon Bedrock embedding models (requires model; optionally credentials)."
+          "description": "Use Amazon Bedrock embedding models (requires model; optionally credentials or api-key)."
         },
         {
           "value": "azure-openai",

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapIT.java
@@ -156,7 +156,7 @@ public class SemanticSimilarityConfigBootstrapIT {
         "camunda.process-test.similarity.embeddingModel.model=nomic-embed-text",
         "camunda.process-test.similarity.embeddingModel.baseUrl=http://localhost:11434/v1",
         "camunda.process-test.similarity.embeddingModel.apiKey=test-key",
-        "camunda.process-test.judge.chatModel.headers.X-Test-Header=test-header-value"
+        "camunda.process-test.similarity.embeddingModel.headers.X-Test-Header=test-header-value"
       })
   @CamundaSpringProcessTest
   class OpenAiCompatibleProviderWithHeaders {

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapIT.java
@@ -346,6 +346,32 @@ public class SemanticSimilarityConfigBootstrapIT {
   }
 
   @Nested
+  @SpringBootTest(
+      classes = SemanticSimilarityConfigBootstrapIT.class,
+      properties = {
+        "camunda.process-test.similarity.embeddingModel.provider=openai",
+        "camunda.process-test.similarity.embeddingModel.model=text-embedding-3-small",
+        "camunda.process-test.similarity.embeddingModel.apiKey=test-key",
+        "camunda.process-test.similarity.embeddingModel.timeout=PT30S"
+      })
+  @CamundaSpringProcessTest
+  class WithTimeout {
+
+    @Autowired CamundaProcessTestRuntimeConfiguration runtimeConfig;
+
+    @Test
+    void shouldBindTimeoutProperty() {
+      final SemanticSimilarityConfig config = CamundaAssert.getSemanticSimilarityConfig();
+      assertThat(config).isNotNull();
+      assertThat(config.getEmbeddingModel()).isNotNull();
+
+      final BaseProviderConfig providerConfig =
+          (BaseProviderConfig) runtimeConfig.getSimilarity().toProviderConfig();
+      assertThat(providerConfig.getTimeout()).isEqualTo(java.time.Duration.ofSeconds(30));
+    }
+  }
+
+  @Nested
   class InvalidConfiguration {
 
     @Test

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapIT.java
@@ -23,8 +23,10 @@ import io.camunda.process.test.api.similarity.ProviderConfig;
 import io.camunda.process.test.api.similarity.SemanticSimilarityConfig;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
 import io.camunda.process.test.impl.similarity.BaseProviderConfig;
+import io.camunda.process.test.impl.similarity.BaseProviderConfig.OpenAiCompatibleConfig;
 import io.camunda.process.test.impl.similarity.EmbeddingModelAdapterResolver;
 import io.camunda.process.test.impl.similarity.OpenAiEmbeddingModelAdapterProvider;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -143,6 +145,35 @@ public class SemanticSimilarityConfigBootstrapIT {
       final SemanticSimilarityConfig config = CamundaAssert.getSemanticSimilarityConfig();
       assertThat(config).isNotNull();
       assertThat(config.getEmbeddingModel()).isNotNull();
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = SemanticSimilarityConfigBootstrapIT.class,
+      properties = {
+        "camunda.process-test.similarity.embeddingModel.provider=openai-compatible",
+        "camunda.process-test.similarity.embeddingModel.model=nomic-embed-text",
+        "camunda.process-test.similarity.embeddingModel.baseUrl=http://localhost:11434/v1",
+        "camunda.process-test.similarity.embeddingModel.apiKey=test-key",
+        "camunda.process-test.judge.chatModel.headers.X-Test-Header=test-header-value"
+      })
+  @CamundaSpringProcessTest
+  class OpenAiCompatibleProviderWithHeaders {
+
+    @Autowired CamundaProcessTestRuntimeConfiguration runtimeConfig;
+
+    @Test
+    void shouldBootstrapOpenAiCompatibleProvider() {
+      final SemanticSimilarityConfig config = CamundaAssert.getSemanticSimilarityConfig();
+      assertThat(config).isNotNull();
+      assertThat(config.getEmbeddingModel()).isNotNull();
+
+      final ProviderConfig providerConfig = runtimeConfig.getSimilarity().toProviderConfig();
+      assertThat(providerConfig).isInstanceOf(OpenAiCompatibleConfig.class);
+      final Map<String, String> headers = ((OpenAiCompatibleConfig) providerConfig).getHeaders();
+      assertThat(headers).isNotNull();
+      assertThat(headers).containsEntry("X-Test-Header", "test-header-value");
     }
   }
 
@@ -327,7 +358,7 @@ public class SemanticSimilarityConfigBootstrapIT {
 
     @Test
     void shouldThrowWhenRequiredFieldMissing() {
-      final ProviderConfig config = new BaseProviderConfig.OpenAiConfig(null, null, null, null);
+      final ProviderConfig config = new BaseProviderConfig.OpenAiConfig(null, null, null);
       final OpenAiEmbeddingModelAdapterProvider provider =
           new OpenAiEmbeddingModelAdapterProvider();
       assertThatThrownBy(() -> provider.create(config)).isInstanceOf(IllegalStateException.class);

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapIT.java
@@ -352,6 +352,32 @@ public class SemanticSimilarityConfigBootstrapIT {
         "camunda.process-test.similarity.embeddingModel.provider=openai",
         "camunda.process-test.similarity.embeddingModel.model=text-embedding-3-small",
         "camunda.process-test.similarity.embeddingModel.apiKey=test-key",
+        "camunda.process-test.similarity.embedding-model.dimensions=512"
+      })
+  @CamundaSpringProcessTest
+  class WithDimensions {
+
+    @Autowired CamundaProcessTestRuntimeConfiguration runtimeConfig;
+
+    @Test
+    void shouldBindDimensionsProperty() {
+      final SemanticSimilarityConfig config = CamundaAssert.getSemanticSimilarityConfig();
+      assertThat(config).isNotNull();
+      assertThat(config.getEmbeddingModel()).isNotNull();
+
+      final BaseProviderConfig providerConfig =
+          (BaseProviderConfig) runtimeConfig.getSimilarity().toProviderConfig();
+      assertThat(providerConfig.getDimensions()).isEqualTo(512);
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = SemanticSimilarityConfigBootstrapIT.class,
+      properties = {
+        "camunda.process-test.similarity.embeddingModel.provider=openai",
+        "camunda.process-test.similarity.embeddingModel.model=text-embedding-3-small",
+        "camunda.process-test.similarity.embeddingModel.apiKey=test-key",
         "camunda.process-test.similarity.embeddingModel.timeout=PT30S"
       })
   @CamundaSpringProcessTest
@@ -384,7 +410,7 @@ public class SemanticSimilarityConfigBootstrapIT {
 
     @Test
     void shouldThrowWhenRequiredFieldMissing() {
-      final ProviderConfig config = new BaseProviderConfig.OpenAiConfig(null, null, null);
+      final ProviderConfig config = new BaseProviderConfig.OpenAiConfig(null, null);
       final OpenAiEmbeddingModelAdapterProvider provider =
           new OpenAiEmbeddingModelAdapterProvider();
       assertThatThrownBy(() -> provider.create(config)).isInstanceOf(IllegalStateException.class);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR aligns the embedding model providers with chat model providers:

- **Azure OpenAI embedding:** fall back to default Azure AD credentials when no API key is configured, matching the behavior of the chat model builder
-  **Bedrock embedding:** add API key (Bearer token) authentication support, which was previously only available for the chat model builder.
- **OpenAI-compatible::** when an _Authorization_ custom header is present ignore the API key, if any
-  Custom headers are now applied only to the openai-compatible provider builder. Previously they were applied to other providers as well.

This PR also improve the tests for the chat model and embedding model builders to verify the parameters are passed correctly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
