### PR TITLE
[Backport stable/8.9] chore: disable actor metrics by default

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Metrics.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metrics.java
@@ -21,7 +21,7 @@ public class Metrics {
       Set.of("zeebe.broker.executionMetricsExporterEnabled");
 
   /** Controls whether to collect metrics about actor usage such as actor job execution latencies */
-  private boolean actor = true;
+  private boolean actor = false;
 
   /** Enable exporter execution metrics */
   private boolean enableExporterExecutionMetrics;

--- a/configuration/src/test/java/io/camunda/configuration/MetricsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/MetricsTest.java
@@ -30,6 +30,20 @@ public class MetricsTest {
   private static final boolean EXPECTED_ENABLE_EXPORTER_EXECUTION_METRICS = true;
 
   @Nested
+  class WithNoPropertiesSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNoPropertiesSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldHaveActorMetricsDisabledByDefault() {
+      assertThat(brokerCfg.getExperimental().getFeatures().isEnableActorMetrics()).isFalse();
+    }
+  }
+
+  @Nested
   @TestPropertySource(
       properties = {
         "camunda.monitoring.metrics.actor=" + EXPECTED_ACTOR,

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -888,7 +888,7 @@ camunda: # Type: io.camunda.configuration.Camunda
     jfr: null # Type: Boolean, Env: CAMUNDA_MONITORING_JFR
     metrics: # Type: io.camunda.configuration.Metrics
       # Controls whether to collect metrics about actor usage such as actor job execution latencies
-      actor: true # Type: Boolean, Env: CAMUNDA_MONITORING_METRICS_ACTOR
+      actor: false # Type: Boolean, Env: CAMUNDA_MONITORING_METRICS_ACTOR
       # Enable exporter execution metrics
       enable-exporter-execution-metrics: false # Type: Boolean, Env: CAMUNDA_MONITORING_METRICS_ENABLEEXPORTEREXECUTIONMETRICS
       job-metrics: # Type: io.camunda.configuration.JobMetricsConfig


### PR DESCRIPTION
# Description
Backport of #46463 to `stable/8.9`.

relates to 