### PR TITLE
ci: pin load tests to a single availability zone

### DIFF
--- a/load-tests/camunda-platform-values-opensearch.yaml
+++ b/load-tests/camunda-platform-values-opensearch.yaml
@@ -77,10 +77,11 @@ resources:
 persistence:
   enabled: true
   size: 512Gi
-  storageClass: "ssd"
+  storageClass: benchmark-ssd-zonal-v1
 
 nodeSelector:
   component: benchmark-n2-standard-8
+  topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
 
 tolerations:
   - key: nodepool

--- a/load-tests/camunda-platform-values-rdbms.yaml
+++ b/load-tests/camunda-platform-values-rdbms.yaml
@@ -97,6 +97,7 @@ primary:
 
   nodeSelector:
     component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
 
   tolerations:
     - key: nodepool
@@ -106,7 +107,7 @@ primary:
 
   persistence:
     size: 128Gi
-    storageClass: "ssd"
+    storageClass: benchmark-ssd-zonal-v1
 
   extendedConfiguration: |-
     # WAL Performance Tuning
@@ -157,7 +158,7 @@ elasticsearch:
     persistence:
       ## @param elasticsearch.master.persistence.size
       size: 256Gi
-      storageClass: "ssd"
+      storageClass: benchmark-ssd-zonal-v1
       accessModes: ["ReadWriteOnce"]
     resources:
       requests:
@@ -168,6 +169,7 @@ elasticsearch:
         memory: 6Gi
     nodeSelector:
       component: benchmark-n2-standard-4
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
     tolerations:
       - key: nodepool
         operator: Equal

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -32,6 +32,13 @@ global:
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets:
       - name: harbor-registry
+
+  # Default node configuration for all the components, unless specific
+  # reconfigured.
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
   # Identity authentication is enabled for Optimize
   identity:
     keycloak:
@@ -58,8 +65,6 @@ identity:
     secret:
       existingSecret: camunda-credentials
       existingSecretKey: identity-firstuser-password
-  nodeSelector:
-    component: benchmark-n2-standard-4
   tolerations:
     - key: nodepool
       operator: Equal
@@ -75,8 +80,6 @@ optimize:
         historyCleanup:
           cronTrigger: '0 1 * * *'
           ttl: 'P1D'
-  nodeSelector:
-    component: benchmark-n2-standard-4
   tolerations:
     - key: nodepool
       operator: Equal
@@ -88,6 +91,7 @@ identityKeycloak:
   fullnameOverride: keycloak # we override the names for simplicity of the deployment
   nodeSelector:
     component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
     - key: nodepool
       operator: Equal
@@ -106,6 +110,11 @@ connectors:
         secret:
           existingSecret: camunda-credentials
           existingSecretKey: connectors-security-authentication-oidc-secret
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 webModeler:
   enabled: false
@@ -157,9 +166,6 @@ orchestration:
       cpu: 3000m
       memory: 2Gi
 
-  nodeSelector:
-    component: benchmark-n2-standard-4
-
   tolerations:
     - key: nodepool
       operator: Equal
@@ -170,7 +176,7 @@ orchestration:
   pvcSize: "64Gi"
   ## @param core.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
   # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.
-  pvcStorageClassName: "ssd"
+  pvcStorageClassName: benchmark-ssd-zonal-v1
   # @extra core.containerSecurityContext defines the security options the container should be run with
   containerSecurityContext:
     ## @param core.containerSecurityContext.allowPrivilegeEscalation
@@ -300,7 +306,7 @@ elasticsearch:
     persistence:
       ## @param elasticsearch.master.persistence.size
       size: 512Gi
-      storageClass: "ssd"
+      storageClass: benchmark-ssd-zonal-v1
       accessModes: ["ReadWriteOnce"]
     resources:
       requests:
@@ -311,6 +317,7 @@ elasticsearch:
         memory: 8Gi
     nodeSelector:
       component: benchmark-n2-standard-8
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
     tolerations:
       - key: nodepool
         operator: Equal

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -38,3 +38,14 @@ saas:
     zeebeGrpcAddress: "http://camunda-gateway:26500"
     # Saas.credentials.authorizationAudience to define the auth audience of the cluster
     authorizationAudience: "orchestration-api"
+
+global:
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule

--- a/load-tests/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/prometheus-elasticsearch-exporter-values.yaml
@@ -15,3 +15,6 @@ serviceMonitor:
   # Labels used by the service monitor, specific to our prometheus installation
   labels:
     release: monitoring
+
+nodeSelector:
+  topology.kubernetes.io/zone: __AVAILABILITY_ZONE__

--- a/load-tests/setup/default/values-preemptible.yaml
+++ b/load-tests/setup/default/values-preemptible.yaml
@@ -5,6 +5,7 @@ orchestration:
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
     component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
 
   tolerations:
   - key: nodepool

--- a/load-tests/setup/default/values-stable.yaml
+++ b/load-tests/setup/default/values-stable.yaml
@@ -5,6 +5,7 @@ orchestration:
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
     component: benchmark-n2-standard-4-stable
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
 
   tolerations:
   - key: nodepool

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -7,13 +7,14 @@ set -exo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize]
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [single_zone]
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
   secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, none. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
   enable_optimize    Optional. true|false to enable Optimize. Default: true.
+  single_zone        Optional. true|false to deploy the cluster on a single zone. Default: true
 
 Options:
   -h, --help         Show this help message.
@@ -80,6 +81,27 @@ else
   echo "Namespace '$namespace' already exists"
 fi
 
