### PR TITLE
[Backport stable/8.8] ci: add nodeSelector and tolerations for identity, optimize, and keycloak

### DIFF
--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -35,12 +35,33 @@ global:
 
 identity:
   enabled: false
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 identityKeycloak:
   enabled: false
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 optimize:
   enabled: false
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 connectors:
   enabled: false


### PR DESCRIPTION
# Description
Backport of #49554 to `stable/8.8`.

relates to #48904