### PR TITLE
48106 Default record variable scope filter wiring

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.exporter.filter;
 import static io.camunda.zeebe.exporter.filter.NameFilterRule.Type.ENDS_WITH;
 import static io.camunda.zeebe.exporter.filter.NameFilterRule.Type.EXACT;
 import static io.camunda.zeebe.exporter.filter.NameFilterRule.Type.STARTS_WITH;
-import static io.camunda.zeebe.exporter.filter.VariableNameFilter.parseRules;
 
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.protocol.record.Record;
@@ -40,17 +39,56 @@ public final class DefaultRecordFilter implements Context.RecordFilter {
 
     final var index = configuration.filterIndexConfig();
 
-    final var variableNameInclusionRules = getVariableNameInclusionRules(index);
-    final var variableNameExclusionRules = getVariableNameExclusionRules(index);
+    final var variableNameInclusionRules =
+        buildNameRules(
+            index.getVariableNameInclusionExact(),
+            index.getVariableNameInclusionStartWith(),
+            index.getVariableNameInclusionEndWith());
+    final var variableNameExclusionRules =
+        buildNameRules(
+            index.getVariableNameExclusionExact(),
+            index.getVariableNameExclusionStartWith(),
+            index.getVariableNameExclusionEndWith());
 
     final Set<VariableValueType> valueTypeInclusion =
         VariableTypeFilter.parseTypes(index.getVariableValueTypeInclusion());
     final Set<VariableValueType> valueTypeExclusion =
         VariableTypeFilter.parseTypes(index.getVariableValueTypeExclusion());
 
-    final List<ExporterRecordFilter> filters = new ArrayList<>();
+    final var localVariableNameInclusionRules =
+        buildNameRules(
+            index.getLocalVariableNameInclusionExact(),
+            index.getLocalVariableNameInclusionStartWith(),
+            index.getLocalVariableNameInclusionEndWith());
+    final var localVariableNameExclusionRules =
+        buildNameRules(
+            index.getLocalVariableNameExclusionExact(),
+            index.getLocalVariableNameExclusionStartWith(),
+            index.getLocalVariableNameExclusionEndWith());
+    final var rootVariableNameInclusionRules =
+        buildNameRules(
+            index.getRootVariableNameInclusionExact(),
+            index.getRootVariableNameInclusionStartWith(),
+            index.getRootVariableNameInclusionEndWith());
+    final var rootVariableNameExclusionRules =
+        buildNameRules(
+            index.getRootVariableNameExclusionExact(),
+            index.getRootVariableNameExclusionStartWith(),
+            index.getRootVariableNameExclusionEndWith());
 
-    // Just add filters if configured
+    final Set<VariableValueType> localValueTypeInclusion =
+        VariableTypeFilter.parseTypes(index.getLocalVariableValueTypeInclusion());
+    final Set<VariableValueType> localValueTypeExclusion =
+        VariableTypeFilter.parseTypes(index.getLocalVariableValueTypeExclusion());
+    final Set<VariableValueType> rootValueTypeInclusion =
+        VariableTypeFilter.parseTypes(index.getRootVariableValueTypeInclusion());
+    final Set<VariableValueType> rootValueTypeExclusion =
+        VariableTypeFilter.parseTypes(index.getRootVariableValueTypeExclusion());
+
+    // Filters are added in order of cheapness/selectivity: the chain short-circuits on the first
+    // rejection, so higher-selectivity and lower-cost filters are placed first to avoid unnecessary
+    // work for slower filters later in the chain.
+    final List<ExporterRecordFilter> filters = new ArrayList<>();
 
     if (index.isOptimizeModeEnabled()) {
       LOG.info(
@@ -58,6 +96,14 @@ public final class DefaultRecordFilter implements Context.RecordFilter {
               + "acceptType, acceptValue, and acceptIntent. If you want to customize the filtering, "
               + "please disable optimize mode and use the other filter configuration options.");
       filters.add(new OptimizeModeFilter());
+    }
+
+    // Placed before VariableNameFilter: a single long comparison is cheaper than string matching,
+    // so local variables are rejected before any name or type work runs.
+    if (!index.isExportLocalVariablesEnabled()) {
+      LOG.info(
+          "Export local variables disabled. Local (sub-element scoped) variables will be filtered out.");
+      filters.add(new ExportLocalVariablesFilter(false));
     }
 
     if (!variableNameInclusionRules.isEmpty() || !variableNameExclusionRules.isEmpty()) {
@@ -76,6 +122,46 @@ public final class DefaultRecordFilter implements Context.RecordFilter {
       filters.add(new VariableTypeFilter(valueTypeInclusion, valueTypeExclusion));
     }
 
+    if (!localVariableNameInclusionRules.isEmpty()
+        || !localVariableNameExclusionRules.isEmpty()
+        || !rootVariableNameInclusionRules.isEmpty()
+        || !rootVariableNameExclusionRules.isEmpty()) {
+      LOG.info(
+          "Variable name scope filters configured. "
+              + "Local inclusion rules: {}, Local exclusion rules: {}, "
+              + "Root inclusion rules: {}, Root exclusion rules: {}.",
+          localVariableNameInclusionRules,
+          localVariableNameExclusionRules,
+          rootVariableNameInclusionRules,
+          rootVariableNameExclusionRules);
+      filters.add(
+          new VariableNameScopeFilter(
+              localVariableNameInclusionRules,
+              localVariableNameExclusionRules,
+              rootVariableNameInclusionRules,
+              rootVariableNameExclusionRules));
+    }
+
+    if (!localValueTypeInclusion.isEmpty()
+        || !localValueTypeExclusion.isEmpty()
+        || !rootValueTypeInclusion.isEmpty()
+        || !rootValueTypeExclusion.isEmpty()) {
+      LOG.info(
+          "Variable type scope filters configured. "
+              + "Local inclusion types: {}, Local exclusion types: {}, "
+              + "Root inclusion types: {}, Root exclusion types: {}.",
+          localValueTypeInclusion,
+          localValueTypeExclusion,
+          rootValueTypeInclusion,
+          rootValueTypeExclusion);
+      filters.add(
+          new VariableTypeScopeFilter(
+              localValueTypeInclusion,
+              localValueTypeExclusion,
+              rootValueTypeInclusion,
+              rootValueTypeExclusion));
+    }
+
     if (!index.getBpmnProcessIdInclusion().isEmpty()
         || !index.getBpmnProcessIdExclusion().isEmpty()) {
       LOG.info(
@@ -90,22 +176,17 @@ public final class DefaultRecordFilter implements Context.RecordFilter {
     return List.copyOf(filters);
   }
 
-  private static List<NameFilterRule> getVariableNameInclusionRules(
-      final FilterConfiguration.IndexConfig index) {
+  /**
+   * Builds a flat list of {@link NameFilterRule}s from three raw string lists — one per match type.
+   * Returns a mutable list; callers own the result.
+   */
+  private static List<NameFilterRule> buildNameRules(
+      final List<String> exact, final List<String> startWith, final List<String> endWith) {
     final List<NameFilterRule> rules = new ArrayList<>();
-    rules.addAll(parseRules(index.getVariableNameInclusionExact(), EXACT));
-    rules.addAll(parseRules(index.getVariableNameInclusionStartWith(), STARTS_WITH));
-    rules.addAll(parseRules(index.getVariableNameInclusionEndWith(), ENDS_WITH));
-    return List.copyOf(rules);
-  }
-
-  private static List<NameFilterRule> getVariableNameExclusionRules(
-      final FilterConfiguration.IndexConfig index) {
-    final List<NameFilterRule> rules = new ArrayList<>();
-    rules.addAll(parseRules(index.getVariableNameExclusionExact(), EXACT));
-    rules.addAll(parseRules(index.getVariableNameExclusionStartWith(), STARTS_WITH));
-    rules.addAll(parseRules(index.getVariableNameExclusionEndWith(), ENDS_WITH));
-    return List.copyOf(rules);
+    rules.addAll(NameFilterRule.parseRules(exact, EXACT));
+    rules.addAll(NameFilterRule.parseRules(startWith, STARTS_WITH));
+    rules.addAll(NameFilterRule.parseRules(endWith, ENDS_WITH));
+    return rules;
   }
 
   @Override

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/NameFilterRule.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/NameFilterRule.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter.filter;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -27,6 +29,22 @@ public record NameFilterRule(Type type, String pattern) {
     if (pattern == null || pattern.isBlank()) {
       throw new IllegalArgumentException("pattern must not be null or blank");
     }
+  }
+
+  /**
+   * Converts a list of raw strings into {@link NameFilterRule}s of the given type. Null and blank
+   * entries are silently ignored.
+   */
+  public static List<NameFilterRule> parseRules(final List<String> rawList, final Type type) {
+    if (rawList == null || rawList.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return rawList.stream()
+        .filter(Objects::nonNull)
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(pattern -> new NameFilterRule(type, pattern))
+        .toList();
   }
 
   public enum Type {

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameFilter.java
@@ -10,9 +10,7 @@ package io.camunda.zeebe.exporter.filter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 public final class VariableNameFilter implements ExporterRecordFilter, RecordVersionFilter {
 
@@ -33,21 +31,6 @@ public final class VariableNameFilter implements ExporterRecordFilter, RecordVer
     }
 
     return nameFilter.accept(variableRecordValue.getName());
-  }
-
-  public static List<NameFilterRule> parseRules(
-      final List<String> rawList, final NameFilterRule.Type type) {
-
-    if (rawList == null || rawList.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    return rawList.stream()
-        .filter(Objects::nonNull)
-        .map(String::trim)
-        .filter(s -> !s.isEmpty())
-        .map(pattern -> new NameFilterRule(type, pattern))
-        .toList();
   }
 
   @Override

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
@@ -70,8 +70,6 @@ final class DefaultRecordFilterTest {
     assertThat(filter.acceptValue(ValueType.JOB))
         .as("Required-only value types should not be accepted as normal indexed types")
         .isFalse();
-
-    assertThat(configuration.shouldIndexRequiredValueType(ValueType.JOB)).isTrue();
   }
 
   @Test
@@ -89,216 +87,6 @@ final class DefaultRecordFilterTest {
   }
 
   @Test
-  void shouldApplyVariableNameInclusionRulesFromTestConfiguration() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    configuration.filterIndexConfig().withVariableNameInclusionExact(List.of("included"));
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    final var included = variableRecord("included");
-    final var other = variableRecord("other");
-
-    // when / then
-    assertThat(filter.acceptRecord(included)).isTrue();
-    assertThat(filter.acceptRecord(other)).isFalse();
-  }
-
-  @Test
-  void shouldApplyVariableNameExclusionRulesFromTestConfiguration() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    // No inclusion rules -> all variable names are included by default,
-    // but we explicitly exclude the exact name "excluded".
-    configuration.filterIndexConfig().withVariableNameExclusionExact(List.of("excluded"));
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    final var excluded = variableRecord("excluded");
-    final var other = variableRecord("other");
-
-    // when / then
-    assertThat(filter.acceptRecord(excluded))
-        .as("name 'excluded' should be rejected by exclusion rules")
-        .isFalse();
-    assertThat(filter.acceptRecord(other))
-        .as("name 'other' is not excluded and should be accepted")
-        .isTrue();
-  }
-
-  @Test
-  void shouldApplyVariableNameInclusionStartWithRulesFromTestConfiguration() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    configuration.filterIndexConfig().withVariableNameInclusionStartWith(List.of("incl"));
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    final var included = variableRecord("includeMe");
-    final var other = variableRecord("other");
-
-    // when / then
-    assertThat(filter.acceptRecord(included)).isTrue();
-    assertThat(filter.acceptRecord(other)).isFalse();
-  }
-
-  @Test
-  void shouldApplyVariableNameInclusionEndWithRulesFromTestConfiguration() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    configuration.filterIndexConfig().withVariableNameInclusionEndWith(List.of("_suffix"));
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    final var included = variableRecord("name_suffix");
-    final var other = variableRecord("name_other");
-
-    // when / then
-    assertThat(filter.acceptRecord(included)).isTrue();
-    assertThat(filter.acceptRecord(other)).isFalse();
-  }
-
-  @Test
-  void shouldApplyVariableNameExclusionStartWithRulesFromTestConfiguration() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    // No inclusion rules -> all variable names are included by default,
-    // but we explicitly exclude names starting with "secret_".
-    configuration.filterIndexConfig().withVariableNameExclusionStartWith(List.of("secret_"));
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    final var excluded = variableRecord("secret_token");
-    final var other = variableRecord("public_value");
-
-    // when / then
-    assertThat(filter.acceptRecord(excluded))
-        .as("names starting with 'secret_' should be rejected by exclusion rules")
-        .isFalse();
-    assertThat(filter.acceptRecord(other))
-        .as("name 'public_value' does not start with 'secret_' and should be accepted")
-        .isTrue();
-  }
-
-  @Test
-  void shouldApplyVariableNameExclusionEndWithRulesFromTestConfiguration() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    // No inclusion rules -> all variable names are included by default,
-    // but we explicitly exclude names ending with "_tmp".
-    configuration.filterIndexConfig().withVariableNameExclusionEndWith(List.of("_tmp"));
-
-    final var excluded = variableRecord("value_tmp");
-    final var other = variableRecord("value");
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    // when / then
-    assertThat(filter.acceptRecord(excluded))
-        .as("names ending with '_tmp' should be rejected by exclusion rules")
-        .isFalse();
-    assertThat(filter.acceptRecord(other))
-        .as("name 'value' does not end with '_tmp' and should be accepted")
-        .isTrue();
-  }
-
-  @Test
-  void shouldApplyVariableValueTypeInclusionFromTestConfiguration() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    // Only STRING variables should be included
-    configuration.filterIndexConfig().withVariableValueTypeInclusion(List.of("STRING"));
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    // JSON string -> STRING
-    final var stringVar = variableRecord("v_string", "\"foo\"");
-    // JSON number -> DOUBLE
-    final var numberVar = variableRecord("v_number", "42");
-
-    // when / then
-    assertThat(filter.acceptRecord(stringVar))
-        .as("STRING variable should be accepted by inclusion type filter")
-        .isTrue();
-    assertThat(filter.acceptRecord(numberVar))
-        .as("non-STRING variable should be rejected by inclusion type filter")
-        .isFalse();
-  }
-
-  @Test
-  void shouldApplyVariableValueTypeExclusionFromTestConfiguration() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    // Exclude DOUBLE variables
-    configuration.filterIndexConfig().withVariableValueTypeExclusion(List.of("NUMBER"));
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    // JSON string -> STRING
-    final var stringVar = variableRecord("v_string", "\"foo\"");
-    // JSON number -> DOUBLE
-    final var numberVar = variableRecord("v_number", "42");
-
-    // when / then
-    assertThat(filter.acceptRecord(numberVar))
-        .as("DOUBLE variable should be rejected by exclusion type filter")
-        .isFalse();
-    assertThat(filter.acceptRecord(stringVar))
-        .as("non-DOUBLE variable should be accepted by exclusion type filter")
-        .isTrue();
-  }
-
-  @Test
-  void shouldNotApplyVariableNameFilterWhenNoNameRulesConfigured() {
-    // given
-    final var configuration =
-        new TestConfiguration()
-            .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.VARIABLE);
-
-    final var filter = new DefaultRecordFilter(configuration);
-
-    final var record1 = variableRecord("anyName");
-
-    // when / then
-    assertThat(filter.acceptRecord(record1))
-        .as("Without name inclusion/exclusion rules, all variable names should be accepted")
-        .isTrue();
-  }
-
-  @Test
   void shouldApplyOptimizeModeFilterWhenOptimizeModeEnabled() {
     // given
     final var configuration =
@@ -307,8 +95,6 @@ final class DefaultRecordFilterTest {
             // We pick JOB because OptimizeModeFilter never accepts JOB records
             .withIndexedValueType(ValueType.JOB);
 
-    // Enable Optimize mode on the index config so that createRecordFilters()
-    // adds an OptimizeModeFilter to the chain.
     configuration.filterIndexConfig().withOptimizeModeEnabled(true);
 
     final var filter = new DefaultRecordFilter(configuration);
@@ -326,26 +112,207 @@ final class DefaultRecordFilterTest {
   }
 
   @Test
-  void shouldNotApplyVariableValueTypeFilterWhenNoTypeRulesConfigured() {
+  void shouldWireVariableNameFilterWhenNameRulesConfigured() {
+    // given: an exact inclusion rule — any other name must be rejected
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.filterIndexConfig().withVariableNameInclusionExact(List.of("allowed"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // when / then
+    assertThat(filter.acceptRecord(variableRecord("allowed")))
+        .as("Variable matching the inclusion rule should be accepted")
+        .isTrue();
+    assertThat(filter.acceptRecord(variableRecord("other")))
+        .as(
+            "Variable not matching the inclusion rule should be rejected, proving the filter is wired")
+        .isFalse();
+  }
+
+  @Test
+  void shouldWireVariableNameFilterHandlingInclusionExclusionConflict() {
+    // given: the same name is both included and excluded — exclusion takes precedence in NameFilter
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration
+        .filterIndexConfig()
+        .withVariableNameInclusionExact(List.of("conflicted"))
+        .withVariableNameExclusionExact(List.of("conflicted"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // when / then
+    assertThat(filter.acceptRecord(variableRecord("conflicted")))
+        .as("When a name matches both inclusion and exclusion rules, exclusion wins")
+        .isFalse();
+  }
+
+  @Test
+  void shouldWireVariableTypeFilterWhenTypeRulesConfigured() {
+    // given: only NUMBER variables are included
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.filterIndexConfig().withVariableValueTypeInclusion(List.of("NUMBER"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // when / then
+    assertThat(filter.acceptRecord(variableRecord("v", "42")))
+        .as("NUMBER variable should be accepted by the inclusion type filter")
+        .isTrue();
+    assertThat(filter.acceptRecord(variableRecord("v", "\"text\"")))
+        .as("STRING variable should be rejected, proving the type filter is wired")
+        .isFalse();
+  }
+
+  @Test
+  void shouldWireExportLocalVariablesFilterWhenFlagDisabled() {
     // given
     final var configuration =
         new TestConfiguration()
             .withIndexedRecordType(RecordType.EVENT)
             .withIndexedValueType(ValueType.VARIABLE);
 
+    configuration.filterIndexConfig().withExportLocalVariablesEnabled(false);
+
     final var filter = new DefaultRecordFilter(configuration);
 
-    final var stringVar = variableRecord("v_string", "\"foo\"");
+    // local variable (scopeKey != processInstanceKey) must be rejected
+    assertThat(filter.acceptRecord(scopedVariableRecord("v", null, 100L, 200L)))
+        .as("Local variables should be rejected when exportLocalVariables is disabled")
+        .isFalse();
 
-    // when / then
-    assertThat(filter.acceptRecord(stringVar))
-        .as("Without type inclusion/exclusion rules, STRING variables should be accepted")
+    // root variable (scopeKey == processInstanceKey) must pass
+    assertThat(filter.acceptRecord(scopedVariableRecord("v", null, 100L, 100L)))
+        .as("Root variables should still be accepted when exportLocalVariables is disabled")
         .isTrue();
   }
 
   @Test
-  void shouldApplyBpmnProcessIdInclusionFromTestConfiguration() {
+  void shouldWireVariableNameScopeFilterWhenLocalNameRulesPresent() {
     // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.filterIndexConfig().withLocalVariableNameInclusionExact(List.of("localOnly"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // local variable matching inclusion rule → accepted
+    assertThat(filter.acceptRecord(scopedVariableRecord("localOnly", null, 100L, 200L)))
+        .as("Local variable matching local inclusion rule should be accepted")
+        .isTrue();
+
+    // local variable not matching inclusion rule → rejected
+    assertThat(filter.acceptRecord(scopedVariableRecord("other", null, 100L, 200L)))
+        .as("Local variable not matching local inclusion rule should be rejected")
+        .isFalse();
+
+    // root variable with no root rules → always accepted
+    assertThat(filter.acceptRecord(scopedVariableRecord("other", null, 100L, 100L)))
+        .as("Root variable should pass when only local rules are configured")
+        .isTrue();
+  }
+
+  @Test
+  void shouldWireVariableNameScopeFilterWhenRootNameRulesPresent() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.filterIndexConfig().withRootVariableNameExclusionExact(List.of("secret"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // root variable matching exclusion rule → rejected
+    assertThat(filter.acceptRecord(scopedVariableRecord("secret", null, 100L, 100L)))
+        .as("Root variable matching root exclusion rule should be rejected")
+        .isFalse();
+
+    // root variable not matching exclusion rule → accepted
+    assertThat(filter.acceptRecord(scopedVariableRecord("public", null, 100L, 100L)))
+        .as("Root variable not matching root exclusion rule should be accepted")
+        .isTrue();
+
+    // local variable with no local rules → always accepted
+    assertThat(filter.acceptRecord(scopedVariableRecord("secret", null, 100L, 200L)))
+        .as("Local variable should pass when only root rules are configured")
+        .isTrue();
+  }
+
+  @Test
+  void shouldWireVariableTypeScopeFilterWhenLocalTypeRulesPresent() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.filterIndexConfig().withLocalVariableValueTypeInclusion(List.of("NUMBER"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // local number variable → accepted by local inclusion
+    assertThat(filter.acceptRecord(scopedVariableRecord("v", "42", 100L, 200L)))
+        .as("Local NUMBER variable should be accepted by local type inclusion")
+        .isTrue();
+
+    // local string variable → rejected by local inclusion
+    assertThat(filter.acceptRecord(scopedVariableRecord("v", "\"text\"", 100L, 200L)))
+        .as("Local STRING variable should be rejected by local type inclusion of NUMBER")
+        .isFalse();
+
+    // root variable with no root rules → always accepted regardless of type
+    assertThat(filter.acceptRecord(scopedVariableRecord("v", "\"text\"", 100L, 100L)))
+        .as("Root variable should pass when only local type rules are configured")
+        .isTrue();
+  }
+
+  @Test
+  void shouldWireVariableTypeScopeFilterWhenRootTypeRulesPresent() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.filterIndexConfig().withRootVariableValueTypeExclusion(List.of("BOOLEAN"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // root boolean variable → rejected by root exclusion
+    assertThat(filter.acceptRecord(scopedVariableRecord("v", "true", 100L, 100L)))
+        .as("Root BOOLEAN variable should be rejected by root type exclusion")
+        .isFalse();
+
+    // root string variable → accepted
+    assertThat(filter.acceptRecord(scopedVariableRecord("v", "\"text\"", 100L, 100L)))
+        .as("Root STRING variable should be accepted when only BOOLEAN is excluded")
+        .isTrue();
+
+    // local variable with no local rules → always accepted
+    assertThat(filter.acceptRecord(scopedVariableRecord("v", "true", 100L, 200L)))
+        .as("Local variable should pass when only root type rules are configured")
+        .isTrue();
+  }
+
+  @Test
+  void shouldWireBpmnProcessFilterWhenProcessIdRulesConfigured() {
+    // given: only "order-process" is included
     final var configuration =
         new TestConfiguration()
             .withIndexedRecordType(RecordType.EVENT)
@@ -355,46 +322,43 @@ final class DefaultRecordFilterTest {
 
     final var filter = new DefaultRecordFilter(configuration);
 
-    final var included = processInstanceRecord("order-process");
-    final var other = processInstanceRecord("payment-process");
-
     // when / then
-    assertThat(filter.acceptRecord(included))
-        .as("Records for included BPMN process id should be accepted")
+    assertThat(filter.acceptRecord(processInstanceRecord("order-process")))
+        .as("Record for the included BPMN process id should be accepted")
         .isTrue();
-    assertThat(filter.acceptRecord(other))
-        .as("Records for non-included BPMN process id should be rejected")
+    assertThat(filter.acceptRecord(processInstanceRecord("other-process")))
+        .as(
+            "Record for a non-included BPMN process id should be rejected, proving the filter is wired")
         .isFalse();
   }
 
   @Test
-  void shouldApplyBpmnProcessIdExclusionFromTestConfiguration() {
-    // given
+  void shouldSkipVersionedFilterForRecordsFromOlderBroker() {
+    // given: a scope name filter (requires broker >= 8.10.0) that would reject "other"
     final var configuration =
         new TestConfiguration()
             .withIndexedRecordType(RecordType.EVENT)
-            .withIndexedValueType(ValueType.PROCESS_INSTANCE);
+            .withIndexedValueType(ValueType.VARIABLE);
 
-    configuration.filterIndexConfig().withBpmnProcessIdExclusion(List.of("deprecated-process"));
+    configuration.filterIndexConfig().withLocalVariableNameInclusionExact(List.of("onlyThis"));
 
     final var filter = new DefaultRecordFilter(configuration);
 
-    final var excluded = processInstanceRecord("deprecated-process");
-    final var other = processInstanceRecord("active-process");
+    // when: record comes from a broker older than the filter's minimum version
+    final var oldBrokerRecord = scopedVariableRecord("other", null, 100L, 200L, "8.9.0");
 
-    // when / then
-    assertThat(filter.acceptRecord(excluded))
-        .as("Records for excluded BPMN process id should be rejected")
-        .isFalse();
-    assertThat(filter.acceptRecord(other))
-        .as("Records for other BPMN process ids should be accepted")
+    // then: the scope filter is skipped, so the record passes
+    assertThat(filter.acceptRecord(oldBrokerRecord))
+        .as("Scope filter should be skipped for records from brokers older than 8.10.0")
         .isTrue();
   }
 
   // ---------------------------------------------------------------------------
   // helpers
   // ---------------------------------------------------------------------------
+
   private static Record<VariableRecordValue> variableRecord(final String name) {
+    // rawValue is null here; only safe when no type filter is configured in the test
     return variableRecord(name, null);
   }
 
@@ -411,6 +375,37 @@ final class DefaultRecordFilterTest {
     when(record.getValue()).thenReturn(value);
     when(value.getName()).thenReturn(name);
     when(value.getValue()).thenReturn(rawValue);
+
+    return record;
+  }
+
+  private static Record<VariableRecordValue> scopedVariableRecord(
+      final String name,
+      final String rawValue,
+      final long processInstanceKey,
+      final long scopeKey) {
+    return scopedVariableRecord(name, rawValue, processInstanceKey, scopeKey, "8.10.0");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> scopedVariableRecord(
+      final String name,
+      final String rawValue,
+      final long processInstanceKey,
+      final long scopeKey,
+      final String brokerVersion) {
+
+    final Record<VariableRecordValue> record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getBrokerVersion()).thenReturn(brokerVersion);
+    when(record.getValue()).thenReturn(value);
+    when(value.getName()).thenReturn(name);
+    when(value.getValue()).thenReturn(rawValue);
+    when(value.getProcessInstanceKey()).thenReturn(processInstanceKey);
+    when(value.getScopeKey()).thenReturn(scopeKey);
 
     return record;
   }

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableNameFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableNameFilterTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.exporter.filter;
 
-import static io.camunda.zeebe.exporter.filter.VariableNameFilter.parseRules;
+import static io.camunda.zeebe.exporter.filter.NameFilterRule.parseRules;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableNameScopeFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableNameScopeFilterTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.exporter.filter;
 
-import static io.camunda.zeebe.exporter.filter.VariableNameFilter.parseRules;
+import static io.camunda.zeebe.exporter.filter.NameFilterRule.parseRules;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
@@ -33,6 +33,27 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
   private List<String> bpmnProcessIdExclusion = List.of();
 
   private boolean optimizeModeEnabled = false;
+  private boolean exportLocalVariablesEnabled = true;
+
+  // Local variable name/type filters
+  private List<String> localVariableNameInclusionExact = List.of();
+  private List<String> localVariableNameInclusionStartWith = List.of();
+  private List<String> localVariableNameInclusionEndWith = List.of();
+  private List<String> localVariableNameExclusionExact = List.of();
+  private List<String> localVariableNameExclusionStartWith = List.of();
+  private List<String> localVariableNameExclusionEndWith = List.of();
+  private List<String> localVariableValueTypeInclusion = List.of();
+  private List<String> localVariableValueTypeExclusion = List.of();
+
+  // Root variable name/type filters
+  private List<String> rootVariableNameInclusionExact = List.of();
+  private List<String> rootVariableNameInclusionStartWith = List.of();
+  private List<String> rootVariableNameInclusionEndWith = List.of();
+  private List<String> rootVariableNameExclusionExact = List.of();
+  private List<String> rootVariableNameExclusionStartWith = List.of();
+  private List<String> rootVariableNameExclusionEndWith = List.of();
+  private List<String> rootVariableValueTypeInclusion = List.of();
+  private List<String> rootVariableValueTypeExclusion = List.of();
 
   // --- fluent setters -------------------------------------------------------
 
@@ -81,6 +102,12 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
     return this;
   }
 
+  public TestIndexConfig withExportLocalVariablesEnabled(
+      final boolean exportLocalVariablesEnabled) {
+    this.exportLocalVariablesEnabled = exportLocalVariablesEnabled;
+    return this;
+  }
+
   public TestIndexConfig withBpmnProcessIdInclusion(final List<String> bpmnProcessIds) {
     bpmnProcessIdInclusion = bpmnProcessIds != null ? bpmnProcessIds : List.of();
     return this;
@@ -88,6 +115,86 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
 
   public TestIndexConfig withBpmnProcessIdExclusion(final List<String> bpmnProcessIds) {
     bpmnProcessIdExclusion = bpmnProcessIds != null ? bpmnProcessIds : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withLocalVariableNameInclusionExact(final List<String> names) {
+    localVariableNameInclusionExact = names != null ? names : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withLocalVariableNameInclusionStartWith(final List<String> prefixes) {
+    localVariableNameInclusionStartWith = prefixes != null ? prefixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withLocalVariableNameInclusionEndWith(final List<String> suffixes) {
+    localVariableNameInclusionEndWith = suffixes != null ? suffixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withLocalVariableNameExclusionExact(final List<String> names) {
+    localVariableNameExclusionExact = names != null ? names : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withLocalVariableNameExclusionStartWith(final List<String> prefixes) {
+    localVariableNameExclusionStartWith = prefixes != null ? prefixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withLocalVariableNameExclusionEndWith(final List<String> suffixes) {
+    localVariableNameExclusionEndWith = suffixes != null ? suffixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withLocalVariableValueTypeInclusion(final List<String> types) {
+    localVariableValueTypeInclusion = types != null ? types : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withLocalVariableValueTypeExclusion(final List<String> types) {
+    localVariableValueTypeExclusion = types != null ? types : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withRootVariableNameInclusionExact(final List<String> names) {
+    rootVariableNameInclusionExact = names != null ? names : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withRootVariableNameInclusionStartWith(final List<String> prefixes) {
+    rootVariableNameInclusionStartWith = prefixes != null ? prefixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withRootVariableNameInclusionEndWith(final List<String> suffixes) {
+    rootVariableNameInclusionEndWith = suffixes != null ? suffixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withRootVariableNameExclusionExact(final List<String> names) {
+    rootVariableNameExclusionExact = names != null ? names : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withRootVariableNameExclusionStartWith(final List<String> prefixes) {
+    rootVariableNameExclusionStartWith = prefixes != null ? prefixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withRootVariableNameExclusionEndWith(final List<String> suffixes) {
+    rootVariableNameExclusionEndWith = suffixes != null ? suffixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withRootVariableValueTypeInclusion(final List<String> types) {
+    rootVariableValueTypeInclusion = types != null ? types : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withRootVariableValueTypeExclusion(final List<String> types) {
+    rootVariableValueTypeExclusion = types != null ? types : List.of();
     return this;
   }
 
@@ -146,5 +253,90 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
   @Override
   public boolean isOptimizeModeEnabled() {
     return optimizeModeEnabled;
+  }
+
+  @Override
+  public boolean isExportLocalVariablesEnabled() {
+    return exportLocalVariablesEnabled;
+  }
+
+  @Override
+  public List<String> getLocalVariableNameInclusionExact() {
+    return localVariableNameInclusionExact;
+  }
+
+  @Override
+  public List<String> getLocalVariableNameInclusionStartWith() {
+    return localVariableNameInclusionStartWith;
+  }
+
+  @Override
+  public List<String> getLocalVariableNameInclusionEndWith() {
+    return localVariableNameInclusionEndWith;
+  }
+
+  @Override
+  public List<String> getLocalVariableNameExclusionExact() {
+    return localVariableNameExclusionExact;
+  }
+
+  @Override
+  public List<String> getLocalVariableNameExclusionStartWith() {
+    return localVariableNameExclusionStartWith;
+  }
+
+  @Override
+  public List<String> getLocalVariableNameExclusionEndWith() {
+    return localVariableNameExclusionEndWith;
+  }
+
+  @Override
+  public List<String> getLocalVariableValueTypeInclusion() {
+    return localVariableValueTypeInclusion;
+  }
+
+  @Override
+  public List<String> getLocalVariableValueTypeExclusion() {
+    return localVariableValueTypeExclusion;
+  }
+
+  @Override
+  public List<String> getRootVariableNameInclusionExact() {
+    return rootVariableNameInclusionExact;
+  }
+
+  @Override
+  public List<String> getRootVariableNameInclusionStartWith() {
+    return rootVariableNameInclusionStartWith;
+  }
+
+  @Override
+  public List<String> getRootVariableNameInclusionEndWith() {
+    return rootVariableNameInclusionEndWith;
+  }
+
+  @Override
+  public List<String> getRootVariableNameExclusionExact() {
+    return rootVariableNameExclusionExact;
+  }
+
+  @Override
+  public List<String> getRootVariableNameExclusionStartWith() {
+    return rootVariableNameExclusionStartWith;
+  }
+
+  @Override
+  public List<String> getRootVariableNameExclusionEndWith() {
+    return rootVariableNameExclusionEndWith;
+  }
+
+  @Override
+  public List<String> getRootVariableValueTypeInclusion() {
+    return rootVariableValueTypeInclusion;
+  }
+
+  @Override
+  public List<String> getRootVariableValueTypeExclusion() {
+    return rootVariableValueTypeExclusion;
   }
 }


### PR DESCRIPTION
# Description                                                                                                                                                 
                                                                                                                                                            
This PR completes the scope-aware variable filtering work by wiring all previously implemented filters into DefaultRecordFilter, which is the single integration point between the exporter configuration and the filter chain.

## Filter wiring (DefaultRecordFilter)                                                                                                                         
  - Wires ExportLocalVariablesFilter when exportLocalVariables is disabled, suppressing sub-element-scoped variables entirely.
  - Wires VariableNameScopeFilter when any local or root name inclusion/exclusion rule is configured, applying separate name-based filters per scope with a  minimum broker version of 8.10.0.                                                                                                                         
  - Wires VariableTypeScopeFilter when any local or root type inclusion/exclusion rule is configured, applying separate JSON-type filters per scope with a minimum broker version of 8.10.0.                                                                                                                       
  - Documents the filter ordering rationale: filters are ordered cheapest/most-selective first to take full advantage of the chain's short-circuit behaviour.
                                                                                                                                                            
## DRY / abstraction cleanup                                                                                                                                   
  - Moves parseRules from VariableNameFilter to NameFilterRule as a static factory method — it converts raw configuration strings into NameFilterRule objects, which is a NameFilterRule concern, not a VariableNameFilter one. This also removes the implicit dependency of DefaultRecordFilter on VariableNameFilter internals.                                                                                                                                                
  - Extracts a buildNameRules(exact, startWith, endWith) helper that eliminates six near-identical rule-parsing methods and removes redundant intermediate List.copyOf calls.                                                                                                                                        
                                                                                                                                                              
## Test coverage (DefaultRecordFilterTest)
  - Replaces per-rule-type behavior tests (EXACT, STARTS_WITH, ENDS_WITH variants for name/type filters) with a single wiring test per filter that proves the filter is present in the chain. Detailed behavior is already covered in the dedicated filter tests (VariableNameFilterTest, VariableTypeFilterTest, etc.).  
  - Adds a version-gating test verifying that scope filters are skipped for records from brokers older than 8.10.0, aligning with ExportRecordFilterChain's RecordVersionFilter semantics.                                                                                                                              
  - Adds an inclusion+exclusion conflict test confirming that exclusion wins when a name matches both rule sets.                                              
  - Extends TestIndexConfig with fluent setters for local and root variable filter rules to support the new wiring tests.
                                                                                                                                                              
  # Related issues                                                                                                                                              
   
  Closes #48106                                                                                                                                               
  Relates to #46267 
