### PR TITLE
test: fix process instance table sorting e2e

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -75,8 +75,7 @@ test.describe('Process Instances Table', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug 38103: https://github.com/camunda/camunda/issues/38103
-  test.skip('Sorting of process instances', async ({
+  test('Sorting of process instances', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,
@@ -155,12 +154,12 @@ test.describe('Process Instances Table', () => {
         .poll(() =>
           operateProcessesPage.processInstancesTable.nth(1).innerText(),
         )
-        .toContain(instanceIds[1].toString());
+        .toContain(instanceIds[0].toString());
       await expect
         .poll(() =>
           operateProcessesPage.processInstancesTable.nth(2).innerText(),
         )
-        .toContain(instanceIds[0].toString());
+        .toContain(instanceIds[1].toString());
     });
 
     await test.step('Check sorting of processes by process version ASC', async () => {


### PR DESCRIPTION
## Description

Change sorting order to reflect default `key` `ASC` API contract

## Workflow run

https://github.com/camunda/camunda/actions/runs/23539262035

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #38103 
