### PR TITLE
[Backport stable/8.9] ci: make maven surefire problem matcher more robust

### DIFF
--- a/.github/maven-matcher.json
+++ b/.github/maven-matcher.json
@@ -13,7 +13,7 @@
       "owner": "maven-surefire-test",
       "pattern": [
         {
-          "regexp": "^\\s*\\[ERROR\\]\\s+(?<message>[A-Za-z0-9_$.]+\\s+--\\s+Time elapsed:.*)$",
+          "regexp": "^\\s*\\[ERROR\\]\\s+(?<message>.+\\s+--\\s+Time elapsed:.*)$",
           "message": 1
         }
       ]


### PR DESCRIPTION
# Description
Backport of #49498 to `stable/8.9`.

relates to 