### PR TITLE
48200 deduplicate already archived process instances

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -44,6 +44,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of completed process instances that have been archived. */
   private final Counter processInstancesArchived;
 
+  /**
+   * Count of how often we see process instances that have been archived already (due to
+   * search/delete visibility in ES/OS).
+   */
+  private final Counter processInstanceArchivingDeduplicated;
+
   /** Count of completed batch operations that are in progress of archiving. */
   private final Counter batchOperationsArchiving;
 
@@ -132,6 +138,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tag("state", "archiving")
             .description(
                 "Count of completed process instances that have been found, and are now in progress of archiving.")
+            .register(meterRegistry);
+    processInstanceArchivingDeduplicated =
+        Counter.builder(meterName("archiver.process.instances"))
+            .tag("state", "deduplicated")
+            .description(
+                "Count of process instances that were previously archived, but were found again in the search for completed entities to archive.")
             .register(meterRegistry);
     batchOperationsArchived =
         Counter.builder(meterName("archiver.batch.operations"))
@@ -343,6 +355,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
     processInstancesArchiving.increment(count);
   }
 
+  public void recordProcessInstancesArchivingDeduplicated(final int count) {
+    processInstanceArchivingDeduplicated.increment(count);
+  }
+
   public void recordBatchOperationsArchived(final int count) {
     batchOperationsArchived.increment(count);
   }
@@ -460,6 +476,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(flushLatency);
     meterRegistry.remove(processInstancesArchived);
     meterRegistry.remove(processInstancesArchiving);
+    meterRegistry.remove(processInstanceArchivingDeduplicated);
     meterRegistry.remove(batchOperationsArchived);
     meterRegistry.remove(batchOperationsArchiving);
     meterRegistry.remove(archiverSearchTimer);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -94,6 +94,10 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
     return archiverRepository;
   }
 
+  protected CamundaExporterMetrics getExporterMetrics() {
+    return exporterMetrics;
+  }
+
   protected Executor getExecutor() {
     return executor;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -35,6 +35,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
   private final HistoryConfiguration config;
   private final ListViewTemplate processInstanceTemplate;
   private final List<ProcessInstanceDependant> processInstanceDependants;
+  private final RecentlyArchivedProcessInstances recentlyArchivedProcessInstances;
   private final Queue<ProcessInstanceArchiveBatch> pendingBatches =
       new java.util.concurrent.ConcurrentLinkedQueue<>();
 
@@ -59,6 +60,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
         processInstanceDependants.stream()
             .sorted(Comparator.comparing(ProcessInstanceDependant::getFullQualifiedName))
             .toList(); // sort to ensure the execution order is stable
+    recentlyArchivedProcessInstances = new RecentlyArchivedProcessInstances(largeBatchSize());
   }
 
   @Override
