### PR TITLE
feat: add sequencer lock contention metrics

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -10130,10 +10130,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_sequencer_lock_hold_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (le, writer))",
+              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.999\"}) by (writer)",
               "format": "time_series",
               "interval": "30s",
-              "legendFormat": "p99 {{writer}}",
+              "legendFormat": "p99.9 {{writer}}",
               "refId": "A"
             },
             {
@@ -10142,10 +10142,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_sequencer_lock_hold_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (le, writer))",
+              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.99\"}) by (writer)",
               "format": "time_series",
               "interval": "30s",
-              "legendFormat": "p50 {{writer}}",
+              "legendFormat": "p99 {{writer}}",
               "refId": "B"
             },
             {
@@ -10154,11 +10154,23 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_sequencer_lock_hold_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.9\"}) by (writer)",
               "format": "time_series",
               "interval": "30s",
-              "legendFormat": "max {{writer}}",
+              "legendFormat": "p90 {{writer}}",
               "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.5\"}) by (writer)",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "p50 {{writer}}",
+              "refId": "D"
             }
           ],
           "title": "Sequencer Lock Hold Time Quantiles",
@@ -10168,7 +10180,7 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "description": "Quantiles of time spent waiting to acquire the sequencer lock, by who held the lock",
+          "description": "Quantiles of time spent waiting to acquire the sequencer lock, by who is waiting",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -10253,10 +10265,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_sequencer_lock_wait_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (le, holder))",
+              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.999\"}) by (waiter)",
               "format": "time_series",
               "interval": "30s",
-              "legendFormat": "p99 {{holder}}",
+              "legendFormat": "p99.9 {{waiter}}",
               "refId": "A"
             },
             {
@@ -10265,10 +10277,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_sequencer_lock_wait_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (le, holder))",
+              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.99\"}) by (waiter)",
               "format": "time_series",
               "interval": "30s",
