### PR TITLE
Revert "deps: Update spring boot to v3.5.12"

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -42,6 +42,7 @@ on:
       - "operate/**"
       - "tasklist/**"
       - "identity/**"
+      - "parent/pom.xml"
 
 # Cancel in-progress runs when a new commit is pushed to the same PR
 concurrency:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,7 +100,7 @@
     <version.rest-assured>5.5.7</version.rest-assured>
     <version.spring>6.2.17</version.spring>
     <version.spring-security>6.5.9</version.spring-security>
-    <version.spring-boot>3.5.12</version.spring-boot>
+    <version.spring-boot>3.5.11</version.spring-boot>
     <version.tomcat>10.1.53</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Through the always green initiative, it was spotted that a change to v8.6 and v8.7 was causing issues, @eamonnmoloney tracked down the change to [this](https://github.com/camunda/camunda/commit/889c2b06aac) commit which we have confirmed via reverting and running tests (in this PR).

The ultimate result here is that the Identity SDK fails to get the configuration it needs, which produces the error:

```
"Request processing failed: io.camunda.identity.sdk.exception.InvalidConfigurationException: 'authorizeUriBuilder' can only be used if OAuth credentials are provided"
```

Its not clear why this patch version has caused this level of failure however to be safe we need to revert it and investigate the issue.