### PR TITLE
[Backport stable/8.6] fix: add registry label to cloud load test namespace setup

### DIFF
--- a/zeebe/benchmarks/setup/cloud-default/Makefile
+++ b/zeebe/benchmarks/setup/cloud-default/Makefile
@@ -3,7 +3,7 @@ curl_image ?= curlimages/curl:7.87.0
 # Optional: additional Helm configuration for the load test release.
 # Use this to pass extra `--set`/`-f` flags when installing/upgrading the load tests.
 # See the load test README for example values and guidance.
-additional_load_test_configuration ?=
+additional_load_test_configuration ?= --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
 
 SHELL = /bin/bash
 
@@ -14,11 +14,11 @@ all: install
 install: install-load-test
 
 .PHONY: realistic
-realistic: additional_load_test_configuration = -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+realistic: additional_load_test_configuration = -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
 realistic: install-load-test
 
 .PHONY: typical
-typical: additional_load_test_configuration = --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn
+typical: additional_load_test_configuration = --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
 typical: install-load-test
 
 # Install/upgrade load test helm chart

--- a/zeebe/benchmarks/setup/newCloudBenchmark.sh
+++ b/zeebe/benchmarks/setup/newCloudBenchmark.sh
@@ -45,6 +45,10 @@ if [[ ! "$namespace" =~ ^c8- ]]; then
 fi
 
 kubectl create namespace $namespace
+
+# Label namespace with registry (required to inject image pull secrets)
+kubectl label namespace "$namespace" registry=harbor --overwrite
+
 cp -rv cloud-default/ $namespace
 cd $namespace
 


### PR DESCRIPTION
# Description
Backport of #49443 to `stable/8.6`.

relates to 