### PR TITLE
[Backport stable/8.9] fix: update listener type filter to include both execution and task listeners

### DIFF
--- a/operate/client/public/mockServiceWorker.js
+++ b/operate/client/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.10'
+const PACKAGE_VERSION = '2.12.13'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
@@ -393,4 +393,138 @@ describe('<ListenersTab />', () => {
       screen.queryByTestId('listener-type-filter'),
     ).not.toBeInTheDocument();
   });
+
+  it('should filter by execution listeners when selected from dropdown', async () => {
+    const allListenersPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
+    mockFetchElementInstance('123456789').withSuccess(
+      mockUserTaskElementInstance,
+    );
+    mockValidatedSearchJobs(
+      allListenersPayload,
+      searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
+    );
+
+    const {user} = render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Execution listener')).toBeInTheDocument();
+    expect(screen.getByText('Task listener')).toBeInTheDocument();
+
+    const executionListenerPayload = buildExpectedPayload(
+      z.literal('EXECUTION_LISTENER'),
+    );
+
+    mockValidatedSearchJobs(
+      executionListenerPayload,
+      searchResult([mockExecutionListenerJob]),
+    );
+
+    await user.click(screen.getByRole('combobox', {name: 'Listener type'}));
+    await user.click(screen.getByRole('option', {name: 'Execution listeners'}));
+
+    expect(await screen.findByText('Execution listener')).toBeInTheDocument();
+    expect(screen.queryByText('Task listener')).not.toBeInTheDocument();
+  });
+
+  it('should filter by user task listeners when selected from dropdown', async () => {
+    const allListenersPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
+    mockFetchElementInstance('123456789').withSuccess(
+      mockUserTaskElementInstance,
+    );
+    mockValidatedSearchJobs(
+      allListenersPayload,
+      searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
+    );
+
+    const {user} = render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Execution listener')).toBeInTheDocument();
+    expect(screen.getByText('Task listener')).toBeInTheDocument();
+
+    const taskListenerPayload = buildExpectedPayload(
+      z.literal('TASK_LISTENER'),
+    );
+
+    mockValidatedSearchJobs(
+      taskListenerPayload,
+      searchResult([mockTaskListenerJob]),
+    );
+
+    await user.click(screen.getByRole('combobox', {name: 'Listener type'}));
+    await user.click(screen.getByRole('option', {name: 'User task listeners'}));
+
+    expect(await screen.findByText('Task listener')).toBeInTheDocument();
+    expect(screen.queryByText('Execution listener')).not.toBeInTheDocument();
+  });
+
+  it('should show all listeners when switching back from a filtered selection', async () => {
+    const allListenersPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
+    mockFetchElementInstance('123456789').withSuccess(
+      mockUserTaskElementInstance,
+    );
+    mockValidatedSearchJobs(
+      allListenersPayload,
+      searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
+    );
+
+    const {user} = render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Execution listener')).toBeInTheDocument();
+    expect(screen.getByText('Task listener')).toBeInTheDocument();
+
+    const executionListenerPayload = buildExpectedPayload(
+      z.literal('EXECUTION_LISTENER'),
+    );
+
+    mockValidatedSearchJobs(
+      executionListenerPayload,
+      searchResult([mockExecutionListenerJob]),
+    );
+
+    await user.click(screen.getByRole('combobox', {name: 'Listener type'}));
+    await user.click(screen.getByRole('option', {name: 'Execution listeners'}));
+
+    expect(await screen.findByText('Execution listener')).toBeInTheDocument();
+    expect(screen.queryByText('Task listener')).not.toBeInTheDocument();
+
+    mockValidatedSearchJobs(
+      allListenersPayload,
+      searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
+    );
+
+    await user.click(screen.getByRole('combobox', {name: 'Listener type'}));
+    await user.click(screen.getByRole('option', {name: 'All listeners'}));
+
+    expect(await screen.findByText('Task listener')).toBeInTheDocument();
+    expect(screen.getByText('Execution listener')).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
@@ -11,16 +11,57 @@ import {createMemoryRouter, RouterProvider} from 'react-router-dom';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {Paths} from 'modules/Routes';
+import {z} from 'zod';
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
 import {ListenersTab} from './index';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
-import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {searchResult} from 'modules/testUtils';
-import type {
-  ElementInstance,
-  Job,
-  ProcessInstance,
-} from '@camunda/camunda-api-zod-schemas/8.9';
+import {
+  endpoints,
+  type QueryJobsResponseBody,
+  type ElementInstance,
+  type Job,
+  type ProcessInstance,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+
+function mockValidatedSearchJobs(
+  schema: z.ZodType,
+  data: QueryJobsResponseBody,
+) {
+  mockServer.use(
+    http.post(
+      endpoints.queryJobs.getUrl(),
+      async ({request}) => {
+        const body = await request.json();
+        const result = schema.safeParse(body);
+
+        if (!result.success) {
+          return HttpResponse.error();
+        }
+
+        return HttpResponse.json(data);
+      },
+      {once: true},
+    ),
+  );
+}
+
+function buildExpectedPayload(kind: z.ZodType) {
+  return z.strictObject({
+    filter: z.strictObject({
+      processInstanceKey: z.literal(PROCESS_INSTANCE_ID),
+      elementId: z.literal('Task_1'),
+      elementInstanceKey: z.literal('123456789'),
+      kind,
+    }),
+    page: z.strictObject({
+      limit: z.literal(50),
+      from: z.literal(0),
+    }),
+  });
+}
 
 const PROCESS_INSTANCE_ID = '111222333';
 const PROCESS_DEFINITION_KEY = '444555666';
@@ -150,10 +191,41 @@ describe('<ListenersTab />', () => {
   beforeEach(() => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
-    mockSearchJobs().withSuccess(searchResult([]));
+  });
+
+  it('should filter job searches by listener kind', async () => {
+    const expectedPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
+    mockValidatedSearchJobs(expectedPayload, searchResult([]));
+
+    render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(
+      await screen.findByText('This element has no execution listeners'),
+    ).toBeInTheDocument();
   });
 
   it('should show empty message when no listeners exist', async () => {
+    const expectedPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
+    mockValidatedSearchJobs(expectedPayload, searchResult([]));
+
     render(<ListenersTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
     });
@@ -164,8 +236,20 @@ describe('<ListenersTab />', () => {
   });
 
   it('should display execution listener jobs', async () => {
+    const expectedPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
     mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
-    mockSearchJobs().withSuccess(searchResult([mockExecutionListenerJob]));
+    mockValidatedSearchJobs(
+      expectedPayload,
+      searchResult([mockExecutionListenerJob]),
+    );
 
     render(<ListenersTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
@@ -179,10 +263,22 @@ describe('<ListenersTab />', () => {
   });
 
   it('should display task listener jobs', async () => {
+    const expectedPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
-    mockSearchJobs().withSuccess(searchResult([mockTaskListenerJob]));
+    mockValidatedSearchJobs(
+      expectedPayload,
+      searchResult([mockTaskListenerJob]),
+    );
 
     render(<ListenersTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
@@ -194,10 +290,20 @@ describe('<ListenersTab />', () => {
   });
 
   it('should display both listener types', async () => {
+    const expectedPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
-    mockSearchJobs().withSuccess(
+    mockValidatedSearchJobs(
+      expectedPayload,
       searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
     );
 
@@ -210,9 +316,19 @@ describe('<ListenersTab />', () => {
   });
 
   it('should show empty message for user task with no listeners', async () => {
+    const expectedPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
+    mockValidatedSearchJobs(expectedPayload, searchResult([]));
 
     render(<ListenersTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
@@ -226,10 +342,20 @@ describe('<ListenersTab />', () => {
   });
 
   it('should show listener type dropdown for user tasks', async () => {
+    const expectedPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
-    mockSearchJobs().withSuccess(
+    mockValidatedSearchJobs(
+      expectedPayload,
       searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
     );
 
@@ -243,8 +369,20 @@ describe('<ListenersTab />', () => {
   });
 
   it('should not show listener type dropdown for non-user-task elements', async () => {
+    const expectedPayload = buildExpectedPayload(
+      z.strictObject({
+        $in: z.tuple([
+          z.literal('EXECUTION_LISTENER'),
+          z.literal('TASK_LISTENER'),
+        ]),
+      }),
+    );
+
     mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
-    mockSearchJobs().withSuccess(searchResult([mockExecutionListenerJob]));
+    mockValidatedSearchJobs(
+      expectedPayload,
+      searchResult([mockExecutionListenerJob]),
+    );
 
     render(<ListenersTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
@@ -24,7 +24,7 @@ import {
   type ElementInstance,
   type Job,
   type ProcessInstance,
-} from '@camunda/camunda-api-zod-schemas/8.10';
+} from '@camunda/camunda-api-zod-schemas/8.9';
 
 function mockValidatedSearchJobs(
   schema: z.ZodType,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
@@ -194,16 +194,17 @@ describe('<ListenersTab />', () => {
   });
 
   it('should filter job searches by listener kind', async () => {
-    const expectedPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
+    mockValidatedSearchJobs(
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
+      searchResult([]),
     );
-
-    mockValidatedSearchJobs(expectedPayload, searchResult([]));
 
     render(<ListenersTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
@@ -215,16 +216,17 @@ describe('<ListenersTab />', () => {
   });
 
   it('should show empty message when no listeners exist', async () => {
-    const expectedPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
+    mockValidatedSearchJobs(
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
+      searchResult([]),
     );
-
-    mockValidatedSearchJobs(expectedPayload, searchResult([]));
 
     render(<ListenersTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
@@ -236,18 +238,16 @@ describe('<ListenersTab />', () => {
   });
 
   it('should display execution listener jobs', async () => {
-    const expectedPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
     mockValidatedSearchJobs(
-      expectedPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockExecutionListenerJob]),
     );
 
@@ -263,20 +263,18 @@ describe('<ListenersTab />', () => {
   });
 
   it('should display task listener jobs', async () => {
-    const expectedPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
     mockValidatedSearchJobs(
-      expectedPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockTaskListenerJob]),
     );
 
@@ -290,20 +288,18 @@ describe('<ListenersTab />', () => {
   });
 
   it('should display both listener types', async () => {
-    const expectedPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
     mockValidatedSearchJobs(
-      expectedPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
     );
 
@@ -316,19 +312,20 @@ describe('<ListenersTab />', () => {
   });
 
   it('should show empty message for user task with no listeners', async () => {
-    const expectedPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
-    mockValidatedSearchJobs(expectedPayload, searchResult([]));
+    mockValidatedSearchJobs(
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
+      searchResult([]),
+    );
 
     render(<ListenersTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
@@ -342,20 +339,18 @@ describe('<ListenersTab />', () => {
   });
 
   it('should show listener type dropdown for user tasks', async () => {
-    const expectedPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
     mockValidatedSearchJobs(
-      expectedPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
     );
 
@@ -369,18 +364,16 @@ describe('<ListenersTab />', () => {
   });
 
   it('should not show listener type dropdown for non-user-task elements', async () => {
-    const expectedPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
     mockValidatedSearchJobs(
-      expectedPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockExecutionListenerJob]),
     );
 
@@ -395,20 +388,18 @@ describe('<ListenersTab />', () => {
   });
 
   it('should filter by execution listeners when selected from dropdown', async () => {
-    const allListenersPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
     mockValidatedSearchJobs(
-      allListenersPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
     );
 
@@ -419,12 +410,8 @@ describe('<ListenersTab />', () => {
     expect(await screen.findByText('Execution listener')).toBeInTheDocument();
     expect(screen.getByText('Task listener')).toBeInTheDocument();
 
-    const executionListenerPayload = buildExpectedPayload(
-      z.literal('EXECUTION_LISTENER'),
-    );
-
     mockValidatedSearchJobs(
-      executionListenerPayload,
+      buildExpectedPayload(z.literal('EXECUTION_LISTENER')),
       searchResult([mockExecutionListenerJob]),
     );
 
@@ -436,20 +423,18 @@ describe('<ListenersTab />', () => {
   });
 
   it('should filter by user task listeners when selected from dropdown', async () => {
-    const allListenersPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
     mockValidatedSearchJobs(
-      allListenersPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
     );
 
@@ -460,12 +445,8 @@ describe('<ListenersTab />', () => {
     expect(await screen.findByText('Execution listener')).toBeInTheDocument();
     expect(screen.getByText('Task listener')).toBeInTheDocument();
 
-    const taskListenerPayload = buildExpectedPayload(
-      z.literal('TASK_LISTENER'),
-    );
-
     mockValidatedSearchJobs(
-      taskListenerPayload,
+      buildExpectedPayload(z.literal('TASK_LISTENER')),
       searchResult([mockTaskListenerJob]),
     );
 
@@ -477,20 +458,18 @@ describe('<ListenersTab />', () => {
   });
 
   it('should show all listeners when switching back from a filtered selection', async () => {
-    const allListenersPayload = buildExpectedPayload(
-      z.strictObject({
-        $in: z.tuple([
-          z.literal('EXECUTION_LISTENER'),
-          z.literal('TASK_LISTENER'),
-        ]),
-      }),
-    );
-
     mockFetchElementInstance('123456789').withSuccess(
       mockUserTaskElementInstance,
     );
     mockValidatedSearchJobs(
-      allListenersPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
     );
 
@@ -501,12 +480,8 @@ describe('<ListenersTab />', () => {
     expect(await screen.findByText('Execution listener')).toBeInTheDocument();
     expect(screen.getByText('Task listener')).toBeInTheDocument();
 
-    const executionListenerPayload = buildExpectedPayload(
-      z.literal('EXECUTION_LISTENER'),
-    );
-
     mockValidatedSearchJobs(
-      executionListenerPayload,
+      buildExpectedPayload(z.literal('EXECUTION_LISTENER')),
       searchResult([mockExecutionListenerJob]),
     );
 
@@ -517,7 +492,14 @@ describe('<ListenersTab />', () => {
     expect(screen.queryByText('Task listener')).not.toBeInTheDocument();
 
     mockValidatedSearchJobs(
-      allListenersPayload,
+      buildExpectedPayload(
+        z.strictObject({
+          $in: z.tuple([
+            z.literal('EXECUTION_LISTENER'),
+            z.literal('TASK_LISTENER'),
+          ]),
+        }),
+      ),
       searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
     );
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
@@ -193,28 +193,6 @@ describe('<ListenersTab />', () => {
     mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
   });
 
-  it('should filter job searches by listener kind', async () => {
-    mockValidatedSearchJobs(
-      buildExpectedPayload(
-        z.strictObject({
-          $in: z.tuple([
-            z.literal('EXECUTION_LISTENER'),
-            z.literal('TASK_LISTENER'),
-          ]),
-        }),
-      ),
-      searchResult([]),
-    );
-
-    render(<ListenersTab />, {
-      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
-    });
-
-    expect(
-      await screen.findByText('This element has no execution listeners'),
-    ).toBeInTheDocument();
-  });
-
   it('should show empty message when no listeners exist', async () => {
     mockValidatedSearchJobs(
       buildExpectedPayload(

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.test.tsx
@@ -1,0 +1,258 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {createMemoryRouter, RouterProvider} from 'react-router-dom';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {Paths} from 'modules/Routes';
+import {ListenersTab} from './index';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {searchResult} from 'modules/testUtils';
+import type {
+  ElementInstance,
+  Job,
+  ProcessInstance,
+} from '@camunda/camunda-api-zod-schemas/8.9';
+
+const PROCESS_INSTANCE_ID = '111222333';
+const PROCESS_DEFINITION_KEY = '444555666';
+
+const mockProcessInstance = {
+  processInstanceKey: PROCESS_INSTANCE_ID,
+  processDefinitionId: 'process-def-1',
+  processDefinitionKey: PROCESS_DEFINITION_KEY,
+  processDefinitionName: 'Main Process',
+  processDefinitionVersion: 1,
+  state: 'ACTIVE',
+  startDate: '2023-01-15T10:00:00.000Z',
+  tenantId: '<default>',
+  parentProcessInstanceKey: null,
+  parentElementInstanceKey: null,
+  hasIncident: false,
+  rootProcessInstanceKey: null,
+  tags: [],
+  processDefinitionVersionTag: null,
+  endDate: null,
+} satisfies ProcessInstance;
+
+const mockElementInstance = {
+  elementInstanceKey: '123456789',
+  elementId: 'Task_1',
+  elementName: 'Service Task',
+  type: 'SERVICE_TASK',
+  state: 'COMPLETED',
+  startDate: '2023-01-15T10:00:00.000Z',
+  endDate: '2023-01-15T10:05:00.000Z',
+  processDefinitionId: 'process-def-1',
+  processInstanceKey: PROCESS_INSTANCE_ID,
+  processDefinitionKey: PROCESS_DEFINITION_KEY,
+  hasIncident: false,
+  tenantId: '<default>',
+  rootProcessInstanceKey: null,
+  incidentKey: null,
+} satisfies ElementInstance;
+
+const mockUserTaskElementInstance = {
+  ...mockElementInstance,
+  type: 'USER_TASK',
+  elementName: 'User Task',
+} satisfies ElementInstance;
+
+const baseJobFields = {
+  processInstanceKey: PROCESS_INSTANCE_ID,
+  processDefinitionKey: PROCESS_DEFINITION_KEY,
+  processDefinitionId: 'process-def-1',
+  elementId: 'Task_1',
+  elementInstanceKey: '123456789',
+  worker: 'worker-1',
+  retries: 3,
+  deadline: null,
+  customHeaders: null,
+  tenantId: '<default>',
+  isDenied: false,
+  deniedReason: null,
+  hasFailedWithRetriesLeft: false,
+  errorCode: null,
+  errorMessage: null,
+  endTime: '2023-01-15T10:05:00.000Z',
+  rootProcessInstanceKey: null,
+  creationTime: null,
+  lastUpdateTime: null,
+  tags: [],
+} satisfies Omit<
+  Job,
+  'jobKey' | 'type' | 'state' | 'kind' | 'listenerEventType'
+>;
+
+const mockExecutionListenerJob = {
+  ...baseJobFields,
+  jobKey: '100000001',
+  type: 'io.camunda:execution-listener',
+  state: 'COMPLETED',
+  kind: 'EXECUTION_LISTENER',
+  listenerEventType: 'START',
+} satisfies Job;
+
+const mockTaskListenerJob = {
+  ...baseJobFields,
+  jobKey: '100000002',
+  type: 'io.camunda:task-listener',
+  state: 'COMPLETED',
+  kind: 'TASK_LISTENER',
+  listenerEventType: 'COMPLETING',
+} satisfies Job;
+
+function getWrapper(initialSearchParams?: string) {
+  const path = Paths.processInstanceListeners({
+    processInstanceId: PROCESS_INSTANCE_ID,
+  });
+  const initialEntry = initialSearchParams
+    ? `${path}?${initialSearchParams}`
+    : path;
+
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: Paths.processInstance(undefined, true),
+          children: [
+            {
+              path: Paths.processInstanceListeners({isRelative: true}),
+              element: children,
+            },
+          ],
+        },
+      ],
+      {
+        initialEntries: [initialEntry],
+      },
+    );
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    );
+  };
+
+  return Wrapper;
+}
+
+describe('<ListenersTab />', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
+    mockSearchJobs().withSuccess(searchResult([]));
+  });
+
+  it('should show empty message when no listeners exist', async () => {
+    render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(
+      await screen.findByText('This element has no execution listeners'),
+    ).toBeInTheDocument();
+  });
+
+  it('should display execution listener jobs', async () => {
+    mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
+    mockSearchJobs().withSuccess(searchResult([mockExecutionListenerJob]));
+
+    render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Execution listener')).toBeInTheDocument();
+    expect(screen.getByText('100000001')).toBeInTheDocument();
+    expect(
+      screen.getByText('io.camunda:execution-listener'),
+    ).toBeInTheDocument();
+  });
+
+  it('should display task listener jobs', async () => {
+    mockFetchElementInstance('123456789').withSuccess(
+      mockUserTaskElementInstance,
+    );
+    mockSearchJobs().withSuccess(searchResult([mockTaskListenerJob]));
+
+    render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Task listener')).toBeInTheDocument();
+    expect(screen.getByText('100000002')).toBeInTheDocument();
+    expect(screen.getByText('io.camunda:task-listener')).toBeInTheDocument();
+  });
+
+  it('should display both listener types', async () => {
+    mockFetchElementInstance('123456789').withSuccess(
+      mockUserTaskElementInstance,
+    );
+    mockSearchJobs().withSuccess(
+      searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
+    );
+
+    render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Execution listener')).toBeInTheDocument();
+    expect(screen.getByText('Task listener')).toBeInTheDocument();
+  });
+
+  it('should show empty message for user task with no listeners', async () => {
+    mockFetchElementInstance('123456789').withSuccess(
+      mockUserTaskElementInstance,
+    );
+
+    render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(
+      await screen.findByText(
+        'This element has no execution listeners nor user task listeners',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should show listener type dropdown for user tasks', async () => {
+    mockFetchElementInstance('123456789').withSuccess(
+      mockUserTaskElementInstance,
+    );
+    mockSearchJobs().withSuccess(
+      searchResult([mockExecutionListenerJob, mockTaskListenerJob]),
+    );
+
+    render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(
+      await screen.findByTestId('listener-type-filter'),
+    ).toBeInTheDocument();
+  });
+
+  it('should not show listener type dropdown for non-user-task elements', async () => {
+    mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
+    mockSearchJobs().withSuccess(searchResult([mockExecutionListenerJob]));
+
+    render(<ListenersTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Execution listener')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('listener-type-filter'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/index.tsx
@@ -67,7 +67,9 @@ const ListenersTab: React.FC = () => {
         processInstanceKey: processInstanceId,
         elementId: selectedElementId ?? undefined,
         elementInstanceKey: resolvedElementInstanceKey ?? undefined,
-        kind: listenerTypeFilter,
+        kind: listenerTypeFilter ?? {
+          $in: ['EXECUTION_LISTENER', 'TASK_LISTENER'],
+        },
       },
     },
     select: (data) => data.pages?.flatMap((page) => page.items),

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/styled.ts
@@ -10,9 +10,13 @@ import {StructuredList as BaseStructuredList} from 'modules/components/Structure
 import {WarningFilled as BaseWarningFilled} from '@carbon/react/icons';
 import {supportError, spacing01, spacing03} from '@carbon/elements';
 import styled from 'styled-components';
-import {Stack as BaseStack, Dropdown as BaseDropdown} from '@carbon/react';
+import {
+  Stack as BaseStack,
+  Dropdown as BaseDropdown,
+  Layer,
+} from '@carbon/react';
 
-const Content = styled.div`
+const Content = styled(Layer)`
   position: relative;
   height: 100%;
   display: flex;


### PR DESCRIPTION
# Description
Backport of #49534 to `stable/8.9`.

relates to #49525