### PR TITLE
fix: CANCELLED job are ignored in JobMetrics

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTypeStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTypeStatisticsIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.activateAndCompleteJobs;
 import static io.camunda.it.util.TestHelper.activateAndFailJobs;
+import static io.camunda.it.util.TestHelper.cancelInstance;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForJobTypeStatistics;
@@ -81,14 +82,29 @@ public class JobTypeStatisticsIT {
     // Wait for failure to be reflected
     waitForJobs(adminClient, f -> f.state(JobState.FAILED).type(JOB_TYPE_A), 1);
 
-    // Wait for metrics to be exported
+    // Start a 3rd process instance and cancel it to verify cancellation doesn't affect metrics
+    final var instanceToCancel = startProcessInstance(adminClient, PROCESS_ID);
+
+    // Wait for its taskA job to be visible before cancelling
+    waitForJobs(adminClient, f -> f.state(JobState.CREATED).type(JOB_TYPE_A), 1);
+
+    // Cancel the process instance (which cancels its pending taskA job)
+    cancelInstance(adminClient, instanceToCancel);
+
+    // Wait for the cancelled job to be reflected
+    waitForJobs(adminClient, f -> f.state(JobState.CANCELED).type(JOB_TYPE_A), 1);
+
+    // Wait for metrics to be exported (3 taskA created: 1 completed, 1 failed, 1 cancelled)
     waitForJobTypeStatistics(
         adminClient,
         NOW.minusDays(1),
         NOW.plusDays(1),
         stats -> {
-          // We should have 2 job types: taskA and taskB
           assertThat(stats.items()).hasSize(2);
+          // Ensure all 3 created jobs are reflected, with failed still at 1 (not incremented by
+          // cancellation)
+          assertThat(stats.items().get(0).getCreated().getCount()).isEqualTo(3L);
+          assertThat(stats.items().get(0).getFailed().getCount()).isEqualTo(1L);
         });
   }
 
@@ -97,7 +113,7 @@ public class JobTypeStatisticsIT {
       @Authenticated(ADMIN) final CamundaClient adminClient) {
     // when/then
     // We have:
-    // - taskA: 2 created, 1 completed, 1 failed
+    // - taskA: 3 created (2 original + 1 cancelled), 1 completed, 1 failed
     // - taskB: 1 created (after completing taskA in instance 1)
     waitForJobTypeStatistics(
         adminClient,
@@ -109,7 +125,7 @@ public class JobTypeStatisticsIT {
           // Results should be sorted by jobType ASC
           final var taskAStats = stats.items().get(0);
           assertThat(taskAStats.getJobType()).isEqualTo(JOB_TYPE_A);
-          assertThat(taskAStats.getCreated().getCount()).isEqualTo(2L);
+          assertThat(taskAStats.getCreated().getCount()).isEqualTo(3L);
           assertThat(taskAStats.getCompleted().getCount()).isEqualTo(1L);
           assertThat(taskAStats.getFailed().getCount()).isEqualTo(1L);
           assertThat(taskAStats.getWorkers()).isEqualTo(1);
@@ -120,6 +136,27 @@ public class JobTypeStatisticsIT {
           assertThat(taskBStats.getCompleted().getCount()).isZero();
           assertThat(taskBStats.getFailed().getCount()).isZero();
           assertThat(taskBStats.getWorkers()).isEqualTo(0); // no worker activated taskB yet
+        });
+  }
+
+  @Test
+  void shouldNotCountCancelledJobInStatistics(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then - a cancelled job should not increment the failed count
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(JOB_TYPE_A),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+
+          final var taskAStats = stats.items().get(0);
+          // The cancelled job was created, so created count includes it
+          assertThat(taskAStats.getCreated().getCount()).isEqualTo(3L);
+          // Cancellation must NOT increment completed or failed
+          assertThat(taskAStats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(taskAStats.getFailed().getCount()).isEqualTo(1L);
         });
   }
 
@@ -137,7 +174,7 @@ public class JobTypeStatisticsIT {
 
           final var taskAStats = stats.items().get(0);
           assertThat(taskAStats.getJobType()).isEqualTo(JOB_TYPE_A);
-          assertThat(taskAStats.getCreated().getCount()).isEqualTo(2L);
+          assertThat(taskAStats.getCreated().getCount()).isEqualTo(3L);
           assertThat(taskAStats.getCompleted().getCount()).isEqualTo(1L);
           assertThat(taskAStats.getFailed().getCount()).isEqualTo(1L);
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -391,6 +391,7 @@ public final class EventAppliers implements EventApplier {
   private void registerJobIntentEventAppliers(final MutableProcessingState state) {
     register(JobIntent.CANCELED, 1, new JobCanceledV1Applier(state));
     register(JobIntent.CANCELED, 2, new JobCanceledV2Applier(state));
+    register(JobIntent.CANCELED, 3, new JobCanceledV3Applier(state));
     register(JobIntent.COMPLETED, 1, new JobCompletedV1Applier(state));
     register(JobIntent.COMPLETED, 2, new JobCompletedV2Applier(state));
     register(JobIntent.COMPLETED, 3, new JobCompletedV3Applier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV3Applier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+public class JobCanceledV3Applier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+
+  JobCanceledV3Applier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+    elementInstanceState = state.getElementInstanceState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.cancel(key, value);
+
+    if (value.isJobToUserTaskMigration()) {
+      final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+      if (elementInstance != null) {
+        elementInstance.setJobKey(-1L);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Job_CANCELED_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Job_CANCELED_v3.golden
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+public class JobCanceledV3Applier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+
+  JobCanceledV3Applier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+    elementInstanceState = state.getElementInstanceState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.cancel(key, value);
+
+    if (value.isJobToUserTaskMigration()) {
+      final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+      if (elementInstance != null) {
+        elementInstance.setJobKey(-1L);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

`CANCELLED` job are not taken into account in the job metrics.

Discussion [here](https://camunda.slack.com/archives/C0AN6L2BQ1F/p1774445171211269?thread_ts=1773997016.133709&cid=C0AN6L2BQ1F)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
