### PR TITLE
fix: display root cause decision in incidents table

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
@@ -30,9 +30,56 @@ import {
 import type {EnhancedIncident} from 'modules/hooks/incidents';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 
+type DecisionInstanceLookup = Record<
+  string,
+  {decisionInstanceKey: string; decisionDefinitionName: string}
+>;
+
+const getElementName = (
+  incident: EnhancedIncident,
+  processInstanceKey: string,
+  decisionInstancesByElementKey?: DecisionInstanceLookup,
+): React.ReactNode => {
+  const decisionInstance =
+    decisionInstancesByElementKey &&
+    (incident.errorType === 'DECISION_EVALUATION_ERROR' ||
+      incident.errorType === 'CALLED_DECISION_ERROR') &&
+    decisionInstancesByElementKey[incident.elementInstanceKey];
+
+  if (decisionInstance) {
+    return (
+      <Link
+        to={Paths.decisionInstance(decisionInstance.decisionInstanceKey)}
+        title={`View root cause decision ${decisionInstance.decisionDefinitionName} - ${decisionInstance.decisionInstanceKey}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {`${decisionInstance.decisionDefinitionName} - ${decisionInstance.decisionInstanceKey}`}
+      </Link>
+    );
+  }
+
+  if (processInstanceKey !== incident.processInstanceKey) {
+    return (
+      <Link
+        to={{
+          pathname: Paths.processInstance(incident.processInstanceKey),
+          search: `?elementId=${incident.elementId}`,
+        }}
+        title={`View root cause instance ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {`${incident.elementId} - ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
+      </Link>
+    );
+  }
+
+  return incident.elementName;
+};
+
 type IncidentsTableProps = {
   processInstanceKey: string;
   incidents: EnhancedIncident[];
+  decisionInstancesByElementKey?: DecisionInstanceLookup;
   state: React.ComponentProps<typeof SortableTable>['state'];
   onVerticalScrollStartReach?: React.ComponentProps<
     typeof SortableTable
@@ -47,6 +94,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
     state,
     incidents,
     processInstanceKey,
+    decisionInstancesByElementKey,
     onVerticalScrollEndReach,
     onVerticalScrollStartReach,
   }) {
@@ -189,22 +237,11 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
             return {
               id: incident.incidentKey,
               errorType: getIncidentErrorName(incident.errorType),
-              elementName:
-                processInstanceKey === incident.processInstanceKey ? (
-                  incident.elementName
-                ) : (
-                  <Link
-                    to={{
-                      pathname: Paths.processInstance(
-                        incident.processInstanceKey,
-                      ),
-                      search: `?elementId=${incident.elementId}`,
-                    }}
-                    title={`View root cause instance ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
-                  >
-                    {`${incident.elementId} - ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
-                  </Link>
-                ),
+              elementName: getElementName(
+                incident,
+                processInstanceKey,
+                decisionInstancesByElementKey,
+              ),
               creationTime: formatDate(incident.creationTime),
               operations: areOperationsVisible ? (
                 <IncidentOperation

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
@@ -9,15 +9,13 @@
 import {IncidentsTable} from '..';
 import {formatDate} from 'modules/utils/date';
 import {render, screen, within} from 'modules/testing-library';
+import {Wrapper, incidentsMock, firstIncident, secondIncident} from './mocks';
 import {
-  Wrapper,
-  incidentsMock,
-  firstIncident,
-  secondIncident,
-} from './mocks';
-import {createEnhancedIncident} from 'modules/testUtils';
+  createEnhancedIncident,
+  createProcessInstance,
+  createUser,
+} from 'modules/testUtils';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
-import {createProcessInstance, createUser} from 'modules/testUtils';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {getIncidentErrorName} from 'modules/utils/incidents';
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
@@ -9,7 +9,13 @@
 import {IncidentsTable} from '..';
 import {formatDate} from 'modules/utils/date';
 import {render, screen, within} from 'modules/testing-library';
-import {Wrapper, incidentsMock, firstIncident, secondIncident} from './mocks';
+import {
+  Wrapper,
+  incidentsMock,
+  firstIncident,
+  secondIncident,
+} from './mocks';
+import {createEnhancedIncident} from 'modules/testUtils';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {createProcessInstance, createUser} from 'modules/testUtils';
 import {mockMe} from 'modules/mocks/api/v2/me';
@@ -221,5 +227,97 @@ describe('IncidentsTable', () => {
     expect(
       secondIncidentRow.queryByRole('button', {name: 'Retry Incident'}),
     ).not.toBeInTheDocument();
+  });
+
+  it('should provide a link to root cause decision instance for DECISION_EVALUATION_ERROR', () => {
+    const decisionIncident = createEnhancedIncident({
+      errorType: 'DECISION_EVALUATION_ERROR',
+      processInstanceKey: '1',
+      errorMessage: 'Decision failed',
+      elementId: 'businessRuleTask_1',
+      elementInstanceKey: 'elementKey_123',
+    });
+
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        decisionInstancesByElementKey={{
+          elementKey_123: {
+            decisionInstanceKey: 'decisionKey_456',
+            decisionDefinitionName: 'MyDecision',
+          },
+        }}
+        incidents={[decisionIncident]}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    const withinRow = within(
+      screen.getByRole('row', {
+        name: /Decision evaluation error/i,
+      }),
+    );
+
+    expect(
+      withinRow.getByRole('link', {
+        name: 'MyDecision - decisionKey_456',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should provide a link to root cause decision instance for CALLED_DECISION_ERROR', () => {
+    const decisionIncident = createEnhancedIncident({
+      errorType: 'CALLED_DECISION_ERROR',
+      processInstanceKey: '1',
+      errorMessage: 'Decision not found',
+      elementId: 'businessRuleTask_2',
+      elementInstanceKey: 'elementKey_789',
+    });
+
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        decisionInstancesByElementKey={{
+          elementKey_789: {
+            decisionInstanceKey: 'decisionKey_101',
+            decisionDefinitionName: 'AnotherDecision',
+          },
+        }}
+        incidents={[decisionIncident]}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    const withinRow = within(
+      screen.getByRole('row', {
+        name: /Called decision error/i,
+      }),
+    );
+
+    expect(
+      withinRow.getByRole('link', {
+        name: 'AnotherDecision - decisionKey_101',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should show plain element name for decision incidents without matching decision instance', () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={[secondIncident]}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    const withinRow = within(
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
+    );
+
+    expect(withinRow.getByText(secondIncident.elementName)).toBeInTheDocument();
+    expect(withinRow.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -28,6 +28,8 @@ import {Container} from './styled';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {Navigate, useLocation} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
+import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
+import {useMemo} from 'react';
 
 const ROW_HEIGHT = 32;
 
@@ -93,6 +95,38 @@ const IncidentsTab: React.FC = observer(() => {
 
   const enhancedIncidents = useEnhancedIncidents(incidents);
 
+  const hasDecisionIncidents = useMemo(
+    () =>
+      incidents.some(
+        ({errorType}) =>
+          errorType === 'DECISION_EVALUATION_ERROR' ||
+          errorType === 'CALLED_DECISION_ERROR',
+      ),
+    [incidents],
+  );
+
+  const {data: decisionInstancesResult} = useDecisionInstancesSearch(
+    {filter: {processInstanceKey: processInstanceId}},
+    {enabled: hasDecisionIncidents},
+  );
+
+  const decisionInstancesByElementKey = useMemo(
+    () =>
+      (decisionInstancesResult?.items ?? []).reduce<
+        Record<
+          string,
+          {decisionInstanceKey: string; decisionDefinitionName: string}
+        >
+      >((acc, instance) => {
+        acc[instance.elementInstanceKey] = {
+          decisionInstanceKey: instance.decisionEvaluationInstanceKey,
+          decisionDefinitionName: instance.decisionDefinitionName,
+        };
+        return acc;
+      }, {}),
+    [decisionInstancesResult],
+  );
+
   if (processInstance?.hasIncident === false) {
     return (
       <Navigate
@@ -116,6 +150,7 @@ const IncidentsTab: React.FC = observer(() => {
         onVerticalScrollEndReach={handleScrollEndReach}
         processInstanceKey={processInstanceId}
         incidents={enhancedIncidents}
+        decisionInstancesByElementKey={decisionInstancesByElementKey}
       />
     </Container>
   );


### PR DESCRIPTION
## Description

Extend "failed element' column with information about the root cause decision

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #49425 
