### PR TITLE
[Backport stable/8.9] fix: remove duplicate default TenantFilterEnum value

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1005,7 +1005,6 @@ components:
       enum:
         - PROVIDED
         - ASSIGNED
-      default: PROVIDED
 
     JobStateEnum:
       description: The state of the job.


### PR DESCRIPTION
# Description
Backport of #49462 to `stable/8.9`.

relates to 