### PR TITLE
[Backport stable/8.6] fix: whitelist JobIntent.TIME_OUT

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -22,6 +22,7 @@ public class WhiteListedCommands {
           JobIntent.COMPLETE,
           JobIntent.FAIL,
           JobIntent.YIELD,
+          JobIntent.TIME_OUT,
           ProcessInstanceIntent.CANCEL,
           DeploymentIntent.CREATE,
           DeploymentIntent.DISTRIBUTE,


### PR DESCRIPTION
# Description
Backport of #49489 to `stable/8.6`.

relates to 