### PR TITLE
deps: Bump Spring Boot version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -106,7 +106,7 @@
     <version.spring-security>6.5.9</version.spring-security>
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>
-    <version.spring-boot>3.5.12</version.spring-boot>
+    <version.spring-boot>3.5.13</version.spring-boot>
     <version.tomcat>10.1.53</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>


### PR DESCRIPTION
## Description

We want to bump the version of Spring Boot to 3.5.12 due to a regression that was identified in 3.5.13. See https://camunda.slack.com/archives/C01H4NG9XDY/p1774470384287499 for more information.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
