### PR TITLE
fix: disable system proxy in REST client WireMock tests to prevent flaky HTML 404s

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/util/ClientRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/util/ClientRestTest.java
@@ -18,16 +18,53 @@ package io.camunda.client.util;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.client.CamundaClient;
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 @WireMockTest
 public abstract class ClientRestTest {
 
+  private static ProxySelector originalProxySelector;
+
   public CamundaClient client;
   public RestGatewayService gatewayService;
+
+  /**
+   * Override the default proxy selector to prevent the Apache HttpClient from routing requests
+   * through a system-configured proxy. The HttpAsyncClientBuilder always uses
+   * ProxySelector.getDefault() for route planning, which on some CI environments or developer
+   * machines may resolve to an external proxy (e.g. nginx), causing intermittent HTML 404 responses
+   * instead of the expected WireMock JSON responses.
+   */
+  @BeforeAll
+  static void disableSystemProxy() {
+    originalProxySelector = ProxySelector.getDefault();
+    ProxySelector.setDefault(
+        new ProxySelector() {
+          @Override
+          public List<Proxy> select(final URI uri) {
+            return Collections.singletonList(Proxy.NO_PROXY);
+          }
+
+          @Override
+          public void connectFailed(final URI uri, final SocketAddress sa, final IOException ioe) {}
+        });
+  }
+
+  @AfterAll
+  static void restoreSystemProxy() {
+    ProxySelector.setDefault(originalProxySelector);
+  }
 
   @BeforeEach
   void beforeEach(final WireMockRuntimeInfo mockInfo) throws URISyntaxException {


### PR DESCRIPTION
## Description

Fixes intermittent `MalformedResponseException` failures in `ClientRestTest`-based tests (e.g. `QueryBatchOperationTest.shouldGetBatchOperationByKey`) caused by requests being routed through a system-configured proxy instead of reaching the local WireMock server.

### Root Cause

Apache HttpClient 5's `HttpAsyncClientBuilder.build()` **always** uses `ProxySelector.getDefault()` for route planning:

```java
final ProxySelector defaultProxySelector = ProxySelector.getDefault();
routePlannerCopy = new SystemDefaultRoutePlanner(schemePortResolverCopy, defaultProxySelector);
```

Note: the `.useSystemProperties()` call in `HttpClientFactory` is [deprecated and a no-op](https://github.com/apache/httpcomponents-client/blob/main/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java#L760-L770) in HC5 — the proxy selector is consulted regardless.

On CI environments or developer machines with a system-configured proxy (e.g. macOS network preferences, PAC files, corporate proxies), `ProxySelector.getDefault()` can intermittently resolve to an external proxy. When the proxy doesn't know about the WireMock path, it returns an HTML 404 page:

```
<!doctype html><title>404 Not Found</title><h1 style="text-align: center">404 Not Found</h1>
```

This HTML is **not** from Jetty/WireMock (which generates `<html><head><title>Error 404...`), confirming it comes from an external server. The client then fails with:

```
MalformedResponseException: Expected to receive a problem body, but got an unknown body type: <!doctype html><title>404 Not Found</title>...
```

### Fix

Override `ProxySelector.getDefault()` in `ClientRestTest` with a direct-only selector (`Proxy.NO_PROXY`) via `@BeforeAll`/`@AfterAll`, ensuring all test HTTP requests reach WireMock directly. The original proxy selector is restored after tests complete.
