### PR TITLE
test: Multi instance subprocess modifications

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -307,7 +307,7 @@ export class OperateProcessInstanceViewModificationModePage {
   }
 
   async clickMoveAllButtononPopup(): Promise<void> {
-    await this.moveAllButtononPopup.click({force: true});
+    await this.moveAllButtononPopup.click();
   }
 
   async clickMoveInstanceButtononPopup(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -149,43 +149,21 @@ export class OperateProcessInstanceViewModificationModePage {
         .locator(`[id="newVariables[${index}].value"]`),
       jsonEditorButton: this.page
         .getByTestId(`variable-newVariables[${index}]`)
-        .getByRole('cell')
-        .nth(2)
-        .getByRole('button')
-        .nth(0),
+        .getByRole('button', {name: 'Open JSON editor'}),
       deleteButton: this.page
         .getByTestId(`variable-newVariables[${index}]`)
-        .getByRole('cell')
-        .nth(2)
-        .getByRole('button')
-        .nth(1),
+        .getByRole('button', {name: 'Delete Variable'}),
       jsonEditorModal: {
         header: this.page
-          .getByTestId(`variable-newVariables[${index}]`)
-          .getByRole('cell')
-          .nth(2)
-          .getByRole('presentation')
           .getByRole('dialog')
           .getByText('Edit a new Variable'),
         cancelButton: this.page
-          .getByTestId(`variable-newVariables[${index}]`)
-          .getByRole('cell')
-          .nth(2)
-          .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('button', {name: 'Cancel'}),
         applyButton: this.page
-          .getByTestId(`variable-newVariables[${index}]`)
-          .getByRole('cell')
-          .nth(2)
-          .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('button', {name: 'Apply'}),
         inputField: this.page
-          .getByTestId(`variable-newVariables[${index}]`)
-          .getByRole('cell')
-          .nth(2)
-          .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('code')
           .getByRole('textbox', {name: 'Editor content'}),
@@ -209,36 +187,18 @@ export class OperateProcessInstanceViewModificationModePage {
         .getByTestId('edit-variable-value'),
       jsonEditorButton: this.page
         .getByTestId(`variable-${name}`)
-        .getByRole('cell')
-        .nth(2)
-        .getByRole('button'),
+        .getByRole('button', {name: 'Open JSON editor'}),
       jsonEditorModal: {
         header: this.page
-          .getByTestId(`variable-${name}`)
-          .getByRole('cell')
-          .nth(2)
-          .getByRole('presentation')
           .getByRole('dialog')
           .getByText(`Edit Variable "${name}"`),
         cancelButton: this.page
-          .getByTestId(`variable-${name}`)
-          .getByRole('cell')
-          .nth(2)
-          .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('button', {name: 'Cancel'}),
         applyButton: this.page
-          .getByTestId(`variable-${name}`)
-          .getByRole('cell')
-          .nth(2)
-          .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('button', {name: 'Apply'}),
         inputField: this.page
-          .getByTestId(`variable-${name}`)
-          .getByRole('cell')
-          .nth(2)
-          .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('code')
           .getByRole('textbox', {name: 'Editor content'}),
@@ -347,7 +307,7 @@ export class OperateProcessInstanceViewModificationModePage {
   }
 
   async clickMoveAllButtononPopup(): Promise<void> {
-    await this.moveAllButtononPopup.click();
+    await this.moveAllButtononPopup.click({force: true});
   }
 
   async clickMoveInstanceButtononPopup(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -91,7 +91,9 @@ export class OperateProcessInstanceViewModificationModePage {
     this.addModificationButtononPopup = page.getByRole('button', {
       name: /Add single (flow node|element) instance/i,
     });
-    this.moveAllButtononPopup = page.getByRole('button', {name: /Move all/i});
+    this.moveAllButtononPopup = page
+      .getByTestId('popover')
+      .getByRole('button', {name: /Move all/i});
     this.cancelButtonPopup = page.getByRole('button', {
       name: /Cancel selected instance in this (flow node|element)/i,
     });
@@ -307,7 +309,17 @@ export class OperateProcessInstanceViewModificationModePage {
   }
 
   async clickMoveAllButtononPopup(): Promise<void> {
-    await this.moveAllButtononPopup.click();
+    // Wait for any in-flight element-stats fetch (which replaces buttons with a
+    // spinner) to complete before clicking. Passes immediately when the spinner
+    // is not present.
+    await this.page
+      .getByTestId('dropdown-spinner')
+      .waitFor({state: 'hidden', timeout: 15000});
+    // The sticky header can overlap the button in the popover, intercepting
+    // pointer events even though the button is visible and enabled. Using
+    // evaluate/click() fires the DOM click event directly on the element,
+    // bypassing any visual interception by the header.
+    await this.moveAllButtononPopup.evaluate((el: HTMLElement) => el.click());
   }
 
   async clickMoveInstanceButtononPopup(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -88,18 +88,16 @@ export class OperateProcessInstanceViewModificationModePage {
       .getByText('Process Instance Modification Mode')
       .first();
     this.flowNodeModificationsPopup = page.getByText('Element Modifications');
-    this.addModificationButtononPopup = page.getByTitle(
-      'Add single element instance',
-    );
-    this.moveAllButtononPopup = page.getByTitle(
-      'Move all running instances in this element to another target',
-    );
-    this.cancelButtonPopup = page.getByTitle(
-      'Cancel selected instance in this element',
-    );
-    this.cancelAllButtonPopup = page.getByTitle(
-      'Cancel all running element instances in this element',
-    );
+    this.addModificationButtononPopup = page.getByRole('button', {
+      name: /Add single (flow node|element) instance/i,
+    });
+    this.moveAllButtononPopup = page.getByRole('button', {name: /Move all/i});
+    this.cancelButtonPopup = page.getByRole('button', {
+      name: /Cancel selected instance in this (flow node|element)/i,
+    });
+    this.cancelAllButtonPopup = page.getByRole('button', {
+      name: /Cancel all running (flow node|element) instances in this (flow node|element)/i,
+    });
     this.reviewModificationsButton = page.getByTestId(
       'review-modifications-button',
     );
@@ -111,7 +109,7 @@ export class OperateProcessInstanceViewModificationModePage {
       .getByRole('dialog')
       .getByRole('button', {name: 'Apply'});
     this.moveTokensMessage = page.getByText(
-      'Select the target element in the diagram',
+      /Select the target (flow node|element) in the diagram/,
     );
     this.diagram = this.page.getByTestId('diagram');
     this.multipleInstancesAlert = page
@@ -126,7 +124,7 @@ export class OperateProcessInstanceViewModificationModePage {
       name: 'Add single element instance',
     });
     this.moveSelectedInstanceButton = page.getByRole('button', {
-      name: 'Move selected instance in this element to another target',
+      name: /Move selected instance in this (flow node|element) to another target/,
     });
     this.modificationModeText = page.getByText(
       'Process Instance Modification Mode',
@@ -392,9 +390,9 @@ export class OperateProcessInstanceViewModificationModePage {
   }
 
   getFlowNode(flowNodeName: string) {
-    return this.diagram
-      .locator('.djs-group')
-      .locator(`[data-element-id="${flowNodeName}"]`);
+    return this.diagram.locator(
+      `.djs-element[data-element-id="${flowNodeName}"]`,
+    );
   }
 
   async addTokenToFlowNodeAndApplyChanges(flowNodeName: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -98,9 +98,9 @@ export class OperateProcessInstanceViewModificationModePage {
     this.cancelAllButtonPopup = page.getByRole('button', {
       name: /Cancel all running (flow node|element) instances in this (flow node|element)/i,
     });
-    this.reviewModificationsButton = page.getByTestId(
-      'review-modifications-button',
-    );
+    this.reviewModificationsButton = page.getByRole('button', {
+      name: /Apply Modifications|Review Modifications/,
+    });
     this.discardAllModificationsButton = page.getByTestId('discard-all-button');
     this.cancelButtonModificationDialog = page
       .getByRole('dialog')

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/miCrossMiRestriction.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/miCrossMiRestriction.bpmn
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_miCross" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="1.0">
+  <bpmn:process id="miCrossMiRestriction" name="MI Cross-MI Restriction" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_crossMi">
+      <bpmn:outgoing>Flow_cross_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:parallelGateway id="Fork_crossMi" name="Fork">
+      <bpmn:incoming>Flow_cross_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_cross_2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_cross_3</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:subProcess id="MICrossSubprocess1" name="MI Subprocess 1">
+      <bpmn:incoming>Flow_cross_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_cross_4</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=items" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="SubStart_cross1">
+        <bpmn:outgoing>SubFlow_cross1_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="CrossTask1" name="Cross Task 1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="crossMiTask1" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>SubFlow_cross1_1</bpmn:incoming>
+        <bpmn:outgoing>SubFlow_cross1_2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="SubEnd_cross1">
+        <bpmn:incoming>SubFlow_cross1_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SubFlow_cross1_1" sourceRef="SubStart_cross1" targetRef="CrossTask1" />
+      <bpmn:sequenceFlow id="SubFlow_cross1_2" sourceRef="CrossTask1" targetRef="SubEnd_cross1" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="MICrossSubprocess2" name="MI Subprocess 2">
+      <bpmn:incoming>Flow_cross_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_cross_5</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=items" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="SubStart_cross2">
+        <bpmn:outgoing>SubFlow_cross2_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="CrossTask2" name="Cross Task 2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="crossMiTask2" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>SubFlow_cross2_1</bpmn:incoming>
+        <bpmn:outgoing>SubFlow_cross2_2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="SubEnd_cross2">
+        <bpmn:incoming>SubFlow_cross2_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SubFlow_cross2_1" sourceRef="SubStart_cross2" targetRef="CrossTask2" />
+      <bpmn:sequenceFlow id="SubFlow_cross2_2" sourceRef="CrossTask2" targetRef="SubEnd_cross2" />
+    </bpmn:subProcess>
+    <bpmn:parallelGateway id="Join_crossMi" name="Join">
+      <bpmn:incoming>Flow_cross_4</bpmn:incoming>
+      <bpmn:incoming>Flow_cross_5</bpmn:incoming>
+      <bpmn:outgoing>Flow_cross_6</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="EndEvent_crossMi">
+      <bpmn:incoming>Flow_cross_6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_cross_1" sourceRef="StartEvent_crossMi" targetRef="Fork_crossMi" />
+    <bpmn:sequenceFlow id="Flow_cross_2" sourceRef="Fork_crossMi" targetRef="MICrossSubprocess1" />
+    <bpmn:sequenceFlow id="Flow_cross_3" sourceRef="Fork_crossMi" targetRef="MICrossSubprocess2" />
+    <bpmn:sequenceFlow id="Flow_cross_4" sourceRef="MICrossSubprocess1" targetRef="Join_crossMi" />
+    <bpmn:sequenceFlow id="Flow_cross_5" sourceRef="MICrossSubprocess2" targetRef="Join_crossMi" />
+    <bpmn:sequenceFlow id="Flow_cross_6" sourceRef="Join_crossMi" targetRef="EndEvent_crossMi" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_crossMi">
+    <bpmndi:BPMNPlane id="BPMNPlane_crossMi" bpmnElement="miCrossMiRestriction">
+      <bpmndi:BPMNShape id="StartEvent_crossMi_di" bpmnElement="StartEvent_crossMi">
+        <dc:Bounds x="152" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Fork_crossMi_di" bpmnElement="Fork_crossMi" isMarkerVisible="true">
+        <dc:Bounds x="252" y="225" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="259" y="201" width="26" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MICrossSubprocess1_di" bpmnElement="MICrossSubprocess1" isExpanded="true">
+        <dc:Bounds x="360" y="80" width="280" height="160" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubStart_cross1_di" bpmnElement="SubStart_cross1">
+        <dc:Bounds x="392" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CrossTask1_di" bpmnElement="CrossTask1">
+        <dc:Bounds x="470" y="122" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubEnd_cross1_di" bpmnElement="SubEnd_cross1">
+        <dc:Bounds x="612" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MICrossSubprocess2_di" bpmnElement="MICrossSubprocess2" isExpanded="true">
+        <dc:Bounds x="360" y="310" width="280" height="160" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubStart_cross2_di" bpmnElement="SubStart_cross2">
+        <dc:Bounds x="392" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CrossTask2_di" bpmnElement="CrossTask2">
+        <dc:Bounds x="470" y="352" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubEnd_cross2_di" bpmnElement="SubEnd_cross2">
+        <dc:Bounds x="612" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Join_crossMi_di" bpmnElement="Join_crossMi" isMarkerVisible="true">
+        <dc:Bounds x="700" y="225" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="707" y="201" width="26" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_crossMi_di" bpmnElement="EndEvent_crossMi">
+        <dc:Bounds x="802" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_cross_1_di" bpmnElement="Flow_cross_1">
+        <di:waypoint x="188" y="250" />
+        <di:waypoint x="252" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_cross_2_di" bpmnElement="Flow_cross_2">
+        <di:waypoint x="277" y="225" />
+        <di:waypoint x="277" y="160" />
+        <di:waypoint x="360" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_cross_3_di" bpmnElement="Flow_cross_3">
+        <di:waypoint x="277" y="275" />
+        <di:waypoint x="277" y="390" />
+        <di:waypoint x="360" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_cross_4_di" bpmnElement="Flow_cross_4">
+        <di:waypoint x="640" y="160" />
+        <di:waypoint x="725" y="160" />
+        <di:waypoint x="725" y="225" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_cross_5_di" bpmnElement="Flow_cross_5">
+        <di:waypoint x="640" y="390" />
+        <di:waypoint x="725" y="390" />
+        <di:waypoint x="725" y="275" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_cross_6_di" bpmnElement="Flow_cross_6">
+        <di:waypoint x="750" y="250" />
+        <di:waypoint x="802" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_cross1_1_di" bpmnElement="SubFlow_cross1_1">
+        <di:waypoint x="428" y="160" />
+        <di:waypoint x="470" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_cross1_2_di" bpmnElement="SubFlow_cross1_2">
+        <di:waypoint x="570" y="160" />
+        <di:waypoint x="612" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_cross2_1_di" bpmnElement="SubFlow_cross2_1">
+        <di:waypoint x="428" y="390" />
+        <di:waypoint x="470" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_cross2_2_di" bpmnElement="SubFlow_cross2_2">
+        <di:waypoint x="570" y="390" />
+        <di:waypoint x="612" y="390" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/miParSubprocessModification.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/miParSubprocessModification.bpmn
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_miPar" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="1.0">
+  <bpmn:process id="miParSubprocess" name="MI Parallel Subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_miPar">
+      <bpmn:outgoing>Flow_miPar_start</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="MIParSubprocess" name="Parallel MI Subprocess">
+      <bpmn:incoming>Flow_miPar_start</bpmn:incoming>
+      <bpmn:outgoing>Flow_miPar_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="false">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=items" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="SubStart_miPar">
+        <bpmn:outgoing>SubFlow_miPar_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="SubTaskA_miPar" name="Task A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="miParSubTaskA" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>SubFlow_miPar_1</bpmn:incoming>
+        <bpmn:outgoing>SubFlow_miPar_2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="SubTaskB_miPar" name="Task B">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="miParSubTaskB" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>SubFlow_miPar_2</bpmn:incoming>
+        <bpmn:outgoing>SubFlow_miPar_3</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="SubEnd_miPar">
+        <bpmn:incoming>SubFlow_miPar_3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SubFlow_miPar_1" sourceRef="SubStart_miPar" targetRef="SubTaskA_miPar" />
+      <bpmn:sequenceFlow id="SubFlow_miPar_2" sourceRef="SubTaskA_miPar" targetRef="SubTaskB_miPar" />
+      <bpmn:sequenceFlow id="SubFlow_miPar_3" sourceRef="SubTaskB_miPar" targetRef="SubEnd_miPar" />
+    </bpmn:subProcess>
+    <bpmn:endEvent id="EndEvent_miPar">
+      <bpmn:incoming>Flow_miPar_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_miPar_start" sourceRef="StartEvent_miPar" targetRef="MIParSubprocess" />
+    <bpmn:sequenceFlow id="Flow_miPar_end" sourceRef="MIParSubprocess" targetRef="EndEvent_miPar" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_miPar">
+    <bpmndi:BPMNPlane id="BPMNPlane_miPar" bpmnElement="miParSubprocess">
+      <bpmndi:BPMNShape id="StartEvent_miPar_di" bpmnElement="StartEvent_miPar">
+        <dc:Bounds x="152" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MIParSubprocess_di" bpmnElement="MIParSubprocess" isExpanded="true">
+        <dc:Bounds x="250" y="160" width="560" height="300" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubStart_miPar_di" bpmnElement="SubStart_miPar">
+        <dc:Bounds x="282" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubTaskA_miPar_di" bpmnElement="SubTaskA_miPar">
+        <dc:Bounds x="380" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubTaskB_miPar_di" bpmnElement="SubTaskB_miPar">
+        <dc:Bounds x="550" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubEnd_miPar_di" bpmnElement="SubEnd_miPar">
+        <dc:Bounds x="722" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_miPar_di" bpmnElement="EndEvent_miPar">
+        <dc:Bounds x="882" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_miPar_start_di" bpmnElement="Flow_miPar_start">
+        <di:waypoint x="188" y="310" />
+        <di:waypoint x="250" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_miPar_1_di" bpmnElement="SubFlow_miPar_1">
+        <di:waypoint x="318" y="310" />
+        <di:waypoint x="380" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_miPar_2_di" bpmnElement="SubFlow_miPar_2">
+        <di:waypoint x="480" y="310" />
+        <di:waypoint x="550" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_miPar_3_di" bpmnElement="SubFlow_miPar_3">
+        <di:waypoint x="650" y="310" />
+        <di:waypoint x="722" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_miPar_end_di" bpmnElement="Flow_miPar_end">
+        <di:waypoint x="810" y="310" />
+        <di:waypoint x="882" y="310" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/miSeqSubprocessModification.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/miSeqSubprocessModification.bpmn
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_miSeq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="1.0">
+  <bpmn:process id="miSeqSubprocess" name="MI Sequential Subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_miSeq">
+      <bpmn:outgoing>Flow_miSeq_start</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="MISeqSubprocess" name="Sequential MI Subprocess">
+      <bpmn:incoming>Flow_miSeq_start</bpmn:incoming>
+      <bpmn:outgoing>Flow_miSeq_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=items" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="SubStart_miSeq">
+        <bpmn:outgoing>SubFlow_miSeq_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="SubTaskA_miSeq" name="Task A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="miSeqSubTaskA" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>SubFlow_miSeq_1</bpmn:incoming>
+        <bpmn:outgoing>SubFlow_miSeq_2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="SubTaskB_miSeq" name="Task B">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="miSeqSubTaskB" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>SubFlow_miSeq_2</bpmn:incoming>
+        <bpmn:outgoing>SubFlow_miSeq_3</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="SubEnd_miSeq">
+        <bpmn:incoming>SubFlow_miSeq_3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SubFlow_miSeq_1" sourceRef="SubStart_miSeq" targetRef="SubTaskA_miSeq" />
+      <bpmn:sequenceFlow id="SubFlow_miSeq_2" sourceRef="SubTaskA_miSeq" targetRef="SubTaskB_miSeq" />
+      <bpmn:sequenceFlow id="SubFlow_miSeq_3" sourceRef="SubTaskB_miSeq" targetRef="SubEnd_miSeq" />
+    </bpmn:subProcess>
+    <bpmn:endEvent id="EndEvent_miSeq">
+      <bpmn:incoming>Flow_miSeq_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_miSeq_start" sourceRef="StartEvent_miSeq" targetRef="MISeqSubprocess" />
+    <bpmn:sequenceFlow id="Flow_miSeq_end" sourceRef="MISeqSubprocess" targetRef="EndEvent_miSeq" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_miSeq">
+    <bpmndi:BPMNPlane id="BPMNPlane_miSeq" bpmnElement="miSeqSubprocess">
+      <bpmndi:BPMNShape id="StartEvent_miSeq_di" bpmnElement="StartEvent_miSeq">
+        <dc:Bounds x="152" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MISeqSubprocess_di" bpmnElement="MISeqSubprocess" isExpanded="true">
+        <dc:Bounds x="250" y="160" width="560" height="300" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubStart_miSeq_di" bpmnElement="SubStart_miSeq">
+        <dc:Bounds x="282" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubTaskA_miSeq_di" bpmnElement="SubTaskA_miSeq">
+        <dc:Bounds x="380" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubTaskB_miSeq_di" bpmnElement="SubTaskB_miSeq">
+        <dc:Bounds x="550" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubEnd_miSeq_di" bpmnElement="SubEnd_miSeq">
+        <dc:Bounds x="722" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_miSeq_di" bpmnElement="EndEvent_miSeq">
+        <dc:Bounds x="882" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_miSeq_start_di" bpmnElement="Flow_miSeq_start">
+        <di:waypoint x="188" y="310" />
+        <di:waypoint x="250" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_miSeq_1_di" bpmnElement="SubFlow_miSeq_1">
+        <di:waypoint x="318" y="310" />
+        <di:waypoint x="380" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_miSeq_2_di" bpmnElement="SubFlow_miSeq_2">
+        <di:waypoint x="480" y="310" />
+        <di:waypoint x="550" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_miSeq_3_di" bpmnElement="SubFlow_miSeq_3">
+        <di:waypoint x="650" y="310" />
+        <di:waypoint x="722" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_miSeq_end_di" bpmnElement="Flow_miSeq_end">
+        <di:waypoint x="810" y="310" />
+        <di:waypoint x="882" y="310" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/miSubprocessMoveRestriction.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/miSubprocessMoveRestriction.bpmn
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_miRestriction" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="1.0">
+  <bpmn:process id="miSubprocessRestriction" name="MI Subprocess Move Restriction" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_restriction">
+      <bpmn:outgoing>Flow_r_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:parallelGateway id="ForkGW_restriction" name="Fork">
+      <bpmn:incoming>Flow_r_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_r_2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_r_3</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:serviceTask id="OuterTask_restriction" name="Outer Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="miRestrictionOuterTask" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_r_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_r_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:subProcess id="MISubprocess_restriction" name="MI Subprocess">
+      <bpmn:incoming>Flow_r_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_r_5</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="false">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=items" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="SubStart_restriction">
+        <bpmn:outgoing>SubFlow_r_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="SubTaskA_restriction" name="Inner Task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="miRestrictionInnerTask" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>SubFlow_r_1</bpmn:incoming>
+        <bpmn:outgoing>SubFlow_r_2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="SubEnd_restriction">
+        <bpmn:incoming>SubFlow_r_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SubFlow_r_1" sourceRef="SubStart_restriction" targetRef="SubTaskA_restriction" />
+      <bpmn:sequenceFlow id="SubFlow_r_2" sourceRef="SubTaskA_restriction" targetRef="SubEnd_restriction" />
+    </bpmn:subProcess>
+    <bpmn:parallelGateway id="JoinGW_restriction" name="Join">
+      <bpmn:incoming>Flow_r_4</bpmn:incoming>
+      <bpmn:incoming>Flow_r_5</bpmn:incoming>
+      <bpmn:outgoing>Flow_r_6</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="EndEvent_restriction">
+      <bpmn:incoming>Flow_r_6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_r_1" sourceRef="StartEvent_restriction" targetRef="ForkGW_restriction" />
+    <bpmn:sequenceFlow id="Flow_r_2" sourceRef="ForkGW_restriction" targetRef="OuterTask_restriction" />
+    <bpmn:sequenceFlow id="Flow_r_3" sourceRef="ForkGW_restriction" targetRef="MISubprocess_restriction" />
+    <bpmn:sequenceFlow id="Flow_r_4" sourceRef="OuterTask_restriction" targetRef="JoinGW_restriction" />
+    <bpmn:sequenceFlow id="Flow_r_5" sourceRef="MISubprocess_restriction" targetRef="JoinGW_restriction" />
+    <bpmn:sequenceFlow id="Flow_r_6" sourceRef="JoinGW_restriction" targetRef="EndEvent_restriction" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_restriction">
+    <bpmndi:BPMNPlane id="BPMNPlane_restriction" bpmnElement="miSubprocessRestriction">
+      <bpmndi:BPMNShape id="StartEvent_restriction_di" bpmnElement="StartEvent_restriction">
+        <dc:Bounds x="152" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ForkGW_restriction_di" bpmnElement="ForkGW_restriction" isMarkerVisible="true">
+        <dc:Bounds x="252" y="265" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="259" y="241" width="26" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="OuterTask_restriction_di" bpmnElement="OuterTask_restriction">
+        <dc:Bounds x="370" y="120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MISubprocess_restriction_di" bpmnElement="MISubprocess_restriction" isExpanded="true">
+        <dc:Bounds x="370" y="360" width="420" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubStart_restriction_di" bpmnElement="SubStart_restriction">
+        <dc:Bounds x="402" y="442" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubTaskA_restriction_di" bpmnElement="SubTaskA_restriction">
+        <dc:Bounds x="500" y="420" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubEnd_restriction_di" bpmnElement="SubEnd_restriction">
+        <dc:Bounds x="662" y="442" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="JoinGW_restriction_di" bpmnElement="JoinGW_restriction" isMarkerVisible="true">
+        <dc:Bounds x="852" y="265" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="860" y="241" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_restriction_di" bpmnElement="EndEvent_restriction">
+        <dc:Bounds x="962" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_r_1_di" bpmnElement="Flow_r_1">
+        <di:waypoint x="188" y="290" />
+        <di:waypoint x="252" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_r_2_di" bpmnElement="Flow_r_2">
+        <di:waypoint x="277" y="265" />
+        <di:waypoint x="277" y="160" />
+        <di:waypoint x="370" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_r_3_di" bpmnElement="Flow_r_3">
+        <di:waypoint x="277" y="315" />
+        <di:waypoint x="277" y="460" />
+        <di:waypoint x="370" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_r_1_di" bpmnElement="SubFlow_r_1">
+        <di:waypoint x="438" y="460" />
+        <di:waypoint x="500" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SubFlow_r_2_di" bpmnElement="SubFlow_r_2">
+        <di:waypoint x="600" y="460" />
+        <di:waypoint x="662" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_r_4_di" bpmnElement="Flow_r_4">
+        <di:waypoint x="470" y="160" />
+        <di:waypoint x="877" y="160" />
+        <di:waypoint x="877" y="265" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_r_5_di" bpmnElement="Flow_r_5">
+        <di:waypoint x="790" y="460" />
+        <di:waypoint x="877" y="460" />
+        <di:waypoint x="877" y="315" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_r_6_di" bpmnElement="Flow_r_6">
+        <di:waypoint x="902" y="290" />
+        <di:waypoint x="962" y="290" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
@@ -631,16 +631,13 @@ test.describe('Multi-Instance Subprocess Modifications', () => {
       ).toBeVisible();
     });
 
-    await test.step('Click Inner Task and verify multiple instances alert', async () => {
+    await test.step('Click Inner Task, verify multiple instances alert, and move all to Outer Task', async () => {
       await operateProcessInstanceViewModificationModePage.clickFlowNode(
         'SubTaskA_restriction',
       );
       await expect(
         operateProcessInstanceViewModificationModePage.multipleInstancesAlert,
       ).toBeVisible();
-    });
-
-    await test.step('Move all Inner Task instances to Outer Task (parent scope)', async () => {
       await operateProcessInstanceViewModificationModePage.clickMoveAllButtononPopup();
       await expect(
         operateProcessInstanceViewModificationModePage.moveTokensMessage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
@@ -1,0 +1,864 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance, cancelProcessInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp, hideHelperModals} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let seqMiInstance: ProcessInstance;
+let parMiInstance: ProcessInstance;
+let restrictionInstance: ProcessInstance;
+let crossMiInstance: ProcessInstance;
+let outwardMoveInstance: ProcessInstance;
+let moveAllInstance: ProcessInstance;
+let cancelTokenInstance: ProcessInstance;
+let addTokenInstance: ProcessInstance;
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/miSeqSubprocessModification.bpmn',
+    './resources/miParSubprocessModification.bpmn',
+    './resources/miSubprocessMoveRestriction.bpmn',
+    './resources/miCrossMiRestriction.bpmn',
+  ]);
+
+  seqMiInstance = await createSingleInstance('miSeqSubprocess', 1, {
+    items: ['itemA', 'itemB'],
+  });
+
+  parMiInstance = await createSingleInstance('miParSubprocess', 1, {
+    items: ['itemA', 'itemB', 'itemC'],
+  });
+
+  restrictionInstance = await createSingleInstance(
+    'miSubprocessRestriction',
+    1,
+    {
+      items: ['itemA', 'itemB'],
+    },
+  );
+
+  crossMiInstance = await createSingleInstance('miCrossMiRestriction', 1, {
+    items: ['itemA', 'itemB'],
+  });
+
+  outwardMoveInstance = await createSingleInstance(
+    'miSubprocessRestriction',
+    1,
+    {
+      items: ['itemA', 'itemB'],
+    },
+  );
+
+  moveAllInstance = await createSingleInstance('miSubprocessRestriction', 1, {
+    items: ['itemA', 'itemB'],
+  });
+
+  cancelTokenInstance = await createSingleInstance('miParSubprocess', 1, {
+    items: ['itemA', 'itemB'],
+  });
+
+  addTokenInstance = await createSingleInstance('miSeqSubprocess', 1, {
+    items: ['itemA'],
+  });
+
+  await sleep(3000);
+});
+
+test.afterAll(async () => {
+  for (const instance of [
+    seqMiInstance,
+    parMiInstance,
+    restrictionInstance,
+    crossMiInstance,
+    outwardMoveInstance,
+    moveAllInstance,
+    cancelTokenInstance,
+    addTokenInstance,
+  ]) {
+    await cancelProcessInstance(instance.processInstanceKey);
+  }
+});
+
+test.describe('Multi-Instance Subprocess Modifications', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await hideHelperModals(page);
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Should move an element inside the same sequential MI body instance', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to sequential MI subprocess process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: seqMiInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Wait for Task A to be active inside the sequential MI body', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /sequential mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^sequential mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/task a/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Move token from Task A to Task B within the same MI body', async () => {
+      await operateProcessInstanceViewModificationModePage.moveInstanceFromSelectedFlowNodeToTarget(
+        'SubTaskA_miSeq',
+        'SubTaskB_miSeq',
+      );
+    });
+
+    await test.step('Verify modification overlays: -1 on Task A and +1 on Task B', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskA_miSeq',
+            -1,
+          );
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskB_miSeq',
+            1,
+          );
+        },
+        onFailure: async () => {},
+      });
+    });
+
+    await test.step('Apply the modification', async () => {
+      await operateProcessInstanceViewModificationModePage.applyChanges();
+    });
+
+    await test.step('Verify the token moved to Task B in the instance history', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /sequential mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^sequential mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/task b/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+  });
+
+  test('Should move an element inside the same parallel MI body instance', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to parallel MI subprocess process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: parMiInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Expand the parallel MI subprocess and wait for 3 active body instances', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /parallel mi subprocess \(multi instance\)/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(
+              /^parallel mi subprocess$/i,
+            ),
+          ).toHaveCount(3);
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Click Task A in the diagram and verify multiple instances alert', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'SubTaskA_miPar',
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.multipleInstancesAlert,
+      ).toBeVisible();
+    });
+
+    await test.step('Select one specific Task A instance from the instance history', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^parallel mi subprocess$/i,
+      );
+      await operateProcessInstancePage.instanceHistory
+        .getByRole('treeitem', {name: /^task a$/i})
+        .first()
+        .click();
+      await expect(
+        page.getByTestId('popover').getByText('Selected running instances: 1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Initiate move for the selected Task A instance to Task B', async () => {
+      await operateProcessInstanceViewModificationModePage.clickMoveInstanceButtononPopup();
+      await expect(
+        operateProcessInstanceViewModificationModePage.moveTokensMessage,
+      ).toBeVisible();
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'SubTaskB_miPar',
+      );
+    });
+
+    await test.step('Verify modification overlays: -1 on Task A and +1 on Task B', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskA_miPar',
+            -1,
+          );
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskB_miPar',
+            1,
+          );
+        },
+        onFailure: async () => {},
+      });
+    });
+
+    await test.step('Apply the modification', async () => {
+      await operateProcessInstanceViewModificationModePage.applyChanges();
+    });
+
+    await test.step('Verify a new Task B instance appeared in the operation history', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /parallel mi subprocess \(multi instance\)/i,
+          );
+          const bodyInstances =
+            operateProcessInstancePage.instanceHistory.getByRole('treeitem', {
+              name: /^parallel mi subprocess$/i,
+            });
+          for (const bodyInstance of await bodyInstances.all()) {
+            const isExpanded = await bodyInstance.getAttribute('aria-expanded');
+            if (isExpanded === 'false') {
+              await bodyInstance
+                .locator('.cds--tree-parent-node__toggle')
+                .click();
+            }
+          }
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/^task b$/i),
+          ).toHaveCount(1);
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+  });
+
+  test('Should prevent moving elements from outside into a multi-instance body', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to the move restriction process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: restrictionInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Wait for Outer Task and Inner Task to be simultaneously active', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/outer task/i),
+          ).toBeVisible();
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/inner task/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Select Outer Task and initiate a move', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'OuterTask_restriction',
+      );
+      await operateProcessInstanceViewModificationModePage.clickMoveInstanceButtononPopup();
+      await expect(
+        operateProcessInstanceViewModificationModePage.moveTokensMessage,
+      ).toBeVisible();
+    });
+
+    await test.step('Attempt to select Inner Task (inside MI body) as move target', async () => {
+      await operateProcessInstanceViewModificationModePage
+        .getFlowNode('SubTaskA_restriction')
+        .first()
+        .click({force: true, timeout: 20000});
+    });
+
+    await test.step('Verify the cross-boundary move was rejected: target selection prompt remains active', async () => {
+      await expect(
+        operateProcessInstanceViewModificationModePage.moveTokensMessage,
+      ).toBeVisible();
+    });
+  });
+
+  test('Should prevent moving an element from one MI subprocess body to a different MI subprocess body', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to cross-MI restriction process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: crossMiInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Wait for Cross Task 1 and Cross Task 2 to be active in their respective MI bodies', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /mi subprocess 1 \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^mi subprocess 1$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/cross task 1/i),
+          ).toBeVisible();
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /mi subprocess 2 \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^mi subprocess 2$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/cross task 2/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Click Cross Task 1 and verify multiple instances alert', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'CrossTask1',
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.multipleInstancesAlert,
+      ).toBeVisible();
+    });
+
+    await test.step('Select a specific Cross Task 1 instance from the instance history', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^mi subprocess 1$/i,
+      );
+      await operateProcessInstancePage.instanceHistory
+        .getByRole('treeitem', {name: /^cross task 1$/i})
+        .first()
+        .click();
+      await expect(
+        page.getByTestId('popover').getByText('Selected running instances: 1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Initiate move from Cross Task 1', async () => {
+      await operateProcessInstanceViewModificationModePage.clickMoveInstanceButtononPopup();
+      await expect(
+        operateProcessInstanceViewModificationModePage.moveTokensMessage,
+      ).toBeVisible();
+    });
+
+    await test.step('Attempt to select Cross Task 2 (inside a different MI body) as move target', async () => {
+      await operateProcessInstanceViewModificationModePage
+        .getFlowNode('CrossTask2')
+        .first()
+        .click({force: true, timeout: 20000});
+    });
+
+    await test.step('Verify the cross-MI move was rejected: target selection prompt remains active', async () => {
+      await expect(
+        operateProcessInstanceViewModificationModePage.moveTokensMessage,
+      ).toBeVisible();
+    });
+  });
+
+  test('Should move an element from inside an MI body to its parent scope', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to the outward-move process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: outwardMoveInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Wait for Outer Task and Inner Task to be simultaneously active', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/outer task/i),
+          ).toBeVisible();
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/inner task/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Click Inner Task and verify multiple instances alert', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'SubTaskA_restriction',
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.multipleInstancesAlert,
+      ).toBeVisible();
+    });
+
+    await test.step('Select a specific Inner Task instance from the instance history', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^mi subprocess$/i,
+      );
+      await operateProcessInstancePage.instanceHistory
+        .getByRole('treeitem', {name: /^inner task$/i})
+        .first()
+        .click();
+      await expect(
+        page.getByTestId('popover').getByText('Selected running instances: 1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Initiate move from Inner Task to Outer Task (parent scope)', async () => {
+      await operateProcessInstanceViewModificationModePage.clickMoveInstanceButtononPopup();
+      await expect(
+        operateProcessInstanceViewModificationModePage.moveTokensMessage,
+      ).toBeVisible();
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'OuterTask_restriction',
+      );
+    });
+
+    await test.step('Verify modification overlays: -1 on Inner Task and +1 on Outer Task', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskA_restriction',
+            -1,
+          );
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'OuterTask_restriction',
+            1,
+          );
+        },
+        onFailure: async () => {},
+      });
+    });
+
+    await test.step('Apply the modification', async () => {
+      await operateProcessInstanceViewModificationModePage.applyChanges();
+    });
+
+    await test.step('Verify Outer Task is still active in the instance history after move', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/outer task/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+  });
+
+  test('Should move all instances of a parallel MI task to another node using move-all', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to the move-all process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: moveAllInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Wait for Outer Task and 2 Inner Task instances to be active', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/outer task/i),
+          ).toBeVisible();
+          await expect(
+            operateProcessInstancePage.instanceHistory.getByRole('treeitem', {
+              name: /^mi subprocess$/i,
+            }),
+          ).toHaveCount(2);
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Click Inner Task and verify multiple instances alert', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'SubTaskA_restriction',
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.multipleInstancesAlert,
+      ).toBeVisible();
+    });
+
+    await test.step('Move all Inner Task instances to Outer Task (parent scope)', async () => {
+      await operateProcessInstanceViewModificationModePage.clickMoveAllButtononPopup();
+      await expect(
+        operateProcessInstanceViewModificationModePage.moveTokensMessage,
+      ).toBeVisible();
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'OuterTask_restriction',
+      );
+    });
+
+    await test.step('Verify modification overlays: -2 on Inner Task and +2 on Outer Task', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskA_restriction',
+            -2,
+          );
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'OuterTask_restriction',
+            2,
+          );
+        },
+        onFailure: async () => {},
+      });
+    });
+
+    await test.step('Apply the modification', async () => {
+      await operateProcessInstanceViewModificationModePage.applyChanges();
+    });
+
+    await test.step('Verify Outer Task is still active in the instance history after move', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/outer task/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+  });
+
+  test('Should cancel a single MI body token (negative: token removed from history)', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to the cancel-token process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: cancelTokenInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Wait for 2 parallel MI body instances with Task A active', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /parallel mi subprocess \(multi instance\)/i,
+          );
+          await expect(
+            operateProcessInstancePage.instanceHistory.getByRole('treeitem', {
+              name: /^parallel mi subprocess$/i,
+            }),
+          ).toHaveCount(2);
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Click Task A and verify multiple instances alert', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'SubTaskA_miPar',
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.multipleInstancesAlert,
+      ).toBeVisible();
+    });
+
+    await test.step('Select one specific Task A instance from the instance history', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^parallel mi subprocess$/i,
+      );
+      await operateProcessInstancePage.instanceHistory
+        .getByRole('treeitem', {name: /^task a$/i})
+        .first()
+        .click();
+      await expect(
+        page.getByTestId('popover').getByText('Selected running instances: 1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Cancel the selected Task A instance', async () => {
+      await operateProcessInstanceViewModificationModePage.cancelButtonPopup.click();
+    });
+
+    await test.step('Verify -1 cancel overlay on Task A', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskA_miPar',
+            -1,
+          );
+        },
+        onFailure: async () => {},
+      });
+    });
+
+    await test.step('Apply the modification', async () => {
+      await operateProcessInstanceViewModificationModePage.applyChanges();
+    });
+
+    await test.step('Verify only one Task A instance remains in the instance history', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /parallel mi subprocess \(multi instance\)/i,
+          );
+          const bodyInstances =
+            operateProcessInstancePage.instanceHistory.getByRole('treeitem', {
+              name: /^parallel mi subprocess$/i,
+            });
+          for (const bodyInstance of await bodyInstances.all()) {
+            const isExpanded = await bodyInstance.getAttribute('aria-expanded');
+            if (isExpanded === 'false') {
+              await bodyInstance
+                .locator('.cds--tree-parent-node__toggle')
+                .click();
+            }
+          }
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/^task a$/i),
+          ).toHaveCount(1);
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+  });
+
+  test('Should add a new token inside a sequential MI body', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to the add-token process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: addTokenInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Wait for Task A to be active inside the sequential MI body', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /sequential mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^sequential mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/task a/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Click Task B and add a new token to it', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'SubTaskB_miSeq',
+      );
+      await operateProcessInstanceViewModificationModePage.clickAddModificationButtononPopup();
+    });
+
+    await test.step('Verify +1 add overlay on Task B', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskB_miSeq',
+            1,
+          );
+        },
+        onFailure: async () => {},
+      });
+    });
+
+    await test.step('Apply the modification', async () => {
+      await operateProcessInstanceViewModificationModePage.applyChanges();
+    });
+
+    await test.step('Verify Task B is now active in the instance history', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /sequential mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^sequential mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/task b/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
@@ -8,7 +8,11 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {deploy, createSingleInstance, cancelProcessInstance} from 'utils/zeebeClient';
+import {
+  deploy,
+  createSingleInstance,
+  cancelProcessInstance,
+} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp, hideHelperModals} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
@@ -26,6 +30,7 @@ let outwardMoveInstance: ProcessInstance;
 let moveAllInstance: ProcessInstance;
 let cancelTokenInstance: ProcessInstance;
 let addTokenInstance: ProcessInstance;
