### PR TITLE
[stable/8.7] fix: wire OAuth resource property in spring-boot-starter-camunda-sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CredentialsProviderConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CredentialsProviderConfiguration.java
@@ -46,6 +46,7 @@ public class CredentialsProviderConfiguration {
             .clientSecret(camundaClientProperties.getAuth().getClientSecret())
             .audience(camundaClientProperties.getZeebe().getAudience())
             .scope(camundaClientProperties.getZeebe().getScope())
+            .resource(camundaClientProperties.getAuth().getResource())
             .authorizationServerUrl(
                 ofNullable(camundaClientProperties.getAuth().getTokenUrl())
                     .map(URI::toString)

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/AuthProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/AuthProperties.java
@@ -31,6 +31,8 @@ public class AuthProperties {
   private URI tokenUrl;
 
   private String credentialsCachePath;
+  private String resource;
+
   private Duration connectTimeout;
   private Duration readTimeout;
 
@@ -44,6 +46,14 @@ public class AuthProperties {
 
   public void setClientAssertion(final CamundaClientAuthClientAssertionProperties clientAssertion) {
     this.clientAssertion = clientAssertion;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public void setResource(final String resource) {
+    this.resource = resource;
   }
 
   public String getCredentialsCachePath() {
@@ -113,6 +123,9 @@ public class AuthProperties {
         + '\''
         + ", clientSecret='"
         + (clientSecret != null ? "***" : null)
+        + '\''
+        + ", resource='"
+        + resource
         + '\''
         + ", tokenUrl="
         + tokenUrl

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
@@ -35,4 +35,5 @@ camunda.client.auth.client-secret=zeebe.client.cloud.client-secret, zeebe.client
 camunda.client.zeebe.audience=zeebe.client.cloud.audience
 camunda.client.zeebe.scope=zeebe.client.cloud.scope, zeebe.token.scope
 camunda.client.auth.token-url=camunda.client.auth.issuer, zeebe.client.cloud.auth-url, zeebe.authorization.server.url
+camunda.client.auth.resource=zeebe.token.resource
 camunda.client.auth.credentials-cache-path=zeebe.client.cloud.credentials-cache-path, zeebe.client.config.path

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/CredentialsProviderResourceTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/CredentialsProviderResourceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.CredentialsProvider;
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProvider;
+import io.camunda.zeebe.spring.client.configuration.CredentialsProviderConfiguration;
+import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
+import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(
+    classes = {CredentialsProviderConfiguration.class},
+    properties = {
+      "camunda.client.mode=self-managed",
+      "camunda.client.auth.client-id=my-client-id",
+      "camunda.client.auth.client-secret=my-client-secret",
+      "camunda.client.auth.token-url=http://localhost:18080/auth/token",
+      "camunda.client.auth.resource=https://api.example.com"
+    })
+@EnableConfigurationProperties(CamundaClientProperties.class)
+public class CredentialsProviderResourceTest {
+
+  @MockitoBean ZeebeClientExecutorService zeebeClientExecutorService;
+
+  @Autowired CredentialsProvider credentialsProvider;
+  @Autowired CamundaClientProperties camundaClientProperties;
+
+  @Test
+  void shouldCreateOAuthCredentialsProviderWithResource() {
+    assertThat(credentialsProvider).isInstanceOf(OAuthCredentialsProvider.class);
+    assertThat(camundaClientProperties.getAuth().getResource())
+        .isEqualTo("https://api.example.com");
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesPostProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesPostProcessorTest.java
@@ -1211,6 +1211,31 @@ public class ZeebeClientPropertiesPostProcessorTest {
               .isEqualTo("alias-password");
         }
       }
+
+      @SpringBootTest(
+          properties = "spring.config.location=classpath:properties/8.7/self-managed.yaml")
+      @Nested
+      class TokenResource {
+        @Autowired CamundaClientProperties camundaClientProperties;
+
+        @Test
+        void shouldReadTokenResource() {
+          assertThat(camundaClientProperties.getAuth().getResource())
+              .isEqualTo("https://api.example.com");
+        }
+      }
+
+      @Nested
+      @SpringBootTest(properties = "zeebe.token.resource=https://api.example.com")
+      class ZeebeTokenResource {
+        @Autowired CamundaClientProperties camundaClientProperties;
+
+        @Test
+        void shouldReadResource() {
+          assertThat(camundaClientProperties.getAuth().getResource())
+              .isEqualTo("https://api.example.com");
+        }
+      }
     }
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/resources/properties/8.7/self-managed.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/resources/properties/8.7/self-managed.yaml
@@ -5,3 +5,4 @@ camunda:
       client-id: <your client id>
       client-secret: <your client secret>
       token-url: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+      resource: https://api.example.com


### PR DESCRIPTION
## Summary

- Adds `resource` property to `AuthProperties` in the Spring Boot SDK, wired through `CredentialsProviderConfiguration` to the `OAuthCredentialsProviderBuilder`
- Adds legacy property mapping `camunda.client.auth.resource` ↔ `zeebe.token.resource`
- Adds tests for both the new property and the legacy property mapping

Backports the Spring Boot SDK config wiring from #34963 to stable/8.7.

closes #49542