### PR TITLE
fix: Disable Standalone Decisions Archive Job

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -85,7 +85,7 @@ public final class ExporterMetrics {
       final ValueType valueType, final long written, final long exporting) {
     exportingLatency
         .computeIfAbsent(valueType, this::registerExportingLatency)
-        .record(exporting - written, TimeUnit.MILLISECONDS);
+        .record(Math.max(0, exporting - written), TimeUnit.MILLISECONDS);
   }
 
   public CloseableSilently startExporterExportingTimer(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -90,6 +90,7 @@ public class CamundaExporter implements Exporter {
   private int partitionId;
   private Context context;
   private long lastFlushTimestamp = 0L;
+  private long firstBufferedAtMs = -1L;
 
   private long flushDelayMs;
 
@@ -184,16 +185,20 @@ public class CamundaExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-    if (writer.getBatchSize() == 0) {
-      metrics.startFlushLatencyMeasurement();
-    }
+    final long now = context.clock().millis();
+    final boolean wasEmpty = writer.getBatchSize() == 0;
 
     // adding record is idempotent
     writer.addRecord(record);
 
     lastPosition = record.getPosition();
 
-    if (shouldFlush()) {
+    if (wasEmpty && writer.getBatchSize() > 0) {
+      firstBufferedAtMs = now;
+      metrics.startFlushLatencyMeasurement();
+    }
+
+    if (shouldFlush(now)) {
       flush();
     }
   }
@@ -298,9 +303,17 @@ public class CamundaExporter implements Exporter {
     return Arrays.stream(names).map(s -> indexPrefix + s).toList();
   }
 
-  private boolean shouldFlush() {
-    return writer.getBatchSize() >= configuration.getBulk().getSize()
-        || writer.getBatchMemoryEstimateInMb() >= configuration.getBulk().getMemoryLimit();
+  private boolean shouldFlush(final long now) {
+    if (writer.getBatchSize() == 0) {
+      return false;
+    }
+    if (writer.getBatchSize() >= configuration.getBulk().getSize()) {
+      return true;
+    }
+    if (writer.getBatchMemoryEstimateInMb() >= configuration.getBulk().getMemoryLimit()) {
+      return true;
+    }
+    return firstBufferedAtMs > 0 && (now - firstBufferedAtMs) >= flushDelayMs;
   }
 
   private ExporterBatchWriter createBatchWriter() {
@@ -341,6 +354,7 @@ public class CamundaExporter implements Exporter {
         metrics.recordFlushOccurrence(Instant.now());
         metrics.stopFlushLatencyMeasurement();
         lastFlushTimestamp = context.clock().millis();
+        firstBufferedAtMs = -1L;
       } catch (final PersistenceException ex) {
         metrics.recordFailedFlush();
         throw new ExporterException(ex.getMessage(), ex);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -265,7 +265,7 @@ public final class BackgroundTaskManagerFactory {
     tasks.add(buildUsageMetricsArchiverJob());
     tasks.add(buildUsageMetricsTUArchiverJob());
     tasks.add(buildJobBatchMetricsArchiverJob());
-    tasks.add(buildStandaloneDecisionArchiverJob());
+    //    tasks.add(buildStandaloneDecisionArchiverJob());
     if (partitionId == START_PARTITION_ID) {
       tasks.add(buildBatchOperationArchiverJob());
       tasks.add(buildBatchOperationUpdateTask());


### PR DESCRIPTION

## Description

Exclude the standalone job for testing

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
