### PR TITLE
fix: add audit log cleanup entity for standalone decisions & remove decision dependent

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/DecisionInstanceDependant.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/DecisionInstanceDependant.java
@@ -17,7 +17,7 @@ package io.camunda.webapps.schema.descriptors;
  */
 public interface DecisionInstanceDependant extends IndexTemplateDescriptor {
 
-  String DECISION_INSTANCE_KEY = "decisionDefinitionKey";
+  String DECISION_INSTANCE_KEY = "decisionInstanceKey";
 
   default String getDecisionDependantField() {
     return DECISION_INSTANCE_KEY;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
@@ -10,7 +10,6 @@ package io.camunda.webapps.schema.descriptors.template;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
-import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
@@ -20,10 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class AuditLogTemplate extends AbstractTemplateDescriptor
-    implements ProcessInstanceDependant,
-        DecisionInstanceDependant,
-        BatchOperationDependant,
-        Prio4Backup {
+    implements ProcessInstanceDependant, BatchOperationDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "audit-log";
   public static final String INDEX_VERSION = "8.9.0";

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -13,7 +13,6 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
-import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
@@ -35,7 +34,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
   private final TestRepository repository = new TestRepository();
   private final DecisionInstanceTemplate decisionInstanceTemplate =
       new DecisionInstanceTemplate("", true);
-  private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
+  private final WeirdlyNamedDependant dependantTemplate = new WeirdlyNamedDependant();
 
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
@@ -47,7 +46,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
           metrics,
           LOGGER,
           executor,
-          List.of(auditLogTemplate));
+          List.of(dependantTemplate));
 
   @BeforeEach
   void setUp() {
@@ -114,9 +113,9 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     assertThat(repository.moves)
         .containsExactly(
             new DocumentMove(
-                auditLogTemplate.getFullQualifiedName(),
-                auditLogTemplate.getFullQualifiedName() + "2024-01-01",
-                Map.of(auditLogTemplate.getDecisionDependantField(), List.of("1", "2", "3")),
+                dependantTemplate.getFullQualifiedName(),
+                dependantTemplate.getFullQualifiedName() + "2024-01-01",
+                Map.of(dependantTemplate.getDecisionDependantField(), List.of("1", "2", "3")),
                 executor),
             new DocumentMove(
                 decisionInstanceTemplate.getFullQualifiedName(),
@@ -139,7 +138,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     assertThat(repository.moves)
         .map(DocumentMove::sourceIndexName)
         .containsExactly(
-            auditLogTemplate.getFullQualifiedName(),
+            dependantTemplate.getFullQualifiedName(),
             decisionInstanceTemplate.getFullQualifiedName());
   }
 


### PR DESCRIPTION
## Description

Remove audit log template dependency from decision archiver tests.

## Related issues

closes https://github.com/camunda/camunda/issues/49761
