### PR TITLE
fix: Loadtest Container Names

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -53,6 +53,7 @@ global:
 
 identity:
   enabled: true
+  fullnameOverride: identity # we override the names for simplicity of the deployment
   firstUser:
     secret:
       existingSecret: camunda-credentials
@@ -67,6 +68,7 @@ identity:
 
 optimize:
   enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
   extraConfiguration:
     - file: application.yml
       content: |
@@ -83,6 +85,7 @@ optimize:
 
 identityKeycloak:
   enabled: true
+  fullnameOverride: keycloak # we override the names for simplicity of the deployment
   nodeSelector:
     component: benchmark-n2-standard-4
   tolerations:
@@ -90,9 +93,12 @@ identityKeycloak:
       operator: Equal
       value: n2-standard-4
       effect: NoSchedule
+  postgresql:
+    fullnameOverride: keycloak-postgresql # we override the names for simplicity of the deployment
 
 connectors:
   enabled: true
+  fullnameOverride: connectors # we override the names for simplicity of the deployment
   security:
     authentication:
       method: oidc
@@ -235,11 +241,11 @@ orchestration:
   extraVolumeMounts:
     - name: logs
       mountPath: /usr/local/camunda/logs
-  # Retention for the ES Exporter indices - legacy Zeebe indices    
+  # Retention for the ES Exporter indices - legacy Zeebe indices
   retention:
     enabled: true
     minimumAge: 1d
-  # Retention for the Camunda Exporter  
+  # Retention for the Camunda Exporter
   history:
     retention:
       ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.


### PR DESCRIPTION


## Description

The identity, optimize and connectors done have a full name set so as a result it will create containers with full namespace name name + container + unique hash and its exceeding the 63 container name char limit most often.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
