### PR TITLE
[Backport stable/8.8] ci: use auto-versioned Teleport in all load test workflows

### DIFF
--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -92,7 +92,8 @@ jobs:
       - name: Set up Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 17.2.2
+          proxy: camunda.teleport.sh:443
+          version: auto
       - name: Authenticate to Cluster using Teleport
         uses: teleport-actions/auth-k8s@v2
         with:

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -443,7 +443,8 @@ jobs:
       - name: Set up Teleport
         uses: teleport-actions/setup@v1
         with:
-            version: 17.2.2
+            proxy: camunda.teleport.sh:443
+            version: auto
 
       - name: Authenticate to Cluster using Teleport
         uses: teleport-actions/auth-k8s@v2

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Set up Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 17.2.2
+          proxy: camunda.teleport.sh:443
+          version: auto
 
       - name: Authenticate to Cluster using Teleport
         uses: teleport-actions/auth-k8s@v2
@@ -117,7 +118,8 @@ jobs:
       - name: Set up Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 17.2.2
+          proxy: camunda.teleport.sh:443
+          version: auto
 
       - name: Authenticate to Cluster using Teleport
         uses: teleport-actions/auth-k8s@v2

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -180,7 +180,8 @@ jobs:
       - name: Set up Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 17.2.2
+          proxy: camunda.teleport.sh:443
+          version: auto
 
       - name: Authenticate to Cluster using Teleport
         uses: teleport-actions/auth-k8s@v2


### PR DESCRIPTION
# Description
Backport of #49497 to `stable/8.8`.

relates to 