@@ -75,7 +77,13 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
         .getProcessInstancesNextBatch(largeBatchSize())
         .thenApply(
             batch -> {
-              final var chunks = batch.chunk(config.getRolloverBatchSize());
+              if (batch == null) {
+                return null;
+              }
+              final var deduped = recentlyArchivedProcessInstances.deduplicate(batch);
+              final var duplication = batch.size() - deduped.size();
+              getExporterMetrics().recordProcessInstancesArchivingDeduplicated(duplication);
+              final var chunks = deduped.chunk(config.getRolloverBatchSize());
               final var first = chunks.removeFirst();
               pendingBatches.addAll(chunks);
               return first;
@@ -91,7 +99,12 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
   protected CompletableFuture<Integer> archive(
       final IndexTemplateDescriptor templateDescriptor, final ProcessInstanceArchiveBatch batch) {
     return archiveProcessDependants(batch)
-        .thenComposeAsync(v -> super.archive(templateDescriptor, batch), getExecutor());
+        .thenComposeAsync(v -> super.archive(templateDescriptor, batch), getExecutor())
+        .thenApply(
+            archived -> {
+              recentlyArchivedProcessInstances.markRecentlyArchived(batch);
+              return archived;
+            });
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/RecentlyArchivedProcessInstances.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/RecentlyArchivedProcessInstances.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import java.time.Duration;
+
+public class RecentlyArchivedProcessInstances {
+  private final Cache<Long, Boolean> recentlyArchived;
+
+  public RecentlyArchivedProcessInstances(final int cacheSize) {
+    this(
+        Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(5))
+            .maximumSize(cacheSize)
+            .build());
+  }
+
+  @VisibleForTesting
+  public RecentlyArchivedProcessInstances(final Cache<Long, Boolean> recentlyArchived) {
+    this.recentlyArchived = recentlyArchived;
+  }
+
+  public int getRecentlyArchivedCount() {
+    return (int) recentlyArchived.estimatedSize();
+  }
+
+  public ProcessInstanceArchiveBatch deduplicate(final ProcessInstanceArchiveBatch batch) {
+    final var processInstanceKeys =
+        batch.processInstanceKeys().stream()
+            .filter(key -> recentlyArchived.getIfPresent(key) == null)
+            .toList();
+    final var rootProcessInstanceKeys =
+        batch.rootProcessInstanceKeys().stream()
+            .filter(key -> recentlyArchived.getIfPresent(key) == null)
+            .toList();
+
+    return new ProcessInstanceArchiveBatch(
+        batch.finishDate(), processInstanceKeys, rootProcessInstanceKeys);
+  }
+
+  public void markRecentlyArchived(final ProcessInstanceArchiveBatch batch) {
+    batch.processInstanceKeys().forEach(key -> recentlyArchived.put(key, Boolean.TRUE));
+    batch.rootProcessInstanceKeys().forEach(key -> recentlyArchived.put(key, Boolean.TRUE));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobTest.java
@@ -52,7 +52,7 @@ final class ArchiverJobTest {
   @Test
   void shouldReturnZeroIfNoBatchGiven() {
     // given no batch
-    repository.batch = null;
+    repository.batches = List.of();
 
     // when
     final int count = job.execute().toCompletableFuture().join();
@@ -70,7 +70,7 @@ final class ArchiverJobTest {
   @Test
   void shouldReturnZeroIfNoBatchIdsGiven() {
     // given
-    repository.batch = new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of());
+    repository.batches = List.of(new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
 
     // when
     final int count = job.execute().toCompletableFuture().join();
@@ -88,7 +88,8 @@ final class ArchiverJobTest {
   @Test
   void shouldMoveInstancesById() {
     // given
-    repository.batch = new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batches =
+        List.of(new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of("1", "2", "3")));
 
     // when
     final int count = job.execute().toCompletableFuture().join();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -43,7 +43,7 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batches = List.of(new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3")));
   }
 
   @AfterEach

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
@@ -43,7 +43,7 @@ final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAb
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batches = List.of(new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3")));
   }
 
   @AfterEach

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -62,8 +62,10 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   @BeforeEach
   void setUp() {
     // given
-    repository.batch =
-        new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L, 3L), List.of());
+    repository.batches =
+        List.of(
+            new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L, 3L), List.of()),
+            new ProcessInstanceArchiveBatch("2024-01-01", List.of(4L, 5L, 6L), List.of()));
   }
 
   @AfterEach
@@ -189,7 +191,8 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
             metrics,
             LOGGER,
             executor);
-    repository.batch = new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L), List.of());
+    repository.batches =
+        List.of(new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L), List.of()));
 
     // when
     final int count = job.execute().toCompletableFuture().join();
