### PR TITLE
48103 variable type scope filter

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
@@ -13,7 +13,6 @@ import static io.camunda.zeebe.exporter.filter.NameFilterRule.Type.STARTS_WITH;
 import static io.camunda.zeebe.exporter.filter.VariableNameFilter.parseRules;
 
 import io.camunda.zeebe.exporter.api.context.Context;
-import io.camunda.zeebe.exporter.filter.VariableTypeFilter.VariableValueType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -46,7 +45,7 @@ public final class DefaultRecordFilter implements Context.RecordFilter {
 
     final Set<VariableValueType> valueTypeInclusion =
         VariableTypeFilter.parseTypes(index.getVariableValueTypeInclusion());
-    final Set<VariableTypeFilter.VariableValueType> valueTypeExclusion =
+    final Set<VariableValueType> valueTypeExclusion =
         VariableTypeFilter.parseTypes(index.getVariableValueTypeExclusion());
 
     final List<ExporterRecordFilter> filters = new ArrayList<>();

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeFilter.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.exporter.filter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
@@ -43,17 +41,10 @@ public final class VariableTypeFilter implements ExporterRecordFilter, RecordVer
       final Set<VariableValueType> inclusion,
       final Set<VariableValueType> exclusion) {
     this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+    Objects.requireNonNull(inclusion, "inclusion must not be null");
+    Objects.requireNonNull(exclusion, "exclusion must not be null");
 
-    final EnumSet<VariableValueType> allowed;
-    if (inclusion.isEmpty()) {
-      allowed = EnumSet.allOf(VariableValueType.class);
-      allowed.removeAll(exclusion);
-    } else {
-      allowed = EnumSet.copyOf(inclusion);
-      allowed.removeAll(exclusion);
-    }
-
-    allowedTypes = Collections.unmodifiableSet(allowed);
+    allowedTypes = VariableValueType.buildAllowedSet(inclusion, exclusion);
   }
 
   @Override
@@ -61,41 +52,10 @@ public final class VariableTypeFilter implements ExporterRecordFilter, RecordVer
     if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {
       return true;
     }
-    final VariableValueType inferredType = inferValueType(variableRecordValue.getValue());
+    final VariableValueType inferredType =
+        VariableValueType.infer(objectMapper, variableRecordValue.getValue());
 
     return allowedTypes.contains(inferredType);
