### PR TITLE
[Backport stable/8.9] fix: return null instead of sentinel values

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
@@ -141,7 +141,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setEntityDescription(final String entityDescription) {
-    this.entityDescription = entityDescription;
+    this.entityDescription = nullIfEmpty(entityDescription);
     return this;
   }
 
@@ -186,7 +186,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setBatchOperationKey(final Long batchOperationKey) {
-    this.batchOperationKey = batchOperationKey;
+    this.batchOperationKey = nullIfNonPositive(batchOperationKey);
     return this;
   }
 
@@ -249,7 +249,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setDeploymentKey(final Long deploymentKey) {
-    this.deploymentKey = deploymentKey;
+    this.deploymentKey = nullIfNonPositive(deploymentKey);
     return this;
   }
 
@@ -258,7 +258,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setFormKey(final Long formKey) {
-    this.formKey = formKey;
+    this.formKey = nullIfNonPositive(formKey);
     return this;
   }
 
@@ -267,7 +267,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setResourceKey(final Long resourceKey) {
-    this.resourceKey = resourceKey;
+    this.resourceKey = nullIfNonPositive(resourceKey);
     return this;
   }
 
@@ -276,7 +276,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setProcessDefinitionKey(final Long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionKey = nullIfNonPositive(processDefinitionKey);
     return this;
   }
 
@@ -285,7 +285,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setProcessInstanceKey(final Long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
+    this.processInstanceKey = nullIfNonPositive(processInstanceKey);
     return this;
   }
 
@@ -294,7 +294,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setElementInstanceKey(final Long elementInstanceKey) {
-    this.elementInstanceKey = elementInstanceKey;
+    this.elementInstanceKey = nullIfNonPositive(elementInstanceKey);
     return this;
   }
 
@@ -303,7 +303,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setJobKey(final Long jobKey) {
-    this.jobKey = jobKey;
+    this.jobKey = nullIfNonPositive(jobKey);
     return this;
   }
 
@@ -312,7 +312,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setUserTaskKey(final Long userTaskKey) {
-    this.userTaskKey = userTaskKey;
+    this.userTaskKey = nullIfNonPositive(userTaskKey);
     return this;
   }
 
@@ -321,7 +321,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setDecisionRequirementsKey(final Long decisionRequirementsKey) {
-    this.decisionRequirementsKey = decisionRequirementsKey;
+    this.decisionRequirementsKey = nullIfNonPositive(decisionRequirementsKey);
     return this;
   }
 
@@ -330,7 +330,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setDecisionDefinitionKey(final Long decisionDefinitionKey) {
-    this.decisionDefinitionKey = decisionDefinitionKey;
+    this.decisionDefinitionKey = nullIfNonPositive(decisionDefinitionKey);
     return this;
   }
 
@@ -339,7 +339,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setProcessDefinitionId(final String processDefinitionId) {
-    this.processDefinitionId = processDefinitionId;
+    this.processDefinitionId = nullIfEmpty(processDefinitionId);
     return this;
   }
 
@@ -348,7 +348,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setDecisionRequirementsId(final String decisionRequirementsId) {
-    this.decisionRequirementsId = decisionRequirementsId;
+    this.decisionRequirementsId = nullIfEmpty(decisionRequirementsId);
     return this;
   }
 
@@ -357,7 +357,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setDecisionDefinitionId(final String decisionDefinitionId) {
-    this.decisionDefinitionId = decisionDefinitionId;
+    this.decisionDefinitionId = nullIfEmpty(decisionDefinitionId);
     return this;
   }
 
@@ -366,7 +366,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setDecisionEvaluationKey(final Long decisionEvaluationKey) {
-    this.decisionEvaluationKey = decisionEvaluationKey;
+    this.decisionEvaluationKey = nullIfNonPositive(decisionEvaluationKey);
     return this;
   }
 
@@ -375,7 +375,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    this.rootProcessInstanceKey = nullIfNonPositive(rootProcessInstanceKey);
     return this;
   }
 
@@ -384,7 +384,7 @@ public class AuditLogEntry {
   }
 
   public AuditLogEntry setRelatedEntityKey(final String relatedEntityKey) {
-    this.relatedEntityKey = relatedEntityKey;
+    this.relatedEntityKey = nullIfEmpty(relatedEntityKey);
     return this;
   }
 