@@ -207,7 +210,8 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   @Test
   void shouldReturnEmptyBatchIfNoIdsGiven() {
     // given
-    repository.batch = new ProcessInstanceArchiveBatch("2024-01-01", List.of(), List.of());
+    repository.batches =
+        List.of(new ProcessInstanceArchiveBatch("2024-01-01", List.of(), List.of()));
 
     // when
     final var nextBatch = job.getNextBatch().toCompletableFuture().join();
@@ -222,9 +226,10 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   @Test
   void shouldRequestLargeBatchAndChunkIt() {
     // given
-    repository.batch =
-        new ProcessInstanceArchiveBatch(
-            "2024-01-01", LongStream.rangeClosed(1L, 300L).boxed().toList(), List.of());
+    repository.batches =
+        List.of(
+            new ProcessInstanceArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(1L, 300L).boxed().toList(), List.of()));
 
     // when
     final var first = job.getNextBatch().toCompletableFuture().join();
@@ -251,9 +256,10 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   @Test
   void shouldRequestAgainWhenChunksExhausted() {
     // given
-    repository.batch =
-        new ProcessInstanceArchiveBatch(
-            "2024-01-01", LongStream.rangeClosed(1L, 200L).boxed().toList(), List.of());
+    repository.batches =
+        List.of(
+            new ProcessInstanceArchiveBatch(
+                "2024-01-01", LongStream.rangeClosed(1L, 200L).boxed().toList(), List.of()));
 
     // when
     final var first = job.getNextBatch().toCompletableFuture().join();
@@ -273,6 +279,34 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
         .isEqualTo(
             new ProcessInstanceArchiveBatch(
                 "2024-01-01", LongStream.rangeClosed(1L, 100L).boxed().toList(), List.of()));
+
+    verify(repository, times(2)).getProcessInstancesNextBatch(1_000);
+  }
+
+  @Test
+  void shouldSkipAlreadyArchivedProcessInstances() {
+    // given
+    repository.batches =
+        List.of(
+            new ProcessInstanceArchiveBatch("2024-01-01", List.of(1L, 2L, 3L), List.of(7L, 8L)));
+    final var count1 = getArchiverJob().execute().toCompletableFuture().join();
+
+    // 2nd batch has overlapping ids with 1st batch, but also new ones. Should skip the overlapping
+    // ones, but still use the new ones
+    repository.batches =
+        List.of(
+            new ProcessInstanceArchiveBatch("2024-01-01", List.of(2L, 3L, 4L), List.of(8L, 9L)));
+
+    // when
+    final var count2 = getArchiverJob().execute().toCompletableFuture().join();
+
+    // then
+    assertThat(count1).isEqualTo(5);
+    assertThat(count2).isEqualTo(2);
+    assertArchivingCounts(7);
+    assertThat(getMeterRegistry().counter(getJobMetricName(), "state", "deduplicated").count())
+        .isEqualTo(3);
+    assertArchiverTimer(2); // job executed twice
 
     verify(repository, times(2)).getProcessInstancesNextBatch(1_000);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/RecentlyArchivedProcessInstancesTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/RecentlyArchivedProcessInstancesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RecentlyArchivedProcessInstancesTest {
+  private final Cache<Long, Boolean> cache = Caffeine.newBuilder().build();
+  private final RecentlyArchivedProcessInstances deduplicator =
+      new RecentlyArchivedProcessInstances(cache);
+
+  @Test
+  public void shouldNotDeduplicateProcessInstanceBatchWhenNothingInCache() {
+    // given
+    final var batch =
+        new ArchiveBatch.ProcessInstanceArchiveBatch(
+            "finished-date", List.of(1L, 2L, 3L), List.of(4L, 5L, 6L));
+
+    // when
+    final var deduplicated = deduplicator.deduplicate(batch);
+
+    // then
+    assertThat(deduplicated)
+        .isEqualTo(
+            new ArchiveBatch.ProcessInstanceArchiveBatch(
+                "finished-date", List.of(1L, 2L, 3L), List.of(4L, 5L, 6L)));
+  }
+
+  @Test
+  public void shouldDeduplicateProcessInstanceBatch() {
+    // given
+    cache.put(1L, Boolean.TRUE);
+    cache.put(3L, Boolean.TRUE);
+    cache.put(5L, Boolean.TRUE);
+
+    final var batch =
+        new ArchiveBatch.ProcessInstanceArchiveBatch(
+            "finished-date", List.of(1L, 2L, 3L), List.of(4L, 5L, 6L));
+
+    // when
+    final var deduplicated = deduplicator.deduplicate(batch);
+
+    // then
+    assertThat(deduplicated)
+        .isEqualTo(
+            new ArchiveBatch.ProcessInstanceArchiveBatch(
+                "finished-date", List.of(2L), List.of(4L, 6L)));
+  }
+
+  @Test
+  public void shouldMarkProcessInstancesAsRecentlyArchived() {
+    // given
+    final var batch =
+        new ArchiveBatch.ProcessInstanceArchiveBatch(
+            "finished-date", List.of(1L, 2L, 3L), List.of(4L, 5L, 6L));
+
+    // when
+    deduplicator.markRecentlyArchived(batch);
+
+    // then
+    assertThat(deduplicator.getRecentlyArchivedCount()).isEqualTo(6);
+    assertThat(cache.asMap()).containsOnlyKeys(1L, 2L, 3L, 4L, 5L, 6L);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -52,7 +52,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batches = List.of(new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3")));
   }
 
   @AfterEach
@@ -151,7 +151,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     final var job =
         new StandaloneDecisionArchiverJob(
             repository, decisionInstanceTemplate, metrics, LOGGER, executor, List.of(dependant));
-    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2"));
+    repository.batches = List.of(new BasicArchiveBatch("2024-01-01", List.of("1", "2")));
 
     // when
     final int count = job.execute().toCompletableFuture().join();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -17,41 +17,47 @@ import java.util.concurrent.Executor;
 
 final class TestRepository extends NoopArchiverRepository {
   final List<DocumentMove> moves = new ArrayList<>();
-  ArchiveBatch batch;
+  List<ArchiveBatch> batches = List.of();
+  int currentBatchIndex = 0;
 
   public <T extends ArchiveBatch> CompletableFuture<T> getNextBatch() {
-    return CompletableFuture.completedFuture((T) batch);
+    if (batches.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+    final var index = currentBatchIndex % batches.size();
+    currentBatchIndex = index + 1;
+    return CompletableFuture.completedFuture((T) batches.get(index));
   }
 
   @Override
   public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch(
       final int size) {
-    return CompletableFuture.completedFuture((ProcessInstanceArchiveBatch) batch);
+    return getNextBatch();
   }
 
   @Override
   public CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch() {
-    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
+    return getNextBatch();
   }
 
   @Override
   public CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch() {
-    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
+    return getNextBatch();
   }
 
   @Override
   public CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch() {
-    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
+    return getNextBatch();
   }
 
   @Override
   public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch() {
-    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
+    return getNextBatch();
   }
 
   @Override
   public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch() {
-    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
+    return getNextBatch();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
@@ -40,7 +40,7 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batches = List.of(new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3")));
   }
 
   @AfterEach

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
@@ -39,7 +39,7 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batches = List.of(new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3")));
   }
 
   @AfterEach


### PR DESCRIPTION
This is a follow on from https://github.com/camunda/camunda/pull/49073

That change helped reduce the amount of duplicated/repeated process instances we archived.  This change adds a further improvement to that, by maintaining a small cache of recently archived process instances that can be used to deduplicate the next batch of PIs we read.

In practice I don't think this will normally yield a massive difference, but when ES/OS is under heavy load it should avoid some extra work being done and it will also make the PI archived metrics more accurate.

With the time between archive runs reduced you can see the different number of PIs archived per second:

<img width="797" height="316" alt="image" src="https://github.com/user-attachments/assets/ac194a27-dcdb-47ac-bd8f-da2c75677d48" />

but it doesn't actually result in that many more documents being reindexed:

<img width="797" height="316" alt="image" src="https://github.com/user-attachments/assets/a3f2b927-59af-483e-b6c1-a282c481892e" />

So it should mean we're at least making fewer requests to ES - even if the amount of "real" work is not much different.

## Related issues

closes: #48200

refs: #39196

