### PR TITLE
ci: trigger helm integration workflow on parent/pom.xml changes

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -44,6 +44,7 @@ on:
       - "tasklist/**"
       - "identity/**"
       - "optimize/**"
+      - "parent/pom.xml"
 
 # Limit workflow to 1 concurrent run per ref (branch) and trigger event (push/schedule/etc): new commit -> old runs are canceled to save costs
 # Exception for main + stable/* branches: complete builds for every commit needed for confidence


### PR DESCRIPTION
## Summary
- Add `parent/pom.xml` to the `pull_request.paths` trigger in the Docker Build & Helm Integration workflow
- Dependency version changes in `parent/pom.xml` can affect the Docker build and helm integration tests, so PRs touching it should be validated

## Test plan
- [ ] Verify the workflow triggers on a PR that modifies `parent/pom.xml`
- [ ] Verify existing path triggers still work