### PR TITLE
[Backport stable/8.9] test: fix process instance table sorting e2e

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -75,8 +75,7 @@ test.describe('Process Instances Table', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  //Skipped due to bug 38103: https://github.com/camunda/camunda/issues/38103
-  test.skip('Sorting of process instances', async ({
+  test('Sorting of process instances', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,
@@ -87,6 +86,7 @@ test.describe('Process Instances Table', () => {
       processB_v_1.processInstanceKey,
       processB_v_2.processInstanceKey,
     ];
+
     await test.step('Extract process instance keys and filter by the extracted values', async () => {
       await operateFiltersPanelPage.displayOptionalFilter(
         'Process Instance Key(s)',
@@ -154,12 +154,12 @@ test.describe('Process Instances Table', () => {
         .poll(() =>
           operateProcessesPage.processInstancesTable.nth(1).innerText(),
         )
-        .toContain(instanceIds[1].toString());
+        .toContain(instanceIds[0].toString());
       await expect
         .poll(() =>
           operateProcessesPage.processInstancesTable.nth(2).innerText(),
         )
-        .toContain(instanceIds[0].toString());
+        .toContain(instanceIds[1].toString());
     });
 
     await test.step('Check sorting of processes by process version ASC', async () => {


### PR DESCRIPTION
# Description
Backport of #49516 to `stable/8.9`.

relates to #38103