### PR TITLE
fix: LoadTests Starter Auth URL

### DIFF
--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -31,7 +31,7 @@ saas:
     # Saas.credentials.zeebeRestAddress to define the rest address of the cluster (including port)
     zeebeRestAddress: "http://camunda-gateway:8080"
     # SaaS.credentials.authServer to define the authentication server to retrieve JWT tokens
-    authServer: "http://__NAMESPACE__-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+    authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
     # Saas.credentials.authType to define the authentication type for the starter and workers
     authType: "OAUTH"
     # Saas.credentials.zeebeGrpcAddress to define the grpc address of the cluster (including port)


### PR DESCRIPTION

## Description

Fixing after removing the namespace from the URL

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