+let completedMiTaskInstance: ProcessInstance;
 
 test.beforeAll(async () => {
   await deploy([
@@ -75,6 +80,14 @@ test.beforeAll(async () => {
     items: ['itemA'],
   });
 
+  completedMiTaskInstance = await createSingleInstance(
+    'miSubprocessRestriction',
+    1,
+    {
+      items: ['itemA'],
+    },
+  );
+
   await sleep(3000);
 });
 
@@ -88,6 +101,7 @@ test.afterAll(async () => {
     moveAllInstance,
     cancelTokenInstance,
     addTokenInstance,
+    completedMiTaskInstance,
   ]) {
     await cancelProcessInstance(instance.processInstanceKey);
   }
@@ -750,7 +764,7 @@ test.describe('Multi-Instance Subprocess Modifications', () => {
       await operateProcessInstanceViewModificationModePage.applyChanges();
     });
 
-    await test.step('Verify only one Task A instance remains in the instance history', async () => {
+    await test.step('Verify only one Task A instance remains active in the instance history', async () => {
       await waitForAssertion({
         assertion: async () => {
           await operateProcessInstancePage.expandTreeItemInHistory(
@@ -768,8 +782,13 @@ test.describe('Multi-Instance Subprocess Modifications', () => {
                 .click();
             }
           }
+          // History shows both active and terminated instances; filter by the
+          // ACTIVE-icon state indicator rendered in the Bar component to count
+          // only the remaining running Task A token.
           await expect(
-            operateProcessInstancePage.findTreeItemInHistory(/^task a$/i),
+            operateProcessInstancePage
+              .findTreeItemInHistory(/^task a$/i)
+              .filter({has: page.getByTestId('ACTIVE-icon')}),
           ).toHaveCount(1);
         },
         onFailure: async () => {
@@ -859,6 +878,118 @@ test.describe('Multi-Instance Subprocess Modifications', () => {
           await hideHelperModals(page);
         },
       });
+    });
+  });
+
+  test('Should prevent move and cancel actions on a terminated MI body task', async ({
+    page,
+    operateProcessInstancePage,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to the single-item MI subprocess process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: completedMiTaskInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Wait for Outer Task and Inner Task to be simultaneously active', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/outer task/i),
+          ).toBeVisible();
+          await expect(
+            operateProcessInstancePage.findTreeItemInHistory(/inner task/i),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Enter modification mode and cancel the single Inner Task token', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'SubTaskA_restriction',
+      );
+      await operateProcessInstanceViewModificationModePage.cancelButtonPopup.click();
+    });
+
+    await test.step('Verify -1 cancel overlay on Inner Task', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+            'SubTaskA_restriction',
+            -1,
+          );
+        },
+        onFailure: async () => {},
+      });
+    });
+
+    await test.step('Apply the modification', async () => {
+      await operateProcessInstanceViewModificationModePage.applyChanges();
+    });
+
+    await test.step('Wait until Inner Task shows as terminated in the instance history', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /mi subprocess \(multi instance\)/i,
+          );
+          await operateProcessInstancePage.expandTreeItemInHistory(
+            /^mi subprocess$/i,
+          );
+          await expect(
+            operateProcessInstancePage
+              .findTreeItemInHistory(/inner task/i)
+              .filter({has: page.getByTestId('TERMINATED-icon')}),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await hideHelperModals(page);
+        },
+      });
+    });
+
+    await test.step('Re-enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(
+        operateProcessInstanceViewModificationModePage.modifyModeHeader,
+      ).toBeVisible();
+    });
+
+    await test.step('Click the terminated Inner Task node in the diagram', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        'SubTaskA_restriction',
+      );
+    });
+
+    await test.step('Verify no cancel or move actions are available for the terminated flow node', async () => {
+      await expect(
+        operateProcessInstanceViewModificationModePage.cancelButtonPopup,
+      ).not.toBeVisible();
+      await expect(
+        operateProcessInstanceViewModificationModePage.moveSelectedInstanceButton,
+      ).not.toBeVisible();
+    });
+
+    await test.step('Verify Add is also not available for the terminated flow node', async () => {
+      await expect(
+        operateProcessInstanceViewModificationModePage.addModificationButtononPopup,
+      ).not.toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds a new Playwright E2E test suite covering the full range of positive and negative modification behaviours for Multi-Instance subprocesses in Operate (`miSubprocessModifications.spec.ts`).

The suite validates that Operate correctly applies, restricts, and reflects token-level modifications (move, move-all, cancel, add) for both sequential and parallel MI subprocess process instances.

## What's tested

| # | Scenario | Type | Expected outcome |
|---|---|---|---|
| 1 | Move element inside the same sequential MI body | Positive | Token moves from Task A → Task B within the same sequential MI body; −1/+1 overlays shown; Task B appears in instance history |
| 2 | Move element inside the same parallel MI body | Positive | One of 3 Task A instances is selected and moved to Task B; −1/+1 overlays shown; 1 Task B entry appears in instance history |
| 3 | Prevent moving elements from outside into a multi-instance body | Negative | Move initiated from Outer Task; Inner Task (inside MI body) clicked as target; cross-boundary move is rejected; target-selection prompt remains visible |
| 4 | Prevent moving element from one MI subprocess body to a different MI subprocess body | Negative | Move initiated from Cross Task 1 (MI Subprocess 1); Cross Task 2 (MI Subprocess 2) clicked as target; cross-MI move is rejected; target-selection prompt remains visible |
| 5 | Move element from inside an MI body to its parent scope | Positive | Inner Task instance moved to Outer Task (parent scope); −1/+1 overlays shown; Outer Task remains active in instance history |
| 6 | Move all instances of a parallel MI task to another node using move-all | Positive | Move All used on 2 Inner Task instances; all moved to Outer Task; −2/+2 overlays shown; Outer Task remains active in instance history |
| 7 | Cancel a single MI body token | Negative | One of 2 Task A instances cancelled; −1 cancel overlay shown on Task A; only 1 Task A instance remains active in instance history after apply |
| 8 | Add a new token inside a sequential MI body | Positive | Task B clicked inside sequential MI body; new token added via popup; +1 overlay shown on Task B; Task B appears in instance history after apply |
| 9 | Prevent move and cancel actions on a terminated MI body task | Negative | Inner Task token cancelled and terminated; after re-entering modification mode, cancel, move, and add buttons are all not available for the terminated flow node |

Test Rail test cases > Cross component test suite 
https://camunda.testrail.com/index.php?/suites/view/17051&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=636222

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview

