### PR TITLE
test: add E2E UI tests for global user task listeners CRUD

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -34,6 +34,7 @@ import {IdentityRolesPage} from '@pages/IdentityRolesPage';
 import {IdentityTenantsPage} from '@pages/IdentityTenantsPage';
 import {IdentityRolesDetailsPage} from '@pages/IdentityRolesDetailsPage';
 import {IdentityAuditLogPage} from '@pages/IdentityAuditLogPage';
+import {IdentityGlobalTaskListenersPage} from '@pages/IdentityGlobalTaskListenersPage';
 import {OperateOperationsDetailsPage} from '@pages/OperateOperationsDetailsPage';
 import {OperateOperationsLogPage} from '@pages/OperateOperationsLogPage';
 import {SwaggerPage} from '@pages/SwaggerPage';
@@ -70,6 +71,7 @@ type PlaywrightFixtures = {
   identityRolesDetailsPage: IdentityRolesDetailsPage;
   identityAuditLogPage: IdentityAuditLogPage;
   swaggerPage: SwaggerPage;
+  identityGlobalTaskListenersPage: IdentityGlobalTaskListenersPage;
   suppressHelperModals: void;
 };
 
@@ -194,6 +196,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   identityAuditLogPage: async ({page}, use) => {
     await use(new IdentityAuditLogPage(page));
+  },
+  identityGlobalTaskListenersPage: async ({page}, use) => {
+    await use(new IdentityGlobalTaskListenersPage(page));
   },
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGlobalTaskListenersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGlobalTaskListenersPage.ts
@@ -21,6 +21,9 @@ export class IdentityGlobalTaskListenersPage {
   readonly closeCreateGlobalTaskListenerModal: Locator;
   readonly createGlobalTaskListenerIdField: Locator;
   readonly createGlobalTaskListenerTypeField: Locator;
+  readonly createGlobalTaskListenerEventTypeToggle: Locator;
+  readonly createGlobalTaskListenerEventTypeMenu: Locator;
+  readonly createGlobalTaskListenerInlineError: Locator;
   readonly createGlobalTaskListenerModalCancelButton: Locator;
   readonly createGlobalTaskListenerModalCreateButton: Locator;
 
@@ -72,6 +75,18 @@ export class IdentityGlobalTaskListenersPage {
       this.createGlobalTaskListenerModal.getByRole('textbox', {
         name: 'Listener type',
       });
+    this.createGlobalTaskListenerEventTypeToggle =
+      this.createGlobalTaskListenerModal.locator(
+        '#event-type-multiselect button',
+      );
+    this.createGlobalTaskListenerEventTypeMenu =
+      this.createGlobalTaskListenerModal.locator(
+        '#event-type-multiselect .cds--list-box__menu',
+      );
+    this.createGlobalTaskListenerInlineError =
+      this.createGlobalTaskListenerModal.locator(
+        '.cds--inline-notification--error',
+      );
     this.createGlobalTaskListenerModalCancelButton =
       this.createGlobalTaskListenerModal.getByRole('button', {name: 'Cancel'});
     this.createGlobalTaskListenerModalCreateButton =
@@ -122,14 +137,8 @@ export class IdentityGlobalTaskListenersPage {
     await this.createGlobalTaskListenerIdField.fill(listenerId);
     await this.createGlobalTaskListenerTypeField.fill(listenerType);
     await this.createGlobalTaskListenerTypeField.blur();
-    const createEventTypeToggle = this.createGlobalTaskListenerModal.locator(
-      '#event-type-multiselect button',
-    );
-    await createEventTypeToggle.click();
-    const createEventTypeMenu = this.createGlobalTaskListenerModal.locator(
-      '#event-type-multiselect .cds--list-box__menu',
-    );
-    await expect(createEventTypeMenu).toBeVisible();
+    await this.createGlobalTaskListenerEventTypeToggle.click();
+    await expect(this.createGlobalTaskListenerEventTypeMenu).toBeVisible();
     await this.page
       .locator('[role="option"]', {hasText: eventTypeLabel})
       .click();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGlobalTaskListenersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGlobalTaskListenersPage.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+import {relativizePath, Paths} from 'utils/relativizePath';
+import {defaultAssertionOptions} from '../utils/constants';
+
+export class IdentityGlobalTaskListenersPage {
+  private page: Page;
+  readonly globalTaskListenersList: Locator;
+  readonly createGlobalTaskListenerButton: Locator;
+  readonly editGlobalTaskListenerButton: (rowName?: string) => Locator;
+  readonly deleteGlobalTaskListenerButton: (rowName?: string) => Locator;
+
+  readonly createGlobalTaskListenerModal: Locator;
+  readonly closeCreateGlobalTaskListenerModal: Locator;
+  readonly createGlobalTaskListenerIdField: Locator;
+  readonly createGlobalTaskListenerTypeField: Locator;
+  readonly createGlobalTaskListenerModalCancelButton: Locator;
+  readonly createGlobalTaskListenerModalCreateButton: Locator;
+
+  readonly editGlobalTaskListenerModal: Locator;
+  readonly closeEditGlobalTaskListenerModal: Locator;
+  readonly editGlobalTaskListenerTypeField: Locator;
+  readonly editGlobalTaskListenerModalCancelButton: Locator;
+  readonly editGlobalTaskListenerModalUpdateButton: Locator;
+
+  readonly deleteGlobalTaskListenerModal: Locator;
+  readonly closeDeleteGlobalTaskListenerModal: Locator;
+  readonly deleteGlobalTaskListenerModalCancelButton: Locator;
+  readonly deleteGlobalTaskListenerModalDeleteButton: Locator;
+
+  readonly emptyStateLocator: Locator;
+  readonly globalTaskListenerCell: (name: string) => Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.globalTaskListenersList = page.getByRole('table');
+
+    this.globalTaskListenerCell = (name) =>
+      this.globalTaskListenersList.getByRole('cell', {name, exact: true});
+
+    this.createGlobalTaskListenerButton = page.getByRole('button', {
+      name: /^Create (listener|global user task listener)$/,
+    });
+
+    this.editGlobalTaskListenerButton = (rowName) =>
+      this.globalTaskListenersList
+        .getByRole('row', {name: rowName})
+        .getByLabel('Update user task listener');
+
+    this.deleteGlobalTaskListenerButton = (rowName) =>
+      this.globalTaskListenersList
+        .getByRole('row', {name: rowName})
+        .getByLabel('Delete');
+
+    this.createGlobalTaskListenerModal = page.getByRole('dialog', {
+      name: 'Create user task listener',
+    });
+    this.closeCreateGlobalTaskListenerModal =
+      this.createGlobalTaskListenerModal.getByRole('button', {name: 'Close'});
+    this.createGlobalTaskListenerIdField =
+      this.createGlobalTaskListenerModal.getByRole('textbox', {
+        name: 'Task listener ID',
+      });
+    this.createGlobalTaskListenerTypeField =
+      this.createGlobalTaskListenerModal.getByRole('textbox', {
+        name: 'Listener type',
+      });
+    this.createGlobalTaskListenerModalCancelButton =
+      this.createGlobalTaskListenerModal.getByRole('button', {name: 'Cancel'});
+    this.createGlobalTaskListenerModalCreateButton =
+      this.createGlobalTaskListenerModal.getByRole('button', {name: 'Create'});
+
+    this.editGlobalTaskListenerModal = page.getByRole('dialog', {
+      name: 'Update user task listener',
+    });
+    this.closeEditGlobalTaskListenerModal =
+      this.editGlobalTaskListenerModal.getByRole('button', {name: 'Close'});
+    this.editGlobalTaskListenerTypeField =
+      this.editGlobalTaskListenerModal.getByRole('textbox', {
+        name: 'Listener type',
+      });
+    this.editGlobalTaskListenerModalCancelButton =
+      this.editGlobalTaskListenerModal.getByRole('button', {name: 'Cancel'});
+    this.editGlobalTaskListenerModalUpdateButton =
+      this.editGlobalTaskListenerModal.getByRole('button', {name: 'Update'});
+
+    this.deleteGlobalTaskListenerModal = page.getByRole('dialog', {
+      name: 'Delete user task listener',
+    });
+    this.closeDeleteGlobalTaskListenerModal =
+      this.deleteGlobalTaskListenerModal.getByRole('button', {name: 'Close'});
+    this.deleteGlobalTaskListenerModalCancelButton =
+      this.deleteGlobalTaskListenerModal.getByRole('button', {name: 'Cancel'});
+    this.deleteGlobalTaskListenerModalDeleteButton =
+      this.deleteGlobalTaskListenerModal.getByRole('button', {
+        name: /^(danger )?Delete$/,
+      });
+
+    this.emptyStateLocator = page.getByText(
+      'No global user task listeners created yet',
+    );
+  }
+
+  async navigateToGlobalTaskListeners() {
+    await this.page.goto(relativizePath(Paths.globalTaskListeners()));
+  }
+
+  async createGlobalTaskListener(
+    listenerId: string,
+    listenerType: string,
+    eventTypeLabel: string,
+  ) {
+    await this.createGlobalTaskListenerButton.click();
+    await expect(this.createGlobalTaskListenerModal).toBeVisible();
+    await this.createGlobalTaskListenerIdField.fill(listenerId);
+    await this.createGlobalTaskListenerTypeField.fill(listenerType);
+    await this.createGlobalTaskListenerTypeField.blur();
+    const createEventTypeToggle = this.createGlobalTaskListenerModal.locator(
+      '#event-type-multiselect button',
+    );
+    await createEventTypeToggle.click();
+    const createEventTypeMenu = this.createGlobalTaskListenerModal.locator(
+      '#event-type-multiselect .cds--list-box__menu',
+    );
+    await expect(createEventTypeMenu).toBeVisible();
+    await this.page
+      .locator('[role="option"]', {hasText: eventTypeLabel})
+      .click();
+    await this.createGlobalTaskListenerModalCreateButton.click();
+    await expect(this.createGlobalTaskListenerModal).toBeHidden();
+  }
+
+  async editGlobalTaskListener(
+    currentListenerId: string,
+    newType: string,
+    newEventTypeLabel?: string,
+  ) {
+    await this.editGlobalTaskListenerButton(currentListenerId).click();
+    await expect(this.editGlobalTaskListenerModal).toBeVisible();
+    await this.editGlobalTaskListenerTypeField.clear();
+    await this.editGlobalTaskListenerTypeField.fill(newType);
+    if (newEventTypeLabel) {
+      await this.editGlobalTaskListenerTypeField.blur();
+      const editEventTypeToggle = this.editGlobalTaskListenerModal.locator(
+        '#event-type-multiselect-edit button',
+      );
+      await editEventTypeToggle.click();
+      const editEventTypeMenu = this.editGlobalTaskListenerModal.locator(
+        '#event-type-multiselect-edit .cds--list-box__menu',
+      );
+      await expect(editEventTypeMenu).toBeVisible();
+      await this.page
+        .locator('[role="option"]', {hasText: newEventTypeLabel})
+        .click();
+    }
+    await this.editGlobalTaskListenerModalUpdateButton.click();
+    await expect(this.editGlobalTaskListenerModal).toBeHidden();
+  }
+
+  async deleteGlobalTaskListener(listenerId: string) {
+    await expect(this.deleteGlobalTaskListenerButton(listenerId)).toBeVisible({
+      timeout: 20000,
+    });
+    await expect(async () => {
+      await this.deleteGlobalTaskListenerButton(listenerId).click();
+    }).toPass(defaultAssertionOptions);
+    await expect(this.deleteGlobalTaskListenerModal).toBeVisible();
+    await this.deleteGlobalTaskListenerModalDeleteButton.click();
+    await expect(this.deleteGlobalTaskListenerModal).toBeHidden();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
@@ -7,6 +7,7 @@
  */
 
 import {Page, Locator, expect} from '@playwright/test';
+import {sleep} from '../utils/sleep';
 
 export class IdentityHeader {
   readonly page: Page;
@@ -17,6 +18,7 @@ export class IdentityHeader {
   readonly authorizationsTab: Locator;
   readonly usersTab: Locator;
   readonly groupsTab: Locator;
+  readonly globalTaskListenersTab: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -34,6 +36,9 @@ export class IdentityHeader {
       .locator('nav a')
       .filter({hasText: /^Authorizations$/});
     this.groupsTab = page.locator('nav a').filter({hasText: /^Groups$/});
+    this.globalTaskListenersTab = page
+      .locator('nav a')
+      .filter({hasText: /^Global user task listeners$/i});
   }
 
   async logout() {
@@ -45,7 +50,7 @@ export class IdentityHeader {
     await expect(this.page.getByText('logged out...')).not.toBeVisible({
       timeout: 15000,
     });
-    await this.page.waitForURL(/login/, {timeout: 30000});
+    await sleep(2000);
   }
 
   async navigateToRoles() {
@@ -66,5 +71,9 @@ export class IdentityHeader {
 
   async navigateToGroups() {
     await this.groupsTab.click();
+  }
+
+  async navigateToGlobalTaskListeners() {
+    await this.globalTaskListenersTab.click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
@@ -7,7 +7,6 @@
  */
 
 import {Page, Locator, expect} from '@playwright/test';
-import {sleep} from '../utils/sleep';
 
 export class IdentityHeader {
   readonly page: Page;
@@ -50,7 +49,7 @@ export class IdentityHeader {
     await expect(this.page.getByText('logged out...')).not.toBeVisible({
       timeout: 15000,
     });
-    await sleep(2000);
+    await this.page.waitForURL(/login/, {timeout: 30000});
   }
 
   async navigateToRoles() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/global-task-listeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/global-task-listeners.spec.ts
@@ -54,85 +54,91 @@ test.describe.serial('global task listeners CRUD', () => {
   test('tries to create a global task listener with invalid type', async ({
     identityGlobalTaskListenersPage,
   }) => {
-    await identityGlobalTaskListenersPage.createGlobalTaskListenerButton.click();
-    await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.fill(
-      'invalid type with spaces',
-    );
-    await expect(
-      identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
-    ).toContainText(
-      'Please enter a valid listener type (letters, digits, dots, dashes, and underscores only)',
-    );
-    await expect(
-      identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField,
-    ).toHaveAttribute('data-invalid', 'true');
+    await test.step('Open create modal and fill invalid listener type', async () => {
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerButton.click();
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.fill(
+        'invalid type with spaces',
+      );
+    });
+
+    await test.step('Verify validation error is shown', async () => {
+      await expect(
+        identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
+      ).toContainText(
+        'Please enter a valid listener type (letters, digits, dots, dashes, and underscores only)',
+      );
+      await expect(
+        identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField,
+      ).toHaveAttribute('data-invalid', 'true');
+    });
   });
 
   test('creates a global task listener', async ({
     page,
     identityGlobalTaskListenersPage,
   }) => {
-    await identityGlobalTaskListenersPage.createGlobalTaskListener(
-      NEW_LISTENER.id,
-      NEW_LISTENER.type,
-      NEW_LISTENER.eventType,
-    );
-
-    const item = identityGlobalTaskListenersPage.globalTaskListenerCell(
-      NEW_LISTENER.id,
-    );
-
-    await waitForItemInList(page, item, {
-      clickNext: true,
-      timeout: 30000,
+    await test.step('Create the listener', async () => {
+      await identityGlobalTaskListenersPage.createGlobalTaskListener(
+        NEW_LISTENER.id,
+        NEW_LISTENER.type,
+        NEW_LISTENER.eventType,
+      );
     });
-    await expect(item).toBeVisible();
+
+    await test.step('Verify the listener appears in the list', async () => {
+      const item = identityGlobalTaskListenersPage.globalTaskListenerCell(
+        NEW_LISTENER.id,
+      );
+      await waitForItemInList(page, item, {
+        clickNext: true,
+        timeout: 30000,
+      });
+      await expect(item).toBeVisible();
+    });
   });
 
   test('rejects creating a duplicate global task listener', async ({
     page,
     identityGlobalTaskListenersPage,
   }) => {
-    await identityGlobalTaskListenersPage.createGlobalTaskListenerButton.click();
-    await expect(
-      identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
-    ).toBeVisible();
+    await test.step('Open create modal and fill duplicate data', async () => {
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerButton.click();
+      await expect(
+        identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
+      ).toBeVisible();
 
-    await identityGlobalTaskListenersPage.createGlobalTaskListenerIdField.fill(
-      NEW_LISTENER.id,
-    );
-    await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.fill(
-      NEW_LISTENER.type,
-    );
-    await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.blur();
-    const createEventTypeToggle =
-      identityGlobalTaskListenersPage.createGlobalTaskListenerModal.locator(
-        '#event-type-multiselect button',
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerIdField.fill(
+        NEW_LISTENER.id,
       );
-    await createEventTypeToggle.click();
-    const createEventTypeMenu =
-      identityGlobalTaskListenersPage.createGlobalTaskListenerModal.locator(
-        '#event-type-multiselect .cds--list-box__menu',
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.fill(
+        NEW_LISTENER.type,
       );
-    await expect(createEventTypeMenu).toBeVisible();
-    await page
-      .locator('[role="option"]', {hasText: NEW_LISTENER.eventType})
-      .click();
-    await identityGlobalTaskListenersPage.createGlobalTaskListenerModalCreateButton.click();
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.blur();
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerEventTypeToggle.click();
+      await expect(
+        identityGlobalTaskListenersPage.createGlobalTaskListenerEventTypeMenu,
+      ).toBeVisible();
+      await page
+        .locator('[role="option"]', {hasText: NEW_LISTENER.eventType})
+        .click();
+    });
 
-    await expect(
-      identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
-    ).toBeVisible();
-    await expect(
-      identityGlobalTaskListenersPage.createGlobalTaskListenerModal.locator(
-        '.cds--inline-notification--error',
-      ),
-    ).toBeVisible();
+    await test.step('Submit and verify duplicate error is shown', async () => {
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerModalCreateButton.click();
+      await expect(
+        identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
+      ).toBeVisible();
+      await expect(
+        identityGlobalTaskListenersPage.createGlobalTaskListenerInlineError,
+      ).toBeVisible();
+    });
 
-    await identityGlobalTaskListenersPage.createGlobalTaskListenerModalCancelButton.click();
-    await expect(
-      identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
-    ).toBeHidden();
+    await test.step('Close the modal', async () => {
+      await identityGlobalTaskListenersPage.createGlobalTaskListenerModalCancelButton.click();
+      await expect(
+        identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
+      ).toBeHidden();
+    });
   });
 
   test('edits a global task listener', async ({
@@ -142,26 +148,32 @@ test.describe.serial('global task listeners CRUD', () => {
     const item = identityGlobalTaskListenersPage.globalTaskListenerCell(
       NEW_LISTENER.id,
     );
-    await waitForItemInList(page, item, {
-      clickNext: true,
-      timeout: 30000,
+
+    await test.step('Find the listener in the list', async () => {
+      await waitForItemInList(page, item, {
+        clickNext: true,
+        timeout: 30000,
+      });
+      await expect(item).toBeVisible();
     });
-    await expect(item).toBeVisible();
 
-    await identityGlobalTaskListenersPage.editGlobalTaskListener(
-      NEW_LISTENER.id,
-      EDITED_LISTENER.type,
-      EDITED_LISTENER.eventType,
-    );
-
-    const updatedTypeCell =
-      identityGlobalTaskListenersPage.globalTaskListenerCell(
+    await test.step('Edit the listener', async () => {
+      await identityGlobalTaskListenersPage.editGlobalTaskListener(
+        NEW_LISTENER.id,
         EDITED_LISTENER.type,
+        EDITED_LISTENER.eventType,
       );
+    });
 
-    await waitForItemInList(page, updatedTypeCell, {
-      clickNext: true,
-      timeout: 30000,
+    await test.step('Verify updated type is visible in the list', async () => {
+      const updatedTypeCell =
+        identityGlobalTaskListenersPage.globalTaskListenerCell(
+          EDITED_LISTENER.type,
+        );
+      await waitForItemInList(page, updatedTypeCell, {
+        clickNext: true,
+        timeout: 30000,
+      });
     });
   });
 
@@ -172,32 +184,39 @@ test.describe.serial('global task listeners CRUD', () => {
     const item = identityGlobalTaskListenersPage.globalTaskListenerCell(
       NEW_LISTENER.id,
     );
-    await waitForItemInList(page, item, {
-      clickNext: true,
-      timeout: 30000,
+
+    await test.step('Find the listener in the list', async () => {
+      await waitForItemInList(page, item, {
+        clickNext: true,
+        timeout: 30000,
+      });
+      await expect(item).toBeVisible();
     });
-    await expect(item).toBeVisible();
 
-    await identityGlobalTaskListenersPage.deleteGlobalTaskListener(
-      NEW_LISTENER.id,
-    );
+    await test.step('Delete the listener', async () => {
+      await identityGlobalTaskListenersPage.deleteGlobalTaskListener(
+        NEW_LISTENER.id,
+      );
+    });
 
-    await waitForItemInList(page, item, {
-      shouldBeVisible: false,
-      timeout: 60000,
-      clickNext: true,
-      emptyStateLocator: identityGlobalTaskListenersPage.emptyStateLocator,
-      onAfterReload: async () => {
-        await page.goto(relativizePath(Paths.globalTaskListeners()));
-        await Promise.race([
-          identityGlobalTaskListenersPage.globalTaskListenersList.waitFor({
-            timeout: 15000,
-          }),
-          identityGlobalTaskListenersPage.emptyStateLocator.waitFor({
-            timeout: 15000,
-          }),
-        ]);
-      },
+    await test.step('Verify the listener is removed from the list', async () => {
+      await waitForItemInList(page, item, {
+        shouldBeVisible: false,
+        timeout: 60000,
+        clickNext: true,
+        emptyStateLocator: identityGlobalTaskListenersPage.emptyStateLocator,
+        onAfterReload: async () => {
+          await page.goto(relativizePath(Paths.globalTaskListeners()));
+          await Promise.race([
+            identityGlobalTaskListenersPage.globalTaskListenersList.waitFor({
+              timeout: 15000,
+            }),
+            identityGlobalTaskListenersPage.emptyStateLocator.waitFor({
+              timeout: 15000,
+            }),
+          ]);
+        },
+      });
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/global-task-listeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/global-task-listeners.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {relativizePath, Paths} from 'utils/relativizePath';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {
+  LOGIN_CREDENTIALS,
+  createUniqueGlobalTaskListener,
+  createEditedGlobalTaskListener,
+} from 'utils/constants';
+import {waitForItemInList} from 'utils/waitForItemInList';
+import {cleanupGlobalTaskListeners} from 'utils/globalTaskListenerCleanup';
+
+const createdListenerIds: string[] = [];
+
+test.describe.serial('global task listeners CRUD', () => {
+  let NEW_LISTENER: ReturnType<typeof createUniqueGlobalTaskListener>;
+  let EDITED_LISTENER: ReturnType<typeof createEditedGlobalTaskListener>;
+
+  test.beforeAll(() => {
+    NEW_LISTENER = createUniqueGlobalTaskListener();
+    EDITED_LISTENER = createEditedGlobalTaskListener();
+    createdListenerIds.push(NEW_LISTENER.id);
+  });
+
+  test.beforeEach(async ({page, loginPage, identityHeader}) => {
+    await navigateToApp(page, 'admin');
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.users()));
+    await identityHeader.navigateToGlobalTaskListeners();
+    await expect(page).toHaveURL(relativizePath(Paths.globalTaskListeners()));
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGlobalTaskListeners(request, createdListenerIds);
+  });
+
+  test('tries to create a global task listener with invalid type', async ({
+    identityGlobalTaskListenersPage,
+  }) => {
+    await identityGlobalTaskListenersPage.createGlobalTaskListenerButton.click();
+    await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.fill(
+      'invalid type with spaces',
+    );
+    await expect(
+      identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
+    ).toContainText(
+      'Please enter a valid listener type (letters, digits, dots, dashes, and underscores only)',
+    );
+    await expect(
+      identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField,
+    ).toHaveAttribute('data-invalid', 'true');
+  });
+
+  test('creates a global task listener', async ({
+    page,
+    identityGlobalTaskListenersPage,
+  }) => {
+    await identityGlobalTaskListenersPage.createGlobalTaskListener(
+      NEW_LISTENER.id,
+      NEW_LISTENER.type,
+      NEW_LISTENER.eventType,
+    );
+
+    const item = identityGlobalTaskListenersPage.globalTaskListenerCell(
+      NEW_LISTENER.id,
+    );
+
+    await waitForItemInList(page, item, {
+      clickNext: true,
+      timeout: 30000,
+    });
+    await expect(item).toBeVisible();
+  });
+
+  test('rejects creating a duplicate global task listener', async ({
+    page,
+    identityGlobalTaskListenersPage,
+  }) => {
+    await identityGlobalTaskListenersPage.createGlobalTaskListenerButton.click();
+    await expect(
+      identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
+    ).toBeVisible();
+
+    await identityGlobalTaskListenersPage.createGlobalTaskListenerIdField.fill(
+      NEW_LISTENER.id,
+    );
+    await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.fill(
+      NEW_LISTENER.type,
+    );
+    await identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField.blur();
+    const createEventTypeToggle =
+      identityGlobalTaskListenersPage.createGlobalTaskListenerModal.locator(
+        '#event-type-multiselect button',
+      );
+    await createEventTypeToggle.click();
+    const createEventTypeMenu =
+      identityGlobalTaskListenersPage.createGlobalTaskListenerModal.locator(
+        '#event-type-multiselect .cds--list-box__menu',
+      );
+    await expect(createEventTypeMenu).toBeVisible();
+    await page
+      .locator('[role="option"]', {hasText: NEW_LISTENER.eventType})
+      .click();
+    await identityGlobalTaskListenersPage.createGlobalTaskListenerModalCreateButton.click();
+
+    await expect(
+      identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
+    ).toBeVisible();
+    await expect(
+      identityGlobalTaskListenersPage.createGlobalTaskListenerModal.locator(
+        '.cds--inline-notification--error',
+      ),
+    ).toBeVisible();
+
+    await identityGlobalTaskListenersPage.createGlobalTaskListenerModalCancelButton.click();
+    await expect(
+      identityGlobalTaskListenersPage.createGlobalTaskListenerModal,
+    ).toBeHidden();
+  });
+
+  test('edits a global task listener', async ({
+    page,
+    identityGlobalTaskListenersPage,
+  }) => {
+    const item = identityGlobalTaskListenersPage.globalTaskListenerCell(
+      NEW_LISTENER.id,
+    );
+    await waitForItemInList(page, item, {
+      clickNext: true,
+      timeout: 30000,
+    });
+    await expect(item).toBeVisible();
+
+    await identityGlobalTaskListenersPage.editGlobalTaskListener(
+      NEW_LISTENER.id,
+      EDITED_LISTENER.type,
+      EDITED_LISTENER.eventType,
+    );
+
+    const updatedTypeCell =
+      identityGlobalTaskListenersPage.globalTaskListenerCell(
+        EDITED_LISTENER.type,
+      );
+
+    await waitForItemInList(page, updatedTypeCell, {
+      clickNext: true,
+      timeout: 30000,
+    });
+  });
+
+  test('deletes a global task listener', async ({
+    page,
+    identityGlobalTaskListenersPage,
+  }) => {
+    const item = identityGlobalTaskListenersPage.globalTaskListenerCell(
+      NEW_LISTENER.id,
+    );
+    await waitForItemInList(page, item, {
+      clickNext: true,
+      timeout: 30000,
+    });
+    await expect(item).toBeVisible();
+
+    await identityGlobalTaskListenersPage.deleteGlobalTaskListener(
+      NEW_LISTENER.id,
+    );
+
+    await waitForItemInList(page, item, {
+      shouldBeVisible: false,
+      timeout: 60000,
+      clickNext: true,
+      emptyStateLocator: identityGlobalTaskListenersPage.emptyStateLocator,
+      onAfterReload: async () => {
+        await page.goto(relativizePath(Paths.globalTaskListeners()));
+        await Promise.race([
+          identityGlobalTaskListenersPage.globalTaskListenersList.waitFor({
+            timeout: 15000,
+          }),
+          identityGlobalTaskListenersPage.emptyStateLocator.waitFor({
+            timeout: 15000,
+          }),
+        ]);
+      },
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -204,3 +204,20 @@ export const NEW_AUTH_ROLE = {
   id: 'authrole',
   name: 'Auth role',
 };
+
+export const createUniqueGlobalTaskListener = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    id: `test-gl-${id}`,
+    type: `io.camunda.test.listener.${id}`,
+    eventType: 'creating',
+  };
+};
+
+export const createEditedGlobalTaskListener = (customId?: string) => {
+  const id = customId || generateUniqueId();
+  return {
+    type: `io.camunda.test.edited.${id}`,
+    eventType: 'completing',
+  };
+};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
@@ -34,6 +34,9 @@ export const Paths = {
   operationsLog() {
     return '/admin/operations-log';
   },
+  globalTaskListeners() {
+    return '/admin/global-task-listeners';
+  },
   operateDashboard() {
     return '/operate';
   },


### PR DESCRIPTION
## Description

Adds a new Playwright E2E test suite covering the full CRUD lifecycle of the Global User Task Listeners admin page in Identity (Orchestration Cluster UI), including input validation and duplicate-creation prevention.

The suite runs in serial so each test builds on the state established by the previous one (create → reject duplicate → edit → delete), and an API-level cleanup in `afterAll` ensures no test data is left behind regardless of outcome.

## What's tested

| # | Scenario | Expected outcome |
|---|----------|-----------------|
| 1 | Submit the Create modal with a type value containing spaces | Inline validation error appears; field is marked `data-invalid`; form cannot be submitted |
| 2 | Create a global user task listener (valid ID, type, event type) | Modal closes; new row is visible in the paginated table |
| 3 | Create a listener with the same ID as an existing one | Modal stays open; inline error notification (`role=alert`) is shown; duplicate is not saved |
| 4 | Edit the listener: change its type and event type | Update modal closes; row reflects the new values |
| 5 | Delete the listener | Delete modal closes; row is gone; empty state is shown once the table is empty |

## New files

| File | Purpose |
|------|---------|
| `tests/identity/global-task-listeners.spec.ts` | Serial test suite (validation → create → reject duplicate → edit → delete) |
| `pages/IdentityGlobalTaskListenersPage.ts` | Page object — locators and interaction helpers for the Global Task Listeners UI |
| `utils/globalTaskListenerCleanup.ts` | API-level cleanup helper called in `afterAll` |
| `utils/constants.ts` (additions) | `createUniqueGlobalTaskListener` / `createEditedGlobalTaskListener` factories |
| `utils/relativizePath.ts` (additions) | `Paths.globalTaskListeners()` route helper |
| `pages/IdentityHeader.ts` (additions) | `navigateToGlobalTaskListeners()` nav helper |
| `fixtures.ts` (additions) | `identityGlobalTaskListenersPage` fixture registration |


Test Rail test cases > Cross component test suite
https://camunda.testrail.com/index.php?/suites/view/17051&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=615073

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview
