### PR TITLE
docs: add release-timeline static site

### DIFF
--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -40,6 +40,8 @@ Not in scope of this process are [SNAPSHOT releases](./ci.md#available-snapshot-
   * no code freeze and no release candidate build
   * source branch is `stable/${minor_version}`
 
+See [this self-updating release timeline page](pathname:///release-timeline/).
+
 ### Release Dependencies
 
 _Caveat: While Optimize is part of the C8 monorepo, it has its own release process separate from the C8 monorepo release process (covers only Operate/Tasklist/Zeebe)._

--- a/monorepo-docs-site/static/release-timeline/index.html
+++ b/monorepo-docs-site/static/release-timeline/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Monorepo Minor Release Timeline</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="script.js"></script>
+  </head>
+  <body>
+    <div class="page">
+      <header class="hero">
+        <div class="hero-copy">
+          <p class="kicker">C8 monorepo release process</p>
+          <h1>Monorepo Release Timeline</h1>
+          <p class="lede">
+            Easily see which releases happen next for <code>camunda/camunda</code>
+            and which branches should be used.
+          </p>
+          <div class="hero-meta">
+            <div>
+              <span class="meta-label">Today</span>
+              <span id="today" class="meta-value">--</span>
+            </div>
+            <div>
+              <span class="meta-label">Current phases</span>
+              <span class="meta-value" id="current-phase">--</span>
+            </div>
+          </div>
+        </div>
+        <div class="hero-card">
+          <h2>Target Branches</h2>
+          <p class="card-note">
+            What should be merged into which branch, based on the current phase.
+          </p>
+          <ul id="merge-targets" class="branch-list"></ul>
+        </div>
+      </header>
+
+      <main>
+        <section class="timeline-section">
+          <div class="section-title">
+            <h3>Release timeline</h3>
+            <p>
+              The active phases are highlighted in orange.
+            </p>
+            <button id="toggle-past" class="toggle-button" type="button">
+              Show past phases
+            </button>
+          </div>
+          <ol id="timeline" class="timeline"></ol>
+          <button id="toggle-future" class="toggle-button" type="button">
+            Show future phases
+          </button>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <p>Static build ready for GitHub Pages.</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/monorepo-docs-site/static/release-timeline/script.js
+++ b/monorepo-docs-site/static/release-timeline/script.js
@@ -1,0 +1,254 @@
+const timelineUrl = "./timeline.json";
+
+const getValidatedQueryDate = () => {
+  const value = new URLSearchParams(window.location.search).get("date");
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+  const utcDate = new Date(Date.UTC(year, month - 1, day, 12));
+  if (
+    Number.isNaN(utcDate.getTime()) ||
+    utcDate.getUTCFullYear() !== year ||
+    utcDate.getUTCMonth() !== month - 1 ||
+    utcDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return new Date(`${value}T12:00:00`);
+};
+
+const today = getValidatedQueryDate() ?? new Date();
+const todayLabel = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+}).format(today);
+
+const todayEl = document.getElementById("today");
+const currentPhaseEl = document.getElementById("current-phase");
+const mergeTargetsEl = document.getElementById("merge-targets");
+const togglePastBtn = document.getElementById("toggle-past");
+const toggleFutureBtn = document.getElementById("toggle-future");
+const timelineEl = document.getElementById("timeline");
+
+let showPast = false;
+let showFuture = false;
+
+const isTodayInRange = (start, end) => {
+  const startDate = new Date(`${start}T00:00:00`);
+  const endDate = new Date(`${end}T23:59:59`);
+  return today >= startDate && today <= endDate;
+};
+
+const isPastPhase = (end) => {
+  const endDate = new Date(`${end}T23:59:59`);
+  return endDate < today;
+};
+
+const isFarFuturePhase = (start) => {
+  const startDate = new Date(`${start}T00:00:00`);
+  const futureCutoff = new Date(today);
+  futureCutoff.setDate(futureCutoff.getDate() + 21);
+  return startDate > futureCutoff;
+};
+
+const formatRange = (start, end) => {
+  const formatter = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
+  const startLabel = formatter.format(new Date(`${start}T00:00:00`));
+  const endLabel = formatter.format(new Date(`${end}T00:00:00`));
+  return `${startLabel} - ${endLabel}`;
+};
+
+const loadTimeline = async () => {
+  const response = await fetch(timelineUrl);
+  if (!response.ok) {
+    throw new Error("Unable to load timeline.json");
+  }
+  const data = await response.json();
+  return Array.isArray(data.timeline) ? data.timeline : [];
+};
+
+const buildChip = (text) => {
+  const chip = document.createElement("span");
+  chip.className = "chip";
+  chip.textContent = text;
+  return chip;
+};
+
+const buildBranchItem = (phase) => {
+  const item = document.createElement("li");
+  item.className = "branch-item";
+
+  const branch = document.createElement("span");
+  branch.className = "branch-pill";
+  branch.textContent = phase.branch || "Unknown branch";
+
+  const note = document.createElement("span");
+  note.className = "branch-note";
+  note.textContent = phase.note || "No note available.";
+
+  item.append(branch, note);
+  return item;
+};
+
+const buildLabeledValue = (label, value) => {
+  const line = document.createElement("span");
+  const labelEl = document.createElement("strong");
+  labelEl.textContent = `${label}: `;
+  const valueEl = document.createElement("span");
+  valueEl.textContent = value;
+  line.append(labelEl, valueEl);
+  return line;
+};
+
+const renderMergeTargets = (phases) => {
+  mergeTargetsEl.replaceChildren();
+  mergeTargetsEl.appendChild(
+    buildBranchItem({
+      branch: "main",
+      note: "Merge features for next minor version.",
+    })
+  );
+
+  if (!phases || phases.length === 0) {
+    return;
+  }
+
+  phases
+    .filter((phase) => phase.branch !== "main")
+    .forEach((phase) => {
+      mergeTargetsEl.appendChild(buildBranchItem(phase));
+    });
+};
+
+const renderTimeline = (timeline, activePhases) => {
+  timelineEl.replaceChildren();
+  timeline.forEach((phase, index) => {
+    const item = document.createElement("li");
+    item.className = "timeline-item fade-in";
+    item.style.animationDelay = `${index * 80}ms`;
+
+    if (isPastPhase(phase.end)) {
+      item.dataset.past = "true";
+      if (!showPast) {
+        item.classList.add("is-hidden");
+      }
+    }
+
+    if (isFarFuturePhase(phase.start)) {
+      item.dataset.future = "true";
+      if (!showFuture) {
+        item.classList.add("is-hidden");
+      }
+    }
+
+    if (activePhases && activePhases.some((active) => active.title === phase.title)) {
+      item.classList.add("active");
+    }
+
+    const dot = document.createElement("span");
+    dot.className = "timeline-dot";
+
+    const card = document.createElement("div");
+    card.className = "timeline-card";
+
+    const title = document.createElement("h4");
+    title.textContent = phase.title;
+
+    const meta = document.createElement("div");
+    meta.className = "timeline-meta";
+
+    const date = buildLabeledValue("Dates", formatRange(phase.start, phase.end));
+    const branches = buildLabeledValue("Branch", phase.branch);
+    const note = buildLabeledValue("Note", phase.note);
+
+    if (phase.description) {
+      const description = buildLabeledValue("Details", phase.description);
+      meta.append(date, branches, note, description);
+    } else {
+      meta.append(date, branches, note);
+    }
+    card.append(title, meta);
+    item.append(dot, card);
+    timelineEl.appendChild(item);
+  });
+};
+
+const updatePastVisibility = () => {
+  if (!togglePastBtn) {
+    return;
+  }
+
+  const pastItems = timelineEl.querySelectorAll('[data-past="true"]');
+  pastItems.forEach((item) => {
+    item.classList.toggle("is-hidden", !showPast);
+  });
+
+  togglePastBtn.hidden = pastItems.length === 0;
+  togglePastBtn.textContent = showPast ? "Hide past phases" : "Show past phases";
+  togglePastBtn.setAttribute("aria-expanded", showPast ? "true" : "false");
+};
+
+const updateFutureVisibility = () => {
+  if (!toggleFutureBtn) {
+    return;
+  }
+
+  const futureItems = timelineEl.querySelectorAll('[data-future="true"]');
+  futureItems.forEach((item) => {
+    item.classList.toggle("is-hidden", !showFuture);
+  });
+
+  toggleFutureBtn.hidden = futureItems.length === 0;
+  toggleFutureBtn.textContent = showFuture
+    ? "Hide future phases"
+    : "Show future phases";
+  toggleFutureBtn.setAttribute("aria-expanded", showFuture ? "true" : "false");
+};
+
+const boot = async () => {
+  todayEl.textContent = todayLabel;
+  try {
+    const timeline = await loadTimeline();
+    const activePhases = timeline.filter((phase) =>
+      isTodayInRange(phase.start, phase.end)
+    );
+
+    currentPhaseEl.replaceChildren();
+    if (activePhases.length) {
+      activePhases.forEach((phase) => {
+        const line = document.createElement("span");
+        line.className = "phase-line";
+        line.textContent = phase.title;
+        currentPhaseEl.appendChild(line);
+      });
+    } else {
+      currentPhaseEl.textContent = "Between phases";
+    }
+    renderMergeTargets(activePhases);
+    renderTimeline(timeline, activePhases);
+    updatePastVisibility();
+    updateFutureVisibility();
+
+    if (togglePastBtn) {
+      togglePastBtn.addEventListener("click", () => {
+        showPast = !showPast;
+        updatePastVisibility();
+      });
+    }
+
+    if (toggleFutureBtn) {
+      toggleFutureBtn.addEventListener("click", () => {
+        showFuture = !showFuture;
+        updateFutureVisibility();
+      });
+    }
+  } catch (error) {
+    currentPhaseEl.textContent = "Timeline unavailable";
+    mergeTargetsEl.replaceChildren();
+    mergeTargetsEl.appendChild(buildChip("Check timeline.json"));
+  }
+};
+
+boot();

--- a/monorepo-docs-site/static/release-timeline/styles.css
+++ b/monorepo-docs-site/static/release-timeline/styles.css
@@ -1,0 +1,360 @@
+:root {
+  --ink: #0c0c0c;
+  --paper: #fff8f4;
+  --mist: #fff2ea;
+  --accent: #fc5d0d;
+  --accent-dark: #c64605;
+  --accent-soft: rgba(252, 93, 13, 0.18);
+  --sage: #2a2a2a;
+  --plum: #111111;
+  --line: rgba(17, 17, 17, 0.12);
+  --shadow: 0 28px 60px rgba(12, 12, 12, 0.18);
+  --radius: 20px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Trebuchet MS", "Segoe UI", "DejaVu Sans", Arial, sans-serif;
+  color: var(--ink);
+  background: radial-gradient(circle at 12% 12%, #ffe7d9 0%, transparent 45%),
+    radial-gradient(circle at 90% 20%, #ffe2d2 0%, transparent 38%),
+    linear-gradient(135deg, var(--paper), var(--mist));
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 56px 28px 48px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 32px;
+  align-items: start;
+  margin-bottom: 56px;
+}
+
+.kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--sage);
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-size: clamp(32px, 4vw, 52px);
+  margin: 0 0 16px;
+  line-height: 1.05;
+}
+
+.lede {
+  font-size: 18px;
+  max-width: 520px;
+  margin: 0 0 28px;
+  color: #2b1a12;
+}
+
+.hero-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+  background: white;
+  padding: 18px 22px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.meta-label {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #5a3b2e;
+}
+
+.meta-value {
+  font-size: 18px;
+  font-weight: 600;
+  white-space: pre-line;
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+
+.phase-line {
+  display: block;
+  position: relative;
+  padding-left: 16px;
+}
+
+.phase-line::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.55em;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.hero-card {
+  background: white;
+  padding: 28px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-card::after {
+  content: "";
+  position: absolute;
+  inset: -40% -20% auto auto;
+  width: 200px;
+  height: 200px;
+  background: radial-gradient(circle, var(--accent-soft), transparent 70%);
+  opacity: 0.8;
+}
+
+.hero-card h2 {
+  margin: 0 0 8px;
+  font-size: 22px;
+}
+
+.card-note {
+  margin: 0 0 20px;
+  color: #4a2f23;
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chip {
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-dark);
+  font-weight: 600;
+  border: 1px solid rgba(252, 93, 13, 0.4);
+}
+
+.branch-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.branch-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: #fff1e7;
+  border: 1px solid rgba(17, 17, 17, 0.08);
+}
+
+.branch-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-dark);
+  font-weight: 600;
+  border: 1px solid rgba(252, 93, 13, 0.4);
+}
+
+.branch-note {
+  color: #4a2f23;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.timeline-section {
+  background: white;
+  padding: 32px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.section-title {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 28px;
+}
+
+.section-title h3 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.section-title p {
+  margin: 0;
+  color: #4a2f23;
+}
+
+.toggle-button {
+  align-self: flex-start;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(17, 17, 17, 0.12);
+  background: #fff1e7;
+  color: var(--plum);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toggle-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(12, 12, 12, 0.12);
+}
+
+.toggle-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.timeline-section > .toggle-button {
+  margin-top: 16px;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 18px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: var(--line);
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  gap: 18px;
+  padding: 18px 0;
+  position: relative;
+}
+
+.timeline-item.is-hidden {
+  display: none;
+}
+
+.timeline-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--plum);
+  margin-left: 11px;
+  align-self: center;
+  position: relative;
+  z-index: 1;
+}
+
+.timeline-card {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 16px 18px;
+  background: #fff7f2;
+  display: grid;
+  gap: 6px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.timeline-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(12, 12, 12, 0.12);
+}
+
+.timeline-card h4 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.timeline-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #4a2f23;
+  font-size: 14px;
+}
+
+.timeline-meta strong {
+  color: var(--ink);
+}
+
+.timeline-item.active .timeline-dot {
+  background: var(--accent);
+  box-shadow: 0 0 0 6px var(--accent-soft);
+}
+
+.timeline-item.active .timeline-card {
+  border-color: rgba(252, 93, 13, 0.45);
+  background: #ffe7d9;
+}
+
+.footer {
+  text-align: center;
+  font-size: 13px;
+  color: #5a3b2e;
+  margin-top: 40px;
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(12px);
+  animation: fadeUp 0.6s ease forwards;
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline-section {
+    padding: 24px;
+  }
+}

