### PR TITLE
build: add skip-fe-build variable, overridable from command line

### DIFF
--- a/operate/Makefile
+++ b/operate/Makefile
@@ -1,27 +1,11 @@
 ## Environment
 
-.PHONY: env-h2-up
-env-h2-up:
-	mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
-    && CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME=demo \
-	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD=demo \
-	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME=Demo \
-	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL=demo@example.com \
-	CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0=demo \
-	CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=true \
-	CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=false \
-	CAMUNDA_BACKUP_WEBAPPS_ENABLED=false \
-	CAMUNDA_DATABASE_URL=jdbc:h2:mem:camunda \
-	CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=rdbms \
-	ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME=io.camunda.exporter.rdbms.RdbmsExporter \
-	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run \
-	  -Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
-	  -Dspring-boot.run.profiles=operate,broker,dev,dev-data,admin,consolidated-auth
+skip-fe-build = false
 
 .PHONY: env-up
 env-up:
 	docker compose -f docker-compose.yml up -d elasticsearch \
-    && mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
+    && mvn install -DskipTests=true -Dskip.fe.build=${skip-fe-build} -DskipChecks -DskipQaBuild \
 	&& CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME=demo \
 	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD=demo \
 	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME=Demo \
@@ -47,9 +31,27 @@ env-up:
 	  -Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
 	  -Dspring-boot.run.profiles=operate,broker,dev,dev-data,consolidated-auth
 
+.PHONY: env-h2-up
+env-h2-up:
+	mvn install -DskipTests=true -Dskip.fe.build=${skip-fe-build} -DskipChecks -DskipQaBuild \
+    && CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME=demo \
+	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD=demo \
+	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME=Demo \
+	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL=demo@example.com \
+	CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0=demo \
+	CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=true \
+	CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=false \
+	CAMUNDA_BACKUP_WEBAPPS_ENABLED=false \
+	CAMUNDA_DATABASE_URL=jdbc:h2:mem:camunda \
+	CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=rdbms \
+	ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME=io.camunda.exporter.rdbms.RdbmsExporter \
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run \
+	  -Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
+	  -Dspring-boot.run.profiles=operate,broker,dev,dev-data,admin,consolidated-auth
+
 env-os-up:
 	docker compose -f docker-compose.yml up -d opensearch zeebe-opensearch \
-	&& mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
+	&& mvn install -DskipTests=true -Dskip.fe.build=${skip-fe-build} -DskipChecks -DskipQaBuild \
 	&& 	CAMUNDA_OPERATE_TASKLIST_URL="http://localhost:8081" \
 	  CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=opensearch \
 	  ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE=opensearch \
@@ -72,7 +74,7 @@ env-os-up:
 env-ldap-up:
 	@echo "Starting ldap-testserver: Look up for users (fry/fry, bender/bender etc) at: https://github.com/rroemhild/docker-test-openldap" \
 	&& docker compose -f docker-compose.yml up -d elasticsearch zeebe ldap-test-server \
-	&& mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
+	&& mvn install -DskipTests=true -Dskip.fe.build=${skip-fe-build} -DskipChecks -DskipQaBuild \
 	&& CAMUNDA_OPERATE_LDAP_BASEDN=dc=planetexpress,dc=com \
        CAMUNDA_OPERATE_LDAP_URL=ldap://localhost:10389/ \
        CAMUNDA_OPERATE_LDAP_MANAGERDN=cn=admin,dc=planetexpress,dc=com \
@@ -85,7 +87,7 @@ env-ldap-up:
 .PHONY: env-sso-up
 env-sso-up:
 	@docker compose -f docker-compose.yml up -d elasticsearch zeebe \
-	&& mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
+	&& mvn install -DskipTests=true -Dskip.fe.build=${skip-fe-build} -DskipChecks -DskipQaBuild \
 	&& CAMUNDA_OPERATE_AUTH0_BACKENDDOMAIN=camunda-dev.eu.auth0.com \
 	   CAMUNDA_OPERATE_AUTH0_CLAIMNAME=https://camunda.com/orgs \
        CAMUNDA_OPERATE_AUTH0_CLIENTID=tgbfvBTrXZroWWap8DgtTIOKGn1Vq9F6 \
@@ -102,7 +104,7 @@ env-sso-up:
 .PHONY: env-identity-up
 env-identity-up:
 	docker compose -f docker-compose.yml up -d elasticsearch \
-    && mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
+    && mvn install -DskipTests=true -Dskip.fe.build=${skip-fe-build} -DskipChecks -DskipQaBuild \
 	&& ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME=io.camunda.exporter.CamundaExporter \
 	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE=1 \
 	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_DELAY=1 \

--- a/operate/README.md
+++ b/operate/README.md
@@ -28,6 +28,14 @@ make env-up
 
 The Operate webapp will be running at `localhost:8080/operate`.
 
+Alternative: To run Camunda 8 and skip the frontend build:
+
+```
+make env-up skip-fe-build=true
+```
+
+This speeds up the startup process in case the frontend is already built (e.g. by a separate frontend development environment like vite).
+
 #### Zeebe + Operate + Identity + Elasticsearch
 
 To run Camunda 8 with Zeebe, Operate and Identity profiles, run this command in the operate folder:


### PR DESCRIPTION
## Description

This PR adds the variable `skip-fe-build` to Operate Makefile which defaults to `false`. This allows to override it from the command line in case a frontend build is not needed (in case a separate frontend dev environment is used):

`make env-up skip-fe-build=true`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