-  }
-
-  /**
-   * Infers a logical type from the JSON representation of the variable value, mirroring Optimize's
-   * ZeebeVariableImportService#getVariableTypeFromJsonNode:
-   *
-   * <p>NUMBER -> NUMBER BOOLEAN -> BOOLEAN STRING -> STRING OBJECT -> OBJECT ARRAY -> OBJECT
-   *
-   * <p>If parsing fails, falls back to UNKNOWN. Null raw value -> NULL.
-   */
-  private VariableValueType inferValueType(final String raw) {
-    if (raw == null) {
-      return VariableValueType.NULL;
-    }
-
-    try {
-      final JsonNode jsonNode = objectMapper.readTree(raw);
-      if (jsonNode == null) {
-        return VariableValueType.UNKNOWN;
-      }
-
-      return switch (jsonNode.getNodeType()) {
-        case NUMBER -> VariableValueType.NUMBER;
-        case BOOLEAN -> VariableValueType.BOOLEAN;
-        case STRING -> VariableValueType.STRING;
-        case OBJECT, ARRAY -> VariableValueType.OBJECT;
-        case NULL -> VariableValueType.NULL;
-        default -> VariableValueType.UNKNOWN;
-      };
-    } catch (final JsonProcessingException e) {
-      return VariableValueType.UNKNOWN;
-    }
   }
 
   public static Set<VariableValueType> parseTypes(final List<String> rawValues) {
@@ -145,15 +105,5 @@ public final class VariableTypeFilter implements ExporterRecordFilter, RecordVer
   @Override
   public SemanticVersion minRecordBrokerVersion() {
     return MIN_BROKER_VERSION;
-  }
-
-  /** Inferred variable value types (aligned with Optimize's JSON-node based mapping). */
-  public enum VariableValueType {
-    BOOLEAN,
-    NUMBER,
-    STRING,
-    OBJECT,
-    NULL,
-    UNKNOWN
   }
 }

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeScopeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeScopeFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Filters variable records by inferred JSON type, applying separate rules depending on whether the
+ * variable is local (scoped to a sub-element) or root (scoped to the process instance itself).
+ *
+ * <p>A variable is considered local when its {@code scopeKey} differs from its {@code
+ * processInstanceKey}; equal keys indicate a root variable.
+ *
+ * <p>Each scope is governed by its own inclusion/exclusion type set. If no rules are configured for
+ * a given scope, all variables in that scope pass through. Non-variable records are always
+ * accepted.
+ */
+public final class VariableTypeScopeFilter implements ExporterRecordFilter, RecordVersionFilter {
+
+  private static final SemanticVersion MIN_BROKER_VERSION =
+      new SemanticVersion(8, 10, 0, null, null);
+
+  private final ObjectMapper objectMapper;
+  private final Set<VariableValueType> allowedLocalTypes;
+  private final Set<VariableValueType> allowedRootTypes;
+  private final boolean hasLocalRules;
+  private final boolean hasRootRules;
+
+  public VariableTypeScopeFilter(
+      final Set<VariableValueType> localInclusion,
+      final Set<VariableValueType> localExclusion,
+      final Set<VariableValueType> rootInclusion,
+      final Set<VariableValueType> rootExclusion) {
+    this(new ObjectMapper(), localInclusion, localExclusion, rootInclusion, rootExclusion);
+  }
+
+  public VariableTypeScopeFilter(
+      final ObjectMapper objectMapper,
+      final Set<VariableValueType> localInclusion,
+      final Set<VariableValueType> localExclusion,
+      final Set<VariableValueType> rootInclusion,
+      final Set<VariableValueType> rootExclusion) {
+
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+    Objects.requireNonNull(localInclusion, "localInclusion must not be null");
+    Objects.requireNonNull(localExclusion, "localExclusion must not be null");
+    Objects.requireNonNull(rootInclusion, "rootInclusion must not be null");
+    Objects.requireNonNull(rootExclusion, "rootExclusion must not be null");
+
+    allowedLocalTypes = VariableValueType.buildAllowedSet(localInclusion, localExclusion);
+    allowedRootTypes = VariableValueType.buildAllowedSet(rootInclusion, rootExclusion);
+    hasLocalRules = !localInclusion.isEmpty() || !localExclusion.isEmpty();
+    hasRootRules = !rootInclusion.isEmpty() || !rootExclusion.isEmpty();
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {
+      return true;
+    }
+
+    if (VariableScope.isLocal(variableRecordValue)) {
+      if (!hasLocalRules) {
+        return true;
+      }
+      return allowedLocalTypes.contains(
+          VariableValueType.infer(objectMapper, variableRecordValue.getValue()));
+    } else {
+      if (!hasRootRules) {
+        return true;
+      }
+      return allowedRootTypes.contains(
+          VariableValueType.infer(objectMapper, variableRecordValue.getValue()));
+    }
+  }
+
+  @Override
+  public SemanticVersion minRecordBrokerVersion() {
+    return MIN_BROKER_VERSION;
+  }
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableValueType.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableValueType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/** Inferred variable value types (aligned with Optimize's JSON-node based mapping). */
+public enum VariableValueType {
+  BOOLEAN,
+  NUMBER,
+  STRING,
+  OBJECT,
+  NULL,
+  UNKNOWN;
+
+  /**
+   * Infers a logical type from the JSON representation of the variable value, mirroring Optimize's
+   * ZeebeVariableImportService#getVariableTypeFromJsonNode:
+   *
+   * <p>NUMBER -> NUMBER BOOLEAN -> BOOLEAN STRING -> STRING OBJECT -> OBJECT ARRAY -> OBJECT
+   *
+   * <p>If parsing fails, falls back to UNKNOWN. Null raw value -> NULL.
+   */
+  static VariableValueType infer(final ObjectMapper objectMapper, final String raw) {
+    if (raw == null) {
+      return NULL;
+    }
+
+    try {
+      final var jsonNode = objectMapper.readTree(raw);
+      return switch (jsonNode.getNodeType()) {
+        case NUMBER -> NUMBER;
+        case BOOLEAN -> BOOLEAN;
+        case STRING -> STRING;
+        case OBJECT, ARRAY -> OBJECT;
+        case NULL -> NULL;
+        default -> UNKNOWN;
+      };
+    } catch (final JsonProcessingException e) {
+      return UNKNOWN;
+    }
+  }
+
+  static Set<VariableValueType> buildAllowedSet(
+      final Set<VariableValueType> inclusion, final Set<VariableValueType> exclusion) {
+    final EnumSet<VariableValueType> allowed =
+        inclusion.isEmpty() ? EnumSet.allOf(VariableValueType.class) : EnumSet.copyOf(inclusion);
+    allowed.removeAll(exclusion);
+    return Collections.unmodifiableSet(allowed);
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableTypeFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableTypeFilterTest.java
@@ -8,23 +8,45 @@
 package io.camunda.zeebe.exporter.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.exporter.filter.VariableTypeFilter.VariableValueType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class VariableTypeFilterTest {
+
+  // ---------------------------------------------------------------------------
+  // Constructor null checks
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRejectNullObjectMapper() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new VariableTypeFilter(null, Set.of(), Set.of()))
+        .withMessage("objectMapper must not be null");
+  }
+
+  @Test
+  void shouldRejectNullInclusion() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new VariableTypeFilter(null, Set.of()))
+        .withMessage("inclusion must not be null");
+  }
+
+  @Test
+  void shouldRejectNullExclusion() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new VariableTypeFilter(Set.of(), null))
+        .withMessage("exclusion must not be null");
+  }
 
   // ---------------------------------------------------------------------------
   // accept(...) behavior
