### PR TITLE
deps: Bump Spring Boot version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -111,7 +111,7 @@
     <version.spring-security>7.0.4</version.spring-security>
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>
-    <version.spring-boot>4.0.4</version.spring-boot>
+    <version.spring-boot>4.0.5</version.spring-boot>
     <version.spring-ai>2.0.0-M3</version.spring-ai>
     <version.mcp-sdk>1.1.0</version.mcp-sdk>
     <version.jsonschema-generator>5.0.0</version.jsonschema-generator>


### PR DESCRIPTION
## Description

We want to bump the version of Spring Boot to `4.0.5` due to a regression that was identified in `4.0.4`. See https://camunda.slack.com/archives/C01H4NG9XDY/p1774470384287499 for more information.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
