### PR TITLE
[Backport stable/8.6] fix: wire OAuth resource property in spring-boot-starter-camunda-sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -343,6 +343,11 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
         configCache);
   }
 
+  @Override
+  public int getMaxHttpConnections() {
+    return camundaClientProperties.getMaxHttpConnections();
+  }
+
   private CredentialsProvider credentialsProvider() {
     final ClientMode clientMode = camundaClientProperties.getMode();
     if (ClientMode.selfManaged.equals(clientMode) || ClientMode.saas.equals(clientMode)) {
@@ -351,6 +356,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
           .clientSecret(camundaClientProperties.getAuth().getClientSecret())
           .audience(camundaClientProperties.getZeebe().getAudience())
           .authorizationServerUrl(camundaClientProperties.getAuth().getIssuer())
+          .resource(camundaClientProperties.getAuth().getResource())
           .scope(camundaClientProperties.getZeebe().getScope())
           .credentialsCachePath(camundaClientProperties.getAuth().getCredentialsCachePath())
           .connectTimeout(camundaClientProperties.getAuth().getConnectTimeout())
@@ -366,11 +372,6 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
           .build();
     }
     return new NoopCredentialsProvider();
-  }
-
-  @Override
-  public int getMaxHttpConnections() {
-    return camundaClientProperties.getMaxHttpConnections();
   }
 
   private String composeGatewayAddress() {
@@ -426,6 +427,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
           .clientId(properties.getCloud().getClientId())
           .clientSecret(properties.getCloud().getClientSecret())
           .audience(properties.getCloud().getAudience())
+          .resource(camundaClientProperties.getAuth().getResource())
           .scope(properties.getCloud().getScope())
           .authorizationServerUrl(properties.getCloud().getAuthUrl())
           .credentialsCachePath(properties.getCloud().getCredentialsCachePath())

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/AuthProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/AuthProperties.java
@@ -27,6 +27,7 @@ public class AuthProperties {
 
   private String issuer;
   private String credentialsCachePath;
+  private String resource;
 
   private Duration connectTimeout;
   private Duration readTimeout;
@@ -41,6 +42,14 @@ public class AuthProperties {
 
   public void setClientAssertion(final CamundaClientAuthClientAssertionProperties clientAssertion) {
     this.clientAssertion = clientAssertion;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public void setResource(final String resource) {
+    this.resource = resource;
   }
 
   public String getCredentialsCachePath() {
@@ -99,6 +108,9 @@ public class AuthProperties {
         + '\''
         + ", clientSecret='"
         + (clientSecret != null ? "***" : null)
+        + '\''
+        + ", resource='"
+        + resource
         + '\''
         + ", issuer="
         + issuer

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/CredentialsProviderResourceTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/CredentialsProviderResourceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProvider;
+import io.camunda.zeebe.spring.client.configuration.JsonMapperConfiguration;
+import io.camunda.zeebe.spring.client.configuration.ZeebeClientConfigurationImpl;
+import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
+import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
+import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(
+    classes = {
+      JsonMapperConfiguration.class,
+      ZeebeClientConfigurationImpl.class,
+    },
+    properties = {
+      "camunda.client.mode=self-managed",
+      "camunda.client.auth.client-id=my-client-id",
+      "camunda.client.auth.client-secret=my-client-secret",
+      "camunda.client.auth.token-url=http://localhost:18080/auth/token",
+      "camunda.client.auth.resource=https://api.example.com"
+    })
+@EnableConfigurationProperties({
+  CamundaClientProperties.class,
+  ZeebeClientConfigurationProperties.class
+})
+public class CredentialsProviderResourceTest {
+
+  @MockitoBean ZeebeClientExecutorService zeebeClientExecutorService;
+
+  @Autowired ZeebeClientConfigurationImpl zeebeClientConfiguration;
+  @Autowired CamundaClientProperties camundaClientProperties;
+
+  @Test
+  void shouldCreateOAuthCredentialsProviderWithResource() {
+    assertThat(zeebeClientConfiguration.getCredentialsProvider())
+        .isInstanceOf(OAuthCredentialsProvider.class);
+    assertThat(camundaClientProperties.getAuth().getResource())
+        .isEqualTo("https://api.example.com");
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesTest.java
@@ -27,7 +27,10 @@ public class CamundaClientPropertiesTest {
   @Nested
   @SpringBootTest(
       classes = CamundaClientPropertiesTestConfig.class,
-      properties = {"camunda.client.auth.credentials-cache-path=/some/path"})
+      properties = {
+        "camunda.client.auth.credentials-cache-path=/some/path",
+        "camunda.client.auth.resource=https://api.example.com"
+      })
   class CredentialsCachePathConfigTest {
     @Autowired CamundaClientProperties camundaClientProperties;
 
@@ -35,6 +38,12 @@ public class CamundaClientPropertiesTest {
     void shouldApplyProperty() {
       assertThat(camundaClientProperties.getAuth().getCredentialsCachePath())
           .isEqualTo("/some/path");
+    }
+
+    @Test
+    void shouldReadResource() {
+      assertThat(camundaClientProperties.getAuth().getResource())
+          .isEqualTo("https://api.example.com");
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #49545 to `stable/8.6`.

relates to #34963 #49542