### PR TITLE
[Backport stable/8.6] ci: extend zeebe testbench job execution time to 20 mins

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -20,7 +20,7 @@ jobs:
   testbench:
     name: Start a test in testbench
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
# Description
Backport of #46816 to `stable/8.6`.

relates to 