### PR TITLE
48102 variable name scope filter

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportLocalVariablesFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportLocalVariablesFilter.java
@@ -38,9 +38,7 @@ public final class ExportLocalVariablesFilter implements ExporterRecordFilter, R
     if (exportLocalVariablesEnabled) {
       return true;
     }
-    final boolean isLocal =
-        variableRecordValue.getScopeKey() != variableRecordValue.getProcessInstanceKey();
-    return !isLocal;
+    return !VariableScope.isLocal(variableRecordValue);
   }
 
   @Override

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameScopeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameScopeFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.List;
+
+/**
+ * Filters variable records by name, applying separate rules depending on whether the variable is
+ * local (scoped to a sub-element) or root (scoped to the process instance itself).
+ *
+ * <p>A variable is considered local when its {@code scopeKey} differs from its {@code
+ * processInstanceKey}; equal keys indicate a root variable.
+ *
+ * <p>Each scope is governed by its own {@link NameFilter}. If no rules are configured for a given
+ * scope, all variables in that scope pass through. Non-variable records are always accepted.
+ */
+public final class VariableNameScopeFilter implements ExporterRecordFilter, RecordVersionFilter {
+
+  private static final SemanticVersion MIN_BROKER_VERSION =
+      new SemanticVersion(8, 10, 0, null, null);
+
+  private final NameFilter localFilter;
+  private final NameFilter rootFilter;
+  private final boolean hasLocalRules;
+  private final boolean hasRootRules;
+
+  public VariableNameScopeFilter(
+      final List<NameFilterRule> localInclusionRules,
+      final List<NameFilterRule> localExclusionRules,
+      final List<NameFilterRule> rootInclusionRules,
+      final List<NameFilterRule> rootExclusionRules) {
+    localFilter = new NameFilter(localInclusionRules, localExclusionRules);
+    rootFilter = new NameFilter(rootInclusionRules, rootExclusionRules);
+    hasLocalRules =
+        (localInclusionRules != null && !localInclusionRules.isEmpty())
+            || (localExclusionRules != null && !localExclusionRules.isEmpty());
+    hasRootRules =
+        (rootInclusionRules != null && !rootInclusionRules.isEmpty())
+            || (rootExclusionRules != null && !rootExclusionRules.isEmpty());
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {
+      return true;
+    }
+
+    if (VariableScope.isLocal(variableRecordValue)) {
+      return !hasLocalRules || localFilter.accept(variableRecordValue.getName());
+    } else {
+      return !hasRootRules || rootFilter.accept(variableRecordValue.getName());
+    }
+  }
+
+  @Override
+  public SemanticVersion minRecordBrokerVersion() {
+    return MIN_BROKER_VERSION;
+  }
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableScope.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableScope.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+
+final class VariableScope {
+
+  private VariableScope() {}
+
+  /**
+   * Returns {@code true} if the variable is local, i.e. its {@code scopeKey} differs from its
+   * {@code processInstanceKey}.
+   */
+  static boolean isLocal(final VariableRecordValue value) {
+    return value.getScopeKey() != value.getProcessInstanceKey();
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableNameScopeFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableNameScopeFilterTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static io.camunda.zeebe.exporter.filter.VariableNameFilter.parseRules;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.filter.NameFilterRule.Type;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class VariableNameScopeFilterTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+
+  // ---------------------------------------------------------------------------
+  // Non-variable records
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptNonVariableRecord() {
+    // given
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), List.of(), List.of());
+    final var record = nonVariableRecord();
+
+    // when / then
+    assertThat(filter.accept(record)).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Local-scope variables
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptLocalVariableMatchedByLocalInclusionRule() {
+    // given
+    final var localInclusion = parseRules(List.of("localVar"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(localInclusion, List.of(), List.of(), List.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord("localVar"))).isTrue();
+  }
+
+  @Test
+  void shouldRejectLocalVariableNotMatchedByLocalInclusionRule() {
+    // given
+    final var localInclusion = parseRules(List.of("localVar"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(localInclusion, List.of(), List.of(), List.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord("other"))).isFalse();
+  }
+
+  @Test
+  void shouldRejectLocalVariableMatchedByLocalExclusionRule() {
+    // given
+    final var localExclusion = parseRules(List.of("debug"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(List.of(), localExclusion, List.of(), List.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord("debug"))).isFalse();
+  }
+
+  @Test
+  void shouldAcceptLocalVariableNotMatchedByLocalExclusionRule() {
+    // given
+    final var localExclusion = parseRules(List.of("debug"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(List.of(), localExclusion, List.of(), List.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord("localVar"))).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Root-scope variables
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptRootVariableMatchedByRootInclusionRule() {
+    // given
+    final var rootInclusion = parseRules(List.of("rootVar"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), rootInclusion, List.of());
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord("rootVar"))).isTrue();
+  }
+
+  @Test
+  void shouldRejectRootVariableNotMatchedByRootInclusionRule() {
+    // given
+    final var rootInclusion = parseRules(List.of("rootVar"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), rootInclusion, List.of());
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord("other"))).isFalse();
+  }
+
+  @Test
+  void shouldRejectRootVariableMatchedByRootExclusionRule() {
+    // given
+    final var rootExclusion = parseRules(List.of("secret"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), List.of(), rootExclusion);
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord("secret"))).isFalse();
+  }
+
+  @Test
+  void shouldAcceptRootVariableNotMatchedByRootExclusionRule() {
+    // given
+    final var rootExclusion = parseRules(List.of("secret"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), List.of(), rootExclusion);
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord("rootVar"))).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Null variable names
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptLocalVariableWithNullNameAndNoRules() {
+    // given
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), List.of(), List.of());
+
+    // when / then
+    assertThat(filter.accept(localVariableRecord(null))).isTrue();
+  }
+
+  @Test
+  void shouldAcceptLocalVariableWithNullNameWhenLocalInclusionConfigured() {
+    // given
+    final var localInclusion = parseRules(List.of("localVar"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(localInclusion, List.of(), List.of(), List.of());
+
+    // when / then — NameFilter.accept(null) returns true, so null names always pass
+    assertThat(filter.accept(localVariableRecord(null))).isTrue();
+  }
+
+  @Test
+  void shouldAcceptRootVariableWithNullNameAndNoRules() {
+    // given
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), List.of(), List.of());
+
+    // when / then
+    assertThat(filter.accept(rootVariableRecord(null))).isTrue();
+  }
+
+  @Test
+  void shouldAcceptRootVariableWithNullNameWhenRootInclusionConfigured() {
+    // given
+    final var rootInclusion = parseRules(List.of("rootVar"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), rootInclusion, List.of());
+
+    // when / then — NameFilter.accept(null) returns true, so null names always pass
+    assertThat(filter.accept(rootVariableRecord(null))).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scope isolation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldNotApplyLocalRulesToRootVariables() {
+    // given: local rules configured, no root rules
+    final var localInclusion = parseRules(List.of("localVar"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(localInclusion, List.of(), List.of(), List.of());
+
+    // a root variable with a name that would fail local inclusion must still pass
+    assertThat(filter.accept(rootVariableRecord("other"))).isTrue();
+  }
+
+  @Test
+  void shouldNotApplyRootRulesToLocalVariables() {
+    // given: root rules configured, no local rules
+    final var rootInclusion = parseRules(List.of("rootVar"), Type.EXACT);
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), rootInclusion, List.of());
+
+    // a local variable with a name that would fail root inclusion must still pass
+    assertThat(filter.accept(localVariableRecord("other"))).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Version constraint
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldExposeMinRecordBrokerVersion() {
+    final var filter = new VariableNameScopeFilter(List.of(), List.of(), List.of(), List.of());
+
+    assertThat(filter.minRecordBrokerVersion().toString()).isEqualTo("8.10.0");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private static Record<ProcessInstanceRecordValue> nonVariableRecord() {
+    final var record = (Record<ProcessInstanceRecordValue>) mock(Record.class);
+    when(record.getValue()).thenReturn(mock(ProcessInstanceRecordValue.class));
+    return record;
+  }
+
+  /** A local variable has a scopeKey that differs from the processInstanceKey. */
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> localVariableRecord(final String name) {
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getScopeKey()).thenReturn(PROCESS_INSTANCE_KEY + 1);
+    when(value.getName()).thenReturn(name);
+    return record;
+  }
+
+  /** A root variable has a scopeKey equal to the processInstanceKey. */
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> rootVariableRecord(final String name) {
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getScopeKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getName()).thenReturn(name);
+    return record;
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces scope-aware variable name filtering for the Elasticsearch exporter:

Adds a VariableScope utility as the single place to decide if a variable is local vs. root (scopeKey != processInstanceKey).
Adds VariableNameScopeFilter to apply separate name-based filters for local and root variables, with a min broker version of 8.10.0 and non-variable records always accepted.
Refactors ExportLocalVariablesFilter to reuse VariableScope.isLocal(...) while preserving existing behavior.
Adds unit tests for VariableNameScopeFilter, including scope isolation, rule application, and version constraint.

Related issues

Closes https://github.com/camunda/camunda/issues/48102
Relates to https://github.com/camunda/camunda/issues/46267 (pdp-3435 – scope-aware variable export configuration for Optimize)
