### PR TITLE
test: skip failing operate test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -761,7 +761,8 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
-  test('Migrated gateways', async ({
+  // skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
+  test.skip('Migrated gateways', async ({
     page,
     operateFiltersPanelPage,
     operateProcessesPage,


### PR DESCRIPTION
## Description

This PR skips test that is failing due to Operate changes. It is listed in https://github.com/camunda/camunda/issues/49095 so it will be handled later
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues
https://github.com/camunda/camunda/issues/49095
