### PR TITLE
[Backport stable/8.9] ci: add nodeSelector and tolerations for identity, optimize, and keycloak

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -51,6 +51,13 @@ identity:
     secret:
       existingSecret: camunda-credentials
       existingSecretKey: identity-firstuser-password
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 optimize:
   enabled: true
@@ -60,9 +67,23 @@ optimize:
         historyCleanup:
           cronTrigger: '0 1 * * *'
           ttl: 'P1D'
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 identityKeycloak:
   enabled: true
+  nodeSelector:
+    component: benchmark-n2-standard-4
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
 connectors:
   enabled: true


### PR DESCRIPTION
# Description
Backport of #49554 to `stable/8.9`.

relates to #48904