### PR TITLE
ci: remove superflous io.minimus.images.galleryURL

### DIFF
--- a/.ci/docker/test/optimize-docker-labels.golden.json
+++ b/.ci/docker/test/optimize-docker-labels.golden.json
@@ -18,6 +18,5 @@
   "org.opencontainers.image.url": "https://docs.camunda.io/docs/components/optimize/what-is-optimize/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
   "io.minimus.images.line": "21"
 }

--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -18,7 +18,6 @@
   "org.opencontainers.image.url": "https://docs.camunda.io/docs/components/optimize/what-is-optimize/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
   "io.minimus.images.line": "21",
   "io.minimus.images.version": "21.0.10-dev"
 }


### PR DESCRIPTION
## Description

Follow up on https://github.com/camunda/camunda/pull/48660/changes/31a404562858f7e6461e3e43d5c91613beb27154

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