@@ -426,7 +426,7 @@ public class AuditLogEntry {
   private static <R extends RecordValue> Long getProcessInstanceKey(final Record<R> record) {
     final var value = record.getValue();
     if (value instanceof final ProcessInstanceRelated processInstanceRelated) {
-      return nullIfNonPositive(processInstanceRelated.getProcessInstanceKey());
+      return processInstanceRelated.getProcessInstanceKey();
     }
     return null;
   }
@@ -450,7 +450,7 @@ public class AuditLogEntry {
   private static <R extends RecordValue> Long getElementInstanceKey(final Record<R> record) {
     final var value = record.getValue();
     if (value instanceof final AuditLogProcessInstanceRelated processInstanceRelated) {
-      return nullIfNonPositive(processInstanceRelated.getElementInstanceKey());
+      return processInstanceRelated.getElementInstanceKey();
     }
     return null;
   }
@@ -458,7 +458,7 @@ public class AuditLogEntry {
   private static <R extends RecordValue> Long getRootProcessInstanceKey(final Record<R> record) {
     final var value = record.getValue();
     if (value instanceof final AuditLogProcessInstanceRelated processInstanceRelated) {
-      return nullIfNonPositive(processInstanceRelated.getRootProcessInstanceKey());
+      return processInstanceRelated.getRootProcessInstanceKey();
     }
     return null;
   }
@@ -466,13 +466,13 @@ public class AuditLogEntry {
   private static <R extends RecordValue> String getProcessDefinitionId(final Record<R> record) {
     final var value = record.getValue();
     if (value instanceof final AuditLogProcessInstanceRelated processInstanceRelated) {
-      return nullIfEmpty(processInstanceRelated.getBpmnProcessId());
+      return processInstanceRelated.getBpmnProcessId();
     }
     return null;
   }
 
-  private static Long nullIfNonPositive(final long value) {
-    return value <= 0 ? null : value;
+  private static Long nullIfNonPositive(final Long value) {
+    return value == null || value <= 0 ? null : value;
   }
 
   private static String nullIfEmpty(final String value) {

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
@@ -425,16 +425,16 @@ public class AuditLogEntry {
 
   private static <R extends RecordValue> Long getProcessInstanceKey(final Record<R> record) {
     final var value = record.getValue();
-    if (value instanceof ProcessInstanceRelated) {
-      return ((ProcessInstanceRelated) value).getProcessInstanceKey();
+    if (value instanceof final ProcessInstanceRelated processInstanceRelated) {
+      return nullIfNonPositive(processInstanceRelated.getProcessInstanceKey());
     }
     return null;
   }
 
   private static <R extends RecordValue> Long getProcessDefinitionKey(final Record<R> record) {
     final var value = record.getValue();
-    if (value instanceof ProcessInstanceRelated) {
-      return ((ProcessInstanceRelated) value).getProcessDefinitionKey();
+    if (value instanceof final ProcessInstanceRelated processInstanceRelated) {
+      return nullIfNonPositive(processInstanceRelated.getProcessDefinitionKey());
     }
     return null;
   }
@@ -449,26 +449,33 @@ public class AuditLogEntry {
 
   private static <R extends RecordValue> Long getElementInstanceKey(final Record<R> record) {
     final var value = record.getValue();
-    if (value instanceof AuditLogProcessInstanceRelated) {
-      return ((AuditLogProcessInstanceRelated) value).getElementInstanceKey();
+    if (value instanceof final AuditLogProcessInstanceRelated processInstanceRelated) {
+      return nullIfNonPositive(processInstanceRelated.getElementInstanceKey());
     }
     return null;
   }
 
   private static <R extends RecordValue> Long getRootProcessInstanceKey(final Record<R> record) {
     final var value = record.getValue();
-    if (value instanceof AuditLogProcessInstanceRelated
-        && ((AuditLogProcessInstanceRelated) value).getRootProcessInstanceKey() > 0) {
-      return ((AuditLogProcessInstanceRelated) value).getRootProcessInstanceKey();
+    if (value instanceof final AuditLogProcessInstanceRelated processInstanceRelated) {
+      return nullIfNonPositive(processInstanceRelated.getRootProcessInstanceKey());
     }
     return null;
   }
 
   private static <R extends RecordValue> String getProcessDefinitionId(final Record<R> record) {
     final var value = record.getValue();
-    if (value instanceof AuditLogProcessInstanceRelated) {
-      return ((AuditLogProcessInstanceRelated) value).getBpmnProcessId();
+    if (value instanceof final AuditLogProcessInstanceRelated processInstanceRelated) {
+      return nullIfEmpty(processInstanceRelated.getBpmnProcessId());
     }
     return null;
+  }
+
+  private static Long nullIfNonPositive(final long value) {
+    return value <= 0 ? null : value;
+  }
+
+  private static String nullIfEmpty(final String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntryTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.time.Instant;
@@ -78,9 +79,9 @@ class AuditLogEntryTest {
     assertThat(entry.getTimestamp())
         .isEqualTo(
             OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC));
-    assertThat(entry.getElementInstanceKey()).isEqualTo(-1L);
 
     // Verify fields that are NOT set by AuditLogEntry.of() are null/empty
+    assertThat(entry.getElementInstanceKey()).isNull();
     assertThat(entry.getBatchOperationType()).isNull();
     assertThat(entry.getResult()).isNull();
     assertThat(entry.getJobKey()).isNull();
@@ -127,5 +128,37 @@ class AuditLogEntryTest {
     final var entry = AuditLogEntry.of(record);
 
     assertThat(entry.getBatchOperationKey()).isNull();
+  }
+
+  @Test
+  void shouldMapNullableFieldsAsNull() {
+    // given
+    final var negativeValue =
+        ImmutableJobRecordValue.builder()
+            .withProcessInstanceKey(-1L)
+            .withElementInstanceKey(-1L)
+            .withRootProcessInstanceKey(-1L)
+            .withBpmnProcessId("")
+            .build();
+    final var record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_MODIFICATION,
+            r ->
+                r.withIntent(ProcessInstanceModificationIntent.MODIFIED)
+                    .withValue(negativeValue)
+                    .withBatchOperationReference(-1L)
+                    .withKey(-1L));
+
+    // when
+    final var entry = AuditLogEntry.of(record);
+
+    // then
+    assertThat(entry.getProcessInstanceKey()).isNull();
+    assertThat(entry.getProcessDefinitionKey()).isNull();
+    assertThat(entry.getElementInstanceKey()).isNull();
+    assertThat(entry.getRootProcessInstanceKey()).isNull();
+    assertThat(entry.getProcessDefinitionId()).isNull();
+    assertThat(entry.getBatchOperationKey()).isNull();
+    assertThat(entry.getJobKey()).isNull();
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntryTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
-import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.time.Instant;
@@ -131,34 +130,52 @@ class AuditLogEntryTest {
   }
 
   @Test
-  void shouldMapNullableFieldsAsNull() {
-    // given
-    final var negativeValue =
-        ImmutableJobRecordValue.builder()
-            .withProcessInstanceKey(-1L)
-            .withElementInstanceKey(-1L)
-            .withRootProcessInstanceKey(-1L)
-            .withBpmnProcessId("")
-            .build();
-    final var record =
-        factory.generateRecord(
-            ValueType.PROCESS_INSTANCE_MODIFICATION,
-            r ->
-                r.withIntent(ProcessInstanceModificationIntent.MODIFIED)
-                    .withValue(negativeValue)
-                    .withBatchOperationReference(-1L)
-                    .withKey(-1L));
-
+  void shouldMapNullableFieldsWithSentinelValuesAsNull() {
     // when
-    final var entry = AuditLogEntry.of(record);
+    final var entry =
+        AuditLogEntry.of(factory.generateRecord(ValueType.PROCESS_INSTANCE_MODIFICATION));
+    entry
+        .setBatchOperationKey(-1L)
+        .setBatchOperationType(null)
+        .setDecisionDefinitionId("")
+        .setDecisionDefinitionKey(-1L)
+        .setDecisionEvaluationKey(-1L)
+        .setDecisionRequirementsId("")
+        .setDecisionRequirementsKey(-1L)
+        .setDeploymentKey(-1L)
+        .setElementInstanceKey(-1L)
+        .setEntityDescription("")
+        .setFormKey(-1L)
+        .setJobKey(-1L)
+        .setProcessDefinitionId("")
+        .setProcessDefinitionKey(-1L)
+        .setProcessInstanceKey(-1L)
+        .setRelatedEntityKey("")
+        .setRelatedEntityType(null)
+        .setResourceKey(-1L)
+        .setRootProcessInstanceKey(-1L)
+        .setUserTaskKey(-1L);
 
     // then
-    assertThat(entry.getProcessInstanceKey()).isNull();
-    assertThat(entry.getProcessDefinitionKey()).isNull();
-    assertThat(entry.getElementInstanceKey()).isNull();
-    assertThat(entry.getRootProcessInstanceKey()).isNull();
-    assertThat(entry.getProcessDefinitionId()).isNull();
     assertThat(entry.getBatchOperationKey()).isNull();
+    assertThat(entry.getBatchOperationType()).isNull();
+    assertThat(entry.getDecisionDefinitionId()).isNull();
+    assertThat(entry.getDecisionDefinitionKey()).isNull();
+    assertThat(entry.getDecisionEvaluationKey()).isNull();
+    assertThat(entry.getDecisionRequirementsId()).isNull();
+    assertThat(entry.getDecisionRequirementsKey()).isNull();
+    assertThat(entry.getDeploymentKey()).isNull();
+    assertThat(entry.getElementInstanceKey()).isNull();
+    assertThat(entry.getEntityDescription()).isNull();
+    assertThat(entry.getFormKey()).isNull();
     assertThat(entry.getJobKey()).isNull();
+    assertThat(entry.getProcessDefinitionId()).isNull();
+    assertThat(entry.getProcessDefinitionKey()).isNull();
+    assertThat(entry.getProcessInstanceKey()).isNull();
+    assertThat(entry.getRelatedEntityKey()).isNull();
+    assertThat(entry.getRelatedEntityType()).isNull();
+    assertThat(entry.getResourceKey()).isNull();
+    assertThat(entry.getRootProcessInstanceKey()).isNull();
+    assertThat(entry.getUserTaskKey()).isNull();
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformerTest.java
@@ -125,7 +125,7 @@ class UserTaskAuditLogTransformerTest {
     assertThat(entity.getEntityKey()).isEqualTo("123");
     assertThat(entity.getProcessInstanceKey()).isEqualTo(456L);
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(789L);
-    assertThat(entity.getRelatedEntityKey()).isEqualTo("");
+    assertThat(entity.getRelatedEntityKey()).isNull();
     assertThat(entity.getRelatedEntityType()).isEqualTo(AuditLogEntityType.USER);
   }
 }


### PR DESCRIPTION
# Description
Backport of #49708 to `stable/8.9`.

relates to #49564