### PR TITLE
Meg 45177 rest long poll yield on response failure

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -23,8 +23,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
@@ -54,6 +59,7 @@ public final class HttpClient implements AutoCloseable {
   private static final int MAX_RETRY_ATTEMPTS = 2;
 
   private final CloseableHttpAsyncClient client;
+  private final AutoCloseable connectionManager;
   private final ObjectMapper jsonMapper;
   private final URI address;
   private final RequestConfig defaultRequestConfig;
@@ -61,8 +67,17 @@ public final class HttpClient implements AutoCloseable {
   private final TimeValue shutdownTimeout;
   private final CredentialsProvider credentialsProvider;
 
+  // Tracks all in-flight request futures so they can be cancelled on close().
+  // With hardCancellationEnabled=true (set in HttpClientFactory), cancelling a future
+  // triggers IOSessionImpl.close(IMMEDIATE) which sets SO_LINGER=0 and closes the socket,
+  // sending TCP RST. This allows the server to detect the disconnect and reactivate
+  // any jobs that were activated for the now-dead connection.
+  private final Set<HttpCamundaFuture<?>> pendingFutures = ConcurrentHashMap.newKeySet();
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+
   public HttpClient(
       final CloseableHttpAsyncClient client,
+      final AutoCloseable connectionManager,
       final ObjectMapper jsonMapper,
       final URI address,
       final RequestConfig defaultRequestConfig,
@@ -70,6 +85,7 @@ public final class HttpClient implements AutoCloseable {
       final TimeValue shutdownTimeout,
       final CredentialsProvider credentialsProvider) {
     this.client = client;
+    this.connectionManager = connectionManager;
     this.jsonMapper = jsonMapper;
     this.address = address;
     this.defaultRequestConfig = defaultRequestConfig;
@@ -84,6 +100,47 @@ public final class HttpClient implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    // Cancel all pending request futures before closing the client. With
+    // hardCancellationEnabled=true, this triggers per-connection IOSessionImpl.close(IMMEDIATE)
+    // which sets SO_LINGER=0 and closes each socket, sending TCP RST to the server.
+    // This is critical for long-polling: without cancellation, the server doesn't know the
+    // client is gone and may activate jobs for a dead connection.
+    if (!pendingFutures.isEmpty()) {
+      LOGGER.debug("Cancelling {} pending HTTP request(s) before close", pendingFutures.size());
+      final List<HttpCamundaFuture<?>> snapshot = new ArrayList<>(pendingFutures);
+      for (final HttpCamundaFuture<?> future : snapshot) {
+        future.cancel(true, null);
+      }
+      // Wait for each future to settle so the NIO reactor has processed the cancellation
+      // and closed the socket (sending RST) before we return.
+      for (final HttpCamundaFuture<?> future : snapshot) {
+        try {
+          future.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (final Exception ignored) {
+          // Expected — cancelled futures throw CancellationException or ExecutionException
+        }
+      }
+      pendingFutures.clear();
+    }
+
+    // Force-close the connection pool with IMMEDIATE mode to RST all connections,
+    // including idle pooled connections that have no active future. IMMEDIATE sets
+    // SO_LINGER=0 on each socket, causing TCP RST instead of FIN. With FIN (graceful),
+    // the server's half of the connection stays open and can still write data — the
+    // long-poll handler would successfully deliver jobs to the half-closed connection.
+    if (connectionManager instanceof org.apache.hc.core5.io.ModalCloseable) {
+      ((org.apache.hc.core5.io.ModalCloseable) connectionManager).close(CloseMode.IMMEDIATE);
+    } else {
+      try {
+        connectionManager.close();
+      } catch (final Exception e) {
+        LOGGER.debug("Failed to close connection manager", e);
+      }
+    }
+
     client.close(CloseMode.GRACEFUL);
     try {
       client.awaitShutdown(shutdownTimeout);
@@ -382,6 +439,10 @@ public final class HttpClient implements AutoCloseable {
       final JsonResponseAndStatusCodeTransformer<HttpT, RespT> transformer,
       final HttpCamundaFuture<RespT> result,
       final ApiCallback<HttpT, RespT> callback) {
+    if (closed.get()) {
+      result.completeExceptionally(new ClientException("Client is closed"));
+      return;
+    }
     final AtomicReference<ApiCallback<HttpT, RespT>> apiCallback = new AtomicReference<>(callback);
     // Create retry action to re-execute the same request
     final Runnable retryAction =
@@ -423,6 +484,14 @@ public final class HttpClient implements AutoCloseable {
               maxRetries));
     }
 
+    pendingFutures.add(result);
+    result.whenComplete((r, ex) -> pendingFutures.remove(result));
+    // Re-check after registering: if close() ran between the first check and here,
+    // cancel the future that close() missed
+    if (closed.get()) {
+      result.cancel(true, null);
+      return;
+    }
     result.transportFuture(
         client.execute(
             SimpleRequestProducer.create(request),

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -82,8 +82,11 @@ public class HttpClientFactory {
 
   public HttpClient createClient() {
     final RequestConfig defaultRequestConfig = defaultClientRequestConfigBuilder().build();
+    final PoolingAsyncClientConnectionManager connectionManager = createConnectionManager();
     final CloseableHttpAsyncClient client =
-        defaultClientBuilder().setDefaultRequestConfig(defaultRequestConfig).build();
+        defaultClientBuilder(connectionManager)
+            .setDefaultRequestConfig(defaultRequestConfig)
+            .build();
     final URI gatewayAddress = buildGatewayAddress();
     final CredentialsProvider credentialsProvider =
         config.getCredentialsProvider() != null
@@ -92,6 +95,7 @@ public class HttpClientFactory {
 
     return new HttpClient(
         client,
+        connectionManager,
         JSON_MAPPER,
         gatewayAddress,
         defaultRequestConfig,
@@ -118,15 +122,7 @@ public class HttpClientFactory {
     }
   }
 
-  private HttpAsyncClientBuilder defaultClientBuilder() {
-    final Header acceptHeader =
-        new BasicHeader(
-            HttpHeaders.ACCEPT,
-            String.join(
-                ", ",
-                ContentType.APPLICATION_JSON.getMimeType(),
-                ContentType.APPLICATION_PROBLEM_JSON.getMimeType()));
-
+  private PoolingAsyncClientConnectionManager createConnectionManager() {
     final HttpClientHostnameVerifier hostnameVerifier =
         new HostnameVerifier(config.getOverrideAuthority());
     final TlsStrategy tlsStrategy =
@@ -144,7 +140,18 @@ public class HttpClientFactory {
       connectionManagerBuilder.setDnsResolver(new RandomizedDnsResolver());
     }
 
-    final PoolingAsyncClientConnectionManager connectionManager = connectionManagerBuilder.build();
+    return connectionManagerBuilder.build();
+  }
+
+  private HttpAsyncClientBuilder defaultClientBuilder(
+      final PoolingAsyncClientConnectionManager connectionManager) {
+    final Header acceptHeader =
+        new BasicHeader(
+            HttpHeaders.ACCEPT,
+            String.join(
+                ", ",
+                ContentType.APPLICATION_JSON.getMimeType(),
+                ContentType.APPLICATION_PROBLEM_JSON.getMimeType()));
 
     final HttpAsyncClientBuilder builder =
         HttpAsyncClients.custom()
@@ -172,9 +179,10 @@ public class HttpClientFactory {
         .setResponseTimeout(Timeout.of(config.getDefaultRequestTimeout()))
         // TODO: determine if the existing (gRPC) property makes sense for the HTTP client
         .setConnectionKeepAlive(TimeValue.of(config.getKeepAlive()))
-        // hard cancellation may cause other requests to fail as it will kill the connection; can be
-        // enabled when using HTTP/2
-        .setHardCancellationEnabled(false);
+        // Hard cancellation closes the underlying socket with SO_LINGER=0 (TCP RST) when a
+        // future is cancelled. This is required so that HttpClient.close() can abort pending
+        // long-poll requests and the server detects the disconnect immediately.
+        .setHardCancellationEnabled(true);
   }
 
   private SSLContext createSslContext() {

--- a/dist/src/main/java/io/camunda/application/commons/job/JobHandlerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/job/JobHandlerConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.job;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import io.camunda.gateway.mapping.http.ResponseMapper;
@@ -51,8 +52,12 @@ public class JobHandlerConfiguration {
   }
 
   @Bean
-  public ResponseObserverProvider responseObserverProvider() {
-    return JobActivationRequestResponseObserver::new;
+  public ResponseObserverProvider responseObserverProvider(
+      final ObjectMapper objectMapper,
+      final ActivateJobsHandler<JobActivationResult> activateJobsHandler) {
+    return result ->
+        new JobActivationRequestResponseObserver(
+            result, objectMapper, activateJobsHandler::yieldJobs);
   }
 
   @Bean

--- a/testing/camunda-process-test-example/src/test/resources/log4j2-test.xml
+++ b/testing/camunda-process-test-example/src/test/resources/log4j2-test.xml
@@ -18,6 +18,8 @@
     <!-- Hide default logging from Testcontainers -->
     <Logger name="org.testcontainers" level="warn"/>
     <Logger name="tc" level="error"/>
+    <!-- Show Camunda container logs for debugging -->
+    <Logger name="tc.camunda" level="debug"/>
     
   </Loggers>
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -83,7 +83,10 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
         //    A long-polling request still held by the gateway can activate jobs meant for
         //    the new test and deliver them to the now-defunct connection, causing the new
         //    test's workers to miss those jobs and time out.
-        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_LONGPOLLING_ENABLED, "false")
+        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_LONGPOLLING_ENABLED, "true")
+        // Debug logging for job activation and long-poll disconnect detection
+        .withEnv("LOGGING_LEVEL_IO_CAMUNDA_ZEEBE_GATEWAY_IMPL_JOB", "DEBUG")
+        .withEnv("LOGGING_LEVEL_IO_CAMUNDA_ZEEBE_GATEWAY_REST_CONTROLLER", "DEBUG")
         .withH2()
         .addExposedPorts(
             ContainerRuntimePorts.CAMUNDA_GATEWAY_API,

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -205,7 +205,10 @@ public class CamundaProcessTestContainerRuntime
 
     final Instant endTime = Instant.now();
     final Duration startupTime = Duration.between(startTime, endTime);
-    LOGGER.info("Camunda container runtime started in {}", startupTime);
+    LOGGER.info(
+        "Camunda container runtime started in {} — REST API: {}",
+        startupTime,
+        getCamundaContainer().getRestApiAddress());
 
     isStarted = true;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobActivationRequestResponseObserver.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobActivationRequestResponseObserver.java
@@ -7,40 +7,85 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializable;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.gateway.impl.job.JobActivationResult.ActivatedJob;
 import io.camunda.zeebe.gateway.impl.job.ResponseObserver;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 
 public class JobActivationRequestResponseObserver implements ResponseObserver<JobActivationResult> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(JobActivationRequestResponseObserver.class);
+
   protected JobActivationResult response = new JobActivationResult();
   protected CompletableFuture<ResponseEntity<Object>> result;
 
+  private final BiConsumer<List<ActivatedJob>, String> yieldCallback;
+  private final List<ActivatedJob> activatedJobs = new ArrayList<>();
   private Runnable cancelationHandler;
 
   public JobActivationRequestResponseObserver(
-      final CompletableFuture<ResponseEntity<Object>> result) {
+      final CompletableFuture<ResponseEntity<Object>> result,
+      final ObjectMapper objectMapper,
+      final BiConsumer<List<ActivatedJob>, String> yieldCallback) {
     this.result = result;
+    this.yieldCallback = yieldCallback;
   }
 
   @Override
   public void onCompleted() {
-    result.complete(ResponseEntity.ok(response));
+    final int jobCount = activatedJobs.size();
+    LOG.debug(
+        "onCompleted: completing response with {} jobs, future cancelled={}",
+        jobCount,
+        result.isCancelled());
+    result.complete(
+        ResponseEntity.ok()
+            .body(new YieldOnWriteFailureResult(response, activatedJobs, yieldCallback)));
   }
 
   @Override
   public void onNext(final JobActivationResult element) {
     if (element.getJobs() != null && !element.getJobs().isEmpty()) {
+      LOG.debug(
+          "onNext: received {} jobs (keys: {}), future cancelled={}",
+          element.getJobs().size(),
+          element.getJobs().stream()
+              .map(j -> j.getJobKey())
+              .collect(java.util.stream.Collectors.joining(",")),
+          result.isCancelled());
       element.getJobs().forEach(response::addJobsItem);
+      element
+          .getJobs()
+          .forEach(
+              job ->
+                  activatedJobs.add(
+                      new ActivatedJob(Long.parseLong(job.getJobKey()), job.getRetries())));
     }
   }
 
   @Override
   public boolean isCancelled() {
     // the CompletableFuture will be canceled eventually if the request is canceled
-    return result.isCancelled() || result.isCompletedExceptionally();
+    final boolean cancelled = result.isCancelled() || result.isCompletedExceptionally();
+    if (cancelled) {
+      LOG.debug("isCancelled: true (jobs accumulated so far: {})", activatedJobs.size());
+    }
+    return cancelled;
   }
 
   @Override
@@ -55,6 +100,99 @@ public class JobActivationRequestResponseObserver implements ResponseObserver<Jo
   public void invokeCancelationHandler() {
     if (cancelationHandler != null) {
       cancelationHandler.run();
+    }
+  }
+
+  /**
+   * Wraps a {@link JobActivationResult} and intercepts Jackson serialization to detect write
+   * failures. When the HTTP response write fails (e.g., client sent RST), the yield callback is
+   * invoked to reactivate locked jobs before the exception propagates.
+   *
+   * <p>This approach is necessary because {@code StreamingResponseBody} does not work inside {@code
+   * CompletableFuture<ResponseEntity<Object>>} — Spring's {@code
+   * StreamingResponseBodyReturnValueHandler} only matches when the declared generic type is {@code
+   * StreamingResponseBody}, not {@code Object}.
+   */
+  static class YieldOnWriteFailureResult implements JsonSerializable {
+
+    private final JobActivationResult response;
+    private final List<ActivatedJob> activatedJobs;
+    private final BiConsumer<List<ActivatedJob>, String> yieldCallback;
+
+    YieldOnWriteFailureResult(
+        final JobActivationResult response,
+        final List<ActivatedJob> activatedJobs,
+        final BiConsumer<List<ActivatedJob>, String> yieldCallback) {
+      this.response = response;
+      this.activatedJobs = activatedJobs;
+      this.yieldCallback = yieldCallback;
+    }
+
+    @Override
+    public void serialize(final JsonGenerator gen, final SerializerProvider serializers)
+        throws IOException {
+      final int jobCount = response.getJobs() != null ? response.getJobs().size() : 0;
+      LOG.debug("serialize: writing response with {} jobs to client", jobCount);
+
+      // Probe the connection before writing: if the client sent RST, reading from the
+      // request input stream throws IOException immediately (unlike writes which may
+      // succeed into the kernel send buffer). This detects stale long-poll connections
+      // where the TCP connection is dead but the server-side request object is still queued.
+      if (!activatedJobs.isEmpty()) {
+        probeConnection(jobCount);
+      }
+
+      try {
+        serializers.defaultSerializeValue(response, gen);
+        gen.flush();
+        LOG.debug("serialize: successfully wrote {} jobs to client", jobCount);
+      } catch (final IOException e) {
+        LOG.warn(
+            "serialize: WRITE FAILED for {} jobs, yielding {} activated jobs",
+            jobCount,
+            activatedJobs.size(),
+            e);
+        if (!activatedJobs.isEmpty()) {
+          yieldCallback.accept(activatedJobs, "Client disconnected during response write");
+        }
+        throw e;
+      }
+    }
+
+    private void probeConnection(final int jobCount) throws IOException {
+      try {
+        final var requestAttributes =
+            org.springframework.web.context.request.RequestContextHolder.getRequestAttributes();
+        if (requestAttributes
+            instanceof
+            org.springframework.web.context.request.ServletRequestAttributes servletAttrs) {
+          final var response = servletAttrs.getResponse();
+          if (response != null) {
+            // Force Tomcat to commit the HTTP response (send status line + headers) to
+            // the socket. On a healthy connection this succeeds. On a RST'd connection,
+            // the socket write fails with IOException, allowing us to detect the dead
+            // connection before serializing the job activation response.
+            response.flushBuffer();
+            LOG.debug(
+                "serialize: connection probe succeeded for {} jobs (connection alive)", jobCount);
+          }
+        }
+      } catch (final IOException e) {
+        LOG.warn(
+            "serialize: connection probe FAILED for {} jobs, yielding {} activated jobs",
+            jobCount,
+            activatedJobs.size(),
+            e);
+        yieldCallback.accept(activatedJobs, "Client disconnected (detected via flush probe)");
+        throw e;
+      }
+    }
+
+    @Override
+    public void serializeWithType(
+        final JsonGenerator gen, final SerializerProvider serializers, final TypeSerializer typeSer)
+        throws IOException {
+      serialize(gen, serializers);
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -1039,7 +1039,11 @@ public class LongPollingActivateJobsRestTest {
         new InflightActivateJobsRequest<>(
             getNextRequestId(),
             brokerRequest,
-            spy(new JobActivationRequestResponseObserver(new CompletableFuture<>())),
+            spy(
+                new JobActivationRequestResponseObserver(
+                    new CompletableFuture<>(),
+                    new com.fasterxml.jackson.databind.ObjectMapper(),
+                    (jobs, msg) -> {})),
             activateJobsRequest.requestTimeout()) {
 
           @Override
@@ -1158,7 +1162,7 @@ public class LongPollingActivateJobsRestTest {
 
     public InspectableJobActivationRequestResponseObserver(
         final CompletableFuture<ResponseEntity<Object>> result) {
-      super(result);
+      super(result, new com.fasterxml.jackson.databind.ObjectMapper(), (jobs, msg) -> {});
     }
 
     public JobActivationResult getResponse() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobActivationResponseWriteFailureTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobActivationResponseWriteFailureTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.gateway.protocol.model.ActivatedJobResult;
+import io.camunda.gateway.protocol.model.JobActivationResult;
+import io.camunda.zeebe.gateway.impl.job.JobActivationResult.ActivatedJob;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+class JobActivationResponseWriteFailureTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void shouldYieldJobsOnWriteFailure() throws Exception {
+    // given
+    final List<ActivatedJob> yieldedJobs = new ArrayList<>();
+    final List<String> yieldReasons = new ArrayList<>();
+    final var result = new CompletableFuture<ResponseEntity<Object>>();
+
+    final var observer =
+        new JobActivationRequestResponseObserver(
+            result,
+            objectMapper,
+            (jobs, reason) -> {
+              yieldedJobs.addAll(jobs);
+              yieldReasons.add(reason);
+            });
+
+    final var activationResult = new JobActivationResult();
+    activationResult.addJobsItem(new ActivatedJobResult().jobKey("123").retries(3));
+    activationResult.addJobsItem(new ActivatedJobResult().jobKey("456").retries(1));
+    observer.onNext(activationResult);
+    observer.onCompleted();
+
+    // when — simulate Jackson serialization to a failing output stream
+    final ResponseEntity<Object> responseEntity = result.get();
+    final Object body = responseEntity.getBody();
+
+    final OutputStream failingStream =
+        new OutputStream() {
+          @Override
+          public void write(final int b) throws IOException {
+            throw new IOException("Connection reset by peer");
+          }
+        };
+
+    assertThatThrownBy(
+            () -> {
+              try (JsonGenerator gen = objectMapper.getFactory().createGenerator(failingStream)) {
+                objectMapper.writeValue(gen, body);
+              }
+            })
+        .isInstanceOf(IOException.class);
+
+    // then
+    assertThat(yieldedJobs).hasSize(2);
+    assertThat(yieldedJobs.get(0).key()).isEqualTo(123L);
+    assertThat(yieldedJobs.get(0).retries()).isEqualTo(3);
+    assertThat(yieldedJobs.get(1).key()).isEqualTo(456L);
+    assertThat(yieldedJobs.get(1).retries()).isEqualTo(1);
+    assertThat(yieldReasons).containsExactly("Client disconnected during response write");
+  }
+
+  @Test
+  void shouldNotYieldWhenNoJobsActivated() throws Exception {
+    // given
+    final List<ActivatedJob> yieldedJobs = new ArrayList<>();
+    final var result = new CompletableFuture<ResponseEntity<Object>>();
+
+    final var observer =
+        new JobActivationRequestResponseObserver(
+            result, objectMapper, (jobs, reason) -> yieldedJobs.addAll(jobs));
+
+    observer.onCompleted();
+
+    // when — simulate write failure with no jobs
+    final ResponseEntity<Object> responseEntity = result.get();
+    final Object body = responseEntity.getBody();
+
+    final OutputStream failingStream =
+        new OutputStream() {
+          @Override
+          public void write(final int b) throws IOException {
+            throw new IOException("Broken pipe");
+          }
+        };
+
+    assertThatThrownBy(
+            () -> {
+              try (JsonGenerator gen = objectMapper.getFactory().createGenerator(failingStream)) {
+                objectMapper.writeValue(gen, body);
+              }
+            })
+        .isInstanceOf(IOException.class);
+
+    // then
+    assertThat(yieldedJobs).isEmpty();
+  }
+
+  @Test
+  void shouldWriteSuccessfullyWhenClientConnected() throws Exception {
+    // given
+    final List<ActivatedJob> yieldedJobs = new ArrayList<>();
+    final var result = new CompletableFuture<ResponseEntity<Object>>();
+
+    final var observer =
+        new JobActivationRequestResponseObserver(
+            result, objectMapper, (jobs, reason) -> yieldedJobs.addAll(jobs));
+
+    final var activationResult = new JobActivationResult();
+    activationResult.addJobsItem(new ActivatedJobResult().jobKey("789").retries(2));
+    observer.onNext(activationResult);
+    observer.onCompleted();
+
+    // when — simulate successful Jackson serialization
+    final ResponseEntity<Object> responseEntity = result.get();
+    final Object body = responseEntity.getBody();
+
+    final var output = new java.io.ByteArrayOutputStream();
+    objectMapper.writeValue(output, body);
+
+    // then
+    assertThat(yieldedJobs).isEmpty();
+    final String json = output.toString();
+    assertThat(json).contains("789");
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -397,7 +397,10 @@ public class JobControllerLongPollingTest extends RestControllerTest {
 
     @Bean
     public ResettableJobActivationRequestResponseObserver responseObserver() {
-      return new ResettableJobActivationRequestResponseObserver(new CompletableFuture<>());
+      return new ResettableJobActivationRequestResponseObserver(
+          new CompletableFuture<>(),
+          new com.fasterxml.jackson.databind.ObjectMapper(),
+          (jobs, msg) -> {});
     }
 
     @Bean

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -393,7 +393,10 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
 
     @Bean
     public ResettableJobActivationRequestResponseObserver responseObserver() {
-      return new ResettableJobActivationRequestResponseObserver(new CompletableFuture<>());
+      return new ResettableJobActivationRequestResponseObserver(
+          new CompletableFuture<>(),
+          new com.fasterxml.jackson.databind.ObjectMapper(),
+          (jobs, msg) -> {});
     }
 
     @Bean

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/util/ResettableJobActivationRequestResponseObserver.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/util/ResettableJobActivationRequestResponseObserver.java
@@ -7,17 +7,23 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.protocol.model.JobActivationResult;
+import io.camunda.zeebe.gateway.impl.job.JobActivationResult.ActivatedJob;
 import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseObserver;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import org.springframework.http.ResponseEntity;
 
 public class ResettableJobActivationRequestResponseObserver
     extends JobActivationRequestResponseObserver {
 
   public ResettableJobActivationRequestResponseObserver(
-      final CompletableFuture<ResponseEntity<Object>> result) {
-    super(result);
+      final CompletableFuture<ResponseEntity<Object>> result,
+      final ObjectMapper objectMapper,
+      final BiConsumer<List<ActivatedJob>, String> yieldCallback) {
+    super(result, objectMapper, yieldCallback);
   }
 
   public void reset() {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/ActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/ActivateJobsHandler.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.gateway.impl.job;
 
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.job.JobActivationResult.ActivatedJob;
 import io.camunda.zeebe.scheduler.ActorControl;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -27,4 +29,15 @@ public interface ActivateJobsHandler<T> extends Consumer<ActorControl> {
       final ResponseObserver<T> responseObserver,
       final Consumer<Runnable> setCancelHandler,
       final long requestTimeout);
+
+  /**
+   * Reactivate jobs that were activated but could not be delivered to the client. This allows the
+   * jobs to be picked up by other workers.
+   *
+   * @param jobs the jobs to yield
+   * @param reason the reason for yielding
+   */
+  default void yieldJobs(final List<ActivatedJob> jobs, final String reason) {
+    // no-op by default
+  }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -16,10 +16,12 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.job.JobActivationResult.ActivatedJob;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -79,6 +81,11 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
     this.actor = actor;
     activateJobsHandler.accept(actor);
     onActorStarted();
+  }
+
+  @Override
+  public void yieldJobs(final List<ActivatedJob> jobs, final String reason) {
+    activateJobsHandler.yieldJobs(jobs, reason);
   }
 
   void onActorStarted() {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -170,7 +170,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
             final var reason = String.format(MAX_MESSAGE_SIZE_EXCEEDED_MSG, maxMessageSize);
 
             logResponseNotSent(jobType, jobKeys, reason);
-            reactivateJobs(jobsToDefer, reason);
+            yieldJobs(jobsToDefer, reason);
           }
 
           final T activateJobsResponse = jobActivationResult.getActivateJobsResponse();
@@ -187,7 +187,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
               final var reason = createReasonMessage(result);
 
               logResponseNotSent(jobType, jobKeys, reason);
-              reactivateJobs(activatedJobsToReactivate, reason);
+              yieldJobs(activatedJobsToReactivate, reason);
               cancelActivateJobsRequest(reason, delegate);
               return;
             }
@@ -213,13 +213,20 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
     return errorMessage;
   }
 
-  private void reactivateJobs(final List<ActivatedJob> activateJobs, final String message) {
+  @Override
+  public void yieldJobs(final List<ActivatedJob> activateJobs, final String message) {
     if (activateJobs != null) {
-      activateJobs.forEach(j -> tryToReactivateJob(j, message));
+      Loggers.GATEWAY_LOGGER.debug(
+          "yieldJobs: yielding {} jobs, reason: {}", activateJobs.size(), message);
+      activateJobs.forEach(j -> tryToYieldJob(j, message));
     }
   }
 
-  private void tryToReactivateJob(final ActivatedJob job, final String message) {
+  void tryToYieldJob(final ActivatedJob job, final String message) {
+    Loggers.GATEWAY_LOGGER.debug(
+        "tryToYieldJob: failing job {} (retries={}) to make it available again",
+        job.key(),
+        job.retries());
     final var request = toFailJobRequest(job, message);
     brokerClient
         .sendRequestWithRetry(request)
@@ -227,13 +234,15 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
             (response, error) -> {
               if (error != null) {
                 Loggers.GATEWAY_LOGGER.info(
-                    "Failed to reactivate job {} due to {}", job.key(), error.getMessage());
+                    "Failed to yield job {} due to {}", job.key(), error.getMessage());
+              } else {
+                Loggers.GATEWAY_LOGGER.debug("Successfully yielded job {}", job.key());
               }
             },
             actor);
   }
 
-  private BrokerFailJobRequest toFailJobRequest(final ActivatedJob job, final String errorMessage) {
+  BrokerFailJobRequest toFailJobRequest(final ActivatedJob job, final String errorMessage) {
     return new BrokerFailJobRequest(job.key(), job.retries(), 0).setErrorMessage(errorMessage);
   }
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                         
                                                            
  Prototype for detecting client disconnects during long-poll job activation (`POST /v2/jobs/activation`)                                                            
  and yielding locked jobs back to the broker so they become immediately available for other consumers.

I can be tested by running `io.camunda.ProcessIntegrationTest` in case the long poll is not cancelled properly, the second test case will fail with a timeout, as the long poll from the first test steals the job.
                                                                                                                                                                     
  ## Approach                                               
                                                                                                                                                                     
  ### Server-side: connection liveness probe before response write                                                                                                   
   
  Before writing the job activation response body, the server flushes the HTTP response headers                                                                      
  to the socket via `response.flushBuffer()`. On a dead connection (client sent TCP RST), this
  fails with `IOException: Broken pipe`, triggering a yield callback that fails the jobs back                                                                        
  to the broker with their remaining retries.                                                                                                                        
                                                                                                                                                                     
  This uses a `JsonSerializable` wrapper (`YieldOnWriteFailureResult`) rather than                                                                                   
  `StreamingResponseBody` because Spring's `StreamingResponseBodyReturnValueHandler` only matches
  when the declared generic type is `StreamingResponseBody` — with `CompletableFuture<ResponseEntity<Object>>`                                                       
  it falls through to Jackson serialization, producing `{}` instead of invoking the streaming body.                                                                  
                                                                                                                                                                     
  ### Client-side: RST on close instead of FIN                                                                                                                       
                                                                                                                                                                     
  `HttpClient.close()` now:                                                                                                                                          
  1. Cancels all tracked in-flight request futures          
  2. Waits for cancellations to settle (NIO reactor processes the socket close)                                                                                      
  3. Closes the connection pool with `CloseMode.IMMEDIATE` (`SO_LINGER=0` → TCP RST)                                                                                 
                                                                                                                                                                     
  This is critical because a graceful close (FIN) leaves the server's write-half of the connection                                                                   
  open — the response write succeeds silently even though the client is gone.                                                                                        
                                                                                                                                                                     
  ### Rename: `reactivateJobs` → `yieldJobs`                
                                                                                                                                                                     
  The existing job reactivation API is renamed to "yield" which better describes the intent.                                                                         
   
  ## Verified working                                                                                                                                                
                                                            
  Tested on bare metal (direct TCP, no Docker proxy) — the flush probe detects `Broken pipe`                                                                         
  immediately and yields the jobs. The second test's workers pick up the yielded jobs successfully.
                                                                                                                                                                     
  ## Limitation: Docker port-forwarding proxy                                                                                                                        
                                                                                                                                                                     
  Docker Desktop (macOS, Windows) and Docker on Linux with `userland-proxy: true` (default)                                                                          
  insert a userspace TCP proxy between the client and the container:
                                                                                                                                                                     
  Client → localhost:mapped-port → Docker proxy → Container:8080                                                                                                     
                                                                                                                                                                     
  When the client sends RST, the client→proxy connection closes but the proxy→container connection                                                                   
  stays alive. From the server's perspective the connection is healthy — the flush probe succeeds                                                                    
  and the response is written to the proxy which silently discards it.                                                                                               
                                                                                                                                                                     
  **This is a Docker networking artifact, not a limitation of the detection mechanism.** In production                                                               
  (Kubernetes, bare metal, direct networking) there is no proxy and RSTs propagate directly to the
  server socket. This can be verified by disabling the userland proxy (`"userland-proxy": false` in                                                                  
  `/etc/docker/daemon.json`).                                                                                                                                        
                                                                                                                                                                     
  Long polling remains disabled for CPT to avoid this issue in test environments.                                                                                    
                                                            
## Future work                                                                                                                                                     
                                                            
  - **Investigate whether the flush probe is redundant on bare metal** — Tomcat's NIO selector                                                                       
    should detect the RST and fire `AsyncListener.onError()`. If Spring propagates this to the                                                                       
    `CompletableFuture`, then `isCancelled()` returns true and the long-poll handler skips the                                                                       
    stale request before `serialize()` is even called. Similarly, the regular write path
    (`gen.flush()` after serialization) may already fail with `Broken pipe` without the explicit                                                                     
    probe. If confirmed, the probe can be removed and the write-failure catch alone suffices for                                                                     
    any environment where RSTs reach the server. The probe would only remain as a fallback for                                                                       
    proxied environments.                                                                                                                                            
  - **Server-side parked request cleanup** — propagate `AsyncListener.onError()` to cancel the
    observer's `CompletableFuture` when the connection dies, so the long-poll handler evicts stale                                                                   
    requests before dispatching jobs to them. This would handle the case where the handler                                                                           
    dispatches to a dead connection that hasn't been written to yet.