-              "legendFormat": "p50 {{holder}}",
+              "legendFormat": "p99 {{waiter}}",
               "refId": "B"
             },
             {
@@ -10277,11 +10289,23 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_sequencer_lock_wait_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.9\"}) by (waiter)",
               "format": "time_series",
               "interval": "30s",
-              "legendFormat": "max {{holder}}",
+              "legendFormat": "p90 {{waiter}}",
               "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.5\"}) by (waiter)",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "p50 {{waiter}}",
+              "refId": "D"
             }
           ],
           "title": "Sequencer Lock Wait Time Quantiles",

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -10045,6 +10045,252 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
+          "description": "Quantiles of time spent holding the sequencer lock during a write, by writer context",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 10,
+                  "type": "log"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 1683
+          },
+          "id": 710,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_sequencer_lock_hold_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (le, writer))",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "p99 {{writer}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_sequencer_lock_hold_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (le, writer))",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "p50 {{writer}}",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "zeebe_sequencer_lock_hold_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "max {{writer}}",
+              "refId": "C"
+            }
+          ],
+          "title": "Sequencer Lock Hold Time Quantiles",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Quantiles of time spent waiting to acquire the sequencer lock, by who held the lock",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 10,
+                  "type": "log"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 1683
+          },
+          "id": 711,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_sequencer_lock_wait_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (le, holder))",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "p99 {{holder}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_sequencer_lock_wait_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (le, holder))",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "p50 {{holder}}",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "zeebe_sequencer_lock_wait_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "max {{holder}}",
+              "refId": "C"
+            }
+          ],
+          "title": "Sequencer Lock Wait Time Quantiles",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
           "description": "Shows the quantiles of: time taken to commit a record to the log (includes write latency)",
           "fieldConfig": {
             "defaults": {
@@ -10105,7 +10351,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1683
+            "y": 1690
           },
           "id": 310,
           "options": {
@@ -10232,7 +10478,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1683
+            "y": 1690
           },
           "id": 311,
           "options": {
@@ -10318,7 +10564,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1690
+            "y": 1697
           },
           "id": 235,
           "options": {
@@ -10401,7 +10647,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1690
+            "y": 1697
           },
           "id": 234,
           "options": {

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -10130,10 +10130,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.999\"}) by (writer)",
+              "expr": "max(zeebe_sequencer_lock_hold_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}) by (writer)",
               "format": "time_series",
               "interval": "30s",
-              "legendFormat": "p99.9 {{writer}}",
+              "legendFormat": "max {{writer}}",
               "refId": "A"
             },
             {
@@ -10265,10 +10265,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.999\"}) by (waiter)",
+              "expr": "max(zeebe_sequencer_lock_wait_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}) by (waiter)",
               "format": "time_series",
               "interval": "30s",
-              "legendFormat": "p99.9 {{waiter}}",
+              "legendFormat": "max {{waiter}}",
               "refId": "A"
             },
             {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsDoc.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsDoc.java
@@ -7,6 +7,12 @@
  */
 package io.camunda.zeebe.logstreams.impl;
 
+import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.logstreams.log.WriteContext.InterPartition;
+import io.camunda.zeebe.logstreams.log.WriteContext.Internal;
+import io.camunda.zeebe.logstreams.log.WriteContext.ProcessingResult;
+import io.camunda.zeebe.logstreams.log.WriteContext.Scheduled;
+import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
@@ -527,6 +533,16 @@ public enum LogStreamMetricsDoc implements ExtendedMeterDocumentation {
 
     FlowControlContext(final String value) {
       this.value = value;
+    }
+
+    public static FlowControlContext from(final WriteContext context) {
+      return switch (context) {
+        case final UserCommand ignored -> FlowControlContext.USER_COMMAND;
+        case final ProcessingResult ignored -> FlowControlContext.PROCESSING_RESULT;
+        case final InterPartition ignored -> FlowControlContext.INTER_PARTITION;
+        case final Scheduled ignored -> FlowControlContext.SCHEDULED;
+        case final Internal ignored -> FlowControlContext.INTERNAL;
+      };
     }
 
     public String getValue() {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsImpl.java
@@ -31,10 +31,6 @@ import io.camunda.zeebe.logstreams.impl.LogStreamMetricsDoc.FlowControlOutcome;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetricsDoc.RecordAppendedKeyNames;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection;
 import io.camunda.zeebe.logstreams.log.WriteContext;
-import io.camunda.zeebe.logstreams.log.WriteContext.InterPartition;
-import io.camunda.zeebe.logstreams.log.WriteContext.Internal;
-import io.camunda.zeebe.logstreams.log.WriteContext.ProcessingResult;
-import io.camunda.zeebe.logstreams.log.WriteContext.Scheduled;
 import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -170,7 +166,7 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
 
     flowControlOutcome
         .computeIfAbsent(
-            tagForContext(context),
+            FlowControlContext.from(context),
             FlowControlOutcome.ACCEPTED,
             this::registerFlowControlOutcomeCounter)
         .increment(size);
@@ -189,7 +185,7 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
 
     flowControlOutcome
         .computeIfAbsent(
-            tagForContext(context),
+            FlowControlContext.from(context),
             tagForRejection(reason),
             this::registerFlowControlOutcomeCounter)
         .increment(size);
@@ -252,16 +248,6 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
     return switch (reason) {
       case WriteRateLimitExhausted -> FlowControlOutcome.WRITE_RATE_LIMIT_EXHAUSTED;
       case RequestLimitExhausted -> FlowControlOutcome.REQUEST_LIMIT_EXHAUSTED;
-    };
-  }
-
-  private static FlowControlContext tagForContext(final WriteContext context) {
-    return switch (context) {
-      case final UserCommand ignored -> FlowControlContext.USER_COMMAND;
-      case final ProcessingResult ignored -> FlowControlContext.PROCESSING_RESULT;
-      case final InterPartition ignored -> FlowControlContext.INTER_PARTITION;
-      case final Scheduled ignored -> FlowControlContext.SCHEDULED;
-      case final Internal ignored -> FlowControlContext.INTERNAL;
     };
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -142,6 +142,8 @@ final class Sequencer implements LogStreamWriter, Closeable {
     }
     final long releaseTime = System.nanoTime();
 
+    flowControl.onAppended(inFlightEntry);
+
     // All metrics are recorded outside the critical section to avoid inflating lock hold time.
     recordMetrics(
         context,
@@ -150,8 +152,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
         batchLength,
         acquireTime - waitStart,
         releaseTime - acquireTime);
-
-    flowControl.onAppended(inFlightEntry);
     return Either.right(highestPosition);
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +40,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
 
   private volatile long position;
   private volatile boolean isClosed = false;
-
-  // Written under the lock, but read by waiters before they acquire it to identify the holder.
-  // Volatile is needed for cross-thread visibility of the write.
-  @Nullable private volatile WriteContext currentLockHolder;
-
   private final ReentrantLock lock = new ReentrantLock();
   private final LogStorage logStorage;
   private final InstantSource clock;
@@ -114,12 +108,10 @@ final class Sequencer implements LogStreamWriter, Closeable {
     final int batchSize = appendEntries.size();
     final int batchLength = calculateBatchLength(appendEntries);
 
-    final WriteContext holderAtWaitTime;
     final long waitStart = System.nanoTime();
-    if (lock.tryLock()) {
-      holderAtWaitTime = null;
-    } else {
-      holderAtWaitTime = currentLockHolder;
+
+    final boolean lockAcquiredImmediately = lock.tryLock();
+    if (!lockAcquiredImmediately) {
       lock.lock();
     }
 
@@ -127,7 +119,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
     final long highestPosition;
     try {
       acquireTime = System.nanoTime();
-      currentLockHolder = context;
       final var currentPosition = position;
       highestPosition = currentPosition + batchSize - 1;
       final var sequencedBatch =
@@ -137,7 +128,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
       logStorage.append(currentPosition, highestPosition, sequencedBatch, appendListener);
       position = currentPosition + batchSize;
     } finally {
-      currentLockHolder = null;
       lock.unlock();
     }
     final long releaseTime = System.nanoTime();
@@ -147,7 +137,7 @@ final class Sequencer implements LogStreamWriter, Closeable {
     // All metrics are recorded outside the critical section to avoid inflating lock hold time.
     recordMetrics(
         context,
-        holderAtWaitTime,
+        lockAcquiredImmediately,
         batchSize,
         batchLength,
         acquireTime - waitStart,
@@ -157,12 +147,12 @@ final class Sequencer implements LogStreamWriter, Closeable {
 
   private void recordMetrics(
       final WriteContext context,
-      final @Nullable WriteContext holderAtWaitTime,
+      final boolean lockAcquiredImmediately,
       final int batchSize,
       final int batchLength,
       final long waitNanos,
       final long holdNanos) {
-    if (holderAtWaitTime != null) {
+    if (!lockAcquiredImmediately) {
       sequencerMetrics.observeLockWaitTime(context, waitNanos);
     }
     sequencerMetrics.observeLockHoldTime(context, holdNanos);

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +41,11 @@ final class Sequencer implements LogStreamWriter, Closeable {
 
   private volatile long position;
   private volatile boolean isClosed = false;
+
+  // Written under the lock, but read by waiters before they acquire it to identify the holder.
+  // Volatile is needed for cross-thread visibility of the write.
+  @Nullable private volatile WriteContext currentLockHolder;
+
   private final ReentrantLock lock = new ReentrantLock();
   private final LogStorage logStorage;
   private final InstantSource clock;
@@ -108,9 +114,19 @@ final class Sequencer implements LogStreamWriter, Closeable {
     final int batchSize = appendEntries.size();
     final int batchLength = calculateBatchLength(appendEntries);
 
-    lock.lock();
+    final WriteContext holderAtWaitTime;
+    final long waitStart = System.nanoTime();
+    if (lock.tryLock()) {
+      holderAtWaitTime = null;
+    } else {
+      holderAtWaitTime = currentLockHolder;
+      lock.lock();
+    }
+    final long acquireTime = System.nanoTime();
+
     final long highestPosition;
     try {
+      currentLockHolder = context;
       final var currentPosition = position;
       highestPosition = currentPosition + batchSize - 1;
       final var sequencedBatch =
@@ -120,12 +136,37 @@ final class Sequencer implements LogStreamWriter, Closeable {
       logStorage.append(currentPosition, highestPosition, sequencedBatch, appendListener);
       position = currentPosition + batchSize;
     } finally {
+      currentLockHolder = null;
       lock.unlock();
-      sequencerMetrics.observeBatchLengthBytes(batchLength);
-      sequencerMetrics.observeBatchSize(batchSize);
     }
+    final long releaseTime = System.nanoTime();
+
+    // All metrics are recorded outside the critical section to avoid inflating lock hold time.
+    recordMetrics(
+        context,
+        holderAtWaitTime,
+        batchSize,
+        batchLength,
+        acquireTime - waitStart,
+        releaseTime - acquireTime);
+
     flowControl.onAppended(inFlightEntry);
     return Either.right(highestPosition);
+  }
+
+  private void recordMetrics(
+      final WriteContext context,
+      final @Nullable WriteContext holderAtWaitTime,
+      final int batchSize,
+      final int batchLength,
+      final long waitNanos,
+      final long holdNanos) {
+    if (holderAtWaitTime != null) {
+      sequencerMetrics.observeLockWaitTime(holderAtWaitTime, waitNanos);
+    }
+    sequencerMetrics.observeLockHoldTime(context, holdNanos);
+    sequencerMetrics.observeBatchLengthBytes(batchLength);
+    sequencerMetrics.observeBatchSize(batchSize);
   }
 
   /**

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -162,7 +162,7 @@ final class Sequencer implements LogStreamWriter, Closeable {
       final long waitNanos,
       final long holdNanos) {
     if (holderAtWaitTime != null) {
-      sequencerMetrics.observeLockWaitTime(holderAtWaitTime, waitNanos);
+      sequencerMetrics.observeLockWaitTime(context, waitNanos);
     }
     sequencerMetrics.observeLockHoldTime(context, holdNanos);
     sequencerMetrics.observeBatchLengthBytes(batchLength);

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -122,10 +122,11 @@ final class Sequencer implements LogStreamWriter, Closeable {
       holderAtWaitTime = currentLockHolder;
       lock.lock();
     }
-    final long acquireTime = System.nanoTime();
 
+    final long acquireTime;
     final long highestPosition;
     try {
+      acquireTime = System.nanoTime();
       currentLockHolder = context;
       final var currentPosition = position;
       highestPosition = currentPosition + batchSize - 1;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -71,7 +71,7 @@ final class SequencerMetrics {
             tag ->
                 Timer.builder(LOCK_WAIT_TIME.getName())
                     .description(LOCK_WAIT_TIME.getDescription())
-                    .publishPercentiles(0.5, 0.9, 0.99, 0.999)
+                    .publishPercentiles(0.5, 0.9, 0.99)
                     .tag(LockKeyNames.WAITER.asString(), tag.getValue())
                     .register(meterRegistry));
     timer.record(durationNanos, TimeUnit.NANOSECONDS);
@@ -85,7 +85,7 @@ final class SequencerMetrics {
             tag ->
                 Timer.builder(LOCK_HOLD_TIME.getName())
                     .description(LOCK_HOLD_TIME.getDescription())
-                    .publishPercentiles(0.5, 0.9, 0.99, 0.999)
+                    .publishPercentiles(0.5, 0.9, 0.99)
                     .tag(LockKeyNames.WRITER.asString(), tag.getValue())
                     .register(meterRegistry));
     timer.record(durationNanos, TimeUnit.NANOSECONDS);

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -20,14 +20,12 @@ import io.camunda.zeebe.logstreams.log.WriteContext.ProcessingResult;
 import io.camunda.zeebe.logstreams.log.WriteContext.Scheduled;
 import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
-import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.NullMarked;
@@ -65,14 +63,16 @@ final class SequencerMetrics {
     batchLengthBytes.record(batchLengthKiloBytes);
   }
 
-  void observeLockWaitTime(final WriteContext holder, final long durationNanos) {
-    final var holderTag = tagForContext(holder);
+  void observeLockWaitTime(final WriteContext waiter, final long durationNanos) {
+    final var waiterTag = tagForContext(waiter);
     final var timer =
         lockWaitTimers.computeIfAbsent(
-            holderTag,
+            waiterTag,
             tag ->
-                MicrometerUtil.buildTimer(LOCK_WAIT_TIME)
-                    .tag(LockKeyNames.HOLDER.asString(), tag.getValue())
+                Timer.builder(LOCK_WAIT_TIME.getName())
+                    .description(LOCK_WAIT_TIME.getDescription())
+                    .publishPercentiles(0.5, 0.9, 0.99, 0.999)
+                    .tag(LockKeyNames.WAITER.asString(), tag.getValue())
                     .register(meterRegistry));
     timer.record(durationNanos, TimeUnit.NANOSECONDS);
   }
@@ -83,7 +83,9 @@ final class SequencerMetrics {
         lockHoldTimers.computeIfAbsent(
             writerTag,
             tag ->
-                MicrometerUtil.buildTimer(LOCK_HOLD_TIME)
+                Timer.builder(LOCK_HOLD_TIME.getName())
+                    .description(LOCK_HOLD_TIME.getDescription())
+                    .publishPercentiles(0.5, 0.9, 0.99, 0.999)
                     .tag(LockKeyNames.WRITER.asString(), tag.getValue())
                     .register(meterRegistry));
     timer.record(durationNanos, TimeUnit.NANOSECONDS);
@@ -98,20 +100,6 @@ final class SequencerMetrics {
       case final Internal ignored -> FlowControlContext.INTERNAL;
     };
   }
-
-  private static final Duration[] LOCK_TIMER_BUCKETS = {
-    Duration.ofNanos(1_000),
-    Duration.ofNanos(10_000),
-    Duration.ofNanos(50_000),
-    Duration.ofNanos(200_000),
-    Duration.ofNanos(500_000),
-    Duration.ofMillis(1),
-    Duration.ofMillis(2),
-    Duration.ofMillis(5),
-    Duration.ofMillis(10),
-    Duration.ofMillis(50),
-    Duration.ofMillis(250)
-  };
 
   @SuppressWarnings("NullableProblems")
   public enum SequencerMetricsDoc implements ExtendedMeterDocumentation {
@@ -180,11 +168,11 @@ final class SequencerMetrics {
       }
     },
 
-    /** Time spent waiting to acquire the sequencer lock, labeled by who held the lock */
+    /** Time spent waiting to acquire the sequencer lock, labeled by who is waiting */
     LOCK_WAIT_TIME {
       @Override
       public String getDescription() {
-        return "Time spent waiting to acquire the sequencer lock, labeled by who held the lock";
+        return "Time spent waiting to acquire the sequencer lock, labeled by who is waiting";
       }
 
       @Override
@@ -198,13 +186,8 @@ final class SequencerMetrics {
       }
 
       @Override
-      public Duration[] getTimerSLOs() {
-        return LOCK_TIMER_BUCKETS;
-      }
-
-      @Override
       public KeyName[] getKeyNames() {
-        return new KeyName[] {LockKeyNames.HOLDER};
+        return new KeyName[] {LockKeyNames.WAITER};
       }
 
       @Override
@@ -231,11 +214,6 @@ final class SequencerMetrics {
       }
 
       @Override
-      public Duration[] getTimerSLOs() {
-        return LOCK_TIMER_BUCKETS;
-      }
-
-      @Override
       public KeyName[] getKeyNames() {
         return new KeyName[] {LockKeyNames.WRITER};
       }
@@ -254,10 +232,10 @@ final class SequencerMetrics {
         return "writer";
       }
     },
-    HOLDER {
+    WAITER {
       @Override
       public String asString() {
-        return "holder";
+        return "waiter";
       }
     }
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -9,21 +9,41 @@ package io.camunda.zeebe.logstreams.impl.log;
 
 import static io.camunda.zeebe.logstreams.impl.log.SequencerMetrics.SequencerMetricsDoc.BATCH_LENGTH_BYTES;
 import static io.camunda.zeebe.logstreams.impl.log.SequencerMetrics.SequencerMetricsDoc.BATCH_SIZE;
+import static io.camunda.zeebe.logstreams.impl.log.SequencerMetrics.SequencerMetricsDoc.LOCK_HOLD_TIME;
+import static io.camunda.zeebe.logstreams.impl.log.SequencerMetrics.SequencerMetricsDoc.LOCK_WAIT_TIME;
 
+import io.camunda.zeebe.logstreams.impl.LogStreamMetricsDoc.FlowControlContext;
+import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.logstreams.log.WriteContext.InterPartition;
+import io.camunda.zeebe.logstreams.log.WriteContext.Internal;
+import io.camunda.zeebe.logstreams.log.WriteContext.ProcessingResult;
+import io.camunda.zeebe.logstreams.log.WriteContext.Scheduled;
+import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 final class SequencerMetrics {
+  private final MeterRegistry meterRegistry;
   private final DistributionSummary batchSize;
   private final DistributionSummary batchLengthBytes;
+  private final ConcurrentHashMap<FlowControlContext, Timer> lockWaitTimers =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<FlowControlContext, Timer> lockHoldTimers =
+      new ConcurrentHashMap<>();
 
   SequencerMetrics(final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
     batchSize =
         DistributionSummary.builder(BATCH_SIZE.getName())
             .description(BATCH_SIZE.getDescription())
@@ -44,6 +64,54 @@ final class SequencerMetrics {
     final int batchLengthKiloBytes = Math.floorDiv(lengthBytes, 1024);
     batchLengthBytes.record(batchLengthKiloBytes);
   }
+
+  void observeLockWaitTime(final WriteContext holder, final long durationNanos) {
+    final var holderTag = tagForContext(holder);
+    final var timer =
+        lockWaitTimers.computeIfAbsent(
+            holderTag,
+            tag ->
+                MicrometerUtil.buildTimer(LOCK_WAIT_TIME)
+                    .tag(LockKeyNames.HOLDER.asString(), tag.getValue())
+                    .register(meterRegistry));
+    timer.record(durationNanos, TimeUnit.NANOSECONDS);
+  }
+
+  void observeLockHoldTime(final WriteContext writer, final long durationNanos) {
+    final var writerTag = tagForContext(writer);
+    final var timer =
+        lockHoldTimers.computeIfAbsent(
+            writerTag,
+            tag ->
+                MicrometerUtil.buildTimer(LOCK_HOLD_TIME)
+                    .tag(LockKeyNames.WRITER.asString(), tag.getValue())
+                    .register(meterRegistry));
+    timer.record(durationNanos, TimeUnit.NANOSECONDS);
+  }
+
+  static FlowControlContext tagForContext(final WriteContext context) {
+    return switch (context) {
+      case final UserCommand ignored -> FlowControlContext.USER_COMMAND;
+      case final ProcessingResult ignored -> FlowControlContext.PROCESSING_RESULT;
+      case final InterPartition ignored -> FlowControlContext.INTER_PARTITION;
+      case final Scheduled ignored -> FlowControlContext.SCHEDULED;
+      case final Internal ignored -> FlowControlContext.INTERNAL;
+    };
+  }
+
+  private static final Duration[] LOCK_TIMER_BUCKETS = {
+    Duration.ofNanos(1_000),
+    Duration.ofNanos(10_000),
+    Duration.ofNanos(50_000),
+    Duration.ofNanos(200_000),
+    Duration.ofNanos(500_000),
+    Duration.ofMillis(1),
+    Duration.ofMillis(2),
+    Duration.ofMillis(5),
+    Duration.ofMillis(10),
+    Duration.ofMillis(50),
+    Duration.ofMillis(250)
+  };
 
   @SuppressWarnings("NullableProblems")
   public enum SequencerMetricsDoc implements ExtendedMeterDocumentation {
@@ -109,6 +177,87 @@ final class SequencerMetrics {
       @Override
       public KeyName[] getAdditionalKeyNames() {
         return PartitionKeyNames.values();
+      }
+    },
+
+    /** Time spent waiting to acquire the sequencer lock, labeled by who held the lock */
+    LOCK_WAIT_TIME {
+      @Override
+      public String getDescription() {
+        return "Time spent waiting to acquire the sequencer lock, labeled by who held the lock";
+      }
+
+      @Override
+      public String getName() {
+        return "zeebe.sequencer.lock.wait.time";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.TIMER;
+      }
+
+      @Override
+      public Duration[] getTimerSLOs() {
+        return LOCK_TIMER_BUCKETS;
+      }
+
+      @Override
+      public KeyName[] getKeyNames() {
+        return new KeyName[] {LockKeyNames.HOLDER};
+      }
+
+      @Override
+      public KeyName[] getAdditionalKeyNames() {
+        return PartitionKeyNames.values();
+      }
+    },
+
+    /** Time the sequencer lock is held during a write, labeled by who held the lock */
+    LOCK_HOLD_TIME {
+      @Override
+      public String getDescription() {
+        return "Time the sequencer lock is held during a write, labeled by who held the lock";
+      }
+
+      @Override
+      public String getName() {
+        return "zeebe.sequencer.lock.hold.time";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.TIMER;
+      }
+
+      @Override
+      public Duration[] getTimerSLOs() {
+        return LOCK_TIMER_BUCKETS;
+      }
+
+      @Override
+      public KeyName[] getKeyNames() {
+        return new KeyName[] {LockKeyNames.WRITER};
+      }
+
+      @Override
+      public KeyName[] getAdditionalKeyNames() {
+        return PartitionKeyNames.values();
+      }
+    }
+  }
+
+  enum LockKeyNames implements KeyName {
+    WRITER {
+      @Override
+      public String asString() {
+        return "writer";
+      }
+    },
+    HOLDER {
+      @Override
+      public String asString() {
+        return "holder";
       }
     }
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -14,11 +14,6 @@ import static io.camunda.zeebe.logstreams.impl.log.SequencerMetrics.SequencerMet
 
 import io.camunda.zeebe.logstreams.impl.LogStreamMetricsDoc.FlowControlContext;
 import io.camunda.zeebe.logstreams.log.WriteContext;
-import io.camunda.zeebe.logstreams.log.WriteContext.InterPartition;
-import io.camunda.zeebe.logstreams.log.WriteContext.Internal;
-import io.camunda.zeebe.logstreams.log.WriteContext.ProcessingResult;
-import io.camunda.zeebe.logstreams.log.WriteContext.Scheduled;
-import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
@@ -64,10 +59,9 @@ final class SequencerMetrics {
   }
 
   void observeLockWaitTime(final WriteContext waiter, final long durationNanos) {
-    final var waiterTag = tagForContext(waiter);
     final var timer =
         lockWaitTimers.computeIfAbsent(
-            waiterTag,
+            FlowControlContext.from(waiter),
             tag ->
                 Timer.builder(LOCK_WAIT_TIME.getName())
                     .description(LOCK_WAIT_TIME.getDescription())
@@ -78,10 +72,9 @@ final class SequencerMetrics {
   }
 
   void observeLockHoldTime(final WriteContext writer, final long durationNanos) {
-    final var writerTag = tagForContext(writer);
     final var timer =
         lockHoldTimers.computeIfAbsent(
-            writerTag,
+            FlowControlContext.from(writer),
             tag ->
                 Timer.builder(LOCK_HOLD_TIME.getName())
                     .description(LOCK_HOLD_TIME.getDescription())
@@ -89,16 +82,6 @@ final class SequencerMetrics {
                     .tag(LockKeyNames.WRITER.asString(), tag.getValue())
                     .register(meterRegistry));
     timer.record(durationNanos, TimeUnit.NANOSECONDS);
-  }
-
-  static FlowControlContext tagForContext(final WriteContext context) {
-    return switch (context) {
-      case final UserCommand ignored -> FlowControlContext.USER_COMMAND;
-      case final ProcessingResult ignored -> FlowControlContext.PROCESSING_RESULT;
-      case final InterPartition ignored -> FlowControlContext.INTER_PARTITION;
-      case final Scheduled ignored -> FlowControlContext.SCHEDULED;
-      case final Internal ignored -> FlowControlContext.INTERNAL;
-    };
   }
 
   @SuppressWarnings("NullableProblems")

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -26,11 +26,15 @@ import java.time.InstantSource;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -39,6 +43,8 @@ import org.mockito.Mockito;
 @SuppressWarnings("resource")
 @Execution(ExecutionMode.CONCURRENT)
 final class SequencerTest {
+
+  @AutoClose ExecutorService executor;
 
   @Test
   void writingSingleEntryIncreasesPositions() {
@@ -275,7 +281,6 @@ final class SequencerTest {
         meterRegistry.find("zeebe.sequencer.lock.hold.time").tag("writer", "internal").timer();
     Assertions.assertThat(timer).isNotNull();
     Assertions.assertThat(timer.count()).isEqualTo(1);
-    Assertions.assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
   }
 
   @Test
@@ -305,28 +310,30 @@ final class SequencerTest {
             new FlowControl(logStreamMetrics));
 
     // when — thread 1 holds lock via blocking append
-    final var holder =
-        new Thread(() -> sequencer.tryWrite(WriteContext.scheduled(), TestEntry.ofDefaults()));
-    holder.start();
+    executor = Executors.newVirtualThreadPerTaskExecutor();
+
+    executor.submit(() -> sequencer.tryWrite(WriteContext.scheduled(), TestEntry.ofDefaults()));
+
     enteredAppendLatch.await();
 
     // thread 2 contends
-    final var waiter =
-        new Thread(
-            () ->
-                sequencer.tryWrite(
-                    WriteContext.processingResult(ProcessInstanceIntent.ACTIVATE_ELEMENT),
-                    TestEntry.ofDefaults()));
-    waiter.start();
+    final var waiterWaiting = new AtomicBoolean(false);
+    executor.submit(
+        () -> {
+          waiterWaiting.set(true);
+          sequencer.tryWrite(
+              WriteContext.processingResult(ProcessInstanceIntent.ACTIVATE_ELEMENT),
+              TestEntry.ofDefaults());
+        });
 
     // wait until the waiter thread is blocked on the lock
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(5))
-        .until(() -> waiter.getState() == Thread.State.WAITING);
+    Awaitility.await().atMost(Duration.ofSeconds(5)).until(waiterWaiting::get);
 
     blockingLatch.countDown(); // release thread 1
-    holder.join(5_000);
-    waiter.join(5_000);
+
+    // terminate executor
+    executor.shutdown();
+    Awaitility.await().until(executor::isShutdown);
 
     // then — wait time is labeled by waiter (who is waiting to acquire the lock)
     final var waitTimer =

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -321,9 +321,12 @@ final class SequencerTest {
     holder.join(5_000);
     waiter.join(5_000);
 
-    // then — wait time is labeled by holder (who caused the wait)
+    // then — wait time is labeled by waiter (who is waiting to acquire the lock)
     final var waitTimer =
-        meterRegistry.find("zeebe.sequencer.lock.wait.time").tag("holder", "scheduled").timer();
+        meterRegistry
+            .find("zeebe.sequencer.lock.wait.time")
+            .tag("waiter", "processingResult")
+            .timer();
     Assertions.assertThat(waitTimer).isNotNull();
     Assertions.assertThat(waitTimer.count()).isEqualTo(1);
     Assertions.assertThat(waitTimer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.time.InstantSource;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -29,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -277,7 +279,7 @@ final class SequencerTest {
   }
 
   @Test
-  void shouldRecordLockWaitTimeByHolder() throws Exception {
+  void shouldRecordLockWaitTimeByWaiter() throws Exception {
     // given
     final var meterRegistry = new SimpleMeterRegistry();
     final var blockingLatch = new CountDownLatch(1);
@@ -316,7 +318,12 @@ final class SequencerTest {
                     WriteContext.processingResult(ProcessInstanceIntent.ACTIVATE_ELEMENT),
                     TestEntry.ofDefaults()));
     waiter.start();
-    Thread.sleep(50); // give thread 2 time to block on lock
+
+    // wait until the waiter thread is blocked on the lock
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .until(() -> waiter.getState() == Thread.State.WAITING);
+
     blockingLatch.countDown(); // release thread 1
     holder.join(5_000);
     waiter.join(5_000);

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -17,12 +17,15 @@ import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import io.camunda.zeebe.logstreams.util.TestEntry;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.InstantSource;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
@@ -245,6 +248,85 @@ final class SequencerTest {
 
     // then -- VerifyingLogStorage did not throw
     Assertions.assertThat(testFailures).isEmpty();
+  }
+
+  @Test
+  void shouldRecordLockHoldTime() {
+    // given
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var logStorage = Mockito.mock(LogStorage.class);
+    final var logStreamMetrics = new LogStreamMetricsImpl(new SimpleMeterRegistry());
+    final var sequencer =
+        new Sequencer(
+            logStorage,
+            1L,
+            16,
+            InstantSource.system(),
+            new SequencerMetrics(meterRegistry),
+            new FlowControl(logStreamMetrics));
+
+    // when
+    sequencer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
+
+    // then
+    final var timer =
+        meterRegistry.find("zeebe.sequencer.lock.hold.time").tag("writer", "internal").timer();
+    Assertions.assertThat(timer).isNotNull();
+    Assertions.assertThat(timer.count()).isEqualTo(1);
+    Assertions.assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  void shouldRecordLockWaitTimeByHolder() throws Exception {
+    // given
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var blockingLatch = new CountDownLatch(1);
+    final var enteredAppendLatch = new CountDownLatch(1);
+    final var logStorage = Mockito.mock(LogStorage.class);
+    Mockito.doAnswer(
+            invocation -> {
+              enteredAppendLatch.countDown();
+              blockingLatch.await();
+              return null;
+            })
+        .when(logStorage)
+        .append(Mockito.anyLong(), Mockito.anyLong(), any(BufferWriter.class), any());
+
+    final var logStreamMetrics = new LogStreamMetricsImpl(new SimpleMeterRegistry());
+    final var sequencer =
+        new Sequencer(
+            logStorage,
+            1L,
+            16,
+            InstantSource.system(),
+            new SequencerMetrics(meterRegistry),
+            new FlowControl(logStreamMetrics));
+
+    // when — thread 1 holds lock via blocking append
+    final var holder =
+        new Thread(() -> sequencer.tryWrite(WriteContext.scheduled(), TestEntry.ofDefaults()));
+    holder.start();
+    enteredAppendLatch.await();
+
+    // thread 2 contends
+    final var waiter =
+        new Thread(
+            () ->
+                sequencer.tryWrite(
+                    WriteContext.processingResult(ProcessInstanceIntent.ACTIVATE_ELEMENT),
+                    TestEntry.ofDefaults()));
+    waiter.start();
+    Thread.sleep(50); // give thread 2 time to block on lock
+    blockingLatch.countDown(); // release thread 1
+    holder.join(5_000);
+    waiter.join(5_000);
+
+    // then — wait time is labeled by holder (who caused the wait)
+    final var waitTimer =
+        meterRegistry.find("zeebe.sequencer.lock.wait.time").tag("holder", "scheduled").timer();
+    Assertions.assertThat(waitTimer).isNotNull();
+    Assertions.assertThat(waitTimer.count()).isEqualTo(1);
+    Assertions.assertThat(waitTimer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
   }
 
   private Thread newWriterThread(


### PR DESCRIPTION


## Description
Add two timer metrics to the Sequencer to diagnose lock contention between concurrent writers (StreamProcessor, scheduled jobs, inter-partition commands, etc.):

- `zeebe.sequencer.lock.hold.time` (labeled by writer): how long each writer type holds the lock
- `zeebe.sequencer.lock.wait.time` (labeled by holder): how long waiters are blocked, attributed to whoever held the lock

Uses tryLock() to detect contention. 
All metrics are recorded outside the critical section to avoid inflating lock hold time.
Percentiles are exported instead of predefined buckets as I found the bucket percentile estimation inaccurate.
The downside is that percentiles should not be aggregated directly like the buckets. However, for simplicity, we can do that considering that partitions have similar amount of counts. 
By selecting a single partitions, then the percentile becomes accurate.

Dashboard metrics:
<img width="1789" height="284" alt="image" src="https://github.com/user-attachments/assets/3afe45c7-9ac6-445f-964b-8c8875aff98d" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
