### PR TITLE
[Backport stable/8.9] Ensure complete API response field assertions in MultiDB integration tests for all entities

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIT.java
@@ -255,6 +255,36 @@ public class AuthorizationIT {
   }
 
   @Test
+  void shouldReturnNonEmptyPermissionTypesListForAuthorization() {
+    // given - create an authorization
+    final var authorization =
+        camundaClient
+            .newCreateAuthorizationCommand()
+            .ownerId(USER_ID_1)
+            .ownerType(OwnerType.USER)
+            .resourceId("test-resource")
+            .resourceType(ResourceType.AUTHORIZATION)
+            .permissionTypes(CREATE)
+            .send()
+            .join();
+
+    // when
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newAuthorizationGetRequest(authorization.getAuthorizationKey())
+                      .send()
+                      .join();
+
+              // then
+              assertThat(result.getPermissionTypes()).containsExactly(CREATE);
+            });
+  }
+
+  @Test
   void searchShouldReturnAuthorizationsFilteredByOwnerId() {
     // when
     final var ownerId = USER_ID_3;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
@@ -180,6 +180,17 @@ public class BatchOperationSearchIT {
   }
 
   @Test
+  void shouldReturnEmptyErrorsNotNullForSuccessfulBatchOperation(
+      @Authenticated final CamundaClient camundaClient) {
+    // when - get a successful batch operation with no errors
+    final var batch = camundaClient.newBatchOperationGetRequest(batchOperationKey1).send().join();
+
+    // then
+    assertThat(batch.getErrors()).isEmpty();
+    assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+  }
+
+  @Test
   void shouldSearchBatchOperationWithIn(@Authenticated final CamundaClient camundaClient) {
     // when
     final var page =
@@ -458,12 +469,14 @@ public class BatchOperationSearchIT {
   private static void assertCancelBatchOperation(final BatchOperation batch) {
     assertThat(batch).isNotNull();
     assertThat(batch.getStartDate()).isNotNull();
+    assertThat(batch.getEndDate()).isAfterOrEqualTo(batch.getStartDate());
     assertThat(batch.getBatchOperationKey()).isEqualTo(batchOperationKey1);
     assertThat(batch.getType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
     assertThat(batch.getOperationsTotalCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_1.size());
     assertThat(batch.getOperationsCompletedCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_1.size());
     assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+    assertThat(batch.getErrors()).isEmpty();
     assertThat(batch.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
     assertThat(batch.getActorId()).isEqualTo(InitializationConfiguration.DEFAULT_USER_USERNAME);
   }
@@ -471,12 +484,14 @@ public class BatchOperationSearchIT {
   private static void assertMigrateBatchOperation(final BatchOperation batch) {
     assertThat(batch).isNotNull();
     assertThat(batch.getStartDate()).isNotNull();
+    assertThat(batch.getEndDate()).isAfterOrEqualTo(batch.getStartDate());
     assertThat(batch.getBatchOperationKey()).isEqualTo(batchOperationKey2);
     assertThat(batch.getType()).isEqualTo(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
     assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
     assertThat(batch.getOperationsTotalCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_2.size());
     assertThat(batch.getOperationsCompletedCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_2.size());
     assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+    assertThat(batch.getErrors()).isEmpty();
     assertThat(batch.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
     assertThat(batch.getActorId()).isEqualTo(InitializationConfiguration.DEFAULT_USER_USERNAME);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchIT.java
@@ -163,6 +163,44 @@ public class ClusterVariableSearchIT {
             largeVarName, largeVarValue));
   }
 
+  // ============ GET TESTS ============
+
+  @Test
+  void shouldGetGloballyScopedClusterVariableByName() {
+    // when
+    final var result =
+        camundaClient
+            .newGloballyScopedClusterVariableGetRequest()
+            .withName(globalVarName1)
+            .send()
+            .join();
+
+    // then - assert all fields
+    assertThat(result.getName()).isEqualTo(globalVarName1);
+    assertThat(result.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValue1));
+    assertThat(result.getTenantId()).isNull();
+    assertThat(result.getScope()).isEqualTo(ClusterVariableScope.GLOBAL);
+    assertThat(result.isTruncated()).isFalse();
+  }
+
+  @Test
+  void shouldGetTenantScopedClusterVariableByName() {
+    // when
+    final var result =
+        camundaClient
+            .newTenantScopedClusterVariableGetRequest(tenantId)
+            .withName(tenantVarName1)
+            .send()
+            .join();
+
+    // then - assert all fields
+    assertThat(result.getName()).isEqualTo(tenantVarName1);
+    assertThat(result.getValue()).isEqualTo(VALUE_RESULT.formatted(tenantVarValue1));
+    assertThat(result.getTenantId()).isEqualTo(tenantId);
+    assertThat(result.getScope()).isEqualTo(ClusterVariableScope.TENANT);
+    assertThat(result.isTruncated()).isFalse();
+  }
+
   // ============ SEARCH TESTS ============
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionSearchIT.java
@@ -75,7 +75,7 @@ public class CorrelatedMessageSubscriptionSearchIT {
         camundaClient.newCorrelatedMessageSubscriptionSearchRequest().send().join();
 
     // Then
-    assertThat(searchResponse.items()).size().isEqualTo(NUMBER_OF_CORRELATED_MESSAGES);
+    assertThat(searchResponse.items()).hasSize(NUMBER_OF_CORRELATED_MESSAGES);
     assertThat(searchResponse.page().totalItems()).isEqualTo(NUMBER_OF_CORRELATED_MESSAGES);
     assertThat(searchResponse.items())
         .containsExactlyInAnyOrderElementsOf(orderedCorrelatedMessageSubscriptions);
@@ -111,7 +111,7 @@ public class CorrelatedMessageSubscriptionSearchIT {
             .join();
 
     // Then
-    assertThat(searchResponse.items()).size().isEqualTo(1);
+    assertThat(searchResponse.items()).hasSize(1);
     assertThat(searchResponse.items().getFirst()).isEqualTo(expectedCorrelatedMessageSubscription);
   }
 
@@ -145,7 +145,7 @@ public class CorrelatedMessageSubscriptionSearchIT {
             .join();
 
     // Then
-    assertThat(searchResponse.items()).size().isEqualTo(1);
+    assertThat(searchResponse.items()).hasSize(1);
     assertThat(searchResponse.items().getFirst()).isEqualTo(expectedCorrelatedMessageSubscription);
   }
 
@@ -160,7 +160,7 @@ public class CorrelatedMessageSubscriptionSearchIT {
             .join();
 
     // Then
-    assertThat(searchResponse.items()).size().isEqualTo(NUMBER_OF_CORRELATED_MESSAGES);
+    assertThat(searchResponse.items()).hasSize(NUMBER_OF_CORRELATED_MESSAGES);
     assertThat(searchResponse.items())
         .containsExactlyElementsOf(
             orderedCorrelatedMessageSubscriptions.stream()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
@@ -689,6 +689,8 @@ class DecisionInstanceSearchIT {
             .getEvaluatedDecisions()
             .getFirst()
             .getDecisionKey();
+    final long rootDecisionDefinitionKey =
+        EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_2).getDecisionKey();
     final var result =
         camundaClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
 
@@ -706,7 +708,7 @@ class DecisionInstanceSearchIT {
     assertThat(result.getDecisionDefinitionType()).isEqualTo(DecisionDefinitionType.DECISION_TABLE);
     assertThat(result.getTenantId()).isEqualTo("<default>");
     assertThat(result.getDecisionDefinitionKey()).isEqualTo(decisionDefinitionKey);
-    assertThat(result.getRootDecisionDefinitionKey()).isEqualTo(decisionDefinitionKey);
+    assertThat(result.getRootDecisionDefinitionKey()).isEqualTo(rootDecisionDefinitionKey);
     assertThat(result.getResult()).isEqualTo("\"day-to-day expense\"");
     assertThat(result.getEvaluationDate()).isNotNull();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
@@ -706,6 +706,7 @@ class DecisionInstanceSearchIT {
     assertThat(result.getDecisionDefinitionType()).isEqualTo(DecisionDefinitionType.DECISION_TABLE);
     assertThat(result.getTenantId()).isEqualTo("<default>");
     assertThat(result.getDecisionDefinitionKey()).isEqualTo(decisionDefinitionKey);
+    assertThat(result.getRootDecisionDefinitionKey()).isEqualTo(decisionDefinitionKey);
     assertThat(result.getResult()).isEqualTo("\"day-to-day expense\"");
     assertThat(result.getEvaluationDate()).isNotNull();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
@@ -679,36 +679,51 @@ class DecisionInstanceSearchIT {
 
   @Test
   void shouldGetDecisionInstance() {
-    // when
+    // given
     final long decisionInstanceKey =
         EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_2).getDecisionEvaluationKey();
-    final var decisionInstanceId = "%d-%d".formatted(decisionInstanceKey, 1);
-    final long decisionDefinitionKey =
-        EVALUATED_DECISIONS
-            .get(DECISION_DEFINITION_ID_2)
-            .getEvaluatedDecisions()
-            .getFirst()
-            .getDecisionKey();
-    final long rootDecisionDefinitionKey =
-        EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_2).getDecisionKey();
+    final var searchResult =
+        camundaClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.decisionInstanceKey(decisionInstanceKey))
+            .send()
+            .join();
+    assertThat(searchResult.items()).hasSize(2);
+    final var expectedDecisionInstance =
+        searchResult.items().stream()
+            .filter(
+                decisionInstance ->
+                    DECISION_DEFINITION_ID_3.equals(decisionInstance.getDecisionDefinitionId()))
+            .findFirst()
+            .orElseThrow();
+
+    // when
     final var result =
-        camundaClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
+        camundaClient
+            .newDecisionInstanceGetRequest(expectedDecisionInstance.getDecisionInstanceId())
+            .send()
+            .join();
 
     // then
     assertThat(result.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
-    assertThat(result.getDecisionInstanceId()).isEqualTo(decisionInstanceId);
+    assertThat(result.getDecisionInstanceId())
+        .isEqualTo(expectedDecisionInstance.getDecisionInstanceId());
     assertThat(result.getState()).isEqualTo(DecisionInstanceState.EVALUATED);
     assertThat(result.getEvaluationFailure()).isNull();
     assertThat(result.getProcessDefinitionKey()).isEqualTo(-1L);
     assertThat(result.getProcessInstanceKey()).isEqualTo(-1L);
     assertThat(result.getElementInstanceKey()).isEqualTo(-1L);
-    assertThat(result.getDecisionDefinitionId()).isEqualTo("invoiceClassification");
-    assertThat(result.getDecisionDefinitionName()).isEqualTo("Invoice Classification");
+    assertThat(result.getDecisionDefinitionId())
+        .isEqualTo(expectedDecisionInstance.getDecisionDefinitionId());
+    assertThat(result.getDecisionDefinitionName())
+        .isEqualTo(expectedDecisionInstance.getDecisionDefinitionName());
     assertThat(result.getDecisionDefinitionVersion()).isEqualTo(1);
     assertThat(result.getDecisionDefinitionType()).isEqualTo(DecisionDefinitionType.DECISION_TABLE);
     assertThat(result.getTenantId()).isEqualTo("<default>");
-    assertThat(result.getDecisionDefinitionKey()).isEqualTo(decisionDefinitionKey);
-    assertThat(result.getRootDecisionDefinitionKey()).isEqualTo(rootDecisionDefinitionKey);
+    assertThat(result.getDecisionDefinitionKey())
+        .isEqualTo(expectedDecisionInstance.getDecisionDefinitionKey());
+    assertThat(result.getRootDecisionDefinitionKey())
+        .isEqualTo(expectedDecisionInstance.getRootDecisionDefinitionKey());
     assertThat(result.getResult()).isEqualTo("\"day-to-day expense\"");
     assertThat(result.getEvaluationDate()).isNotNull();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchIT.java
@@ -567,9 +567,16 @@ class DecisionSearchIT {
             .send()
             .join();
 
-    // then
+    // then - assert all fields
     assertThat(result.getDecisionRequirementsKey())
         .isEqualTo(exampleDecisionRequirements.getDecisionRequirementsKey());
+    assertThat(result.getDmnDecisionRequirementsId())
+        .isEqualTo(exampleDecisionRequirements.getDmnDecisionRequirementsId());
+    assertThat(result.getDmnDecisionRequirementsName())
+        .isEqualTo(exampleDecisionRequirements.getDmnDecisionRequirementsName());
+    assertThat(result.getVersion()).isEqualTo(exampleDecisionRequirements.getVersion());
+    assertThat(result.getResourceName()).isEqualTo(exampleDecisionRequirements.getResourceName());
+    assertThat(result.getTenantId()).isEqualTo(exampleDecisionRequirements.getTenantId());
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchIT.java
@@ -738,7 +738,7 @@ public class ElementInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items()).size().isEqualTo(3);
+    assertThat(result.items()).hasSize(3);
     assertThat(result.items().stream().map(ElementInstance::getElementId))
         .containsExactlyInAnyOrder("start_event", "sub_process", "end_event");
   }
@@ -767,7 +767,7 @@ public class ElementInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items()).size().isEqualTo(3);
+    assertThat(result.items()).hasSize(3);
     assertThat(result.items().stream().map(ElementInstance::getElementId))
         .containsExactlyInAnyOrder("sub_start_event", "bar_mi_task", "sub_end_event");
   }
@@ -798,7 +798,7 @@ public class ElementInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items()).size().isEqualTo(2);
+    assertThat(result.items()).hasSize(2);
     assertThat(result.items().stream().map(ElementInstance::getElementId))
         .containsExactlyInAnyOrder("bar_mi_task", "bar_mi_task");
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchIT.java
@@ -334,7 +334,7 @@ public class ElementInstanceSearchIT {
     final var result = camundaClient.newElementInstanceGetRequest(elementInstanceKey).send().join();
 
     // then
-    assertThat(result).isNotNull().isEqualTo(elementInstance);
+    assertThat(result).isEqualTo(elementInstance);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchIT.java
@@ -118,9 +118,7 @@ class IncidentSearchIT {
     final var result = camundaClient.newIncidentGetRequest(incidentKey).send().join();
 
     // then
-    assertThat(result).isNotNull();
-    assertThat(result.getIncidentKey()).isEqualTo(incidentKey);
-    assertThat(result.getRootProcessInstanceKey()).isEqualTo(incident.getProcessInstanceKey());
+    assertThat(result).isEqualTo(incident);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchIT.java
@@ -244,11 +244,10 @@ public class JobSearchIT {
             .send()
             .join();
 
-    // then
+    // then - assert all fields with explicit expected values to ensure consistency across storage
+    // backends
     assertThat(result.items()).hasSize(1);
-    assertThat(result.items().getFirst().getJobKey()).isEqualTo(taskABpmnJob.getJobKey());
-    assertThat(result.items().getFirst().getRootProcessInstanceKey())
-        .isEqualTo(taskABpmnJob.getProcessInstanceKey());
+    assertThat(result.items().getFirst()).isEqualTo(taskABpmnJob);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchIT.java
@@ -247,7 +247,7 @@ public class JobSearchIT {
     // then - assert all fields with explicit expected values to ensure consistency across storage
     // backends
     assertThat(result.items()).hasSize(1);
-    assertThat(result.items().getFirst()).isEqualTo(taskABpmnJob);
+    assertThat(result.items().getFirst()).usingRecursiveComparison().isEqualTo(taskABpmnJob);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesSearchIT.java
@@ -42,6 +42,18 @@ public class MappingRulesSearchIT {
   }
 
   @Test
+  void shouldGetMappingRuleById() {
+    // when
+    final var mappingRule = camundaClient.newMappingRuleGetRequest(MAPPING_RULE_ID_1).send().join();
+
+    // then - assert all fields
+    assertThat(mappingRule.getMappingRuleId()).isEqualTo(MAPPING_RULE_ID_1);
+    assertThat(mappingRule.getClaimName()).isEqualTo(CLAIM_NAME_1);
+    assertThat(mappingRule.getClaimValue()).isEqualTo(CLAIM_VALUE_1);
+    assertThat(mappingRule.getName()).isEqualTo("test-" + MAPPING_RULE_ID_1);
+  }
+
+  @Test
   void searchShouldReturnAllMappingRules() {
     // when
     final var mappingRuleSearchResponse =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
@@ -73,7 +73,7 @@ public class MessageSubscriptionSearchIT {
     final var searchResponse = camundaClient.newMessageSubscriptionSearchRequest().send().join();
 
     // Then
-    assertThat(searchResponse.items()).size().isEqualTo(NUMBER_OF_MESSAGE_SUBSCRIPTIONS);
+    assertThat(searchResponse.items()).hasSize(NUMBER_OF_MESSAGE_SUBSCRIPTIONS);
     assertThat(searchResponse.page().totalItems()).isEqualTo(NUMBER_OF_MESSAGE_SUBSCRIPTIONS);
     assertThat(searchResponse.items())
         .containsExactlyInAnyOrderElementsOf(orderedMessageSubscriptions);
@@ -107,7 +107,7 @@ public class MessageSubscriptionSearchIT {
             .join();
 
     // Then
-    assertThat(searchResponse.items()).size().isEqualTo(1);
+    assertThat(searchResponse.items()).hasSize(1);
     assertThat(searchResponse.items().getFirst()).isEqualTo(expectedMessageSubscription);
   }
 
@@ -122,7 +122,7 @@ public class MessageSubscriptionSearchIT {
             .join();
 
     // Then
-    assertThat(searchResponse.items()).size().isEqualTo(1);
+    assertThat(searchResponse.items()).hasSize(1);
     assertThat(searchResponse.items().getFirst())
         .extracting("messageName", "messageSubscriptionState")
         .containsExactly("Message1", MessageSubscriptionState.CORRELATED);
@@ -139,7 +139,7 @@ public class MessageSubscriptionSearchIT {
             .join();
 
     // Then
-    assertThat(searchResponse.items()).size().isEqualTo(NUMBER_OF_MESSAGE_SUBSCRIPTIONS);
+    assertThat(searchResponse.items()).hasSize(NUMBER_OF_MESSAGE_SUBSCRIPTIONS);
     assertThat(searchResponse.items())
         .containsExactlyElementsOf(
             orderedMessageSubscriptions.stream()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
@@ -109,8 +109,6 @@ public class MessageSubscriptionSearchIT {
     // Then
     assertThat(searchResponse.items()).size().isEqualTo(1);
     assertThat(searchResponse.items().getFirst()).isEqualTo(expectedMessageSubscription);
-    assertThat(searchResponse.items().getFirst().getRootProcessInstanceKey())
-        .isEqualTo(expectedMessageSubscription.getProcessInstanceKey());
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -124,18 +124,20 @@ public class ProcessInstanceSearchIT {
     final var result = camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
 
     // then
-    assertThat(result).isNotNull();
     assertThat(result.getProcessInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(result.getProcessDefinitionId()).isEqualTo(bpmnProcessId);
     assertThat(result.getProcessDefinitionName()).isEqualTo("Service tasks v1");
     assertThat(result.getProcessDefinitionVersion()).isEqualTo(1);
+    assertThat(result.getProcessDefinitionVersionTag()).isNull();
     assertThat(result.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+    assertThat(result.getParentProcessInstanceKey()).isNull();
+    assertThat(result.getParentElementInstanceKey()).isNull();
     assertThat(result.getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
-    assertThat(result.getStartDate()).isNotNull();
     assertThat(result.getEndDate()).isNull();
     assertThat(result.getState()).isEqualTo(ACTIVE);
     assertThat(result.getHasIncident()).isFalse();
     assertThat(result.getTenantId()).isEqualTo("<default>");
+    assertThat(result.getTags()).isEmpty();
   }
 
   @Test
@@ -769,6 +771,9 @@ public class ProcessInstanceSearchIT {
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items().stream().map(ProcessInstance::getProcessDefinitionId).toList())
         .containsExactlyInAnyOrder("child_process_v1");
+    // Verify that parentProcessInstanceKey is correctly set in the results
+    assertThat(result.items().getFirst().getParentProcessInstanceKey())
+        .isEqualTo(parentProcessInstanceKey);
     assertThat(result.items().getFirst().getRootProcessInstanceKey())
         .isEqualTo(parentProcessInstanceKey);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -489,7 +489,7 @@ public class ProcessInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items()).size().isEqualTo(5);
+    assertThat(result.items()).hasSize(5);
   }
 
   @Test
@@ -503,7 +503,7 @@ public class ProcessInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items()).size().isEqualTo(5);
+    assertThat(result.items()).hasSize(5);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchIT.java
@@ -40,6 +40,17 @@ public class RolesSearchIT {
   }
 
   @Test
+  void shouldGetRoleById() {
+    // when
+    final var role = camundaClient.newRoleGetRequest(ROLE_ID_1).send().join();
+
+    // then - assert all fields
+    assertThat(role.getRoleId()).isEqualTo(ROLE_ID_1);
+    assertThat(role.getName()).isEqualTo(ROLE_NAME_1);
+    assertThat(role.getDescription()).isEqualTo("description");
+  }
+
+  @Test
   void searchShouldReturnRoleFilteredByRoleName() {
     final var roleSearchResponse =
         camundaClient.newRolesSearchRequest().filter(fn -> fn.name(ROLE_NAME_1)).send().join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantsSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantsSearchIT.java
@@ -40,6 +40,17 @@ public class TenantsSearchIT {
   }
 
   @Test
+  void shouldGetTenantById() {
+    // when
+    final var tenant = camundaClient.newTenantGetRequest(TENANT_ID_1).send().join();
+
+    // then - assert all fields
+    assertThat(tenant.getTenantId()).isEqualTo(TENANT_ID_1);
+    assertThat(tenant.getName()).isEqualTo(TENANT_NAME_1);
+    assertThat(tenant.getDescription()).isEqualTo("description");
+  }
+
+  @Test
   void searchShouldReturnTenantFilteredByTenantName() {
     final var tenantSearchResponse =
         camundaClient.newTenantsSearchRequest().filter(fn -> fn.name(TENANT_NAME_1)).send().join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
@@ -681,7 +681,7 @@ class UserTaskSearchIT {
     final var result = camundaClient.newUserTaskGetRequest(userTaskSubprocessKey).send().join();
 
     // then
-    assertThat(result).isEqualTo(expectedTask);
+    assertThat(result).usingRecursiveComparison().isEqualTo(expectedTask);
   }
 
   @Test
@@ -797,7 +797,7 @@ class UserTaskSearchIT {
             .join();
 
     // then - assert optional text fields are null (not empty string)
-    assertThat(result.items()).hasSize(2);
+    assertThat(result.items()).hasSize(1);
     final var task = result.items().getFirst();
     assertThat(task.getAssignee()).isNull();
     assertThat(task.getFormKey()).isNull();
@@ -815,7 +815,7 @@ class UserTaskSearchIT {
             .join();
 
     // then - assert optional date fields
-    assertThat(result.items()).hasSize(2);
+    assertThat(result.items()).hasSize(1);
     final var task = result.items().getFirst();
     assertThat(task.getCompletionDate()).isNull();
     assertThat(task.getDueDate())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
@@ -673,11 +673,7 @@ class UserTaskSearchIT {
   void shouldGetUserTaskByKey() {
     // given
     final var searchResult =
-        camundaClient
-            .newUserTaskSearchRequest()
-            .filter(f -> f.elementId("TaskSub"))
-            .send()
-            .join();
+        camundaClient.newUserTaskSearchRequest().filter(f -> f.elementId("TaskSub")).send().join();
     assertThat(searchResult.items()).hasSize(1);
     final var expectedTask = searchResult.items().getFirst();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -670,11 +671,21 @@ class UserTaskSearchIT {
 
   @Test
   void shouldGetUserTaskByKey() {
-    // when
-    final var result = camundaClient.newUserTaskGetRequest(userTaskKeyTaskAssigned).send().join();
+    // given
+    final var searchResult =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.elementId("TaskSub"))
+            .send()
+            .join();
+    assertThat(searchResult.items()).hasSize(1);
+    final var expectedTask = searchResult.items().getFirst();
+
+    // when - retrieve the subprocess task which is in an active state
+    final var result = camundaClient.newUserTaskGetRequest(userTaskSubprocessKey).send().join();
 
     // then
-    assertThat(result.getUserTaskKey()).isEqualTo(userTaskKeyTaskAssigned);
+    assertThat(result).isEqualTo(expectedTask);
   }
 
   @Test
@@ -730,6 +741,95 @@ class UserTaskSearchIT {
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
         .contains("User Task with key '%d' not found".formatted(userTaskKey));
+  }
+
+  @Test
+  void shouldReturnEmptyCollectionsNotNullForUserTaskWithoutCandidates() {
+    // given - find a task without candidate groups or users (process "simple.bpmn" has no
+    // candidates)
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items())
+        .allSatisfy(
+            task -> {
+              assertThat(task.getBpmnProcessId()).isEqualTo("process");
+              assertThat(task.getCandidateGroups()).isEmpty();
+              assertThat(task.getCandidateUsers()).isEmpty();
+              assertThat(task.getCustomHeaders()).isEmpty();
+              assertThat(task.getTags()).isEmpty();
+            });
+  }
+
+  @Test
+  void shouldReturnEmptyCollectionsNotNullWhenGettingUserTaskByKey() {
+    // given - get task by key (process "simple.bpmn" has no candidates)
+    final var searchResult =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process"))
+            .send()
+            .join();
+    assertThat(searchResult.items()).hasSize(2);
+    final var taskKey = searchResult.items().getFirst().getUserTaskKey();
+
+    // when
+    final var result = camundaClient.newUserTaskGetRequest(taskKey).send().join();
+
+    // then
+    assertThat(result.getUserTaskKey()).isEqualTo(taskKey);
+    assertThat(result.getCandidateGroups()).isEmpty();
+    assertThat(result.getCandidateUsers()).isEmpty();
+    assertThat(result.getCustomHeaders()).isEmpty();
+    assertThat(result.getTags()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNullForOptionalTextFields() {
+    // given - find a task without assignee, formKey, externalFormReference
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process").state(UserTaskState.CREATED))
+            .send()
+            .join();
+
+    // then - assert optional text fields are null (not empty string)
+    assertThat(result.items()).hasSize(2);
+    final var task = result.items().getFirst();
+    assertThat(task.getAssignee()).isNull();
+    assertThat(task.getFormKey()).isNull();
+    assertThat(task.getExternalFormReference()).isNull();
+  }
+
+  @Test
+  void shouldReturnNullOrDefaultForOptionalDateFields() {
+    // given - find a task that hasn't been completed (no completion/due/followUp dates)
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process").state(UserTaskState.CREATED))
+            .send()
+            .join();
+
+    // then - assert optional date fields
+    assertThat(result.items()).hasSize(2);
+    final var task = result.items().getFirst();
+    assertThat(task.getCompletionDate()).isNull();
+    assertThat(task.getDueDate())
+        .isCloseTo(
+            OffsetDateTime.now().minusDays(1),
+            new TemporalUnitWithinOffset(5, java.time.temporal.ChronoUnit.SECONDS));
+    assertThat(task.getFollowUpDate())
+        .isCloseTo(
+            OffsetDateTime.now().minusDays(1),
+            new TemporalUnitWithinOffset(5, java.time.temporal.ChronoUnit.SECONDS));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchIT.java
@@ -326,7 +326,7 @@ class VariableSearchIT {
     final var result = camundaClient.newVariableGetRequest(variable.getVariableKey()).send().join();
 
     // then
-    assertThat(result).isEqualTo(variable);
+    assertThat(result).usingRecursiveComparison().isEqualTo(variable);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchIT.java
@@ -326,8 +326,7 @@ class VariableSearchIT {
     final var result = camundaClient.newVariableGetRequest(variable.getVariableKey()).send().join();
 
     // then
-    assertThat(result.getVariableKey()).isEqualTo(variable.getVariableKey());
-    assertThat(result.getRootProcessInstanceKey()).isEqualTo(variable.getProcessInstanceKey());
+    assertThat(result).isEqualTo(variable);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #45388 to `stable/8.9`.

relates to camunda/camunda#45124