@@ -81,65 +103,8 @@ final class VariableTypeFilterTest {
     assertThat(filter.accept(numberVar)).isTrue();
   }
 
-  @Test
-  void shouldLetExclusionOverrideInclusionWhenBothPresent() {
-    // given
-    final var filter =
-        new VariableTypeFilter(
-            /* inclusion */ Set.of(VariableValueType.STRING, VariableValueType.OBJECT),
-            /* exclusion */ Set.of(VariableValueType.STRING));
-
-    final var stringVar = variableRecord("\"foo\"");
-    final var objectVar = variableRecord("{\"a\":1}");
-
-    // when / then
-    assertThat(filter.accept(stringVar))
-        .as("STRING is included but also excluded -> should be rejected")
-        .isFalse();
-    assertThat(filter.accept(objectVar)).as("OBJECT is only included -> accepted").isTrue();
-  }
-
-  @Test
-  void shouldSupportNullVariablesWhenExplicitlyIncluded() {
-    // given
-    final var filter =
-        new VariableTypeFilter(
-            /* inclusion */ Set.of(VariableValueType.NULL), /* exclusion */ Set.of());
-
-    final var nullVar = variableRecord(null);
-    final var nonNullVar = variableRecord("\"foo\"");
-
-    // when / then
-    assertThat(filter.accept(nullVar)).isTrue();
-    assertThat(filter.accept(nonNullVar)).isFalse();
-  }
-
-  @Test
-  void shouldInferJsonNullAsNullType() {
-    // Only allow NULL so we can detect that branch via accept()
-    final var filter =
-        new VariableTypeFilter(
-            EnumSet.of(VariableTypeFilter.VariableValueType.NULL), Collections.emptySet());
-
-    @SuppressWarnings("unchecked")
-    final Record<VariableRecordValue> record = (Record<VariableRecordValue>) mock(Record.class);
-    final var value = mock(VariableRecordValue.class);
-
-    when(record.getValue()).thenReturn(value);
-    // Jackson will parse this into a NullNode with nodeType == JsonNodeType.NULL
-    when(value.getValue()).thenReturn("null");
-
-    // when
-    final boolean accepted = filter.accept(record);
-
-    // then
-    assertThat(accepted)
-        .as("JSON literal 'null' should be inferred as VariableValueType.NULL")
-        .isTrue();
-  }
-
   // ---------------------------------------------------------------------------
-  // Type inference via accept(...)
+  // parseTypes(...)
   // ---------------------------------------------------------------------------
 
   @Test
@@ -147,10 +112,6 @@ final class VariableTypeFilterTest {
     assertThat(VariableTypeFilter.parseTypes(null)).isEmpty();
     assertThat(VariableTypeFilter.parseTypes(List.of())).isEmpty();
   }
