### PR TITLE
ci: add nodeSelector and tolerations for identity, optimize, and keycloak

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -57,6 +57,13 @@ identity:
     secret:
       existingSecret: camunda-credentials
       existingSecretKey: identity-firstuser-password
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 optimize:
   enabled: true
@@ -66,9 +73,23 @@ optimize:
         historyCleanup:
           cronTrigger: '0 1 * * *'
           ttl: 'P1D'
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 identityKeycloak:
   enabled: true
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 connectors:
   enabled: true


### PR DESCRIPTION
## Summary

- Pin identity, optimize, and identityKeycloak pods to `benchmark-n2-standard-4` nodes in load test helm values
- Consistent with other load test components that already have these node constraints

## Related issues

Extracted from #48904

🤖 Generated with [Claude Code](https://claude.com/claude-code)