### PR TITLE
ci: make maven surefire problem matcher more robust

### DIFF
--- a/.github/maven-matcher.json
+++ b/.github/maven-matcher.json
@@ -13,7 +13,7 @@
       "owner": "maven-surefire-test",
       "pattern": [
         {
-          "regexp": "^\\s*\\[ERROR\\]\\s+(?<message>[A-Za-z0-9_$.]+\\s+--\\s+Time elapsed:.*)$",
+          "regexp": "^\\s*\\[ERROR\\]\\s+(?<message>.+\\s+--\\s+Time elapsed:.*)$",
           "message": 1
         }
       ]


### PR DESCRIPTION
## Description

Helps matching these test case names with e.g. ( and ) in their name: https://github.com/camunda/camunda/actions/runs/23490656801/job/68357746945#step:14:535

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