-
-  // ---------------------------------------------------------------------------
-  // parseTypes(...)
-  // ---------------------------------------------------------------------------
 
   @Test
   void shouldParseValidTypeTokensCaseInsensitively() {
@@ -197,7 +158,7 @@ final class VariableTypeFilterTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Versioning
+  // Test helpers
   // ---------------------------------------------------------------------------
 
   @SuppressWarnings("unchecked")
@@ -211,10 +172,6 @@ final class VariableTypeFilterTest {
     return record;
   }
 
-  // ---------------------------------------------------------------------------
-  // Test helpers
-  // ---------------------------------------------------------------------------
-
   private static Record<?> nonVariableRecord() {
     @SuppressWarnings("unchecked")
     final var record = (Record<RecordValue>) mock(Record.class);
@@ -223,54 +180,5 @@ final class VariableTypeFilterTest {
     when(record.getValue()).thenReturn(someOtherValue);
 
     return record;
-  }
-
-  @Nested
-  final class TypeInference {
-
-    private final VariableTypeFilter booleanOnlyFilter =
-        new VariableTypeFilter(Set.of(VariableValueType.BOOLEAN), Set.of());
-    private final VariableTypeFilter doubleOnlyFilter =
-        new VariableTypeFilter(Set.of(VariableValueType.NUMBER), Set.of());
-    private final VariableTypeFilter stringOnlyFilter =
-        new VariableTypeFilter(Set.of(VariableValueType.STRING), Set.of());
-    private final VariableTypeFilter objectOnlyFilter =
-        new VariableTypeFilter(Set.of(VariableValueType.OBJECT), Set.of());
-
-    @Test
-    void shouldInferBooleanFromJsonBoolean() {
-      assertThat(booleanOnlyFilter.accept(variableRecord("true"))).isTrue();
-      assertThat(booleanOnlyFilter.accept(variableRecord("false"))).isTrue();
-      assertThat(booleanOnlyFilter.accept(variableRecord("\"true\"")))
-          .as("JSON string '\"true\"' is STRING, not BOOLEAN")
-          .isFalse();
-    }
-
-    @Test
-    void shouldInferDoubleFromJsonNumber() {
-      assertThat(doubleOnlyFilter.accept(variableRecord("0"))).isTrue();
-      assertThat(doubleOnlyFilter.accept(variableRecord("1.23"))).isTrue();
-      assertThat(doubleOnlyFilter.accept(variableRecord("\"1.23\"")))
-          .as("JSON string '\"1.23\"' is STRING, not DOUBLE")
-          .isFalse();
-    }
-
-    @Test
-    void shouldInferStringFromJsonString() {
-      assertThat(stringOnlyFilter.accept(variableRecord("\"foo\""))).isTrue();
-    }
-
-    @Test
-    void shouldInferUnknownFromInvalidJson() {
-      assertThat(stringOnlyFilter.accept(variableRecord("foo")))
-          .as("invalid JSON treated as UNKNOWN")
-          .isFalse();
-    }
-
-    @Test
-    void shouldInferObjectFromJsonObjectOrArray() {
-      assertThat(objectOnlyFilter.accept(variableRecord("{\"a\":1}"))).isTrue();
-      assertThat(objectOnlyFilter.accept(variableRecord("[1,2,3]"))).isTrue();
-    }
   }
 }

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableTypeScopeFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableTypeScopeFilterTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class VariableTypeScopeFilterTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+
+  // ---------------------------------------------------------------------------
+  // Non-variable records
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptNonVariableRecord() {
+    // given
+    final var filter = new VariableTypeScopeFilter(Set.of(), Set.of(), Set.of(), Set.of());
+    final var record = nonVariableRecord();
+
+    // when / then
+    assertThat(filter.accept(record)).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Local-scope variables
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptLocalVariableWithMatchingLocalInclusionType() {
+    // given
+    final var filter =
+        new VariableTypeScopeFilter(Set.of(VariableValueType.NUMBER), Set.of(), Set.of(), Set.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord("42"))).isTrue();
+  }
+
+  @Test
+  void shouldRejectLocalVariableWithNonMatchingLocalInclusionType() {
+    // given
+    final var filter =
+        new VariableTypeScopeFilter(Set.of(VariableValueType.NUMBER), Set.of(), Set.of(), Set.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord("\"text\""))).isFalse();
+  }
+
+  @Test
+  void shouldRejectLocalVariableWithMatchingLocalExclusionType() {
+    // given
+    final var filter =
+        new VariableTypeScopeFilter(
+            Set.of(), Set.of(VariableValueType.BOOLEAN), Set.of(), Set.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord("true"))).isFalse();
+  }
+
+  @Test
+  void shouldAcceptLocalVariableNotMatchingLocalExclusionType() {
+    // given
+    final var filter =
+        new VariableTypeScopeFilter(
+            Set.of(), Set.of(VariableValueType.BOOLEAN), Set.of(), Set.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord("42"))).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Root-scope variables
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptRootVariableWithMatchingRootInclusionType() {
+    // given
+    final var filter =
+        new VariableTypeScopeFilter(Set.of(), Set.of(), Set.of(VariableValueType.STRING), Set.of());
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord("\"hello\""))).isTrue();
+  }
+
+  @Test
+  void shouldRejectRootVariableWithNonMatchingRootInclusionType() {
+    // given
+    final var filter =
+        new VariableTypeScopeFilter(Set.of(), Set.of(), Set.of(VariableValueType.STRING), Set.of());
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord("42"))).isFalse();
+  }
+
+  @Test
+  void shouldRejectRootVariableWithMatchingRootExclusionType() {
+    // given
+    final var filter =
+        new VariableTypeScopeFilter(Set.of(), Set.of(), Set.of(), Set.of(VariableValueType.OBJECT));
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord("{\"a\":1}"))).isFalse();
+  }
+
+  @Test
+  void shouldAcceptRootVariableNotMatchingRootExclusionType() {
+    // given
+    final var filter =
+        new VariableTypeScopeFilter(Set.of(), Set.of(), Set.of(), Set.of(VariableValueType.OBJECT));
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord("\"text\""))).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scope isolation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldNotApplyLocalRulesToRootVariables() {
+    // given: local rules exclude BOOLEAN, no root rules
+    final var filter =
+        new VariableTypeScopeFilter(
+            Set.of(), Set.of(VariableValueType.BOOLEAN), Set.of(), Set.of());
+
+    // a root boolean variable must still pass because root has no rules
+    assertThat(filter.accept(rootVariableRecord("true"))).isTrue();
+  }
+
+  @Test
+  void shouldNotApplyRootRulesToLocalVariables() {
+    // given: root rules include only STRING, no local rules
+    final var filter =
+        new VariableTypeScopeFilter(Set.of(), Set.of(), Set.of(VariableValueType.STRING), Set.of());
+
+    // a local number variable must still pass because local has no rules
+    assertThat(filter.accept(localVariableRecord("42"))).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Version constraint
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldExposeMinRecordBrokerVersion() {
+    final var filter = new VariableTypeScopeFilter(Set.of(), Set.of(), Set.of(), Set.of());
+
+    assertThat(filter.minRecordBrokerVersion())
+        .isEqualTo(new SemanticVersion(8, 10, 0, null, null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private static Record<ProcessInstanceRecordValue> nonVariableRecord() {
+    final var record = (Record<ProcessInstanceRecordValue>) mock(Record.class);
+    when(record.getValue()).thenReturn(mock(ProcessInstanceRecordValue.class));
+    return record;
+  }
+
+  /** A local variable has a scopeKey that differs from the processInstanceKey. */
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> localVariableRecord(final String jsonValue) {
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getScopeKey()).thenReturn(PROCESS_INSTANCE_KEY + 1);
+    when(value.getValue()).thenReturn(jsonValue);
+    return record;
+  }
+
+  /** A root variable has a scopeKey equal to the processInstanceKey. */
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> rootVariableRecord(final String jsonValue) {
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getScopeKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getValue()).thenReturn(jsonValue);
+    return record;
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableValueTypeTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableValueTypeTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class VariableValueTypeTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  // ---------------------------------------------------------------------------
+  // infer(...)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldInferNullTypeFromNullRawValue() {
+    assertThat(VariableValueType.infer(MAPPER, null)).isEqualTo(VariableValueType.NULL);
+  }
+
+  @Test
+  void shouldInferNullTypeFromJsonNullLiteral() {
+    assertThat(VariableValueType.infer(MAPPER, "null")).isEqualTo(VariableValueType.NULL);
+  }
+
+  @Test
+  void shouldInferBooleanFromJsonBoolean() {
+    assertThat(VariableValueType.infer(MAPPER, "true")).isEqualTo(VariableValueType.BOOLEAN);
+    assertThat(VariableValueType.infer(MAPPER, "false")).isEqualTo(VariableValueType.BOOLEAN);
+    assertThat(VariableValueType.infer(MAPPER, "\"true\""))
+        .as("JSON string '\"true\"' is STRING, not BOOLEAN")
+        .isEqualTo(VariableValueType.STRING);
+  }
+
+  @Test
+  void shouldInferNumberFromJsonNumber() {
+    assertThat(VariableValueType.infer(MAPPER, "0")).isEqualTo(VariableValueType.NUMBER);
+    assertThat(VariableValueType.infer(MAPPER, "1.23")).isEqualTo(VariableValueType.NUMBER);
+    assertThat(VariableValueType.infer(MAPPER, "\"1.23\""))
+        .as("JSON string '\"1.23\"' is STRING, not NUMBER")
+        .isEqualTo(VariableValueType.STRING);
+  }
+
+  @Test
+  void shouldInferStringFromJsonString() {
+    assertThat(VariableValueType.infer(MAPPER, "\"foo\"")).isEqualTo(VariableValueType.STRING);
+  }
+
+  @Test
+  void shouldInferObjectFromJsonObject() {
+    assertThat(VariableValueType.infer(MAPPER, "{\"a\":1}")).isEqualTo(VariableValueType.OBJECT);
+  }
+
+  @Test
+  void shouldInferObjectFromJsonArray() {
+    assertThat(VariableValueType.infer(MAPPER, "[1,2,3]")).isEqualTo(VariableValueType.OBJECT);
+  }
+
+  @Test
+  void shouldInferUnknownFromInvalidJson() {
+    assertThat(VariableValueType.infer(MAPPER, "foo")).isEqualTo(VariableValueType.UNKNOWN);
+  }
+
+  // ---------------------------------------------------------------------------
+  // buildAllowedSet(...)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAllowAllTypesWhenInclusionAndExclusionAreEmpty() {
+    // given / when
+    final var allowed = VariableValueType.buildAllowedSet(Set.of(), Set.of());
+
+    // then
+    assertThat(allowed).containsExactlyInAnyOrder(VariableValueType.values());
+  }
+
+  @Test
+  void shouldRestrictToInclusionWhenProvided() {
+    // given / when
+    final var allowed =
+        VariableValueType.buildAllowedSet(
+            Set.of(VariableValueType.STRING, VariableValueType.NUMBER), Set.of());
+
+    // then
+    assertThat(allowed)
+        .containsExactlyInAnyOrder(VariableValueType.STRING, VariableValueType.NUMBER);
+  }
+
+  @Test
+  void shouldExcludeFromAllTypesWhenNoInclusionProvided() {
+    // given / when
+    final var allowed =
+        VariableValueType.buildAllowedSet(Set.of(), Set.of(VariableValueType.OBJECT));
+
+    // then
+    assertThat(allowed).doesNotContain(VariableValueType.OBJECT);
+    assertThat(allowed)
+        .containsExactlyInAnyOrder(
+            VariableValueType.BOOLEAN,
+            VariableValueType.NUMBER,
+            VariableValueType.STRING,
+            VariableValueType.NULL,
+            VariableValueType.UNKNOWN);
+  }
+
+  @Test
+  void shouldLetExclusionOverrideInclusion() {
+    // given — STRING is in both sets; exclusion wins
+    final var allowed =
+        VariableValueType.buildAllowedSet(
+            Set.of(VariableValueType.STRING, VariableValueType.NUMBER),
+            Set.of(VariableValueType.STRING));
+
+    // then
+    assertThat(allowed)
+        .as("STRING excluded even though it is also included")
+        .containsExactlyInAnyOrder(VariableValueType.NUMBER);
+  }
+}


### PR DESCRIPTION
## Description

Introduce a scope-aware variable type filter for exporter records, allowing different inclusion/exclusion rules for local variables vs root process-instance variables.

Extracts VariableTypeFilter.inferValueType into a static helper that accepts an ObjectMapper, so it can be reused by other filters.

Adds VariableTypeScopeFilter, which:

- Infers the JSON type of variable values and applies separate allowed-type sets depending on whether the variable is local (scopeKey != processInstanceKey) or root (scopeKey == processInstanceKey).
- Supports independent inclusion/exclusion configuration per scope and derives immutable allowed-type sets.
- Accepts all non-variable records and only filters VariableRecordValue instances.
- Is guarded by a minimum broker version 8.10.0, where the required scope information is available.

Adds unit tests for VariableTypeScopeFilter to cover:

- Local vs root scope behavior.
- Inclusion-only, exclusion-only, and mixed configurations.
- Fallback behavior when no rules are configured for a given scope.

This is a building block for downstream components (e.g., Optimize) to configure scope-aware variable export based on inferred variable types.

## Related issues

Closes: https://github.com/camunda/camunda/issues/48103
Relates to https://github.com/camunda/camunda/issues/46267 (pdp-3435 – scope-aware variable export configuration for Optimize)
