### PR TITLE
fix: escape gpg passphrase used on maven:perform release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -289,6 +289,7 @@ jobs:
           # Assign the amount of seconds that the plugin will wait for a deployment
           # state. Can not be less than Constants.WAIT_MAX_TIME_DEFAULT_VALUE.
           CENTRAL_WAIT_MAX_TIME: "3600"
+          MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
         run: |
           # Perform a maven release
           # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
@@ -309,15 +310,18 @@ jobs:
             ARGUMENTS_PROFILE="-P!include-optimize"
           fi
 
+          GPG_PASSPHRASE_FOR_ARGS=${MAVEN_GPG_PASSPHRASE//\\/\\\\}
+          GPG_PASSPHRASE_FOR_ARGS=${GPG_PASSPHRASE_FOR_ARGS//\"/\\\"}
+
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \
             -DreleaseVersion="${RELEASE_VERSION}" \
-            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
+            -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}" \
             -DlocalCheckout="${{ inputs.dryRun }}" \
             -DskipQaBuild=true \
             -P-autoFormat \
             ${PROFILE_FLAGS} \
-            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${GPG_PASSPHRASE_FOR_ARGS}\""
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory


### PR DESCRIPTION
## Description

This pull request updates the Maven release workflow to improve how the GPG passphrase is handled and passed to Maven commands. The changes ensure that the GPG passphrase is securely and correctly injected into the workflow and properly escaped for use in shell arguments.

Motivation:
```
Error: ROR] Unknown lifecycle phase "${arguments}". You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: pre-clean, clean, post-clean, validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-site, site, post-site, site-deploy. -> [Help 1]
Error: ROR] 
Error: ROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
Error: ROR] Re-run Maven using the -X switch to enable full debug logging.
Error: ROR] 
Error: ROR] For more information about the errors and possible solutions, please read the following articles:
Error: ROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/LifecyclePhaseNotFoundException
```

I will [cherry-pick the fix for RC1](https://github.com/camunda/camunda/pull/49446) here, and re-run to see we get all things fixed.

Main: https://github.com/camunda/camunda/actions/runs/23506535842 -> kinda worked, we have other errors
Stable: https://github.com/camunda/camunda/actions/runs/23506542963 -> didn't work, probably because the dry run depend on the stable versions of `camunda-platform-release` -> this is what we are testing with this.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
