### PR TITLE
[Backport release-8.9.0] fix: normalize "identity" component name to "admin" in authorized components and c8Links

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -92,7 +92,14 @@ public class BasicCamundaUserService implements CamundaUserService {
     final var componentAccess =
         resourceAccessProvider.resolveResourceAccess(
             authentication, COMPONENT_ACCESS_AUTHORIZATION);
-    return componentAccess.allowed() ? componentAccess.authorization().resourceIds() : List.of();
+    if (!componentAccess.allowed()) {
+      return List.of();
+    }
+    final var resourceIds = componentAccess.authorization().resourceIds();
+    if (resourceIds == null) {
+      return List.of();
+    }
+    return resourceIds.stream().map(id -> "identity".equals(id) ? "admin" : id).distinct().toList();
   }
 
   private List<TenantEntity> getTenantsForCamundaAuthentication(

--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -168,7 +168,14 @@ public class OidcCamundaUserService implements CamundaUserService {
     final var componentAccess =
         resourceAccessProvider.resolveResourceAccess(
             authentication, COMPONENT_ACCESS_AUTHORIZATION);
-    return componentAccess.allowed() ? componentAccess.authorization().resourceIds() : List.of();
+    if (!componentAccess.allowed()) {
+      return List.of();
+    }
+    final var resourceIds = componentAccess.authorization().resourceIds();
+    if (resourceIds == null) {
+      return List.of();
+    }
+    return resourceIds.stream().map(id -> "identity".equals(id) ? "admin" : id).distinct().toList();
   }
 
   protected List<TenantEntity> getTenantsForCamundaAuthentication(

--- a/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
@@ -131,6 +131,21 @@ public class BasicCamundaUserServiceTest {
   }
 
   @Test
+  void shouldNormalizeIdentityComponentToAdmin() {
+    // given
+    final var allowedAuthorization = withAuthorization(COMPONENT_ACCESS_AUTHORIZATION, "identity");
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.allowed(allowedAuthorization));
+
+    // when
+    final var currentUser = basicCamundaUserService.getCurrentUser();
+
+    // then
+    assertThat(currentUser.authorizedComponents()).containsExactlyInAnyOrder("admin");
+  }
+
+  @Test
   void shouldContainWildcardInAuthorizedComponents() {
     // given
     final var allowedAuthorization = withAuthorization(COMPONENT_ACCESS_AUTHORIZATION, "*");

--- a/authentication/src/test/java/io/camunda/authentication/service/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/OidcCamundaUserServiceTest.java
@@ -170,6 +170,21 @@ public class OidcCamundaUserServiceTest {
   }
 
   @Test
+  void shouldNormalizeIdentityComponentToAdmin() {
+    // given
+    final var allowedAuthorization = withAuthorization(COMPONENT_ACCESS_AUTHORIZATION, "identity");
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(camundaAuthentication), eq(COMPONENT_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.allowed(allowedAuthorization));
+
+    // when
+    final var currentUser = userService.getCurrentUser();
+
+    // then
+    assertThat(currentUser.authorizedComponents()).containsExactlyInAnyOrder("admin");
+  }
+
+  @Test
   void shouldContainWildcardInAuthorizedComponents() {
     // given
     final var allowedAuthorization = withAuthorization(COMPONENT_ACCESS_AUTHORIZATION, "*");

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1155,8 +1155,8 @@ public final class SearchQueryResponseMapper {
         .collect(
             toMap(
                 e -> {
-                  final String key = e.getKey().getValue();
-                  return "identity".equals(key) ? "admin" : key;
+                  final AppName appName = e.getKey();
+                  return appName == AppName.IDENTITY ? "admin" : appName.getValue();
                 },
                 Map.Entry::getValue,
                 (v1, v2) -> v1));

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1152,7 +1152,14 @@ public final class SearchQueryResponseMapper {
   private static Map<String, String> toCamundaUserResultC8Links(
       final Map<AppName, String> c8Links) {
     return c8Links.entrySet().stream()
-        .collect(toMap(e -> e.getKey().getValue(), Map.Entry::getValue, (v1, v2) -> v1));
+        .collect(
+            toMap(
+                e -> {
+                  final String key = e.getKey().getValue();
+                  return "identity".equals(key) ? "admin" : key;
+                },
+                Map.Entry::getValue,
+                (v1, v2) -> v1));
   }
 
   private static List<DecisionInstanceResult> toDecisionInstances(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -9,6 +9,7 @@ package io.camunda.gateway.mapping.http.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
@@ -45,8 +46,10 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.UserTaskEntity.UserTaskState;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.entity.ClusterMetadata.AppName;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class SearchQueryResponseMapperTest {
@@ -701,5 +704,79 @@ class SearchQueryResponseMapperTest {
 
     // then
     assertThat(response.getRootProcessInstanceKey()).isNull();
+  }
+
+  @Test
+  void shouldMapIdentityC8LinkKeyToAdmin() {
+    // given
+    final var dto =
+        new CamundaUserDTO(
+            "displayName",
+            "username",
+            "email",
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            null,
+            Map.of(AppName.IDENTITY, "https://identity.example.com"),
+            true);
+
+    // when
+    final var result = SearchQueryResponseMapper.toCamundaUser(dto);
+
+    // then
+    assertThat(result.getC8Links()).containsEntry("admin", "https://identity.example.com");
+    assertThat(result.getC8Links()).doesNotContainKey("identity");
+  }
+
+  @Test
+  void shouldMapAdminC8LinkKeyDirectly() {
+    // given
+    final var dto =
+        new CamundaUserDTO(
+            "displayName",
+            "username",
+            "email",
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            null,
+            Map.of(AppName.ADMIN, "https://admin.example.com"),
+            true);
+
+    // when
+    final var result = SearchQueryResponseMapper.toCamundaUser(dto);
+
+    // then
+    assertThat(result.getC8Links()).containsEntry("admin", "https://admin.example.com");
+  }
+
+  @Test
+  void shouldNotAffectOtherC8LinkKeys() {
+    // given
+    final var dto =
+        new CamundaUserDTO(
+            "displayName",
+            "username",
+            "email",
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            null,
+            Map.of(
+                AppName.OPERATE, "https://operate.example.com",
+                AppName.TASKLIST, "https://tasklist.example.com"),
+            true);
+
+    // when
+    final var result = SearchQueryResponseMapper.toCamundaUser(dto);
+
+    // then
+    assertThat(result.getC8Links())
+        .containsEntry("operate", "https://operate.example.com")
+        .containsEntry("tasklist", "https://tasklist.example.com");
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
@@ -96,7 +96,9 @@ public class ClusterMetadata implements Serializable {
     @JsonProperty("zeebe")
     ZEEBE,
     @JsonProperty("connectors")
-    CONNECTORS;
+    CONNECTORS,
+    @JsonProperty("identity")
+    IDENTITY;
 
     public String getValue() {
       return name().toLowerCase();

--- a/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
@@ -98,7 +98,9 @@ public class ClusterMetadata implements Serializable {
     @JsonProperty("connectors")
     CONNECTORS,
     @JsonProperty("identity")
-    IDENTITY;
+    IDENTITY,
+    @JsonProperty("admin")
+    ADMIN;
 
     public String getValue() {
       return name().toLowerCase();


### PR DESCRIPTION
# Description
Backport of #49514 to `release-8.9.0`.

relates to #49512 #49512