### PR TITLE
[Backport stable/8.8] fix: add await for group user assignment

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
@@ -9,14 +9,16 @@ package io.camunda.it.operate;
 
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ;
 import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
 import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
 import static io.camunda.client.api.search.enums.ResourceType.GROUP;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static io.camunda.it.util.TestHelper.waitForProcessInstances;
+import static io.camunda.it.util.TestHelper.waitForUserGroupAssignment;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -74,6 +76,7 @@ public class OperateInternalApiGroupPermissionsIT {
           ADMIN_USERNAME,
           ADMIN_USERNAME,
           List.of(
+              new Permissions(GROUP, READ, List.of("*")),
               new Permissions(GROUP, CREATE, List.of("*")),
               new Permissions(GROUP, UPDATE, List.of("*")),
               new Permissions(AUTHORIZATION, CREATE, List.of("*")),
@@ -127,18 +130,8 @@ public class OperateInternalApiGroupPermissionsIT {
             .send()
             .join()
             .getProcessInstanceKey();
-    await()
-        .untilAsserted(
-            () ->
-                assertThat(
-                        adminClient
-                            .newProcessInstanceSearchRequest()
-                            .filter(f -> f.processInstanceKey(processInstanceKey))
-                            .send()
-                            .join()
-                            .items())
-                    .describedAs("Wait until the process instance is exported")
-                    .hasSize(1));
+    waitForProcessInstances(adminClient, f -> f.processInstanceKey(processInstanceKey), 1);
+    waitForUserGroupAssignment(adminClient, groupId, AUTHORIZED_USERNAME);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
@@ -9,14 +9,16 @@ package io.camunda.it.operate;
 
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ;
 import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
 import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static io.camunda.client.api.search.enums.ResourceType.ROLE;
+import static io.camunda.it.util.TestHelper.waitForProcessInstances;
+import static io.camunda.it.util.TestHelper.waitForUserRoleAssignment;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -74,6 +76,7 @@ public class OperateInternalApiRolePermissionsIT {
           ADMIN_USERNAME,
           ADMIN_USERNAME,
           List.of(
+              new Permissions(ROLE, READ, List.of("*")),
               new Permissions(ROLE, CREATE, List.of("*")),
               new Permissions(ROLE, UPDATE, List.of("*")),
               new Permissions(AUTHORIZATION, CREATE, List.of("*")),
@@ -132,18 +135,8 @@ public class OperateInternalApiRolePermissionsIT {
             .send()
             .join()
             .getProcessInstanceKey();
-    await()
-        .untilAsserted(
-            () ->
-                assertThat(
-                        adminClient
-                            .newProcessInstanceSearchRequest()
-                            .filter(f -> f.processInstanceKey(processInstanceKey))
-                            .send()
-                            .join()
-                            .items())
-                    .describedAs("Wait until the process instance is exported")
-                    .hasSize(1));
+    waitForProcessInstances(adminClient, f -> f.processInstanceKey(processInstanceKey), 1);
+    waitForUserRoleAssignment(adminClient, roleId, AUTHORIZED_USERNAME);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -31,8 +31,10 @@ import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
+import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.response.Job;
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Tenant;
 import io.camunda.client.api.search.response.UserTask;
@@ -1069,6 +1071,31 @@ public final class TestHelper {
                       .join();
               assertThat(result.items().size()).isOne();
             });
+  }
+
+  public static void waitForUserGroupAssignment(
+      final CamundaClient camundaClient, final String groupId, final String username) {
+    Awaitility.await("should wait until user group assignment is visible")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient.newUsersByGroupSearchRequest(groupId).send().join().items())
+                    .extracting(GroupUser::getUsername)
+                    .contains(username));
+  }
+
+  public static void waitForUserRoleAssignment(
+      final CamundaClient camundaClient, final String roleId, final String username) {
+    Awaitility.await("should wait until user role assignment is visible")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(camundaClient.newUsersByRoleSearchRequest(roleId).send().join().items())
+                    .extracting(RoleUser::getUsername)
+                    .contains(username));
   }
 
   public static <T, U extends Comparable<U>> void assertSorted(


### PR DESCRIPTION
# Description
Backport of #40676 to `stable/8.8`.

relates to camunda/camunda#40672