### PR TITLE
  feat: per-process-definition round-robin for CreateProcessInstance

### DIFF
--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -84,7 +84,7 @@ public final class ProcessInstanceServices
   private final RequestRetryHandler requestRetryHandler;
   private final ExecutorService executor;
   private final int maxVariableNameLength;
-  private final ConcurrentHashMap<String, RequestRetryHandler> processIdToRetryHandler =
+  private final ConcurrentHashMap<Long, RequestRetryHandler> definitionKeyToRetryHandler =
       new ConcurrentHashMap<>();
 
   public ProcessInstanceServices(
@@ -302,7 +302,7 @@ public final class ProcessInstanceServices
       return sendRequestWithRetryPartitions(brokerRequest, authentication);
     }
     return sendWithPerProcessRoundRobin(
-        brokerRequest, request.bpmnProcessId(), authentication, null);
+        brokerRequest, request.processDefinitionKey(), authentication, null);
   }
 
   public CompletableFuture<ProcessInstanceResultRecord> createProcessInstanceWithResult(
@@ -335,7 +335,7 @@ public final class ProcessInstanceServices
     }
 
     return sendWithPerProcessRoundRobin(
-        brokerRequest, request.bpmnProcessId(), authentication, timeout);
+        brokerRequest, request.processDefinitionKey(), authentication, timeout);
   }
 
   public CompletableFuture<ProcessInstanceRecord> cancelProcessInstance(
@@ -520,25 +520,25 @@ public final class ProcessInstanceServices
 
   private <R> CompletableFuture<R> sendWithPerProcessRoundRobin(
       final BrokerRequest<R> brokerRequest,
-      final String bpmnProcessId,
+      final Long definitionKey,
       final CamundaAuthentication authentication,
       final Duration requestTimeout) {
-    final var handler = getRetryHandler(bpmnProcessId);
+    final var handler = getRetryHandler(definitionKey);
     return sendRequestWithRetryPartitions(brokerRequest, authentication, requestTimeout, handler)
         .whenComplete(
             (response, error) -> {
-              if (error == null && bpmnProcessId != null) {
-                processIdToRetryHandler.computeIfAbsent(
-                    bpmnProcessId, ignored -> createRetryHandler());
+              if (error == null && definitionKey != null) {
+                definitionKeyToRetryHandler.computeIfAbsent(
+                    definitionKey, ignored -> createRetryHandler());
               }
             });
   }
 
-  private RequestRetryHandler getRetryHandler(final String bpmnProcessId) {
-    if (bpmnProcessId == null) {
+  private RequestRetryHandler getRetryHandler(final Long definitionKey) {
+    if (definitionKey == null) {
       return requestRetryHandler;
     }
-    final var handler = processIdToRetryHandler.get(bpmnProcessId);
+    final var handler = definitionKeyToRetryHandler.get(definitionKey);
     return handler != null ? handler : requestRetryHandler;
   }
 

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -86,8 +86,9 @@ public final class ProcessInstanceServices
   private final RequestRetryHandler requestRetryHandler;
   private final ExecutorService executor;
   private final int maxVariableNameLength;
-  private final Cache<Long, RequestRetryHandler> definitionKeyToRetryHandler =
-      Caffeine.newBuilder().maximumSize(MAX_CACHED_DEFINITIONS).build();
+  private final Cache<ProcessDefinitionIdentifier, RequestRetryHandler>
+      definitionKeyToRetryHandler =
+          Caffeine.newBuilder().maximumSize(MAX_CACHED_DEFINITIONS).build();
 
   public ProcessInstanceServices(
       final BrokerClient brokerClient,
@@ -304,7 +305,7 @@ public final class ProcessInstanceServices
       return sendRequestWithRetryPartitions(brokerRequest, authentication);
     }
     return sendWithPerProcessRoundRobin(
-        brokerRequest, request.processDefinitionKey(), authentication, null);
+        brokerRequest, request.processDefinitionIdentifier(), authentication, null);
   }
 
   public CompletableFuture<ProcessInstanceResultRecord> createProcessInstanceWithResult(
@@ -337,7 +338,7 @@ public final class ProcessInstanceServices
     }
 
     return sendWithPerProcessRoundRobin(
-        brokerRequest, request.processDefinitionKey(), authentication, timeout);
+        brokerRequest, request.processDefinitionIdentifier(), authentication, timeout);
   }
 
   public CompletableFuture<ProcessInstanceRecord> cancelProcessInstance(
@@ -522,25 +523,24 @@ public final class ProcessInstanceServices
 
   private <R> CompletableFuture<R> sendWithPerProcessRoundRobin(
       final BrokerRequest<R> brokerRequest,
-      final Long definitionKey,
+      final ProcessDefinitionIdentifier identifier,
       final CamundaAuthentication authentication,
       final Duration requestTimeout) {
-    final var handler = getRetryHandler(definitionKey);
+    final var handler = getRetryHandler(identifier);
     return sendRequestWithRetryPartitions(brokerRequest, authentication, requestTimeout, handler)
         .whenComplete(
             (response, error) -> {
-              if (error == null && definitionKey != null) {
-                definitionKeyToRetryHandler.get(
-                    definitionKey, ignored -> createRetryHandler());
+              if (error == null && identifier != null) {
+                definitionKeyToRetryHandler.get(identifier, ignored -> createRetryHandler());
               }
             });
   }
 
-  private RequestRetryHandler getRetryHandler(final Long definitionKey) {
-    if (definitionKey == null) {
+  private RequestRetryHandler getRetryHandler(final ProcessDefinitionIdentifier identifier) {
+    if (identifier == null) {
       return requestRetryHandler;
     }
-    final var handler = definitionKeyToRetryHandler.getIfPresent(definitionKey);
+    final var handler = definitionKeyToRetryHandler.getIfPresent(identifier);
     return handler != null ? handler : requestRetryHandler;
   }
 
@@ -605,7 +605,20 @@ public final class ProcessInstanceServices
       List<ProcessInstanceCreationRuntimeInstruction> runtimeInstructions,
       List<String> fetchVariables,
       Set<String> tags,
-      String businessId) {}
+      String businessId) {
+
+    ProcessDefinitionIdentifier processDefinitionIdentifier() {
+      if (processDefinitionKey > 0L) {
+        return new ProcessDefinitionIdentifier.ByKey(processDefinitionKey);
+      } else if (bpmnProcessId != null && !bpmnProcessId.isEmpty()) {
+        return new ProcessDefinitionIdentifier.ById(bpmnProcessId);
+      } else {
+        throw new IllegalStateException(
+            "Expected to have processDefinitionKey or bpmnProcessId set, but they are key=%d, id=%s"
+                .formatted(processDefinitionKey, bpmnProcessId));
+      }
+    }
+  }
 
   public record ProcessInstanceCancelRequest(Long processInstanceKey, Long operationReference) {}
 
@@ -630,4 +643,11 @@ public final class ProcessInstanceServices
   public record ProcessInstanceModifyBatchOperationRequest(
       ProcessInstanceFilter filter,
       List<ProcessInstanceModificationMoveInstruction> moveInstructions) {}
+
+  /** The process can be identified by the key or by the definitionId. */
+  sealed interface ProcessDefinitionIdentifier {
+    record ByKey(long key) implements ProcessDefinitionIdentifier {}
+
+    record ById(String id) implements ProcessDefinitionIdentifier {}
+  }
 }

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -12,6 +12,8 @@ import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.PROCESS_INSTANCE_READ_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.PROCESS_INSTANCE_UPDATE_AUTHORIZATION;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.SequenceFlowSearchClient;
 import io.camunda.search.entities.IncidentEntity;
@@ -69,7 +71,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -78,14 +79,15 @@ public final class ProcessInstanceServices
     extends SearchQueryService<
         ProcessInstanceServices, ProcessInstanceQuery, ProcessInstanceEntity> {
 
+  private static final int MAX_CACHED_DEFINITIONS = 1024;
   private final ProcessInstanceSearchClient processInstanceSearchClient;
   private final SequenceFlowSearchClient sequenceFlowSearchClient;
   private final IncidentServices incidentServices;
   private final RequestRetryHandler requestRetryHandler;
   private final ExecutorService executor;
   private final int maxVariableNameLength;
-  private final ConcurrentHashMap<Long, RequestRetryHandler> definitionKeyToRetryHandler =
-      new ConcurrentHashMap<>();
+  private final Cache<Long, RequestRetryHandler> definitionKeyToRetryHandler =
+      Caffeine.newBuilder().maximumSize(MAX_CACHED_DEFINITIONS).build();
 
   public ProcessInstanceServices(
       final BrokerClient brokerClient,
@@ -528,7 +530,7 @@ public final class ProcessInstanceServices
         .whenComplete(
             (response, error) -> {
               if (error == null && definitionKey != null) {
-                definitionKeyToRetryHandler.computeIfAbsent(
+                definitionKeyToRetryHandler.get(
                     definitionKey, ignored -> createRetryHandler());
               }
             });
@@ -538,7 +540,7 @@ public final class ProcessInstanceServices
     if (definitionKey == null) {
       return requestRetryHandler;
     }
-    final var handler = definitionKeyToRetryHandler.get(definitionKey);
+    final var handler = definitionKeyToRetryHandler.getIfPresent(definitionKey);
     return handler != null ? handler : requestRetryHandler;
   }
 

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -36,7 +36,6 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.service.util.TreePathParser;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.RequestRetryHandler;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
@@ -302,15 +301,8 @@ public final class ProcessInstanceServices
     if (request.businessId() != null) {
       return sendRequestWithRetryPartitions(brokerRequest, authentication);
     }
-    final var handler = getOrCreateRetryHandler(request.bpmnProcessId());
-    return sendRequestWithRetryPartitions(brokerRequest, authentication, null, handler)
-        .whenComplete(
-            (response, error) -> {
-              if (error == null && request.bpmnProcessId() != null) {
-                processIdToRetryHandler.computeIfAbsent(
-                    request.bpmnProcessId(), this::createRetryHandler);
-              }
-            });
+    return sendWithPerProcessRoundRobin(
+        brokerRequest, request.bpmnProcessId(), authentication, null);
   }
 
   public CompletableFuture<ProcessInstanceResultRecord> createProcessInstanceWithResult(
@@ -342,19 +334,12 @@ public final class ProcessInstanceServices
       return sendRequestWithRetryPartitions(brokerRequest, authentication);
     }
 
-    final var handler = getOrCreateRetryHandler(request.bpmnProcessId());
     final Duration timeout =
         request.requestTimeout() != null && request.requestTimeout() > 0
             ? Duration.ofMillis(request.requestTimeout())
             : null;
-    return sendRequestWithRetryPartitions(brokerRequest, authentication, timeout, handler)
-        .whenComplete(
-            (response, error) -> {
-              if (error == null && request.bpmnProcessId() != null) {
-                processIdToRetryHandler.computeIfAbsent(
-                    request.bpmnProcessId(), this::createRetryHandler);
-              }
-            });
+    return sendWithPerProcessRoundRobin(
+        brokerRequest, request.bpmnProcessId(), authentication, timeout);
   }
 
   public CompletableFuture<ProcessInstanceRecord> cancelProcessInstance(
@@ -537,7 +522,23 @@ public final class ProcessInstanceServices
         authentication);
   }
 
