### PR TITLE
[Backport stable/8.9] fix: deduplicate batch lifecycle audit logs

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerRegistry.java
@@ -79,6 +79,7 @@ public final class AuditLogTransformerRegistry {
     return List.of(
         AuthorizationAuditLogTransformer::new,
         BatchOperationCreationAuditLogTransformer::new,
+        BatchOperationLifecycleManagementAuditLogTransformer::new,
         DecisionRequirementsRecordAuditLogTransformer::new,
         DecisionAuditLogTransformer::new,
         FormAuditLogTransformer::new,
@@ -102,7 +103,6 @@ public final class AuditLogTransformerRegistry {
    */
   public static List<Supplier<AuditLogTransformer<?>>> getAllPartitionTransformerSuppliers() {
     return List.of(
-        BatchOperationLifecycleManagementAuditLogTransformer::new,
         DecisionEvaluationAuditLogTransformer::new,
         IncidentResolutionAuditLogTransformer::new,
         JobAuditLogTransformer::new,


### PR DESCRIPTION
# Description
Backport of #49444 to `stable/8.9`.

relates to camunda/camunda#49428