### PR TITLE
[Backport stable/8.9] fix: Loadtest Container Names

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -47,6 +47,7 @@ global:
 
 identity:
   enabled: true
+  fullnameOverride: identity # we override the names for simplicity of the deployment
   firstUser:
     secret:
       existingSecret: camunda-credentials
@@ -61,6 +62,7 @@ identity:
 
 optimize:
   enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
   extraConfiguration:
     - file: application.yml
       content: |
@@ -77,6 +79,7 @@ optimize:
 
 identityKeycloak:
   enabled: true
+  fullnameOverride: keycloak # we override the names for simplicity of the deployment
   nodeSelector:
     component: benchmark-n2-standard-4
   tolerations:
@@ -84,9 +87,12 @@ identityKeycloak:
       operator: Equal
       value: n2-standard-4
       effect: NoSchedule
+  postgresql:
+    fullnameOverride: keycloak-postgresql # we override the names for simplicity of the deployment
 
 connectors:
   enabled: true
+  fullnameOverride: connectors # we override the names for simplicity of the deployment
   security:
     authentication:
       method: oidc
@@ -229,11 +235,11 @@ orchestration:
   extraVolumeMounts:
     - name: logs
       mountPath: /usr/local/camunda/logs
-  # Retention for the ES Exporter indices - legacy Zeebe indices    
+  # Retention for the ES Exporter indices - legacy Zeebe indices
   retention:
     enabled: true
     minimumAge: 1d
-  # Retention for the Camunda Exporter  
+  # Retention for the Camunda Exporter
   history:
     retention:
       ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -31,7 +31,7 @@ saas:
     # Saas.credentials.zeebeRestAddress to define the rest address of the cluster (including port)
     zeebeRestAddress: "http://camunda-gateway:8080"
     # SaaS.credentials.authServer to define the authentication server to retrieve JWT tokens
-    authServer: "http://__NAMESPACE__-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+    authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
     # Saas.credentials.authType to define the authentication type for the starter and workers
     authType: "OAUTH"
     # Saas.credentials.zeebeGrpcAddress to define the grpc address of the cluster (including port)


### PR DESCRIPTION
# Description
Backport of #49568 to `stable/8.9`.

relates to 