-  private RequestRetryHandler getOrCreateRetryHandler(final String bpmnProcessId) {
+  private <R> CompletableFuture<R> sendWithPerProcessRoundRobin(
+      final BrokerRequest<R> brokerRequest,
+      final String bpmnProcessId,
+      final CamundaAuthentication authentication,
+      final Duration requestTimeout) {
+    final var handler = getRetryHandler(bpmnProcessId);
+    return sendRequestWithRetryPartitions(brokerRequest, authentication, requestTimeout, handler)
+        .whenComplete(
+            (response, error) -> {
+              if (error == null && bpmnProcessId != null) {
+                processIdToRetryHandler.computeIfAbsent(
+                    bpmnProcessId, ignored -> createRetryHandler());
+              }
+            });
+  }
+
+  private RequestRetryHandler getRetryHandler(final String bpmnProcessId) {
     if (bpmnProcessId == null) {
       return requestRetryHandler;
     }
@@ -545,10 +546,8 @@ public final class ProcessInstanceServices
     return handler != null ? handler : requestRetryHandler;
   }
 
-  private RequestRetryHandler createRetryHandler(final String bpmnProcessId) {
-    final var topologyManager = brokerClient.getTopologyManager();
-    return new RequestRetryHandler(
-        brokerClient, topologyManager, RequestDispatchStrategy.roundRobin());
+  private RequestRetryHandler createRetryHandler() {
+    return new RequestRetryHandler(brokerClient, brokerClient.getTopologyManager());
   }
 
   private <R> CompletableFuture<R> sendRequestWithRetryPartitions(

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -36,6 +36,7 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.service.util.TreePathParser;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.RequestRetryHandler;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
@@ -69,6 +70,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -83,6 +85,8 @@ public final class ProcessInstanceServices
   private final RequestRetryHandler requestRetryHandler;
   private final ExecutorService executor;
   private final int maxVariableNameLength;
+  private final ConcurrentHashMap<String, RequestRetryHandler> processIdToRetryHandler =
+      new ConcurrentHashMap<>();
 
   public ProcessInstanceServices(
       final BrokerClient brokerClient,
@@ -295,7 +299,18 @@ public final class ProcessInstanceServices
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
     }
-    return sendRequestWithRetryPartitions(brokerRequest, authentication);
+    if (request.businessId() != null) {
+      return sendRequestWithRetryPartitions(brokerRequest, authentication);
+    }
+    final var handler = getOrCreateRetryHandler(request.bpmnProcessId());
+    return sendRequestWithRetryPartitions(brokerRequest, authentication, null, handler)
+        .whenComplete(
+            (response, error) -> {
+              if (error == null && request.bpmnProcessId() != null) {
+                processIdToRetryHandler.computeIfAbsent(
+                    request.bpmnProcessId(), this::createRetryHandler);
+              }
+            });
   }
 
   public CompletableFuture<ProcessInstanceResultRecord> createProcessInstanceWithResult(
@@ -319,12 +334,27 @@ public final class ProcessInstanceServices
       brokerRequest.setOperationReference(request.operationReference());
     }
 
-    // Use custom request timeout if provided, otherwise use default
-    if (request.requestTimeout() != null && request.requestTimeout() > 0) {
-      return sendRequestWithRetryPartitions(
-          brokerRequest, authentication, Duration.ofMillis(request.requestTimeout()));
+    if (request.businessId() != null) {
+      if (request.requestTimeout() != null && request.requestTimeout() > 0) {
+        return sendRequestWithRetryPartitions(
+            brokerRequest, authentication, Duration.ofMillis(request.requestTimeout()));
+      }
+      return sendRequestWithRetryPartitions(brokerRequest, authentication);
     }
-    return sendRequestWithRetryPartitions(brokerRequest, authentication);
+
+    final var handler = getOrCreateRetryHandler(request.bpmnProcessId());
+    final Duration timeout =
+        request.requestTimeout() != null && request.requestTimeout() > 0
+            ? Duration.ofMillis(request.requestTimeout())
+            : null;
+    return sendRequestWithRetryPartitions(brokerRequest, authentication, timeout, handler)
+        .whenComplete(
+            (response, error) -> {
+              if (error == null && request.bpmnProcessId() != null) {
+                processIdToRetryHandler.computeIfAbsent(
+                    request.bpmnProcessId(), this::createRetryHandler);
+              }
+            });
   }
 
   public CompletableFuture<ProcessInstanceRecord> cancelProcessInstance(
@@ -507,27 +537,50 @@ public final class ProcessInstanceServices
         authentication);
   }
 
+  private RequestRetryHandler getOrCreateRetryHandler(final String bpmnProcessId) {
+    if (bpmnProcessId == null) {
+      return requestRetryHandler;
+    }
+    final var handler = processIdToRetryHandler.get(bpmnProcessId);
+    return handler != null ? handler : requestRetryHandler;
+  }
+
+  private RequestRetryHandler createRetryHandler(final String bpmnProcessId) {
+    final var topologyManager = brokerClient.getTopologyManager();
+    return new RequestRetryHandler(
+        brokerClient, topologyManager, RequestDispatchStrategy.roundRobin());
+  }
+
   private <R> CompletableFuture<R> sendRequestWithRetryPartitions(
       final BrokerRequest<R> brokerRequest, final CamundaAuthentication authentication) {
-    return sendRequestWithRetryPartitions(brokerRequest, authentication, null);
+    return sendRequestWithRetryPartitions(brokerRequest, authentication, null, requestRetryHandler);
   }
 
   private <R> CompletableFuture<R> sendRequestWithRetryPartitions(
       final BrokerRequest<R> brokerRequest,
       final CamundaAuthentication authentication,
       final Duration requestTimeout) {
+    return sendRequestWithRetryPartitions(
+        brokerRequest, authentication, requestTimeout, requestRetryHandler);
+  }
+
+  private <R> CompletableFuture<R> sendRequestWithRetryPartitions(
+      final BrokerRequest<R> brokerRequest,
+      final CamundaAuthentication authentication,
+      final Duration requestTimeout,
+      final RequestRetryHandler handler) {
     final var brokerRequestAuthorization =
         brokerRequestAuthorizationConverter.convert(authentication);
     brokerRequest.setAuthorization(brokerRequestAuthorization);
     final CompletableFuture<R> responseFuture = new CompletableFuture<>();
     if (requestTimeout != null) {
-      requestRetryHandler.sendRequest(
+      handler.sendRequest(
           brokerRequest,
           (key, response) -> responseFuture.complete(response),
           responseFuture::completeExceptionally,
           requestTimeout);
     } else {
-      requestRetryHandler.sendRequest(
+      handler.sendRequest(
           brokerRequest,
           (key, response) -> responseFuture.complete(response),
           responseFuture::completeExceptionally);

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -326,18 +326,14 @@ public final class ProcessInstanceServices
       brokerRequest.setOperationReference(request.operationReference());
     }
 
-    if (request.businessId() != null) {
-      if (request.requestTimeout() != null && request.requestTimeout() > 0) {
-        return sendRequestWithRetryPartitions(
-            brokerRequest, authentication, Duration.ofMillis(request.requestTimeout()));
-      }
-      return sendRequestWithRetryPartitions(brokerRequest, authentication);
-    }
-
     final Duration timeout =
         request.requestTimeout() != null && request.requestTimeout() > 0
             ? Duration.ofMillis(request.requestTimeout())
             : null;
+    if (request.businessId() != null) {
+      return sendRequestWithRetryPartitions(brokerRequest, authentication, timeout);
+    }
+
     return sendWithPerProcessRoundRobin(
         brokerRequest, request.bpmnProcessId(), authentication, timeout);
   }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
@@ -95,10 +95,10 @@ final class ProcessInstanceRoundRobinDispatchTest {
     }
     final var partitionsB = List.copyOf(partitions);
 
-    // then — both process definitions cycle through the same partition sequence independently
+    // then — both process definitions independently cover all partitions
     assertThat(partitionsA).hasSize(PARTITION_COUNT).doesNotHaveDuplicates();
     assertThat(partitionsB).hasSize(PARTITION_COUNT).doesNotHaveDuplicates();
-    assertThat(partitionsA).isEqualTo(partitionsB);
+    assertThat(partitionsA).containsExactlyInAnyOrderElementsOf(partitionsB);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
@@ -60,14 +60,14 @@ final class ProcessInstanceRoundRobinDispatchTest {
   }
 
   @Test
-  void shouldRoundRobinAcrossPartitionsForSameProcessId() {
+  void shouldRoundRobinAcrossPartitionsForSameDefinitionKey() {
     // given
     final var partitions = capturePartitions();
 
     // when — first request warms up the per-definition handler via the global handler;
     // subsequent requests use the per-definition handler and cycle through all partitions
     for (int i = 0; i < PARTITION_COUNT + 1; i++) {
-      services.createProcessInstance(createRequest("my-process"), authentication).join();
+      services.createProcessInstance(createRequest(100L), authentication).join();
     }
 
     // then — the per-definition handler (requests 2..N) hit every partition
@@ -76,22 +76,22 @@ final class ProcessInstanceRoundRobinDispatchTest {
   }
 
   @Test
-  void shouldDistributeIndependentlyPerProcessId() {
-    // given — warm up per-definition handlers for both process IDs
+  void shouldDistributeIndependentlyPerDefinitionKey() {
+    // given — warm up per-definition handlers for both definition keys
     final var partitions = capturePartitions();
-    services.createProcessInstance(createRequest("process-a"), authentication).join();
-    services.createProcessInstance(createRequest("process-b"), authentication).join();
+    services.createProcessInstance(createRequest(100L), authentication).join();
+    services.createProcessInstance(createRequest(200L), authentication).join();
     partitions.clear();
 
     // when — send PARTITION_COUNT requests for each process definition
     for (int i = 0; i < PARTITION_COUNT; i++) {
-      services.createProcessInstance(createRequest("process-a"), authentication).join();
+      services.createProcessInstance(createRequest(100L), authentication).join();
     }
     final var partitionsA = List.copyOf(partitions);
     partitions.clear();
 
     for (int i = 0; i < PARTITION_COUNT; i++) {
-      services.createProcessInstance(createRequest("process-b"), authentication).join();
+      services.createProcessInstance(createRequest(200L), authentication).join();
     }
     final var partitionsB = List.copyOf(partitions);
 
@@ -116,7 +116,7 @@ final class ProcessInstanceRoundRobinDispatchTest {
             });
 
     try {
-      services.createProcessInstance(createRequest("my-process"), authentication).join();
+      services.createProcessInstance(createRequest(100L), authentication).join();
     } catch (final Exception ignored) {
       // expected
     }
@@ -133,8 +133,8 @@ final class ProcessInstanceRoundRobinDispatchTest {
                   new BrokerResponse<>(new ProcessInstanceCreationRecord()));
             });
 
-    // when — send a second request for the same bpmnProcessId
-    services.createProcessInstance(createRequest("my-process"), authentication).join();
+    // when — send a second request for the same definition key
+    services.createProcessInstance(createRequest(100L), authentication).join();
 
     // then — the second request used the global handler (not a per-definition one),
     // so its partition is the global handler's next offset, different from the first
@@ -157,10 +157,10 @@ final class ProcessInstanceRoundRobinDispatchTest {
     return partitions;
   }
 
-  private static ProcessInstanceCreateRequest createRequest(final String bpmnProcessId) {
+  private static ProcessInstanceCreateRequest createRequest(final long definitionKey) {
     return new ProcessInstanceCreateRequest(
-        123L,
-        bpmnProcessId,
+        definitionKey,
+        "process",
         -1,
         null,
         "<default>",

--- a/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.ProcessInstanceSearchClient;
+import io.camunda.search.clients.SequenceFlowSearchClient;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.gateway.api.util.StubbedTopologyManager;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class ProcessInstanceRoundRobinDispatchTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  private BrokerClient brokerClient;
+  private ProcessInstanceServices services;
+  private CamundaAuthentication authentication;
+
+  @BeforeEach
+  void setUp() {
+    brokerClient = mock(BrokerClient.class);
+    when(brokerClient.getTopologyManager()).thenReturn(new StubbedTopologyManager(PARTITION_COUNT));
+
+    final var executorProvider = mock(ApiServicesExecutorProvider.class);
+    when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
+
+    authentication = CamundaAuthentication.none();
+
+    services =
+        new ProcessInstanceServices(
+            brokerClient,
+            mock(SecurityContextProvider.class),
+            mock(ProcessInstanceSearchClient.class),
+            mock(SequenceFlowSearchClient.class),
+            mock(IncidentServices.class),
+            executorProvider,
+            mock(BrokerRequestAuthorizationConverter.class));
+  }
+
+  @Test
+  void shouldRoundRobinAcrossPartitionsForSameProcessId() {
+    // given
+    final var partitions = capturePartitions();
+
+    // when — first request warms up the per-definition handler via the global handler;
+    // subsequent requests use the per-definition handler and cycle through all partitions
+    for (int i = 0; i < PARTITION_COUNT + 1; i++) {
+      services.createProcessInstance(createRequest("my-process"), authentication).join();
+    }
+
+    // then — the per-definition handler (requests 2..N) hit every partition
+    final var perDefPartitions = partitions.subList(1, partitions.size());
+    assertThat(perDefPartitions).hasSize(PARTITION_COUNT).doesNotHaveDuplicates();
+  }
+
+  @Test
+  void shouldDistributeIndependentlyPerProcessId() {
+    // given — warm up per-definition handlers for both process IDs
+    final var partitions = capturePartitions();
+    services.createProcessInstance(createRequest("process-a"), authentication).join();
+    services.createProcessInstance(createRequest("process-b"), authentication).join();
+    partitions.clear();
+
+    // when — send PARTITION_COUNT requests for each process definition
+    for (int i = 0; i < PARTITION_COUNT; i++) {
+      services.createProcessInstance(createRequest("process-a"), authentication).join();
+    }
+    final var partitionsA = List.copyOf(partitions);
+    partitions.clear();
+
+    for (int i = 0; i < PARTITION_COUNT; i++) {
+      services.createProcessInstance(createRequest("process-b"), authentication).join();
+    }
+    final var partitionsB = List.copyOf(partitions);
+
+    // then — both process definitions cycle through the same partition sequence independently
+    assertThat(partitionsA).hasSize(PARTITION_COUNT).doesNotHaveDuplicates();
+    assertThat(partitionsB).hasSize(PARTITION_COUNT).doesNotHaveDuplicates();
+    assertThat(partitionsA).isEqualTo(partitionsB);
+  }
+
+  @Test
+  void shouldNotPopulateMapOnFailedRequest() {
+    // given — first request fails (RuntimeException is not retryable, so no retry)
+    final var partitions = new ArrayList<Integer>();
+    when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              partitions.add(
+                  invocation
+                      .getArgument(0, BrokerCreateProcessInstanceRequest.class)
+                      .getPartitionId());
+              return CompletableFuture.failedFuture(new RuntimeException("broker error"));
+            });
+
+    try {
+      services.createProcessInstance(createRequest("my-process"), authentication).join();
+    } catch (final Exception ignored) {
+      // expected
+    }
+
+    // given — subsequent requests succeed
+    when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              partitions.add(
+                  invocation
+                      .getArgument(0, BrokerCreateProcessInstanceRequest.class)
+                      .getPartitionId());
+              return CompletableFuture.completedFuture(
+                  new BrokerResponse<>(new ProcessInstanceCreationRecord()));
+            });
+
+    // when — send a second request for the same bpmnProcessId
+    services.createProcessInstance(createRequest("my-process"), authentication).join();
+
+    // then — the second request used the global handler (not a per-definition one),
+    // so its partition is the global handler's next offset, different from the first
+    assertThat(partitions).hasSize(2);
+    assertThat(partitions.get(0)).isNotEqualTo(partitions.get(1));
+  }
+
+  private List<Integer> capturePartitions() {
+    final var partitions = new ArrayList<Integer>();
+    when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              partitions.add(
+                  invocation
+                      .getArgument(0, BrokerCreateProcessInstanceRequest.class)
+                      .getPartitionId());
+              return CompletableFuture.completedFuture(
+                  new BrokerResponse<>(new ProcessInstanceCreationRecord()));
+            });
+    return partitions;
+  }
+
+  private static ProcessInstanceCreateRequest createRequest(final String bpmnProcessId) {
+    return new ProcessInstanceCreateRequest(
+        123L,
+        bpmnProcessId,
+        -1,
+        null,
+        "<default>",
+        null,
+        null,
+        null,
+        List.of(),
+        List.of(),
+        null,
+        null,
+        null);
+  }
+}

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/RequestDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/RequestDispatchStrategy.java
@@ -30,7 +30,6 @@ public interface RequestDispatchStrategy {
    * starting from a random offset to avoid all gateway pods hitting the same partition first.
    */
   static RequestDispatchStrategy roundRobin() {
-    return new RoundRobinDispatchStrategy(
-        ThreadLocalRandom.current().nextInt(MAX_RANDOM_OFFSET));
+    return new RoundRobinDispatchStrategy(ThreadLocalRandom.current().nextInt(MAX_RANDOM_OFFSET));
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/RequestDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/RequestDispatchStrategy.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.client.api;
 
 import io.camunda.zeebe.broker.client.impl.RoundRobinDispatchStrategy;
+import java.util.concurrent.ThreadLocalRandom;
 
 /** Implementations must be thread-safe. */
 public interface RequestDispatchStrategy {
@@ -18,9 +19,10 @@ public interface RequestDispatchStrategy {
   int determinePartition(final BrokerTopologyManager topologyManager);
 
   /**
-   * Returns a dispatch strategy which will perform a stateful round robin between the partitions.
+   * Returns a dispatch strategy which will perform a stateful round robin between the partitions,
+   * starting from a random offset to avoid all gateway pods hitting the same partition first.
    */
   static RequestDispatchStrategy roundRobin() {
-    return new RoundRobinDispatchStrategy();
+    return new RoundRobinDispatchStrategy(ThreadLocalRandom.current().nextInt(128));
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/RequestDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/RequestDispatchStrategy.java
@@ -14,6 +14,13 @@ import java.util.concurrent.ThreadLocalRandom;
 public interface RequestDispatchStrategy {
 
   /**
+   * Upper bound for the random initial offset. Chosen to be larger than any realistic partition
+   * count so that different gateway pods start at well-spread positions in the round-robin cycle,
+   * avoiding the thundering-herd problem on startup.
+   */
+  int MAX_RANDOM_OFFSET = 128;
+
+  /**
    * @return {@link BrokerClusterState#PARTITION_ID_NULL} if no partition can be determined
    */
   int determinePartition(final BrokerTopologyManager topologyManager);
@@ -23,6 +30,7 @@ public interface RequestDispatchStrategy {
    * starting from a random offset to avoid all gateway pods hitting the same partition first.
    */
   static RequestDispatchStrategy roundRobin() {
-    return new RoundRobinDispatchStrategy(ThreadLocalRandom.current().nextInt(128));
+    return new RoundRobinDispatchStrategy(
+        ThreadLocalRandom.current().nextInt(MAX_RANDOM_OFFSET));
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -33,6 +33,10 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
   }
 
   public RoundRobinDispatchStrategy(final int initialOffset) {
+    if (initialOffset < 0) {
+      throw new IllegalArgumentException(
+          "Expected initialOffset to be >= 0, but got %d".formatted(initialOffset));
+    }
     offset = new AtomicLong(initialOffset);
   }
 
@@ -117,7 +121,7 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
     }
 
     public int partitionAtOffset(final long offset) {
-      return partitions[(int) (offset % partitions.length)];
+      return partitions[Math.floorMod(offset, partitions.length)];
     }
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -26,7 +26,15 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
   private final AtomicReference<VersionedPartitionRing> partitionRing =
       new AtomicReference<>(VersionedPartitionRing.uninitialized());
 
-  private final AtomicInteger offset = new AtomicInteger(0);
+  private final AtomicLong offset;
+
+  public RoundRobinDispatchStrategy() {
+    this(0);
+  }
+
+  public RoundRobinDispatchStrategy(final int initialOffset) {
+    offset = new AtomicLong(initialOffset);
+  }
 
   @Override
   public int determinePartition(final BrokerTopologyManager topologyManager) {
@@ -108,8 +116,8 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
       return new PartitionRing(sorted);
     }
 
-    public int partitionAtOffset(final int offset) {
-      return partitions[offset % partitions.length];
+    public int partitionAtOffset(final long offset) {
+      return partitions[(int) (offset % partitions.length)];
     }
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -197,9 +197,9 @@ public final class RequestRetryHandler {
    * partition.
    */
   private int determineNextPartition(
-      final Set<Integer> triedPartitions, final int partitionsCount) {
+      final Set<Integer> triedPartitions, final int partitionCount) {
     final var seen = new HashSet<Integer>();
-    while (seen.size() < partitionsCount) {
+    for (int i = 0; i < partitionCount; i++) {
       final int partition = dispatchStrategy.determinePartition(topologyManager);
       if (partition == BrokerClusterState.PARTITION_ID_NULL) {
         return BrokerClusterState.PARTITION_ID_NULL;
@@ -207,7 +207,10 @@ public final class RequestRetryHandler {
       if (!triedPartitions.contains(partition)) {
         return partition;
       }
-      seen.add(partition);
+      if (!seen.add(partition)) {
+        // The strategy is cycling over partitions we've already tried; stop early.
+        return BrokerClusterState.PARTITION_ID_NULL;
+      }
     }
     return BrokerClusterState.PARTITION_ID_NULL;
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -39,16 +39,22 @@ import org.slf4j.LoggerFactory;
 public final class RequestRetryHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(RequestRetryHandler.class);
 
-  private final RequestDispatchStrategy roundRobinDispatchStrategy =
-      RequestDispatchStrategy.roundRobin();
-
+  private final RequestDispatchStrategy dispatchStrategy;
   private final BrokerClient brokerClient;
   private final BrokerTopologyManager topologyManager;
 
   public RequestRetryHandler(
       final BrokerClient brokerClient, final BrokerTopologyManager topologyManager) {
+    this(brokerClient, topologyManager, RequestDispatchStrategy.roundRobin());
+  }
+
+  public RequestRetryHandler(
+      final BrokerClient brokerClient,
+      final BrokerTopologyManager topologyManager,
+      final RequestDispatchStrategy dispatchStrategy) {
     this.brokerClient = brokerClient;
     this.topologyManager = topologyManager;
+    this.dispatchStrategy = dispatchStrategy;
   }
 
   public <BrokerResponseT> void sendRequest(
@@ -194,7 +200,7 @@ public final class RequestRetryHandler {
   }
 
   private PartitionIdIterator partitionIdIteratorForType(final int partitionsCount) {
-    final int nextPartitionId = roundRobinDispatchStrategy.determinePartition(topologyManager);
+    final int nextPartitionId = dispatchStrategy.determinePartition(topologyManager);
     return new PartitionIdIterator(nextPartitionId, partitionsCount, topologyManager);
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl.broker;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -16,12 +17,13 @@ import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
-import io.camunda.zeebe.broker.client.impl.PartitionIdIterator;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import java.net.ConnectException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -105,7 +107,8 @@ public final class RequestRetryHandler {
     sendRequestWithRetry(
         request,
         requestSender,
-        partitionIdIteratorForType(topology.getPartitionsCount()),
+        topology.getPartitionsCount(),
+        new HashSet<>(),
         responseConsumer,
         throwableConsumer,
         new ArrayList<>());
@@ -148,45 +151,65 @@ public final class RequestRetryHandler {
       final Function<
               BrokerRequest<BrokerResponseT>, CompletableFuture<BrokerResponse<BrokerResponseT>>>
           requestSender,
-      final PartitionIdIterator partitionIdIterator,
+      final int partitionCount,
+      final Set<Integer> triedPartitions,
       final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
       final Consumer<Throwable> throwableConsumer,
       final Collection<Throwable> errors) {
 
-    if (partitionIdIterator.hasNext()) {
-      final int partitionId = partitionIdIterator.next();
-
-      // partitions to check
-      request.setPartitionId(partitionId);
-      requestSender
-          .apply(request)
-          .whenComplete(
-              (response, error) -> {
-                if (error == null) {
-                  responseConsumer.accept(response.getKey(), response.getResponse());
-                } else if (shouldRetryWithNextPartition(error)) {
-                  LOGGER.trace(
-                      "Failed to create process on partition {}",
-                      partitionIdIterator.getCurrentPartitionId(),
-                      error);
-                  errors.add(error);
-                  sendRequestWithRetry(
-                      request,
-                      requestSender,
-                      partitionIdIterator,
-                      responseConsumer,
-                      throwableConsumer,
-                      errors);
-                } else {
-                  throwableConsumer.accept(error);
-                }
-              });
-    } else {
-      // no partition left to check
+    final int partitionId = determineNextPartition(triedPartitions, partitionCount);
+    if (partitionId == BrokerClusterState.PARTITION_ID_NULL) {
       final var exception = new RequestRetriesExhaustedException();
       errors.forEach(exception::addSuppressed);
       throwableConsumer.accept(exception);
+      return;
     }
+
+    triedPartitions.add(partitionId);
+    request.setPartitionId(partitionId);
+    requestSender
+        .apply(request)
+        .whenComplete(
+            (response, error) -> {
+              if (error == null) {
+                responseConsumer.accept(response.getKey(), response.getResponse());
+              } else if (shouldRetryWithNextPartition(error)) {
+                LOGGER.trace("Failed to create process on partition {}", partitionId, error);
+                errors.add(error);
+                sendRequestWithRetry(
+                    request,
+                    requestSender,
+                    partitionCount,
+                    triedPartitions,
+                    responseConsumer,
+                    throwableConsumer,
+                    errors);
+              } else {
+                throwableConsumer.accept(error);
+              }
+            });
+  }
+
+  /**
+   * Determines the next partition to try using the dispatch strategy, skipping partitions that have
+   * already been tried. Uses the dispatch strategy (round-robin) for each attempt so that
+   * concurrent retries scatter across partitions instead of all cascading to the same next
+   * partition.
+   */
+  private int determineNextPartition(
+      final Set<Integer> triedPartitions, final int partitionsCount) {
+    final var seen = new HashSet<Integer>();
+    while (seen.size() < partitionsCount) {
+      final int partition = dispatchStrategy.determinePartition(topologyManager);
+      if (partition == BrokerClusterState.PARTITION_ID_NULL) {
+        return BrokerClusterState.PARTITION_ID_NULL;
+      }
+      if (!triedPartitions.contains(partition)) {
+        return partition;
+      }
+      seen.add(partition);
+    }
+    return BrokerClusterState.PARTITION_ID_NULL;
   }
 
   private boolean shouldRetryWithNextPartition(final Throwable error) {
@@ -197,10 +220,5 @@ public final class RequestRetryHandler {
       return code == ErrorCode.PARTITION_LEADER_MISMATCH || code == ErrorCode.RESOURCE_EXHAUSTED;
     }
     return false;
-  }
-
-  private PartitionIdIterator partitionIdIteratorForType(final int partitionsCount) {
-    final int nextPartitionId = dispatchStrategy.determinePartition(topologyManager);
-    return new PartitionIdIterator(nextPartitionId, partitionsCount, topologyManager);
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -196,8 +196,7 @@ public final class RequestRetryHandler {
    * concurrent retries scatter across partitions instead of all cascading to the same next
    * partition.
    */
-  private int determineNextPartition(
-      final Set<Integer> triedPartitions, final int partitionCount) {
+  private int determineNextPartition(final Set<Integer> triedPartitions, final int partitionCount) {
     final var seen = new HashSet<Integer>();
     for (int i = 0; i < partitionCount; i++) {
       final int partition = dispatchStrategy.determinePartition(topologyManager);

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
+import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
@@ -118,6 +119,24 @@ final class RequestRetryHandlerTest {
     assertThat(error.get()).isNull();
     assertThat(result.get()).isEqualTo("result");
     assertThat(brokerClient.partitionsHit).containsExactly(1, 2);
+  }
+
+  @Test
+  void shouldNotSpinWhenActivePartitionsFewerThanTopologyCount() {
+    // given - topology reports 3 partitions, but the strategy always returns partition 1
+    // (e.g. only one active partition in routing state)
+    final RequestDispatchStrategy fixedStrategy = ignored -> 1;
+    final var handler = new RequestRetryHandler(brokerClient, topologyManager, fixedStrategy);
+    final var request = new TestBrokerRequest(Optional.empty());
+    brokerClient.setError(new ConnectException("connection refused"));
+
+    // when
+    final var error = new AtomicReference<Throwable>();
+    handler.sendRequest(request, (key, response) -> {}, error::set);
+
+    // then - tried partition 1 once, detected the strategy is cycling, gave up
+    assertThat(brokerClient.sendCount.get()).isEqualTo(1);
+    assertThat(error.get()).isInstanceOf(RequestRetriesExhaustedException.class);
   }
 
   @Test

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -10,19 +10,25 @@ package io.camunda.zeebe.gateway.impl.broker;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.broker.client.impl.RoundRobinDispatchStrategy;
 import io.camunda.zeebe.gateway.api.util.StubbedTopologyManager;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.net.ConnectException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,12 +44,15 @@ final class RequestRetryHandlerTest {
 
   private TestBrokerClient brokerClient;
   private RequestRetryHandler retryHandler;
+  private StubbedTopologyManager topologyManager;
 
   @BeforeEach
   void setUp() {
-    final var topologyManager = new StubbedTopologyManager(PARTITION_COUNT);
+    topologyManager = new StubbedTopologyManager(PARTITION_COUNT);
     brokerClient = new TestBrokerClient();
-    retryHandler = new RequestRetryHandler(brokerClient, topologyManager);
+    // Use a deterministic round-robin starting at offset 0 → partitions 1, 2, 3, 1, ...
+    final var dispatchStrategy = new RoundRobinDispatchStrategy(0);
+    retryHandler = new RequestRetryHandler(brokerClient, topologyManager, dispatchStrategy);
   }
 
   @Test
@@ -93,6 +102,25 @@ final class RequestRetryHandlerTest {
   }
 
   @Test
+  void shouldRetryOnNextRoundRobinPartitionOnResourceExhausted() {
+    // given - a broker client that fails with RESOURCE_EXHAUSTED on the first attempt
+    final var request = new TestBrokerRequest(Optional.empty());
+    final var exhaustedError =
+        new BrokerErrorException(new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure"));
+    brokerClient.failOnPartitionThenSucceed(exhaustedError);
+
+    // when
+    final var result = new AtomicReference<String>();
+    final var error = new AtomicReference<Throwable>();
+    retryHandler.sendRequest(request, (key, response) -> result.set(response), error::set);
+
+    // then - first attempt hit partition 1, retry hit partition 2 (round-robin from offset 0)
+    assertThat(error.get()).isNull();
+    assertThat(result.get()).isEqualTo("result");
+    assertThat(brokerClient.partitionsHit).containsExactly(1, 2);
+  }
+
+  @Test
   void shouldPropagateStrategyExceptionWhenDispatchStrategyFails() {
     // given - a request whose dispatch strategy throws
     final var request =
@@ -113,8 +141,10 @@ final class RequestRetryHandlerTest {
 
   private static final class TestBrokerClient implements BrokerClient {
     final AtomicInteger sendCount = new AtomicInteger(0);
+    final List<Integer> partitionsHit = new ArrayList<>();
     private BrokerResponse<String> response;
     private Throwable error;
+    private Throwable failFirstError;
 
     void setResponse(final BrokerResponse<String> response) {
       this.response = response;
@@ -124,6 +154,12 @@ final class RequestRetryHandlerTest {
     void setError(final Throwable error) {
       this.error = error;
       response = null;
+    }
+
+    void failOnPartitionThenSucceed(final Throwable firstError) {
+      failFirstError = firstError;
+      response = new BrokerResponse<>("result", 1, 1);
+      error = null;
     }
 
     @Override
@@ -137,9 +173,13 @@ final class RequestRetryHandlerTest {
     @Override
     @SuppressWarnings("unchecked")
     public <T> CompletableFuture<BrokerResponse<T>> sendRequest(final BrokerRequest<T> request) {
-      sendCount.incrementAndGet();
+      final int count = sendCount.incrementAndGet();
+      partitionsHit.add(request.getPartitionId());
       if (error != null) {
         return CompletableFuture.failedFuture(error);
+      }
+      if (failFirstError != null && count == 1) {
+        return CompletableFuture.failedFuture(failFirstError);
       }
       return CompletableFuture.completedFuture((BrokerResponse<T>) response);
     }


### PR DESCRIPTION
## Description

  ### Summary

  - Each `bpmnProcessId` gets its own `RequestRetryHandler` with an independent round-robin cycle, so low-volume process definitions distribute evenly across partitions instead of sharing a
  global offset with all other request types
  - The per-definition handler map is populated lazily on the first successful broker response (DOS protection: unknown process IDs don't consume memory)
  - Requests with a `businessId` continue to use hash-based routing to a fixed partition (unchanged)
  - Round-robin dispatch now starts from a random offset (`[0, 128)`) to avoid thundering herd when multiple gateway pods start simultaneously
  - `RoundRobinDispatchStrategy` uses `AtomicLong` instead of `AtomicInteger` to avoid overflow

  ### Limitations

  Distribution is best-effort, not perfect. Each gateway pod maintains its own independent round-robin state, so with multiple pods behind a load balancer the overall partition distribution
  depends on how requests are spread across pods. This is the same trade-off as the existing round-robin for job activation.

### Benchmark
With this feature the distribution across partition looks very nice when there's no backpressure, [dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=c8-cs-rr-pi-creation&orgId=1&from=2026-03-26T14:36:11.417Z&to=2026-03-26T14:47:53.544Z&timezone=browser&var-DS_PROMETHEUS=prometheus&var-cluster=$__all&var-pod=$__all&var-partition=$__all&var-memory_state=committed&refresh=auto):
<img width="837" height="202" alt="image" src="https://github.com/user-attachments/assets/0737c866-07bd-4222-a967-97b47fc3b0be" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #49530
