### PR TITLE
fix: remove duplicate default TenantFilterEnum value

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1005,7 +1005,6 @@ components:
       enum:
         - PROVIDED
         - ASSIGNED
-      default: PROVIDED
 
     JobStateEnum:
       description: The state of the job.


### PR DESCRIPTION
## Description

~I got an error while doing some TS type auto-gen which made the build fail~

~[`#/components/schemas/TenantFilterEnum`](https://github.com/camunda/camunda/blob/b3e5354438b1d824769571d57c107f17f5b643b1/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml#L998-L1007) is identical to the previous types. Doing a simple ref like this fixes my auto-generation~

I simply removed the double default enum value instead

