### PR TITLE
feat: Secure xml formatting during maven release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -174,7 +174,8 @@ jobs:
           #
           # -DpreparationGoals
           #   Goals to run as part of the preparation step, after transformation but before committing. Space delimited.
-          #   Default is 'clean verify'; We want to skip all the checks and packaging (as it will be done again later) so we set it to empty
+          #   Default is 'clean verify'. We only run spotless to keep release-prepare generated POM changes
+          #   in a consistent format before the release commit is created.
           #
           # -Darguments
           #   Additional arguments to pass to the Maven executions, separated by spaces.
@@ -199,7 +200,7 @@ jobs:
             -DremoteTagging="${PUSH_CHANGES}" \
             -DcompletionGoals="spotless:apply" \
             -P-autoFormat \
-            -DpreparationGoals="" \
+            -DpreparationGoals="spotless:apply" \
             ${PROFILE_FLAGS} \
             -Darguments="${ARGUMENTS_PROFILE}"
 


### PR DESCRIPTION
## Background
`release:prepare` creates two commits:
1. release-version commit
2. next-development commit

In our release runs, Maven Release Plugin sometimes rewrote empty XML tags in POM files (for example `<relativePath />` to `<relativePath></relativePath>`).  
This is semantically equivalent XML, but Spotless enforces canonical text formatting, so the first generated commit could fail `spotless:check`.

## Summary
Run Spotless in both `release:prepare` commit phases so Maven-generated POM changes are normalized before each commit is created.

## Change
Updated `.github/workflows/camunda-platform-release.yml`:

- kept `-DcompletionGoals="spotless:apply"` (before the next-development commit)
- added `-DpreparationGoals="spotless:apply"` (before the release-version commit)

## Why this fixes it
Previously, Spotless only ran before commit #2, leaving commit #1 vulnerable to formatting drift.  
Now Spotless runs before both commit points, so both generated commits match repo formatting expectations and do not fail due to XML style-only differences.

## Notes
- No extra release commit is introduced.
- This change only affects formatting timing in the release workflow.

## 🧪 Testing
Before the change
<img width="822" height="154" alt="image" src="https://github.com/user-attachments/assets/1ab692c4-f29b-4dac-96ba-57c201e1c3de" />


With the change
<img width="830" height="665" alt="image" src="https://github.com/user-attachments/assets/b5bd2677-b13b-4f00-a9ee-2d1addc9042d" />

## Dry-run
[successful workflow run with the change](https://github.com/camunda/camunda/actions/runs/23639373160/job/68856016581#step:10:39)

Related to #35247