--- a/monorepo-docs-site/static/release-timeline/timeline.json
+++ b/monorepo-docs-site/static/release-timeline/timeline.json
@@ -1,0 +1,132 @@
+{
+  "timeline": [
+    {
+      "title": "Code freeze of 8.9.0-alpha3",
+      "start": "2025-12-18",
+      "end": "2026-01-05",
+      "branch": "release-8.9.0-alpha3",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.9.0-alpha3",
+      "start": "2026-01-06",
+      "end": "2026-01-06",
+      "branch": "release-8.9.0-alpha3",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    },
+    {
+      "title": "Code freeze of 8.9.0-alpha4",
+      "start": "2026-01-27",
+      "end": "2026-02-02",
+      "branch": "release-8.9.0-alpha4",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.9.0-alpha4",
+      "start": "2026-02-03",
+      "end": "2026-02-03",
+      "branch": "release-8.9.0-alpha4",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    },
+    {
+      "title": "Stable branch creation for 8.9",
+      "start": "2026-02-17",
+      "end": "2026-02-24",
+      "branch": "stable/8.9",
+      "note": "Features for 8.9 should be backported here, from main.",
+      "description": "Monorepo Release Manager creates the new stable branch from main, adjusting CI workflows as necessary. Features should be merged to main and backported here."
+    },
+    {
+      "title": "Feature freeze of 8.9.0",
+      "start": "2026-02-24",
+      "end": "2026-03-24",
+      "branch": "stable/8.9",
+      "note": "No new features, scope extensions, or risky changes are allowed on this branch anymore without exemption.",
+      "description": "Lock the scope for the minor release. Allow only stabilization, fixes, testing improvements and late features with exemptions."
+    },
+    {
+      "title": "Code freeze of 8.9.0-alpha5",
+      "start": "2026-02-24",
+      "end": "2026-03-02",
+      "branch": "release-8.9.0-alpha5",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.9.0-alpha5",
+      "start": "2026-03-03",
+      "end": "2026-03-03",
+      "branch": "release-8.9.0-alpha5",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    },
+    {
+      "title": "Code freeze of 8.9.0",
+      "start": "2026-03-24",
+      "end": "2026-04-06",
+      "branch": "release-8.9.0",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.9.0",
+      "start": "2026-04-07",
+      "end": "2026-04-07",
+      "branch": "release-8.9.0",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    },
+    {
+      "title": "Code freeze of 8.10.0-alpha1",
+      "start": "2026-04-28",
+      "end": "2026-05-04",
+      "branch": "release-8.10.0-alpha1",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.10.0-alpha1",
+      "start": "2026-05-05",
+      "end": "2026-05-05",
+      "branch": "release-8.10.0-alpha1",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    },
+    {
+      "title": "Code freeze of 8.10.0-alpha2",
+      "start": "2026-05-26",
+      "end": "2026-06-02",
+      "branch": "release-8.10.0-alpha2",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.10.0-alpha2",
+      "start": "2026-06-02",
+      "end": "2026-06-02",
+      "branch": "release-8.10.0-alpha2",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    },
+    {
+      "title": "Code freeze of 8.10.0-alpha3",
+      "start": "2026-06-30",
+      "end": "2026-07-07",
+      "branch": "release-8.10.0-alpha3",
+      "note": "Only bug fixes found during QA should be backported to this branch.",
+      "description": "During this phase, release candidates are built from the branch until the release date whenever new fixes need QA validation."
+    },
+    {
+      "title": "Release of 8.10.0-alpha3",
+      "start": "2026-07-07",
+      "end": "2026-07-07",
+      "branch": "release-8.10.0-alpha3",
+      "note": "No more merges.",
+      "description": "Final camunda/camunda artifacts should be tested and available for the overall C8 release train."
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Add a visual overview (self-updated daily) about which phase of the Monorepo release we are in, and what branches are available for merges (under which condition): https://camunda.github.io/camunda/pr-preview/pr-49533/release-timeline/

Large parts of the HTML, CSS and JS have been AI-generated and visually confirmed.

A link is added to our release docs via the https://docusaurus.io/docs/advanced/routing#escaping-from-spa-redirects feature

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
