### PR TITLE
[Backport stable/8.9] fix: clear variables from ProcessInstanceCreation CREATED follow-up event

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -118,6 +118,7 @@ public final class ProcessInstanceCreationCreateProcessor
 
     // Variables are already persisted via setVariablesFromDocument(); clear them to save batch
     // space.
+    // Prevent buffer cloning overhead if response will not be returned.
     final var variablesBuffer =
         command.hasRequestMetadata() ? BufferUtil.cloneBuffer(record.getVariablesBuffer()) : null;
     record.setVariables(DocumentValue.EMPTY_DOCUMENT);
@@ -125,6 +126,7 @@ public final class ProcessInstanceCreationCreateProcessor
     stateWriter.appendFollowUpEvent(entityKey, ProcessInstanceCreationIntent.CREATED, record);
 
     if (command.hasRequestMetadata()) {
+      // set variables back to return them in the response
       record.setVariables(variablesBuffer);
       responseWriter.writeEventOnCommand(
           entityKey, ProcessInstanceCreationIntent.CREATED, record, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public final class ProcessInstanceCreationCreateProcessor
     implements TypedRecordProcessor<ProcessInstanceCreationRecord> {
@@ -115,16 +116,18 @@ public final class ProcessInstanceCreationCreateProcessor
 
     final var entityKey = commandKey < 0 ? keyGenerator.nextKey() : commandKey;
 
+    // Variables are already persisted via setVariablesFromDocument(); clear them to save batch
+    // space.
+    final var variablesBuffer = BufferUtil.cloneBuffer(record.getVariablesBuffer());
+    record.setVariables(DocumentValue.EMPTY_DOCUMENT);
+
+    stateWriter.appendFollowUpEvent(entityKey, ProcessInstanceCreationIntent.CREATED, record);
+
+    record.setVariables(variablesBuffer);
     if (command.hasRequestMetadata()) {
       responseWriter.writeEventOnCommand(
           entityKey, ProcessInstanceCreationIntent.CREATED, record, command);
     }
-
-    // Variables are already persisted via setVariablesFromDocument(); clear them to save batch
-    // space.
-    record.setVariables(DocumentValue.EMPTY_DOCUMENT);
-
-    stateWriter.appendFollowUpEvent(entityKey, ProcessInstanceCreationIntent.CREATED, record);
 
     metrics.processInstanceCreated(record);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
@@ -111,6 +112,13 @@ public final class ProcessInstanceCreationCreateProcessor
     }
 
     helper.updateCreationRecord(record, processInstance);
+
+    // Clear variables before writing the CREATED follow-up event.
+    // Variables have already been persisted to state via setVariablesFromDocument()
+    // and are available in the Variable:CREATED records.
+    // Including them in this event is unnecessary and wastes batch space,
+    // causing ExceededBatchRecordSizeException for large payloads.
+    record.setVariables(DocumentValue.EMPTY_DOCUMENT);
 
     final var entityKey = commandKey < 0 ? keyGenerator.nextKey() : commandKey;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -113,20 +113,18 @@ public final class ProcessInstanceCreationCreateProcessor
 
     helper.updateCreationRecord(record, processInstance);
 
-    // Clear variables before writing the CREATED follow-up event.
-    // Variables have already been persisted to state via setVariablesFromDocument()
-    // and are available in the Variable:CREATED records.
-    // Including them in this event is unnecessary and wastes batch space,
-    // causing ExceededBatchRecordSizeException for large payloads.
-    record.setVariables(DocumentValue.EMPTY_DOCUMENT);
-
     final var entityKey = commandKey < 0 ? keyGenerator.nextKey() : commandKey;
 
-    stateWriter.appendFollowUpEvent(entityKey, ProcessInstanceCreationIntent.CREATED, record);
     if (command.hasRequestMetadata()) {
       responseWriter.writeEventOnCommand(
           entityKey, ProcessInstanceCreationIntent.CREATED, record, command);
     }
+
+    // Variables are already persisted via setVariablesFromDocument(); clear them to save batch
+    // space.
+    record.setVariables(DocumentValue.EMPTY_DOCUMENT);
+
+    stateWriter.appendFollowUpEvent(entityKey, ProcessInstanceCreationIntent.CREATED, record);
 
     metrics.processInstanceCreated(record);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -118,13 +118,14 @@ public final class ProcessInstanceCreationCreateProcessor
 
     // Variables are already persisted via setVariablesFromDocument(); clear them to save batch
     // space.
-    final var variablesBuffer = BufferUtil.cloneBuffer(record.getVariablesBuffer());
+    final var variablesBuffer =
+        command.hasRequestMetadata() ? BufferUtil.cloneBuffer(record.getVariablesBuffer()) : null;
     record.setVariables(DocumentValue.EMPTY_DOCUMENT);
 
     stateWriter.appendFollowUpEvent(entityKey, ProcessInstanceCreationIntent.CREATED, record);
 
-    record.setVariables(variablesBuffer);
     if (command.hasRequestMetadata()) {
+      record.setVariables(variablesBuffer);
       responseWriter.writeEventOnCommand(
           entityKey, ProcessInstanceCreationIntent.CREATED, record, command);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.instance.AwaitProcessInstanceResultMetadata;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
@@ -125,6 +126,11 @@ public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
             .setFetchVariables(record.fetchVariables());
     elementInstanceState.setAwaitResultRequestMetadata(
         record.getProcessInstanceKey(), awaitResultMetadata);
+
+    // Clear variables before writing the CREATED follow-up event.
+    // Variables have already been persisted to state via setVariablesFromDocument()
+    // and are available in the Variable:CREATED records.
+    record.setVariables(DocumentValue.EMPTY_DOCUMENT);
 
     stateWriter.appendFollowUpEvent(entityKey, ProcessInstanceCreationIntent.CREATED, record);
     metrics.processInstanceCreated(record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
@@ -127,9 +127,8 @@ public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
     elementInstanceState.setAwaitResultRequestMetadata(
         record.getProcessInstanceKey(), awaitResultMetadata);
 
-    // Clear variables before writing the CREATED follow-up event.
-    // Variables have already been persisted to state via setVariablesFromDocument()
-    // and are available in the Variable:CREATED records.
+    // Variables are already persisted via setVariablesFromDocument(); clear them to save batch
+    // space.
     record.setVariables(DocumentValue.EMPTY_DOCUMENT);
 
     stateWriter.appendFollowUpEvent(entityKey, ProcessInstanceCreationIntent.CREATED, record);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -652,8 +652,7 @@ public final class CreateProcessInstanceTest {
                 .done())
         .deploy();
 
-    // A ~2MB variable value
-    final int variableSize = (int) ByteValue.ofMegabytes(3);
+    final int variableSize = (int) ByteValue.ofMegabytes(2);
     final String largeValue = "x".repeat(variableSize);
 
     // when - create a process instance with the large variable
@@ -704,7 +703,7 @@ public final class CreateProcessInstanceTest {
         .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
         .deploy();
 
-    // A ~2MB variable value
+    // A ~3MB variable value
     final int variableSize = (int) ByteValue.ofMegabytes(3);
     final String largeValue = "x".repeat(variableSize);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -652,7 +652,8 @@ public final class CreateProcessInstanceTest {
                 .done())
         .deploy();
 
-    final int variableSize = (int) ByteValue.ofMegabytes(2);
+    // Near 4MB variable value
+    final int variableSize = (int) ByteValue.ofMegabytes(3) + (int) ByteValue.ofKilobytes(900);
     final String largeValue = "x".repeat(variableSize);
 
     // when - create a process instance with the large variable
@@ -703,8 +704,8 @@ public final class CreateProcessInstanceTest {
         .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
         .deploy();
 
-    // A ~3MB variable value
-    final int variableSize = (int) ByteValue.ofMegabytes(3);
+    // Near 4MB variable value
+    final int variableSize = (int) ByteValue.ofMegabytes(3) + (int) ByteValue.ofKilobytes(900);
     final String largeValue = "x".repeat(variableSize);
 
     // when - create a process instance with result and the large variable

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -23,12 +23,14 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.ByteValue;
 import java.util.List;
 import java.util.Map;
 import org.junit.ClassRule;
@@ -633,5 +635,115 @@ public final class CreateProcessInstanceTest {
                 .getValue())
         .hasBusinessId(businessId)
         .hasProcessInstanceKey(secondInstanceKey);
+  }
+
+  @Test
+  public void shouldCreateProcessInstanceWithLargeVariablesBelowMaxMessageSize() {
+    final String processId = helper.getBpmnProcessId();
+
+    // given - deploy a simple process
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // A ~2MB variable value
+    final int variableSize = (int) ByteValue.ofMegabytes(3);
+    final String largeValue = "x".repeat(variableSize);
+
+    // when - create a process instance with the large variable
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("large_variable", largeValue)
+            .create();
+
+    // then - the process instance should be created successfully as we no longer put variables to
+    // follow-up events, which caused the command rejection with EXCEEDED_BATCH_RECORD_SIZE instead
+    // of being processed.
+    assertThat(processInstanceKey).isGreaterThan(0);
+
+    // Verify the CREATED event was produced for the process instance creation
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withBpmnProcessId(processId)
+                .findFirst())
+        .isPresent();
+
+    // Verify the variable was actually created
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("large_variable")
+                .findFirst())
+        .isPresent();
+
+    // Verify the process instance was activated (i.e., not stuck)
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .findFirst())
+        .isPresent();
+  }
+
+  @Test
+  public void shouldCreateProcessInstanceWithResultWithLargeVariablesBelowMaxMessageSize() {
+    final String processId = helper.getBpmnProcessId();
+
+    // given - deploy a simple process that completes immediately
+    ENGINE
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+        .deploy();
+
+    // A ~2MB variable value
+    final int variableSize = (int) ByteValue.ofMegabytes(3);
+    final String largeValue = "x".repeat(variableSize);
+
+    // when - create a process instance with result and the large variable
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("large_variable", largeValue)
+            .withResult()
+            .create();
+
+    // then - the process instance should be created successfully as we no longer put variables to
+    // follow-up events, which caused the command rejection with EXCEEDED_BATCH_RECORD_SIZE instead
+    // of being processed.
+    assertThat(processInstanceKey).isGreaterThan(0);
+
+    // Verify the CREATED event was produced for the process instance creation
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withBpmnProcessId(processId)
+                .findFirst())
+        .isPresent();
+
+    // Verify the process instance completed
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .findFirst())
+        .isPresent();
+
+    // Verify the variable was persisted
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("large_variable")
+                .findFirst())
+        .isPresent();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
@@ -350,12 +350,11 @@ public final class CreateProcessInstanceTest {
 
     final var variableRecord =
         RecordingExporter.variableRecords()
-            .withProcessInstanceKey(event.getProcessInstanceKey())
+            .withScopeKey(event.getProcessInstanceKey())
             .withName(key)
             .getFirst();
 
     assertThat(variableRecord.getValue().getName()).isEqualTo(key);
-    assertThat(variableRecord.getValue().getValue()).isEqualTo("\"" + value + "\"");
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
@@ -139,7 +139,7 @@ public final class CreateProcessInstanceTest {
             .withInstanceKey(event.getProcessInstanceKey())
             .getFirst();
 
-    assertThat(createdEvent.getValue().getVariables()).containsExactlyEntriesOf(variables);
+    assertThat(createdEvent.getValue().getVariables()).isEmpty();
   }
 
   @ParameterizedTest
@@ -337,7 +337,7 @@ public final class CreateProcessInstanceTest {
             .withInstanceKey(event.getProcessInstanceKey())
             .getFirst();
 
-    assertThat(createdEvent.getValue().getVariables()).containsExactlyEntriesOf(Map.of(key, value));
+    assertThat(createdEvent.getValue().getVariables()).isEmpty();
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
@@ -140,6 +140,15 @@ public final class CreateProcessInstanceTest {
             .getFirst();
 
     assertThat(createdEvent.getValue().getVariables()).isEmpty();
+
+    final var variableRecord =
+        RecordingExporter.variableRecords()
+            .withProcessInstanceKey(event.getProcessInstanceKey())
+            .withName("foo")
+            .getFirst();
+
+    assertThat(variableRecord.getValue().getName()).isEqualTo("foo");
+    assertThat(variableRecord.getValue().getValue()).isEqualTo("123");
   }
 
   @ParameterizedTest
@@ -338,6 +347,15 @@ public final class CreateProcessInstanceTest {
             .getFirst();
 
     assertThat(createdEvent.getValue().getVariables()).isEmpty();
+
+    final var variableRecord =
+        RecordingExporter.variableRecords()
+            .withProcessInstanceKey(event.getProcessInstanceKey())
+            .withName(key)
+            .getFirst();
+
+    assertThat(variableRecord.getValue().getName()).isEqualTo(key);
+    assertThat(variableRecord.getValue().getValue()).isEqualTo("\"" + value + "\"");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
# Description
Backport of #49319 to `stable/8.9`.

relates to #12873 #13016 #10336