+# Pick a "random" zone, selected from the input value.
+function hashmod_zone() {
+    local input="${1?"Specify an initial value to compute the zone from"}"
+
+    # We can get the list of zones with already created nodes with:
+    # kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io\/zone}{"\n"}{end}' | sort | uniq -c
+    zones=(
+        europe-west1-b
+        europe-west1-c
+        europe-west1-d
+    )
+    nb_zones=${#zones[@]}
+
+    # bc only accept hexadecimal with capitalized letters
+    checksum="$(echo "$input" | md5sum | cut -c 1-32 | tr "a-z" "A-Z")"
+    hashmod="$(echo "ibase=16; $checksum % $nb_zones" | bc)"
+
+    zone="${zones[$hashmod]}"
+    echo "$zone"
+}
+
 # Sanitize a string to be a valid Kubernetes label value
 sanitize_k8s_label() {
   local value="$1"
@@ -126,11 +148,22 @@ cp -v ../*.yaml $namespace/
 
 cd $namespace
 
+enable_single_zone="${5:-true}"
+enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
+if [[ "$enable_single_zone" == "true" ]]; then
+    availability_zone="$(hashmod_zone "$namespace")"
+    echo "Will configure pods to deploy into the $availability_zone AZ only."
+else
+    availability_zone="~"
+    echo "Will NOT configure pods to deploy into a single zone."
+fi
+
 # Update Makefile to use the namespace and secondary storage
 sed_inplace "s/__NAMESPACE__/$namespace/" Makefile
 sed_inplace "s/__NAMESPACE__/$namespace/" load-test-values.yaml
 sed_inplace "s/__STORAGE_TYPE__/$secondaryStorage/" Makefile
 sed_inplace "s/__ENABLE_OPTIMIZE__/$enable_optimize/" Makefile
+sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" *.yaml
 
 # Add/update helm repositories
 helm repo add camunda https://helm.camunda.io/ --force-update

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -7,14 +7,14 @@ set -exo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [single_zone]
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
   secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, none. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
   enable_optimize    Optional. true|false to enable Optimize. Default: true.
-  single_zone        Optional. true|false to deploy the cluster on a single zone. Default: true
+  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true
 
 Options:
   -h, --help         Show this help message.
@@ -74,13 +74,6 @@ if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
   exit 1
 fi
 
-# Create namespace if it doesn't exist
-if ! kubectl get namespace $namespace >/dev/null 2>&1; then
-  kubectl create namespace $namespace
-else
-  echo "Namespace '$namespace' already exists"
-fi
-
 # Pick a "random" zone, selected from the input value.
 function hashmod_zone() {
     local input="${1?"Specify an initial value to compute the zone from"}"
@@ -101,6 +94,42 @@ function hashmod_zone() {
     zone="${zones[$hashmod]}"
     echo "$zone"
 }
+
+enable_single_zone="${5:-true}"
+enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
+single_zone_annotation_name="topology.kubernetes.io/zone"
+availability_zone="~"
+
+# Create namespace if it doesn't exist
+if ! kubectl get namespace $namespace >/dev/null 2>&1; then
+  kubectl create namespace "$namespace"
+  if [[ "$enable_single_zone" == "true" ]]; then
+    availability_zone="$(hashmod_zone "$namespace")"
+    kubectl annotate namespace "$namespace" "${single_zone_annotation_name}=${availability_zone}"
+    echo "Will configure pods to deploy into the $availability_zone AZ only."
+  else
+    availability_zone="~"
+    echo "Will NOT configure pods to deploy into a single zone."
+  fi
+else
+  echo "Namespace '$namespace' already exists"
+  existing_zone="$(kubectl get ns "$namespace" -o json | jq --raw-output ".metadata.annotations[\"$single_zone_annotation_name\"]")"
+
+  if [[ "$existing_zone" == "null" ]]
+  then
+    # Existing namespace, but not labelled. Don't change scheduling there.
+    # This is for backward compatibility reasons and prevent already running
+    # tests, scheduled over multiple zones, from being forcefully rescheduled
+    # on a new single zone.
+    # Once all the namespaces have the annotation, this backward compatibility
+    # step can be removed.
+    availability_zone="~"
+    echo "Namespace ${namespace} is NOT configured to run on a single availability zone ; scheduling will not be changed."
+  else
+    availability_zone="$existing_zone"
+    echo "Namespace ${namespace} has previously been configured to run on the single availability zone: $availability_zone"
+  fi
+fi
 
 # Sanitize a string to be a valid Kubernetes label value
 sanitize_k8s_label() {
@@ -147,16 +176,6 @@ cp -rv default/ $namespace
 cp -v ../*.yaml $namespace/
 
 cd $namespace
-
-enable_single_zone="${5:-true}"
-enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
-if [[ "$enable_single_zone" == "true" ]]; then
-    availability_zone="$(hashmod_zone "$namespace")"
-    echo "Will configure pods to deploy into the $availability_zone AZ only."
-else
-    availability_zone="~"
-    echo "Will NOT configure pods to deploy into a single zone."
-fi
 
 # Update Makefile to use the namespace and secondary storage
 sed_inplace "s/__NAMESPACE__/$namespace/" Makefile


### PR DESCRIPTION
## Description

The availability zone is picked up once during when the load tests is initialized, based on the load test namespace name.

This should help to reduce the costs of running them by decreasing the inter-zone network traffic.

The "single zone deployment" is currently enforced by default, but we could configure it via a dedicated flag.

For already existing tests: single zone scheduling will not affect these tests, as the underlying disks may not always be available in the selected availability zone.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/50028
