### PR TITLE
[Backport stable/8.9] test: skip failing operate test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -132,7 +132,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug 43097: https://github.com/camunda/camunda/issues/43097
+  //Skipped due to bug 43097: https://github.com/camunda/camunda/issues/43097
   test.skip('Suspend active batch operation returns 204 and status becomes SUSPENDED without resume', async ({
     request,
   }) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-tenant-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-tenant-api-tests.spec.ts
@@ -126,7 +126,7 @@ test.describe.parallel('Cluster Variable API Tests - Tenant Scope', () => {
     await assertBadRequest(res, /value/i, 'INVALID_ARGUMENT');
   });
 
-  // skipped due to bug 42049: https://github.com/camunda/camunda/issues/42049
+  //Skipped due to bug 42049: https://github.com/camunda/camunda/issues/42049
   test.skip('Create Tenant Cluster Variable Invalid Tenant Not Found', async ({
     request,
   }) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts
@@ -52,7 +52,7 @@ test.describe
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug 41209:  https://github.com/camunda/camunda/issues/41209
+  //Skipped due to bug 41209:  https://github.com/camunda/camunda/issues/41209
   test.skip('Create a Batch Operation to Resolve Incidents - Success', async ({
     request,
   }) => {
@@ -153,7 +153,7 @@ test.describe
     );
   });
 
-  // Skipped due to bug 41209:  https://github.com/camunda/camunda/issues/41209
+  //Skipped due to bug 41209:  https://github.com/camunda/camunda/issues/41209
   test.skip('Create a Batch Operation to Resolve Incidents - With Multiple Filters', async ({
     request,
   }) => {
@@ -255,7 +255,7 @@ test.describe
     await cancelProcessInstance(localState.processInstanceKey2);
   });
 
-  // Skipped due to bug 41209:  https://github.com/camunda/camunda/issues/41209
+  //Skipped due to bug 41209:  https://github.com/camunda/camunda/issues/41209
   test.skip('Create a Batch Operation to Resolve Incidents - With Or Filters', async ({
     request,
   }) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
@@ -77,7 +77,7 @@ test.describe.parallel('Unassign User Task Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug #38880: https://github.com/camunda/camunda/issues/38880
+  //Skipped due to bug #38880: https://github.com/camunda/camunda/issues/38880
   test.skip('Unassign user task - not found', async ({request}) => {
     const unknownUserTaskKey = '2251799813694876';
     const res = await request.delete(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -137,7 +137,7 @@ test.describe('Dashboard', () => {
     });
   });
 
-  // skipped due to bug 45129: https://github.com/camunda/camunda/issues/45129
+  //Skipped due to bug 45129: https://github.com/camunda/camunda/issues/45129
   test.skip('Navigate to processes view (same truncated error message)', async ({
     operateDashboardPage,
     operateProcessInstancePage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -44,7 +44,7 @@ test.describe('Decision Navigation', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // skipped due to bug 49425: https://github.com/camunda/camunda/issues/49425
+  //Skipped due to bug 49425: https://github.com/camunda/camunda/issues/49425
   test.skip('Navigation between process and decision', async ({
     operateProcessInstancePage,
     operateDecisionInstancePage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -760,7 +760,7 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
-// skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
+//Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
   test.skip('Migrated gateways', async ({
     operateFiltersPanelPage,
     operateProcessesPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -760,7 +760,8 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
-  test('Migrated gateways', async ({
+// skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
+  test.skip('Migrated gateways', async ({
     operateFiltersPanelPage,
     operateProcessesPage,
     operateDiagramPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -80,7 +80,7 @@ test.describe('Process Instances Filters', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // skipped due to bug 45156: https://github.com/camunda/camunda/issues/45156
+  //Skipped due to bug 45156: https://github.com/camunda/camunda/issues/45156
   test.skip('Interaction between diagram and filters', async ({
     operateProcessesPage,
     operateFiltersPanelPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -75,7 +75,7 @@ test.describe('Process Instances Table', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug 38103: https://github.com/camunda/camunda/issues/38103
+  //Skipped due to bug 38103: https://github.com/camunda/camunda/issues/38103
   test.skip('Sorting of process instances', async ({
     page,
     operateProcessesPage,


### PR DESCRIPTION
## Description
Backport of #49715 to `stable/8.9`.

This PR skips test that is failing due to Operate changes. It is listed in https://github.com/camunda/camunda/issues/49095 so it will be handled later

## Related issues
relates to  camunda/camunda#49095