### PR TITLE
feat: support configurable rate unit and fractional rates in load tester

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -179,7 +179,10 @@ public class Starter extends App {
             DataReadMeterQueryProvider.getDefaultQueries());
     dataReadMeter.setContextProcessDefinitionId(starterCfg.getProcessId());
     dataReadMeter.setContextBusinessKeySupplier(
-        () -> Pair.of(starterCfg.getBusinessKey(), businessKey.get() - starterCfg.getRate() * 60L));
+        () ->
+            Pair.of(
+                starterCfg.getBusinessKey(),
+                businessKey.get() - (long) (starterCfg.getRatePerSecond() * 60.0)));
   }
 
   private ScheduledFuture<?> scheduleProcessInstanceCreation(
@@ -187,8 +190,12 @@ public class Starter extends App {
       final CountDownLatch countDownLatch,
       final CamundaClient client) {
 
-    final long intervalNanos = Math.floorDiv(NANOS_PER_SECOND, starterCfg.getRate());
-    LOG.info("Creating an instance every {}ns", intervalNanos);
+    final long intervalNanos = (long) (NANOS_PER_SECOND / starterCfg.getRatePerSecond());
+    LOG.info(
+        "Creating an instance every {}ns (rate: {} per {})",
+        intervalNanos,
+        starterCfg.getRate(),
+        starterCfg.getRateDuration());
 
     final String variablesString = readVariables(starterCfg.getPayloadPath());
     final Map<String, Object> baseVariables =

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterCfg.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterCfg.java
@@ -13,7 +13,8 @@ import java.util.List;
 public class StarterCfg {
 
   private String processId;
-  private int rate;
+  private double rate;
+  private Duration rateDuration = Duration.ofSeconds(1);
   private int threads;
 
   /** Paths are relative to classpath. */
@@ -56,12 +57,24 @@ public class StarterCfg {
     this.processId = processId;
   }
 
-  public int getRate() {
+  public double getRate() {
     return rate;
   }
 
-  public void setRate(final int rate) {
+  public void setRate(final double rate) {
     this.rate = rate;
+  }
+
+  public Duration getRateDuration() {
+    return rateDuration;
+  }
+
+  public void setRateDuration(final Duration rateDuration) {
+    this.rateDuration = rateDuration;
+  }
+
+  public double getRatePerSecond() {
+    return rate / (rateDuration.toNanos() / 1_000_000_000.0);
   }
 
   public int getThreads() {

--- a/load-tests/load-tester/src/main/resources/application.conf
+++ b/load-tests/load-tester/src/main/resources/application.conf
@@ -34,6 +34,7 @@ app {
   starter {
     processId = "benchmark"
     rate = 300
+    rateDuration = 1s
     threads = 2
     bpmnXmlPath = "bpmn/one_task.bpmn"
     extraBpmnModels = []

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 public class ConfigTest {
@@ -39,7 +41,8 @@ public class ConfigTest {
     assertThat(starterCfg).isNotNull();
 
     assertThat(starterCfg.getProcessId()).isEqualTo("benchmark");
-    assertThat(starterCfg.getRate()).isEqualTo(300);
+    assertThat(starterCfg.getRate()).isEqualTo(300.0);
+    assertThat(starterCfg.getRateDuration()).hasSeconds(1);
     assertThat(starterCfg.getThreads()).isEqualTo(2);
     assertThat(starterCfg.getBpmnXmlPath()).isEqualTo("bpmn/one_task.bpmn");
     assertThat(starterCfg.getExtraBpmnModels()).isEmpty();
@@ -102,7 +105,9 @@ public class ConfigTest {
     assertThat(starterCfg).isNotNull();
 
     assertThat(starterCfg.getProcessId()).isEqualTo("benchmark");
-    assertThat(starterCfg.getRate()).isEqualTo(300);
+    assertThat(starterCfg.getRate()).isEqualTo(30.5);
+    assertThat(starterCfg.getRateDuration()).hasMinutes(5);
+    assertThat(starterCfg.getRatePerSecond()).isCloseTo(30.5 / 300.0, within(1e-9));
     assertThat(starterCfg.getThreads()).isEqualTo(2);
     assertThat(starterCfg.getBpmnXmlPath())
         .isEqualTo("bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn");
@@ -135,5 +140,33 @@ public class ConfigTest {
     assertThat(workerCfg.getMessageName()).isEqualTo("msg");
     assertThat(workerCfg.isSendMessage()).isTrue();
     assertThat(workerCfg.getCorrelationKeyVariableName()).isEqualTo("var");
+  }
+
+  @Test
+  public void shouldConvertFractionalRateWithCustomDuration() {
+    // given
+    final var starterCfg = new StarterCfg();
+    starterCfg.setRate(30.5);
+    starterCfg.setRateDuration(Duration.ofMinutes(1));
+
+    // when
+    final double ratePerSecond = starterCfg.getRatePerSecond();
+
+    // then
+    assertThat(ratePerSecond).isCloseTo(30.5 / 60.0, within(1e-9));
+  }
+
+  @Test
+  public void shouldReturnRateUnchangedForOneSecondDuration() {
+    // given
+    final var starterCfg = new StarterCfg();
+    starterCfg.setRate(0.5);
+    starterCfg.setRateDuration(Duration.ofSeconds(1));
+
+    // when
+    final double ratePerSecond = starterCfg.getRatePerSecond();
+
+    // then
+    assertThat(ratePerSecond).isEqualTo(0.5);
   }
 }

--- a/load-tests/load-tester/src/test/resources/different-application.conf
+++ b/load-tests/load-tester/src/test/resources/different-application.conf
@@ -26,7 +26,8 @@ app {
 
   starter {
     processId = "benchmark"
-    rate = 300
+    rate = 30.5
+    rateDuration = 5m
     threads = 2
     bpmnXmlPath = "bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn"
     extraBpmnModels = ["bpmn/realistic/determineFraudRatingConfidence.dmn", "bpmn/realistic/refundingProcess.bpmn"]


### PR DESCRIPTION
## Description
The starter rate was an integer per second, making it impossible to express sub-second or per-minute rates. Change rate to double and add a rateUnit field (java.util.concurrent.TimeUnit, defaulting to SECONDS) so users can configure e.g. `rate = 1, rateUnit = MINUTES`.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
