### PR TITLE
[Backport stable/8.7] fix: when entry cannot be processed in time we should mark it as dropped

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -85,7 +85,7 @@ public final class InFlightEntry {
   }
 
   public void cleanup() {
-    closeRequestListener(Listener::onIgnore);
+    closeRequestListener(Listener::onDropped);
     // Discard timers without recording — displaced entries don't represent actual
     // write/commit latency. Timer.Sample is a pure value object (two longs), so
     // dropping it without stop() does not leak resources.

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.Either;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -31,6 +32,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -119,6 +121,43 @@ public class FlowControlTest {
     assertThat(permits).first().satisfies(first -> EitherAssert.assertThat(first).isRight());
     assertThat(permits.subList(1, permits.size()))
         .allSatisfy(permit -> EitherAssert.assertThat(permit).isRight());
+  }
+
+  @Test
+  void shouldReduceRequestLimitWhenRingBufferWrapsAround() {
+    // given — small ring buffer so wraparound happens quickly
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var metrics = new LogStreamMetricsImpl(meterRegistry);
+    final var requestLimit =
+        StabilizingAIMDLimit.newBuilder().initialLimit(100).backoffRatio(0.9).build();
+    final var fc = new FlowControl(metrics, requestLimit, RateLimit.disabled(), /* capacity= */ 4);
+    final var intent = ProcessInstanceCreationIntent.CREATE;
+    final var context = new UserCommand(intent);
+
+    // when — acquire and register more entries than the ring buffer capacity
+    // without processing any, so wraparound displaces unprocessed entries
+    for (int i = 0; i < 8; i++) {
+      final var result =
+          fc.tryAcquire(
+              context,
+              List.of(
+                  LogAppendEntry.of(
+                      new RecordMetadata()
+                          .recordType(RecordType.COMMAND)
+                          .valueType(ValueType.PROCESS_INSTANCE_CREATION)
+                          .intent(intent),
+                      new UnifiedRecordValue(0))));
+      if (result.isRight()) {
+        fc.registerEntry(i + 1, result.get());
+      }
+    }
+
+    // then — displaced entries called onDropped, which should reduce the AIMD limit
+    // 4 entries are displaced, each calling onDropped which applies backoffRatio (0.9):
+    // 100 → 90 → 81 → 72 → 64
+    assertThat(requestLimit.getLimit())
+        .as("request limit should decrease due to displaced entries calling onDropped")
+        .isLessThanOrEqualTo(65);
   }
 
   private List<Either<FlowControl.Rejection, InFlightEntry>> acquireMultiplePermits(

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntryTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntryTest.java
@@ -177,14 +177,14 @@ final class InFlightEntryTest {
   class Cleanup {
 
     @Test
-    void callsOnIgnore() {
+    void callsOnDropped() {
       final var listener = new CountingListener();
       final var entry = new InFlightEntry(metrics, null, listener);
       entry.onAppend();
 
       entry.cleanup();
 
-      assertThat(listener.ignoreCount.get()).isEqualTo(1);
+      assertThat(listener.droppedCount.get()).isEqualTo(1);
     }
 
     @Test
@@ -209,7 +209,7 @@ final class InFlightEntryTest {
       entry.cleanup();
       entry.cleanup();
 
-      assertThat(listener.ignoreCount.get()).isEqualTo(1);
+      assertThat(listener.droppedCount.get()).isEqualTo(1);
     }
 
     @Test

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -187,19 +187,19 @@ final class RingBufferTest {
   @Test
   void findAndRemoveCleansUpRequestListenerOnSkippedEntries() {
     // given
-    final var ignored = new AtomicBoolean(false);
+    final var dropped = new AtomicBoolean(false);
     final Listener listener =
         new Listener() {
           @Override
           public void onSuccess() {}
 
           @Override
-          public void onIgnore() {
-            ignored.set(true);
-          }
+          public void onIgnore() {}
 
           @Override
-          public void onDropped() {}
+          public void onDropped() {
+            dropped.set(true);
+          }
         };
     final var buffer = new RingBuffer(8);
     final var skipped = new InFlightEntry(METRICS, null, listener);
@@ -211,8 +211,8 @@ final class RingBufferTest {
     // when
     buffer.findAndRemove(200);
 
-    // then — cleanup() should have called onIgnore on the skipped entry's listener
-    assertThat(ignored.get()).as("skipped entry's listener should receive onIgnore").isTrue();
+    // then — cleanup() should have called onDropped on the skipped entry's listener
+    assertThat(dropped.get()).as("skipped entry's listener should receive onDropped").isTrue();
   }
 
   /**


### PR DESCRIPTION
# Description
Backport of #49712 to `stable/8.7`.

relates to 