### PR TITLE
[Backport stable/8.9] fix: handle chunking empty batches correctly

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -38,11 +38,11 @@ public interface ArchiveBatch {
     }
 
     public List<ProcessInstanceArchiveBatch> chunk(final int chunkSize) {
-      if (isEmpty()) {
-        return List.of(this);
-      }
-
       final var chunks = new ArrayList<ProcessInstanceArchiveBatch>();
+      if (isEmpty()) {
+        chunks.add(this);
+        return chunks;
+      }
 
       List<Long> currentRootProcessInstanceKeys = new ArrayList<>();
       List<Long> currentProcessInstanceKeys = new ArrayList<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -205,6 +205,21 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   }
 
   @Test
+  void shouldReturnEmptyBatchIfNoIdsGiven() {
+    // given
+    repository.batch = new ProcessInstanceArchiveBatch("2024-01-01", List.of(), List.of());
+
+    // when
+    final var nextBatch = job.getNextBatch().toCompletableFuture().join();
+
+    // then
+    assertThat(nextBatch)
+        .isEqualTo(new ProcessInstanceArchiveBatch("2024-01-01", List.of(), List.of()));
+
+    verify(repository).getProcessInstancesNextBatch(1_000);
+  }
+
+  @Test
   void shouldRequestLargeBatchAndChunkIt() {
     // given
     repository.batch =


### PR DESCRIPTION
# Description
Backport of #49411 to `stable/8.9`.

relates to #49073 #48200